### PR TITLE
Feat/ext 121

### DIFF
--- a/gravitee-apim-portal-webui-next/src/app/api/api-details/api-tab-subscriptions/subscriptions-details/subscriptions-details.component.html
+++ b/gravitee-apim-portal-webui-next/src/app/api/api-details/api-tab-subscriptions/subscriptions-details/subscriptions-details.component.html
@@ -56,6 +56,7 @@
           [apiType]="detailsVM.result.api?.type"
           [apiKeyConfigUsername]="detailsVM.result.apiKeyConfigUsername"
           (apiKeyRevoked)="reloadSubscriptionDetails()"
+          (apiKeyRenewed)="reloadSubscriptionDetails()"
         />
       }
     </div>

--- a/gravitee-apim-portal-webui-next/src/components/api-access/api-access.component.html
+++ b/gravitee-apim-portal-webui-next/src/components/api-access/api-access.component.html
@@ -20,6 +20,19 @@
     <mat-card-header>
       <div class="api-access__header-row">
         <div class="next-gen-h5 api-access__header" i18n="@@subscriptionDetailsApiAccessHeader">API access</div>
+        @if (planSecurity === 'API_KEY' && subscription?.status === 'ACCEPTED' && canManageApiKey) {
+          <button
+            mat-stroked-button
+            type="button"
+            matTooltip="Renew API Key"
+            i18n-matTooltip="@@subscriptionDetailsRenewApiKeyTooltip"
+            [disabled]="isRenewingApiKey()"
+            data-testid="renew-api-key-button"
+            (click)="renewApiKey()"
+          >
+            <span class="next-gen-small-bold" i18n="@@subscriptionDetailsRenewApiKey">Renew API Key</span>
+          </button>
+        }
       </div>
     </mat-card-header>
     <mat-card-content class="api-access__copy-code-content">
@@ -42,6 +55,18 @@
         @if (planSecurity === 'API_KEY') {
           <div class="api-access__copy-code-content__api-keys-list">
             <div class="next-gen-h5" i18n="@@subscriptionDetailsApiAccessApiKeysHeader">API keys</div>
+            @if (apiKeyRenewFeedback(); as renewFeedback) {
+              <div
+                class="next-gen-body api-access__renew-feedback"
+                [class.api-access__renew-feedback--error]="renewFeedback.type === 'error'"
+                [class.api-access__renew-feedback--success]="renewFeedback.type === 'success'"
+                [attr.role]="renewFeedback.type === 'error' ? 'alert' : null"
+                [attr.aria-live]="renewFeedback.type === 'success' ? 'polite' : null"
+                data-testid="renew-api-key-feedback"
+              >
+                {{ renewFeedback.message }}
+              </div>
+            }
             @if (apiKeyRows().length > 0) {
               <app-paginated-table
                 [columns]="apiKeysColumns"

--- a/gravitee-apim-portal-webui-next/src/components/api-access/api-access.component.scss
+++ b/gravitee-apim-portal-webui-next/src/components/api-access/api-access.component.scss
@@ -13,6 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+@use '../../scss/theme' as app-theme;
+
 :host {
   width: 100%;
 }
@@ -59,6 +61,16 @@
       display: flex;
       flex-flow: column;
       gap: 8px;
+    }
+  }
+
+  &__renew-feedback {
+    &--success {
+      color: app-theme.$primary-main-color;
+    }
+
+    &--error {
+      color: app-theme.$error-main-color;
     }
   }
 }

--- a/gravitee-apim-portal-webui-next/src/components/api-access/api-access.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/components/api-access/api-access.component.spec.ts
@@ -400,6 +400,43 @@ describe('ApiAccessComponent', () => {
           await expect(revokeButtonsAfterCancel[1].isDisabled()).resolves.toBeFalsy();
         });
 
+        it('should not open another confirmation dialog while one is already open', async () => {
+          component.planSecurity = 'API_KEY';
+          component.subscription = { id: 'subscription-id', status: 'ACCEPTED' } as Subscription;
+          component.apiKeys = [
+            { key: 'api-key-1', application: { id: 'app-id', name: 'app-name' } },
+            { key: 'api-key-2', application: { id: 'app-id', name: 'app-name' } },
+          ];
+          const matDialogOpenSpy = jest.spyOn(TestBed.inject(MatDialog), 'open');
+
+          fixture.detectChanges();
+
+          const revokeButtons = await getRevokeApiKeyButtons();
+          expect(revokeButtons).toHaveLength(2);
+
+          await revokeButtons[0].click();
+          fixture.detectChanges();
+
+          expect(matDialogOpenSpy).toHaveBeenCalledTimes(1);
+          await expect(revokeButtons[0].isDisabled()).resolves.toBeTruthy();
+          await expect(revokeButtons[1].isDisabled()).resolves.toBeTruthy();
+
+          (component as unknown as { revokeApiKeyRow: (apiKey: { isActive: boolean; key: string }) => void }).revokeApiKeyRow({
+            isActive: true,
+            key: 'api-key-2',
+          });
+
+          expect(matDialogOpenSpy).toHaveBeenCalledTimes(1);
+
+          const confirmDialog = await rootLoader.getHarness(ConfirmDialogHarness);
+          await confirmDialog.cancel();
+          fixture.detectChanges();
+
+          const revokeButtonsAfterCancel = await getRevokeApiKeyButtons();
+          await expect(revokeButtonsAfterCancel[0].isDisabled()).resolves.toBeFalsy();
+          await expect(revokeButtonsAfterCancel[1].isDisabled()).resolves.toBeFalsy();
+        });
+
         it('should not emit revoke event when revoke service fails', async () => {
           component.planSecurity = 'API_KEY';
           component.subscription = { id: 'subscription-id', status: 'ACCEPTED' } as Subscription;

--- a/gravitee-apim-portal-webui-next/src/components/api-access/api-access.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/components/api-access/api-access.component.spec.ts
@@ -23,6 +23,7 @@ import { MatDialog } from '@angular/material/dialog';
 import { MatIconTestingModule } from '@angular/material/icon/testing';
 import { MatSelectHarness } from '@angular/material/select/testing';
 import { MatTabGroupHarness } from '@angular/material/tabs/testing';
+import { MatTooltipHarness } from '@angular/material/tooltip/testing';
 import { By } from '@angular/platform-browser';
 
 import { ApiAccessComponent } from './api-access.component';
@@ -170,6 +171,143 @@ describe('ApiAccessComponent', () => {
           fixture.detectChanges();
 
           expect(await revokeApiKeyButtonShown()).toBeFalsy();
+          expect(await renewApiKeyButtonShown()).toBeFalsy();
+        });
+
+        it('should show renew api key button with tooltip', async () => {
+          component.planSecurity = 'API_KEY';
+          component.subscription = { id: 'subscription-id', status: 'ACCEPTED' } as Subscription;
+          component.entrypointUrls = ['my-entrypoint-url'];
+          component.apiKeys = [{ key: 'api-key', application: { id: 'app-id', name: 'app-name' } }];
+
+          fixture.detectChanges();
+
+          const renewButton = await getRenewApiKeyButton();
+          expect(renewButton).toBeTruthy();
+          expect(await renewButton!.getText()).toContain('Renew API Key');
+
+          const tooltip = await getRenewApiKeyTooltip();
+          expect(tooltip).toBeTruthy();
+          await tooltip!.show();
+          expect(await tooltip!.getTooltipText()).toBe('Renew API Key');
+        });
+
+        it('should open confirmation dialog and call renew service after confirmation', async () => {
+          component.planSecurity = 'API_KEY';
+          component.subscription = { id: 'subscription-id', status: 'ACCEPTED' } as Subscription;
+          component.entrypointUrls = ['my-entrypoint-url'];
+          component.apiKeys = [{ key: 'api-key', application: { id: 'app-id', name: 'app-name' } }];
+          const apiKeyRenewedSpy = jest.spyOn(component.apiKeyRenewed, 'emit');
+
+          fixture.detectChanges();
+
+          const renewButton = await getRenewApiKeyButton();
+          expect(renewButton).toBeTruthy();
+
+          await renewButton!.click();
+          const confirmDialog = await rootLoader.getHarness(ConfirmDialogHarness);
+          expect(await confirmDialog.getTitle()).toContain('Renew API Key?');
+          expect(await confirmDialog.getContent()).toContain('API Key renewal will eventually deprecate the current key');
+          expect(await confirmDialog.getCancelText()).toContain('Cancel');
+          expect(await confirmDialog.getConfirmText()).toContain('Yes, renew');
+
+          await confirmDialog.confirm();
+          expectRenewApiKeyRequest('subscription-id').flush(null);
+          fixture.detectChanges();
+
+          expect(apiKeyRenewedSpy).toHaveBeenCalled();
+          expect(getRenewApiKeyFeedbackText()).toContain('API key renewed successfully. You can now use it to access the API.');
+          expect(getRenewApiKeyFeedbackAttribute('aria-live')).toBe('polite');
+          expect(getRenewApiKeyFeedbackAttribute('role')).toBeNull();
+        });
+
+        it('should not call renew service when dialog is canceled', async () => {
+          component.planSecurity = 'API_KEY';
+          component.subscription = { id: 'subscription-id', status: 'ACCEPTED' } as Subscription;
+          component.entrypointUrls = ['my-entrypoint-url'];
+          component.apiKeys = [{ key: 'api-key', application: { id: 'app-id', name: 'app-name' } }];
+
+          fixture.detectChanges();
+
+          const renewButton = await getRenewApiKeyButton();
+          expect(renewButton).toBeTruthy();
+
+          await renewButton!.click();
+          const confirmDialog = await rootLoader.getHarness(ConfirmDialogHarness);
+          await confirmDialog.cancel();
+
+          expectNoRenewApiKeyRequest();
+        });
+
+        it('should not emit revoke event when renew service fails', async () => {
+          component.planSecurity = 'API_KEY';
+          component.subscription = { id: 'subscription-id', status: 'ACCEPTED' } as Subscription;
+          component.entrypointUrls = ['my-entrypoint-url'];
+          component.apiKeys = [{ key: 'api-key', application: { id: 'app-id', name: 'app-name' } }];
+          const apiKeyRenewedSpy = jest.spyOn(component.apiKeyRenewed, 'emit');
+
+          fixture.detectChanges();
+
+          const renewButton = await getRenewApiKeyButton();
+          expect(renewButton).toBeTruthy();
+
+          await renewButton!.click();
+          const confirmDialog = await rootLoader.getHarness(ConfirmDialogHarness);
+          await confirmDialog.confirm();
+
+          expectRenewApiKeyRequest('subscription-id').flush('Failed to renew API key', {
+            status: 500,
+            statusText: 'Server Error',
+          });
+          fixture.detectChanges();
+
+          expect(apiKeyRenewedSpy).not.toHaveBeenCalled();
+          expect(getRenewApiKeyFeedbackText()).toContain('Failed to renew API key. Please try again.');
+          expect(getRenewApiKeyFeedbackAttribute('role')).toBe('alert');
+          expect(getRenewApiKeyFeedbackAttribute('aria-live')).toBeNull();
+        });
+
+        it('should not call renew service when subscription id is missing', async () => {
+          component.planSecurity = 'API_KEY';
+          component.subscription = { status: 'ACCEPTED' } as Subscription;
+          component.entrypointUrls = ['my-entrypoint-url'];
+          component.apiKeys = [{ key: 'api-key', application: { id: 'app-id', name: 'app-name' } }];
+
+          fixture.detectChanges();
+
+          const renewButton = await getRenewApiKeyButton();
+          expect(renewButton).toBeTruthy();
+          await renewButton!.click();
+
+          expectNoRenewApiKeyRequest();
+        });
+
+        it('should disable renew button while request is in flight', async () => {
+          component.planSecurity = 'API_KEY';
+          component.subscription = { id: 'subscription-id', status: 'ACCEPTED' } as Subscription;
+          component.entrypointUrls = ['my-entrypoint-url'];
+          component.apiKeys = [{ key: 'api-key', application: { id: 'app-id', name: 'app-name' } }];
+
+          fixture.detectChanges();
+
+          const renewButton = await getRenewApiKeyButton();
+          expect(renewButton).toBeTruthy();
+          expect(await renewButton!.isDisabled()).toBeFalsy();
+
+          await renewButton!.click();
+          const confirmDialog = await rootLoader.getHarness(ConfirmDialogHarness);
+          await confirmDialog.confirm();
+          fixture.detectChanges();
+
+          const request = expectRenewApiKeyRequest('subscription-id');
+          const renewButtonWhileLoading = await getRenewApiKeyButton();
+          expect(await renewButtonWhileLoading!.isDisabled()).toBeTruthy();
+
+          request.flush(null);
+          fixture.detectChanges();
+
+          const renewButtonAfterDone = await getRenewApiKeyButton();
+          expect(await renewButtonAfterDone!.isDisabled()).toBeFalsy();
         });
 
         it('should show revoke button only for active api keys', async () => {
@@ -713,6 +851,18 @@ describe('ApiAccessComponent', () => {
   function expectNoRevokeApiKeyRequest() {
     httpTestingController.expectNone(request => request.url.includes('/_revoke'), 'revoke API key request');
   }
+  function renewApiKeyUrl(subscriptionId: string): string {
+    return `${TESTING_BASE_URL}/subscriptions/${subscriptionId}/keys/_renew`;
+  }
+  function expectRenewApiKeyRequest(subscriptionId: string) {
+    const request = httpTestingController.expectOne(renewApiKeyUrl(subscriptionId));
+    expect(request.request.method).toEqual('POST');
+    expect(request.request.body).toBeNull();
+    return request;
+  }
+  function expectNoRenewApiKeyRequest() {
+    httpTestingController.expectNone(request => request.url.includes('/_renew'), 'renew API key request');
+  }
   function getApiKeyStatusIcons() {
     return fixture.debugElement
       .queryAll(By.css('[data-testid="api-key-status-icon"]'))
@@ -734,6 +884,26 @@ describe('ApiAccessComponent', () => {
   }
   async function revokeApiKeyButtonShown() {
     return !!(await getRevokeApiKeyButton());
+  }
+  async function getRenewApiKeyButton() {
+    return await harnessLoader.getHarnessOrNull(MatButtonHarness.with({ selector: '[data-testid="renew-api-key-button"]' }));
+  }
+  async function renewApiKeyButtonShown() {
+    return !!(await getRenewApiKeyButton());
+  }
+  async function getRenewApiKeyTooltip() {
+    return await harnessLoader.getHarnessOrNull(MatTooltipHarness.with({ selector: '[data-testid="renew-api-key-button"]' }));
+  }
+  function getRenewApiKeyFeedback() {
+    return fixture.debugElement.query(By.css('[data-testid="renew-api-key-feedback"]'));
+  }
+  function getRenewApiKeyFeedbackText() {
+    const element = getRenewApiKeyFeedback()?.nativeElement as HTMLElement | undefined;
+    return element?.textContent?.trim();
+  }
+  function getRenewApiKeyFeedbackAttribute(attribute: string) {
+    const element = getRenewApiKeyFeedback()?.nativeElement as HTMLElement | undefined;
+    return element?.getAttribute(attribute) ?? null;
   }
   function getApiKeyRevokeButtonApiKeys() {
     return fixture.debugElement

--- a/gravitee-apim-portal-webui-next/src/components/api-access/api-access.component.ts
+++ b/gravitee-apim-portal-webui-next/src/components/api-access/api-access.component.ts
@@ -48,6 +48,11 @@ interface ApiKeyTableRow {
   closedAt?: string;
 }
 
+interface ApiKeyRenewFeedback {
+  type: 'success' | 'error';
+  message: string;
+}
+
 @Component({
   selector: 'app-api-access',
   imports: [
@@ -159,6 +164,7 @@ export class ApiAccessComponent {
   }
 
   apiKeyRevoked = output<void>();
+  apiKeyRenewed = output<void>();
 
   protected readonly apiKeysColumns: TableColumn[] = [
     { id: 'status', label: $localize`:@@subscriptionDetailsApiAccessApiKeysColumnStatus:Status` },
@@ -178,6 +184,9 @@ export class ApiAccessComponent {
   private readonly clientIdInput = signal<string | undefined>(undefined);
   private readonly clientSecretInput = signal<string | undefined>(undefined);
   private readonly canManageApiKeyInput = signal(false);
+  protected readonly apiKeyRenewFeedback = signal<ApiKeyRenewFeedback | undefined>(undefined);
+  protected readonly isRenewingApiKey = signal(false);
+  protected readonly isRenewApiKeyDialogOpen = signal(false);
 
   protected readonly entrypointUrlValues = computed(() => this.entrypointUrlsInput() ?? []);
   protected readonly apiKeyRows = computed<ApiKeyTableRow[]>(() =>
@@ -266,6 +275,34 @@ export class ApiAccessComponent {
       .subscribe(() => this.executeApiKeyRevocation(apiKey.key));
   }
 
+  protected renewApiKey(): void {
+    if (!this.canManageApiKeyInput() || this.isRenewingApiKey() || this.isRenewApiKeyDialogOpen() || !this.subscription?.id) {
+      return;
+    }
+
+    const dialogData: ConfirmDialogData = {
+      title: $localize`:@@subscriptionDetailsRenewApiKeyDialogTitle:Renew API Key?`,
+      content: $localize`:@@subscriptionDetailsRenewApiKeyDialogContent:API Key renewal will eventually deprecate the current key`,
+      confirmLabel: $localize`:@@subscriptionDetailsRenewApiKeyDialogConfirm:Yes, renew`,
+      cancelLabel: $localize`:@@subscriptionDetailsRenewApiKeyDialogCancel:Cancel`,
+    };
+
+    this.isRenewApiKeyDialogOpen.set(true);
+    this.dialog
+      .open<ConfirmDialogComponent, ConfirmDialogData, boolean>(ConfirmDialogComponent, {
+        role: 'alertdialog',
+        id: 'confirmDialog',
+        data: dialogData,
+      })
+      .afterClosed()
+      .pipe(
+        tap(() => this.isRenewApiKeyDialogOpen.set(false)),
+        filter(confirmed => !!confirmed),
+        takeUntilDestroyed(this.destroyRef),
+      )
+      .subscribe(() => this.executeApiKeyRenewal());
+  }
+
   private isActiveApiKey(apiKey: SubscriptionDataKeys): boolean {
     if (apiKey.revoked_at) {
       return false;
@@ -312,6 +349,37 @@ export class ApiAccessComponent {
               panelClass: 'gio-snack-bar-error',
             },
           );
+        },
+      });
+  }
+
+  private executeApiKeyRenewal(): void {
+    const subscriptionId = this.subscription?.id;
+    if (!subscriptionId) {
+      return;
+    }
+
+    this.isRenewingApiKey.set(true);
+    this.apiKeyRenewFeedback.set(undefined);
+    this.subscriptionKeysService
+      .renew(subscriptionId)
+      .pipe(
+        finalize(() => this.isRenewingApiKey.set(false)),
+        takeUntilDestroyed(this.destroyRef),
+      )
+      .subscribe({
+        next: () => {
+          this.apiKeyRenewed.emit();
+          this.apiKeyRenewFeedback.set({
+            type: 'success',
+            message: $localize`:@@subscriptionDetailsApiAccessRenewSuccess:API key renewed successfully. You can now use it to access the API.`,
+          });
+        },
+        error: () => {
+          this.apiKeyRenewFeedback.set({
+            type: 'error',
+            message: $localize`:@@subscriptionDetailsApiAccessRenewError:Failed to renew API key. Please try again.`,
+          });
         },
       });
   }

--- a/gravitee-apim-portal-webui-next/src/services/subscription-keys.service.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/services/subscription-keys.service.spec.ts
@@ -49,4 +49,16 @@ describe('SubscriptionKeysService', () => {
 
     req.flush(null);
   });
+
+  it('should renew key subscription', done => {
+    service.renew(subscriptionId).subscribe(() => {
+      done();
+    });
+
+    const req = httpTestingController.expectOne(`${TESTING_BASE_URL}/subscriptions/${subscriptionId}/keys/_renew`);
+    expect(req.request.method).toEqual('POST');
+    expect(req.request.body).toBeNull();
+
+    req.flush(null);
+  });
 });

--- a/gravitee-apim-portal-webui-next/src/services/subscription-keys.service.ts
+++ b/gravitee-apim-portal-webui-next/src/services/subscription-keys.service.ts
@@ -29,4 +29,8 @@ export class SubscriptionKeysService {
   revoke(subscriptionId: string, apiKey: string): Observable<void> {
     return this.http.post<void>(`${this.configService.baseURL}/subscriptions/${subscriptionId}/keys/${apiKey}/_revoke`, null);
   }
+
+  renew(subscriptionId: string): Observable<void> {
+    return this.http.post<void>(`${this.configService.baseURL}/subscriptions/${subscriptionId}/keys/_renew`, null);
+  }
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/EXT-121

## Description

- added button to renew the active api key next to each active API key on the list
- added a modal to be displayed after clicking the button to confirm the action

## Additional context

- when renewing an API key the page should be updated with the current status of the keys

## Testing scenarios

- renew the API key when no active API key is present, ensure the page is refreshed and new API key is visible on the list, the API Access section is updated with the latest API key
- renew the API key when other active API key is present, ensure the page is refreshed, new API key is visible on the list, the API Access section is updated with the latest API key and previous API key is updated with the date it will be expired


https://github.com/user-attachments/assets/b82b163e-f1c9-4ec1-b2f0-7d3f058b3f7b

