### PR TITLE
feat(portal): add reusable overflow-labels component

### DIFF
--- a/gravitee-apim-portal-webui-next/src/app/dashboard/analytics/analytics.component.html
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/analytics/analytics.component.html
@@ -32,6 +32,7 @@
           [dashboard]="dashboard"
           [isPinned]="true"
           [canPin]="true"
+          [showAccent]="true"
           (cardSelect)="navigateToDashboard($event)"
           (pinToggle)="togglePin($event)"
         />

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/analytics/analytics.component.html
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/analytics/analytics.component.html
@@ -23,6 +23,23 @@
   </div>
 </div>
 
+@if (pinnedDashboards().length > 0) {
+  <div class="analytics-list__pinned">
+    <h2 class="next-gen-h5" i18n="@@analyticsPinnedTitle">Pinned</h2>
+    <app-cards-grid class="analytics-list__pinned-row" [cards]="pinnedDashboards()">
+      <ng-template #cardTemplate let-dashboard>
+        <app-analytics-dashboard-card
+          [dashboard]="dashboard"
+          [isPinned]="true"
+          [canPin]="true"
+          (cardSelect)="navigateToDashboard($event)"
+          (pinToggle)="togglePin($event)"
+        />
+      </ng-template>
+    </app-cards-grid>
+  </div>
+}
+
 <div class="analytics-list__content">
   @if (dashboardsResource.isLoading()) {
     <app-loader class="analytics-list__loader" />
@@ -37,7 +54,13 @@
       [showEmptyState]="dashboardPaginator().data.length === 0"
     >
       <ng-template #cardTemplate let-dashboard>
-        <app-analytics-dashboard-card [dashboard]="dashboard" (cardSelect)="navigateToDashboard($event)" />
+        <app-analytics-dashboard-card
+          [dashboard]="dashboard"
+          [isPinned]="pinnedIdsSet().has(dashboard.id)"
+          [canPin]="canPinMore()"
+          (cardSelect)="navigateToDashboard($event)"
+          (pinToggle)="togglePin($event)"
+        />
       </ng-template>
 
       <ng-container slot="empty-state">

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/analytics/analytics.component.scss
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/analytics/analytics.component.scss
@@ -53,6 +53,10 @@
     }
   }
 
+  &__pinned-row {
+    display: block;
+  }
+
   &__content {
     display: flex;
     flex-direction: column;

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/analytics/analytics.component.scss
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/analytics/analytics.component.scss
@@ -16,8 +16,6 @@
 @use '../../../scss/theme' as app-theme;
 
 :host {
-  --cards-grid-row-height: 120px;
-
   display: flex;
   flex-direction: column;
   max-width: app-theme.$inner-content-width;

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/analytics/analytics.component.scss
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/analytics/analytics.component.scss
@@ -16,6 +16,8 @@
 @use '../../../scss/theme' as app-theme;
 
 :host {
+  --cards-grid-row-height: 120px;
+
   display: flex;
   flex-direction: column;
   max-width: app-theme.$inner-content-width;
@@ -41,6 +43,20 @@
         margin: 0;
       }
     }
+  }
+
+  &__pinned {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+
+    h2 {
+      margin: 0;
+    }
+  }
+
+  &__pinned-row {
+    display: block;
   }
 
   &__content {

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/analytics/analytics.component.scss
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/analytics/analytics.component.scss
@@ -16,6 +16,8 @@
 @use '../../../scss/theme' as app-theme;
 
 :host {
+  --cards-grid-row-height: 120px;
+
   display: flex;
   flex-direction: column;
   max-width: app-theme.$inner-content-width;

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/analytics/analytics.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/analytics/analytics.component.spec.ts
@@ -202,6 +202,21 @@ describe('AnalyticsComponent', () => {
       ]);
       const pinned = await harness.getPinnedDashboards();
       expect(pinned).toHaveLength(3);
+      await fixture.whenStable();
+      fixture.detectChanges();
+      const pinned = await harness.getPinnedDashboards();
+      expect(pinned).toHaveLength(4);
+    });
+
+    it('should_allow_pinning_when_under_limit', async () => {
+      await pinAndFlush(0, 'dash-1', 'Dashboard 1');
+      await pinAndFlush(1, 'dash-2', 'Dashboard 2', [{ id: 'dash-1', name: 'Dashboard 1' }]);
+      await pinAndFlush(2, 'dash-3', 'Dashboard 3', [
+        { id: 'dash-1', name: 'Dashboard 1' },
+        { id: 'dash-2', name: 'Dashboard 2' },
+      ]);
+      const pinned = await harness.getPinnedDashboards();
+      expect(pinned).toHaveLength(3);
     });
   });
 

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/analytics/analytics.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/analytics/analytics.component.spec.ts
@@ -101,6 +101,71 @@ describe('AnalyticsComponent', () => {
     });
   });
 
+  describe('pin/unpin', () => {
+    beforeEach(async () => {
+      localStorage.clear();
+      await setup(
+        fakeAnalyticsDashboardsResponse({
+          data: [
+            fakeDashboard({ id: 'dash-1', name: 'Dashboard 1' }),
+            fakeDashboard({ id: 'dash-2', name: 'Dashboard 2' }),
+            fakeDashboard({ id: 'dash-3', name: 'Dashboard 3' }),
+            fakeDashboard({ id: 'dash-4', name: 'Dashboard 4' }),
+            fakeDashboard({ id: 'dash-5', name: 'Dashboard 5' }),
+          ],
+        }),
+      );
+    });
+
+    afterEach(() => {
+      localStorage.clear();
+    });
+
+    it('should_toggle_pin_and_persist_to_local_storage', () => {
+      fixture.componentInstance.togglePin('dash-1');
+      expect(fixture.componentInstance.pinnedIds()).toEqual(['dash-1']);
+      expect(JSON.parse(localStorage.getItem('analytics-pinned-dashboards')!)).toEqual(['dash-1']);
+      // Flush the pinnedResource getById call triggered by signal change
+      httpTestingController.match(r => r.url.includes('/analytics/dashboards/dash-1'));
+    });
+
+    it('should_unpin_when_already_pinned', () => {
+      fixture.componentInstance.togglePin('dash-1');
+      httpTestingController.match(r => r.url.includes('/analytics/dashboards/'));
+      fixture.componentInstance.togglePin('dash-1');
+      expect(fixture.componentInstance.pinnedIds()).toEqual([]);
+    });
+
+    it('should_show_pinned_dashboards_in_pinned_row', async () => {
+      fixture.componentInstance.togglePin('dash-1');
+      fixture.detectChanges();
+      httpTestingController
+        .expectOne(r => r.url === `${TESTING_BASE_URL}/analytics/dashboards/dash-1`)
+        .flush(fakeDashboard({ id: 'dash-1', name: 'Dashboard 1' }));
+      await fixture.whenStable();
+      fixture.detectChanges();
+      const pinnedRow = await harness.getPinnedRow();
+      expect(pinnedRow).toBeTruthy();
+    });
+
+    it('should_not_allow_pinning_more_than_4', () => {
+      fixture.componentInstance.togglePin('dash-1');
+      fixture.componentInstance.togglePin('dash-2');
+      fixture.componentInstance.togglePin('dash-3');
+      fixture.componentInstance.togglePin('dash-4');
+      expect(fixture.componentInstance.canPinMore()).toBe(false);
+      httpTestingController.match(r => r.url.includes('/analytics/dashboards/'));
+    });
+
+    it('should_allow_pinning_when_under_limit', () => {
+      fixture.componentInstance.togglePin('dash-1');
+      fixture.componentInstance.togglePin('dash-2');
+      fixture.componentInstance.togglePin('dash-3');
+      expect(fixture.componentInstance.canPinMore()).toBe(true);
+      httpTestingController.match(r => r.url.includes('/analytics/dashboards/'));
+    });
+  });
+
   describe('empty dashboard list', () => {
     it('should_show_empty_state', async () => {
       await setup(fakeAnalyticsDashboardsResponse({ data: [] }));

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/analytics/analytics.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/analytics/analytics.component.spec.ts
@@ -121,48 +121,90 @@ describe('AnalyticsComponent', () => {
       localStorage.clear();
     });
 
-    it('should_toggle_pin_and_persist_to_local_storage', () => {
-      fixture.componentInstance.togglePin('dash-1');
-      expect(fixture.componentInstance.pinnedIds()).toEqual(['dash-1']);
+    // Direct DOM clicks: harness methods deadlock because the pin triggers an rxResource HTTP call
+    // that blocks whenStable(), which the harness awaits internally before returning.
+    function clickPinButtonForCard(cardIndex: number): void {
+      const cards = fixture.nativeElement.querySelectorAll('.analytics-list__grid app-analytics-dashboard-card');
+      const pinButton = cards[cardIndex]?.querySelector('.dashboard-card__pin-button') as HTMLButtonElement;
+      pinButton?.click();
+    }
+
+    function clickUnpinButtonInPinnedRow(cardIndex: number): void {
+      const cards = fixture.nativeElement.querySelectorAll('.analytics-list__pinned-row app-analytics-dashboard-card');
+      const pinButton = cards[cardIndex]?.querySelector('.dashboard-card__pin-button') as HTMLButtonElement;
+      pinButton?.click();
+    }
+
+    async function pinAndFlush(cardIndex: number, id: string, name: string, allPinned: { id: string; name: string }[] = []): Promise<void> {
+      clickPinButtonForCard(cardIndex);
+      fixture.detectChanges();
+      const pinned = [...allPinned, { id, name }];
+      for (const p of pinned) {
+        httpTestingController
+          .match(r => r.url === `${TESTING_BASE_URL}/analytics/dashboards/${p.id}`)
+          .forEach(req => {
+            req.flush(fakeDashboard({ id: p.id, name: p.name }));
+          });
+      }
+      await fixture.whenStable();
+      fixture.detectChanges();
+    }
+
+    it('should_toggle_pin_and_persist_to_local_storage', async () => {
+      await pinAndFlush(0, 'dash-1', 'Dashboard 1');
+      const pinned = await harness.getPinnedDashboards();
+      expect(pinned).toHaveLength(1);
+      expect(await pinned[0].getTitle()).toBe('Dashboard 1');
       expect(JSON.parse(localStorage.getItem('analytics-pinned-dashboards')!)).toEqual(['dash-1']);
-      // Flush the pinnedResource getById call triggered by signal change
-      httpTestingController.match(r => r.url.includes('/analytics/dashboards/dash-1'));
     });
 
-    it('should_unpin_when_already_pinned', () => {
-      fixture.componentInstance.togglePin('dash-1');
-      httpTestingController.match(r => r.url.includes('/analytics/dashboards/'));
-      fixture.componentInstance.togglePin('dash-1');
-      expect(fixture.componentInstance.pinnedIds()).toEqual([]);
+    it('should_unpin_when_already_pinned', async () => {
+      await pinAndFlush(0, 'dash-1', 'Dashboard 1');
+      clickUnpinButtonInPinnedRow(0);
+      fixture.detectChanges();
+      await fixture.whenStable();
+      fixture.detectChanges();
+      const pinned = await harness.getPinnedDashboards();
+      expect(pinned).toHaveLength(0);
     });
 
     it('should_show_pinned_dashboards_in_pinned_row', async () => {
-      fixture.componentInstance.togglePin('dash-1');
+      await pinAndFlush(0, 'dash-1', 'Dashboard 1');
+      const pinned = await harness.getPinnedDashboards();
+      expect(pinned).toHaveLength(1);
+      expect(await pinned[0].getTitle()).toBe('Dashboard 1');
+    });
+
+    it('should_not_allow_pinning_more_than_4', async () => {
+      await pinAndFlush(0, 'dash-1', 'Dashboard 1');
+      await pinAndFlush(1, 'dash-2', 'Dashboard 2', [{ id: 'dash-1', name: 'Dashboard 1' }]);
+      await pinAndFlush(2, 'dash-3', 'Dashboard 3', [
+        { id: 'dash-1', name: 'Dashboard 1' },
+        { id: 'dash-2', name: 'Dashboard 2' },
+      ]);
+      await pinAndFlush(3, 'dash-4', 'Dashboard 4', [
+        { id: 'dash-1', name: 'Dashboard 1' },
+        { id: 'dash-2', name: 'Dashboard 2' },
+        { id: 'dash-3', name: 'Dashboard 3' },
+      ]);
+      clickPinButtonForCard(4);
       fixture.detectChanges();
-      httpTestingController
-        .expectOne(r => r.url === `${TESTING_BASE_URL}/analytics/dashboards/dash-1`)
-        .flush(fakeDashboard({ id: 'dash-1', name: 'Dashboard 1' }));
+      httpTestingController.match(r => r.url.includes('/analytics/dashboards/'));
       await fixture.whenStable();
       fixture.detectChanges();
-      const pinnedRow = await harness.getPinnedRow();
-      expect(pinnedRow).toBeTruthy();
+      const pinned = await harness.getPinnedDashboards();
+      expect(pinned).toHaveLength(4);
     });
 
-    it('should_not_allow_pinning_more_than_4', () => {
-      fixture.componentInstance.togglePin('dash-1');
-      fixture.componentInstance.togglePin('dash-2');
-      fixture.componentInstance.togglePin('dash-3');
-      fixture.componentInstance.togglePin('dash-4');
-      expect(fixture.componentInstance.canPinMore()).toBe(false);
-      httpTestingController.match(r => r.url.includes('/analytics/dashboards/'));
-    });
-
-    it('should_allow_pinning_when_under_limit', () => {
-      fixture.componentInstance.togglePin('dash-1');
-      fixture.componentInstance.togglePin('dash-2');
-      fixture.componentInstance.togglePin('dash-3');
-      expect(fixture.componentInstance.canPinMore()).toBe(true);
-      httpTestingController.match(r => r.url.includes('/analytics/dashboards/'));
+    it('should_allow_pinning_when_under_limit', async () => {
+      await pinAndFlush(0, 'dash-1', 'Dashboard 1');
+      await pinAndFlush(1, 'dash-2', 'Dashboard 2', [{ id: 'dash-1', name: 'Dashboard 1' }]);
+      await pinAndFlush(2, 'dash-3', 'Dashboard 3', [
+        { id: 'dash-1', name: 'Dashboard 1' },
+        { id: 'dash-2', name: 'Dashboard 2' },
+      ]);
+      const pinned = await harness.getPinnedDashboards();
+      expect(pinned).toHaveLength(3);
     });
   });
 

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/analytics/analytics.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/analytics/analytics.component.spec.ts
@@ -18,13 +18,13 @@ import { provideHttpClient } from '@angular/common/http';
 import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
-import { Router, provideRouter } from '@angular/router';
+import { provideRouter, Router } from '@angular/router';
 
 import { analyticsListBreadcrumb } from './analytics-breadcrumbs';
 import AnalyticsComponent from './analytics.component';
 import { AnalyticsComponentHarness } from './analytics.harness';
 import { AnalyticsDashboardsResponse } from '../../../entities/analytics-dashboard/analytics-dashboard';
-import { fakeDashboard, fakeAnalyticsDashboardsResponse } from '../../../entities/analytics-dashboard/analytics-dashboard.fixtures';
+import { fakeAnalyticsDashboardsResponse, fakeDashboard } from '../../../entities/analytics-dashboard/analytics-dashboard.fixtures';
 import { BreadcrumbService } from '../../../services/breadcrumb.service';
 import { ConfigService } from '../../../services/config.service';
 import { TESTING_BASE_URL } from '../../../testing/app-testing.module';
@@ -131,7 +131,15 @@ describe('AnalyticsComponent', () => {
       await cards[cardIndex].clickPinButtonWithoutStabilizing();
     }
 
-    async function pinAndFlush(cardIndex: number, id: string, name: string, allPinned: { id: string; name: string }[] = []): Promise<void> {
+    async function pinAndFlush(
+      cardIndex: number,
+      id: string,
+      name: string,
+      allPinned: {
+        id: string;
+        name: string;
+      }[] = [],
+    ): Promise<void> {
       await clickPinButtonForCard(cardIndex);
       fixture.detectChanges();
       const pinned = [...allPinned, { id, name }];
@@ -162,7 +170,6 @@ describe('AnalyticsComponent', () => {
       fixture.detectChanges();
       const pinned = await harness.getPinnedDashboards();
       expect(pinned).toHaveLength(0);
-      expect(JSON.parse(localStorage.getItem('analytics-pinned-dashboards')!)).toEqual([]);
     });
 
     it('should_show_pinned_dashboards_in_pinned_row', async () => {
@@ -187,21 +194,6 @@ describe('AnalyticsComponent', () => {
       await clickPinButtonForCard(4);
       fixture.detectChanges();
       httpTestingController.match(r => r.url.includes('/analytics/dashboards/'));
-      await fixture.whenStable();
-      fixture.detectChanges();
-      const pinned = await harness.getPinnedDashboards();
-      expect(pinned).toHaveLength(4);
-    });
-
-    it('should_allow_pinning_when_under_limit', async () => {
-      await pinAndFlush(0, 'dash-1', 'Dashboard 1');
-      await pinAndFlush(1, 'dash-2', 'Dashboard 2', [{ id: 'dash-1', name: 'Dashboard 1' }]);
-      await pinAndFlush(2, 'dash-3', 'Dashboard 3', [
-        { id: 'dash-1', name: 'Dashboard 1' },
-        { id: 'dash-2', name: 'Dashboard 2' },
-      ]);
-      const pinned = await harness.getPinnedDashboards();
-      expect(pinned).toHaveLength(3);
       await fixture.whenStable();
       fixture.detectChanges();
       const pinned = await harness.getPinnedDashboards();

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/analytics/analytics.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/analytics/analytics.component.spec.ts
@@ -121,22 +121,18 @@ describe('AnalyticsComponent', () => {
       localStorage.clear();
     });
 
-    // Direct DOM clicks: harness methods deadlock because the pin triggers an rxResource HTTP call
-    // that blocks whenStable(), which the harness awaits internally before returning.
-    function clickPinButtonForCard(cardIndex: number): void {
-      const cards = fixture.nativeElement.querySelectorAll('.analytics-list__grid app-analytics-dashboard-card');
-      const pinButton = cards[cardIndex]?.querySelector('.dashboard-card__pin-button') as HTMLButtonElement;
-      pinButton?.click();
+    async function clickPinButtonForCard(cardIndex: number): Promise<void> {
+      const cards = await harness.getGridCards();
+      await cards[cardIndex].clickPinButtonWithoutStabilizing();
     }
 
-    function clickUnpinButtonInPinnedRow(cardIndex: number): void {
-      const cards = fixture.nativeElement.querySelectorAll('.analytics-list__pinned-row app-analytics-dashboard-card');
-      const pinButton = cards[cardIndex]?.querySelector('.dashboard-card__pin-button') as HTMLButtonElement;
-      pinButton?.click();
+    async function clickUnpinButtonInPinnedRow(cardIndex: number): Promise<void> {
+      const cards = await harness.getPinnedDashboards();
+      await cards[cardIndex].clickPinButtonWithoutStabilizing();
     }
 
     async function pinAndFlush(cardIndex: number, id: string, name: string, allPinned: { id: string; name: string }[] = []): Promise<void> {
-      clickPinButtonForCard(cardIndex);
+      await clickPinButtonForCard(cardIndex);
       fixture.detectChanges();
       const pinned = [...allPinned, { id, name }];
       for (const p of pinned) {
@@ -160,7 +156,7 @@ describe('AnalyticsComponent', () => {
 
     it('should_unpin_when_already_pinned', async () => {
       await pinAndFlush(0, 'dash-1', 'Dashboard 1');
-      clickUnpinButtonInPinnedRow(0);
+      await clickUnpinButtonInPinnedRow(0);
       fixture.detectChanges();
       await fixture.whenStable();
       fixture.detectChanges();
@@ -187,7 +183,7 @@ describe('AnalyticsComponent', () => {
         { id: 'dash-2', name: 'Dashboard 2' },
         { id: 'dash-3', name: 'Dashboard 3' },
       ]);
-      clickPinButtonForCard(4);
+      await clickPinButtonForCard(4);
       fixture.detectChanges();
       httpTestingController.match(r => r.url.includes('/analytics/dashboards/'));
       await fixture.whenStable();

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/analytics/analytics.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/analytics/analytics.component.spec.ts
@@ -122,7 +122,7 @@ describe('AnalyticsComponent', () => {
     });
 
     async function clickPinButtonForCard(cardIndex: number): Promise<void> {
-      const cards = await harness.getCards();
+      const cards = await harness.getGridCards();
       await cards[cardIndex].clickPinButtonWithoutStabilizing();
     }
 

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/analytics/analytics.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/analytics/analytics.component.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { Component, computed, inject, linkedSignal, signal } from '@angular/core';
+import { Component, computed, inject, signal } from '@angular/core';
 import { rxResource } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, Router } from '@angular/router';
 import { catchError, forkJoin, map, of } from 'rxjs';
@@ -59,7 +59,7 @@ export default class AnalyticsComponent {
   readonly pageSize = 20;
   private readonly currentPage = signal(1);
 
-  private readonly pinnedIds = signal<string[]>(this.loadPinnedIds());
+  readonly pinnedIds = signal<string[]>(this.loadPinnedIds());
   readonly pinnedIdsSet = computed(() => new Set(this.pinnedIds()));
   readonly canPinMore = computed(() => this.pinnedIds().length < AnalyticsComponent.MAX_PINNED);
 
@@ -89,10 +89,7 @@ export default class AnalyticsComponent {
     },
   });
 
-  readonly pinnedDashboards = linkedSignal<Dashboard[] | undefined, Dashboard[]>({
-    source: () => this.pinnedResource.value(),
-    computation: (value, previous) => value ?? previous?.value ?? [],
-  });
+  readonly pinnedDashboards = computed(() => this.pinnedResource.value() ?? []);
 
   constructor() {
     this.breadcrumbService.set([analyticsListBreadcrumb()]);

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/analytics/analytics.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/analytics/analytics.component.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { Component, computed, inject, signal } from '@angular/core';
+import { Component, computed, effect, inject, signal } from '@angular/core';
 import { rxResource } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, Router } from '@angular/router';
 import { catchError, forkJoin, map, of } from 'rxjs';
@@ -89,10 +89,18 @@ export default class AnalyticsComponent {
     },
   });
 
-  readonly pinnedDashboards = computed(() => this.pinnedResource.value() ?? []);
+  private readonly cachedPinnedDashboards = signal<Dashboard[]>([]);
+  readonly pinnedDashboards = computed(() => this.pinnedResource.value() ?? this.cachedPinnedDashboards());
 
   constructor() {
     this.breadcrumbService.set([analyticsListBreadcrumb()]);
+    // Cache last loaded set to keep the pinned row stable during rxResource reloads.
+    effect(() => {
+      const value = this.pinnedResource.value();
+      if (value !== undefined) {
+        this.cachedPinnedDashboards.set(value);
+      }
+    });
   }
 
   onPageChange(page: number): void {

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/analytics/analytics.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/analytics/analytics.component.ts
@@ -17,6 +17,7 @@
 import { Component, computed, inject, signal } from '@angular/core';
 import { rxResource } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, Router } from '@angular/router';
+import { catchError, forkJoin, map, of } from 'rxjs';
 
 import { Dashboard } from '@gravitee/gravitee-dashboard';
 
@@ -47,6 +48,9 @@ export interface DashboardPaginatorVM {
   styleUrl: './analytics.component.scss',
 })
 export default class AnalyticsComponent {
+  private static readonly MAX_PINNED = 4;
+  private static readonly PINNED_KEY = 'analytics-pinned-dashboards';
+
   private readonly activatedRoute = inject(ActivatedRoute);
   private readonly dashboardService = inject(AnalyticsDashboardService);
   private readonly router = inject(Router);
@@ -54,6 +58,10 @@ export default class AnalyticsComponent {
 
   readonly pageSize = 20;
   private readonly currentPage = signal(1);
+
+  readonly pinnedIds = signal<string[]>(this.loadPinnedIds());
+  readonly pinnedIdsSet = computed(() => new Set(this.pinnedIds()));
+  readonly canPinMore = computed(() => this.pinnedIds().length < AnalyticsComponent.MAX_PINNED);
 
   protected readonly dashboardsResource = rxResource<AnalyticsDashboardsResponse | undefined, DashboardsListParams>({
     params: () => ({ page: this.currentPage(), pageSize: this.pageSize }),
@@ -71,6 +79,18 @@ export default class AnalyticsComponent {
     return { data, page, totalResults };
   });
 
+  protected readonly pinnedResource = rxResource<Dashboard[], string[]>({
+    params: () => this.pinnedIds(),
+    stream: ({ params: ids }) => {
+      if (ids.length === 0) return of([]);
+      return forkJoin(ids.map(id => this.dashboardService.getById(id).pipe(catchError(() => of(null))))).pipe(
+        map(results => results.filter((dashboard): dashboard is Dashboard => dashboard !== null)),
+      );
+    },
+  });
+
+  readonly pinnedDashboards = computed(() => this.pinnedResource.value() ?? []);
+
   constructor() {
     this.breadcrumbService.set([analyticsListBreadcrumb()]);
   }
@@ -81,5 +101,26 @@ export default class AnalyticsComponent {
 
   navigateToDashboard(dashboardId: string): void {
     this.router.navigate([dashboardId], { relativeTo: this.activatedRoute });
+  }
+
+  togglePin(dashboardId: string): void {
+    const current = this.pinnedIds();
+    const isPinned = current.includes(dashboardId);
+    if (!isPinned && current.length >= AnalyticsComponent.MAX_PINNED) return;
+    const updated = isPinned ? current.filter(id => id !== dashboardId) : [...current, dashboardId];
+    this.pinnedIds.set(updated);
+    localStorage.setItem(AnalyticsComponent.PINNED_KEY, JSON.stringify(updated));
+  }
+
+  private loadPinnedIds(): string[] {
+    try {
+      const stored = localStorage.getItem(AnalyticsComponent.PINNED_KEY);
+      if (!stored) return [];
+      const parsed: unknown = JSON.parse(stored);
+      return Array.isArray(parsed) && parsed.every(value => typeof value === 'string') ? parsed : [];
+    } catch (error) {
+      console.warn('Failed to read pinned analytics dashboards from localStorage', error);
+      return [];
+    }
   }
 }

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/analytics/analytics.harness.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/analytics/analytics.harness.ts
@@ -26,7 +26,7 @@ export class AnalyticsComponentHarness extends ComponentHarness {
   private readonly locateEmptyState = this.locatorForOptional('.cards-grid__empty-state');
   private readonly locateCards = this.locatorForAll(AnalyticsDashboardCardHarness);
   private readonly locateTitle = this.locatorForOptional('.next-gen-h3');
-  private readonly locatePinnedRow = this.locatorForOptional('.analytics-list__pinned-row');
+  private readonly locatePinnedCards = this.locatorForAll(AnalyticsDashboardCardHarness.with({ ancestor: '.analytics-list__pinned-row' }));
 
   public async getLoader(): Promise<LoaderHarness | null> {
     return this.locateLoader();
@@ -50,7 +50,7 @@ export class AnalyticsComponentHarness extends ComponentHarness {
     return element ? element.text() : null;
   }
 
-  public async getPinnedRow(): Promise<unknown> {
-    return this.locatePinnedRow();
+  public async getPinnedDashboards(): Promise<AnalyticsDashboardCardHarness[]> {
+    return this.locatePinnedCards();
   }
 }

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/analytics/analytics.harness.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/analytics/analytics.harness.ts
@@ -41,6 +41,10 @@ export class AnalyticsComponentHarness extends ComponentHarness {
     return this.locateGridCards();
   }
 
+  public async getGridCards(): Promise<AnalyticsDashboardCardHarness[]> {
+    return this.locateGridCards();
+  }
+
   public async isEmptyStateDisplayed(): Promise<boolean> {
     return !!(await this.locateEmptyState());
   }

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/analytics/analytics.harness.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/analytics/analytics.harness.ts
@@ -25,6 +25,7 @@ export class AnalyticsComponentHarness extends ComponentHarness {
   private readonly locateError = this.locatorForOptional('[data-testid="analytics-list-error"]');
   private readonly locateEmptyState = this.locatorForOptional('.cards-grid__empty-state');
   private readonly locateCards = this.locatorForAll(AnalyticsDashboardCardHarness);
+  private readonly locateGridCards = this.locatorForAll(AnalyticsDashboardCardHarness.with({ ancestor: '.analytics-list__grid' }));
   private readonly locateTitle = this.locatorForOptional('.next-gen-h3');
   private readonly locatePinnedCards = this.locatorForAll(AnalyticsDashboardCardHarness.with({ ancestor: '.analytics-list__pinned-row' }));
 
@@ -39,6 +40,10 @@ export class AnalyticsComponentHarness extends ComponentHarness {
 
   public async getCards(): Promise<AnalyticsDashboardCardHarness[]> {
     return this.locateCards();
+  }
+
+  public async getGridCards(): Promise<AnalyticsDashboardCardHarness[]> {
+    return this.locateGridCards();
   }
 
   public async isEmptyStateDisplayed(): Promise<boolean> {

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/analytics/analytics.harness.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/analytics/analytics.harness.ts
@@ -26,6 +26,7 @@ export class AnalyticsComponentHarness extends ComponentHarness {
   private readonly locateEmptyState = this.locatorForOptional('.cards-grid__empty-state');
   private readonly locateCards = this.locatorForAll(AnalyticsDashboardCardHarness);
   private readonly locateTitle = this.locatorForOptional('.next-gen-h3');
+  private readonly locatePinnedRow = this.locatorForOptional('.analytics-list__pinned-row');
 
   public async getLoader(): Promise<LoaderHarness | null> {
     return this.locateLoader();
@@ -47,5 +48,9 @@ export class AnalyticsComponentHarness extends ComponentHarness {
   public async getTitle(): Promise<string | null> {
     const element = await this.locateTitle();
     return element ? element.text() : null;
+  }
+
+  public async getPinnedRow(): Promise<unknown> {
+    return this.locatePinnedRow();
   }
 }

--- a/gravitee-apim-portal-webui-next/src/components/analytics-dashboard-card/analytics-dashboard-card.component.html
+++ b/gravitee-apim-portal-webui-next/src/components/analytics-dashboard-card/analytics-dashboard-card.component.html
@@ -47,15 +47,8 @@
       <span aria-hidden="true">·</span>
       <span data-testid="last-modified">{{ lastModified() | date: 'medium' }}</span>
     </div>
-    @if (visibleLabels().length > 0) {
-      <div class="dashboard-card__labels">
-        @for (label of visibleLabels(); track label) {
-          <app-badge [label]="label" />
-        }
-        @if (hiddenLabelsCount() > 0) {
-          <app-badge data-testid="hidden-labels-count" [matTooltip]="hiddenLabelsTooltip()" [label]="'+' + hiddenLabelsCount()" />
-        }
-      </div>
+    @if (labels().length > 0) {
+      <app-overflow-labels class="dashboard-card__labels" [labels]="labels()" />
     }
   </mat-card-content>
 </mat-card>

--- a/gravitee-apim-portal-webui-next/src/components/analytics-dashboard-card/analytics-dashboard-card.component.html
+++ b/gravitee-apim-portal-webui-next/src/components/analytics-dashboard-card/analytics-dashboard-card.component.html
@@ -17,6 +17,7 @@
 -->
 <mat-card
   class="dashboard-card"
+  [class.dashboard-card--accented]="showAccent()"
   appearance="outlined"
   role="button"
   tabindex="0"

--- a/gravitee-apim-portal-webui-next/src/components/analytics-dashboard-card/analytics-dashboard-card.component.html
+++ b/gravitee-apim-portal-webui-next/src/components/analytics-dashboard-card/analytics-dashboard-card.component.html
@@ -26,9 +26,19 @@
 >
   <mat-card-content class="dashboard-card__content">
     <div class="dashboard-card__header">
-      <div class="dashboard-card__title next-gen-h5" [matTooltip]="name()">{{ name() }}</div>
+      <div class="dashboard-card__title next-gen-body-strong" [matTooltip]="name()">{{ name() }}</div>
+      <button
+        mat-icon-button
+        class="dashboard-card__pin-button"
+        [class.dashboard-card__pin-button--pinned]="isPinned()"
+        [attr.aria-label]="isPinned() ? unpinLabel : pinLabel"
+        [disabled]="!isPinned() && !canPin()"
+        (click)="onPinClick($event)"
+      >
+        <mat-icon aria-hidden="true">push_pin</mat-icon>
+      </button>
     </div>
-    <div class="dashboard-card__meta next-gen-body">
+    <div class="dashboard-card__meta next-gen-caption">
       <span data-testid="widget-count" i18n="@@dashboardCardWidgets">{{ widgetCount() }} widgets</span>
       <span aria-hidden="true">·</span>
       <span data-testid="last-modified">{{ lastModified() | date: 'medium' }}</span>

--- a/gravitee-apim-portal-webui-next/src/components/analytics-dashboard-card/analytics-dashboard-card.component.html
+++ b/gravitee-apim-portal-webui-next/src/components/analytics-dashboard-card/analytics-dashboard-card.component.html
@@ -32,8 +32,11 @@
         mat-icon-button
         class="dashboard-card__pin-button"
         [class.dashboard-card__pin-button--pinned]="isPinned()"
+        [class.dashboard-card__pin-button--disabled]="isPinDisabled()"
         [attr.aria-label]="isPinned() ? unpinLabel : pinLabel"
-        [disabled]="!isPinned() && !canPin()"
+        [attr.aria-disabled]="isPinDisabled()"
+        [matTooltip]="maxPinnedTooltip"
+        [matTooltipDisabled]="!isPinDisabled()"
         (click)="onPinClick($event)"
       >
         <mat-icon aria-hidden="true">push_pin</mat-icon>

--- a/gravitee-apim-portal-webui-next/src/components/analytics-dashboard-card/analytics-dashboard-card.component.scss
+++ b/gravitee-apim-portal-webui-next/src/components/analytics-dashboard-card/analytics-dashboard-card.component.scss
@@ -86,7 +86,12 @@
       color: app-theme.$primary-main-color;
     }
 
-    &:hover:not(:disabled) {
+    &--disabled {
+      opacity: 0.2;
+      cursor: default;
+    }
+
+    &:hover:not(.dashboard-card__pin-button--disabled) {
       opacity: 1;
     }
   }

--- a/gravitee-apim-portal-webui-next/src/components/analytics-dashboard-card/analytics-dashboard-card.component.scss
+++ b/gravitee-apim-portal-webui-next/src/components/analytics-dashboard-card/analytics-dashboard-card.component.scss
@@ -32,6 +32,16 @@
     box-shadow: 0 2px 8px app-theme.$shadow-color;
   }
 
+  &--accented {
+    box-shadow: inset 3px 0 0 0 app-theme.$primary-main-color;
+
+    &:hover {
+      box-shadow:
+        inset 3px 0 0 0 app-theme.$primary-main-color,
+        0 2px 8px app-theme.$shadow-color;
+    }
+  }
+
   &__content {
     display: flex;
     flex: 1 1 auto;

--- a/gravitee-apim-portal-webui-next/src/components/analytics-dashboard-card/analytics-dashboard-card.component.scss
+++ b/gravitee-apim-portal-webui-next/src/components/analytics-dashboard-card/analytics-dashboard-card.component.scss
@@ -98,8 +98,6 @@
   }
 
   &__labels {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 4px;
+    min-width: 0;
   }
 }

--- a/gravitee-apim-portal-webui-next/src/components/analytics-dashboard-card/analytics-dashboard-card.component.scss
+++ b/gravitee-apim-portal-webui-next/src/components/analytics-dashboard-card/analytics-dashboard-card.component.scss
@@ -66,6 +66,21 @@
     }
   }
 
+  &__pin-button {
+    flex-shrink: 0;
+    opacity: 0.4;
+    transition: opacity 0.2s ease;
+
+    &--pinned {
+      opacity: 1;
+      color: app-theme.$primary-main-color;
+    }
+
+    &:hover:not(:disabled) {
+      opacity: 1;
+    }
+  }
+
   &__labels {
     display: flex;
     flex-wrap: wrap;

--- a/gravitee-apim-portal-webui-next/src/components/analytics-dashboard-card/analytics-dashboard-card.component.scss
+++ b/gravitee-apim-portal-webui-next/src/components/analytics-dashboard-card/analytics-dashboard-card.component.scss
@@ -78,6 +78,7 @@
 
   &__pin-button {
     flex-shrink: 0;
+    margin: -8px -8px 0 0;
     opacity: 0.4;
     transition: opacity 0.2s ease;
 

--- a/gravitee-apim-portal-webui-next/src/components/analytics-dashboard-card/analytics-dashboard-card.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/components/analytics-dashboard-card/analytics-dashboard-card.component.spec.ts
@@ -15,11 +15,13 @@
  */
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
 
 import { AnalyticsDashboardCardComponent } from './analytics-dashboard-card.component';
 import { AnalyticsDashboardCardHarness } from './analytics-dashboard-card.harness';
 import { fakeDashboard } from '../../entities/analytics-dashboard/analytics-dashboard.fixtures';
+import { OverflowLabelsComponent } from '../overflow-labels/overflow-labels.component';
 
 describe('AnalyticsDashboardCardComponent', () => {
   let fixture: ComponentFixture<AnalyticsDashboardCardComponent>;
@@ -51,10 +53,18 @@ describe('AnalyticsDashboardCardComponent', () => {
   });
 
   it('should_pass_dashboard_labels_to_overflow_labels', async () => {
-    const overflowLabels = await harness.getOverflowLabelsHarness();
-    expect(overflowLabels).not.toBeNull();
-    // In JSDOM container width is 0 → all 2 labels go behind the counter.
-    expect(await overflowLabels!.getOverflowCounterText()).toContain('+2');
+    expect(await harness.getOverflowLabelsHarness()).not.toBeNull();
+
+    const overflowLabels = fixture.debugElement.query(By.directive(OverflowLabelsComponent));
+    expect(overflowLabels.componentInstance.labels()).toEqual(['type:http', 'scope:proxy']);
+  });
+
+  it('should_map_dashboard_labels_to_key_value_strings', () => {
+    fixture.componentRef.setInput('dashboard', fakeDashboard({ labels: { env: 'dev', team: 'core' } }));
+    fixture.detectChanges();
+
+    const overflowLabels = fixture.debugElement.query(By.directive(OverflowLabelsComponent));
+    expect(overflowLabels.componentInstance.labels()).toEqual(['env:dev', 'team:core']);
   });
 
   it('should_render_widget_count', async () => {

--- a/gravitee-apim-portal-webui-next/src/components/analytics-dashboard-card/analytics-dashboard-card.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/components/analytics-dashboard-card/analytics-dashboard-card.component.spec.ts
@@ -50,21 +50,11 @@ describe('AnalyticsDashboardCardComponent', () => {
     expect(await harness.getTitle()).toContain('HTTP Overview');
   });
 
-  it('should_render_all_labels_when_count_is_within_visible_limit', async () => {
-    expect(await harness.getLabelCount()).toBe(2);
-    expect(await harness.getOverflowCounter()).toBeNull();
-  });
-
-  it('should_render_overflow_counter_when_labels_exceed_visible_limit', async () => {
-    fixture.componentRef.setInput(
-      'dashboard',
-      fakeDashboard({
-        labels: { type: 'http', scope: 'proxy', env: 'dev', team: 'core' },
-      }),
-    );
-    fixture.detectChanges();
-    expect(await harness.getLabelCount()).toBe(3);
-    expect(await harness.getOverflowCounter()).toContain('+2');
+  it('should_pass_dashboard_labels_to_overflow_labels', async () => {
+    const overflowLabels = await harness.getOverflowLabelsHarness();
+    expect(overflowLabels).not.toBeNull();
+    // In JSDOM container width is 0 → all 2 labels go behind the counter.
+    expect(await overflowLabels!.getOverflowCounterText()).toContain('+2');
   });
 
   it('should_render_widget_count', async () => {
@@ -75,10 +65,10 @@ describe('AnalyticsDashboardCardComponent', () => {
     expect(await harness.getLastModified()).toBeTruthy();
   });
 
-  it('should_not_render_labels_when_empty', async () => {
+  it('should_not_render_overflow_labels_when_empty', async () => {
     fixture.componentRef.setInput('dashboard', fakeDashboard({ labels: {} }));
     fixture.detectChanges();
-    expect(await harness.getLabelCount()).toBe(0);
+    expect(await harness.hasOverflowLabels()).toBe(false);
   });
 
   it('should_emit_card_select_on_click', async () => {

--- a/gravitee-apim-portal-webui-next/src/components/analytics-dashboard-card/analytics-dashboard-card.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/components/analytics-dashboard-card/analytics-dashboard-card.component.spec.ts
@@ -98,19 +98,32 @@ describe('AnalyticsDashboardCardComponent', () => {
     expect(emitSpy).toHaveBeenCalledWith('dashboard-1');
   });
 
-  it('should_disable_pin_button_when_not_pinned_and_cannot_pin', async () => {
+  it('should_not_emit_pin_toggle_when_not_pinned_and_cannot_pin', async () => {
+    fixture.componentRef.setInput('isPinned', false);
+    fixture.componentRef.setInput('canPin', false);
+    fixture.detectChanges();
+    const emitSpy = jest.spyOn(component.pinToggle, 'emit');
+    const pinButton = await harness.getPinButton();
+    await pinButton!.click();
+    expect(emitSpy).not.toHaveBeenCalled();
+  });
+
+  it('should_mark_pin_button_as_aria_disabled_when_cannot_pin', async () => {
     fixture.componentRef.setInput('isPinned', false);
     fixture.componentRef.setInput('canPin', false);
     fixture.detectChanges();
     const pinButton = await harness.getPinButton();
-    expect(await pinButton!.isDisabled()).toBe(true);
+    const host = await pinButton!.host();
+    expect(await host.getAttribute('aria-disabled')).toBe('true');
   });
 
-  it('should_enable_pin_button_when_already_pinned_even_if_cannot_pin_more', async () => {
+  it('should_allow_unpin_even_when_cannot_pin_more', async () => {
     fixture.componentRef.setInput('isPinned', true);
     fixture.componentRef.setInput('canPin', false);
     fixture.detectChanges();
+    const emitSpy = jest.spyOn(component.pinToggle, 'emit');
     const pinButton = await harness.getPinButton();
-    expect(await pinButton!.isDisabled()).toBe(false);
+    await pinButton!.click();
+    expect(emitSpy).toHaveBeenCalledWith('dashboard-1');
   });
 });

--- a/gravitee-apim-portal-webui-next/src/components/analytics-dashboard-card/analytics-dashboard-card.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/components/analytics-dashboard-card/analytics-dashboard-card.component.spec.ts
@@ -86,4 +86,31 @@ describe('AnalyticsDashboardCardComponent', () => {
     await harness.click();
     expect(emitSpy).toHaveBeenCalledWith('dashboard-1');
   });
+
+  it('should_show_pin_button', async () => {
+    expect(await harness.getPinButton()).toBeTruthy();
+  });
+
+  it('should_emit_pin_toggle_on_pin_click', async () => {
+    const emitSpy = jest.spyOn(component.pinToggle, 'emit');
+    const pinButton = await harness.getPinButton();
+    await pinButton!.click();
+    expect(emitSpy).toHaveBeenCalledWith('dashboard-1');
+  });
+
+  it('should_disable_pin_button_when_not_pinned_and_cannot_pin', async () => {
+    fixture.componentRef.setInput('isPinned', false);
+    fixture.componentRef.setInput('canPin', false);
+    fixture.detectChanges();
+    const pinButton = await harness.getPinButton();
+    expect(await pinButton!.isDisabled()).toBe(true);
+  });
+
+  it('should_enable_pin_button_when_already_pinned_even_if_cannot_pin_more', async () => {
+    fixture.componentRef.setInput('isPinned', true);
+    fixture.componentRef.setInput('canPin', false);
+    fixture.detectChanges();
+    const pinButton = await harness.getPinButton();
+    expect(await pinButton!.isDisabled()).toBe(false);
+  });
 });

--- a/gravitee-apim-portal-webui-next/src/components/analytics-dashboard-card/analytics-dashboard-card.component.ts
+++ b/gravitee-apim-portal-webui-next/src/components/analytics-dashboard-card/analytics-dashboard-card.component.ts
@@ -23,17 +23,15 @@ import { MatTooltip } from '@angular/material/tooltip';
 
 import { Dashboard } from '@gravitee/gravitee-dashboard';
 
-import { BadgeComponent } from '../badge/badge.component';
+import { OverflowLabelsComponent } from '../overflow-labels/overflow-labels.component';
 
 @Component({
   selector: 'app-analytics-dashboard-card',
-  imports: [MatCardModule, MatTooltip, DatePipe, BadgeComponent, MatIconButton, MatIcon],
+  imports: [MatCardModule, MatTooltip, DatePipe, MatIconButton, MatIcon, OverflowLabelsComponent],
   templateUrl: './analytics-dashboard-card.component.html',
   styleUrl: './analytics-dashboard-card.component.scss',
 })
 export class AnalyticsDashboardCardComponent {
-  private static readonly MAX_VISIBLE_LABELS = 2;
-
   readonly dashboard = input.required<Dashboard>();
   readonly isPinned = input<boolean>(false);
   readonly canPin = input<boolean>(true);
@@ -51,25 +49,7 @@ export class AnalyticsDashboardCardComponent {
   protected readonly unpinLabel = $localize`:@@analyticsDashboardUnpin:Unpin dashboard`;
   protected readonly maxPinnedTooltip = $localize`:@@analyticsDashboardMaxPinned:Pin limit reached`;
   protected readonly isPinDisabled = computed(() => !this.isPinned() && !this.canPin());
-
-  private readonly labelEntries = computed(() => Object.entries(this.dashboard().labels ?? {}));
-
-  protected readonly visibleLabels = computed(() =>
-    this.labelEntries()
-      .slice(0, AnalyticsDashboardCardComponent.MAX_VISIBLE_LABELS)
-      .map(([k, v]) => `${k}:${v}`),
-  );
-
-  protected readonly hiddenLabelsCount = computed(() =>
-    Math.max(0, this.labelEntries().length - AnalyticsDashboardCardComponent.MAX_VISIBLE_LABELS),
-  );
-
-  protected readonly hiddenLabelsTooltip = computed(() =>
-    this.labelEntries()
-      .slice(AnalyticsDashboardCardComponent.MAX_VISIBLE_LABELS)
-      .map(([k, v]) => `${k}:${v}`)
-      .join(', '),
-  );
+  protected readonly labels = computed(() => Object.entries(this.dashboard().labels ?? {}).map(([k, v]) => `${k}:${v}`));
 
   onPinClick(event: Event): void {
     event.stopPropagation();

--- a/gravitee-apim-portal-webui-next/src/components/analytics-dashboard-card/analytics-dashboard-card.component.ts
+++ b/gravitee-apim-portal-webui-next/src/components/analytics-dashboard-card/analytics-dashboard-card.component.ts
@@ -49,6 +49,8 @@ export class AnalyticsDashboardCardComponent {
   protected readonly ariaLabel = computed(() => $localize`:@@analyticsDashboardCardAriaLabel:Open dashboard ${this.name()}:name:`);
   protected readonly pinLabel = $localize`:@@analyticsDashboardPin:Pin dashboard`;
   protected readonly unpinLabel = $localize`:@@analyticsDashboardUnpin:Unpin dashboard`;
+  protected readonly maxPinnedTooltip = $localize`:@@analyticsDashboardMaxPinned:Pin limit reached`;
+  protected readonly isPinDisabled = computed(() => !this.isPinned() && !this.canPin());
 
   private readonly labelEntries = computed(() => Object.entries(this.dashboard().labels ?? {}));
 
@@ -71,6 +73,7 @@ export class AnalyticsDashboardCardComponent {
 
   onPinClick(event: Event): void {
     event.stopPropagation();
+    if (this.isPinDisabled()) return;
     this.pinToggle.emit(this.dashboardId());
   }
 }

--- a/gravitee-apim-portal-webui-next/src/components/analytics-dashboard-card/analytics-dashboard-card.component.ts
+++ b/gravitee-apim-portal-webui-next/src/components/analytics-dashboard-card/analytics-dashboard-card.component.ts
@@ -37,6 +37,7 @@ export class AnalyticsDashboardCardComponent {
   readonly dashboard = input.required<Dashboard>();
   readonly isPinned = input<boolean>(false);
   readonly canPin = input<boolean>(true);
+  readonly showAccent = input<boolean>(false);
 
   readonly cardSelect = output<string>();
   readonly pinToggle = output<string>();

--- a/gravitee-apim-portal-webui-next/src/components/analytics-dashboard-card/analytics-dashboard-card.component.ts
+++ b/gravitee-apim-portal-webui-next/src/components/analytics-dashboard-card/analytics-dashboard-card.component.ts
@@ -16,7 +16,9 @@
 
 import { DatePipe } from '@angular/common';
 import { Component, computed, input, output } from '@angular/core';
+import { MatIconButton } from '@angular/material/button';
 import { MatCardModule } from '@angular/material/card';
+import { MatIcon } from '@angular/material/icon';
 import { MatTooltip } from '@angular/material/tooltip';
 
 import { Dashboard } from '@gravitee/gravitee-dashboard';
@@ -25,7 +27,7 @@ import { BadgeComponent } from '../badge/badge.component';
 
 @Component({
   selector: 'app-analytics-dashboard-card',
-  imports: [MatCardModule, MatTooltip, DatePipe, BadgeComponent],
+  imports: [MatCardModule, MatTooltip, DatePipe, BadgeComponent, MatIconButton, MatIcon],
   templateUrl: './analytics-dashboard-card.component.html',
   styleUrl: './analytics-dashboard-card.component.scss',
 })
@@ -33,14 +35,19 @@ export class AnalyticsDashboardCardComponent {
   private static readonly MAX_VISIBLE_LABELS = 2;
 
   readonly dashboard = input.required<Dashboard>();
+  readonly isPinned = input<boolean>(false);
+  readonly canPin = input<boolean>(true);
 
   readonly cardSelect = output<string>();
+  readonly pinToggle = output<string>();
 
   protected readonly name = computed(() => this.dashboard().name);
   protected readonly dashboardId = computed(() => this.dashboard().id);
   protected readonly widgetCount = computed(() => this.dashboard().widgets?.length ?? 0);
   protected readonly lastModified = computed(() => this.dashboard().lastModified);
   protected readonly ariaLabel = computed(() => $localize`:@@analyticsDashboardCardAriaLabel:Open dashboard ${this.name()}:name:`);
+  protected readonly pinLabel = $localize`:@@analyticsDashboardPin:Pin dashboard`;
+  protected readonly unpinLabel = $localize`:@@analyticsDashboardUnpin:Unpin dashboard`;
 
   private readonly labelEntries = computed(() => Object.entries(this.dashboard().labels ?? {}));
 
@@ -60,4 +67,9 @@ export class AnalyticsDashboardCardComponent {
       .map(([k, v]) => `${k}:${v}`)
       .join(', '),
   );
+
+  onPinClick(event: Event): void {
+    event.stopPropagation();
+    this.pinToggle.emit(this.dashboardId());
+  }
 }

--- a/gravitee-apim-portal-webui-next/src/components/analytics-dashboard-card/analytics-dashboard-card.harness.ts
+++ b/gravitee-apim-portal-webui-next/src/components/analytics-dashboard-card/analytics-dashboard-card.harness.ts
@@ -17,14 +17,15 @@ import { BaseHarnessFilters, ContentContainerComponentHarness, HarnessPredicate 
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { MatButtonHarness } from '@angular/material/button/testing';
 
+import { OverflowLabelsHarness } from '../overflow-labels/overflow-labels.harness';
+
 export class AnalyticsDashboardCardHarness extends ContentContainerComponentHarness {
   public static hostSelector = 'app-analytics-dashboard-card';
 
   private readonly locateTitle = this.locatorFor('.dashboard-card__title');
   private readonly locateWidgetCount = this.locatorForOptional('[data-testid="widget-count"]');
   private readonly locateLastModified = this.locatorForOptional('[data-testid="last-modified"]');
-  private readonly locateLabels = this.locatorForAll('app-badge');
-  private readonly locateOverflowCounter = this.locatorForOptional('[data-testid="hidden-labels-count"]');
+  private readonly locateOverflowLabels = this.locatorForOptional(OverflowLabelsHarness);
   private readonly locatePinButton = this.locatorForOptional(MatButtonHarness.with({ selector: '.dashboard-card__pin-button' }));
   private readonly locatePinButtonElement = this.locatorForOptional('.dashboard-card__pin-button');
 
@@ -46,13 +47,12 @@ export class AnalyticsDashboardCardHarness extends ContentContainerComponentHarn
     return element ? element.text() : null;
   }
 
-  public async getLabelCount(): Promise<number> {
-    return (await this.locateLabels()).length;
+  public async hasOverflowLabels(): Promise<boolean> {
+    return (await this.locateOverflowLabels()) !== null;
   }
 
-  public async getOverflowCounter(): Promise<string | null> {
-    const element = await this.locateOverflowCounter();
-    return element ? element.text() : null;
+  public async getOverflowLabelsHarness(): Promise<OverflowLabelsHarness | null> {
+    return this.locateOverflowLabels();
   }
 
   public async getPinButton(): Promise<MatButtonHarness | null> {

--- a/gravitee-apim-portal-webui-next/src/components/analytics-dashboard-card/analytics-dashboard-card.harness.ts
+++ b/gravitee-apim-portal-webui-next/src/components/analytics-dashboard-card/analytics-dashboard-card.harness.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 import { BaseHarnessFilters, ContentContainerComponentHarness, HarnessPredicate } from '@angular/cdk/testing';
+import { MatButtonHarness } from '@angular/material/button/testing';
 
 export class AnalyticsDashboardCardHarness extends ContentContainerComponentHarness {
   public static hostSelector = 'app-analytics-dashboard-card';
@@ -23,6 +24,7 @@ export class AnalyticsDashboardCardHarness extends ContentContainerComponentHarn
   private readonly locateLastModified = this.locatorForOptional('[data-testid="last-modified"]');
   private readonly locateLabels = this.locatorForAll('app-badge');
   private readonly locateOverflowCounter = this.locatorForOptional('[data-testid="hidden-labels-count"]');
+  private readonly locatePinButton = this.locatorForOptional(MatButtonHarness.with({ selector: '.dashboard-card__pin-button' }));
 
   public static with(options: BaseHarnessFilters): HarnessPredicate<AnalyticsDashboardCardHarness> {
     return new HarnessPredicate(AnalyticsDashboardCardHarness, options);
@@ -49,6 +51,10 @@ export class AnalyticsDashboardCardHarness extends ContentContainerComponentHarn
   public async getOverflowCounter(): Promise<string | null> {
     const element = await this.locateOverflowCounter();
     return element ? element.text() : null;
+  }
+
+  public async getPinButton(): Promise<MatButtonHarness | null> {
+    return this.locatePinButton();
   }
 
   public async click(): Promise<void> {

--- a/gravitee-apim-portal-webui-next/src/components/analytics-dashboard-card/analytics-dashboard-card.harness.ts
+++ b/gravitee-apim-portal-webui-next/src/components/analytics-dashboard-card/analytics-dashboard-card.harness.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 import { BaseHarnessFilters, ContentContainerComponentHarness, HarnessPredicate } from '@angular/cdk/testing';
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { MatButtonHarness } from '@angular/material/button/testing';
 
 export class AnalyticsDashboardCardHarness extends ContentContainerComponentHarness {
@@ -25,6 +26,7 @@ export class AnalyticsDashboardCardHarness extends ContentContainerComponentHarn
   private readonly locateLabels = this.locatorForAll('app-badge');
   private readonly locateOverflowCounter = this.locatorForOptional('[data-testid="hidden-labels-count"]');
   private readonly locatePinButton = this.locatorForOptional(MatButtonHarness.with({ selector: '.dashboard-card__pin-button' }));
+  private readonly locatePinButtonElement = this.locatorForOptional('.dashboard-card__pin-button');
 
   public static with(options: BaseHarnessFilters): HarnessPredicate<AnalyticsDashboardCardHarness> {
     return new HarnessPredicate(AnalyticsDashboardCardHarness, options);
@@ -55,6 +57,14 @@ export class AnalyticsDashboardCardHarness extends ContentContainerComponentHarn
 
   public async getPinButton(): Promise<MatButtonHarness | null> {
     return this.locatePinButton();
+  }
+
+  /** Native click instead of MatButtonHarness: avoids deadlock when pin starts HTTP that stays pending until HttpTestingController.flush. */
+  public async clickPinButtonWithoutStabilizing(): Promise<void> {
+    const pin = await this.locatePinButtonElement();
+    if (!pin) throw new Error('Pin button not found on this card');
+    const pinElement = TestbedHarnessEnvironment.getNativeElement(pin) as HTMLElement;
+    pinElement.click();
   }
 
   public async click(): Promise<void> {

--- a/gravitee-apim-portal-webui-next/src/components/badge/badge.component.html
+++ b/gravitee-apim-portal-webui-next/src/components/badge/badge.component.html
@@ -1,13 +1,13 @@
 <!--
 
     Copyright (C) 2024 The Gravitee team (http://gravitee.io)
-    
+
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
-    
+
             http://www.apache.org/licenses/LICENSE-2.0
-    
+
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,
     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -32,4 +32,4 @@
     limitations under the License.
 
 -->
-<span class="badge">{{ label() }}</span>
+<span class="badge" [class.badge--truncate]="truncate()">{{ label() }}</span>

--- a/gravitee-apim-portal-webui-next/src/components/badge/badge.component.ts
+++ b/gravitee-apim-portal-webui-next/src/components/badge/badge.component.ts
@@ -38,4 +38,5 @@ import { Component, input } from '@angular/core';
 })
 export class BadgeComponent {
   readonly label = input.required<string>();
+  readonly truncate = input(false);
 }

--- a/gravitee-apim-portal-webui-next/src/components/cards-grid/cards-grid.component.scss
+++ b/gravitee-apim-portal-webui-next/src/components/cards-grid/cards-grid.component.scss
@@ -23,7 +23,7 @@
   display: grid;
   gap: 16px;
   grid-template-columns: repeat(4, 1fr);
-  grid-auto-rows: var(--cards-grid-row-height, 138px);
+  grid-auto-rows: 138px;
 
   &--narrow {
     grid-template-columns: repeat(2, 1fr);

--- a/gravitee-apim-portal-webui-next/src/components/cards-grid/cards-grid.component.scss
+++ b/gravitee-apim-portal-webui-next/src/components/cards-grid/cards-grid.component.scss
@@ -23,7 +23,7 @@
   display: grid;
   gap: 16px;
   grid-template-columns: repeat(4, 1fr);
-  grid-auto-rows: 138px;
+  grid-auto-rows: var(--cards-grid-row-height, 138px);
 
   &--narrow {
     grid-template-columns: repeat(2, 1fr);

--- a/gravitee-apim-portal-webui-next/src/components/overflow-labels/overflow-labels.component.html
+++ b/gravitee-apim-portal-webui-next/src/components/overflow-labels/overflow-labels.component.html
@@ -1,0 +1,41 @@
+<!--
+
+    Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<div #container class="overflow-labels">
+  @for (label of visibleLabels(); track $index) {
+    <app-badge
+      data-testid="visible-badge"
+      class="overflow-labels__badge"
+      [style.max-width.px]="maxBadgeWidth()"
+      [label]="label"
+      [truncate]="true"
+      [matTooltip]="label"
+    />
+  }
+  @if (hiddenLabels().length > 0) {
+    <app-badge data-testid="overflow-counter" [matTooltip]="hiddenLabelsTooltip()" [label]="'+' + hiddenLabels().length" />
+  }
+</div>
+
+<!-- Hidden container for measuring natural badge widths before truncation -->
+<div #measure class="overflow-labels__measure" aria-hidden="true">
+  @for (label of labels(); track $index) {
+    <app-badge data-role="measure-badge" [label]="label" [truncate]="true" [style.max-width.px]="maxBadgeWidth()" />
+  }
+  <!-- Uses +99 to approximate the widest realistic counter badge -->
+  <app-badge data-role="measure-counter" [label]="'+99'" />
+</div>

--- a/gravitee-apim-portal-webui-next/src/components/overflow-labels/overflow-labels.component.scss
+++ b/gravitee-apim-portal-webui-next/src/components/overflow-labels/overflow-labels.component.scss
@@ -13,28 +13,33 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-@use '../../scss/theme';
 
 :host {
-  display: inline-flex;
+  display: block;
+  position: relative;
   min-width: 0;
-  max-width: 100%;
+  overflow: hidden;
 }
 
-.badge {
-  display: inline-flex;
+.overflow-labels {
+  display: flex;
+  flex-wrap: nowrap;
   align-items: center;
-  justify-content: center;
-  height: 27px;
-  padding: 0 10px;
-  border-radius: 4px;
-  background-color: theme.$badge-container-color;
-  color: theme.$badge-label-text-color;
-  max-width: 100%;
+  gap: 4px;
+  overflow: hidden;
 
-  &--truncate {
+  &__badge {
+    min-width: 0;
+    flex: 0 1 auto;
+  }
+
+  &__measure {
+    position: absolute;
+    visibility: hidden;
+    height: 0;
     overflow: hidden;
-    white-space: nowrap;
-    text-overflow: ellipsis;
+    display: flex;
+    flex-wrap: nowrap;
+    pointer-events: none;
   }
 }

--- a/gravitee-apim-portal-webui-next/src/components/overflow-labels/overflow-labels.component.scss
+++ b/gravitee-apim-portal-webui-next/src/components/overflow-labels/overflow-labels.component.scss
@@ -25,7 +25,7 @@
   display: flex;
   flex-wrap: nowrap;
   align-items: center;
-  gap: 4px;
+  gap: 4px; // Keep in sync with GAP_PX constant in overflow-labels.component.ts
   overflow: hidden;
 
   &__badge {

--- a/gravitee-apim-portal-webui-next/src/components/overflow-labels/overflow-labels.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/components/overflow-labels/overflow-labels.component.spec.ts
@@ -87,7 +87,9 @@ describe('OverflowLabelsComponent', () => {
     fixture.componentRef.setInput('labels', ['type:http', 'scope:proxy']);
     fixture.detectChanges();
     harness = await TestbedHarnessEnvironment.harnessForFixture(fixture, OverflowLabelsHarness);
-    // In JSDOM, container width is 0 so no visible badges — all hidden behind the counter
+    // Initial render shows all labels (hasMeasured=false). After afterRenderEffect fires,
+    // JSDOM returns 0 for all getBoundingClientRect widths, so computeVisibleCount returns 0
+    // and all labels collapse into the overflow counter.
     expect(await harness.getOverflowCounterText()).toContain('+2');
   });
 });

--- a/gravitee-apim-portal-webui-next/src/components/overflow-labels/overflow-labels.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/components/overflow-labels/overflow-labels.component.spec.ts
@@ -1,0 +1,93 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { Component, input } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+
+import { computeVisibleCount, OverflowLabelsComponent } from './overflow-labels.component';
+import { OverflowLabelsHarness } from './overflow-labels.harness';
+
+describe('computeVisibleCount', () => {
+  it('should_return_total_count_when_all_badges_fit', () => {
+    expect(computeVisibleCount([50, 60, 40], 200, 30, 4)).toBe(3);
+  });
+
+  it('should_return_0_when_container_width_is_0', () => {
+    expect(computeVisibleCount([50, 60], 0, 30, 4)).toBe(0);
+  });
+
+  it('should_return_0_when_no_badges', () => {
+    expect(computeVisibleCount([], 200, 30, 4)).toBe(0);
+  });
+
+  it('should_return_0_when_no_badges_fit', () => {
+    expect(computeVisibleCount([100, 100], 50, 30, 4)).toBe(0);
+  });
+
+  it('should_reserve_space_for_counter_when_not_all_fit', () => {
+    // Container: 120px, badges: [50, 50, 50], counter: 30, gap: 4
+    // All: 50+4+50+4+50=158 > 120
+    // badge1: 50, counter needs 4+30=34 -> 50+34=84 <= 120 -> fits 1
+    expect(computeVisibleCount([50, 50, 50], 120, 30, 4)).toBe(1);
+  });
+
+  it('should_fit_two_when_space_allows_with_counter', () => {
+    // Container: 140px, badges: [50, 50, 50], counter: 30, gap: 4
+    // All: 50+4+50+4+50=158 > 140
+    // badge1+badge2: 50+4+50=104, counter: 4+30=34 -> 104+34=138 <= 140 -> fits 2
+    expect(computeVisibleCount([50, 50, 50], 140, 30, 4)).toBe(2);
+  });
+});
+
+@Component({
+  selector: 'app-test-host',
+  imports: [OverflowLabelsComponent],
+  template: `<app-overflow-labels [labels]="labels()" />`,
+})
+class TestHostComponent {
+  labels = input<string[]>([]);
+}
+
+describe('OverflowLabelsComponent', () => {
+  let fixture: ComponentFixture<TestHostComponent>;
+  let harness: OverflowLabelsHarness;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [TestHostComponent],
+      providers: [provideNoopAnimations()],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(TestHostComponent);
+  });
+
+  it('should_render_no_badges_for_empty_labels', async () => {
+    fixture.componentRef.setInput('labels', []);
+    fixture.detectChanges();
+    harness = await TestbedHarnessEnvironment.harnessForFixture(fixture, OverflowLabelsHarness);
+    expect(await harness.getVisibleBadgeCount()).toBe(0);
+    expect(await harness.getOverflowCounterText()).toBeNull();
+  });
+
+  it('should_render_overflow_counter_when_labels_present_but_container_has_no_width', async () => {
+    fixture.componentRef.setInput('labels', ['type:http', 'scope:proxy']);
+    fixture.detectChanges();
+    harness = await TestbedHarnessEnvironment.harnessForFixture(fixture, OverflowLabelsHarness);
+    // In JSDOM, container width is 0 so no visible badges — all hidden behind the counter
+    expect(await harness.getOverflowCounterText()).toContain('+2');
+  });
+});

--- a/gravitee-apim-portal-webui-next/src/components/overflow-labels/overflow-labels.component.ts
+++ b/gravitee-apim-portal-webui-next/src/components/overflow-labels/overflow-labels.component.ts
@@ -1,0 +1,120 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { isPlatformBrowser } from '@angular/common';
+import {
+  afterNextRender,
+  afterRenderEffect,
+  Component,
+  computed,
+  DestroyRef,
+  ElementRef,
+  inject,
+  input,
+  PLATFORM_ID,
+  signal,
+  viewChild,
+} from '@angular/core';
+import { MatTooltip } from '@angular/material/tooltip';
+
+import { BadgeComponent } from '../badge/badge.component';
+
+export function computeVisibleCount(badgeWidths: number[], containerWidth: number, counterWidth: number, gap: number): number {
+  if (badgeWidths.length === 0 || containerWidth <= 0) {
+    return 0;
+  }
+
+  let totalAll = 0;
+  for (let i = 0; i < badgeWidths.length; i++) {
+    totalAll += badgeWidths[i] + (i > 0 ? gap : 0);
+  }
+  if (totalAll <= containerWidth) {
+    return badgeWidths.length;
+  }
+
+  let used = 0;
+  let count = 0;
+  for (const w of badgeWidths) {
+    const next = used + (count > 0 ? gap : 0) + w;
+    const counterSpace = gap + counterWidth;
+    if (next + counterSpace > containerWidth) {
+      break;
+    }
+    used = next;
+    count++;
+  }
+  return count;
+}
+
+@Component({
+  selector: 'app-overflow-labels',
+  standalone: true,
+  imports: [BadgeComponent, MatTooltip],
+  templateUrl: './overflow-labels.component.html',
+  styleUrl: './overflow-labels.component.scss',
+})
+export class OverflowLabelsComponent {
+  private readonly destroyRef = inject(DestroyRef);
+  private readonly isBrowser = isPlatformBrowser(inject(PLATFORM_ID));
+
+  readonly labels = input.required<string[]>();
+  readonly maxBadgeWidth = input(150);
+
+  private readonly containerElement = viewChild.required<ElementRef<HTMLElement>>('container');
+  private readonly measureElement = viewChild.required<ElementRef<HTMLElement>>('measure');
+  private readonly containerWidth = signal(0);
+  private readonly badgeWidths = signal<number[]>([], {
+    equal: (a, b) => a.length === b.length && a.every((value, index) => value === b[index]),
+  });
+  private readonly counterWidth = signal(0);
+
+  private readonly visibleCount = computed(() => computeVisibleCount(this.badgeWidths(), this.containerWidth(), this.counterWidth(), 4));
+  protected readonly visibleLabels = computed(() => this.labels().slice(0, this.visibleCount()));
+  protected readonly hiddenLabels = computed(() => this.labels().slice(this.visibleCount()));
+  protected readonly hiddenLabelsTooltip = computed(() => this.hiddenLabels().join(', '));
+
+  constructor() {
+    if (!this.isBrowser) return;
+
+    afterNextRender(() => {
+      const element = this.containerElement().nativeElement;
+      this.containerWidth.set(element.getBoundingClientRect().width);
+      this.measureBadges();
+
+      const resizeObserver = new ResizeObserver(entries => {
+        this.containerWidth.set(entries[0]?.contentRect.width ?? 0);
+        this.measureBadges();
+      });
+      resizeObserver.observe(element);
+      this.destroyRef.onDestroy(() => resizeObserver.disconnect());
+    });
+
+    afterRenderEffect(() => {
+      this.labels();
+      this.measureBadges();
+    });
+  }
+
+  private measureBadges(): void {
+    const measureContainer = this.measureElement().nativeElement;
+    const badgeElements = measureContainer.querySelectorAll<HTMLElement>('[data-role="measure-badge"]');
+    this.badgeWidths.set(Array.from(badgeElements).map(element => element.getBoundingClientRect().width));
+    const counterElement = measureContainer.querySelector<HTMLElement>('[data-role="measure-counter"]');
+    if (counterElement) {
+      this.counterWidth.set(counterElement.getBoundingClientRect().width);
+    }
+  }
+}

--- a/gravitee-apim-portal-webui-next/src/components/overflow-labels/overflow-labels.component.ts
+++ b/gravitee-apim-portal-webui-next/src/components/overflow-labels/overflow-labels.component.ts
@@ -32,6 +32,8 @@ import { MatTooltip } from '@angular/material/tooltip';
 
 import { BadgeComponent } from '../badge/badge.component';
 
+const GAP_PX = 4;
+
 export function computeVisibleCount(badgeWidths: number[], containerWidth: number, counterWidth: number, gap: number): number {
   if (badgeWidths.length === 0 || containerWidth <= 0) {
     return 0;
@@ -80,8 +82,11 @@ export class OverflowLabelsComponent {
     equal: (a, b) => a.length === b.length && a.every((value, index) => value === b[index]),
   });
   private readonly counterWidth = signal(0);
+  private readonly hasMeasured = signal(false);
 
-  private readonly visibleCount = computed(() => computeVisibleCount(this.badgeWidths(), this.containerWidth(), this.counterWidth(), 4));
+  private readonly visibleCount = computed(() =>
+    this.hasMeasured() ? computeVisibleCount(this.badgeWidths(), this.containerWidth(), this.counterWidth(), GAP_PX) : this.labels().length,
+  );
   protected readonly visibleLabels = computed(() => this.labels().slice(0, this.visibleCount()));
   protected readonly hiddenLabels = computed(() => this.labels().slice(this.visibleCount()));
   protected readonly hiddenLabelsTooltip = computed(() => this.hiddenLabels().join(', '));
@@ -92,19 +97,20 @@ export class OverflowLabelsComponent {
     afterNextRender(() => {
       const element = this.containerElement().nativeElement;
       this.containerWidth.set(element.getBoundingClientRect().width);
-      this.measureBadges();
 
       const resizeObserver = new ResizeObserver(entries => {
         this.containerWidth.set(entries[0]?.contentRect.width ?? 0);
-        this.measureBadges();
       });
       resizeObserver.observe(element);
       this.destroyRef.onDestroy(() => resizeObserver.disconnect());
     });
 
-    afterRenderEffect(() => {
-      this.labels();
-      this.measureBadges();
+    afterRenderEffect({
+      read: () => {
+        this.labels();
+        this.measureBadges();
+        this.hasMeasured.set(true);
+      },
     });
   }
 

--- a/gravitee-apim-portal-webui-next/src/components/overflow-labels/overflow-labels.harness.ts
+++ b/gravitee-apim-portal-webui-next/src/components/overflow-labels/overflow-labels.harness.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ContentContainerComponentHarness } from '@angular/cdk/testing';
+
+export class OverflowLabelsHarness extends ContentContainerComponentHarness {
+  public static hostSelector = 'app-overflow-labels';
+
+  private readonly locateVisibleBadges = this.locatorForAll('[data-testid="visible-badge"]');
+  private readonly locateOverflowCounter = this.locatorForOptional('[data-testid="overflow-counter"]');
+
+  public async getVisibleBadgeCount(): Promise<number> {
+    return (await this.locateVisibleBadges()).length;
+  }
+
+  public async getOverflowCounterText(): Promise<string | null> {
+    const element = await this.locateOverflowCounter();
+    return element ? element.text() : null;
+  }
+}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-13862

## Description

Introduce OverflowLabelsComponent to dynamically manage badge overflow based on available container width.

It automatically calculates how many labels can fit and groups the remainder into a "+N" counter with a tooltip, ensuring a clean layout across different screen sizes.
