### PR TITLE
feat(portal): add cdkScrollable to tree container

### DIFF
--- a/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.html
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.html
@@ -51,7 +51,7 @@
     </header>
 
     @if (menuLinks$ | async; as menuLinks) {
-      <mat-card appearance="outlined" class="sections-panel__tree__container">
+      <mat-card appearance="outlined" class="sections-panel__tree__container" cdkScrollable>
         <portal-flat-tree-component
           [links]="menuLinks"
           [selectedId]="navId()"

--- a/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.ts
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.ts
@@ -36,6 +36,7 @@ import { MatTooltipModule } from '@angular/material/tooltip';
 import { BehaviorSubject, EMPTY, Observable, of } from 'rxjs';
 import { AsyncPipe, NgTemplateOutlet, TitleCasePipe } from '@angular/common';
 import { MatCardModule } from '@angular/material/card';
+import { CdkScrollable } from '@angular/cdk/scrolling';
 
 import {
   SectionEditorDialogComponent,
@@ -97,6 +98,7 @@ import { OpenApiEditorComponent } from '../components/openapi-editor/openapi-edi
     NgTemplateOutlet,
     TitleCasePipe,
     PortalNavigationItemIconPipe,
+    CdkScrollable,
   ],
 })
 export class PortalNavigationItemsComponent implements HasUnsavedChanges {


### PR DESCRIPTION
clean up navigation item template

Introduce `cdkScrollable` to the tree container for better scroll tracking.

## Issue

https://gravitee.atlassian.net/browse/APIM-14070

## Description

Improves drag-and-drop for Developer Portal navigation items by marking the tree’s scroll container with Angular CDK’s cdkScrollable, so the CDK can detect and scroll that region during drags. Also includes minor template cleanup and stricter typing around page content loading.


Changes

- cdkScrollable on the tree panel — The mat-card that wraps portal-flat-tree-component is now a CDK scrollable (sections-panel__tree__container). CdkScrollable is imported and added to the component imports array.
- Template — Whitespace / formatting cleanup in portal-navigation-items.component.html (no behavior change beyond the scrollable directive).
- Types — loadPageContent now has an explicit return type; the selected PAGE branch uses a typed cast to PortalNavigationPage when reading portalPageContentId.

https://github.com/user-attachments/assets/aeca93b6-2ed8-43dc-b9e1-01f3c673df10


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

