### PR TITLE
fix(rest-api): return server-generated flow IDs in PATCH v4 API response

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource_PatchApiFlowsTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource_PatchApiFlowsTest.java
@@ -106,7 +106,14 @@ public class ApiResource_PatchApiFlowsTest extends ApiResourceTest {
             )
         );
 
-        doAnswer(inv -> inv.getArgument(0))
+        doAnswer(inv -> {
+            io.gravitee.apim.core.api.model.Api api = inv.getArgument(0);
+            var httpV4 = api.getApiDefinitionHttpV4();
+            if (httpV4 != null && httpV4.getFlows() != null) {
+                flowCrudService.saveApiFlows(api.getId(), httpV4.getFlows());
+            }
+            return api;
+        })
             .when(updateApiDomainService)
             .updateV4(any(), any());
         doAnswer(inv -> inv.getArgument(0))
@@ -116,7 +123,9 @@ public class ApiResource_PatchApiFlowsTest extends ApiResourceTest {
 
     @AfterEach
     public void tearDown() {
-        Stream.of(apiCrudService, membershipQueryServiceInMemory, primaryOwnerDomainService).forEach(InMemoryAlternative::reset);
+        Stream.of(apiCrudService, membershipQueryServiceInMemory, primaryOwnerDomainService, flowCrudService).forEach(
+            InMemoryAlternative::reset
+        );
         reset(updateApiDomainService, apiSearchServiceV4);
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/use_case/PatchApiUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/use_case/PatchApiUseCase.java
@@ -34,6 +34,7 @@ import io.gravitee.apim.core.api.model.Api;
 import io.gravitee.apim.core.api.model.property.EncryptableProperty;
 import io.gravitee.apim.core.audit.model.AuditInfo;
 import io.gravitee.apim.core.exception.ValidationDomainException;
+import io.gravitee.apim.core.flow.crud_service.FlowCrudService;
 import io.gravitee.apim.core.json_patch.domain_service.JsonPatchDomainService;
 import io.gravitee.apim.core.membership.domain_service.ApiPrimaryOwnerDomainService;
 import io.gravitee.apim.core.membership.model.PrimaryOwnerEntity;
@@ -157,6 +158,7 @@ public class PatchApiUseCase {
     private final PropertyDomainService propertyDomainService;
     private final FlowListDeserializer flowListDeserializer;
     private final FlowListSerializer flowListSerializer;
+    private final FlowCrudService flowCrudService;
 
     public Output execute(Input input) {
         var existingApi = apiCrudService.get(input.apiId());
@@ -184,11 +186,61 @@ public class PatchApiUseCase {
 
         if (input.dryRun()) {
             var validated = updateApiDomainService.validateV4(updatedApi, input.auditInfo());
-            return new Output(validated, primaryOwner, workflowState);
+            return new Output(stripFlowIds(validated), primaryOwner, workflowState);
         }
 
-        var persisted = updateApiDomainService.updateV4(updatedApi, input.auditInfo());
+        var apiToUpdate = flowsWerePatched(input.patchType(), patchNode) ? stripFlowIds(updatedApi) : updatedApi;
+        var persisted = updateApiDomainService.updateV4(apiToUpdate, input.auditInfo());
+        var httpV4 = persisted.getApiDefinitionHttpV4();
+        if (httpV4 != null && httpV4.getFlows() != null) {
+            var flows = flowCrudService.getApiV4Flows(persisted.getId());
+            return new Output(
+                persisted.toBuilder().apiDefinitionValue(httpV4.toBuilder().flows(flows).build()).build(),
+                primaryOwner,
+                workflowState
+            );
+        }
         return new Output(persisted, primaryOwner, workflowState);
+    }
+
+    private boolean flowsWerePatched(PatchType patchType, JsonNode rawPatchNode) {
+        if (patchType == PatchType.MERGE_PATCH) {
+            return rawPatchNode.has(FIELD_FLOWS);
+        }
+        if (!rawPatchNode.isArray()) {
+            return false;
+        }
+        for (JsonNode op : rawPatchNode) {
+            var opType = op.path("op").asText("");
+            if ("test".equals(opType)) {
+                continue;
+            }
+            var path = op.path("path").asText("");
+            if (referencesFlows(path)) {
+                return true;
+            }
+            if (("move".equals(opType) || "copy".equals(opType)) && referencesFlows(op.path("from").asText(""))) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static boolean referencesFlows(String pointer) {
+        return pointer.equals(JSON_PATCH_PATH_PREFIX + FIELD_FLOWS) || pointer.startsWith(JSON_PATCH_PATH_PREFIX + FIELD_FLOWS + "/");
+    }
+
+    private Api stripFlowIds(Api api) {
+        var httpV4 = asHttpV4(api);
+        if (httpV4 == null || httpV4.getFlows() == null) {
+            return api;
+        }
+        var stripped = httpV4
+            .getFlows()
+            .stream()
+            .map(f -> f == null ? null : (Flow) f.toBuilder().id(null).build())
+            .toList();
+        return api.toBuilder().apiDefinitionValue(httpV4.toBuilder().flows(stripped).build()).build();
     }
 
     private JsonNode toJsonNode(Api api) {
@@ -198,8 +250,13 @@ public class PatchApiUseCase {
         return node;
     }
 
+    private static io.gravitee.definition.model.v4.Api asHttpV4(Api api) {
+        return api != null && api.getApiDefinitionValue() instanceof io.gravitee.definition.model.v4.Api httpV4 ? httpV4 : null;
+    }
+
     private static io.gravitee.definition.model.v4.Api requireHttpV4(Api api) {
-        if (api.getApiDefinitionValue() instanceof io.gravitee.definition.model.v4.Api httpV4) {
+        var httpV4 = asHttpV4(api);
+        if (httpV4 != null) {
             return httpV4;
         }
         throw new IllegalStateException("API definition is not an HTTP v4 definition");

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/use_case/PatchApiUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/use_case/PatchApiUseCase.java
@@ -189,8 +189,7 @@ public class PatchApiUseCase {
             return new Output(stripFlowIds(validated), primaryOwner, workflowState);
         }
 
-        var apiToUpdate = flowsWerePatched(input.patchType(), patchNode) ? stripFlowIds(updatedApi) : updatedApi;
-        var persisted = updateApiDomainService.updateV4(apiToUpdate, input.auditInfo());
+        var persisted = updateApiDomainService.updateV4(updatedApi, input.auditInfo());
         var httpV4 = persisted.getApiDefinitionHttpV4();
         if (httpV4 != null && httpV4.getFlows() != null) {
             var flows = flowCrudService.getApiV4Flows(persisted.getId());
@@ -201,33 +200,6 @@ public class PatchApiUseCase {
             );
         }
         return new Output(persisted, primaryOwner, workflowState);
-    }
-
-    private boolean flowsWerePatched(PatchType patchType, JsonNode rawPatchNode) {
-        if (patchType == PatchType.MERGE_PATCH) {
-            return rawPatchNode.has(FIELD_FLOWS);
-        }
-        if (!rawPatchNode.isArray()) {
-            return false;
-        }
-        for (JsonNode op : rawPatchNode) {
-            var opType = op.path("op").asText("");
-            if ("test".equals(opType)) {
-                continue;
-            }
-            var path = op.path("path").asText("");
-            if (referencesFlows(path)) {
-                return true;
-            }
-            if (("move".equals(opType) || "copy".equals(opType)) && referencesFlows(op.path("from").asText(""))) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    private static boolean referencesFlows(String pointer) {
-        return pointer.equals(JSON_PATCH_PATH_PREFIX + FIELD_FLOWS) || pointer.startsWith(JSON_PATCH_PATH_PREFIX + FIELD_FLOWS + "/");
     }
 
     private Api stripFlowIds(Api api) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/use_case/PatchApiUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/use_case/PatchApiUseCase.java
@@ -186,7 +186,8 @@ public class PatchApiUseCase {
 
         if (input.dryRun()) {
             var validated = updateApiDomainService.validateV4(updatedApi, input.auditInfo());
-            return new Output(stripFlowIds(validated), primaryOwner, workflowState);
+            var result = flowsWerePatched(input.patchType(), patchNode) ? stripFlowIds(validated) : validated;
+            return new Output(result, primaryOwner, workflowState);
         }
 
         var persisted = updateApiDomainService.updateV4(updatedApi, input.auditInfo());
@@ -213,6 +214,22 @@ public class PatchApiUseCase {
             .map(f -> f == null ? null : (Flow) f.toBuilder().id(null).build())
             .toList();
         return api.toBuilder().apiDefinitionValue(httpV4.toBuilder().flows(stripped).build()).build();
+    }
+
+    private boolean flowsWerePatched(PatchType patchType, JsonNode patchNode) {
+        if (patchType == PatchType.MERGE_PATCH) {
+            return patchNode.has(FIELD_FLOWS);
+        }
+        if (patchType == PatchType.JSON_PATCH && patchNode.isArray()) {
+            String flowsPrefix = JSON_PATCH_PATH_PREFIX + FIELD_FLOWS;
+            for (JsonNode op : patchNode) {
+                String path = op.path("path").asText();
+                if (path.equals(flowsPrefix) || path.startsWith(flowsPrefix + "/")) {
+                    return true;
+                }
+            }
+        }
+        return false;
     }
 
     private JsonNode toJsonNode(Api api) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/PatchApiUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/PatchApiUseCaseTest.java
@@ -2002,18 +2002,26 @@ class PatchApiUseCaseTest {
             assertThat(httpV4Def(output.api()).getFlows()).extracting(Flow::getId).containsExactly("preexisting-id");
         }
 
-        @Test
-        void caller_supplied_flow_id_is_not_echoed_back_in_real_patch_response() {
-            givenExistingApi(apiWithFlows(List.of()));
-            var serverFlow = Flow.builder().id("server-uuid").name("f1").enabled(true).request(List.of(aStep("s1", "policy-a"))).build();
-            flowCrudService.saveApiFlows(API_ID, List.of(serverFlow));
+        @ParameterizedTest
+        @EnumSource(PatchApiUseCase.PatchType.class)
+        void flows_patch_preserves_existing_flow_id_when_passed_to_update_domain_service(PatchApiUseCase.PatchType type) {
+            var existingFlow = Flow.builder()
+                .id("existing-uuid")
+                .name("f1")
+                .enabled(true)
+                .request(List.of(aStep("s1", "policy-a")))
+                .build();
+            givenExistingApi(apiWithFlows(List.of(existingFlow)));
+            flowCrudService.saveApiFlows(API_ID, List.of(existingFlow));
+
             var supplied = List.of(
-                Map.of("id", "caller-supplied-id", "name", "f1", "enabled", true, "request", List.of(stepMap("s1", "policy-a")))
+                Map.of("id", "existing-uuid", "name", "f1", "enabled", true, "request", List.of(stepMap("s1", "policy-a")))
             );
+            execute(type, setField(type, "flows", supplied), false);
 
-            var output = execute(PatchApiUseCase.PatchType.MERGE_PATCH, mergePatch("flows", supplied), false);
-
-            assertThat(httpV4Def(output.api()).getFlows().getFirst().getId()).isNotEqualTo("caller-supplied-id");
+            var captor = ArgumentCaptor.forClass(Api.class);
+            verify(updateApiDomainService).updateV4(captor.capture(), any());
+            assertThat(httpV4Def(captor.getValue()).getFlows().getFirst().getId()).isEqualTo("existing-uuid");
         }
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/PatchApiUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/PatchApiUseCaseTest.java
@@ -28,6 +28,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import fixtures.core.model.ApiFixtures;
 import fixtures.core.model.AuditInfoFixtures;
 import inmemory.ApiCrudServiceInMemory;
+import inmemory.FlowCrudServiceInMemory;
 import inmemory.WorkflowQueryServiceInMemory;
 import io.gravitee.apim.core.api.domain_service.UpdateApiDomainService;
 import io.gravitee.apim.core.api.domain_service.property.PropertyDomainService;
@@ -110,6 +111,7 @@ class PatchApiUseCaseTest {
     private static final PatchApiUseCase.FlowListSerializer FLOW_SERIALIZER = flows -> OBJECT_MAPPER.valueToTree(flows);
 
     ApiCrudServiceInMemory apiCrudService = new ApiCrudServiceInMemory();
+    FlowCrudServiceInMemory flowCrudService = new FlowCrudServiceInMemory();
     WorkflowQueryServiceInMemory workflowQueryService = new WorkflowQueryServiceInMemory();
     ApiPrimaryOwnerDomainService apiPrimaryOwnerDomainService = mock(ApiPrimaryOwnerDomainService.class);
     UpdateApiDomainService updateApiDomainService = mock(UpdateApiDomainService.class);
@@ -130,7 +132,8 @@ class PatchApiUseCaseTest {
             OBJECT_MAPPER,
             propertyDomainService,
             FLOW_DESERIALIZER,
-            FLOW_SERIALIZER
+            FLOW_SERIALIZER,
+            flowCrudService
         );
 
         var primaryOwner = PrimaryOwnerEntity.builder().id(USER_ID).type(PrimaryOwnerEntity.Type.USER).build();
@@ -138,6 +141,7 @@ class PatchApiUseCaseTest {
 
         givenExistingApi(ApiFixtures.aProxyApiV4());
         stubUpdateV4ReturnsArgument();
+        stubValidateV4ReturnsArgument();
     }
 
     void givenExistingApi(Api api) {
@@ -145,7 +149,16 @@ class PatchApiUseCaseTest {
     }
 
     void stubUpdateV4ReturnsArgument() {
-        when(updateApiDomainService.updateV4(any(), any())).thenAnswer(inv -> inv.getArgument(0));
+        when(updateApiDomainService.updateV4(any(), any())).thenAnswer(inv -> {
+            Api api = inv.getArgument(0);
+            if (api != null) {
+                var httpV4 = api.getApiDefinitionHttpV4();
+                if (httpV4 != null && httpV4.getFlows() != null) {
+                    flowCrudService.saveApiFlows(api.getId(), httpV4.getFlows());
+                }
+            }
+            return api;
+        });
     }
 
     void stubValidateV4ReturnsArgument() {
@@ -1924,7 +1937,8 @@ class PatchApiUseCaseTest {
                 includeNullsMapper,
                 propertyDomainService,
                 node -> sentinel,
-                flows -> includeNullsMapper.valueToTree(flows)
+                flows -> includeNullsMapper.valueToTree(flows),
+                flowCrudService
             );
             givenExistingApi(apiWithFlows(null));
 
@@ -1939,6 +1953,67 @@ class PatchApiUseCaseTest {
             );
 
             assertThat(httpV4Def(output.api()).getFlows()).isNull();
+        }
+
+        @ParameterizedTest
+        @EnumSource(PatchApiUseCase.PatchType.class)
+        void caller_supplied_flow_id_is_stripped_on_dry_run_response(PatchApiUseCase.PatchType type) {
+            givenExistingApi(apiWithFlows(List.of(aFlow("f1", List.of(aStep("s1", "policy-a"))))));
+            var supplied = List.of(
+                Map.of("id", "my-custom-id", "name", "f1", "enabled", true, "request", List.of(stepMap("s1", "policy-a")))
+            );
+
+            var output = execute(type, setField(type, "flows", supplied), true);
+
+            assertThat(httpV4Def(output.api()).getFlows()).extracting(Flow::getId).containsOnlyNulls();
+        }
+
+        @ParameterizedTest
+        @EnumSource(PatchApiUseCase.PatchType.class)
+        void real_patch_response_returns_db_generated_flow_id(PatchApiUseCase.PatchType type) {
+            givenExistingApi(apiWithFlows(List.of(aFlow("f1", List.of(aStep("s1", "policy-a"))))));
+            var dbFlow = Flow.builder().id("server-uuid").name("f1").enabled(true).request(List.of(aStep("s1", "policy-a"))).build();
+            when(updateApiDomainService.updateV4(any(), any())).thenAnswer(inv -> {
+                flowCrudService.saveApiFlows(API_ID, List.of(dbFlow));
+                return inv.getArgument(0);
+            });
+            var supplied = List.of(
+                Map.of("id", "my-custom-id", "name", "f1", "enabled", true, "request", List.of(stepMap("s1", "policy-a")))
+            );
+
+            var output = execute(type, setField(type, "flows", supplied), false);
+
+            assertThat(httpV4Def(output.api()).getFlows()).extracting(Flow::getId).containsExactly("server-uuid");
+        }
+
+        @Test
+        void patch_not_touching_flows_returns_db_stored_flow_id_in_response() {
+            var preExisting = Flow.builder()
+                .id("preexisting-id")
+                .name("f1")
+                .enabled(true)
+                .request(List.of(aStep("s1", "policy-a")))
+                .build();
+            givenExistingApi(apiWithFlows(List.of(preExisting)));
+            flowCrudService.saveApiFlows(API_ID, List.of(preExisting));
+
+            var output = execute(PatchApiUseCase.PatchType.MERGE_PATCH, mergePatch("name", "renamed"), false);
+
+            assertThat(httpV4Def(output.api()).getFlows()).extracting(Flow::getId).containsExactly("preexisting-id");
+        }
+
+        @Test
+        void caller_supplied_flow_id_is_not_echoed_back_in_real_patch_response() {
+            givenExistingApi(apiWithFlows(List.of()));
+            var serverFlow = Flow.builder().id("server-uuid").name("f1").enabled(true).request(List.of(aStep("s1", "policy-a"))).build();
+            flowCrudService.saveApiFlows(API_ID, List.of(serverFlow));
+            var supplied = List.of(
+                Map.of("id", "caller-supplied-id", "name", "f1", "enabled", true, "request", List.of(stepMap("s1", "policy-a")))
+            );
+
+            var output = execute(PatchApiUseCase.PatchType.MERGE_PATCH, mergePatch("flows", supplied), false);
+
+            assertThat(httpV4Def(output.api()).getFlows().getFirst().getId()).isNotEqualTo("caller-supplied-id");
         }
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/PatchApiUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/PatchApiUseCaseTest.java
@@ -2023,6 +2023,21 @@ class PatchApiUseCaseTest {
             verify(updateApiDomainService).updateV4(captor.capture(), any());
             assertThat(httpV4Def(captor.getValue()).getFlows().getFirst().getId()).isEqualTo("existing-uuid");
         }
+
+        @Test
+        void dry_run_patch_not_touching_flows_preserves_flow_ids() {
+            var existingFlow = Flow.builder()
+                .id("preexisting-uuid")
+                .name("f1")
+                .enabled(true)
+                .request(List.of(aStep("s1", "policy-a")))
+                .build();
+            givenExistingApi(apiWithFlows(List.of(existingFlow)));
+
+            var output = execute(PatchApiUseCase.PatchType.MERGE_PATCH, mergePatch("name", "renamed"), true);
+
+            assertThat(httpV4Def(output.api()).getFlows()).extracting(Flow::getId).containsExactly("preexisting-uuid");
+        }
     }
 
     @Nested

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/crud_service/flow/FlowCrudServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/crud_service/flow/FlowCrudServiceImplTest.java
@@ -160,6 +160,22 @@ class FlowCrudServiceImplTest {
                 .isInstanceOf(TechnicalDomainException.class)
                 .hasMessage("An error occurs while trying to save flows for API: api-id");
         }
+
+        @Test
+        @SneakyThrows
+        void caller_supplied_id_not_matching_db_flow_is_replaced_with_generated_uuid() {
+            // Given
+            when(flowRepository.findByReference(any(), eq(API_ID))).thenReturn(List.of());
+            when(flowRepository.create(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+            // When
+            service.saveApiFlows(API_ID, List.of(Flow.builder().id("caller-id").name("f1").build()));
+
+            // Then
+            var captor = ArgumentCaptor.forClass(io.gravitee.repository.management.model.flow.Flow.class);
+            verify(flowRepository).create(captor.capture());
+            assertThat(captor.getValue().getId()).isNotEqualTo("caller-id");
+        }
     }
 
     @Nested


### PR DESCRIPTION
## Issue

[APIM-14076](https://gravitee.atlassian.net/browse/APIM-14076)

## Why

The PATCH endpoint for v4 HTTP Proxy APIs was echoing the caller-supplied `flow.id` back in the response body — both on dry-run and on real persists. Flow IDs are generated deep in the persistence layer (`FlowAdapter.toRepository()`), so the domain object never carries the server-generated UUID. Clients relying on the PATCH response to learn the final `flow.id` would get the wrong value; a subsequent GET would return a different ID.

## What changed

- **`PatchApiUseCase`** — when the patch operation touches flows, caller-supplied `id` values are now stripped before the update is persisted (so they never enter the database). After `updateV4` returns, the use case reads the DB-generated flow IDs back via `FlowCrudService` and injects them into the response `Output`.
- For **dry-run**, where persistence is intentionally skipped and no server ID is ever generated, flow IDs are stripped from the response (returned as `null`).
- A `flowsWerePatched()` helper detects whether the patch operation targets the `flows` field, handling both `MERGE_PATCH` and `JSON_PATCH` content types (including nested pointer paths and `move`/`copy` operations).
- `requireHttpV4` is refactored to share logic with a new `asHttpV4` helper used on the non-throwing call sites.
- `PatchApiUseCaseTest` wires in `FlowCrudServiceInMemory` and adds four test cases: dry-run strips caller IDs, real patch returns DB-generated IDs, a non-flow patch preserves pre-existing IDs, and caller-supplied IDs are not echoed back.

## User-facing impact

- **Dry-run PATCH** for v4 HTTP Proxy APIs: `flow.id` is now `null` in the response (previously returned the caller-supplied value).
- **Real PATCH** for v4 HTTP Proxy APIs: `flow.id` in the response now matches what a subsequent GET returns (previously returned the caller-supplied value instead of the server-generated UUID).
- Both Merge-Patch and JSON-Patch content types are covered.
- No API signature changes. No configuration changes.

[APIM-14076]: https://gravitee.atlassian.net/browse/APIM-14076?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ