### PR TITLE
feat: allow listeners field in v4 HTTP Proxy API PATCH allow-list

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-apis.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-apis.yaml
@@ -300,7 +300,7 @@ paths:
                 Only the following fields are patchable: name, description, apiVersion, visibility, labels, tags,
                 lifecycleState, categories, analytics, failover, flowExecution, flows, services, resources,
                 allowedInApiProducts, allowMultiJwtOauth2Subscriptions, disableMembershipNotifications,
-                properties, responseTemplates.
+                properties, responseTemplates, listeners.
 
                 JSON Patch operations targeting /resources/N/configuration/... (any depth under configuration) are
                 rejected with 400. Replace the full configuration object at /resources/N/configuration instead.

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource_PatchApiTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource_PatchApiTest.java
@@ -37,6 +37,9 @@ import io.gravitee.apim.core.api.model.Api;
 import io.gravitee.apim.core.exception.ValidationDomainException;
 import io.gravitee.apim.core.membership.model.Membership;
 import io.gravitee.apim.core.membership.model.PrimaryOwnerEntity;
+import io.gravitee.definition.model.v4.listener.entrypoint.Entrypoint;
+import io.gravitee.definition.model.v4.listener.http.HttpListener;
+import io.gravitee.definition.model.v4.listener.http.Path;
 import io.gravitee.rest.api.management.v2.rest.model.ApiServices;
 import io.gravitee.rest.api.management.v2.rest.model.ApiV4;
 import io.gravitee.rest.api.management.v2.rest.model.FlowExecution;
@@ -293,8 +296,8 @@ public class ApiResource_PatchApiTest extends ApiResourceTest {
         return Stream.of(
             Arguments.of("{\"state\":\"STARTED\"}", MERGE_PATCH_TYPE, "state"),
             Arguments.of("[{\"op\":\"replace\",\"path\":\"/state\",\"value\":\"STARTED\"}]", JSON_PATCH_TYPE, "state"),
-            Arguments.of("{\"listeners\":[]}", MERGE_PATCH_TYPE, "listeners"),
-            Arguments.of("[{\"op\":\"replace\",\"path\":\"/listeners\",\"value\":[]}]", JSON_PATCH_TYPE, "listeners")
+            Arguments.of("{\"endpointGroups\":[]}", MERGE_PATCH_TYPE, "endpointGroups"),
+            Arguments.of("[{\"op\":\"replace\",\"path\":\"/endpointGroups\",\"value\":[]}]", JSON_PATCH_TYPE, "endpointGroups")
         );
     }
 
@@ -407,6 +410,37 @@ public class ApiResource_PatchApiTest extends ApiResourceTest {
                 Arguments.of("{\"tags\":[\"forbidden\"]}", MERGE_PATCH_TYPE),
                 Arguments.of("[{\"op\":\"replace\",\"path\":\"/tags\",\"value\":[\"forbidden\"]}]", JSON_PATCH_TYPE)
             );
+        }
+
+        @Test
+        void should_return_200_with_sanitized_listeners() {
+            doAnswer(inv -> {
+                Api api = inv.getArgument(0);
+                var sanitizedListener = HttpListener.builder()
+                    .paths(List.of(Path.builder().path("/sanitized").build()))
+                    .entrypoints(List.of(Entrypoint.builder().type("http-proxy").configuration("{}").build()))
+                    .build();
+                var sanitizedDef = api.getApiDefinitionHttpV4().toBuilder().listeners(List.of(sanitizedListener)).build();
+                return api.toBuilder().apiDefinitionValue(sanitizedDef).build();
+            })
+                .when(updateApiDomainService)
+                .validateV4(any(), any());
+
+            var response = rootTarget(API)
+                .queryParam("dryRun", "true")
+                .request()
+                .method("PATCH", Entity.entity("{\"listeners\":[" + listenerJson("/requested") + "]}", MERGE_PATCH_TYPE));
+
+            assertThat(response)
+                .hasStatus(OK_200)
+                .asEntity(ApiV4.class)
+                .satisfies(apiV4 -> {
+                    var listeners = apiV4.getListeners();
+                    Assertions.assertThat(listeners).hasSize(1);
+                    Assertions.assertThat(listeners.getFirst().getHttpListener().getPaths().getFirst().getPath()).isEqualTo("/sanitized");
+                });
+            verify(updateApiDomainService).validateV4(any(), any());
+            verify(updateApiDomainService, never()).updateV4(any(), any());
         }
     }
 
@@ -804,6 +838,37 @@ public class ApiResource_PatchApiTest extends ApiResourceTest {
                 "[{\"op\":\"replace\",\"path\":\"/responseTemplates\",\"value\":{\"FOO_KEY\":{\"application/json\":{\"statusCode\":400,\"body\":\"{}\"}}}}]",
                 JSON_PATCH_TYPE
             )
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("listenersUpdateVariants")
+    void should_update_listeners(String body, String contentType) {
+        var response = rootTarget(API).request().method("PATCH", Entity.entity(body, contentType));
+
+        assertThat(response)
+            .hasStatus(OK_200)
+            .asEntity(ApiV4.class)
+            .satisfies(apiV4 -> {
+                var listeners = apiV4.getListeners();
+                Assertions.assertThat(listeners).hasSize(1);
+                Assertions.assertThat(listeners.getFirst().getHttpListener().getPaths().getFirst().getPath()).isEqualTo("/patched");
+            });
+    }
+
+    static Stream<Arguments> listenersUpdateVariants() {
+        var listenerJson = listenerJson("/patched");
+        return Stream.of(
+            Arguments.of("{\"listeners\":[" + listenerJson + "]}", MERGE_PATCH_TYPE),
+            Arguments.of("[{\"op\":\"replace\",\"path\":\"/listeners\",\"value\":[" + listenerJson + "]}]", JSON_PATCH_TYPE)
+        );
+    }
+
+    private static String listenerJson(String path) {
+        return (
+            "{\"type\":\"http\",\"paths\":[{\"path\":\"" +
+            path +
+            "\"}],\"entrypoints\":[{\"type\":\"http-proxy\",\"configuration\":\"{}\"}]}"
         );
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/use_case/PatchApiUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/use_case/PatchApiUseCase.java
@@ -49,6 +49,7 @@ import io.gravitee.definition.model.v4.failover.Failover;
 import io.gravitee.definition.model.v4.flow.Flow;
 import io.gravitee.definition.model.v4.flow.execution.FlowExecution;
 import io.gravitee.definition.model.v4.flow.execution.FlowMode;
+import io.gravitee.definition.model.v4.listener.Listener;
 import io.gravitee.definition.model.v4.property.Property;
 import io.gravitee.definition.model.v4.resource.Resource;
 import io.gravitee.definition.model.v4.service.ApiServices;
@@ -88,6 +89,7 @@ public class PatchApiUseCase {
     private static final String FIELD_RESPONSE_TEMPLATES = "responseTemplates";
     private static final String FIELD_FLOWS = "flows";
     private static final String FIELD_RESOURCES = "resources";
+    private static final String FIELD_LISTENERS = "listeners";
 
     private static final String JSON_PATCH_PATH_PREFIX = "/";
 
@@ -114,13 +116,14 @@ public class PatchApiUseCase {
         FIELD_PROPERTIES,
         FIELD_RESPONSE_TEMPLATES,
         FIELD_FLOWS,
-        FIELD_RESOURCES
+        FIELD_RESOURCES,
+        FIELD_LISTENERS
     );
 
     private static final int MAX_PATCH_OPS = 200;
 
     private static final Set<String> BLOCKED_WITH_HINT = Set.of("state");
-    private static final Set<String> BLOCKED_WITHOUT_HINT = Set.of("endpointGroups", "listeners");
+    private static final Set<String> BLOCKED_WITHOUT_HINT = Set.of("endpointGroups");
 
     private static final String NULL_NOT_ALLOWED_MESSAGE_FORMAT =
         "'%s' cannot be null; omit the field to leave it unchanged, or send an explicit value";
@@ -378,6 +381,7 @@ public class PatchApiUseCase {
         var responseTemplates = resolveResponseTemplates(patchType, rawPatchNode, patchedNode, httpV4.getResponseTemplates());
         var flows = resolvePatchableList(patchType, rawPatchNode, patchedNode, FIELD_FLOWS, Flow.class, httpV4.getFlows());
         var resources = resolvePatchableList(patchType, rawPatchNode, patchedNode, FIELD_RESOURCES, Resource.class, httpV4.getResources());
+        var listeners = resolvePatchableList(patchType, rawPatchNode, patchedNode, FIELD_LISTENERS, Listener.class, httpV4.getListeners());
 
         var updatedDefinition = httpV4
             .toBuilder()
@@ -393,6 +397,7 @@ public class PatchApiUseCase {
             .responseTemplates(responseTemplates)
             .flows(flows)
             .resources(resources)
+            .listeners(listeners)
             .build();
 
         return existingApi
@@ -829,7 +834,8 @@ public class PatchApiUseCase {
         List<PatchableProperty> properties,
         Map<String, Map<String, PatchableResponseTemplate>> responseTemplates,
         List<Flow> flows,
-        List<Resource> resources
+        List<Resource> resources,
+        List<Listener> listeners
     ) {
         static PatchableView from(Api api, io.gravitee.definition.model.v4.Api httpV4) {
             return new PatchableView(
@@ -851,7 +857,8 @@ public class PatchApiUseCase {
                 PatchableProperty.fromList(httpV4.getProperties()),
                 toPatchableResponseTemplates(httpV4.getResponseTemplates()),
                 httpV4.getFlows(),
-                httpV4.getResources()
+                httpV4.getResources(),
+                httpV4.getListeners()
             );
         }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/api/UpdateApiDomainServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/api/UpdateApiDomainServiceImpl.java
@@ -92,6 +92,7 @@ public class UpdateApiDomainServiceImpl implements UpdateApiDomainService {
             .responseTemplates(coalesce(sanitized.getResponseTemplates(), originalDefinition.getResponseTemplates()))
             .resources(coalesce(sanitized.getResources(), originalDefinition.getResources()))
             .properties(coalesce(toProperties(sanitized.getProperties()), originalDefinition.getProperties()))
+            .listeners(coalesce(sanitized.getListeners(), originalDefinition.getListeners()))
             .build();
         return original
             .toBuilder()

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/PatchApiUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/PatchApiUseCaseTest.java
@@ -55,6 +55,10 @@ import io.gravitee.definition.model.v4.flow.execution.FlowMode;
 import io.gravitee.definition.model.v4.flow.selector.ConditionSelector;
 import io.gravitee.definition.model.v4.flow.selector.HttpSelector;
 import io.gravitee.definition.model.v4.flow.step.Step;
+import io.gravitee.definition.model.v4.listener.Listener;
+import io.gravitee.definition.model.v4.listener.entrypoint.Entrypoint;
+import io.gravitee.definition.model.v4.listener.http.HttpListener;
+import io.gravitee.definition.model.v4.listener.http.Path;
 import io.gravitee.definition.model.v4.property.Property;
 import io.gravitee.definition.model.v4.resource.Resource;
 import io.gravitee.definition.model.v4.service.ApiServices;
@@ -270,6 +274,29 @@ class PatchApiUseCaseTest {
         return base.toBuilder().apiDefinitionValue(httpV4Def(base).toBuilder().flows(flows).build()).build();
     }
 
+    static Api apiWithListeners(List<Listener> listeners) {
+        var base = ApiFixtures.aProxyApiV4();
+        return base.toBuilder().apiDefinitionValue(httpV4Def(base).toBuilder().listeners(listeners).build()).build();
+    }
+
+    static HttpListener anHttpListener(String path) {
+        return HttpListener.builder()
+            .paths(List.of(Path.builder().path(path).build()))
+            .entrypoints(List.of(Entrypoint.builder().type("http-proxy").configuration("{}").build()))
+            .build();
+    }
+
+    static Map<String, Object> listenerMap(String path) {
+        return Map.of(
+            "type",
+            "http",
+            "paths",
+            List.of(Map.of("path", path)),
+            "entrypoints",
+            List.of(Map.of("type", "http-proxy", "configuration", "{}"))
+        );
+    }
+
     static Api apiWithResources(List<Resource> resources) {
         var base = ApiFixtures.aProxyApiV4();
         return base.toBuilder().apiDefinitionValue(httpV4Def(base).toBuilder().resources(resources).build()).build();
@@ -473,14 +500,6 @@ class PatchApiUseCaseTest {
                 .isInstanceOf(ApiPatchNotAllowedException.class)
                 .hasMessageContaining("state")
                 .hasMessageContaining("_start");
-        }
-
-        @ParameterizedTest
-        @EnumSource(PatchApiUseCase.PatchType.class)
-        void listeners_field_is_rejected(PatchApiUseCase.PatchType type) {
-            assertThatThrownBy(() -> execute(type, setField(type, "listeners", List.of()), false))
-                .isInstanceOf(ApiPatchNotAllowedException.class)
-                .hasMessageContaining("listeners");
         }
 
         @ParameterizedTest
@@ -814,23 +833,23 @@ class PatchApiUseCaseTest {
 
         @Test
         void move_op_with_disallowed_from_field_is_rejected() {
-            assertThatThrownBy(() -> execute(PatchApiUseCase.PatchType.JSON_PATCH, movePatch("/listeners/0", "/name"), false))
+            assertThatThrownBy(() -> execute(PatchApiUseCase.PatchType.JSON_PATCH, movePatch("/endpointGroups/0", "/name"), false))
                 .isInstanceOf(ApiPatchNotAllowedException.class)
-                .hasMessageContaining("listeners");
+                .hasMessageContaining("endpointGroups");
         }
 
         @Test
         void copy_op_with_disallowed_from_field_is_rejected() {
-            assertThatThrownBy(() -> execute(PatchApiUseCase.PatchType.JSON_PATCH, copyPatch("/listeners/0", "/name"), false))
+            assertThatThrownBy(() -> execute(PatchApiUseCase.PatchType.JSON_PATCH, copyPatch("/endpointGroups/0", "/name"), false))
                 .isInstanceOf(ApiPatchNotAllowedException.class)
-                .hasMessageContaining("listeners");
+                .hasMessageContaining("endpointGroups");
         }
 
         @Test
         void move_op_with_disallowed_destination_path_is_rejected() {
-            assertThatThrownBy(() -> execute(PatchApiUseCase.PatchType.JSON_PATCH, movePatch("/name", "/listeners/0"), false))
+            assertThatThrownBy(() -> execute(PatchApiUseCase.PatchType.JSON_PATCH, movePatch("/name", "/endpointGroups/0"), false))
                 .isInstanceOf(ApiPatchNotAllowedException.class)
-                .hasMessageContaining("listeners");
+                .hasMessageContaining("endpointGroups");
         }
 
         @Test
@@ -842,9 +861,9 @@ class PatchApiUseCaseTest {
 
         @Test
         void disallowed_field_via_path_segment_is_rejected() {
-            assertThatThrownBy(() -> execute(PatchApiUseCase.PatchType.JSON_PATCH, patch("replace", "/listeners/0/type", "HTTP"), false))
+            assertThatThrownBy(() -> execute(PatchApiUseCase.PatchType.JSON_PATCH, patch("replace", "/endpointGroups/0/name", "x"), false))
                 .isInstanceOf(ApiPatchNotAllowedException.class)
-                .hasMessageContaining("listeners");
+                .hasMessageContaining("endpointGroups");
         }
 
         @Test
@@ -906,9 +925,9 @@ class PatchApiUseCaseTest {
 
         @Test
         void add_op_on_blocked_path_is_rejected() {
-            assertThatThrownBy(() -> execute(PatchApiUseCase.PatchType.JSON_PATCH, patch("add", "/listeners/0", Map.of()), false))
+            assertThatThrownBy(() -> execute(PatchApiUseCase.PatchType.JSON_PATCH, patch("add", "/endpointGroups/0", Map.of()), false))
                 .isInstanceOf(ApiPatchNotAllowedException.class)
-                .hasMessageContaining("listeners");
+                .hasMessageContaining("endpointGroups");
         }
 
         @Test
@@ -2004,6 +2023,227 @@ class PatchApiUseCaseTest {
             );
 
             assertThat(httpV4Def(output.api()).getResources()).isEqualTo(sanitisedResources);
+        }
+    }
+
+    @Nested
+    class ListenersResolution {
+
+        @Test
+        void merge_patch_with_null_listeners_erases_them() {
+            givenExistingApi(apiWithListeners(List.of(anHttpListener("/existing"))));
+
+            var output = execute(PatchApiUseCase.PatchType.MERGE_PATCH, mergePatch("listeners", null), false);
+
+            assertThat(httpV4Def(output.api()).getListeners()).isEmpty();
+        }
+
+        @Test
+        void merge_patch_with_empty_array_clears_listeners() {
+            givenExistingApi(apiWithListeners(List.of(anHttpListener("/existing"))));
+
+            var output = execute(PatchApiUseCase.PatchType.MERGE_PATCH, mergePatch("listeners", List.of()), false);
+
+            assertThat(httpV4Def(output.api()).getListeners()).isEmpty();
+        }
+
+        @Test
+        void merge_patch_omitting_listeners_leaves_them_unchanged() {
+            var existing = anHttpListener("/existing");
+            givenExistingApi(apiWithListeners(List.of(existing)));
+
+            var output = execute(PatchApiUseCase.PatchType.MERGE_PATCH, mergePatch("name", "renamed"), false);
+
+            assertThat(httpV4Def(output.api()).getListeners()).containsExactly(existing);
+        }
+
+        @Test
+        void merge_patch_sets_listeners_when_previously_absent() {
+            givenExistingApi(apiWithListeners(null));
+
+            var output = execute(PatchApiUseCase.PatchType.MERGE_PATCH, mergePatch("listeners", List.of(listenerMap("/new"))), false);
+
+            assertThat(httpV4Def(output.api()).getListeners()).hasSize(1);
+            assertThat(((HttpListener) httpV4Def(output.api()).getListeners().getFirst()).getPaths().getFirst().getPath()).isEqualTo(
+                "/new"
+            );
+        }
+
+        @Test
+        void json_patch_add_listener_at_index() {
+            givenExistingApi(apiWithListeners(List.of(anHttpListener("/existing"))));
+
+            var output = execute(PatchApiUseCase.PatchType.JSON_PATCH, patch("add", "/listeners/0", listenerMap("/inserted")), false);
+
+            assertThat(httpV4Def(output.api()).getListeners()).hasSize(2);
+            assertThat(((HttpListener) httpV4Def(output.api()).getListeners().getFirst()).getPaths().getFirst().getPath()).isEqualTo(
+                "/inserted"
+            );
+        }
+
+        @Test
+        void json_patch_append_listener_using_dash() {
+            givenExistingApi(apiWithListeners(List.of(anHttpListener("/existing"))));
+
+            var output = execute(PatchApiUseCase.PatchType.JSON_PATCH, patch("add", "/listeners/-", listenerMap("/appended")), false);
+
+            assertThat(httpV4Def(output.api()).getListeners()).hasSize(2);
+            assertThat(((HttpListener) httpV4Def(output.api()).getListeners().get(1)).getPaths().getFirst().getPath()).isEqualTo(
+                "/appended"
+            );
+        }
+
+        @Test
+        void json_patch_remove_listener_at_index() {
+            givenExistingApi(apiWithListeners(List.of(anHttpListener("/first"), anHttpListener("/second"))));
+
+            var output = execute(PatchApiUseCase.PatchType.JSON_PATCH, patch("remove", "/listeners/0"), false);
+
+            assertThat(httpV4Def(output.api()).getListeners()).hasSize(1);
+            assertThat(((HttpListener) httpV4Def(output.api()).getListeners().getFirst()).getPaths().getFirst().getPath()).isEqualTo(
+                "/second"
+            );
+        }
+
+        @Test
+        void merge_patch_with_new_listener_adds_it_to_existing_list() {
+            givenExistingApi(apiWithListeners(List.of(anHttpListener("/existing"))));
+            var supplied = List.of(listenerMap("/existing"), listenerMap("/new"));
+
+            var output = execute(PatchApiUseCase.PatchType.MERGE_PATCH, mergePatch("listeners", supplied), false);
+
+            assertThat(httpV4Def(output.api()).getListeners()).hasSize(2);
+            assertThat(((HttpListener) httpV4Def(output.api()).getListeners().get(1)).getPaths().getFirst().getPath()).isEqualTo("/new");
+        }
+
+        @Test
+        void json_patch_replace_listeners_with_new_entry_replaces_list() {
+            givenExistingApi(apiWithListeners(List.of(anHttpListener("/old"))));
+            var supplied = List.of(listenerMap("/replaced"));
+
+            var output = execute(PatchApiUseCase.PatchType.JSON_PATCH, patch("replace", "/listeners", supplied), false);
+
+            var listeners = httpV4Def(output.api()).getListeners();
+            assertThat(listeners).hasSize(1);
+            assertThat(((HttpListener) listeners.getFirst()).getPaths().getFirst().getPath()).isEqualTo("/replaced");
+        }
+
+        @Test
+        void merge_patch_replaces_existing_listener_in_place() {
+            givenExistingApi(apiWithListeners(List.of(anHttpListener("/original"))));
+            var modified = List.of(listenerMap("/modified"));
+
+            var output = execute(PatchApiUseCase.PatchType.MERGE_PATCH, mergePatch("listeners", modified), false);
+
+            assertThat(httpV4Def(output.api()).getListeners()).hasSize(1);
+            assertThat(((HttpListener) httpV4Def(output.api()).getListeners().getFirst()).getPaths().getFirst().getPath()).isEqualTo(
+                "/modified"
+            );
+        }
+
+        @Test
+        void merge_patch_updates_entrypoints_on_existing_listener() {
+            givenExistingApi(apiWithListeners(List.of(anHttpListener("/path"))));
+            var withTwoEntrypoints = Map.of(
+                "type",
+                "http",
+                "paths",
+                List.of(Map.of("path", "/path")),
+                "entrypoints",
+                List.of(Map.of("type", "http-proxy", "configuration", "{}"), Map.of("type", "http-get", "configuration", "{}"))
+            );
+
+            var output = execute(PatchApiUseCase.PatchType.MERGE_PATCH, mergePatch("listeners", List.of(withTwoEntrypoints)), false);
+
+            var listeners = httpV4Def(output.api()).getListeners();
+            assertThat(listeners).hasSize(1);
+            assertThat(((HttpListener) listeners.getFirst()).getEntrypoints()).hasSize(2);
+        }
+
+        @Test
+        void merge_patch_removes_listener_by_sending_shorter_list() {
+            givenExistingApi(apiWithListeners(List.of(anHttpListener("/first"), anHttpListener("/second"))));
+            var withoutSecond = List.of(listenerMap("/first"));
+
+            var output = execute(PatchApiUseCase.PatchType.MERGE_PATCH, mergePatch("listeners", withoutSecond), false);
+
+            assertThat(httpV4Def(output.api()).getListeners()).hasSize(1);
+            assertThat(((HttpListener) httpV4Def(output.api()).getListeners().getFirst()).getPaths().getFirst().getPath()).isEqualTo(
+                "/first"
+            );
+        }
+
+        @Test
+        void json_patch_remove_listeners_clears_list() {
+            givenExistingApi(apiWithListeners(List.of(anHttpListener("/first"), anHttpListener("/second"))));
+
+            var output = execute(PatchApiUseCase.PatchType.JSON_PATCH, patch("remove", "/listeners"), false);
+
+            assertThat(httpV4Def(output.api()).getListeners()).isEmpty();
+        }
+
+        static Stream<Arguments> reorderListenersVariants() {
+            var reordered = List.of(listenerMap("/second"), listenerMap("/first"));
+            return Stream.of(
+                Arguments.of(PatchApiUseCase.PatchType.MERGE_PATCH, mergePatch("listeners", reordered)),
+                Arguments.of(PatchApiUseCase.PatchType.JSON_PATCH, patch("replace", "/listeners", reordered))
+            );
+        }
+
+        @ParameterizedTest
+        @MethodSource("reorderListenersVariants")
+        void reordering_listeners_reflects_new_order(PatchApiUseCase.PatchType type, String body) {
+            givenExistingApi(apiWithListeners(List.of(anHttpListener("/first"), anHttpListener("/second"))));
+
+            var output = execute(type, body, false);
+
+            var listeners = httpV4Def(output.api()).getListeners();
+            assertThat(listeners).hasSize(2);
+            assertThat(((HttpListener) listeners.getFirst()).getPaths().getFirst().getPath()).isEqualTo("/second");
+            assertThat(((HttpListener) listeners.get(1)).getPaths().getFirst().getPath()).isEqualTo("/first");
+        }
+
+        @Test
+        void validation_failure_on_listeners_surfaces_as_exception() {
+            doThrow(new ValidationDomainException("duplicate listener", Map.of("listeners", "duplicate path")))
+                .when(updateApiDomainService)
+                .updateV4(any(), any());
+            var duplicated = List.of(listenerMap("/dup"), listenerMap("/dup"));
+
+            assertThatThrownBy(() ->
+                execute(PatchApiUseCase.PatchType.MERGE_PATCH, mergePatch("listeners", duplicated), false)
+            ).isExactlyInstanceOf(ValidationDomainException.class);
+        }
+
+        @Test
+        void dry_run_returns_sanitised_listeners() {
+            List<Listener> sanitisedListeners = List.of(
+                HttpListener.builder()
+                    .paths(List.of(Path.builder().path("/sanitized").build()))
+                    .entrypoints(List.of(Entrypoint.builder().type("http-proxy").configuration("{}").build()))
+                    .build()
+            );
+            when(updateApiDomainService.validateV4(any(), any())).thenAnswer(inv -> {
+                Api api = inv.getArgument(0);
+                var def = api.getApiDefinitionHttpV4();
+                return api.toBuilder().apiDefinitionValue(def.toBuilder().listeners(sanitisedListeners).build()).build();
+            });
+
+            var output = execute(PatchApiUseCase.PatchType.MERGE_PATCH, mergePatch("listeners", List.of(listenerMap("/requested"))), true);
+
+            assertThat(httpV4Def(output.api()).getListeners()).isEqualTo(sanitisedListeners);
+        }
+
+        @Test
+        void dry_run_does_not_persist_listeners_change() {
+            stubValidateV4ReturnsArgument();
+            var original = apiWithListeners(List.of(anHttpListener("/original")));
+            givenExistingApi(original);
+
+            execute(PatchApiUseCase.PatchType.MERGE_PATCH, mergePatch("listeners", List.of(listenerMap("/changed"))), true);
+
+            var stored = apiCrudService.storage().getFirst();
+            assertThat(((HttpListener) httpV4Def(stored).getListeners().getFirst()).getPaths().getFirst().getPath()).isEqualTo("/original");
         }
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/api/UpdateApiDomainServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/api/UpdateApiDomainServiceImplTest.java
@@ -33,6 +33,10 @@ import io.gravitee.definition.model.v4.analytics.Analytics;
 import io.gravitee.definition.model.v4.failover.Failover;
 import io.gravitee.definition.model.v4.flow.Flow;
 import io.gravitee.definition.model.v4.flow.execution.FlowExecution;
+import io.gravitee.definition.model.v4.listener.Listener;
+import io.gravitee.definition.model.v4.listener.entrypoint.Entrypoint;
+import io.gravitee.definition.model.v4.listener.http.HttpListener;
+import io.gravitee.definition.model.v4.listener.http.Path;
 import io.gravitee.definition.model.v4.property.Property;
 import io.gravitee.definition.model.v4.resource.Resource;
 import io.gravitee.definition.model.v4.service.ApiServices;
@@ -367,6 +371,42 @@ class UpdateApiDomainServiceImplTest {
         var result = cut.validateV4(api, auditInfo);
 
         assertThat(result.getApiDefinitionHttpV4().getProperties()).hasSize(1).first().isNotInstanceOf(PropertyEntity.class);
+        verify(delegate, never()).update(any(), any(), any(), anyBoolean(), any());
+    }
+
+    @Test
+    void should_preserve_original_listeners_when_validator_returns_null() {
+        var existingListener = HttpListener.builder()
+            .paths(List.of(Path.builder().path("/original").build()))
+            .entrypoints(List.of(Entrypoint.builder().type("http-proxy").configuration("{}").build()))
+            .build();
+        var originalDefinition = ApiFixtures.aProxyApiV4()
+            .getApiDefinitionHttpV4()
+            .toBuilder()
+            .listeners(List.of(existingListener))
+            .build();
+        var api = ApiFixtures.aProxyApiV4().toBuilder().apiDefinitionHttpV4(originalDefinition).build();
+        stubValidate(entity -> entity.setListeners(null));
+
+        var result = cut.validateV4(api, auditInfo);
+
+        assertThat(result.getApiDefinitionHttpV4().getListeners()).containsExactly(existingListener);
+    }
+
+    @Test
+    void should_return_sanitized_listeners_from_mutated_update_api_entity() {
+        var api = ApiFixtures.aProxyApiV4();
+        List<Listener> sanitizedListeners = List.of(
+            HttpListener.builder()
+                .paths(List.of(Path.builder().path("/sanitized").build()))
+                .entrypoints(List.of(Entrypoint.builder().type("http-proxy").configuration("{}").build()))
+                .build()
+        );
+        stubValidate(entity -> entity.setListeners(sanitizedListeners));
+
+        var result = cut.validateV4(api, auditInfo);
+
+        assertThat(result.getApiDefinitionHttpV4().getListeners()).isEqualTo(sanitizedListeners);
         verify(delegate, never()).update(any(), any(), any(), anyBoolean(), any());
     }
 }


### PR DESCRIPTION
## Issue

[APIM-13947](https://gravitee.atlassian.net/browse/APIM-13947)

## Why

DevOps engineers automating API management via mAPI currently cannot update `listeners` on a v4 HTTP Proxy API without resending the full definition. The PATCH endpoint introduced in APIM-12243 intentionally blocked `listeners` while the field was unimplemented; this change lifts that restriction so automation can make targeted structural updates to listener paths, entrypoints, and CORS — matching v2 PATCH coverage.

## What changed

- **`PatchApiUseCase`**: added `listeners` to `ALLOWED_FIELDS` and `PatchableView`; removed it from `BLOCKED_WITHOUT_HINT`; wired listener resolution through `resolvePatchableList` and into the v4 HTTP Proxy API builder.
- **`UpdateApiDomainServiceImpl`**: propagates sanitized `listeners` back into the dry-run response so callers see validator-injected defaults (e.g. plugin-default entrypoint config) in the `200` body.
- **`openapi-apis.yaml`**: documents `listeners` as a patchable field in the `PATCH /apis/{apiId}` operation description.

## User-facing impact

`listeners` is now a patchable field on `PATCH /management/v2/environments/{envId}/apis/{apiId}` for v4 HTTP Proxy APIs. Callers can make targeted updates to listener paths, entrypoints, and CORS without resending the full definition. Previously, patching `listeners` returned `400`; it now succeeds and runs through the same validation as `PUT`.

## Gotchas / Follow-up

- `endpointGroups` is still blocked; it is handled by a separate technical task.
- `ETag` / `If-Match` concurrency protection is deferred to a follow-up technical task.

[APIM-13947]: https://gravitee.atlassian.net/browse/APIM-13947?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ