### PR TITLE
feat(gamma-apim): add API General page and Entrypoints page

### DIFF
--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/app/AppRoutes.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/app/AppRoutes.tsx
@@ -26,6 +26,8 @@ import { AnalyticsPage } from '../pages/AnalyticsPage';
 import { ApiAlertsPage } from '../pages/ApiAlertsPage';
 import { ApiDetailOverviewPage } from '../pages/ApiDetailOverviewPage';
 import { ApiDetailPlaceholderPage } from '../pages/ApiDetailPlaceholderPage';
+import { ApiEntrypointsPage } from '../pages/ApiEntrypointsPage';
+import { ApiGeneralPage } from '../pages/ApiGeneralPage';
 import { ApiProductsPage } from '../pages/ApiProductsPage';
 import { ApisPage } from '../pages/ApisPage';
 import { ApplicationsPage } from '../pages/ApplicationsPage';
@@ -79,14 +81,14 @@ export function AppRoutes() {
                         <Route path=":apiId" element={<ApiDetailLayout />}>
                             <Route index element={<ApiDetailIndexRedirect />} />
                             <Route path="overview" element={<ApiDetailOverviewPage />} />
-                            <Route path="general" element={<ApiDetailPlaceholderPage title="General" />} />
+                            <Route path="general" element={<ApiGeneralPage />} />
                             <Route path="properties" element={<ApiDetailPlaceholderPage title="API Properties" />} />
                             <Route path="resources" element={<ApiDetailPlaceholderPage title="Resources" />} />
                             <Route path="notifications" element={<ApiDetailPlaceholderPage title="Notifications" />} />
                             <Route path="api-score" element={<ApiDetailPlaceholderPage title="API Score" />} />
                             <Route path="response-templates" element={<ApiDetailPlaceholderPage title="Response Templates" />} />
                             <Route path="cors" element={<ApiDetailPlaceholderPage title="CORS" />} />
-                            <Route path="entrypoints" element={<ApiDetailPlaceholderPage title="Entrypoints" />} />
+                            <Route path="entrypoints" element={<ApiEntrypointsPage />} />
                             <Route path="endpoints">
                                 <Route index element={<Navigate to="list" replace />} />
                                 <Route path="list" element={<ApiDetailPlaceholderPage title="Endpoints" />} />

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/components/detail/entrypoints/ContextPathsCard.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/components/detail/entrypoints/ContextPathsCard.tsx
@@ -1,0 +1,126 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Button, Card, CardContent, Input, Label, Switch, cn } from '@gravitee/graphene-core';
+import { PlusIcon, Trash2Icon } from '@gravitee/graphene-core/icons';
+
+import { InfoTooltip } from './InfoTooltip';
+import type { ContextPathRow } from './types';
+import { validatePath } from './types';
+
+function hasDuplicates(rows: ContextPathRow[]): boolean {
+    const paths = rows.map(r => r.path);
+    return new Set(paths).size !== paths.length;
+}
+
+interface ContextPathsCardProps {
+    rows: ContextPathRow[];
+    onAdd: () => void;
+    onDelete: (id: string) => void;
+    onPathChange: (id: string, path: string) => void;
+    onToggleVirtualHosts: () => void;
+    isReadOnly: boolean;
+}
+
+export function ContextPathsCard({
+    rows,
+    onAdd,
+    onDelete,
+    onPathChange,
+    onToggleVirtualHosts,
+    isReadOnly,
+}: Readonly<ContextPathsCardProps>) {
+    const hasDuplicatePaths = hasDuplicates(rows);
+    const canDelete = rows.length > 1;
+
+    return (
+        <Card>
+            <CardContent className="p-5 space-y-4">
+                {/* Header row */}
+                <div className="flex items-start justify-between gap-4">
+                    <div>
+                        <p className="text-sm font-semibold text-foreground flex items-center">
+                            Entrypoint context-paths
+                            <InfoTooltip text="Each row defines a context path that routes requests to this API through the gateway." />
+                        </p>
+                        <p className="mt-0.5 text-xs text-muted-foreground">
+                            Each row is served under the shared gateway host. Add or remove context paths as needed.
+                        </p>
+                    </div>
+                    {!isReadOnly && (
+                        <div className="flex items-center gap-2 shrink-0">
+                            <span className="text-xs text-muted-foreground whitespace-nowrap">Enable virtual hosts</span>
+                            <Switch checked={false} onCheckedChange={onToggleVirtualHosts} aria-label="Enable virtual hosts" />
+                        </div>
+                    )}
+                </div>
+
+                {/* Column header */}
+                <div>
+                    <Label className="text-xs font-medium text-muted-foreground">Context path</Label>
+                    <p className="text-xs text-muted-foreground mt-0.5">Must start with /. Requests are routed under the gateway host.</p>
+                </div>
+
+                {/* Path rows */}
+                <div className="space-y-2">
+                    {rows.map(row => {
+                        const pathError = validatePath(row.path);
+                        const isDuplicate = hasDuplicatePaths && rows.filter(r => r.path === row.path).length > 1;
+                        const error = isDuplicate ? 'Duplicate context path is not allowed.' : pathError;
+
+                        return (
+                            <div key={row.id} className="flex items-start gap-2">
+                                <div className="flex-1 space-y-1">
+                                    <Input
+                                        value={row.path}
+                                        onChange={e => onPathChange(row.id, e.target.value)}
+                                        placeholder="/"
+                                        disabled={isReadOnly}
+                                        aria-invalid={error !== null}
+                                        aria-label="Context path"
+                                    />
+                                    {error && <p className="text-xs text-destructive">{error}</p>}
+                                </div>
+                                {!isReadOnly && (
+                                    <button
+                                        type="button"
+                                        onClick={() => onDelete(row.id)}
+                                        disabled={!canDelete}
+                                        aria-label="Delete context path"
+                                        className={cn(
+                                            'mt-1 p-1.5 rounded-md transition-colors',
+                                            canDelete
+                                                ? 'text-muted-foreground hover:text-destructive hover:bg-destructive/10'
+                                                : 'text-muted-foreground/30 cursor-not-allowed',
+                                        )}
+                                    >
+                                        <Trash2Icon className="size-4" />
+                                    </button>
+                                )}
+                            </div>
+                        );
+                    })}
+                </div>
+
+                {!isReadOnly && (
+                    <Button variant="outline" size="sm" onClick={onAdd} className="gap-1.5">
+                        <PlusIcon className="size-3.5" />
+                        Add context path
+                    </Button>
+                )}
+            </CardContent>
+        </Card>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/components/detail/entrypoints/CopyButton.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/components/detail/entrypoints/CopyButton.tsx
@@ -1,0 +1,43 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { cn } from '@gravitee/graphene-core';
+import { CircleCheckIcon, CopyIcon } from '@gravitee/graphene-core/icons';
+import { useState } from 'react';
+
+export function CopyButton({ value }: { readonly value: string }) {
+    const [copied, setCopied] = useState(false);
+
+    function handleCopy() {
+        void navigator.clipboard.writeText(value).then(() => {
+            setCopied(true);
+            setTimeout(() => setCopied(false), 1500);
+        });
+    }
+
+    return (
+        <button
+            type="button"
+            onClick={handleCopy}
+            aria-label={`Copy ${value}`}
+            className={cn(
+                'p-1.5 rounded-md transition-colors',
+                copied ? 'text-success' : 'text-muted-foreground hover:text-foreground hover:bg-muted',
+            )}
+        >
+            {copied ? <CircleCheckIcon className="size-4" /> : <CopyIcon className="size-4" />}
+        </button>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/components/detail/entrypoints/EntrypointsLanding.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/components/detail/entrypoints/EntrypointsLanding.tsx
@@ -1,0 +1,77 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Card, CardContent } from '@gravitee/graphene-core';
+import { ArrowRightIcon, CircleCheckIcon, GlobeIcon, ServerIcon, WaypointsIcon } from '@gravitee/graphene-core/icons';
+
+export function EntrypointsLanding() {
+    return (
+        <Card>
+            <CardContent className="p-6 space-y-5">
+                <div>
+                    <p className="text-sm font-semibold text-foreground">Why configure entrypoints?</p>
+                    <p className="mt-1 text-sm text-muted-foreground">
+                        Entrypoints define the URLs consumers use to reach your API. Each context path or virtual host maps to a gateway
+                        listener that routes traffic to your backend.
+                    </p>
+                </div>
+
+                {/* Flow diagram */}
+                <div className="rounded-xl border border-primary/20 bg-primary/5 p-4">
+                    <p className="text-xs font-medium text-primary mb-4">How it works</p>
+                    <div className="flex items-center justify-center gap-4">
+                        <div className="flex flex-col items-center gap-1.5">
+                            <div className="size-10 rounded-xl border bg-card flex items-center justify-center">
+                                <GlobeIcon className="size-4 text-muted-foreground" />
+                            </div>
+                            <span className="text-xs text-muted-foreground">Consumer</span>
+                        </div>
+                        <ArrowRightIcon className="size-4 text-muted-foreground shrink-0" />
+                        <div className="flex flex-col items-center gap-1.5">
+                            <div
+                                className="size-10 rounded-xl border bg-card flex items-center justify-center"
+                                style={{ borderWidth: '2px', borderColor: 'var(--color-primary)' }}
+                            >
+                                <WaypointsIcon className="size-4 text-primary" />
+                            </div>
+                            <span className="text-xs font-medium text-primary">Context path</span>
+                        </div>
+                        <ArrowRightIcon className="size-4 text-muted-foreground shrink-0" />
+                        <div className="flex flex-col items-center gap-1.5">
+                            <div className="size-10 rounded-xl border bg-card flex items-center justify-center">
+                                <ServerIcon className="size-4 text-muted-foreground" />
+                            </div>
+                            <span className="text-xs text-muted-foreground">Gateway</span>
+                        </div>
+                    </div>
+                </div>
+
+                {/* Benefits */}
+                <ul className="space-y-2">
+                    {[
+                        'Expose multiple context paths for versioning or feature routes',
+                        'Virtual host routing for multi-domain gateway deployments',
+                        'Auto-generated portal URLs for developer documentation',
+                    ].map(item => (
+                        <li key={item} className="flex items-start gap-2 text-sm text-muted-foreground">
+                            <CircleCheckIcon className="size-4 text-success shrink-0 mt-0.5" />
+                            {item}
+                        </li>
+                    ))}
+                </ul>
+            </CardContent>
+        </Card>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/components/detail/entrypoints/ExposedEntrypointsCard.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/components/detail/entrypoints/ExposedEntrypointsCard.tsx
@@ -1,0 +1,75 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Card, CardContent, Skeleton } from '@gravitee/graphene-core';
+
+import { CopyButton } from './CopyButton';
+import { InfoTooltip } from './InfoTooltip';
+
+function entrypointLabel(index: number, virtualHostMode: boolean): string {
+    if (virtualHostMode) return `Virtual host row ${index + 1}`;
+    if (index === 0) return 'Gateway URL';
+    if (index === 1) return 'Internal URL';
+    return `URL ${index + 1}`;
+}
+
+interface ExposedEntrypointsCardProps {
+    entrypoints: { value: string }[];
+    isLoading: boolean;
+    virtualHostMode: boolean;
+}
+
+export function ExposedEntrypointsCard({ entrypoints, isLoading, virtualHostMode }: Readonly<ExposedEntrypointsCardProps>) {
+    return (
+        <Card>
+            <CardContent className="p-5 space-y-4">
+                <div>
+                    <p className="text-sm font-semibold text-foreground flex items-center">
+                        Exposed entrypoints
+                        <InfoTooltip text="Preview of gateway URLs for the paths configured above (plus internal routing where applicable)." />
+                    </p>
+                    <p className="mt-0.5 text-xs text-muted-foreground">
+                        Preview of gateway URLs for the paths configured above (plus internal routing where applicable).
+                    </p>
+                </div>
+
+                {isLoading ? (
+                    <div className="space-y-2">
+                        <Skeleton className="h-12 w-full rounded-lg" />
+                        <Skeleton className="h-12 w-full rounded-lg" />
+                    </div>
+                ) : entrypoints.length === 0 ? (
+                    <p className="text-xs text-muted-foreground italic">No exposed entrypoints available.</p>
+                ) : (
+                    <div className="space-y-2">
+                        {entrypoints.map((ep, index) => (
+                            <div
+                                key={ep.value}
+                                className="flex items-center justify-between rounded-lg border px-3 py-2.5 gap-3"
+                                style={{ backgroundColor: 'color-mix(in oklab, var(--color-muted) 40%, transparent)' }}
+                            >
+                                <div className="min-w-0">
+                                    <p className="text-xs text-muted-foreground">{entrypointLabel(index, virtualHostMode)}</p>
+                                    <p className="text-sm font-medium font-mono truncate">{ep.value}</p>
+                                </div>
+                                <CopyButton value={ep.value} />
+                            </div>
+                        ))}
+                    </div>
+                )}
+            </CardContent>
+        </Card>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/components/detail/entrypoints/InfoTooltip.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/components/detail/entrypoints/InfoTooltip.tsx
@@ -1,0 +1,24 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { InfoIcon } from '@gravitee/graphene-core/icons';
+
+export function InfoTooltip({ text }: { readonly text: string }) {
+    return (
+        <span title={text} className="ml-1 inline-flex items-center align-middle cursor-default">
+            <InfoIcon className="size-3.5 text-muted-foreground" aria-hidden />
+        </span>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/components/detail/entrypoints/SwitchModeDialog.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/components/detail/entrypoints/SwitchModeDialog.tsx
@@ -1,0 +1,51 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+    Button,
+    Dialog,
+    DialogClose,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+} from '@gravitee/graphene-core';
+
+export function SwitchModeDialog({ open, onConfirm, onCancel }: Readonly<{ open: boolean; onConfirm: () => void; onCancel: () => void }>) {
+    return (
+        <Dialog open={open} onOpenChange={v => !v && onCancel()}>
+            <DialogContent style={{ maxWidth: '440px' }}>
+                <DialogHeader>
+                    <DialogTitle>Switch to context-path mode</DialogTitle>
+                    <DialogDescription>
+                        By moving back to context-path mode you will lose all virtual-host configuration. The paths you entered will be
+                        preserved. Are you sure you want to continue?
+                    </DialogDescription>
+                </DialogHeader>
+                <DialogFooter>
+                    <DialogClose asChild>
+                        <Button variant="outline" onClick={onCancel}>
+                            Cancel
+                        </Button>
+                    </DialogClose>
+                    <Button variant="destructive" onClick={onConfirm}>
+                        Switch
+                    </Button>
+                </DialogFooter>
+            </DialogContent>
+        </Dialog>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/components/detail/entrypoints/VirtualHostsCard.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/components/detail/entrypoints/VirtualHostsCard.tsx
@@ -1,0 +1,151 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Button, Card, CardContent, Input, Switch } from '@gravitee/graphene-core';
+import { PlusIcon, Trash2Icon } from '@gravitee/graphene-core/icons';
+
+import { InfoTooltip } from './InfoTooltip';
+import type { VirtualHostRow } from './types';
+import { validatePath } from './types';
+
+interface VirtualHostsCardProps {
+    rows: VirtualHostRow[];
+    onAdd: () => void;
+    onDelete: (id: string) => void;
+    onFieldChange: (id: string, field: 'host' | 'path' | 'overrideAccess', value: string | boolean) => void;
+    onDisableVirtualHosts: () => void;
+    isReadOnly: boolean;
+}
+
+export function VirtualHostsCard({
+    rows,
+    onAdd,
+    onDelete,
+    onFieldChange,
+    onDisableVirtualHosts,
+    isReadOnly,
+}: Readonly<VirtualHostsCardProps>) {
+    return (
+        <Card>
+            <CardContent className="p-5 space-y-4">
+                {/* Header row */}
+                <div className="flex items-start justify-between gap-4">
+                    <div>
+                        <p className="text-sm font-semibold text-foreground flex items-center">
+                            Virtual hosts
+                            <InfoTooltip text="Map Virtual host, Context path, and Override access per row — matching the management console listener configuration." />
+                        </p>
+                        <p className="mt-0.5 text-xs text-muted-foreground">
+                            Map Virtual host, Context path, and Override access per row — matching the management console listener
+                            configuration.
+                        </p>
+                    </div>
+                    {!isReadOnly && (
+                        <div className="flex items-center gap-2 shrink-0">
+                            <span className="text-xs text-muted-foreground whitespace-nowrap">Enable virtual hosts</span>
+                            <Switch checked={true} onCheckedChange={onDisableVirtualHosts} aria-label="Enable virtual hosts" />
+                        </div>
+                    )}
+                </div>
+
+                {/* Column headers */}
+                <div className="grid gap-2" style={{ gridTemplateColumns: '1fr 1fr auto auto' }}>
+                    <div>
+                        <p className="text-xs font-medium text-muted-foreground">Virtual host</p>
+                        <p className="text-xs text-muted-foreground">
+                            Host that must be set in the HTTP request to access this entrypoint.
+                        </p>
+                    </div>
+                    <div>
+                        <p className="text-xs font-medium text-muted-foreground flex items-center">
+                            Context path
+                            <InfoTooltip text="Path segment appended to the virtual host for this listener." />
+                        </p>
+                        <p className="text-xs text-muted-foreground">Path segment appended to the virtual host for this listener.</p>
+                    </div>
+                    <div>
+                        <p className="text-xs font-medium text-muted-foreground flex items-center">
+                            Override access
+                            <InfoTooltip text="Portal access URL override for this virtual host." />
+                        </p>
+                        <p className="text-xs text-muted-foreground">Portal access URL override for this virtual host.</p>
+                    </div>
+                    <div />
+                </div>
+
+                {/* Host rows */}
+                <div className="space-y-2">
+                    {rows.map(row => {
+                        const pathError = validatePath(row.path);
+                        return (
+                            <div key={row.id} className="grid items-start gap-2" style={{ gridTemplateColumns: '1fr 1fr auto auto' }}>
+                                <Input
+                                    value={row.host}
+                                    onChange={e => onFieldChange(row.id, 'host', e.target.value)}
+                                    placeholder="api.company.com"
+                                    disabled={isReadOnly}
+                                    aria-label="Virtual host"
+                                />
+                                <div className="space-y-1">
+                                    <Input
+                                        value={row.path}
+                                        onChange={e => onFieldChange(row.id, 'path', e.target.value)}
+                                        placeholder="/"
+                                        disabled={isReadOnly}
+                                        aria-label="Context path"
+                                        aria-invalid={pathError !== null}
+                                    />
+                                    {pathError && <p className="text-xs text-destructive">{pathError}</p>}
+                                </div>
+                                <div className="flex items-center justify-center gap-1.5 pt-2">
+                                    <Switch
+                                        checked={row.overrideAccess}
+                                        onCheckedChange={v => onFieldChange(row.id, 'overrideAccess', v)}
+                                        disabled={isReadOnly}
+                                        aria-label="Enable override access"
+                                    />
+                                    <span className="text-xs text-muted-foreground">Enable</span>
+                                </div>
+                                {!isReadOnly && (
+                                    <button
+                                        type="button"
+                                        onClick={() => onDelete(row.id)}
+                                        aria-label="Delete virtual host row"
+                                        className="p-1.5 mt-1 rounded-md text-muted-foreground hover:text-destructive hover:bg-destructive/10 transition-colors"
+                                    >
+                                        <Trash2Icon className="size-4" />
+                                    </button>
+                                )}
+                            </div>
+                        );
+                    })}
+                </div>
+
+                {!isReadOnly && (
+                    <Button variant="outline" size="sm" onClick={onAdd} className="gap-1.5">
+                        <PlusIcon className="size-3.5" />
+                        Add virtual host row
+                    </Button>
+                )}
+
+                <p className="text-xs text-muted-foreground flex items-start gap-1.5">
+                    <span className="shrink-0">↕</span>
+                    Switching off virtual hosts keeps separate context-path and virtual-host lists; host-specific values are not applied
+                    until you enable virtual hosts again.
+                </p>
+            </CardContent>
+        </Card>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/components/detail/entrypoints/types.ts
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/components/detail/entrypoints/types.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export interface ContextPathRow {
+    id: string;
+    path: string;
+}
+
+export interface VirtualHostRow {
+    id: string;
+    host: string;
+    path: string;
+    overrideAccess: boolean;
+}
+
+export function validatePath(path: string): string | null {
+    if (!path.trim()) return 'Path is required.';
+    if (!path.startsWith('/')) return 'Path must start with /.';
+    return null;
+}

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/components/detail/general/ChipInput.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/components/detail/general/ChipInput.tsx
@@ -1,0 +1,65 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Badge } from '@gravitee/graphene-core';
+import { XIcon } from '@gravitee/graphene-core/icons';
+import { useState } from 'react';
+
+export function ChipInput({
+    id,
+    values,
+    onChange,
+    placeholder,
+}: Readonly<{ id?: string; values: string[]; onChange: (next: string[]) => void; placeholder: string }>) {
+    const [draft, setDraft] = useState('');
+
+    const add = (v: string) => {
+        const trimmed = v.trim();
+        if (!trimmed || values.includes(trimmed)) return;
+        onChange([...values, trimmed]);
+        setDraft('');
+    };
+
+    const remove = (v: string) => onChange(values.filter(x => x !== v));
+
+    return (
+        <div className="flex flex-wrap gap-1.5 rounded-md border bg-muted/30 p-2" style={{ minHeight: '38px' }}>
+            {values.map(v => (
+                <Badge key={v} variant="secondary" style={{ fontSize: '11px', gap: '2px' }}>
+                    {v}
+                    <button type="button" onClick={() => remove(v)} className="hover:text-destructive ml-0.5" aria-label={`Remove ${v}`}>
+                        <XIcon className="size-3" />
+                    </button>
+                </Badge>
+            ))}
+            <input
+                id={id}
+                className="flex-1 bg-transparent outline-none text-sm"
+                style={{ minWidth: '100px' }}
+                placeholder={placeholder}
+                value={draft}
+                onChange={e => setDraft(e.target.value)}
+                onKeyDown={e => {
+                    if (e.key === 'Enter' || e.key === ',') {
+                        e.preventDefault();
+                        add(draft);
+                    } else if (e.key === 'Backspace' && !draft && values.length) {
+                        remove(values[values.length - 1]);
+                    }
+                }}
+            />
+        </div>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/components/detail/general/DeleteDialog.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/components/detail/general/DeleteDialog.tsx
@@ -1,0 +1,88 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+    Button,
+    Dialog,
+    DialogClose,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+    Input,
+    Label,
+} from '@gravitee/graphene-core';
+import { Trash2Icon } from '@gravitee/graphene-core/icons';
+import { useEffect, useState } from 'react';
+
+export function DeleteDialog({
+    open,
+    onOpenChange,
+    apiName,
+    onDelete,
+    isLoading,
+    error,
+}: Readonly<{
+    open: boolean;
+    onOpenChange: (v: boolean) => void;
+    apiName: string;
+    onDelete: () => void;
+    isLoading: boolean;
+    error?: string | null;
+}>) {
+    const [confirm, setConfirm] = useState('');
+
+    useEffect(() => {
+        if (!open) setConfirm('');
+    }, [open]);
+
+    return (
+        <Dialog open={open} onOpenChange={onOpenChange}>
+            <DialogContent>
+                <DialogHeader>
+                    <DialogTitle>Delete API permanently?</DialogTitle>
+                    <DialogDescription>
+                        This will permanently delete <strong>{apiName}</strong> along with all plans, subscriptions, and analytics data.
+                        This action cannot be undone.
+                    </DialogDescription>
+                </DialogHeader>
+                <div className="py-2 space-y-2">
+                    <Label htmlFor="delete-confirm">
+                        Type <span className="font-mono font-semibold">{apiName}</span> to confirm
+                    </Label>
+                    <Input
+                        id="delete-confirm"
+                        value={confirm}
+                        onChange={e => setConfirm(e.target.value)}
+                        placeholder={apiName}
+                        autoComplete="off"
+                    />
+                    {error && <p className="text-sm text-destructive">{error}</p>}
+                </div>
+                <DialogFooter>
+                    <DialogClose asChild>
+                        <Button type="button" variant="outline">
+                            Cancel
+                        </Button>
+                    </DialogClose>
+                    <Button type="button" variant="destructive" disabled={confirm !== apiName || isLoading} onClick={onDelete}>
+                        <Trash2Icon className="size-4" /> {isLoading ? 'Deleting…' : 'Delete permanently'}
+                    </Button>
+                </DialogFooter>
+            </DialogContent>
+        </Dialog>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/components/detail/general/DuplicateDialog.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/components/detail/general/DuplicateDialog.tsx
@@ -1,0 +1,104 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+    Button,
+    Dialog,
+    DialogClose,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+    Input,
+    Label,
+} from '@gravitee/graphene-core';
+import { CopyIcon } from '@gravitee/graphene-core/icons';
+import { useEffect, useState } from 'react';
+
+export function DuplicateDialog({
+    open,
+    onOpenChange,
+    initialName,
+    initialVersion,
+    onDuplicate,
+    isLoading,
+    error,
+}: Readonly<{
+    open: boolean;
+    onOpenChange: (v: boolean) => void;
+    initialName: string;
+    initialVersion: string;
+    onDuplicate: (opts: { version: string; contextPath: string }) => void;
+    isLoading: boolean;
+    error?: string | null;
+}>) {
+    const [version, setVersion] = useState(initialVersion);
+    const [contextPath, setContextPath] = useState('');
+
+    useEffect(() => {
+        if (open) {
+            setVersion(initialVersion);
+            setContextPath('');
+        }
+    }, [open, initialVersion]);
+
+    return (
+        <Dialog open={open} onOpenChange={onOpenChange}>
+            <DialogContent style={{ maxWidth: '512px' }}>
+                <DialogHeader>
+                    <DialogTitle>Duplicate API</DialogTitle>
+                    <DialogDescription>
+                        Create a copy of <strong>{initialName}</strong>. Subscriptions are not copied.
+                    </DialogDescription>
+                </DialogHeader>
+                <div className="space-y-3 py-2">
+                    <div className="space-y-1">
+                        <Label htmlFor="dup-version">
+                            Version <span className="text-destructive">*</span>
+                        </Label>
+                        <Input id="dup-version" value={version} onChange={e => setVersion(e.target.value)} placeholder="v1.0.0" />
+                    </div>
+                    <div className="space-y-1">
+                        <Label htmlFor="dup-path">
+                            Context Path <span className="text-muted-foreground text-xs font-normal">(optional)</span>
+                        </Label>
+                        <Input
+                            id="dup-path"
+                            value={contextPath}
+                            onChange={e => setContextPath(e.target.value)}
+                            placeholder="/my-api/v1-copy"
+                        />
+                    </div>
+                    {error && <p className="text-sm text-destructive">{error}</p>}
+                </div>
+                <DialogFooter>
+                    <DialogClose asChild>
+                        <Button type="button" variant="outline">
+                            Cancel
+                        </Button>
+                    </DialogClose>
+                    <Button
+                        type="button"
+                        disabled={!version.trim() || isLoading}
+                        onClick={() => onDuplicate({ version: version.trim(), contextPath: contextPath.trim() })}
+                    >
+                        <CopyIcon className="size-4" /> {isLoading ? 'Duplicating…' : 'Duplicate'}
+                    </Button>
+                </DialogFooter>
+            </DialogContent>
+        </Dialog>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/components/detail/general/ExportDialog.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/components/detail/general/ExportDialog.tsx
@@ -1,0 +1,64 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+    Button,
+    Dialog,
+    DialogClose,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+} from '@gravitee/graphene-core';
+import { DownloadIcon } from '@gravitee/graphene-core/icons';
+
+export function ExportDialog({
+    open,
+    onOpenChange,
+    onExport,
+}: Readonly<{ open: boolean; onOpenChange: (v: boolean) => void; onExport: () => void }>) {
+    return (
+        <Dialog open={open} onOpenChange={onOpenChange}>
+            <DialogContent className="sm:max-w-lg">
+                <DialogHeader>
+                    <DialogTitle>Export API Definition</DialogTitle>
+                    <DialogDescription>Download the full API definition as a Gravitee JSON file.</DialogDescription>
+                </DialogHeader>
+                <div className="py-2">
+                    <p className="rounded-md bg-muted/30 border p-3 text-sm text-muted-foreground">
+                        The exported file contains the complete API definition. Plans, members, and documentation pages are not included.
+                    </p>
+                </div>
+                <DialogFooter>
+                    <DialogClose asChild>
+                        <Button type="button" variant="outline">
+                            Cancel
+                        </Button>
+                    </DialogClose>
+                    <Button
+                        type="button"
+                        onClick={() => {
+                            onExport();
+                            onOpenChange(false);
+                        }}
+                    >
+                        <DownloadIcon className="size-4" /> Export
+                    </Button>
+                </DialogFooter>
+            </DialogContent>
+        </Dialog>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/components/detail/general/ImagePicker.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/components/detail/general/ImagePicker.tsx
@@ -1,0 +1,116 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { cn } from '@gravitee/graphene-core';
+import { UploadIcon } from '@gravitee/graphene-core/icons';
+import { useCallback, useRef, useState } from 'react';
+
+const MAX_SIZE_BYTES = 500 * 1024;
+
+function fileToBase64(file: File): Promise<string> {
+    return new Promise((resolve, reject) => {
+        const reader = new FileReader();
+        reader.onload = () => resolve(reader.result as string);
+        reader.onerror = reject;
+        reader.readAsDataURL(file);
+    });
+}
+
+export function ImagePicker({
+    label,
+    preview,
+    width,
+    height,
+    onSelect,
+    onRemove,
+    disabled,
+}: Readonly<{
+    label: string;
+    preview?: string;
+    width: number;
+    height: number;
+    onSelect: (base64: string) => void;
+    onRemove: () => void;
+    disabled?: boolean;
+}>) {
+    const inputRef = useRef<HTMLInputElement>(null);
+    const [sizeError, setSizeError] = useState<string | null>(null);
+
+    const handleFile = useCallback(
+        async (file: File) => {
+            if (file.size > MAX_SIZE_BYTES) {
+                setSizeError('File exceeds 500 KB limit.');
+                return;
+            }
+            setSizeError(null);
+            const base64 = await fileToBase64(file);
+            onSelect(base64);
+        },
+        [onSelect],
+    );
+
+    return (
+        <div className="space-y-1 text-center">
+            <div
+                role="button"
+                tabIndex={0}
+                onClick={() => !disabled && inputRef.current?.click()}
+                onKeyDown={e => !disabled && (e.key === 'Enter' || e.key === ' ') && inputRef.current?.click()}
+                className={cn(
+                    'flex items-center justify-center rounded-xl border-dashed border-border transition-colors overflow-hidden',
+                    disabled ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer hover:border-primary/50',
+                )}
+                style={{
+                    width,
+                    height,
+                    borderWidth: '2px',
+                    backgroundColor: 'color-mix(in oklab, var(--color-muted) 40%, transparent)',
+                }}
+                aria-label={`Upload ${label}`}
+            >
+                {preview ? (
+                    <img src={preview} alt={label} className="w-full h-full object-cover" />
+                ) : (
+                    <UploadIcon className="size-6 text-muted-foreground" />
+                )}
+            </div>
+            <p className="text-muted-foreground" style={{ fontSize: '10px' }}>
+                {label}
+            </p>
+            {sizeError && <p className="text-xs text-destructive">{sizeError}</p>}
+            {preview && !disabled && (
+                <button
+                    type="button"
+                    onClick={onRemove}
+                    className="text-destructive hover:underline block mx-auto"
+                    style={{ fontSize: '10px' }}
+                >
+                    Remove
+                </button>
+            )}
+            <input
+                ref={inputRef}
+                type="file"
+                accept="image/png,image/jpeg,image/svg+xml"
+                className="sr-only"
+                onChange={e => {
+                    const file = e.target.files?.[0];
+                    if (file) void handleFile(file);
+                    e.target.value = '';
+                }}
+            />
+        </div>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/components/detail/general/ImportDialog.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/components/detail/general/ImportDialog.tsx
@@ -1,0 +1,119 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+    Button,
+    Dialog,
+    DialogClose,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+} from '@gravitee/graphene-core';
+import { FileUpIcon, UploadIcon } from '@gravitee/graphene-core/icons';
+import { useRef, useState } from 'react';
+
+export function ImportDialog({
+    open,
+    onOpenChange,
+    onImport,
+    isLoading,
+    error,
+}: Readonly<{
+    open: boolean;
+    onOpenChange: (v: boolean) => void;
+    onImport: (definition: unknown) => void;
+    isLoading: boolean;
+    error?: string | null;
+}>) {
+    const inputRef = useRef<HTMLInputElement>(null);
+    const [fileName, setFileName] = useState<string | null>(null);
+    const [definition, setDefinition] = useState<unknown>(null);
+    const [parseError, setParseError] = useState<string | null>(null);
+
+    const handleFile = async (file: File) => {
+        setParseError(null);
+        setFileName(file.name);
+        try {
+            setDefinition(JSON.parse(await file.text()) as unknown);
+        } catch {
+            setParseError('Invalid JSON. Please upload a valid Gravitee API definition file.');
+            setDefinition(null);
+        }
+    };
+
+    const reset = () => {
+        setFileName(null);
+        setDefinition(null);
+        setParseError(null);
+    };
+
+    return (
+        <Dialog
+            open={open}
+            onOpenChange={v => {
+                onOpenChange(v);
+                if (!v) reset();
+            }}
+        >
+            <DialogContent style={{ maxWidth: '512px' }}>
+                <DialogHeader>
+                    <DialogTitle>Import API Definition</DialogTitle>
+                    <DialogDescription>Upload a Gravitee JSON definition to overwrite the current API configuration.</DialogDescription>
+                </DialogHeader>
+                <div className="py-2 space-y-3">
+                    <div
+                        role="button"
+                        tabIndex={0}
+                        onClick={() => inputRef.current?.click()}
+                        onKeyDown={e => (e.key === 'Enter' || e.key === ' ') && inputRef.current?.click()}
+                        className="flex items-center justify-center rounded-lg border-dashed bg-muted/40 p-6 cursor-pointer hover:border-primary/40 transition-colors"
+                        style={{ borderWidth: '2px' }}
+                    >
+                        <div className="text-center space-y-1">
+                            <FileUpIcon className="size-7 text-muted-foreground mx-auto" />
+                            <p className="text-sm font-medium">{fileName ?? 'Drop file here or click to browse'}</p>
+                            <p className="text-xs text-muted-foreground">Gravitee JSON</p>
+                        </div>
+                    </div>
+                    {parseError && <p className="text-xs text-destructive">{parseError}</p>}
+                    {error && <p className="text-sm text-destructive">{error}</p>}
+                    <input
+                        ref={inputRef}
+                        type="file"
+                        accept=".json,application/json"
+                        className="sr-only"
+                        onChange={async e => {
+                            const file = e.target.files?.[0];
+                            if (file) await handleFile(file);
+                            e.target.value = '';
+                        }}
+                    />
+                </div>
+                <DialogFooter>
+                    <DialogClose asChild>
+                        <Button type="button" variant="outline" onClick={reset}>
+                            Cancel
+                        </Button>
+                    </DialogClose>
+                    <Button type="button" disabled={!definition || isLoading} onClick={() => definition && onImport(definition)}>
+                        <UploadIcon className="size-4" /> {isLoading ? 'Importing…' : 'Import'}
+                    </Button>
+                </DialogFooter>
+            </DialogContent>
+        </Dialog>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/components/detail/general/PromoteDialog.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/components/detail/general/PromoteDialog.tsx
@@ -1,0 +1,51 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+    Button,
+    Dialog,
+    DialogClose,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+} from '@gravitee/graphene-core';
+
+export function PromoteDialog({ open, onOpenChange }: Readonly<{ open: boolean; onOpenChange: (v: boolean) => void }>) {
+    return (
+        <Dialog open={open} onOpenChange={onOpenChange}>
+            <DialogContent className="sm:max-w-lg">
+                <DialogHeader>
+                    <DialogTitle>Promote API</DialogTitle>
+                    <DialogDescription>Replicate this API to another environment via Gravitee Cloud.</DialogDescription>
+                </DialogHeader>
+                <div className="py-2">
+                    <p className="rounded-md bg-muted/30 border p-3 text-sm text-muted-foreground">
+                        API promotion is managed through Gravitee Cockpit. Connect your environment to Gravitee Cloud to enable
+                        cross-environment promotion.
+                    </p>
+                </div>
+                <DialogFooter>
+                    <DialogClose asChild>
+                        <Button type="button" variant="outline">
+                            Close
+                        </Button>
+                    </DialogClose>
+                </DialogFooter>
+            </DialogContent>
+        </Dialog>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/components/steps/EntrypointsStep.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/components/steps/EntrypointsStep.tsx
@@ -16,14 +16,15 @@
 import { Button, Input, Label, Switch } from '@gravitee/graphene-core';
 import { PlusIcon, ServerIcon, Trash2Icon } from '@gravitee/graphene-core/icons';
 
+import { useGatewayPrefix } from '../../hooks/useGatewayPrefix';
 import { useVerifyContextPath } from '../../hooks/useVerifyContextPath';
 import { useApiCreation } from '../../store/apiCreationStore';
 import type { VirtualHostEntry } from '../../types/apiCreation';
-import { GATEWAY_URL_PLACEHOLDER } from '../../utils/apiProxyMapper';
 
 export function EntrypointsStep() {
     const { state, dispatch } = useApiCreation();
     const { form, validationErrors: errors } = state;
+    const gatewayPrefix = useGatewayPrefix();
     useVerifyContextPath();
 
     function update(patch: Partial<typeof form>) {
@@ -120,7 +121,7 @@ export function EntrypointsStep() {
                                     className="flex items-center px-3 text-sm font-mono text-muted-foreground whitespace-nowrap border-r bg-muted/30 select-none"
                                     aria-hidden
                                 >
-                                    {GATEWAY_URL_PLACEHOLDER}
+                                    {gatewayPrefix}
                                 </span>
                                 <Input
                                     id="context-path"

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/components/steps/EssentialsStep.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/components/steps/EssentialsStep.tsx
@@ -18,14 +18,15 @@ import { ServerIcon, ShieldIcon } from '@gravitee/graphene-core/icons';
 import type { CSSProperties } from 'react';
 
 import { SecurityPlanFields } from './SecurityPlanFields';
+import { useGatewayPrefix } from '../../hooks/useGatewayPrefix';
 import { useVerifyContextPath } from '../../hooks/useVerifyContextPath';
 import { useApiCreation } from '../../store/apiCreationStore';
-import { GATEWAY_URL_PLACEHOLDER } from '../../utils/apiProxyMapper';
 import { AUTH_LABEL } from '../../utils/securityFormatters';
 
 export function EssentialsStep() {
     const { state, dispatch } = useApiCreation();
     const { form, validationErrors: errors } = state;
+    const gatewayPrefix = useGatewayPrefix();
     useVerifyContextPath();
 
     function update(patch: Partial<typeof form>) {
@@ -88,6 +89,34 @@ export function EssentialsStep() {
                     <p className="text-xs text-muted-foreground text-right">{form.apiDescription.length}/250</p>
                 </div>
 
+                {/* Context Path with gateway prefix */}
+                <div className="space-y-2">
+                    <Label htmlFor="essentials-context-path">
+                        Context path <span className="text-destructive">*</span>
+                    </Label>
+                    <div
+                        className="flex items-stretch rounded-md border overflow-hidden"
+                        style={errors['contextPath'] ? { borderColor: 'var(--color-destructive)' } : undefined}
+                    >
+                        <span
+                            className="flex items-center px-3 text-sm font-mono text-muted-foreground whitespace-nowrap border-r bg-muted/30 select-none"
+                            aria-hidden
+                        >
+                            {gatewayPrefix}
+                        </span>
+                        <Input
+                            id="essentials-context-path"
+                            placeholder="/my-api"
+                            value={form.contextPath}
+                            onChange={e => update({ contextPath: e.target.value })}
+                            aria-invalid={Boolean(errors['contextPath'])}
+                            style={{ border: 'none', borderRadius: 0, boxShadow: 'none', flex: 1, fontFamily: 'monospace' }}
+                        />
+                    </div>
+                    {errors['contextPath'] && <p className="text-xs text-destructive">{errors['contextPath']}</p>}
+                    <p className="text-xs text-muted-foreground">Path prefix clients use to reach this API on the gateway.</p>
+                </div>
+
                 {/* Target URL */}
                 <div className="space-y-2">
                     <Label htmlFor="essentials-target-url">
@@ -109,34 +138,6 @@ export function EssentialsStep() {
                     </div>
                     {errors['targetUrl'] && <p className="text-xs text-destructive">{errors['targetUrl']}</p>}
                     <p className="text-xs text-muted-foreground">The upstream backend the gateway will forward requests to.</p>
-                </div>
-
-                {/* Context Path with gateway prefix */}
-                <div className="space-y-2">
-                    <Label htmlFor="essentials-context-path">
-                        Context path <span className="text-destructive">*</span>
-                    </Label>
-                    <div
-                        className="flex items-stretch rounded-md border overflow-hidden"
-                        style={errors['contextPath'] ? { borderColor: 'var(--color-destructive)' } : undefined}
-                    >
-                        <span
-                            className="flex items-center px-3 text-sm font-mono text-muted-foreground whitespace-nowrap border-r bg-muted/30 select-none"
-                            aria-hidden
-                        >
-                            {GATEWAY_URL_PLACEHOLDER}
-                        </span>
-                        <Input
-                            id="essentials-context-path"
-                            placeholder="/my-api"
-                            value={form.contextPath}
-                            onChange={e => update({ contextPath: e.target.value })}
-                            aria-invalid={Boolean(errors['contextPath'])}
-                            style={{ border: 'none', borderRadius: 0, boxShadow: 'none', flex: 1, fontFamily: 'monospace' }}
-                        />
-                    </div>
-                    {errors['contextPath'] && <p className="text-xs text-destructive">{errors['contextPath']}</p>}
-                    <p className="text-xs text-muted-foreground">Path prefix clients use to reach this API on the gateway.</p>
                 </div>
 
                 {/* Security — pre-configured from template */}

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/components/steps/ReviewDeployStep.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/components/steps/ReviewDeployStep.tsx
@@ -19,6 +19,7 @@ import type { ReactNode } from 'react';
 import { useState } from 'react';
 
 import { SecurityPlanFields } from './SecurityPlanFields';
+import { useGatewayPrefix } from '../../hooks/useGatewayPrefix';
 import { useApiCreation } from '../../store/apiCreationStore';
 import { buildPlanName, buildPreviewGatewayUrl } from '../../utils/apiProxyMapper';
 import { AUTH_LABEL } from '../../utils/securityFormatters';
@@ -91,7 +92,8 @@ export function ReviewDeployStep() {
         dispatch({ type: 'SET_STEP', step });
     }
 
-    const gatewayUrl = buildPreviewGatewayUrl(form);
+    const gatewayPrefix = useGatewayPrefix();
+    const gatewayUrl = buildPreviewGatewayUrl(form, gatewayPrefix);
     const planName = buildPlanName(form);
 
     // template: step 0 = Essentials (covers details + proxy + security)

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/components/wizard/ProxyFlowVisualization.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/components/wizard/ProxyFlowVisualization.tsx
@@ -15,6 +15,7 @@
  */
 import { cn } from '@gravitee/graphene-core';
 
+import { useGatewayPrefix } from '../../hooks/useGatewayPrefix';
 import { useApiCreation } from '../../store/apiCreationStore';
 import { buildPreviewGatewayUrl } from '../../utils/apiProxyMapper';
 import { AUTH_LABEL } from '../../utils/securityFormatters';
@@ -116,6 +117,7 @@ interface ProxyFlowVisualizationProps {
 export function ProxyFlowVisualization({ mode }: ProxyFlowVisualizationProps) {
     const { state } = useApiCreation();
     const { form, step } = state;
+    const gatewayPrefix = useGatewayPrefix();
 
     const client = nodeState('client', mode, step);
     const gateway = nodeState('gateway', mode, step);
@@ -123,7 +125,7 @@ export function ProxyFlowVisualization({ mode }: ProxyFlowVisualizationProps) {
     const upstream = nodeState('upstream', mode, step);
 
     // Strip protocol prefix — URL is already clear from context
-    const gatewayDisplay = buildPreviewGatewayUrl(form).replace(/^https?:\/\//, '');
+    const gatewayDisplay = buildPreviewGatewayUrl(form, gatewayPrefix).replace(/^https?:\/\//, '');
     const upstreamDisplay = form.targetUrl.trim() || 'upstream:port';
     const securityLabel = AUTH_LABEL[form.authType];
     const caption = stepCaption(mode, step);

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/hooks/useApiEntrypoints.ts
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/hooks/useApiEntrypoints.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useEnvironment } from '@gravitee/gamma-modules-sdk';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useParams } from 'react-router-dom';
+
+import { getExposedEntrypoints, updateApiListeners } from '../../../services/apis/entrypoints';
+import { useApiDetailContext } from '../context/ApiDetailContext';
+import type { HttpListener } from '../types/api';
+import { apiDetailKeys, apiEntrypointKeys } from '../utils/queryKeys';
+
+export function useApiEntrypoints(showConfig: boolean) {
+    const { api } = useApiDetailContext();
+    const { apiId } = useParams<{ apiId: string }>();
+    const env = useEnvironment();
+    const queryClient = useQueryClient();
+
+    const exposedQuery = useQuery({
+        queryKey: apiEntrypointKeys.exposed(env?.id ?? '', apiId ?? ''),
+        queryFn: () => getExposedEntrypoints(env!.id, apiId!),
+        enabled: Boolean(env && apiId && showConfig),
+        staleTime: 30_000,
+    });
+
+    const saveMutation = useMutation({
+        mutationFn: (listeners: HttpListener[]) => updateApiListeners(env!.id, apiId!, api!, listeners),
+        onSuccess: () => {
+            void queryClient.invalidateQueries({ queryKey: apiDetailKeys.detail(env?.id ?? '', apiId ?? '') });
+            void queryClient.invalidateQueries({ queryKey: apiEntrypointKeys.exposed(env?.id ?? '', apiId ?? '') });
+        },
+    });
+
+    return { exposedQuery, saveMutation };
+}

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/hooks/useApiGeneralMutations.ts
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/hooks/useApiGeneralMutations.ts
@@ -1,0 +1,122 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useEnvironment } from '@gravitee/gamma-modules-sdk';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useRef } from 'react';
+import { useParams } from 'react-router-dom';
+
+import {
+    deleteApi,
+    deleteApiBackground,
+    deleteApiPicture,
+    duplicateApi,
+    startApi,
+    stopApi,
+    updateApiBackground,
+    updateApiFromDefinition,
+    updateApiGeneral,
+    updateApiPicture,
+} from '../../../services/apis/apis';
+import type { ApiDetailDto } from '../types/api';
+import { apiDetailKeys } from '../utils/queryKeys';
+
+interface ApiGeneralSideEffects {
+    onDeleteSuccess?: () => void;
+    onDuplicateSuccess?: (newApi: ApiDetailDto) => void;
+    onImportSuccess?: (updatedApi: ApiDetailDto) => void;
+}
+
+export function useApiGeneralMutations(api: ApiDetailDto | null, sideEffects: ApiGeneralSideEffects = {}) {
+    const { apiId } = useParams<{ apiId: string }>();
+    const env = useEnvironment();
+    const queryClient = useQueryClient();
+
+    // Keep callbacks in a ref so mutations always call the latest version
+    const sideEffectsRef = useRef(sideEffects);
+    sideEffectsRef.current = sideEffects;
+
+    const invalidateDetail = () => void queryClient.invalidateQueries({ queryKey: apiDetailKeys.detail(env?.id ?? '', apiId ?? '') });
+
+    const saveMutation = useMutation({
+        mutationFn: (patch: Partial<ApiDetailDto>) => updateApiGeneral(env!.id, apiId!, api!, patch),
+        onSuccess: invalidateDetail,
+    });
+
+    const startMutation = useMutation({
+        mutationFn: () => startApi(env!.id, apiId!),
+        onSuccess: invalidateDetail,
+    });
+
+    const stopMutation = useMutation({
+        mutationFn: () => stopApi(env!.id, apiId!),
+        onSuccess: invalidateDetail,
+    });
+
+    const deleteMutation = useMutation({
+        mutationFn: () => deleteApi(env!.id, apiId!),
+        onSuccess: () => sideEffectsRef.current.onDeleteSuccess?.(),
+    });
+
+    const duplicateMutation = useMutation({
+        mutationFn: (opts: { version: string; contextPath: string }) =>
+            duplicateApi(env!.id, apiId!, {
+                version: opts.version,
+                ...(opts.contextPath ? { contextPath: opts.contextPath } : {}),
+            }),
+        onSuccess: newApi => sideEffectsRef.current.onDuplicateSuccess?.(newApi),
+    });
+
+    const importMutation = useMutation({
+        mutationFn: (definition: unknown) => updateApiFromDefinition(env!.id, apiId!, definition),
+        onSuccess: updatedApi => {
+            invalidateDetail();
+            sideEffectsRef.current.onImportSuccess?.(updatedApi);
+        },
+    });
+
+    const pictureMutation = useMutation({
+        mutationFn: (b64: string) => updateApiPicture(env!.id, apiId!, b64),
+        onSuccess: invalidateDetail,
+    });
+
+    const removePictureMutation = useMutation({
+        mutationFn: () => deleteApiPicture(env!.id, apiId!),
+        onSuccess: invalidateDetail,
+    });
+
+    const backgroundMutation = useMutation({
+        mutationFn: (b64: string) => updateApiBackground(env!.id, apiId!, b64),
+        onSuccess: invalidateDetail,
+    });
+
+    const removeBackgroundMutation = useMutation({
+        mutationFn: () => deleteApiBackground(env!.id, apiId!),
+        onSuccess: invalidateDetail,
+    });
+
+    return {
+        saveMutation,
+        startMutation,
+        stopMutation,
+        deleteMutation,
+        duplicateMutation,
+        importMutation,
+        pictureMutation,
+        removePictureMutation,
+        backgroundMutation,
+        removeBackgroundMutation,
+    };
+}

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/hooks/useGatewayPrefix.ts
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/hooks/useGatewayPrefix.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useEnvironment } from '@gravitee/gamma-modules-sdk';
+import { useQuery } from '@tanstack/react-query';
+
+import { getEnvironmentPortalSettings } from '../../../services/portal/settings';
+import { GATEWAY_URL_PLACEHOLDER } from '../utils/apiProxyMapper';
+import { portalSettingsKeys } from '../utils/queryKeys';
+
+export function useGatewayPrefix(): string {
+    const env = useEnvironment();
+    const { data } = useQuery({
+        queryKey: portalSettingsKeys.env(env?.id ?? ''),
+        queryFn: () => getEnvironmentPortalSettings(env!.id),
+        enabled: Boolean(env?.id),
+        staleTime: 5 * 60_000,
+    });
+    const entrypoint = data?.portal?.entrypoint?.replace(/\/$/, '');
+    return entrypoint || GATEWAY_URL_PLACEHOLDER;
+}

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/store/apiCreationStore.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/store/apiCreationStore.tsx
@@ -31,7 +31,7 @@ const INITIAL_FORM: ApiProxyDraft = {
     apiName: '',
     apiVersion: '1.0.0',
     apiDescription: '',
-    contextPath: '',
+    contextPath: '/',
     virtualHostsEnabled: false,
     virtualHosts: [{ id: crypto.randomUUID(), host: '', path: '/', overrideAccess: false }],
     targetUrl: '',

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/types/api.ts
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/types/api.ts
@@ -97,6 +97,12 @@ export type ApiState = 'CLOSED' | 'INITIALIZED' | 'STARTED' | 'STOPPED' | 'STOPP
 export type ApiDeploymentState = 'NEED_REDEPLOY' | 'DEPLOYED';
 export type ApiLifecycleState = 'ARCHIVED' | 'CREATED' | 'DEPRECATED' | 'PUBLISHED' | 'UNPUBLISHED';
 export type ApiVisibility = 'PUBLIC' | 'PRIVATE';
+
+export interface DuplicateApiOptions {
+    contextPath?: string;
+    version: string;
+    filteredFields?: ('GROUPS' | 'MEMBERS' | 'PAGES' | 'PLANS')[];
+}
 export type ApiType = 'PROXY' | 'MESSAGE' | 'NATIVE';
 
 export interface ApiListListener {
@@ -151,9 +157,27 @@ export interface ApiDetailDto {
     type?: ApiType;
     apiVersion?: string;
     definitionVersion?: 'V4' | 'V4_NATIVE';
+    lifecycleState?: ApiLifecycleState;
+    visibility?: ApiVisibility;
     tags?: string[];
+    labels?: string[];
+    categories?: string[];
     groups?: string[];
+    allowedInApiProducts?: boolean;
     disableMembershipNotifications?: boolean;
+    primaryOwner?: { id?: string; displayName?: string; email?: string };
+    createdAt?: string;
+    updatedAt?: string;
+    picture?: string;
+    background?: string;
+    properties?: Property[];
+    services?: { dynamicProperty?: DynamicPropertyConfig };
+    listeners?: HttpListener[];
+    /** Populated for APIs synced from an external source (e.g. Kubernetes operator). */
+    definitionContext?: {
+        origin?: 'MANAGEMENT' | 'KUBERNETES';
+        syncFrom?: string;
+    };
 }
 
 export interface ApiEvent {
@@ -183,4 +207,29 @@ export interface OrgShardingTag {
     id: string;
     name: string;
     description?: string;
+}
+
+// ─── Properties types ─────────────────────────────────────────────────────────
+
+export interface Property {
+    key: string;
+    value: string;
+    encrypted?: boolean;
+    encryptable?: boolean;
+    dynamic?: boolean;
+}
+
+export type DynamicPropertyProvider = 'HTTP' | 'CUSTOM';
+
+export interface DynamicPropertyConfig {
+    enabled: boolean;
+    schedule?: string;
+    provider?: DynamicPropertyProvider;
+    configuration?: Record<string, unknown>;
+}
+
+// ─── Entrypoints types ───────────────────────────────────────────────────────
+
+export interface ExposedEntrypoint {
+    value: string;
 }

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/utils/apiProxyMapper.ts
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/utils/apiProxyMapper.ts
@@ -18,15 +18,15 @@ import type { ApiProxyDraft } from '../types/apiCreation';
 
 export const GATEWAY_URL_PLACEHOLDER = 'https://gateway.company.com';
 
-export function buildPreviewGatewayUrl(form: ApiProxyDraft): string {
+export function buildPreviewGatewayUrl(form: ApiProxyDraft, gatewayPrefix = GATEWAY_URL_PLACEHOLDER): string {
     if (form.virtualHostsEnabled && form.virtualHosts.length > 0) {
         const first = form.virtualHosts[0];
-        const host = first.host || GATEWAY_URL_PLACEHOLDER;
+        const host = first.host || gatewayPrefix;
         const path = first.path || '/';
         return `${host}${path}`;
     }
     const path = form.contextPath || '/your-api';
-    return `${GATEWAY_URL_PLACEHOLDER}${path}`;
+    return `${gatewayPrefix}${path}`;
 }
 
 function buildListener(form: ApiProxyDraft): HttpListener {

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/utils/queryKeys.ts
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/utils/queryKeys.ts
@@ -67,3 +67,13 @@ export const apiPermissionKeys = {
     all: ['api-permissions'] as const,
     detail: (envId: string, apiId: string) => [...apiPermissionKeys.all, envId, apiId] as const,
 };
+
+export const apiEntrypointKeys = {
+    all: ['api-entrypoints'] as const,
+    exposed: (envId: string, apiId: string) => [...apiEntrypointKeys.all, 'exposed', envId, apiId] as const,
+};
+
+export const portalSettingsKeys = {
+    all: ['portal-settings'] as const,
+    env: (envId: string) => [...portalSettingsKeys.all, envId] as const,
+};

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/pages/ApiEntrypointsPage.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/pages/ApiEntrypointsPage.spec.tsx
@@ -1,0 +1,377 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useEnvironment, useHasPermission } from '@gravitee/gamma-modules-sdk';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+
+jest.mock('@gravitee/gamma-modules-sdk', () => ({
+    ...jest.requireActual<object>('@gravitee/gamma-modules-sdk'),
+    useEnvironment: jest.fn(() => ({ id: 'DEFAULT' })),
+    useHasPermission: jest.fn(() => true),
+    permissionService: {
+        load: jest.fn(),
+        clear: jest.fn(),
+        hasAllOf: jest.fn(() => true),
+        hasAnyOf: jest.fn(() => true),
+        getAllPermissions: jest.fn(() => []),
+        subscribe: jest.fn(() => () => {}),
+        getSnapshot: jest.fn(() => 0),
+    },
+}));
+
+jest.mock('@gravitee/graphene-core', () => ({
+    Button: ({
+        children,
+        onClick,
+        disabled,
+        variant: _variant,
+        size: _size,
+        className: _className,
+        asChild,
+    }: {
+        children?: ReactNode;
+        onClick?: () => void;
+        disabled?: boolean;
+        variant?: string;
+        size?: string;
+        className?: string;
+        asChild?: boolean;
+    }) =>
+        asChild ? (
+            <>{children}</>
+        ) : (
+            <button type="button" onClick={onClick} disabled={disabled}>
+                {children}
+            </button>
+        ),
+    Card: ({ children, className }: { children?: ReactNode; className?: string }) => <div className={className}>{children}</div>,
+    CardContent: ({ children, className }: { children?: ReactNode; className?: string }) => <div className={className}>{children}</div>,
+    Dialog: ({ children, open }: { children?: ReactNode; open?: boolean }) => (open ? <div role="dialog">{children}</div> : null),
+    DialogClose: ({ children }: { children?: ReactNode }) => <>{children}</>,
+    DialogContent: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+    DialogDescription: ({ children }: { children?: ReactNode }) => <p>{children}</p>,
+    DialogFooter: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+    DialogHeader: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+    DialogTitle: ({ children }: { children?: ReactNode }) => <h2>{children}</h2>,
+    Input: ({
+        id,
+        value,
+        onChange,
+        placeholder,
+        disabled,
+        'aria-label': ariaLabel,
+        'aria-invalid': ariaInvalid,
+    }: {
+        id?: string;
+        value?: string;
+        onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
+        placeholder?: string;
+        disabled?: boolean;
+        'aria-label'?: string;
+        'aria-invalid'?: boolean;
+    }) => (
+        <input
+            id={id}
+            value={value}
+            onChange={onChange}
+            placeholder={placeholder}
+            disabled={disabled}
+            aria-label={ariaLabel}
+            aria-invalid={ariaInvalid}
+        />
+    ),
+    Label: ({ children, htmlFor, className }: { children?: ReactNode; htmlFor?: string; className?: string }) => (
+        <label htmlFor={htmlFor} className={className}>
+            {children}
+        </label>
+    ),
+    Separator: () => <hr />,
+    Skeleton: () => <div data-testid="skeleton" />,
+    Switch: ({
+        checked,
+        onCheckedChange,
+        disabled,
+        'aria-label': ariaLabel,
+    }: {
+        checked?: boolean;
+        onCheckedChange?: (v: boolean) => void;
+        disabled?: boolean;
+        'aria-label'?: string;
+    }) => (
+        <input
+            type="checkbox"
+            checked={checked}
+            onChange={e => onCheckedChange?.(e.target.checked)}
+            disabled={disabled}
+            aria-label={ariaLabel}
+        />
+    ),
+    cn: (...args: string[]) => args.filter(Boolean).join(' '),
+}));
+
+jest.mock('@gravitee/graphene-core/icons', () => new Proxy({}, { get: () => () => null }));
+
+jest.mock('../features/apis/context/ApiDetailContext', () => ({
+    useApiDetailContext: jest.fn(),
+}));
+
+jest.mock('../services/apis/entrypoints', () => ({
+    getExposedEntrypoints: jest.fn(),
+    updateApiListeners: jest.fn(),
+}));
+
+jest.mock('../features/apis/utils/queryKeys', () => ({
+    apiDetailKeys: {
+        all: ['api-detail'],
+        detail: (envId: string, apiId: string) => ['api-detail', envId, apiId],
+    },
+    apiEntrypointKeys: {
+        all: ['api-entrypoints'],
+        exposed: (envId: string, apiId: string) => ['api-entrypoints', 'exposed', envId, apiId],
+    },
+}));
+
+import { ApiEntrypointsPage } from './ApiEntrypointsPage';
+import { useApiDetailContext } from '../features/apis/context/ApiDetailContext';
+import { getExposedEntrypoints, updateApiListeners } from '../services/apis/entrypoints';
+
+const mockUseEnvironment = useEnvironment as jest.Mock;
+const mockUseHasPermission = useHasPermission as jest.Mock;
+const mockUseApiDetailContext = useApiDetailContext as jest.Mock;
+const mockGetExposedEntrypoints = getExposedEntrypoints as jest.Mock;
+const mockUpdateApiListeners = updateApiListeners as jest.Mock;
+
+const API_WITH_PATHS = {
+    id: 'api-1',
+    name: 'Passenger Boarding API',
+    listeners: [
+        {
+            type: 'HTTP' as const,
+            paths: [{ path: '/boarding' }],
+            hosts: [],
+            entrypoints: [{ type: 'http-proxy' }],
+        },
+    ],
+};
+
+const API_NO_ENTRYPOINTS = {
+    id: 'api-1',
+    name: 'New API',
+    listeners: [],
+};
+
+const API_WITH_VIRTUAL_HOSTS = {
+    id: 'api-1',
+    name: 'VH API',
+    listeners: [
+        {
+            type: 'HTTP' as const,
+            paths: [],
+            hosts: [{ host: 'api.company.com', path: '/v1', overrideAccess: false }],
+            entrypoints: [{ type: 'http-proxy' }],
+        },
+    ],
+};
+
+function makeClient() {
+    return new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } });
+}
+
+function renderPage(apiId = 'api-1') {
+    const client = makeClient();
+    return render(
+        <QueryClientProvider client={client}>
+            <MemoryRouter initialEntries={[`/apis/${apiId}/entrypoints`]}>
+                <Routes>
+                    <Route path="apis/:apiId/entrypoints" element={<ApiEntrypointsPage />} />
+                </Routes>
+            </MemoryRouter>
+        </QueryClientProvider>,
+    );
+}
+
+describe('ApiEntrypointsPage', () => {
+    beforeEach(() => {
+        mockUseEnvironment.mockReturnValue({ id: 'DEFAULT' });
+        // Default: full permissions granted, permissions loaded
+        mockUseHasPermission.mockReturnValue(true);
+        mockUseApiDetailContext.mockReturnValue({ api: API_WITH_PATHS, isLoading: false, permissionsReady: true });
+        mockGetExposedEntrypoints.mockResolvedValue([{ value: 'http://localhost:8080/boarding' }]);
+        mockUpdateApiListeners.mockResolvedValue(API_WITH_PATHS);
+    });
+
+    afterEach(() => jest.clearAllMocks());
+
+    it('shows loading skeleton when API context is loading', () => {
+        mockUseApiDetailContext.mockReturnValue({ api: null, isLoading: true, permissionsReady: false });
+        renderPage();
+        expect(screen.getAllByTestId('skeleton').length).toBeGreaterThan(0);
+    });
+
+    it('shows landing page when API has no entrypoints configured', () => {
+        mockUseApiDetailContext.mockReturnValue({ api: API_NO_ENTRYPOINTS, isLoading: false, permissionsReady: true });
+        renderPage();
+        expect(screen.getByText(/why configure entrypoints/i)).toBeInTheDocument();
+        expect(screen.queryByText(/entrypoint context-paths/i)).not.toBeInTheDocument();
+    });
+
+    it('shows config view when API already has context paths', () => {
+        renderPage();
+        expect(screen.queryByText(/why configure entrypoints/i)).not.toBeInTheDocument();
+        expect(screen.getByText(/entrypoint context-paths/i)).toBeInTheDocument();
+    });
+
+    it('transitions from landing to config when Add context path is clicked', () => {
+        mockUseApiDetailContext.mockReturnValue({ api: API_NO_ENTRYPOINTS, isLoading: false, permissionsReady: true });
+        renderPage();
+        fireEvent.click(screen.getByRole('button', { name: /add context path/i }));
+        expect(screen.getByText(/entrypoint context-paths/i)).toBeInTheDocument();
+        expect(screen.queryByText(/why configure entrypoints/i)).not.toBeInTheDocument();
+    });
+
+    it('seeds path input from API data', () => {
+        renderPage();
+        const inputs = screen.getAllByRole('textbox', { name: /context path/i });
+        expect((inputs[0] as HTMLInputElement).value).toBe('/boarding');
+    });
+
+    it('disables Save button when form is clean', () => {
+        renderPage();
+        expect(screen.getByRole('button', { name: /save changes/i })).toBeDisabled();
+    });
+
+    it('enables Save button after editing a path', () => {
+        renderPage();
+        const input = screen.getAllByRole('textbox', { name: /context path/i })[0];
+        fireEvent.change(input, { target: { value: '/new-path' } });
+        expect(screen.getByRole('button', { name: /save changes/i })).not.toBeDisabled();
+    });
+
+    it('disables delete button when only one context path remains', () => {
+        renderPage();
+        const deleteBtn = screen.getByRole('button', { name: /delete context path/i });
+        expect(deleteBtn).toBeDisabled();
+    });
+
+    it('enables deleting extra context paths when more than one exists', () => {
+        renderPage();
+        // Add a second path via the in-card button (last "Add context path" button rendered)
+        const addBtns = screen.getAllByRole('button', { name: /add context path/i });
+        fireEvent.click(addBtns[addBtns.length - 1]);
+        const deleteBtns = screen.getAllByRole('button', { name: /delete context path/i });
+        expect(deleteBtns.length).toBe(2);
+        expect(deleteBtns[0]).not.toBeDisabled();
+    });
+
+    it('calls updateApiListeners with correct listeners payload on Save', async () => {
+        renderPage();
+
+        const input = screen.getAllByRole('textbox', { name: /context path/i })[0];
+        fireEvent.change(input, { target: { value: '/updated' } });
+        fireEvent.click(screen.getByRole('button', { name: /save changes/i }));
+
+        await waitFor(() => expect(mockUpdateApiListeners).toHaveBeenCalledTimes(1));
+
+        // Signature is now (envId, apiId, current, listeners)
+        const [envId, apiId, _current, listeners] = mockUpdateApiListeners.mock.calls[0];
+        expect(envId).toBe('DEFAULT');
+        expect(apiId).toBe('api-1');
+        expect(listeners).toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({
+                    type: 'HTTP',
+                    paths: [{ path: '/updated' }],
+                    hosts: [],
+                }),
+            ]),
+        );
+    });
+
+    it('shows virtual hosts card when API is in virtual host mode', () => {
+        mockUseApiDetailContext.mockReturnValue({ api: API_WITH_VIRTUAL_HOSTS, isLoading: false, permissionsReady: true });
+        renderPage();
+        // The card heading "Virtual hosts" (not the toggle label)
+        expect(screen.getByRole('textbox', { name: /virtual host/i })).toBeInTheDocument();
+        expect(screen.queryByText(/entrypoint context-paths/i)).not.toBeInTheDocument();
+    });
+
+    it('opens switch-mode dialog when virtual host toggle is turned off', () => {
+        mockUseApiDetailContext.mockReturnValue({ api: API_WITH_VIRTUAL_HOSTS, isLoading: false, permissionsReady: true });
+        renderPage();
+        const toggle = screen.getByRole('checkbox', { name: /enable virtual hosts/i });
+        fireEvent.click(toggle);
+        expect(screen.getByRole('dialog')).toBeInTheDocument();
+        expect(screen.getByText(/switch to context-path mode/i)).toBeInTheDocument();
+    });
+
+    it('switches to context-path mode after confirming the dialog', () => {
+        mockUseApiDetailContext.mockReturnValue({ api: API_WITH_VIRTUAL_HOSTS, isLoading: false, permissionsReady: true });
+        renderPage();
+        fireEvent.click(screen.getByRole('checkbox', { name: /enable virtual hosts/i }));
+        fireEvent.click(screen.getByRole('button', { name: /switch/i }));
+        expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+        expect(screen.getByText(/entrypoint context-paths/i)).toBeInTheDocument();
+    });
+
+    // ── permission guard tests ──────────────────────────────────────────────────
+
+    it('hides Save and mutating controls when user lacks api-definition-u permission', () => {
+        mockUseHasPermission.mockReturnValue(false);
+        renderPage();
+        expect(screen.queryByRole('button', { name: /save changes/i })).not.toBeInTheDocument();
+        expect(screen.queryByRole('button', { name: /add context path/i })).not.toBeInTheDocument();
+        // Inputs still visible but disabled
+        const inputs = screen.getAllByRole('textbox', { name: /context path/i });
+        expect(inputs[0]).toBeDisabled();
+    });
+
+    it('hides Save and mutating controls when permissions are not yet loaded', () => {
+        mockUseApiDetailContext.mockReturnValue({ api: API_WITH_PATHS, isLoading: false, permissionsReady: false });
+        renderPage();
+        expect(screen.queryByRole('button', { name: /save changes/i })).not.toBeInTheDocument();
+        expect(screen.queryByRole('button', { name: /add context path/i })).not.toBeInTheDocument();
+    });
+
+    it('is read-only when only one of the two required permissions is held', () => {
+        // Having api-definition-u but NOT api-gateway_definition-u must still block edits
+        mockUseHasPermission.mockImplementation(({ allOf }: { allOf?: string[] }) => {
+            if (allOf) {
+                // allOf permission check: requires BOTH; return false if any is missing
+                return allOf.every(p => p === 'api-definition-u');
+            }
+            return true;
+        });
+        renderPage();
+        expect(screen.queryByRole('button', { name: /save changes/i })).not.toBeInTheDocument();
+        expect(screen.queryByRole('button', { name: /add context path/i })).not.toBeInTheDocument();
+        const inputs = screen.getAllByRole('textbox', { name: /context path/i });
+        expect(inputs[0]).toBeDisabled();
+    });
+
+    it('forces read-only mode for Kubernetes-managed APIs regardless of permissions', () => {
+        const kubernetesApi = {
+            ...API_WITH_PATHS,
+            definitionContext: { origin: 'KUBERNETES' as const },
+        };
+        mockUseApiDetailContext.mockReturnValue({ api: kubernetesApi, isLoading: false, permissionsReady: true });
+        renderPage();
+        expect(screen.queryByRole('button', { name: /save changes/i })).not.toBeInTheDocument();
+        const inputs = screen.getAllByRole('textbox', { name: /context path/i });
+        expect(inputs[0]).toBeDisabled();
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/pages/ApiEntrypointsPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/pages/ApiEntrypointsPage.tsx
@@ -1,0 +1,315 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useHasPermission } from '@gravitee/gamma-modules-sdk';
+import { Button, Skeleton } from '@gravitee/graphene-core';
+import { CheckIcon, PlusIcon } from '@gravitee/graphene-core/icons';
+import { useEffect, useState } from 'react';
+
+import { ContextPathsCard } from '../features/apis/components/detail/entrypoints/ContextPathsCard';
+import { EntrypointsLanding } from '../features/apis/components/detail/entrypoints/EntrypointsLanding';
+import { ExposedEntrypointsCard } from '../features/apis/components/detail/entrypoints/ExposedEntrypointsCard';
+import { SwitchModeDialog } from '../features/apis/components/detail/entrypoints/SwitchModeDialog';
+import type { ContextPathRow, VirtualHostRow } from '../features/apis/components/detail/entrypoints/types';
+import { validatePath } from '../features/apis/components/detail/entrypoints/types';
+import { VirtualHostsCard } from '../features/apis/components/detail/entrypoints/VirtualHostsCard';
+import { useApiDetailContext } from '../features/apis/context/ApiDetailContext';
+import { useApiEntrypoints } from '../features/apis/hooks/useApiEntrypoints';
+import type { ApiDetailDto, HttpListener } from '../features/apis/types/api';
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function newId(): string {
+    return Math.random().toString(36).slice(2, 10);
+}
+
+function getHttpListener(api: ApiDetailDto | null): HttpListener | undefined {
+    return api?.listeners?.find(l => l.type === 'HTTP');
+}
+
+function isVirtualHostMode(listener: HttpListener | undefined): boolean {
+    return (listener?.hosts?.length ?? 0) > 0;
+}
+
+function listenerHasEntrypoints(listener: HttpListener | undefined): boolean {
+    return (listener?.paths?.length ?? 0) > 0 || (listener?.hosts?.length ?? 0) > 0;
+}
+
+function hasDuplicates(rows: ContextPathRow[]): boolean {
+    const paths = rows.map(r => r.path);
+    return new Set(paths).size !== paths.length;
+}
+
+// ─── ApiEntrypointsPage ───────────────────────────────────────────────────────
+
+export function ApiEntrypointsPage() {
+    const { api, isLoading: apiLoading, permissionsReady } = useApiDetailContext();
+
+    // ── permission guard (mirrors legacy api-entrypoints.component.ts) ──
+    // Requires both api-definition-u AND api-gateway_definition-u.
+    // Kubernetes-managed APIs are always read-only regardless of user permissions.
+    const canUpdateEntrypoints = useHasPermission({ allOf: ['api-definition-u', 'api-gateway_definition-u'] });
+    const isKubernetesManaged = api?.definitionContext?.origin === 'KUBERNETES';
+    const isReadOnly = !permissionsReady || !canUpdateEntrypoints || isKubernetesManaged;
+
+    // ── derive initial form state from api ──
+    const [showConfig, setShowConfig] = useState(false);
+    const [virtualHostMode, setVirtualHostMode] = useState(false);
+    const [contextPaths, setContextPaths] = useState<ContextPathRow[]>([{ id: newId(), path: '/' }]);
+    const [virtualHosts, setVirtualHosts] = useState<VirtualHostRow[]>([{ id: newId(), host: '', path: '/', overrideAccess: false }]);
+    const [isDirty, setIsDirty] = useState(false);
+    const [switchModeDialogOpen, setSwitchModeDialogOpen] = useState(false);
+    const [saveError, setSaveError] = useState<string | null>(null);
+
+    const { exposedQuery, saveMutation } = useApiEntrypoints(showConfig);
+
+    // Initialize form once api data arrives
+    useEffect(() => {
+        if (!api) return;
+        const listener = getHttpListener(api);
+
+        if (isVirtualHostMode(listener)) {
+            setVirtualHostMode(true);
+            setVirtualHosts(
+                (listener?.hosts ?? []).map(h => ({ id: newId(), host: h.host, path: h.path, overrideAccess: h.overrideAccess ?? false })),
+            );
+            setContextPaths((listener?.paths ?? []).map(p => ({ id: newId(), path: p.path })));
+        } else {
+            setVirtualHostMode(false);
+            const paths = listener?.paths ?? [];
+            setContextPaths(paths.length > 0 ? paths.map(p => ({ id: newId(), path: p.path })) : [{ id: newId(), path: '/' }]);
+        }
+
+        setShowConfig(listenerHasEntrypoints(listener));
+        setIsDirty(false);
+        setSaveError(null);
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [api?.id]); // Re-init only when API identity changes, not on every save response
+
+    // ── validation ──
+    const contextPathErrors = contextPaths.map(r => validatePath(r.path));
+    const contextPathHasDupes = hasDuplicates(contextPaths);
+    const virtualHostErrors = virtualHosts.map(r => validatePath(r.path));
+
+    const isContextPathValid = contextPathErrors.every(e => e === null) && !contextPathHasDupes;
+    const isVirtualHostValid = virtualHostErrors.every(e => e === null);
+    const isFormValid = virtualHostMode ? isVirtualHostValid : isContextPathValid;
+    const canSave = isDirty && isFormValid && !saveMutation.isPending;
+
+    // ── form mutations ──
+    function markDirty() {
+        setIsDirty(true);
+        setSaveError(null);
+    }
+
+    function addContextPath() {
+        setContextPaths(prev => [...prev, { id: newId(), path: '/' }]);
+        markDirty();
+    }
+
+    function deleteContextPath(id: string) {
+        if (contextPaths.length <= 1) return;
+        setContextPaths(prev => prev.filter(r => r.id !== id));
+        markDirty();
+    }
+
+    function updateContextPath(id: string, path: string) {
+        setContextPaths(prev => prev.map(r => (r.id === id ? { ...r, path } : r)));
+        markDirty();
+    }
+
+    function addVirtualHost() {
+        setVirtualHosts(prev => [...prev, { id: newId(), host: '', path: '/', overrideAccess: false }]);
+        markDirty();
+    }
+
+    function deleteVirtualHost(id: string) {
+        setVirtualHosts(prev => prev.filter(r => r.id !== id));
+        markDirty();
+    }
+
+    function updateVirtualHostField(id: string, field: 'host' | 'path' | 'overrideAccess', value: string | boolean) {
+        setVirtualHosts(prev => prev.map(r => (r.id === id ? { ...r, [field]: value } : r)));
+        markDirty();
+    }
+
+    function handleEnableVirtualHosts() {
+        setVirtualHostMode(true);
+        if (virtualHosts.length === 0) {
+            setVirtualHosts([{ id: newId(), host: '', path: '/', overrideAccess: false }]);
+        }
+        markDirty();
+    }
+
+    function handleDisableVirtualHosts() {
+        setSwitchModeDialogOpen(true);
+    }
+
+    function confirmSwitchToContextPath() {
+        setSwitchModeDialogOpen(false);
+        setVirtualHostMode(false);
+        if (contextPaths.length === 0) {
+            setContextPaths([{ id: newId(), path: '/' }]);
+        }
+        markDirty();
+    }
+
+    function handleAddFirstContextPath() {
+        setContextPaths([{ id: newId(), path: '/' }]);
+        setShowConfig(true);
+        markDirty();
+    }
+
+    // ── save ──
+    function handleSave() {
+        if (!api || !isFormValid) return;
+
+        const existingListener = getHttpListener(api);
+        const updatedListener: HttpListener = {
+            ...(existingListener ?? { type: 'HTTP' }),
+            paths: virtualHostMode ? (existingListener?.paths ?? []) : contextPaths.map(r => ({ path: r.path })),
+            hosts: virtualHostMode ? virtualHosts.map(r => ({ host: r.host, path: r.path, overrideAccess: r.overrideAccess })) : [],
+        };
+
+        // Keep all listeners, replace/add the HTTP one
+        const otherListeners = (api.listeners ?? []).filter(l => l.type !== 'HTTP');
+        const updatedListeners: HttpListener[] = [...otherListeners, updatedListener];
+
+        saveMutation.mutate(updatedListeners, {
+            onSuccess: () => {
+                setIsDirty(false);
+                setSaveError(null);
+            },
+            onError: (err: unknown) => {
+                const message = err instanceof Error ? err.message : 'Failed to save entrypoints.';
+                setSaveError(message);
+            },
+        });
+    }
+
+    // ── render ──
+    if (apiLoading) {
+        return (
+            <div className="space-y-6 pb-8">
+                <div className="flex items-start justify-between gap-4">
+                    <div className="space-y-1.5">
+                        <Skeleton className="h-7 w-40 rounded" />
+                        <Skeleton className="h-4 w-72 rounded" />
+                    </div>
+                    <Skeleton className="h-9 w-28 rounded-md" />
+                </div>
+                <Skeleton className="h-48 w-full rounded-xl" />
+            </div>
+        );
+    }
+
+    return (
+        <div className="space-y-6 pb-8">
+            {/* ── Page header ── */}
+            <div className="flex items-start justify-between gap-4">
+                <div className="space-y-1">
+                    <h1 className="text-2xl font-semibold tracking-tight">Entrypoints</h1>
+                    <p className="text-sm text-muted-foreground">Configure how consumers reach this API through the gateway.</p>
+                </div>
+
+                <div className="flex items-center gap-2 shrink-0">
+                    {showConfig && (
+                        <Button variant="outline" size="sm" className="gap-1.5" asChild>
+                            <a
+                                href="https://documentation.gravitee.io/apim/configuration/api-configuration/entrypoints"
+                                target="_blank"
+                                rel="noopener noreferrer"
+                            >
+                                Documentation
+                            </a>
+                        </Button>
+                    )}
+                    {showConfig && !isReadOnly && (
+                        <Button size="sm" onClick={handleSave} disabled={!canSave} className="gap-1.5" aria-label="Save changes">
+                            <CheckIcon className="size-3.5" />
+                            Save changes
+                        </Button>
+                    )}
+                    {!isReadOnly && !virtualHostMode && (
+                        <Button
+                            variant={showConfig ? 'outline' : 'default'}
+                            size="sm"
+                            onClick={showConfig ? addContextPath : handleAddFirstContextPath}
+                            className="gap-1.5"
+                        >
+                            <PlusIcon className="size-3.5" />
+                            Add context path
+                        </Button>
+                    )}
+                </div>
+            </div>
+
+            {saveError && (
+                <div className="rounded-lg border border-destructive/30 bg-destructive/5 px-4 py-3">
+                    <p className="text-sm text-destructive">{saveError}</p>
+                </div>
+            )}
+
+            {saveMutation.isSuccess && !isDirty && (
+                <div className="rounded-lg border border-success/30 bg-success/5 px-4 py-3">
+                    <p className="text-sm text-success">Configuration successfully saved!</p>
+                </div>
+            )}
+
+            {/* ── Landing state ── */}
+            {!showConfig && <EntrypointsLanding />}
+
+            {/* ── Config state ── */}
+            {showConfig && (
+                <>
+                    {!virtualHostMode && (
+                        <ContextPathsCard
+                            rows={contextPaths}
+                            onAdd={addContextPath}
+                            onDelete={deleteContextPath}
+                            onPathChange={updateContextPath}
+                            onToggleVirtualHosts={handleEnableVirtualHosts}
+                            isReadOnly={isReadOnly}
+                        />
+                    )}
+
+                    {virtualHostMode && (
+                        <VirtualHostsCard
+                            rows={virtualHosts}
+                            onAdd={addVirtualHost}
+                            onDelete={deleteVirtualHost}
+                            onFieldChange={updateVirtualHostField}
+                            onDisableVirtualHosts={handleDisableVirtualHosts}
+                            isReadOnly={isReadOnly}
+                        />
+                    )}
+
+                    <ExposedEntrypointsCard
+                        entrypoints={exposedQuery.data ?? []}
+                        isLoading={exposedQuery.isLoading}
+                        virtualHostMode={virtualHostMode}
+                    />
+                </>
+            )}
+
+            {/* ── Switch mode confirmation dialog ── */}
+            <SwitchModeDialog
+                open={switchModeDialogOpen}
+                onConfirm={confirmSwitchToContextPath}
+                onCancel={() => setSwitchModeDialogOpen(false)}
+            />
+        </div>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/pages/ApiGeneralPage.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/pages/ApiGeneralPage.spec.tsx
@@ -1,0 +1,396 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useEnvironment, useHasPermission } from '@gravitee/gamma-modules-sdk';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+
+jest.mock('@gravitee/gamma-modules-sdk', () => ({
+    ...jest.requireActual<object>('@gravitee/gamma-modules-sdk'),
+    useEnvironment: jest.fn(() => ({ id: 'DEFAULT' })),
+    useHasPermission: jest.fn(() => true),
+    permissionService: {
+        load: jest.fn(),
+        clear: jest.fn(),
+        hasAllOf: jest.fn(() => true),
+        hasAnyOf: jest.fn(() => true),
+        getAllPermissions: jest.fn(() => []),
+        subscribe: jest.fn(() => () => {}),
+        getSnapshot: jest.fn(() => 0),
+    },
+}));
+
+jest.mock('@gravitee/graphene-core', () => ({
+    Badge: ({ children, className }: { children?: ReactNode; className?: string }) => <span className={className}>{children}</span>,
+    Button: ({ children, onClick, disabled, type }: { children?: ReactNode; onClick?: () => void; disabled?: boolean; type?: string }) => (
+        <button type={type ?? 'button'} onClick={onClick} disabled={disabled}>
+            {children}
+        </button>
+    ),
+    Card: ({ children, className }: { children?: ReactNode; className?: string }) => <div className={className}>{children}</div>,
+    CardContent: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+    Dialog: ({ children, open }: { children?: ReactNode; open?: boolean }) => (open ? <div role="dialog">{children}</div> : null),
+    DialogClose: ({ children }: { children?: ReactNode }) => <>{children}</>,
+    DialogContent: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+    DialogDescription: ({ children }: { children?: ReactNode }) => <p>{children}</p>,
+    DialogFooter: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+    DialogHeader: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+    DialogTitle: ({ children }: { children?: ReactNode }) => <h2>{children}</h2>,
+    Input: ({
+        id,
+        value,
+        onChange,
+        placeholder,
+        disabled,
+    }: {
+        id?: string;
+        value?: string;
+        onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
+        placeholder?: string;
+        disabled?: boolean;
+    }) => <input id={id} value={value} onChange={onChange} placeholder={placeholder} disabled={disabled} />,
+    Label: ({ children, htmlFor }: { children?: ReactNode; htmlFor?: string }) => <label htmlFor={htmlFor}>{children}</label>,
+    Separator: () => <hr />,
+    Skeleton: () => <div data-testid="skeleton" />,
+    Switch: ({ checked, onCheckedChange, disabled }: { checked?: boolean; onCheckedChange?: (v: boolean) => void; disabled?: boolean }) => (
+        <input type="checkbox" checked={checked} onChange={e => onCheckedChange?.(e.target.checked)} disabled={disabled} />
+    ),
+    Textarea: ({
+        id,
+        value,
+        onChange,
+        placeholder,
+        disabled,
+    }: {
+        id?: string;
+        value?: string;
+        onChange?: (e: React.ChangeEvent<HTMLTextAreaElement>) => void;
+        placeholder?: string;
+        disabled?: boolean;
+    }) => <textarea id={id} value={value} onChange={onChange} placeholder={placeholder} disabled={disabled} />,
+    cn: (...args: string[]) => args.filter(Boolean).join(' '),
+}));
+
+jest.mock('@gravitee/graphene-core/icons', () => new Proxy({}, { get: () => () => null }));
+
+jest.mock('../features/apis/context/ApiDetailContext', () => ({
+    useApiDetailContext: jest.fn(),
+}));
+
+jest.mock('../services/apis/apis', () => ({
+    updateApiGeneral: jest.fn(),
+    startApi: jest.fn(),
+    stopApi: jest.fn(),
+    deleteApi: jest.fn(),
+    duplicateApi: jest.fn(),
+    exportApiDefinition: jest.fn(),
+    updateApiFromDefinition: jest.fn(),
+    updateApiPicture: jest.fn(),
+    deleteApiPicture: jest.fn(),
+    updateApiBackground: jest.fn(),
+    deleteApiBackground: jest.fn(),
+}));
+
+jest.mock('../features/apis/utils/queryKeys', () => ({
+    apiDetailKeys: {
+        all: ['api-detail'],
+        detail: (envId: string, apiId: string) => ['api-detail', envId, apiId],
+    },
+}));
+
+import { ApiGeneralPage } from './ApiGeneralPage';
+import { useApiDetailContext } from '../features/apis/context/ApiDetailContext';
+import { updateApiGeneral, startApi, stopApi, deleteApi } from '../services/apis/apis';
+
+const mockUseEnvironment = useEnvironment as jest.Mock;
+const mockUseApiDetailContext = useApiDetailContext as jest.Mock;
+const mockUseHasPermission = useHasPermission as jest.Mock;
+const mockUpdateApiGeneral = updateApiGeneral as jest.Mock;
+const mockStartApi = startApi as jest.Mock;
+const mockStopApi = stopApi as jest.Mock;
+const mockDeleteApi = deleteApi as jest.Mock;
+
+// lifecycleState: 'CREATED' so the delete button is not blocked by cannotDelete
+const STUB_API = {
+    id: 'api-1',
+    name: 'My Test API',
+    apiVersion: 'v1.0',
+    description: 'A test API',
+    labels: ['alpha'],
+    categories: ['Ops'],
+    allowedInApiProducts: false,
+    lifecycleState: 'CREATED',
+    visibility: 'PRIVATE',
+    state: 'STOPPED',
+    primaryOwner: { displayName: 'Admin User', email: 'admin@example.com' },
+    createdAt: '2025-01-01T00:00:00Z',
+    updatedAt: '2025-06-01T00:00:00Z',
+};
+
+function makeClient() {
+    return new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } });
+}
+
+function renderPage(apiId = 'api-1') {
+    const client = makeClient();
+    return render(
+        <QueryClientProvider client={client}>
+            <MemoryRouter initialEntries={[`/apis/${apiId}/general`]}>
+                <Routes>
+                    <Route path="apis">
+                        <Route index element={<div data-testid="apis-list" />} />
+                        <Route path=":apiId">
+                            <Route path="general" element={<ApiGeneralPage />} />
+                        </Route>
+                    </Route>
+                </Routes>
+            </MemoryRouter>
+        </QueryClientProvider>,
+    );
+}
+
+describe('ApiGeneralPage', () => {
+    beforeEach(() => {
+        mockUseEnvironment.mockReturnValue({ id: 'DEFAULT' });
+        mockUseApiDetailContext.mockReturnValue({ api: STUB_API, isLoading: false, permissionsReady: true });
+        mockUseHasPermission.mockReturnValue(true);
+        mockUpdateApiGeneral.mockResolvedValue({ ...STUB_API, name: 'Updated API' });
+        mockStartApi.mockResolvedValue(undefined);
+        mockStopApi.mockResolvedValue(undefined);
+        mockDeleteApi.mockResolvedValue(undefined);
+    });
+
+    afterEach(() => jest.clearAllMocks());
+
+    // ── Loading & initial render ─────────────────────────────────────────────
+
+    it('shows loading skeleton when context is loading', () => {
+        mockUseApiDetailContext.mockReturnValue({ api: null, isLoading: true, permissionsReady: false });
+        renderPage();
+        expect(screen.getAllByTestId('skeleton').length).toBeGreaterThan(0);
+    });
+
+    it('renders form fields seeded from API data', () => {
+        renderPage();
+        expect((screen.getByRole('textbox', { name: /name/i }) as HTMLInputElement).value).toBe('My Test API');
+        expect((screen.getByRole('textbox', { name: /version/i }) as HTMLInputElement).value).toBe('v1.0');
+        expect((screen.getByRole('textbox', { name: /description/i }) as HTMLTextAreaElement).value).toBe('A test API');
+    });
+
+    // ── Dirty tracking & save ────────────────────────────────────────────────
+
+    it('does not show Save button initially when form is clean', () => {
+        renderPage();
+        expect(screen.queryByRole('button', { name: /save changes/i })).toBeNull();
+    });
+
+    it('shows Save and Discard buttons after name is edited', () => {
+        renderPage();
+        const nameInput = screen.getByRole('textbox', { name: /name/i });
+        fireEvent.change(nameInput, { target: { value: 'Renamed API' } });
+        expect(screen.getByRole('button', { name: /save changes/i })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: /discard/i })).toBeInTheDocument();
+    });
+
+    it('clears dirty state when Discard is clicked', () => {
+        renderPage();
+        const nameInput = screen.getByRole('textbox', { name: /name/i });
+        fireEvent.change(nameInput, { target: { value: 'Renamed API' } });
+        fireEvent.click(screen.getByRole('button', { name: /discard/i }));
+        expect(screen.queryByRole('button', { name: /save changes/i })).toBeNull();
+        expect((screen.getByRole('textbox', { name: /name/i }) as HTMLInputElement).value).toBe('My Test API');
+    });
+
+    it('calls updateApiGeneral with edited values on Save', async () => {
+        renderPage();
+        fireEvent.change(screen.getByRole('textbox', { name: /name/i }), { target: { value: 'Renamed API' } });
+        fireEvent.click(screen.getByRole('button', { name: /save changes/i }));
+        await waitFor(() => expect(mockUpdateApiGeneral).toHaveBeenCalledTimes(1));
+        // Signature is now (envId, apiId, current, patch)
+        expect(mockUpdateApiGeneral).toHaveBeenCalledWith(
+            'DEFAULT',
+            'api-1',
+            expect.objectContaining({ id: 'api-1' }),
+            expect.objectContaining({ name: 'Renamed API' }),
+        );
+    });
+
+    // ── Start / Stop ─────────────────────────────────────────────────────────
+
+    it('shows Start button when API is stopped', () => {
+        renderPage();
+        expect(screen.getByRole('button', { name: /start/i })).toBeInTheDocument();
+    });
+
+    it('shows Stop button when API is started', () => {
+        mockUseApiDetailContext.mockReturnValue({
+            api: { ...STUB_API, state: 'STARTED' },
+            isLoading: false,
+            permissionsReady: true,
+        });
+        renderPage();
+        expect(screen.getByRole('button', { name: /stop/i })).toBeInTheDocument();
+    });
+
+    it('calls startApi when Start button is clicked', async () => {
+        renderPage();
+        fireEvent.click(screen.getByRole('button', { name: /start/i }));
+        await waitFor(() => expect(mockStartApi).toHaveBeenCalledWith('DEFAULT', 'api-1'));
+    });
+
+    it('calls stopApi when Stop button is clicked', async () => {
+        mockUseApiDetailContext.mockReturnValue({
+            api: { ...STUB_API, state: 'STARTED' },
+            isLoading: false,
+            permissionsReady: true,
+        });
+        renderPage();
+        fireEvent.click(screen.getByRole('button', { name: /stop/i }));
+        await waitFor(() => expect(mockStopApi).toHaveBeenCalledWith('DEFAULT', 'api-1'));
+    });
+
+    // ── Delete ───────────────────────────────────────────────────────────────
+
+    it('opens delete dialog when Delete button is clicked', () => {
+        renderPage();
+        fireEvent.click(screen.getByRole('button', { name: /^delete$/i }));
+        expect(screen.getByRole('dialog')).toBeInTheDocument();
+        expect(screen.getByText(/delete api permanently/i)).toBeInTheDocument();
+    });
+
+    it('keeps delete confirm button disabled until exact API name is typed', () => {
+        renderPage();
+        fireEvent.click(screen.getByRole('button', { name: /^delete$/i }));
+        const confirmBtn = screen.getByRole('button', { name: /delete permanently/i });
+        expect(confirmBtn).toBeDisabled();
+        fireEvent.change(screen.getByPlaceholderText('My Test API'), { target: { value: 'My Test API' } });
+        expect(confirmBtn).not.toBeDisabled();
+    });
+
+    it('calls deleteApi and closes dialog on confirmed delete', async () => {
+        renderPage();
+        fireEvent.click(screen.getByRole('button', { name: /^delete$/i }));
+        fireEvent.change(screen.getByPlaceholderText('My Test API'), { target: { value: 'My Test API' } });
+        fireEvent.click(screen.getByRole('button', { name: /delete permanently/i }));
+        await waitFor(() => expect(mockDeleteApi).toHaveBeenCalledWith('DEFAULT', 'api-1'));
+        await waitFor(() => expect(screen.queryByRole('dialog')).toBeNull());
+    });
+
+    it('disables Delete button when API is running', () => {
+        mockUseApiDetailContext.mockReturnValue({
+            api: { ...STUB_API, state: 'STARTED', lifecycleState: 'CREATED' },
+            isLoading: false,
+            permissionsReady: true,
+        });
+        renderPage();
+        expect(screen.getByRole('button', { name: /^delete$/i })).toBeDisabled();
+    });
+
+    it('disables Delete button when API is published', () => {
+        mockUseApiDetailContext.mockReturnValue({
+            api: { ...STUB_API, state: 'STOPPED', lifecycleState: 'PUBLISHED' },
+            isLoading: false,
+            permissionsReady: true,
+        });
+        renderPage();
+        expect(screen.getByRole('button', { name: /^delete$/i })).toBeDisabled();
+    });
+
+    // ── Actions strip ────────────────────────────────────────────────────────
+
+    it('renders Export, Import, Duplicate, and Promote action buttons', () => {
+        renderPage();
+        expect(screen.getByRole('button', { name: /export/i })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: /import/i })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: /duplicate/i })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: /promote/i })).toBeInTheDocument();
+    });
+
+    it('opens Export dialog when Export is clicked', () => {
+        renderPage();
+        fireEvent.click(screen.getByRole('button', { name: /export/i }));
+        expect(screen.getByRole('dialog')).toBeInTheDocument();
+        expect(screen.getByText(/export api definition/i)).toBeInTheDocument();
+    });
+
+    it('opens Duplicate dialog when Duplicate is clicked', () => {
+        renderPage();
+        fireEvent.click(screen.getByRole('button', { name: /duplicate/i }));
+        expect(screen.getByRole('dialog')).toBeInTheDocument();
+        expect(screen.getByText(/duplicate api/i)).toBeInTheDocument();
+    });
+
+    // ── Permission-gated rendering ────────────────────────────────────────────
+
+    it('hides Export button when user lacks api-definition-r permission', () => {
+        // api-definition-r is checked for Export; return false only for 'api-definition-r'
+        mockUseHasPermission.mockImplementation(({ anyOf }: { anyOf: string[] }) => !anyOf.includes('api-definition-r'));
+        renderPage();
+        expect(screen.queryByRole('button', { name: /export/i })).toBeNull();
+    });
+
+    it('hides Import and Duplicate buttons when user lacks api-definition-c permission', () => {
+        mockUseHasPermission.mockImplementation(({ anyOf }: { anyOf: string[] }) => !anyOf.includes('api-definition-c'));
+        renderPage();
+        expect(screen.queryByRole('button', { name: /import/i })).toBeNull();
+        expect(screen.queryByRole('button', { name: /duplicate/i })).toBeNull();
+    });
+
+    it('hides Promote button and API Events section when user lacks api-definition-u permission', () => {
+        mockUseHasPermission.mockImplementation(({ anyOf }: { anyOf: string[] }) => !anyOf.includes('api-definition-u'));
+        renderPage();
+        expect(screen.queryByRole('button', { name: /promote/i })).toBeNull();
+        expect(screen.queryByRole('button', { name: /start/i })).toBeNull();
+    });
+
+    it('hides Delete section when user lacks api-definition-d permission', () => {
+        mockUseHasPermission.mockImplementation(({ anyOf }: { anyOf: string[] }) => !anyOf.includes('api-definition-d'));
+        renderPage();
+        expect(screen.queryByRole('button', { name: /^delete$/i })).toBeNull();
+    });
+
+    it('disables form inputs when user lacks api-definition-u permission', () => {
+        mockUseHasPermission.mockImplementation(({ anyOf }: { anyOf: string[] }) => !anyOf.includes('api-definition-u'));
+        renderPage();
+        expect((screen.getByRole('textbox', { name: /name/i }) as HTMLInputElement).disabled).toBe(true);
+        expect((screen.getByRole('textbox', { name: /version/i }) as HTMLInputElement).disabled).toBe(true);
+        expect((screen.getByRole('textbox', { name: /description/i }) as HTMLTextAreaElement).disabled).toBe(true);
+    });
+
+    it('shows Kubernetes banner and makes form read-only when API is managed by Kubernetes operator', () => {
+        mockUseApiDetailContext.mockReturnValue({
+            api: { ...STUB_API, definitionContext: { origin: 'KUBERNETES' } },
+            isLoading: false,
+            permissionsReady: true,
+        });
+        renderPage();
+        expect(screen.getByText(/managed by the kubernetes operator/i)).toBeInTheDocument();
+        expect((screen.getByRole('textbox', { name: /name/i }) as HTMLInputElement).disabled).toBe(true);
+    });
+
+    it('does not show Save button when form is edited but API is Kubernetes-managed', () => {
+        mockUseApiDetailContext.mockReturnValue({
+            api: { ...STUB_API, definitionContext: { origin: 'KUBERNETES' } },
+            isLoading: false,
+            permissionsReady: true,
+        });
+        renderPage();
+        fireEvent.change(screen.getByRole('textbox', { name: /name/i }), { target: { value: 'Changed' } });
+        // Input is disabled so value won't actually change, but even if it did, save must not appear
+        expect(screen.queryByRole('button', { name: /save changes/i })).toBeNull();
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/pages/ApiGeneralPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/pages/ApiGeneralPage.tsx
@@ -1,0 +1,676 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useEnvironment, useHasPermission } from '@gravitee/gamma-modules-sdk';
+import { Badge, Button, Card, CardContent, Input, Label, Separator, Skeleton, Switch, Textarea, cn } from '@gravitee/graphene-core';
+import {
+    BoxesIcon,
+    CheckIcon,
+    CircleStopIcon,
+    ClockIcon,
+    CopyIcon,
+    DownloadIcon,
+    ExternalLinkIcon,
+    EyeIcon,
+    EyeOffIcon,
+    FileUpIcon,
+    GlobeIcon,
+    PlayIcon,
+    Trash2Icon,
+    UserIcon,
+} from '@gravitee/graphene-core/icons';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+
+import { ChipInput } from '../features/apis/components/detail/general/ChipInput';
+import { DeleteDialog } from '../features/apis/components/detail/general/DeleteDialog';
+import { DuplicateDialog } from '../features/apis/components/detail/general/DuplicateDialog';
+import { ExportDialog } from '../features/apis/components/detail/general/ExportDialog';
+import { ImagePicker } from '../features/apis/components/detail/general/ImagePicker';
+import { ImportDialog } from '../features/apis/components/detail/general/ImportDialog';
+import { PromoteDialog } from '../features/apis/components/detail/general/PromoteDialog';
+import { useApiDetailContext } from '../features/apis/context/ApiDetailContext';
+import { useApiGeneralMutations } from '../features/apis/hooks/useApiGeneralMutations';
+import type { ApiDetailDto } from '../features/apis/types/api';
+import { exportApiDefinition } from '../services/apis/apis';
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+interface GeneralForm {
+    name: string;
+    apiVersion: string;
+    description: string;
+    labels: string[];
+    categories: string[];
+    allowedInApiProducts: boolean;
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function formFromApi(api: ApiDetailDto): GeneralForm {
+    return {
+        name: api.name ?? '',
+        apiVersion: api.apiVersion ?? '',
+        description: api.description ?? '',
+        labels: api.labels ?? [],
+        categories: api.categories ?? [],
+        allowedInApiProducts: api.allowedInApiProducts ?? false,
+    };
+}
+
+function formatDate(iso?: string): string {
+    if (!iso) return '—';
+    return new Date(iso).toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' });
+}
+
+// ─── Page ─────────────────────────────────────────────────────────────────────
+
+export function ApiGeneralPage() {
+    const { apiId } = useParams<{ apiId: string }>();
+    const env = useEnvironment();
+    const navigate = useNavigate();
+    const { api, isLoading, permissionsReady } = useApiDetailContext();
+
+    // ── Permissions (mirrors legacy api-general-info.component.ts) ────────────
+    // api-definition-r : read form / see export / see allow-in-products toggle
+    // api-definition-u : edit form / save / start / stop / promote
+    // api-definition-c : import / duplicate
+    // api-definition-d : delete
+    const canReadDefinition = useHasPermission({ anyOf: ['api-definition-r'] });
+    const canEditDefinition = useHasPermission({ anyOf: ['api-definition-u'] });
+    const canCreateDefinition = useHasPermission({ anyOf: ['api-definition-c'] });
+    const canDeleteDefinition = useHasPermission({ anyOf: ['api-definition-d'] });
+
+    const isKubernetesManaged = api?.definitionContext?.origin === 'KUBERNETES';
+
+    // Form is read-only until permissions are resolved, if user lacks update rights,
+    // or if the API is managed by the Kubernetes operator.
+    const isReadOnly = !permissionsReady || !canEditDefinition || isKubernetesManaged;
+
+    // Delete is blocked while the API is running or published (matches legacy canDelete logic).
+    const cannotDelete = api?.state === 'STARTED' || api?.lifecycleState === 'PUBLISHED';
+
+    // ── Form state ────────────────────────────────────────────────────────────
+
+    const [form, setForm] = useState<GeneralForm | null>(null);
+    const [savedForm, setSavedForm] = useState<GeneralForm | null>(null);
+    const [saveError, setSaveError] = useState<string | null>(null);
+
+    const [exportOpen, setExportOpen] = useState(false);
+    const [importOpen, setImportOpen] = useState(false);
+    const [duplicateOpen, setDuplicateOpen] = useState(false);
+    const [promoteOpen, setPromoteOpen] = useState(false);
+    const [deleteOpen, setDeleteOpen] = useState(false);
+
+    // Seed form once per API identity; re-seeds if the user navigates to a different API.
+    useEffect(() => {
+        if (!api) return;
+        const seed = formFromApi(api);
+        setSavedForm(seed);
+        setForm(seed);
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [api?.id]);
+
+    const isDirty = useMemo(
+        () => form !== null && savedForm !== null && JSON.stringify(form) !== JSON.stringify(savedForm),
+        [form, savedForm],
+    );
+
+    const setField = useCallback(<K extends keyof GeneralForm>(key: K, value: GeneralForm[K]) => {
+        setForm(prev => (prev ? { ...prev, [key]: value } : prev));
+        setSaveError(null);
+    }, []);
+
+    // ── Mutations ─────────────────────────────────────────────────────────────
+
+    const {
+        saveMutation,
+        startMutation,
+        stopMutation,
+        deleteMutation,
+        duplicateMutation,
+        importMutation,
+        pictureMutation,
+        removePictureMutation,
+        backgroundMutation,
+        removeBackgroundMutation,
+    } = useApiGeneralMutations(api, {
+        onDeleteSuccess: () => {
+            setDeleteOpen(false);
+            navigate('../..');
+        },
+        onDuplicateSuccess: newApi => {
+            setDuplicateOpen(false);
+            navigate(`../../${newApi.id}/general`);
+        },
+        onImportSuccess: updatedApi => {
+            setImportOpen(false);
+            const seed = formFromApi(updatedApi);
+            setSavedForm(seed);
+            setForm(seed);
+        },
+    });
+
+    const handleSave = useCallback(() => {
+        if (!form) return;
+        saveMutation.mutate(
+            {
+                name: form.name,
+                apiVersion: form.apiVersion,
+                description: form.description,
+                labels: form.labels,
+                categories: form.categories,
+                allowedInApiProducts: form.allowedInApiProducts,
+            },
+            {
+                onSuccess: () => {
+                    setSavedForm(form);
+                    setSaveError(null);
+                },
+                onError: (e: unknown) => setSaveError(e instanceof Error ? e.message : 'Failed to save changes.'),
+            },
+        );
+    }, [form, saveMutation]);
+
+    const handleExport = useCallback(async () => {
+        const blob = await exportApiDefinition(env!.id, apiId!);
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = `${form?.name ?? apiId}-definition.json`;
+        a.click();
+        URL.revokeObjectURL(url);
+    }, [env, apiId, form?.name]);
+
+    const apiStarted = api?.state === 'STARTED';
+
+    const startStopError =
+        startMutation.isError || stopMutation.isError
+            ? startMutation.isError
+                ? startMutation.error instanceof Error
+                    ? startMutation.error.message
+                    : 'Failed to start API.'
+                : stopMutation.error instanceof Error
+                  ? stopMutation.error.message
+                  : 'Failed to stop API.'
+            : null;
+
+    const deleteError = deleteMutation.isError
+        ? deleteMutation.error instanceof Error
+            ? deleteMutation.error.message
+            : 'Failed to delete API.'
+        : null;
+
+    const duplicateError = duplicateMutation.isError
+        ? duplicateMutation.error instanceof Error
+            ? duplicateMutation.error.message
+            : 'Failed to duplicate API.'
+        : null;
+
+    const importError = importMutation.isError
+        ? importMutation.error instanceof Error
+            ? importMutation.error.message
+            : 'Failed to import API definition.'
+        : null;
+
+    // ── Loading ───────────────────────────────────────────────────────────────
+
+    if (isLoading || !form) {
+        return (
+            <div className="space-y-5 p-6">
+                <div className="flex items-start justify-between gap-4">
+                    <div className="space-y-2">
+                        <Skeleton className="h-7 w-24 rounded" />
+                        <Skeleton className="h-4 w-64 rounded" />
+                    </div>
+                </div>
+                <Skeleton className="h-72 w-full rounded-xl" />
+            </div>
+        );
+    }
+
+    return (
+        <div className="space-y-5 p-6">
+            {/* ── Page Header ─────────────────────────────────────────────── */}
+            <div className="flex items-start justify-between gap-4">
+                <div className="space-y-1">
+                    <h1 className="text-2xl font-semibold tracking-tight">General</h1>
+                    <p className="text-sm text-muted-foreground">Manage name, version, metadata, and lifecycle for this API.</p>
+                </div>
+                {isDirty && !isReadOnly && (
+                    <div className="flex shrink-0 items-center gap-2">
+                        <Button
+                            type="button"
+                            variant="outline"
+                            size="sm"
+                            onClick={() => {
+                                setForm(savedForm);
+                                setSaveError(null);
+                            }}
+                            disabled={saveMutation.isPending}
+                        >
+                            Discard
+                        </Button>
+                        <Button type="button" size="sm" onClick={handleSave} disabled={saveMutation.isPending}>
+                            <CheckIcon className="size-4" />
+                            {saveMutation.isPending ? 'Saving…' : 'Save changes'}
+                        </Button>
+                    </div>
+                )}
+            </div>
+
+            {saveError && (
+                <Card className="border-destructive/30 bg-destructive/5 p-4">
+                    <p className="text-sm text-destructive">{saveError}</p>
+                </Card>
+            )}
+
+            {isKubernetesManaged && (
+                <Card className="border-primary/20 bg-primary/5 p-4">
+                    <p className="text-sm text-primary">
+                        This API is managed by the Kubernetes operator. Configuration changes must be made in your Kubernetes manifests.
+                    </p>
+                </Card>
+            )}
+
+            {/* ── Main Card ───────────────────────────────────────────────── */}
+            <Card>
+                <CardContent className="pt-6">
+                    <div className="flex flex-row gap-8">
+                        {/* ─ Left: form ─ */}
+                        <div className="flex-1 min-w-0 space-y-4">
+                            <div className="flex gap-4">
+                                <div className="flex-[4] min-w-0 space-y-1">
+                                    <Label htmlFor="api-name">
+                                        Name <span className="text-destructive">*</span>
+                                    </Label>
+                                    <Input
+                                        id="api-name"
+                                        value={form.name}
+                                        onChange={e => setField('name', e.target.value)}
+                                        placeholder="e.g. My API"
+                                        disabled={isReadOnly}
+                                    />
+                                </div>
+                                <div className="flex-1 space-y-1" style={{ minWidth: '120px' }}>
+                                    <Label htmlFor="api-version">
+                                        Version <span className="text-destructive">*</span>
+                                    </Label>
+                                    <Input
+                                        id="api-version"
+                                        value={form.apiVersion}
+                                        onChange={e => setField('apiVersion', e.target.value)}
+                                        maxLength={32}
+                                        placeholder="v1.0.0"
+                                        disabled={isReadOnly}
+                                    />
+                                </div>
+                            </div>
+
+                            <div className="space-y-1">
+                                <Label htmlFor="api-description">Description</Label>
+                                <Textarea
+                                    id="api-description"
+                                    rows={3}
+                                    style={{ fieldSizing: 'fixed' } as React.CSSProperties}
+                                    value={form.description}
+                                    onChange={e => setField('description', e.target.value)}
+                                    placeholder="Describe what this API does…"
+                                    disabled={isReadOnly}
+                                />
+                            </div>
+
+                            <div className="space-y-1">
+                                <Label htmlFor="api-labels">Labels</Label>
+                                <ChipInput
+                                    id="api-labels"
+                                    values={form.labels}
+                                    onChange={v => !isReadOnly && setField('labels', v)}
+                                    placeholder={isReadOnly ? '' : 'Type a label and press Enter'}
+                                />
+                            </div>
+
+                            <div className="space-y-1">
+                                <Label htmlFor="api-categories">Categories</Label>
+                                <ChipInput
+                                    id="api-categories"
+                                    values={form.categories}
+                                    onChange={v => !isReadOnly && setField('categories', v)}
+                                    placeholder={isReadOnly ? '' : 'Type a category and press Enter'}
+                                />
+                            </div>
+
+                            {canReadDefinition && (
+                                <div className="flex items-center justify-between gap-4 rounded-lg border bg-muted/40 px-4 py-3">
+                                    <div className="flex items-start gap-3">
+                                        <BoxesIcon className="size-4 text-primary mt-0.5 shrink-0" />
+                                        <div>
+                                            <p className="text-sm font-medium">Allow in API Products</p>
+                                            <p className="text-xs text-muted-foreground">
+                                                When enabled, this API can be bundled into API Products for grouped consumer access.
+                                            </p>
+                                        </div>
+                                    </div>
+                                    <Switch
+                                        checked={form.allowedInApiProducts}
+                                        onCheckedChange={v => !isReadOnly && setField('allowedInApiProducts', v)}
+                                        disabled={isReadOnly}
+                                    />
+                                </div>
+                            )}
+                        </div>
+
+                        {/* ─ Right: images + metadata ─ */}
+                        <div className="shrink-0 border-l pl-8 space-y-5" style={{ width: '280px' }}>
+                            <div className="space-y-3">
+                                <p className="text-xs font-medium text-muted-foreground uppercase tracking-wider">Images</p>
+                                <div className="flex gap-3 items-start">
+                                    <ImagePicker
+                                        label="Picture"
+                                        preview={api?.picture}
+                                        width={88}
+                                        height={88}
+                                        onSelect={b64 => pictureMutation.mutate(b64)}
+                                        onRemove={() => removePictureMutation.mutate()}
+                                        disabled={isReadOnly || pictureMutation.isPending || removePictureMutation.isPending}
+                                    />
+                                    <ImagePicker
+                                        label="Background"
+                                        preview={api?.background}
+                                        width={152}
+                                        height={88}
+                                        onSelect={b64 => backgroundMutation.mutate(b64)}
+                                        onRemove={() => removeBackgroundMutation.mutate()}
+                                        disabled={isReadOnly || backgroundMutation.isPending || removeBackgroundMutation.isPending}
+                                    />
+                                </div>
+                                <p className="text-center text-muted-foreground" style={{ fontSize: '10px' }}>
+                                    PNG, JPG, SVG · max 500 KB
+                                </p>
+                                {(pictureMutation.isError ||
+                                    removePictureMutation.isError ||
+                                    backgroundMutation.isError ||
+                                    removeBackgroundMutation.isError) && (
+                                    <p className="text-xs text-destructive text-center">
+                                        {pictureMutation.isError
+                                            ? pictureMutation.error instanceof Error
+                                                ? pictureMutation.error.message
+                                                : 'Failed to update picture.'
+                                            : removePictureMutation.isError
+                                              ? removePictureMutation.error instanceof Error
+                                                  ? removePictureMutation.error.message
+                                                  : 'Failed to remove picture.'
+                                              : backgroundMutation.isError
+                                                ? backgroundMutation.error instanceof Error
+                                                    ? backgroundMutation.error.message
+                                                    : 'Failed to update background.'
+                                                : removeBackgroundMutation.error instanceof Error
+                                                  ? removeBackgroundMutation.error.message
+                                                  : 'Failed to remove background.'}
+                                    </p>
+                                )}
+                            </div>
+
+                            <Separator />
+
+                            {/* Metadata */}
+                            <div className="space-y-3">
+                                <p className="text-xs font-medium text-muted-foreground uppercase tracking-wider">Details</p>
+                                <dl className="space-y-2.5">
+                                    <DetailRow
+                                        label={
+                                            <>
+                                                <UserIcon className="size-3" /> Owner
+                                            </>
+                                        }
+                                        value={api?.primaryOwner?.displayName ?? api?.primaryOwner?.email ?? '—'}
+                                    />
+                                    <DetailRow
+                                        label={
+                                            <>
+                                                <ClockIcon className="size-3" /> Created
+                                            </>
+                                        }
+                                        value={formatDate(api?.createdAt)}
+                                    />
+                                    <DetailRow
+                                        label={
+                                            <>
+                                                <ClockIcon className="size-3" /> Updated
+                                            </>
+                                        }
+                                        value={formatDate(api?.updatedAt)}
+                                    />
+                                    <div className="flex items-center justify-between gap-2">
+                                        <dt className="text-muted-foreground flex items-center gap-1.5 shrink-0 text-xs">
+                                            <GlobeIcon className="size-3" /> Visibility
+                                        </dt>
+                                        <dd>
+                                            <Badge variant="outline" className="gap-1" style={{ fontSize: '10px' }}>
+                                                {api?.visibility === 'PUBLIC' ? (
+                                                    <EyeIcon className="size-2.5" />
+                                                ) : (
+                                                    <EyeOffIcon className="size-2.5" />
+                                                )}
+                                                {api?.visibility ?? '—'}
+                                            </Badge>
+                                        </dd>
+                                    </div>
+                                    <div className="flex items-center justify-between gap-2">
+                                        <dt className="text-muted-foreground shrink-0 text-xs">Lifecycle</dt>
+                                        <dd>
+                                            <Badge variant="secondary" style={{ fontSize: '10px' }}>
+                                                {api?.lifecycleState ?? '—'}
+                                            </Badge>
+                                        </dd>
+                                    </div>
+                                    <div className="flex items-center justify-between gap-2">
+                                        <dt className="text-muted-foreground shrink-0 text-xs">Status</dt>
+                                        <dd>
+                                            <StatusBadge state={api?.state} />
+                                        </dd>
+                                    </div>
+                                </dl>
+                            </div>
+                        </div>
+                    </div>
+
+                    {/* ─ Action strip ─ */}
+                    <Separator className="my-5" />
+                    <div className="flex flex-wrap items-center gap-2">
+                        {canReadDefinition && (
+                            <Button type="button" variant="outline" size="sm" onClick={() => setExportOpen(true)}>
+                                <DownloadIcon className="size-3.5" /> Export
+                            </Button>
+                        )}
+                        {canCreateDefinition && (
+                            <Button
+                                type="button"
+                                variant="outline"
+                                size="sm"
+                                onClick={() => setImportOpen(true)}
+                                disabled={isKubernetesManaged}
+                            >
+                                <FileUpIcon className="size-3.5" /> Import
+                            </Button>
+                        )}
+                        {canCreateDefinition && api?.type !== 'NATIVE' && (
+                            <Button
+                                type="button"
+                                variant="outline"
+                                size="sm"
+                                onClick={() => setDuplicateOpen(true)}
+                                disabled={isKubernetesManaged}
+                            >
+                                <CopyIcon className="size-3.5" /> Duplicate
+                            </Button>
+                        )}
+                        {canEditDefinition && (
+                            <Button
+                                type="button"
+                                variant="outline"
+                                size="sm"
+                                onClick={() => setPromoteOpen(true)}
+                                disabled={isKubernetesManaged || api?.lifecycleState === 'DEPRECATED'}
+                            >
+                                <ExternalLinkIcon className="size-3.5" /> Promote
+                            </Button>
+                        )}
+                    </div>
+                </CardContent>
+            </Card>
+
+            {/* ── API Events ──────────────────────────────────────────────── */}
+            {(canEditDefinition || canDeleteDefinition) && (
+                <Card>
+                    <CardContent className="pt-5 pb-5">
+                        <div className="space-y-4">
+                            <div>
+                                <p className="text-sm font-semibold">API Events</p>
+                                <p className="text-xs text-muted-foreground mt-0.5">
+                                    These actions alter the runtime state of your API on the gateway.
+                                </p>
+                            </div>
+                            <div className="grid grid-cols-2 gap-3">
+                                {canEditDefinition && (
+                                    <button
+                                        type="button"
+                                        className={cn(
+                                            'flex items-center gap-3 rounded-lg border p-4 text-left transition-colors',
+                                            isReadOnly || startMutation.isPending || stopMutation.isPending
+                                                ? 'cursor-not-allowed opacity-50'
+                                                : 'cursor-pointer hover:bg-muted/50',
+                                        )}
+                                        onClick={() => !isReadOnly && (apiStarted ? stopMutation.mutate() : startMutation.mutate())}
+                                        disabled={isReadOnly || startMutation.isPending || stopMutation.isPending}
+                                    >
+                                        <div className={cn('shrink-0 rounded-lg p-2', apiStarted ? 'bg-warning/10' : 'bg-success/10')}>
+                                            {apiStarted ? (
+                                                <CircleStopIcon className="size-5 text-warning" />
+                                            ) : (
+                                                <PlayIcon className="size-5 text-success" />
+                                            )}
+                                        </div>
+                                        <div>
+                                            <p className="text-sm font-medium">
+                                                {apiStarted
+                                                    ? stopMutation.isPending
+                                                        ? 'Stopping…'
+                                                        : 'Stop API'
+                                                    : startMutation.isPending
+                                                      ? 'Starting…'
+                                                      : 'Start API'}
+                                            </p>
+                                            <p className="text-xs text-muted-foreground">
+                                                {apiStarted
+                                                    ? 'Gateway stops accepting requests. Subscriptions are preserved.'
+                                                    : 'Start the API and make it available on all connected gateways.'}
+                                            </p>
+                                        </div>
+                                    </button>
+                                )}
+                                {canDeleteDefinition && (
+                                    <button
+                                        type="button"
+                                        className={cn(
+                                            'flex items-center gap-3 rounded-lg border p-4 text-left transition-colors',
+                                            cannotDelete ? 'cursor-not-allowed opacity-50' : 'cursor-pointer hover:bg-destructive/5',
+                                        )}
+                                        onClick={() => !cannotDelete && setDeleteOpen(true)}
+                                        disabled={cannotDelete}
+                                    >
+                                        <div className="shrink-0 rounded-lg p-2 bg-destructive/10">
+                                            <Trash2Icon className="size-5 text-destructive" />
+                                        </div>
+                                        <div>
+                                            <p className="text-sm font-medium text-destructive">Delete this API</p>
+                                            <p className="text-xs text-muted-foreground">
+                                                {cannotDelete
+                                                    ? 'A running or published API cannot be deleted.'
+                                                    : 'Permanently removes the API, all plans, subscriptions, and analytics data.'}
+                                            </p>
+                                        </div>
+                                    </button>
+                                )}
+                            </div>
+                            {startStopError && <p className="text-sm text-destructive">{startStopError}</p>}
+                        </div>
+                    </CardContent>
+                </Card>
+            )}
+
+            {/* ── Dialogs ─────────────────────────────────────────────────── */}
+            <ExportDialog open={exportOpen} onOpenChange={setExportOpen} onExport={() => void handleExport()} />
+            <ImportDialog
+                open={importOpen}
+                onOpenChange={setImportOpen}
+                onImport={def => importMutation.mutate(def)}
+                isLoading={importMutation.isPending}
+                error={importError}
+            />
+            <DuplicateDialog
+                open={duplicateOpen}
+                onOpenChange={setDuplicateOpen}
+                initialName={api?.name ?? ''}
+                initialVersion={api?.apiVersion ?? ''}
+                onDuplicate={opts => duplicateMutation.mutate(opts)}
+                isLoading={duplicateMutation.isPending}
+                error={duplicateError}
+            />
+            <PromoteDialog open={promoteOpen} onOpenChange={setPromoteOpen} />
+            <DeleteDialog
+                open={deleteOpen}
+                onOpenChange={setDeleteOpen}
+                apiName={api?.name ?? ''}
+                onDelete={() => deleteMutation.mutate()}
+                isLoading={deleteMutation.isPending}
+                error={deleteError}
+            />
+        </div>
+    );
+}
+
+// ─── Small local helpers ──────────────────────────────────────────────────────
+
+function DetailRow({ label, value }: Readonly<{ label: React.ReactNode; value: string }>) {
+    return (
+        <div className="flex items-center justify-between gap-2">
+            <dt className="text-muted-foreground flex items-center gap-1.5 shrink-0 text-xs">{label}</dt>
+            <dd className="text-right text-xs font-medium truncate">{value}</dd>
+        </div>
+    );
+}
+
+function StatusBadge({ state }: Readonly<{ state?: string }>) {
+    if (state === 'STARTED') {
+        return (
+            <Badge variant="outline" className="gap-1 border-success/20 text-success" style={{ fontSize: '10px' }}>
+                <div className="size-1.5 rounded-full bg-success" /> Started
+            </Badge>
+        );
+    }
+    if (state === 'STOPPED') {
+        return (
+            <Badge variant="outline" className="gap-1 text-warning" style={{ fontSize: '10px', borderColor: 'var(--color-warning)' }}>
+                <div className="size-1.5 rounded-full" style={{ backgroundColor: 'var(--color-warning)' }} /> Stopped
+            </Badge>
+        );
+    }
+    return (
+        <Badge variant="secondary" style={{ fontSize: '10px' }}>
+            {state ?? '—'}
+        </Badge>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/services/apis/apis.ts
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/services/apis/apis.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import type { ApiDetailDto, ApiEventsPage } from '../../features/apis/types/api';
+import type { ApiDetailDto, ApiEventsPage, DuplicateApiOptions } from '../../features/apis/types/api';
 import { apimFetchJsonV2 } from '../../shared/api/apimClient';
 
 const JSON_HEADERS = { 'Content-Type': 'application/json' };
@@ -48,5 +48,87 @@ export async function rollbackApi(environmentId: string, apiId: string, eventId:
         method: 'POST',
         headers: JSON_HEADERS,
         body: JSON.stringify({ eventId }),
+    });
+}
+
+export async function updateApiGeneral(
+    environmentId: string,
+    apiId: string,
+    current: ApiDetailDto,
+    patch: Partial<ApiDetailDto>,
+): Promise<ApiDetailDto> {
+    return apimFetchJsonV2<ApiDetailDto>(environmentId, `/apis/${encodeURIComponent(apiId)}`, {
+        method: 'PUT',
+        headers: JSON_HEADERS,
+        body: JSON.stringify({ ...current, ...patch }),
+    });
+}
+
+export async function startApi(environmentId: string, apiId: string): Promise<void> {
+    await apimFetchJsonV2(environmentId, `/apis/${encodeURIComponent(apiId)}/_start`, {
+        method: 'POST',
+        headers: JSON_HEADERS,
+    });
+}
+
+export async function stopApi(environmentId: string, apiId: string): Promise<void> {
+    await apimFetchJsonV2(environmentId, `/apis/${encodeURIComponent(apiId)}/_stop`, {
+        method: 'POST',
+        headers: JSON_HEADERS,
+    });
+}
+
+export async function deleteApi(environmentId: string, apiId: string): Promise<void> {
+    await apimFetchJsonV2(environmentId, `/apis/${encodeURIComponent(apiId)}`, {
+        method: 'DELETE',
+    });
+}
+
+export async function duplicateApi(environmentId: string, apiId: string, options: DuplicateApiOptions): Promise<ApiDetailDto> {
+    return apimFetchJsonV2<ApiDetailDto>(environmentId, `/apis/${encodeURIComponent(apiId)}/_duplicate`, {
+        method: 'POST',
+        headers: JSON_HEADERS,
+        body: JSON.stringify(options),
+    });
+}
+
+export async function exportApiDefinition(environmentId: string, apiId: string): Promise<Blob> {
+    const definition = await apimFetchJsonV2<unknown>(environmentId, `/apis/${encodeURIComponent(apiId)}`);
+    return new Blob([JSON.stringify(definition, null, 2)], { type: 'application/json' });
+}
+
+export async function updateApiFromDefinition(environmentId: string, apiId: string, definition: unknown): Promise<ApiDetailDto> {
+    return apimFetchJsonV2<ApiDetailDto>(environmentId, `/apis/${encodeURIComponent(apiId)}/definition`, {
+        method: 'PUT',
+        headers: JSON_HEADERS,
+        body: JSON.stringify(definition),
+    });
+}
+
+export async function updateApiPicture(environmentId: string, apiId: string, base64: string): Promise<void> {
+    await apimFetchJsonV2(environmentId, `/apis/${encodeURIComponent(apiId)}/picture`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'text/plain' },
+        body: base64,
+    });
+}
+
+export async function deleteApiPicture(environmentId: string, apiId: string): Promise<void> {
+    await apimFetchJsonV2(environmentId, `/apis/${encodeURIComponent(apiId)}/picture`, {
+        method: 'DELETE',
+    });
+}
+
+export async function updateApiBackground(environmentId: string, apiId: string, base64: string): Promise<void> {
+    await apimFetchJsonV2(environmentId, `/apis/${encodeURIComponent(apiId)}/background`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'text/plain' },
+        body: base64,
+    });
+}
+
+export async function deleteApiBackground(environmentId: string, apiId: string): Promise<void> {
+    await apimFetchJsonV2(environmentId, `/apis/${encodeURIComponent(apiId)}/background`, {
+        method: 'DELETE',
     });
 }

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/services/apis/entrypoints.ts
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/services/apis/entrypoints.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import type { ApiDetailDto, ExposedEntrypoint, HttpListener } from '../../features/apis/types/api';
+import { apimFetchJsonV2 } from '../../shared/api/apimClient';
+
+const JSON_HEADERS = { 'Content-Type': 'application/json' };
+
+export async function getExposedEntrypoints(environmentId: string, apiId: string): Promise<ExposedEntrypoint[]> {
+    return apimFetchJsonV2<ExposedEntrypoint[]>(environmentId, `/apis/${encodeURIComponent(apiId)}/exposedEntrypoints`);
+}
+
+export async function updateApiListeners(
+    environmentId: string,
+    apiId: string,
+    current: ApiDetailDto,
+    listeners: HttpListener[],
+): Promise<ApiDetailDto> {
+    return apimFetchJsonV2<ApiDetailDto>(environmentId, `/apis/${encodeURIComponent(apiId)}`, {
+        method: 'PUT',
+        headers: JSON_HEADERS,
+        body: JSON.stringify({ ...current, listeners }),
+    });
+}

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/services/portal/settings.ts
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/services/portal/settings.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { apimFetchJsonV1Env } from '../../shared/api/apimClient';
+
+export interface EnvironmentPortalSettings {
+    portal?: { entrypoint?: string };
+}
+
+export async function getEnvironmentPortalSettings(environmentId: string): Promise<EnvironmentPortalSettings> {
+    return apimFetchJsonV1Env<EnvironmentPortalSettings>(environmentId, '/settings');
+}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/GMA-231

## Description

## Summary

### API General page (`ApiGeneralPage`)
- Full form for editing API name, version, description, labels, categories, visibility, lifecycle state, and `allowedInApiProducts` flag
- Dirty-tracking with Save / Discard actions; saves via `updateApiGeneral` (GET + PUT)
- Start / Stop lifecycle buttons wired to `startApi` / `stopApi`
- Image and background pickers with upload, preview, and remove actions
- Action buttons: Export (JSON definition), Import (overwrite), Duplicate, Promote
- Delete zone with confirmation dialog requiring exact API name to proceed
- Permission guards matching legacy console:
  - `api-definition-r` → hides Export
  - `api-definition-c` → hides Import / Duplicate
  - `api-definition-u` → read-only form, hides Promote and API Events section
  - `api-definition-d` → hides Delete zone
  - `origin: KUBERNETES` → full read-only mode with Kubernetes banner

### API Entrypoints page (`ApiEntrypointsPage`)
- Landing/education card when no entrypoints are configured; transitions to config view on "Add context path"
- Context-path mode: list of path inputs, at least one required, inline duplicate/format validation, Add / Delete row controls
- Virtual-host mode: host + path + override-access inputs per row
- "Enable virtual hosts" toggle with confirmation dialog when switching VH → context-path (warns about data loss)
- Exposed entrypoints card showing Gateway URL / Internal URL (context-path) or Virtual host row N (VH mode) with copy-to-clipboard
- Save via GET current API + merge listeners + PUT (same pattern as General)
- Permission guards: `api-definition-u` + `api-gateway_definition-u` (both required); `permissionsReady` gate; Kubernetes origin → full read-only

### Wizard enhancements
- Gateway prefix in context-path inputs (scratch and template wizards) now
  fetched live from `GET /settings` (`portal.entrypoint`), falling back to
  the hardcoded placeholder when unavailable (`useGatewayPrefix` hook)
- Context path field pre-populated with `/` instead of empty string
- Template wizard (`EssentialsStep`): field order changed to
  Context path → Target URL (was Target URL → Context path)
  
  

https://github.com/user-attachments/assets/551e449d-173a-4fe9-aebb-38e8e5ad38cb



## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

