### PR TITLE
feat(portal): APIM-13766 add application members flow

### DIFF
--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-members-add-dialog/application-members-add-dialog.component.harness.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-members-add-dialog/application-members-add-dialog.component.harness.ts
@@ -1,0 +1,129 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ComponentHarness } from '@angular/cdk/testing';
+import { MatAutocompleteHarness } from '@angular/material/autocomplete/testing';
+import { MatButtonHarness } from '@angular/material/button/testing';
+import { MatChipHarness } from '@angular/material/chips/testing';
+import { MatSelectHarness } from '@angular/material/select/testing';
+
+export class ApplicationMembersAddDialogHarness extends ComponentHarness {
+  static readonly hostSelector = 'app-application-members-add-dialog';
+
+  private readonly locateUserAutocomplete = this.locatorFor(
+    MatAutocompleteHarness.with({ selector: '[data-testid="add-members-search-input"]' }),
+  );
+  private readonly locateRoleSelect = this.locatorFor(MatSelectHarness.with({ selector: '[data-testid="add-members-role-select"]' }));
+  private readonly locateSubmitButton = this.locatorFor(MatButtonHarness.with({ selector: '[data-testid="add-members-submit-button"]' }));
+  private readonly locateCancelButton = this.locatorFor(MatButtonHarness.with({ selector: '[data-testid="add-members-cancel-button"]' }));
+  private readonly locateSearchError = this.locatorForOptional('[data-testid="add-members-search-error"]');
+  private readonly locateSubmitError = this.locatorForOptional('[data-testid="add-members-submit-error"]');
+  private readonly locateUserErrors = this.locatorForAll('[data-testid="add-members-user-error"]');
+  private readonly locateSelectedUserChips = this.locatorForAll(
+    MatChipHarness.with({ selector: '[data-testid="add-members-selected-user-chip"]' }),
+  );
+
+  async getSearchNoMatchText(): Promise<string | null> {
+    const autocomplete = await this.openUserAutocomplete();
+    const options = await autocomplete.getOptions({ text: /No users found/ });
+    return options[0]?.getText() ?? null;
+  }
+
+  async getSearchErrorText(): Promise<string | null> {
+    const element = await this.locateSearchError();
+    return element ? element.text() : null;
+  }
+
+  async getSubmitErrorText(): Promise<string | null> {
+    const element = await this.locateSubmitError();
+    return element ? element.text() : null;
+  }
+
+  async getUserErrorTexts(): Promise<string[]> {
+    return Promise.all((await this.locateUserErrors()).map(element => element.text()));
+  }
+
+  async getUserOptionTexts(): Promise<string[]> {
+    const autocomplete = await this.openUserAutocomplete();
+    return Promise.all((await autocomplete.getOptions()).map(option => option.getText()));
+  }
+
+  async getSelectedUserChipTexts(): Promise<string[]> {
+    return Promise.all((await this.locateSelectedUserChips()).map(chip => chip.getText()));
+  }
+
+  async removeSelectedUserChip(text: string | RegExp): Promise<void> {
+    const chips = await this.locateSelectedUserChips();
+    for (const chip of chips) {
+      const chipText = await chip.getText();
+      const matches = typeof text === 'string' ? chipText.includes(text) : text.test(chipText);
+      if (matches) {
+        await chip.remove();
+        return;
+      }
+    }
+    throw new Error(`Unable to find selected user chip matching ${text.toString()}`);
+  }
+
+  async selectUser(text: string | RegExp): Promise<void> {
+    const autocomplete = await this.openUserAutocomplete();
+    return autocomplete.selectOption({ text });
+  }
+
+  async isUserOptionDisabled(text: string | RegExp): Promise<boolean> {
+    const autocomplete = await this.openUserAutocomplete();
+    const options = await autocomplete.getOptions({ text });
+    return options[0]?.isDisabled() ?? false;
+  }
+
+  async selectRole(role: string): Promise<void> {
+    const select = await this.locateRoleSelect();
+    await select.open();
+    return select.clickOptions({ text: role });
+  }
+
+  async getRoleOptionTexts(): Promise<string[]> {
+    const select = await this.locateRoleSelect();
+    await select.open();
+    return Promise.all((await select.getOptions()).map(option => option.getText()));
+  }
+
+  async getRoleValueText(): Promise<string> {
+    return (await this.locateRoleSelect()).getValueText();
+  }
+
+  async clickSubmit(): Promise<void> {
+    return (await this.locateSubmitButton()).click();
+  }
+
+  async getSubmitButtonText(): Promise<string> {
+    return (await this.locateSubmitButton()).getText();
+  }
+
+  async isSubmitDisabled(): Promise<boolean> {
+    return (await this.locateSubmitButton()).isDisabled();
+  }
+
+  async clickCancel(): Promise<void> {
+    return (await this.locateCancelButton()).click();
+  }
+
+  private async openUserAutocomplete(): Promise<MatAutocompleteHarness> {
+    const autocomplete = await this.locateUserAutocomplete();
+    await autocomplete.blur();
+    await autocomplete.focus();
+    return autocomplete;
+  }
+}

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-members-add-dialog/application-members-add-dialog.component.html
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-members-add-dialog/application-members-add-dialog.component.html
@@ -1,0 +1,173 @@
+<!--
+
+    Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<h2 mat-dialog-title i18n="@@addApplicationMembersDialogTitle">Add members</h2>
+
+<mat-dialog-content class="application-members-add-dialog">
+  <section class="application-members-add-dialog__section">
+    <mat-form-field appearance="outline" class="application-members-add-dialog__field">
+      <mat-label i18n="@@addApplicationMembersRoleLabel">Member Role</mat-label>
+      <mat-select
+        [formControl]="roleControl"
+        data-testid="add-members-role-select"
+        aria-label="Member role"
+        i18n-aria-label="@@addApplicationMembersRoleAriaLabel"
+      >
+        @for (role of assignableRoles(); track role.name) {
+          <mat-option [value]="role.name">{{ role.name }}</mat-option>
+        }
+      </mat-select>
+      @if (roleControl.hasError('required') && roleControl.touched) {
+        <mat-error i18n="@@addApplicationMembersRoleRequired">Application role is required.</mat-error>
+      }
+    </mat-form-field>
+
+    @if (rolesResource.isLoading()) {
+      <div class="application-members-add-dialog__loading" aria-live="polite" data-testid="add-members-roles-loading">
+        <mat-progress-spinner diameter="20" mode="indeterminate" />
+        <span class="next-gen-small" i18n="@@addApplicationMembersRolesLoading">Loading roles...</span>
+      </div>
+    } @else if (rolesResource.error()) {
+      <p class="application-members-add-dialog__error next-gen-small" role="alert" data-testid="add-members-roles-error" i18n>
+        An error occurred while loading application roles. Please try again.
+      </p>
+    } @else if (assignableRoles().length === 0) {
+      <p class="application-members-add-dialog__error next-gen-small" role="alert" data-testid="add-members-no-roles" i18n>
+        No assignable application roles are available.
+      </p>
+    }
+  </section>
+
+  <section class="application-members-add-dialog__section">
+    <mat-form-field appearance="outline" class="application-members-add-dialog__field">
+      <mat-label i18n="@@addApplicationMemberSearchLabel">Search user</mat-label>
+      <input
+        matInput
+        type="search"
+        [formControl]="userControl"
+        [matAutocomplete]="userAutocomplete"
+        data-testid="add-members-search-input"
+        aria-label="Search user"
+        i18n-aria-label="@@addApplicationMemberSearchAriaLabel"
+        placeholder="Name or email..."
+        i18n-placeholder="@@addApplicationMemberSearchPlaceholder"
+      />
+      <mat-autocomplete #userAutocomplete="matAutocomplete">
+        @if (usersResource.isLoading()) {
+          <mat-option disabled data-testid="add-members-search-loading">
+            <div class="application-members-add-dialog__option">
+              <mat-progress-spinner diameter="20" mode="indeterminate" />
+              <span class="next-gen-small" i18n="@@addApplicationMemberSearchLoading">Searching users...</span>
+            </div>
+          </mat-option>
+        }
+        @for (option of userOptions(); track option.id) {
+          <mat-option
+            [value]="searchQuery()"
+            [disabled]="option.isDisabled"
+            (onSelectionChange)="$event.isUserInput && onUserSelected(option.user)"
+          >
+            <div class="application-members-add-dialog__option">
+              <app-user-cell [user]="option.vm" />
+              @if (option.isAlreadyMember) {
+                <span
+                  class="application-members-add-dialog__already-added next-gen-small"
+                  data-testid="add-members-user-already-added"
+                  i18n
+                >
+                  Already added
+                </span>
+              } @else if (option.isSelected) {
+                <span
+                  class="application-members-add-dialog__already-added next-gen-small"
+                  data-testid="add-members-user-already-selected"
+                  i18n
+                >
+                  Already selected
+                </span>
+              }
+            </div>
+          </mat-option>
+        }
+        @if (noUsersFound()) {
+          <mat-option disabled data-testid="add-members-search-no-match">
+            <span i18n="@@addApplicationMemberNoUsersFound">No users found</span>
+          </mat-option>
+        }
+      </mat-autocomplete>
+      <mat-hint i18n="@@addApplicationMemberSearchHint">Search by name or email.</mat-hint>
+      @if (selectedUsers().length === 0 && userControl.touched) {
+        <mat-error i18n="@@addApplicationMemberUserRequired">Please select a user.</mat-error>
+      }
+    </mat-form-field>
+
+    @if (selectedUsers().length > 0) {
+      <div class="application-members-add-dialog__selected-users" data-testid="add-members-selected-users">
+        <mat-chip-set aria-label="Selected members" i18n-aria-label="@@addApplicationMembersSelectedMembersAriaLabel">
+          @for (selectedUser of selectedUsers(); track selectedUser.id) {
+            <mat-chip
+              data-testid="add-members-selected-user-chip"
+              [removable]="!isSubmitting()"
+              (removed)="removeSelectedUser(selectedUser.id)"
+            >
+              <span>{{ selectedUser.displayName }}</span>
+              @if (selectedUser.email) {
+                <span class="application-members-add-dialog__selected-user-email next-gen-small">{{ selectedUser.email }}</span>
+              }
+              <button matChipRemove type="button" [disabled]="isSubmitting()" [attr.aria-label]="selectedUser.removeLabel">
+                <mat-icon aria-hidden="true">cancel</mat-icon>
+              </button>
+            </mat-chip>
+          }
+        </mat-chip-set>
+      </div>
+    }
+
+    @if (usersResource.error()) {
+      <p class="application-members-add-dialog__error next-gen-small" data-testid="add-members-search-error" role="alert" i18n>
+        An error occurred while searching users. Please try again.
+      </p>
+    }
+    @for (error of userSubmitErrors(); track error) {
+      <p class="application-members-add-dialog__error next-gen-small" role="alert" data-testid="add-members-user-error">
+        {{ error }}
+      </p>
+    }
+  </section>
+
+  @if (submitError(); as error) {
+    <p class="application-members-add-dialog__error next-gen-small" data-testid="add-members-submit-error" role="alert">
+      {{ error }}
+    </p>
+  }
+</mat-dialog-content>
+
+<mat-dialog-actions align="end">
+  <button mat-stroked-button type="button" (click)="onCancel()" data-testid="add-members-cancel-button" i18n>Cancel</button>
+  <button
+    mat-flat-button
+    color="primary"
+    type="button"
+    [disabled]="!canSubmit()"
+    (click)="onSubmit()"
+    data-testid="add-members-submit-button"
+  >
+    <span i18n="@@addApplicationMembersSubmitButton">
+      {selectedUsers().length, plural, =0 {Add member} =1 {Add member} other {Add {{ selectedUsers().length }} members}}
+    </span>
+  </button>
+</mat-dialog-actions>

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-members-add-dialog/application-members-add-dialog.component.scss
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-members-add-dialog/application-members-add-dialog.component.scss
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2026 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@use '../../../../scss/theme/index' as app-theme;
+
+.application-members-add-dialog {
+  display: flex;
+  width: 640px;
+  max-width: 100%;
+  flex-direction: column;
+  gap: 24px;
+  padding-top: app-theme.$form-field-container-vertical-padding;
+
+  &__section {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+  }
+
+  &__field {
+    width: 100%;
+  }
+
+  &__section:first-child &__field {
+    margin-top: app-theme.$form-field-container-vertical-padding;
+  }
+
+  &__loading {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    color: app-theme.$paragraph-color;
+  }
+
+  &__hint {
+    margin: 0;
+    color: app-theme.$paragraph-color;
+  }
+
+  &__error {
+    margin: 0;
+    color: app-theme.$error-main-color;
+  }
+
+  &__option {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 16px;
+    width: 100%;
+  }
+
+  &__already-added {
+    flex-shrink: 0;
+    color: app-theme.$paragraph-color;
+  }
+
+  &__selected-user-email {
+    margin-left: 4px;
+    color: app-theme.$paragraph-color;
+  }
+}

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-members-add-dialog/application-members-add-dialog.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-members-add-dialog/application-members-add-dialog.component.spec.ts
@@ -1,0 +1,358 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { provideHttpClient } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+
+import { ApplicationMembersAddDialogComponent, ApplicationMembersAddDialogData } from './application-members-add-dialog.component';
+import { ApplicationMembersAddDialogHarness } from './application-members-add-dialog.component.harness';
+import { APPLICATION_PRIMARY_OWNER_ROLE_NAME, ApplicationRole } from '../../../../entities/application/application';
+import { User, UsersResponse } from '../../../../entities/user/user';
+import { fakeUser, fakeUsersResponse } from '../../../../entities/user/user.fixtures';
+import { ConfigService } from '../../../../services/config.service';
+import { TESTING_BASE_URL } from '../../../../testing/app-testing.module';
+
+const APPLICATION_ID = 'app-1';
+const ROLES_URL = `${TESTING_BASE_URL}/configuration/applications/roles`;
+const MEMBERS_URL = `${TESTING_BASE_URL}/applications/${APPLICATION_ID}/members`;
+const USERS_SEARCH_URL = `${TESTING_BASE_URL}/users/_search`;
+const MOCK_DATE = new Date(1466424490000);
+
+const APPLICATION_ROLES: ApplicationRole[] = [
+  { id: APPLICATION_PRIMARY_OWNER_ROLE_NAME, name: APPLICATION_PRIMARY_OWNER_ROLE_NAME, default: false, system: true },
+  { id: 'SYSTEM_AUDITOR', name: 'SYSTEM_AUDITOR', default: false, system: true },
+  { id: 'OWNER', name: 'OWNER', default: false, system: false },
+  { id: 'USER', name: 'USER', default: true, system: false },
+];
+
+describe('ApplicationMembersAddDialogComponent', () => {
+  let fixture: ComponentFixture<ApplicationMembersAddDialogComponent>;
+  let harness: ApplicationMembersAddDialogHarness;
+  let httpTestingController: HttpTestingController;
+  let dialogRef: { close: jest.Mock };
+
+  async function init(data: ApplicationMembersAddDialogData = { applicationId: APPLICATION_ID }): Promise<void> {
+    jest.useRealTimers();
+    dialogRef = { close: jest.fn() };
+
+    await TestBed.configureTestingModule({
+      imports: [ApplicationMembersAddDialogComponent],
+      providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        provideNoopAnimations(),
+        { provide: ConfigService, useValue: { baseURL: TESTING_BASE_URL } },
+        { provide: MAT_DIALOG_DATA, useValue: data },
+        { provide: MatDialogRef, useValue: dialogRef },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ApplicationMembersAddDialogComponent);
+    httpTestingController = TestBed.inject(HttpTestingController);
+
+    fixture.detectChanges();
+    flushRoles();
+    await fixture.whenStable();
+    fixture.detectChanges();
+    harness = await TestbedHarnessEnvironment.harnessForFixture(fixture, ApplicationMembersAddDialogHarness);
+  }
+
+  function flushRoles(roles: ApplicationRole[] = APPLICATION_ROLES): void {
+    const req = httpTestingController.expectOne(ROLES_URL);
+    expect(req.request.method).toBe('GET');
+    req.flush({ data: roles });
+  }
+
+  async function searchUsers(query: string, response: UsersResponse): Promise<void> {
+    fixture.componentInstance.userControl.setValue(query);
+    fixture.detectChanges();
+    await new Promise(resolve => setTimeout(resolve, 350));
+    fixture.detectChanges();
+
+    const req = httpTestingController.expectOne(req => req.url === USERS_SEARCH_URL);
+    expect(req.request.method).toBe('POST');
+    expect(req.request.params.get('page')).toBe('1');
+    expect(req.request.params.get('size')).toBe('20');
+    expect(req.request.body).toEqual({
+      filters: {
+        query,
+      },
+      includes: {
+        applicationMembership: APPLICATION_ID,
+      },
+    });
+    req.flush(response);
+    await fixture.whenStable();
+    fixture.detectChanges();
+  }
+
+  async function selectUser(user: User): Promise<void> {
+    const displayName = user.display_name ?? user.id ?? '';
+    await searchUsers(displayName, usersResponse([user]));
+    await harness.selectUser(new RegExp(displayName));
+    fixture.detectChanges();
+  }
+
+  afterEach(() => {
+    httpTestingController.verify();
+    jest.useFakeTimers({ advanceTimers: 1, now: MOCK_DATE });
+  });
+
+  it('should preselect default application role', async () => {
+    await init();
+
+    expect(fixture.componentInstance.roleControl.value).toBe('USER');
+    expect(await harness.getRoleValueText()).toBe('USER');
+  });
+
+  it('should not offer system application roles', async () => {
+    await init({
+      applicationId: APPLICATION_ID,
+    });
+
+    expect(await harness.getRoleOptionTexts()).toEqual(['OWNER', 'USER']);
+  });
+
+  it('should keep submit disabled without calling users search for blank query', async () => {
+    await init();
+
+    httpTestingController.expectNone(USERS_SEARCH_URL);
+    expect(await harness.isSubmitDisabled()).toBe(true);
+  });
+
+  it('should search users through application-aware users service contract', async () => {
+    const user = fakeUser({ id: 'user-1', display_name: 'Ada Lovelace', email: 'ada@example.com' });
+    await init();
+
+    await searchUsers('Ada', usersResponse([user]));
+
+    expect(await harness.getUserOptionTexts()).toEqual([expect.stringContaining('Ada Lovelace')]);
+  });
+
+  it('should mark already assigned users as not selectable', async () => {
+    const user = fakeUser({ id: 'user-1', display_name: 'Ada Lovelace' });
+    await init();
+
+    await searchUsers('Ada', usersResponse([user], { 'user-1': true }));
+
+    expect(await harness.getUserOptionTexts()).toEqual([expect.stringContaining('Already added')]);
+    expect(await harness.isUserOptionDisabled(/Ada Lovelace/)).toBe(true);
+  });
+
+  it('should show no users found option when search has no result', async () => {
+    await init();
+
+    await searchUsers('Ada', usersResponse([]));
+
+    expect(await harness.getSearchNoMatchText()).toBe('No users found');
+  });
+
+  it('should require selecting a user before submit when default role is available', async () => {
+    const user = fakeUser({ id: 'user-1', display_name: 'Ada Lovelace' });
+    await init();
+    await searchUsers('Ada', usersResponse([user]));
+
+    expect(await harness.isSubmitDisabled()).toBe(true);
+
+    await harness.selectUser(/Ada Lovelace/);
+    fixture.detectChanges();
+
+    expect(await harness.getSelectedUserChipTexts()).toEqual([expect.stringContaining('Ada Lovelace')]);
+    expect(await harness.getSubmitButtonText()).toBe('Add member');
+    expect(await harness.isSubmitDisabled()).toBe(false);
+  });
+
+  it('should remove selected users from chips', async () => {
+    const user = fakeUser({ id: 'user-1', display_name: 'Ada Lovelace' });
+    await init();
+    await searchUsers('Ada', usersResponse([user]));
+    await harness.selectUser(/Ada Lovelace/);
+    await harness.selectRole('USER');
+    fixture.detectChanges();
+
+    expect(await harness.isSubmitDisabled()).toBe(false);
+
+    await harness.removeSelectedUserChip(/Ada Lovelace/);
+    fixture.detectChanges();
+
+    expect(await harness.getSelectedUserChipTexts()).toEqual([]);
+    expect(await harness.isSubmitDisabled()).toBe(true);
+  });
+
+  it('should mark selected users as not selectable when they appear again in search results', async () => {
+    const user = fakeUser({ id: 'user-1', display_name: 'Ada Lovelace' });
+    await init();
+    await searchUsers('Ada', usersResponse([user]));
+    await harness.selectUser(/Ada Lovelace/);
+    fixture.detectChanges();
+
+    await searchUsers('Ada', usersResponse([user]));
+
+    expect(await harness.getUserOptionTexts()).toEqual([expect.stringContaining('Already selected')]);
+    expect(await harness.isUserOptionDisabled(/Ada Lovelace/)).toBe(true);
+  });
+
+  it('should create selected application members and close dialog on success', async () => {
+    const ada = fakeUser({ id: 'user-1', display_name: 'Ada Lovelace' });
+    const bob = fakeUser({ id: 'user-2', display_name: 'Bob Martin' });
+    await init();
+    await searchUsers('Ada', usersResponse([ada]));
+    await harness.selectUser(/Ada Lovelace/);
+    await searchUsers('Bob', usersResponse([bob]));
+    await harness.selectUser(/Bob Martin/);
+    await harness.selectRole('USER');
+    fixture.detectChanges();
+
+    expect(await harness.getSubmitButtonText()).toBe('Add 2 members');
+
+    fixture.componentInstance.onSubmit();
+    fixture.detectChanges();
+
+    const requests = httpTestingController.match(req => req.url === MEMBERS_URL);
+    expect(requests).toHaveLength(2);
+    expect(requests.map(req => req.request.method)).toEqual(['POST', 'POST']);
+    expect(requests.map(req => req.request.body)).toEqual([
+      { user: 'user-1', role: 'USER' },
+      { user: 'user-2', role: 'USER' },
+    ]);
+    requests[0].flush({ id: 'member-1', role: 'USER' });
+    requests[1].flush({ id: 'member-2', role: 'USER' });
+    await fixture.whenStable();
+
+    expect(dialogRef.close).toHaveBeenCalledWith(true);
+  });
+
+  it('should limit member creation to three concurrent requests', async () => {
+    const users = [
+      fakeUser({ id: 'user-1', display_name: 'Ada Lovelace' }),
+      fakeUser({ id: 'user-2', display_name: 'Bob Martin' }),
+      fakeUser({ id: 'user-3', display_name: 'Grace Hopper' }),
+      fakeUser({ id: 'user-4', display_name: 'Katherine Johnson' }),
+    ];
+    await init();
+    for (const user of users) {
+      await selectUser(user);
+    }
+    await harness.selectRole('USER');
+    fixture.detectChanges();
+
+    fixture.componentInstance.onSubmit();
+    fixture.detectChanges();
+
+    const initialRequests = httpTestingController.match(req => req.url === MEMBERS_URL);
+    expect(initialRequests).toHaveLength(3);
+    expect(initialRequests.map(req => req.request.body.user)).toEqual(['user-1', 'user-2', 'user-3']);
+
+    initialRequests[0].flush({ id: 'member-1', role: 'USER' });
+
+    const fourthRequest = httpTestingController.expectOne(req => req.url === MEMBERS_URL && req.body.user === 'user-4');
+    expect(fourthRequest.request.method).toBe('POST');
+    expect(fourthRequest.request.body).toEqual({ user: 'user-4', role: 'USER' });
+
+    initialRequests[1].flush({ id: 'member-2', role: 'USER' });
+    initialRequests[2].flush({ id: 'member-3', role: 'USER' });
+    fourthRequest.flush({ id: 'member-4', role: 'USER' });
+    await fixture.whenStable();
+
+    expect(dialogRef.close).toHaveBeenCalledWith(true);
+  });
+
+  it('should keep dialog open and show conflict error when backend rejects existing member', async () => {
+    const user = fakeUser({ id: 'user-1', display_name: 'Ada Lovelace' });
+    await init();
+    await searchUsers('Ada', usersResponse([user]));
+    await harness.selectUser(/Ada Lovelace/);
+    await harness.selectRole('USER');
+    fixture.detectChanges();
+
+    fixture.componentInstance.onSubmit();
+    fixture.detectChanges();
+
+    httpTestingController.expectOne(MEMBERS_URL).flush({ message: 'Already exists' }, { status: 409, statusText: 'Conflict' });
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    expect(dialogRef.close).not.toHaveBeenCalled();
+    expect(await harness.getSubmitErrorText()).toContain('No members were added');
+    const userErrors = await harness.getUserErrorTexts();
+    expect(userErrors).toHaveLength(1);
+    expect(userErrors[0]).toContain('Ada Lovelace');
+    expect(userErrors[0]).toContain('This user is already a member of the application.');
+  });
+
+  it('should keep failed users selected when add members partially fails', async () => {
+    const ada = fakeUser({ id: 'user-1', display_name: 'Ada Lovelace' });
+    const bob = fakeUser({ id: 'user-2', display_name: 'Bob Martin' });
+    await init();
+    await searchUsers('Ada', usersResponse([ada]));
+    await harness.selectUser(/Ada Lovelace/);
+    await searchUsers('Bob', usersResponse([bob]));
+    await harness.selectUser(/Bob Martin/);
+    await harness.selectRole('USER');
+    fixture.detectChanges();
+
+    fixture.componentInstance.onSubmit();
+    fixture.detectChanges();
+
+    const requests = httpTestingController.match(req => req.url === MEMBERS_URL);
+    expect(requests).toHaveLength(2);
+    requests[0].flush({ id: 'member-1', role: 'USER' });
+    requests[1].flush({ message: 'Server error' }, { status: 500, statusText: 'Error' });
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    expect(dialogRef.close).not.toHaveBeenCalled();
+    expect(await harness.getSubmitErrorText()).toContain('Some members were added');
+    expect(await harness.getSelectedUserChipTexts()).toEqual([expect.stringContaining('Bob Martin')]);
+    const userErrors = await harness.getUserErrorTexts();
+    expect(userErrors).toHaveLength(1);
+    expect(userErrors[0]).toContain('Bob Martin');
+    expect(userErrors[0]).toContain('This member could not be added.');
+
+    await harness.clickCancel();
+
+    expect(dialogRef.close).toHaveBeenCalledWith(true);
+  });
+
+  it('should show recoverable search error', async () => {
+    await init();
+    fixture.componentInstance.userControl.setValue('Ada');
+    fixture.detectChanges();
+    await new Promise(resolve => setTimeout(resolve, 350));
+    fixture.detectChanges();
+
+    httpTestingController
+      .expectOne(req => req.url === USERS_SEARCH_URL)
+      .flush({ message: 'Server error' }, { status: 500, statusText: 'Error' });
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    expect(await harness.getSearchErrorText()).toContain('An error occurred while searching users');
+  });
+});
+
+function usersResponse(users: User[], applicationMembership: Record<string, boolean> = {}): UsersResponse {
+  return fakeUsersResponse({
+    data: users,
+    metadata: {
+      data: { total: users.length },
+      applicationMembership,
+    },
+  });
+}

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-members-add-dialog/application-members-add-dialog.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-members-add-dialog/application-members-add-dialog.component.ts
@@ -1,0 +1,328 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { HttpErrorResponse } from '@angular/common/http';
+import { Component, computed, DestroyRef, effect, inject, signal } from '@angular/core';
+import { rxResource, takeUntilDestroyed, toSignal } from '@angular/core/rxjs-interop';
+import { FormControl, ReactiveFormsModule, Validators } from '@angular/forms';
+import { MatAutocompleteModule } from '@angular/material/autocomplete';
+import { MatButtonModule } from '@angular/material/button';
+import { MatChipsModule } from '@angular/material/chips';
+import { MAT_DIALOG_DATA, MatDialogModule, MatDialogRef } from '@angular/material/dialog';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatIconModule } from '@angular/material/icon';
+import { MatInputModule } from '@angular/material/input';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+import { MatSelectModule } from '@angular/material/select';
+import { catchError, debounceTime, from, map, mergeMap, Observable, of, startWith, toArray } from 'rxjs';
+
+import { UserCellComponent, UserCellVM } from '../../../../components/user-cell/user-cell.component';
+import { APPLICATION_PRIMARY_OWNER_ROLE_NAME, ApplicationRole } from '../../../../entities/application/application';
+import { User, UsersResponse } from '../../../../entities/user/user';
+import { ApplicationService } from '../../../../services/application.service';
+import { MembershipService } from '../../../../services/membership.service';
+import { UsersService } from '../../../../services/users.service';
+
+export interface ApplicationMembersAddDialogData {
+  applicationId: string;
+}
+
+const MEMBERS_CREATION_CONCURRENCY = 3;
+
+interface UserOption {
+  id: string;
+  user: User;
+  vm: UserCellVM;
+  isAlreadyMember: boolean;
+  isSelected: boolean;
+  isDisabled: boolean;
+}
+
+interface SelectedUser {
+  id: string;
+  displayName: string;
+  email?: string;
+  removeLabel: string;
+}
+
+interface MemberCreationResult {
+  user: SelectedUser;
+  success: boolean;
+  errorMessage?: string;
+}
+
+@Component({
+  selector: 'app-application-members-add-dialog',
+  standalone: true,
+  imports: [
+    MatAutocompleteModule,
+    MatButtonModule,
+    MatChipsModule,
+    MatDialogModule,
+    MatFormFieldModule,
+    MatIconModule,
+    MatInputModule,
+    MatProgressSpinnerModule,
+    MatSelectModule,
+    ReactiveFormsModule,
+    UserCellComponent,
+  ],
+  templateUrl: './application-members-add-dialog.component.html',
+  styleUrl: './application-members-add-dialog.component.scss',
+})
+export class ApplicationMembersAddDialogComponent {
+  private readonly applicationService = inject(ApplicationService);
+  private readonly destroyRef = inject(DestroyRef);
+  private readonly dialogRef = inject(MatDialogRef<ApplicationMembersAddDialogComponent, boolean>);
+  private readonly membershipService = inject(MembershipService);
+  private readonly usersService = inject(UsersService);
+  private readonly data: ApplicationMembersAddDialogData = inject(MAT_DIALOG_DATA);
+
+  readonly userControl = new FormControl('', { nonNullable: true });
+  readonly roleControl = new FormControl('', { nonNullable: true, validators: [Validators.required] });
+
+  readonly submitError = signal<string | null>(null);
+  readonly userSubmitErrors = signal<string[]>([]);
+  readonly isSubmitting = signal(false);
+  readonly selectedUsers = signal<SelectedUser[]>([]);
+
+  private readonly hasCreatedMembers = signal(false);
+  private hasInitializedDefaultRole = false;
+
+  private readonly userSearchValue = toSignal(this.userControl.valueChanges.pipe(debounceTime(300), startWith(this.userControl.value)), {
+    initialValue: this.userControl.value,
+  });
+
+  readonly searchQuery = computed(() => this.userSearchValue().trim());
+
+  readonly selectedUserIds = computed(() => new Set(this.selectedUsers().map(user => user.id)));
+
+  private readonly selectedRole = toSignal(this.roleControl.valueChanges.pipe(startWith(this.roleControl.value)), {
+    initialValue: this.roleControl.value,
+  });
+
+  protected readonly rolesResource = rxResource({
+    stream: () => this.applicationService.getApplicationRoles(),
+  });
+
+  protected readonly usersResource = rxResource<UsersResponse | undefined, string>({
+    params: this.searchQuery,
+    stream: ({ params }) =>
+      params.length > 0 ? this.usersService.searchUsersForApplicationMembership(this.data.applicationId, params) : of(undefined),
+  });
+
+  readonly assignableRoles = computed(() => (this.rolesResource.value() ?? []).filter(role => this.isAssignableRole(role)));
+
+  private readonly defaultRoleSelectionEffect = effect(() => {
+    if (this.hasInitializedDefaultRole || this.roleControl.value) {
+      return;
+    }
+
+    const defaultRole = this.assignableRoles().find(role => role.default);
+    if (!defaultRole) {
+      return;
+    }
+
+    this.hasInitializedDefaultRole = true;
+    this.roleControl.setValue(defaultRole.name);
+  });
+
+  readonly userOptions = computed<UserOption[]>(() => {
+    if (this.usersResource.error()) {
+      return [];
+    }
+
+    const response = this.usersResource.value();
+    const membership = response?.metadata?.applicationMembership ?? {};
+    const selectedUserIds = this.selectedUserIds();
+
+    return (response?.data ?? []).map(user => {
+      const id = user.id ?? '';
+      const isAlreadyMember = !!id && membership[id] === true;
+      const isSelected = !!id && selectedUserIds.has(id);
+
+      return {
+        id,
+        user,
+        vm: this.toUserCell(user),
+        isAlreadyMember,
+        isSelected,
+        isDisabled: !id || isAlreadyMember || isSelected,
+      };
+    });
+  });
+
+  readonly noUsersFound = computed(
+    () => this.searchQuery() !== '' && !this.usersResource.isLoading() && !this.usersResource.error() && this.userOptions().length === 0,
+  );
+
+  readonly canSubmit = computed(
+    () =>
+      !this.isSubmitting() &&
+      this.selectedUsers().length > 0 &&
+      !!this.selectedRole() &&
+      this.assignableRoles().some(role => role.name === this.selectedRole()) &&
+      !this.rolesResource.error(),
+  );
+
+  onUserSelected(user: User): void {
+    const id = user.id;
+    if (!id || this.selectedUserIds().has(id)) {
+      this.clearUserSearchControl();
+      return;
+    }
+
+    this.submitError.set(null);
+    this.userSubmitErrors.set([]);
+    this.selectedUsers.update(users => [...users, this.toSelectedUser(user, id)]);
+    this.clearUserSearchControl();
+  }
+
+  removeSelectedUser(userId: string): void {
+    this.submitError.set(null);
+    this.userSubmitErrors.set([]);
+    this.selectedUsers.update(users => users.filter(user => user.id !== userId));
+  }
+
+  onCancel(): void {
+    this.dialogRef.close(this.hasCreatedMembers());
+  }
+
+  onSubmit(): void {
+    this.userControl.markAsTouched();
+    this.roleControl.markAsTouched();
+    const users = this.selectedUsers();
+    const role = this.roleControl.value;
+
+    if (!this.canSubmit() || users.length === 0) {
+      return;
+    }
+
+    this.isSubmitting.set(true);
+    this.submitError.set(null);
+    this.userSubmitErrors.set([]);
+
+    from(users.map((user, index) => ({ index, user })))
+      .pipe(
+        mergeMap(
+          ({ index, user }) => this.createMember(user, role).pipe(map(result => ({ ...result, index }))),
+          MEMBERS_CREATION_CONCURRENCY,
+        ),
+        toArray(),
+        map(results =>
+          results
+            .sort((a, b) => a.index - b.index)
+            .map(result => ({ user: result.user, success: result.success, errorMessage: result.errorMessage })),
+        ),
+        takeUntilDestroyed(this.destroyRef),
+      )
+      .subscribe(results => this.handleCreationResults(results));
+  }
+
+  private handleCreationResults(results: MemberCreationResult[]): void {
+    this.isSubmitting.set(false);
+
+    const failedResults = results.filter(result => !result.success);
+    if (failedResults.length === 0) {
+      this.dialogRef.close(true);
+      return;
+    }
+
+    const failedUserIds = new Set(failedResults.map(result => result.user.id));
+    const successCount = results.length - failedResults.length;
+    if (successCount > 0) {
+      this.hasCreatedMembers.set(true);
+      this.selectedUsers.update(users => users.filter(user => failedUserIds.has(user.id)));
+      this.submitError.set(
+        $localize`:@@addApplicationMembersPartialSubmitError:Some members were added. Review the remaining users and try again.`,
+      );
+    } else {
+      this.submitError.set($localize`:@@addApplicationMembersSubmitError:No members were added. Review the selected users and try again.`);
+    }
+
+    this.userSubmitErrors.set(
+      failedResults.map(
+        result =>
+          $localize`:@@addApplicationMemberUserSubmitError:${result.user.displayName}:userName:: ${
+            result.errorMessage ?? this.genericCreationError()
+          }:errorMessage:`,
+      ),
+    );
+  }
+
+  private createMember(user: SelectedUser, role: string): Observable<MemberCreationResult> {
+    return this.membershipService.addApplicationMember(this.data.applicationId, { user: user.id, role }).pipe(
+      map((): MemberCreationResult => ({ user, success: true })),
+      catchError((error: HttpErrorResponse) =>
+        of({
+          user,
+          success: false,
+          errorMessage:
+            error.status === 409
+              ? $localize`:@@addApplicationMemberConflictError:This user is already a member of the application.`
+              : this.genericCreationError(),
+        }),
+      ),
+    );
+  }
+
+  private genericCreationError(): string {
+    return $localize`:@@addApplicationMemberGenericError:This member could not be added.`;
+  }
+
+  private clearUserSearchControl(): void {
+    queueMicrotask(() => this.userControl.setValue(''));
+  }
+
+  private isAssignableRole(role: ApplicationRole): role is ApplicationRole & { name: string } {
+    return !!role.name && !role.system && role.name !== APPLICATION_PRIMARY_OWNER_ROLE_NAME;
+  }
+
+  private toSelectedUser(user: User, id: string): SelectedUser {
+    const vm = this.toUserCell(user);
+    return {
+      id,
+      displayName: vm.displayName,
+      email: vm.email,
+      removeLabel: $localize`:@@removeSelectedApplicationMemberAriaLabel:Remove ${vm.displayName}:userName: from selected members`,
+    };
+  }
+
+  private toUserCell(user: User): UserCellVM {
+    const displayName =
+      user.display_name ??
+      (user.first_name || user.last_name ? `${user.first_name ?? ''} ${user.last_name ?? ''}`.trim() : (user.id ?? ''));
+
+    return {
+      displayName,
+      email: user.email,
+      avatarUrl: user._links?.avatar,
+      initials: this.getInitialsFromDisplayName(displayName),
+    };
+  }
+
+  private getInitialsFromDisplayName(displayName: string): string {
+    const parts = displayName
+      .trim()
+      .split(/\s+/)
+      .filter(part => part.length > 0);
+
+    return parts
+      .slice(0, 2)
+      .map(part => part[0])
+      .join('')
+      .toUpperCase();
+  }
+}

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-members/application-tab-members.component.harness.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-members/application-tab-members.component.harness.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 import { ComponentHarness, TestElement } from '@angular/cdk/testing';
+import { MatButtonHarness } from '@angular/material/button/testing';
 
 import { LoaderHarness } from '../../../../components/loader/loader.harness';
 import { PaginatedTableHarness } from '../../../../components/paginated-table/paginated-table.harness';
@@ -29,6 +30,9 @@ export class ApplicationTabMembersComponentHarness extends ComponentHarness {
   private readonly locatePaginatedTable = this.locatorForOptional(PaginatedTableHarness);
   private readonly locateUserCells = this.locatorForAll(UserCellHarness);
   private readonly locatePrimaryOwnerRoleCell = this.locatorForOptional('[data-testid="members-role-primary-owner"]');
+  private readonly locateAddMembersButton = this.locatorForOptional(
+    MatButtonHarness.with({ selector: '[data-testid="members-add-button"]' }),
+  );
 
   public async getLoader(): Promise<LoaderHarness | null> {
     return this.locateLoader();
@@ -48,6 +52,14 @@ export class ApplicationTabMembersComponentHarness extends ComponentHarness {
 
   public async getPaginatedTable(): Promise<PaginatedTableHarness | null> {
     return this.locatePaginatedTable();
+  }
+
+  public async getAddMembersButton(): Promise<MatButtonHarness | null> {
+    return this.locateAddMembersButton();
+  }
+
+  public async clickAddMembersButton(): Promise<void> {
+    return (await this.locateAddMembersButton())!.click();
   }
 
   public async getUserCells(): Promise<UserCellHarness[]> {

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-members/application-tab-members.component.html
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-members/application-tab-members.component.html
@@ -16,7 +16,22 @@
 
 -->
 @if (canRead()) {
-  <app-search-bar (searchTerm)="onSearchTermChange($event)" />
+  <div class="members__toolbar">
+    <app-search-bar (searchTerm)="onSearchTermChange($event)" />
+    @if (canCreate()) {
+      <button
+        mat-flat-button
+        color="primary"
+        type="button"
+        data-testid="members-add-button"
+        (click)="openAddMembersDialog()"
+        i18n="@@applicationMembersAddButton"
+      >
+        <mat-icon aria-hidden="true">person_add</mat-icon>
+        Add Members
+      </button>
+    }
+  </div>
   <h4 class="next-gen-h4 members__title" data-testid="members-section-title" i18n="@@applicationMembersTitle">
     Members ({{ totalElements() }})
   </h4>

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-members/application-tab-members.component.scss
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-members/application-tab-members.component.scss
@@ -17,11 +17,18 @@
 
 app-search-bar {
   display: block;
-  margin-bottom: 24px;
   max-width: 400px;
 }
 
 .members {
+  &__toolbar {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 16px;
+    margin-bottom: 24px;
+  }
+
   &__title {
     margin: 0 0 16px;
   }

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-members/application-tab-members.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-members/application-tab-members.component.spec.ts
@@ -19,22 +19,29 @@ import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { provideHttpClient } from '@angular/common/http';
 import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { MatDialogModule } from '@angular/material/dialog';
+import { MatDialog, MatDialogModule } from '@angular/material/dialog';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { provideRouter } from '@angular/router';
+import { of } from 'rxjs';
 
 import { ApplicationTabMembersComponent } from './application-tab-members.component';
 import { ApplicationTabMembersComponentHarness } from './application-tab-members.component.harness';
 import { ConfirmDialogComponent } from '../../../../components/confirm-dialog/confirm-dialog.component';
 import { ConfirmDialogHarness } from '../../../../components/confirm-dialog/confirm-dialog.harness';
+import { APPLICATION_PRIMARY_OWNER_ROLE_NAME, ApplicationRole } from '../../../../entities/application/application';
 import { MembersResponse } from '../../../../entities/member/member';
 import { fakeMember, fakeMembersResponse } from '../../../../entities/member/member.fixtures';
 import { fakeUserApplicationPermissions } from '../../../../entities/permission/permission.fixtures';
+import { ApplicationService } from '../../../../services/application.service';
 import { ConfigService } from '../../../../services/config.service';
 import { CurrentUserService } from '../../../../services/current-user.service';
 import { TESTING_BASE_URL } from '../../../../testing/app-testing.module';
 
 const CURRENT_USER_ID = 'current-user-id';
+const APPLICATION_ROLES: ApplicationRole[] = [
+  { id: APPLICATION_PRIMARY_OWNER_ROLE_NAME, name: APPLICATION_PRIMARY_OWNER_ROLE_NAME, default: false, system: true },
+  { id: 'USER', name: 'USER', default: true, system: false },
+];
 
 describe('ApplicationTabMembersComponent', () => {
   let fixture: ComponentFixture<ApplicationTabMembersComponent>;
@@ -52,9 +59,10 @@ describe('ApplicationTabMembersComponent', () => {
         provideRouter([]),
         { provide: ConfigService, useValue: { baseURL: TESTING_BASE_URL } },
         { provide: CurrentUserService, useValue: { user: () => ({ id: CURRENT_USER_ID }) } },
+        { provide: ApplicationService, useValue: { getApplicationRoles: () => of(APPLICATION_ROLES) } },
       ],
     })
-      .overrideProvider(InteractivityChecker, { useValue: { isFocusable: () => true } })
+      .overrideProvider(InteractivityChecker, { useValue: { isFocusable: () => true, isTabbable: () => true } })
       .compileComponents();
 
     fixture = TestBed.createComponent(ApplicationTabMembersComponent);
@@ -147,7 +155,9 @@ describe('ApplicationTabMembersComponent', () => {
   });
 
   it('should not show delete button when user lacks MEMBER[D] permission', async () => {
-    const harness = await flush(fakeMembersResponse([fakeMember(), fakeMember({ id: 'member-2', role: 'PRIMARY_OWNER' })]));
+    const harness = await flush(
+      fakeMembersResponse([fakeMember(), fakeMember({ id: 'member-2', role: APPLICATION_PRIMARY_OWNER_ROLE_NAME })]),
+    );
     const table = await harness.getPaginatedTable();
     const actions = await table!.getActionButtons();
     expect(actions.length).toBe(0);
@@ -309,12 +319,12 @@ describe('ApplicationTabMembersComponent', () => {
   });
 
   describe('role cell', () => {
-    it('should mark PRIMARY_OWNER via data-testid', async () => {
-      const harness = await flush(fakeMembersResponse([fakeMember({ role: 'PRIMARY_OWNER' })]));
+    it('should mark primary owner via data-testid', async () => {
+      const harness = await flush(fakeMembersResponse([fakeMember({ role: APPLICATION_PRIMARY_OWNER_ROLE_NAME })]));
       expect(await harness.isPrimaryOwnerRoleVisible()).toBe(true);
     });
 
-    it('should not mark other roles as PRIMARY_OWNER', async () => {
+    it('should not mark other roles as primary owner', async () => {
       const harness = await flush(fakeMembersResponse([fakeMember({ role: 'USER' })]));
       expect(await harness.isPrimaryOwnerRoleVisible()).toBe(false);
     });
@@ -332,8 +342,8 @@ describe('ApplicationTabMembersComponent', () => {
       expect(deleteButton).not.toBeNull();
     });
 
-    it('should hide delete button for PRIMARY_OWNER', async () => {
-      const harness = await flush(fakeMembersResponse([fakeMember({ role: 'PRIMARY_OWNER' })]));
+    it('should hide delete button for primary owner', async () => {
+      const harness = await flush(fakeMembersResponse([fakeMember({ role: APPLICATION_PRIMARY_OWNER_ROLE_NAME })]));
       const table = await harness.getPaginatedTable();
       const deleteButton = await table!.getActionButton('delete');
       expect(deleteButton).toBeNull();
@@ -395,6 +405,50 @@ describe('ApplicationTabMembersComponent', () => {
       fixture.detectChanges();
 
       httpTestingController.expectNone(r => r.method === 'DELETE');
+    });
+  });
+
+  describe('add action', () => {
+    it('should not show add members button when user lacks MEMBER[C] permission', async () => {
+      const harness = await flush(fakeMembersResponse([fakeMember()]));
+
+      expect(await harness.getAddMembersButton()).toBeNull();
+    });
+
+    it('should show add members button when user has MEMBER[C] permission', async () => {
+      fixture.componentRef.setInput('userApplicationPermissions', fakeUserApplicationPermissions({ MEMBER: ['R', 'C'] }));
+      const harness = await flush(fakeMembersResponse([fakeMember()]));
+
+      expect(await harness.getAddMembersButton()).not.toBeNull();
+    });
+
+    it('should open add members dialog', async () => {
+      fixture.componentRef.setInput('userApplicationPermissions', fakeUserApplicationPermissions({ MEMBER: ['R', 'C'] }));
+      const harness = await flush(fakeMembersResponse([fakeMember()]));
+      expect(await harness.getAddMembersButton()).not.toBeNull();
+
+      await harness.clickAddMembersButton();
+      await fixture.whenStable();
+      fixture.detectChanges();
+
+      expect(TestBed.inject(MatDialog).openDialogs).toHaveLength(1);
+    });
+
+    it('should reload members list after add members dialog closes with members added', async () => {
+      fixture.componentRef.setInput('userApplicationPermissions', fakeUserApplicationPermissions({ MEMBER: ['R', 'C'] }));
+      const harness = await flush(fakeMembersResponse([fakeMember()]));
+      expect(await harness.getAddMembersButton()).not.toBeNull();
+      await harness.clickAddMembersButton();
+      await fixture.whenStable();
+      fixture.detectChanges();
+
+      TestBed.inject(MatDialog).openDialogs[0].close(true);
+      fixture.detectChanges();
+      await fixture.whenStable();
+      fixture.detectChanges();
+
+      httpTestingController.expectOne(r => r.url.includes('members/_search')).flush(fakeMembersResponse([fakeMember({ id: 'member-2' })]));
+      await fixture.whenStable();
     });
   });
 });

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-members/application-tab-members.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-members/application-tab-members.component.ts
@@ -15,8 +15,10 @@
  */
 import { Component, computed, DestroyRef, inject, input, signal } from '@angular/core';
 import { rxResource, takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { MatButtonModule } from '@angular/material/button';
 import { MatDialog, MatDialogModule } from '@angular/material/dialog';
-import { EMPTY, of, switchMap, tap } from 'rxjs';
+import { MatIconModule } from '@angular/material/icon';
+import { EMPTY, filter, of, switchMap, tap } from 'rxjs';
 
 import { ConfirmDialogComponent, ConfirmDialogData } from '../../../../components/confirm-dialog/confirm-dialog.component';
 import { LoaderComponent } from '../../../../components/loader/loader.component';
@@ -24,10 +26,15 @@ import { PaginatedTableComponent, TableAction, TableColumn } from '../../../../c
 import { TableCellDirective } from '../../../../components/paginated-table/table-cell.directive';
 import { SearchBarComponent } from '../../../../components/search-bar/search-bar.component';
 import { UserCellComponent, UserCellVM } from '../../../../components/user-cell/user-cell.component';
+import { APPLICATION_PRIMARY_OWNER_ROLE_NAME } from '../../../../entities/application/application';
 import { Member, MemberSearchFilters, MembersResponse } from '../../../../entities/member/member';
 import { UserApplicationPermissions } from '../../../../entities/permission/permission';
 import { CurrentUserService } from '../../../../services/current-user.service';
 import { MembershipService } from '../../../../services/membership.service';
+import {
+  ApplicationMembersAddDialogComponent,
+  ApplicationMembersAddDialogData,
+} from '../application-members-add-dialog/application-members-add-dialog.component';
 
 interface MemberTableRow {
   id: string;
@@ -47,7 +54,16 @@ interface MembersRequestParams {
 @Component({
   selector: 'app-application-tab-members',
   standalone: true,
-  imports: [LoaderComponent, MatDialogModule, PaginatedTableComponent, SearchBarComponent, TableCellDirective, UserCellComponent],
+  imports: [
+    LoaderComponent,
+    MatButtonModule,
+    MatDialogModule,
+    MatIconModule,
+    PaginatedTableComponent,
+    SearchBarComponent,
+    TableCellDirective,
+    UserCellComponent,
+  ],
   templateUrl: './application-tab-members.component.html',
   styleUrl: './application-tab-members.component.scss',
 })
@@ -71,6 +87,7 @@ export class ApplicationTabMembersComponent {
   ];
 
   readonly canRead = computed(() => this.userApplicationPermissions().MEMBER?.includes('R') ?? false);
+  readonly canCreate = computed(() => this.userApplicationPermissions().MEMBER?.includes('C') ?? false);
   readonly canDelete = computed(() => this.userApplicationPermissions().MEMBER?.includes('D') ?? false);
 
   readonly actions = computed<TableAction<MemberTableRow>[]>(() =>
@@ -138,6 +155,22 @@ export class ApplicationTabMembersComponent {
     }
   }
 
+  openAddMembersDialog(): void {
+    this.error.set(null);
+    this.matDialog
+      .open<ApplicationMembersAddDialogComponent, ApplicationMembersAddDialogData, boolean>(ApplicationMembersAddDialogComponent, {
+        data: { applicationId: this.applicationId() },
+        disableClose: true,
+      })
+      .afterClosed()
+      .pipe(
+        filter((membersAdded): membersAdded is true => membersAdded === true),
+        tap(() => this.membersResource.reload()),
+        takeUntilDestroyed(this.destroyRef),
+      )
+      .subscribe();
+  }
+
   private openDeleteConfirmation(member: MemberTableRow): void {
     this.error.set(null);
     this.matDialog
@@ -176,7 +209,7 @@ export class ApplicationTabMembersComponent {
       },
       isCurrentUser: !!user?.id && user.id === this.currentUserService.user()?.id,
       role: member.role ?? '',
-      isPrimaryOwner: member.role === 'PRIMARY_OWNER',
+      isPrimaryOwner: member.role === APPLICATION_PRIMARY_OWNER_ROLE_NAME,
     };
   }
 

--- a/gravitee-apim-portal-webui-next/src/entities/application/application.ts
+++ b/gravitee-apim-portal-webui-next/src/entities/application/application.ts
@@ -115,6 +115,19 @@ export interface ApplicationsMetadataSubscriptions {
   [applicationId: string]: Subscription[];
 }
 
+export interface ApplicationRole {
+  id?: string;
+  name: string;
+  default?: boolean;
+  system?: boolean;
+}
+
+export const APPLICATION_PRIMARY_OWNER_ROLE_NAME = 'PRIMARY_OWNER';
+
+export interface ConfigurationApplicationRolesResponse {
+  data?: ApplicationRole[];
+}
+
 export interface ApplicationType {
   id?: string;
   name: string;

--- a/gravitee-apim-portal-webui-next/src/entities/member/member.ts
+++ b/gravitee-apim-portal-webui-next/src/entities/member/member.ts
@@ -23,6 +23,12 @@ export interface Member {
   role?: string;
 }
 
+export interface MemberInput {
+  user?: string;
+  reference?: string;
+  role: string;
+}
+
 export interface MembersResponse {
   data?: Member[];
   metadata?: {

--- a/gravitee-apim-portal-webui-next/src/services/application.service.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/services/application.service.spec.ts
@@ -17,7 +17,7 @@ import { HttpTestingController } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
 
 import { ApplicationService } from './application.service';
-import { Application, ApplicationsResponse, ApplicationType } from '../entities/application/application';
+import { Application, ApplicationRole, ApplicationsResponse, ApplicationType } from '../entities/application/application';
 import { fakeApplication, fakeApplicationsResponse, fakeSimpleApplicationType } from '../entities/application/application.fixture';
 import { AppTestingModule, TESTING_BASE_URL } from '../testing/app-testing.module';
 
@@ -75,6 +75,23 @@ describe('ApplicationService', () => {
     expect(req.request.method).toEqual('GET');
 
     req.flush(applicationType);
+  });
+
+  it('should return application roles', done => {
+    const applicationRoles: ApplicationRole[] = [
+      { id: 'USER', name: 'USER', default: true, system: false },
+      { id: 'OWNER', name: 'OWNER', default: false, system: false },
+    ];
+
+    service.getApplicationRoles().subscribe(response => {
+      expect(response).toEqual(applicationRoles);
+      done();
+    });
+
+    const req = httpTestingController.expectOne(`${TESTING_BASE_URL}/configuration/applications/roles`);
+    expect(req.request.method).toEqual('GET');
+
+    req.flush({ data: applicationRoles });
   });
 
   it('should save application', done => {

--- a/gravitee-apim-portal-webui-next/src/services/application.service.ts
+++ b/gravitee-apim-portal-webui-next/src/services/application.service.ts
@@ -14,20 +14,25 @@
  * limitations under the License.
  */
 import { HttpClient } from '@angular/common/http';
-import { Injectable } from '@angular/core';
+import { inject, Injectable } from '@angular/core';
 import { Observable, map } from 'rxjs';
 
 import { ConfigService } from './config.service';
-import { Application, ApplicationInput, ApplicationsResponse, ApplicationType } from '../entities/application/application';
+import {
+  Application,
+  ApplicationInput,
+  ApplicationRole,
+  ApplicationsResponse,
+  ApplicationType,
+  ConfigurationApplicationRolesResponse,
+} from '../entities/application/application';
 
 @Injectable({
   providedIn: 'root',
 })
 export class ApplicationService {
-  constructor(
-    private readonly http: HttpClient,
-    private configService: ConfigService,
-  ) {}
+  private readonly http = inject(HttpClient);
+  private readonly configService = inject(ConfigService);
 
   get(applicationId: string): Observable<Application> {
     return this.http.get<Application>(`${this.configService.baseURL}/applications/${applicationId}`);
@@ -40,6 +45,12 @@ export class ApplicationService {
   getEnabledApplicationTypes(): Observable<ApplicationType[]> {
     return this.http
       .get<{ data: ApplicationType[] }>(`${this.configService.baseURL}/configuration/applications/types`)
+      .pipe(map(response => response.data ?? []));
+  }
+
+  getApplicationRoles(): Observable<ApplicationRole[]> {
+    return this.http
+      .get<ConfigurationApplicationRolesResponse>(`${this.configService.baseURL}/configuration/applications/roles`)
       .pipe(map(response => response.data ?? []));
   }
 

--- a/gravitee-apim-portal-webui-next/src/services/membership.service.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/services/membership.service.spec.ts
@@ -89,4 +89,19 @@ describe('MembershipService', () => {
     );
     req.flush(null, { status: 204, statusText: 'No Content' });
   });
+
+  it('should add an application member', done => {
+    const member: Member = { id: 'member-1', role: 'USER' };
+
+    service.addApplicationMember(applicationId, { user: 'user-1', role: 'USER' }).subscribe(res => {
+      expect(res).toEqual(member);
+      done();
+    });
+
+    const req = httpTestingController.expectOne(
+      r => r.url === `${TESTING_BASE_URL}/applications/${applicationId}/members` && r.method === 'POST',
+    );
+    expect(req.request.body).toEqual({ user: 'user-1', role: 'USER' });
+    req.flush(member);
+  });
 });

--- a/gravitee-apim-portal-webui-next/src/services/membership.service.ts
+++ b/gravitee-apim-portal-webui-next/src/services/membership.service.ts
@@ -18,7 +18,7 @@ import { inject, Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
 
 import { ConfigService } from './config.service';
-import { MemberSearchFilters, MembersResponse } from '../entities/member/member';
+import { Member, MemberInput, MemberSearchFilters, MembersResponse } from '../entities/member/member';
 
 @Injectable({
   providedIn: 'root',
@@ -37,5 +37,9 @@ export class MembershipService {
 
   deleteApplicationMember(applicationId: string, memberId: string): Observable<void> {
     return this.http.delete<void>(`${this.configService.baseURL}/applications/${applicationId}/members/${memberId}`);
+  }
+
+  addApplicationMember(applicationId: string, memberInput: MemberInput): Observable<Member> {
+    return this.http.post<Member>(`${this.configService.baseURL}/applications/${applicationId}/members`, memberInput);
   }
 }

--- a/gravitee-apim-portal-webui-next/src/services/users.service.ts
+++ b/gravitee-apim-portal-webui-next/src/services/users.service.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import { HttpClient } from '@angular/common/http';
-import { Injectable } from '@angular/core';
+import { inject, Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
 
 import { ConfigService } from './config.service';
@@ -67,10 +67,8 @@ export interface FinalizeRegistrationInput {
   providedIn: 'root',
 })
 export class UsersService {
-  constructor(
-    private readonly http: HttpClient,
-    private readonly configService: ConfigService,
-  ) {}
+  private readonly http = inject(HttpClient);
+  private readonly configService = inject(ConfigService);
 
   listCustomUserFields(): Observable<Array<CustomUserField>> {
     return this.http.get<Array<CustomUserField>>(`${this.configService.baseURL}/configuration/users/custom-fields`);


### PR DESCRIPTION


## Summary

Adds the application members flow in Portal Next:
- show Add Members action when the user has MEMBER[C]
- search users with application membership metadata
- prevent selecting users already assigned to the application
- choose an application role excluding PRIMARY_OWNER
- create selected members and refresh the members list after success

## Notes

Notify Added Members is intentionally not included because the backend MemberInput contract does not support it.

## See


https://github.com/user-attachments/assets/f2fc685a-b4d5-436f-b9c3-1a8375557a2a

