### PR TITLE
fix: accept uppercase selector type discriminators in v4 API PATCH flows

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/java/io/gravitee/apim/rest/api/automation/spring/RestAutomationConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/java/io/gravitee/apim/rest/api/automation/spring/RestAutomationConfiguration.java
@@ -15,9 +15,14 @@
  */
 package io.gravitee.apim.rest.api.automation.spring;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.gravitee.apim.core.api.use_case.PatchApiUseCase.FlowListDeserializer;
 import io.gravitee.apim.infra.spring.UsecaseSpringConfiguration;
+import io.gravitee.definition.model.v4.flow.Flow;
 import io.gravitee.el.ExpressionLanguageInitializer;
 import io.gravitee.rest.api.service.spring.ServiceConfiguration;
+import java.util.List;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
@@ -31,6 +36,11 @@ import org.springframework.scheduling.annotation.EnableAsync;
 @Import({ ServiceConfiguration.class, UsecaseSpringConfiguration.class })
 @EnableAsync
 public class RestAutomationConfiguration {
+
+    @Bean
+    public FlowListDeserializer flowListDeserializer(ObjectMapper objectMapper) {
+        return node -> objectMapper.treeToValue(node, new TypeReference<List<Flow>>() {});
+    }
 
     @Bean
     public ExpressionLanguageInitializer expressionLanguageInitializer() {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/java/io/gravitee/apim/rest/api/automation/spring/RestAutomationConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/java/io/gravitee/apim/rest/api/automation/spring/RestAutomationConfiguration.java
@@ -18,6 +18,7 @@ package io.gravitee.apim.rest.api.automation.spring;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.gravitee.apim.core.api.use_case.PatchApiUseCase.FlowListDeserializer;
+import io.gravitee.apim.core.api.use_case.PatchApiUseCase.FlowListSerializer;
 import io.gravitee.apim.infra.spring.UsecaseSpringConfiguration;
 import io.gravitee.definition.model.v4.flow.Flow;
 import io.gravitee.el.ExpressionLanguageInitializer;
@@ -40,6 +41,11 @@ public class RestAutomationConfiguration {
     @Bean
     public FlowListDeserializer flowListDeserializer(ObjectMapper objectMapper) {
         return node -> objectMapper.treeToValue(node, new TypeReference<List<Flow>>() {});
+    }
+
+    @Bean
+    public FlowListSerializer flowListSerializer(ObjectMapper objectMapper) {
+        return flows -> objectMapper.valueToTree(flows);
     }
 
     @Bean

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/spring/ResourceContextConfiguration.java
@@ -71,6 +71,7 @@ import io.gravitee.apim.core.api.use_case.GetApiDefinitionUseCase;
 import io.gravitee.apim.core.api.use_case.GetExposedEntrypointsUseCase;
 import io.gravitee.apim.core.api.use_case.ImportApiCRDUseCase;
 import io.gravitee.apim.core.api.use_case.PatchApiUseCase.FlowListDeserializer;
+import io.gravitee.apim.core.api.use_case.PatchApiUseCase.FlowListSerializer;
 import io.gravitee.apim.core.api.use_case.RollbackApiUseCase;
 import io.gravitee.apim.core.api_key.domain_service.ReconcileApiKeysDomainService;
 import io.gravitee.apim.core.apim.service_provider.ApimProductInfo;
@@ -253,6 +254,11 @@ public class ResourceContextConfiguration {
     @Bean
     public FlowListDeserializer flowListDeserializer(ObjectMapper objectMapper) {
         return node -> objectMapper.treeToValue(node, new TypeReference<List<Flow>>() {});
+    }
+
+    @Bean
+    public FlowListSerializer flowListSerializer(ObjectMapper objectMapper) {
+        return flows -> objectMapper.valueToTree(flows);
     }
 
     @Bean

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/spring/ResourceContextConfiguration.java
@@ -18,6 +18,7 @@ package io.gravitee.apim.rest.api.automation.spring;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import fakes.spring.FakeConfiguration;
 import inmemory.ApiCRDExportDomainServiceInMemory;
@@ -69,6 +70,7 @@ import io.gravitee.apim.core.api.use_case.ExportApiUseCase;
 import io.gravitee.apim.core.api.use_case.GetApiDefinitionUseCase;
 import io.gravitee.apim.core.api.use_case.GetExposedEntrypointsUseCase;
 import io.gravitee.apim.core.api.use_case.ImportApiCRDUseCase;
+import io.gravitee.apim.core.api.use_case.PatchApiUseCase.FlowListDeserializer;
 import io.gravitee.apim.core.api.use_case.RollbackApiUseCase;
 import io.gravitee.apim.core.api_key.domain_service.ReconcileApiKeysDomainService;
 import io.gravitee.apim.core.apim.service_provider.ApimProductInfo;
@@ -199,6 +201,7 @@ import io.gravitee.apim.infra.json.jackson.JacksonSpringConfiguration;
 import io.gravitee.apim.infra.sanitizer.HtmlSanitizerImpl;
 import io.gravitee.apim.infra.spring.UsecaseSpringConfiguration;
 import io.gravitee.common.util.DataEncryptor;
+import io.gravitee.definition.model.v4.flow.Flow;
 import io.gravitee.node.api.license.LicenseManager;
 import io.gravitee.repository.management.api.ApiRepository;
 import io.gravitee.repository.management.api.ApplicationRepository;
@@ -232,6 +235,7 @@ import io.gravitee.rest.api.service.v4.PlanSearchService;
 import io.gravitee.rest.api.service.v4.PlanService;
 import io.gravitee.rest.api.service.v4.PolicyPluginService;
 import io.vertx.rxjava3.core.Vertx;
+import java.util.List;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
@@ -245,6 +249,11 @@ import org.springframework.mock.env.MockEnvironment;
 @Configuration
 @Import({ UsecaseSpringConfiguration.class, JacksonSpringConfiguration.class, InMemoryConfiguration.class, FakeConfiguration.class })
 public class ResourceContextConfiguration {
+
+    @Bean
+    public FlowListDeserializer flowListDeserializer(ObjectMapper objectMapper) {
+        return node -> objectMapper.treeToValue(node, new TypeReference<List<Flow>>() {});
+    }
 
     @Bean
     public ApiRepository apiRepository() {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/spring/RestManagementConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/spring/RestManagementConfiguration.java
@@ -15,11 +15,14 @@
  */
 package io.gravitee.rest.api.management.v2.rest.spring;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.gravitee.apim.core.analytics_engine.domain_service.AnalyticsQueryContextLoader;
 import io.gravitee.apim.core.analytics_engine.domain_service.BucketNamesPostProcessor;
 import io.gravitee.apim.core.analytics_engine.domain_service.QueryFilterTransformer;
 import io.gravitee.apim.core.analytics_engine.domain_service.UnitEnrichmentPostProcessor;
 import io.gravitee.apim.core.analytics_engine.query_service.AnalyticsDefinitionQueryService;
+import io.gravitee.apim.core.api.use_case.PatchApiUseCase.FlowListDeserializer;
 import io.gravitee.apim.core.user.domain_service.UserContextLoader;
 import io.gravitee.apim.infra.domain_service.analytics_engine.ManagementContextLoader;
 import io.gravitee.apim.infra.domain_service.analytics_engine.processors.ApiTypeFilterTransformer;
@@ -30,12 +33,15 @@ import io.gravitee.apim.infra.spring.UsecaseSpringConfiguration;
 import io.gravitee.el.ExpressionLanguageInitializer;
 import io.gravitee.repository.management.api.ApiRepository;
 import io.gravitee.rest.api.kafkaexplorer.spring.KafkaExplorerSpringConfiguration;
+import io.gravitee.rest.api.management.v2.rest.mapper.FlowMapper;
+import io.gravitee.rest.api.management.v2.rest.model.FlowV4;
 import io.gravitee.rest.api.management.v2.rest.utils.SubscriptionExpandHelper;
 import io.gravitee.rest.api.service.ApplicationService;
 import io.gravitee.rest.api.service.UserService;
 import io.gravitee.rest.api.service.spring.ServiceConfiguration;
 import io.gravitee.rest.api.service.v4.ApiAuthorizationService;
 import io.gravitee.rest.api.service.v4.PlanSearchService;
+import java.util.List;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
@@ -50,6 +56,11 @@ import org.springframework.scheduling.annotation.EnableAsync;
 @Import({ ServiceConfiguration.class, UsecaseSpringConfiguration.class, KafkaExplorerSpringConfiguration.class })
 @EnableAsync
 public class RestManagementConfiguration {
+
+    @Bean
+    public FlowListDeserializer flowListDeserializer(ObjectMapper objectMapper) {
+        return node -> FlowMapper.INSTANCE.mapToHttpV4(objectMapper.treeToValue(node, new TypeReference<List<FlowV4>>() {}));
+    }
 
     @Bean
     public ExpressionLanguageInitializer expressionLanguageInitializer() {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/spring/RestManagementConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/spring/RestManagementConfiguration.java
@@ -23,6 +23,7 @@ import io.gravitee.apim.core.analytics_engine.domain_service.QueryFilterTransfor
 import io.gravitee.apim.core.analytics_engine.domain_service.UnitEnrichmentPostProcessor;
 import io.gravitee.apim.core.analytics_engine.query_service.AnalyticsDefinitionQueryService;
 import io.gravitee.apim.core.api.use_case.PatchApiUseCase.FlowListDeserializer;
+import io.gravitee.apim.core.api.use_case.PatchApiUseCase.FlowListSerializer;
 import io.gravitee.apim.core.user.domain_service.UserContextLoader;
 import io.gravitee.apim.infra.domain_service.analytics_engine.ManagementContextLoader;
 import io.gravitee.apim.infra.domain_service.analytics_engine.processors.ApiTypeFilterTransformer;
@@ -60,6 +61,11 @@ public class RestManagementConfiguration {
     @Bean
     public FlowListDeserializer flowListDeserializer(ObjectMapper objectMapper) {
         return node -> FlowMapper.INSTANCE.mapToHttpV4(objectMapper.treeToValue(node, new TypeReference<List<FlowV4>>() {}));
+    }
+
+    @Bean
+    public FlowListSerializer flowListSerializer(ObjectMapper objectMapper) {
+        return flows -> objectMapper.valueToTree(FlowMapper.INSTANCE.mapFromHttpV4(flows));
     }
 
     @Bean

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource_PatchApiFlowsTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource_PatchApiFlowsTest.java
@@ -231,6 +231,22 @@ public class ApiResource_PatchApiFlowsTest extends ApiResourceTest {
             return bothFlowsReplaceVariants(flows);
         }
 
+        static Stream<Arguments> lowercaseSelectorTypeVariants() {
+            var flows = List.of(
+                Map.of(
+                    "name",
+                    "f1",
+                    "enabled",
+                    true,
+                    "selectors",
+                    List.of(Map.of("type", "http", "path", "/api", "pathOperator", "EQUALS")),
+                    "request",
+                    List.of(stepMap("s1", "p1"))
+                )
+            );
+            return bothFlowsReplaceVariants(flows);
+        }
+
         static Stream<Arguments> uppercaseSelectorTypeVariants() {
             var flows = List.of(
                 Map.of(
@@ -274,8 +290,8 @@ public class ApiResource_PatchApiFlowsTest extends ApiResourceTest {
         }
 
         @ParameterizedTest
-        @MethodSource("uppercaseSelectorTypeVariants")
-        void patch_with_uppercase_http_selector_type_returns_400_with_invalidValue_envelope(String body, String contentType) {
+        @MethodSource("lowercaseSelectorTypeVariants")
+        void patch_with_lowercase_http_selector_type_returns_400_with_invalidValue_envelope(String body, String contentType) {
             givenApiWithFlows(List.of(flow("f1", List.of(step("s1", "p1")))));
 
             var response = rootTarget(API).request().method("PATCH", Entity.entity(body, contentType));
@@ -284,6 +300,16 @@ public class ApiResource_PatchApiFlowsTest extends ApiResourceTest {
             Assertions.assertThat(error.getTechnicalCode()).isEqualTo("invalidValue");
             Assertions.assertThat(error.getParameters()).containsKey("location");
             Assertions.assertThat(error.getParameters().get("location")).startsWith("/flows");
+        }
+
+        @ParameterizedTest
+        @MethodSource("uppercaseSelectorTypeVariants")
+        void patch_with_uppercase_http_selector_type_succeeds(String body, String contentType) {
+            givenApiWithFlows(List.of(flow("f1", List.of(step("s1", "p1")))));
+
+            var response = rootTarget(API).request().method("PATCH", Entity.entity(body, contentType));
+
+            assertThat(response).hasStatus(OK_200);
         }
 
         @ParameterizedTest

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource_PatchApiFlowsTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource_PatchApiFlowsTest.java
@@ -37,6 +37,7 @@ import io.gravitee.apim.core.membership.model.PrimaryOwnerEntity;
 import io.gravitee.definition.model.DefinitionVersion;
 import io.gravitee.definition.model.v4.ApiType;
 import io.gravitee.definition.model.v4.flow.Flow;
+import io.gravitee.definition.model.v4.flow.selector.HttpSelector;
 import io.gravitee.definition.model.v4.flow.step.Step;
 import io.gravitee.rest.api.management.v2.rest.model.ApiV4;
 import io.gravitee.rest.api.model.permissions.RolePermission;
@@ -232,19 +233,16 @@ public class ApiResource_PatchApiFlowsTest extends ApiResourceTest {
         }
 
         static Stream<Arguments> lowercaseSelectorTypeVariants() {
-            var flows = List.of(
-                Map.of(
-                    "name",
-                    "f1",
-                    "enabled",
-                    true,
-                    "selectors",
-                    List.of(Map.of("type", "http", "path", "/api", "pathOperator", "EQUALS")),
-                    "request",
-                    List.of(stepMap("s1", "p1"))
+            return Stream.of(
+                List.of(Map.of("type", "http", "path", "/api", "pathOperator", "EQUALS")),
+                List.of(Map.of("type", "channel", "channel", "/", "channelOperator", "STARTS_WITH")),
+                List.of(Map.of("type", "condition", "condition", "#true")),
+                List.of(Map.of("type", "mcp"))
+            ).flatMap(selectors ->
+                bothFlowsReplaceVariants(
+                    List.of(Map.of("name", "f1", "enabled", true, "selectors", selectors, "request", List.of(stepMap("s1", "p1"))))
                 )
             );
-            return bothFlowsReplaceVariants(flows);
         }
 
         static Stream<Arguments> uppercaseSelectorTypeVariants() {
@@ -343,6 +341,47 @@ public class ApiResource_PatchApiFlowsTest extends ApiResourceTest {
 
             var error = assertThat(response).hasStatus(BAD_REQUEST_400).asError().actual();
             Assertions.assertThat(error.getMessage()).containsIgnoringCase("path");
+        }
+
+        @Test
+        void json_patch_add_sub_pointer_selector_with_uppercase_type_returns_200() {
+            givenApiWithFlows(
+                List.of(
+                    Flow.builder()
+                        .name("f1")
+                        .enabled(true)
+                        .selectors(List.of(HttpSelector.builder().path("/api").build()))
+                        .request(List.of(step("s1", "p1")))
+                        .build()
+                )
+            );
+
+            var body =
+                "[{\"op\":\"add\",\"path\":\"/flows/0/selectors/-\",\"value\":{\"type\":\"HTTP\",\"path\":\"/api2\",\"pathOperator\":\"EQUALS\"}}]";
+            var response = rootTarget(API).request().method("PATCH", Entity.entity(body, JSON_PATCH_TYPE));
+
+            assertThat(response).hasStatus(OK_200);
+        }
+
+        @Test
+        void json_patch_add_sub_pointer_selector_with_lowercase_type_returns_400_with_invalidValue_envelope() {
+            givenApiWithFlows(
+                List.of(
+                    Flow.builder()
+                        .name("f1")
+                        .enabled(true)
+                        .selectors(List.of(HttpSelector.builder().path("/api").build()))
+                        .request(List.of(step("s1", "p1")))
+                        .build()
+                )
+            );
+
+            var body =
+                "[{\"op\":\"add\",\"path\":\"/flows/0/selectors/-\",\"value\":{\"type\":\"http\",\"path\":\"/api2\",\"pathOperator\":\"EQUALS\"}}]";
+            var response = rootTarget(API).request().method("PATCH", Entity.entity(body, JSON_PATCH_TYPE));
+
+            var error = assertThat(response).hasStatus(BAD_REQUEST_400).asError().actual();
+            Assertions.assertThat(error.getTechnicalCode()).isEqualTo("invalidValue");
         }
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/spring/ResourceContextConfiguration.java
@@ -81,6 +81,7 @@ import io.gravitee.apim.core.api.use_case.ImportApiDefinitionFromUrlUseCase;
 import io.gravitee.apim.core.api.use_case.ImportApiDefinitionUseCase;
 import io.gravitee.apim.core.api.use_case.OAIToUpdateApiUseCase;
 import io.gravitee.apim.core.api.use_case.PatchApiUseCase.FlowListDeserializer;
+import io.gravitee.apim.core.api.use_case.PatchApiUseCase.FlowListSerializer;
 import io.gravitee.apim.core.api.use_case.RollbackApiUseCase;
 import io.gravitee.apim.core.api.use_case.UpdateApiDefinitionFromImportUseCase;
 import io.gravitee.apim.core.api.use_case.UpdateApiGroupsUseCase;
@@ -320,6 +321,11 @@ public class ResourceContextConfiguration {
     @Bean
     public FlowListDeserializer flowListDeserializer(ObjectMapper objectMapper) {
         return node -> FlowMapper.INSTANCE.mapToHttpV4(objectMapper.treeToValue(node, new TypeReference<List<FlowV4>>() {}));
+    }
+
+    @Bean
+    public FlowListSerializer flowListSerializer(ObjectMapper objectMapper) {
+        return flows -> objectMapper.valueToTree(FlowMapper.INSTANCE.mapFromHttpV4(flows));
     }
 
     @Bean

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/spring/ResourceContextConfiguration.java
@@ -20,6 +20,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import fakes.spring.FakeConfiguration;
 import fixtures.core.model.LicenseFixtures;
@@ -79,6 +80,7 @@ import io.gravitee.apim.core.api.use_case.GetExposedEntrypointsUseCase;
 import io.gravitee.apim.core.api.use_case.ImportApiDefinitionFromUrlUseCase;
 import io.gravitee.apim.core.api.use_case.ImportApiDefinitionUseCase;
 import io.gravitee.apim.core.api.use_case.OAIToUpdateApiUseCase;
+import io.gravitee.apim.core.api.use_case.PatchApiUseCase.FlowListDeserializer;
 import io.gravitee.apim.core.api.use_case.RollbackApiUseCase;
 import io.gravitee.apim.core.api.use_case.UpdateApiDefinitionFromImportUseCase;
 import io.gravitee.apim.core.api.use_case.UpdateApiGroupsUseCase;
@@ -259,6 +261,8 @@ import io.gravitee.repository.log.v4.api.AnalyticsRepository;
 import io.gravitee.repository.management.api.ApiRepository;
 import io.gravitee.repository.management.api.ApplicationRepository;
 import io.gravitee.repository.management.api.CustomDashboardRepository;
+import io.gravitee.rest.api.management.v2.rest.mapper.FlowMapper;
+import io.gravitee.rest.api.management.v2.rest.model.FlowV4;
 import io.gravitee.rest.api.management.v2.rest.utils.SubscriptionExpandHelper;
 import io.gravitee.rest.api.service.ApiDuplicatorService;
 import io.gravitee.rest.api.service.ApiKeyService;
@@ -311,6 +315,11 @@ public class ResourceContextConfiguration {
     @Primary
     public ObjectMapper objectMapper() {
         return new GraviteeMapper();
+    }
+
+    @Bean
+    public FlowListDeserializer flowListDeserializer(ObjectMapper objectMapper) {
+        return node -> FlowMapper.INSTANCE.mapToHttpV4(objectMapper.treeToValue(node, new TypeReference<List<FlowV4>>() {}));
     }
 
     @Bean

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/spring/RestManagementConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/spring/RestManagementConfiguration.java
@@ -18,6 +18,7 @@ package io.gravitee.rest.api.management.rest.spring;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.gravitee.apim.core.api.use_case.PatchApiUseCase.FlowListDeserializer;
+import io.gravitee.apim.core.api.use_case.PatchApiUseCase.FlowListSerializer;
 import io.gravitee.apim.infra.spring.UsecaseSpringConfiguration;
 import io.gravitee.definition.model.v4.flow.Flow;
 import io.gravitee.el.ExpressionLanguageInitializer;
@@ -42,6 +43,11 @@ public class RestManagementConfiguration {
     @Bean
     public FlowListDeserializer flowListDeserializer(ObjectMapper objectMapper) {
         return node -> objectMapper.treeToValue(node, new TypeReference<List<Flow>>() {});
+    }
+
+    @Bean
+    public FlowListSerializer flowListSerializer(ObjectMapper objectMapper) {
+        return flows -> objectMapper.valueToTree(flows);
     }
 
     @Bean

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/spring/RestManagementConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/spring/RestManagementConfiguration.java
@@ -15,11 +15,16 @@
  */
 package io.gravitee.rest.api.management.rest.spring;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.gravitee.apim.core.api.use_case.PatchApiUseCase.FlowListDeserializer;
 import io.gravitee.apim.infra.spring.UsecaseSpringConfiguration;
+import io.gravitee.definition.model.v4.flow.Flow;
 import io.gravitee.el.ExpressionLanguageInitializer;
 import io.gravitee.plugin.core.spring.PluginConfiguration;
 import io.gravitee.rest.api.idp.core.spring.IdentityProviderPluginConfiguration;
 import io.gravitee.rest.api.service.spring.ServiceConfiguration;
+import java.util.List;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
@@ -33,6 +38,11 @@ import org.springframework.scheduling.annotation.EnableAsync;
 @Import({ ServiceConfiguration.class, UsecaseSpringConfiguration.class })
 @EnableAsync
 public class RestManagementConfiguration {
+
+    @Bean
+    public FlowListDeserializer flowListDeserializer(ObjectMapper objectMapper) {
+        return node -> objectMapper.treeToValue(node, new TypeReference<List<Flow>>() {});
+    }
 
     @Bean
     public ExpressionLanguageInitializer expressionLanguageInitializer() {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/spring/ResourceContextConfiguration.java
@@ -18,6 +18,7 @@ package io.gravitee.rest.api.management.rest.spring;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import fakes.spring.FakeConfiguration;
 import inmemory.ApiCrudServiceInMemory;
@@ -62,6 +63,7 @@ import io.gravitee.apim.core.api.query_service.ApiMetadataQueryService;
 import io.gravitee.apim.core.api.query_service.ApiQueryService;
 import io.gravitee.apim.core.api.service_provider.ApiTemplateModelProvider;
 import io.gravitee.apim.core.api.use_case.GetExposedEntrypointsUseCase;
+import io.gravitee.apim.core.api.use_case.PatchApiUseCase.FlowListDeserializer;
 import io.gravitee.apim.core.api.use_case.RollbackApiUseCase;
 import io.gravitee.apim.core.api_key.domain_service.ReconcileApiKeysDomainService;
 import io.gravitee.apim.core.api_product.use_case.GetApiProductsUseCase;
@@ -191,6 +193,7 @@ import io.gravitee.apim.infra.spring.UsecaseSpringConfiguration;
 import io.gravitee.common.event.EventManager;
 import io.gravitee.common.util.DataEncryptor;
 import io.gravitee.definition.jackson.datatype.GraviteeMapper;
+import io.gravitee.definition.model.v4.flow.Flow;
 import io.gravitee.node.api.license.LicenseManager;
 import io.gravitee.repository.management.api.ApplicationRepository;
 import io.gravitee.repository.management.api.GroupRepository;
@@ -264,6 +267,7 @@ import io.gravitee.rest.api.service.search.SearchEngineService;
 import io.gravitee.rest.api.service.v4.ApiGroupService;
 import io.gravitee.rest.api.service.v4.PlanSearchService;
 import io.vertx.rxjava3.core.Vertx;
+import java.util.List;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
@@ -672,6 +676,11 @@ public class ResourceContextConfiguration {
     @Bean
     public ObjectMapper objectMapper() {
         return mock(GraviteeMapper.class);
+    }
+
+    @Bean
+    public FlowListDeserializer flowListDeserializer(ObjectMapper objectMapper) {
+        return node -> objectMapper.treeToValue(node, new TypeReference<List<Flow>>() {});
     }
 
     @Bean

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/spring/ResourceContextConfiguration.java
@@ -64,6 +64,7 @@ import io.gravitee.apim.core.api.query_service.ApiQueryService;
 import io.gravitee.apim.core.api.service_provider.ApiTemplateModelProvider;
 import io.gravitee.apim.core.api.use_case.GetExposedEntrypointsUseCase;
 import io.gravitee.apim.core.api.use_case.PatchApiUseCase.FlowListDeserializer;
+import io.gravitee.apim.core.api.use_case.PatchApiUseCase.FlowListSerializer;
 import io.gravitee.apim.core.api.use_case.RollbackApiUseCase;
 import io.gravitee.apim.core.api_key.domain_service.ReconcileApiKeysDomainService;
 import io.gravitee.apim.core.api_product.use_case.GetApiProductsUseCase;
@@ -681,6 +682,11 @@ public class ResourceContextConfiguration {
     @Bean
     public FlowListDeserializer flowListDeserializer(ObjectMapper objectMapper) {
         return node -> objectMapper.treeToValue(node, new TypeReference<List<Flow>>() {});
+    }
+
+    @Bean
+    public FlowListSerializer flowListSerializer(ObjectMapper objectMapper) {
+        return flows -> objectMapper.valueToTree(flows);
     }
 
     @Bean

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/spring/ResourceContextConfiguration.java
@@ -67,6 +67,7 @@ import io.gravitee.apim.core.api.query_service.ApiQueryService;
 import io.gravitee.apim.core.api.service_provider.ApiTemplateModelProvider;
 import io.gravitee.apim.core.api.use_case.GetExposedEntrypointsUseCase;
 import io.gravitee.apim.core.api.use_case.PatchApiUseCase.FlowListDeserializer;
+import io.gravitee.apim.core.api.use_case.PatchApiUseCase.FlowListSerializer;
 import io.gravitee.apim.core.api.use_case.RollbackApiUseCase;
 import io.gravitee.apim.core.api_key.domain_service.ReconcileApiKeysDomainService;
 import io.gravitee.apim.core.api_product.use_case.TransferApiProductOwnershipUseCase;
@@ -680,6 +681,11 @@ public class ResourceContextConfiguration {
     @Bean
     public FlowListDeserializer flowListDeserializer(ObjectMapper objectMapper) {
         return node -> objectMapper.treeToValue(node, new TypeReference<List<Flow>>() {});
+    }
+
+    @Bean
+    public FlowListSerializer flowListSerializer(ObjectMapper objectMapper) {
+        return flows -> objectMapper.valueToTree(flows);
     }
 
     @Bean

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/spring/ResourceContextConfiguration.java
@@ -17,6 +17,7 @@ package io.gravitee.rest.api.portal.rest.spring;
 
 import static org.mockito.Mockito.mock;
 
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import fakes.spring.FakeConfiguration;
 import inmemory.ApiCrudServiceInMemory;
@@ -65,6 +66,7 @@ import io.gravitee.apim.core.api.query_service.ApiMetadataQueryService;
 import io.gravitee.apim.core.api.query_service.ApiQueryService;
 import io.gravitee.apim.core.api.service_provider.ApiTemplateModelProvider;
 import io.gravitee.apim.core.api.use_case.GetExposedEntrypointsUseCase;
+import io.gravitee.apim.core.api.use_case.PatchApiUseCase.FlowListDeserializer;
 import io.gravitee.apim.core.api.use_case.RollbackApiUseCase;
 import io.gravitee.apim.core.api_key.domain_service.ReconcileApiKeysDomainService;
 import io.gravitee.apim.core.api_product.use_case.TransferApiProductOwnershipUseCase;
@@ -199,6 +201,7 @@ import io.gravitee.apim.infra.sanitizer.HtmlSanitizerImpl;
 import io.gravitee.apim.infra.spring.UsecaseSpringConfiguration;
 import io.gravitee.common.util.DataEncryptor;
 import io.gravitee.definition.jackson.datatype.GraviteeMapper;
+import io.gravitee.definition.model.v4.flow.Flow;
 import io.gravitee.node.api.license.LicenseManager;
 import io.gravitee.repository.management.api.ApplicationRepository;
 import io.gravitee.rest.api.portal.rest.mapper.AnalyticsMapper;
@@ -272,6 +275,7 @@ import io.gravitee.rest.api.service.v4.ApiSearchService;
 import io.gravitee.rest.api.service.v4.EndpointConnectorPluginService;
 import io.gravitee.rest.api.service.v4.PlanSearchService;
 import io.vertx.rxjava3.core.Vertx;
+import java.util.List;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
@@ -671,6 +675,11 @@ public class ResourceContextConfiguration {
     @Bean
     public ObjectMapper objectMapper() {
         return new GraviteeMapper();
+    }
+
+    @Bean
+    public FlowListDeserializer flowListDeserializer(ObjectMapper objectMapper) {
+        return node -> objectMapper.treeToValue(node, new TypeReference<List<Flow>>() {});
     }
 
     @Bean

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/use_case/PatchApiUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/use_case/PatchApiUseCase.java
@@ -54,6 +54,7 @@ import io.gravitee.definition.model.v4.listener.Listener;
 import io.gravitee.definition.model.v4.property.Property;
 import io.gravitee.definition.model.v4.resource.Resource;
 import io.gravitee.definition.model.v4.service.ApiServices;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -153,6 +154,7 @@ public class PatchApiUseCase {
     private final WorkflowQueryService workflowQueryService;
     private final ObjectMapper objectMapper;
     private final PropertyDomainService propertyDomainService;
+    private final FlowListDeserializer flowListDeserializer;
 
     public Output execute(Input input) {
         var existingApi = apiCrudService.get(input.apiId());
@@ -411,7 +413,7 @@ public class PatchApiUseCase {
         );
         var properties = encryptProperties(patchableProperties);
         var responseTemplates = resolveResponseTemplates(patchType, rawPatchNode, patchedNode, httpV4.getResponseTemplates());
-        var flows = resolvePatchableList(patchType, rawPatchNode, patchedNode, FIELD_FLOWS, Flow.class, httpV4.getFlows());
+        var flows = resolveFlows(patchType, rawPatchNode, patchedNode, httpV4.getFlows());
         var resources = resolvePatchableList(patchType, rawPatchNode, patchedNode, FIELD_RESOURCES, Resource.class, httpV4.getResources());
         var listeners = resolvePatchableList(patchType, rawPatchNode, patchedNode, FIELD_LISTENERS, Listener.class, httpV4.getListeners());
         var endpointGroups = resolvePatchableList(
@@ -509,6 +511,44 @@ public class PatchApiUseCase {
             }
         }
         return existing;
+    }
+
+    private List<Flow> resolveFlows(PatchType patchType, JsonNode rawPatchNode, JsonNode patchedNode, List<Flow> existing) {
+        if (patchType == PatchType.MERGE_PATCH && rawPatchNode.has(FIELD_FLOWS)) {
+            if (rawPatchNode.get(FIELD_FLOWS).isNull()) {
+                return null;
+            }
+            return deserializeFlows(patchedNode.get(FIELD_FLOWS));
+        }
+        if (patchType == PatchType.JSON_PATCH) {
+            return resolveFlowsForJsonPatch(rawPatchNode, patchedNode, existing);
+        }
+        return existing;
+    }
+
+    private List<Flow> resolveFlowsForJsonPatch(JsonNode rawPatchNode, JsonNode patchedNode, List<Flow> existing) {
+        if (patchedNode.get(FIELD_FLOWS) == null && isNullifiedByJsonPatch(rawPatchNode, FIELD_FLOWS)) {
+            return null;
+        }
+        if (!patchedNode.has(FIELD_FLOWS)) {
+            return existing;
+        }
+        if (patchedNode.get(FIELD_FLOWS).isNull()) {
+            return isNullifiedByJsonPatch(rawPatchNode, FIELD_FLOWS) ? null : existing;
+        }
+        return deserializeFlows(patchedNode.get(FIELD_FLOWS));
+    }
+
+    private List<Flow> deserializeFlows(JsonNode flowsArrayNode) {
+        try {
+            return flowListDeserializer.deserialize(flowsArrayNode);
+        } catch (IOException e) {
+            throw new ValidationDomainException(
+                "Invalid value for field '" + FIELD_FLOWS + "': " + e.getMessage(),
+                Map.of("location", deserializationLocation(FIELD_FLOWS, e)),
+                "invalidValue"
+            );
+        }
     }
 
     private Map<String, Map<String, ResponseTemplate>> parseResponseTemplates(JsonNode patchedNode) {
@@ -779,6 +819,11 @@ public class PatchApiUseCase {
                 .encryptable(encryptable)
                 .build();
         }
+    }
+
+    @FunctionalInterface
+    public interface FlowListDeserializer {
+        List<Flow> deserialize(JsonNode flowsArrayNode) throws IOException;
     }
 
     public enum PatchType {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/use_case/PatchApiUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/use_case/PatchApiUseCase.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.gravitee.apim.core.UseCase;
 import io.gravitee.apim.core.api.crud_service.ApiCrudService;
 import io.gravitee.apim.core.api.domain_service.UpdateApiDomainService;
@@ -155,6 +156,7 @@ public class PatchApiUseCase {
     private final ObjectMapper objectMapper;
     private final PropertyDomainService propertyDomainService;
     private final FlowListDeserializer flowListDeserializer;
+    private final FlowListSerializer flowListSerializer;
 
     public Output execute(Input input) {
         var existingApi = apiCrudService.get(input.apiId());
@@ -190,7 +192,10 @@ public class PatchApiUseCase {
     }
 
     private JsonNode toJsonNode(Api api) {
-        return objectMapper.valueToTree(PatchableView.from(api, requireHttpV4(api)));
+        var httpV4 = requireHttpV4(api);
+        var node = (ObjectNode) objectMapper.valueToTree(PatchableView.from(api, httpV4));
+        node.set(FIELD_FLOWS, flowListSerializer.serialize(httpV4.getFlows()));
+        return node;
     }
 
     private static io.gravitee.definition.model.v4.Api requireHttpV4(Api api) {
@@ -824,6 +829,11 @@ public class PatchApiUseCase {
     @FunctionalInterface
     public interface FlowListDeserializer {
         List<Flow> deserialize(JsonNode flowsArrayNode) throws IOException;
+    }
+
+    @FunctionalInterface
+    public interface FlowListSerializer {
+        JsonNode serialize(List<Flow> flows);
     }
 
     public enum PatchType {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/PatchApiUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/PatchApiUseCaseTest.java
@@ -22,6 +22,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import fixtures.core.model.ApiFixtures;
@@ -101,6 +102,11 @@ class PatchApiUseCaseTest {
 
     static final ObjectMapper OBJECT_MAPPER = new GraviteeMapper(false);
 
+    private static final PatchApiUseCase.FlowListDeserializer FLOW_DESERIALIZER = node ->
+        OBJECT_MAPPER.<List<Flow>>readerFor(OBJECT_MAPPER.getTypeFactory().constructCollectionType(List.class, Flow.class))
+            .with(DeserializationFeature.FAIL_ON_INVALID_SUBTYPE)
+            .readValue(node);
+
     ApiCrudServiceInMemory apiCrudService = new ApiCrudServiceInMemory();
     WorkflowQueryServiceInMemory workflowQueryService = new WorkflowQueryServiceInMemory();
     ApiPrimaryOwnerDomainService apiPrimaryOwnerDomainService = mock(ApiPrimaryOwnerDomainService.class);
@@ -120,7 +126,8 @@ class PatchApiUseCaseTest {
             new JsonPatchDomainService(new JsonMergePatchServiceImpl(), new JsonPatchServiceImpl()),
             workflowQueryService,
             OBJECT_MAPPER,
-            propertyDomainService
+            propertyDomainService,
+            FLOW_DESERIALIZER
         );
 
         var primaryOwner = PrimaryOwnerEntity.builder().id(USER_ID).type(PrimaryOwnerEntity.Type.USER).build();
@@ -1898,6 +1905,36 @@ class PatchApiUseCaseTest {
             );
 
             assertThat(httpV4Def(output.api()).getFlowExecution()).isEqualTo(flowExecution);
+        }
+
+        @Test
+        void json_patch_not_touching_flows_preserves_null_flows_without_calling_deserializer() {
+            var sentinel = List.of(aFlow("sentinel", List.of()));
+            var includeNullsMapper = new GraviteeMapper(false);
+            includeNullsMapper.setSerializationInclusion(JsonInclude.Include.ALWAYS);
+            var localCut = new PatchApiUseCase(
+                apiCrudService,
+                apiPrimaryOwnerDomainService,
+                updateApiDomainService,
+                new JsonPatchDomainService(new JsonMergePatchServiceImpl(), new JsonPatchServiceImpl()),
+                workflowQueryService,
+                includeNullsMapper,
+                propertyDomainService,
+                node -> sentinel
+            );
+            givenExistingApi(apiWithFlows(null));
+
+            var output = localCut.execute(
+                PatchApiUseCase.Input.builder()
+                    .apiId(API_ID)
+                    .patchType(PatchApiUseCase.PatchType.JSON_PATCH)
+                    .patchBody(patch("replace", "/name", "patched-name"))
+                    .dryRun(false)
+                    .auditInfo(AuditInfoFixtures.anAuditInfo(ORGANIZATION_ID, ENVIRONMENT_ID, USER_ID))
+                    .build()
+            );
+
+            assertThat(httpV4Def(output.api()).getFlows()).isNull();
         }
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/PatchApiUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/PatchApiUseCaseTest.java
@@ -107,6 +107,8 @@ class PatchApiUseCaseTest {
             .with(DeserializationFeature.FAIL_ON_INVALID_SUBTYPE)
             .readValue(node);
 
+    private static final PatchApiUseCase.FlowListSerializer FLOW_SERIALIZER = flows -> OBJECT_MAPPER.valueToTree(flows);
+
     ApiCrudServiceInMemory apiCrudService = new ApiCrudServiceInMemory();
     WorkflowQueryServiceInMemory workflowQueryService = new WorkflowQueryServiceInMemory();
     ApiPrimaryOwnerDomainService apiPrimaryOwnerDomainService = mock(ApiPrimaryOwnerDomainService.class);
@@ -127,7 +129,8 @@ class PatchApiUseCaseTest {
             workflowQueryService,
             OBJECT_MAPPER,
             propertyDomainService,
-            FLOW_DESERIALIZER
+            FLOW_DESERIALIZER,
+            FLOW_SERIALIZER
         );
 
         var primaryOwner = PrimaryOwnerEntity.builder().id(USER_ID).type(PrimaryOwnerEntity.Type.USER).build();
@@ -1920,7 +1923,8 @@ class PatchApiUseCaseTest {
                 workflowQueryService,
                 includeNullsMapper,
                 propertyDomainService,
-                node -> sentinel
+                node -> sentinel,
+                flows -> includeNullsMapper.valueToTree(flows)
             );
             givenExistingApi(apiWithFlows(null));
 


### PR DESCRIPTION
## Issue

[APIM-14077](https://gravitee.atlassian.net/browse/APIM-14077)

## Why

`PATCH /management/v2/environments/{env}/apis/{apiId}` rejects flow selectors with `"type": "HTTP"` (uppercase), even though both `GET` and `PUT` produce uppercase values. This means a client cannot copy a selector from a GET or PUT response and resubmit it in a PATCH without manually lowercasing the `type` field — a round-trip that should work transparently.

The root cause is that PATCH deserialization used the definition model's `@JsonSubTypes` labels (`http`, `channel`, `condition`, `mcp`) while PUT/GET use the OpenAPI-generated enum values (`HTTP`, `CHANNEL`, `CONDITION`, `MCP`).

## What changed

- `PatchApiUseCase` — `resolveFlows` now guards against a JSON-null `flows` node and delegates deserialization to `FlowListDeserializer` instead of inline Jackson binding, so selector type matching is case-insensitive.
- `FlowListDeserializer` — injected as a Spring bean with a shared `ObjectMapper` in the v1 management, v2 management, and portal Spring contexts (`RestManagementConfiguration`, `ResourceContextConfiguration`).

## How to test

1. Create or use an existing v4 HTTP Proxy API.
2. `GET /management/v2/environments/DEFAULT/apis/{apiId}` — note `flows[0].selectors[0].type` = `"HTTP"`.
3. Submit that exact response body (unmodified) as a `PATCH` on the same endpoint.
4. Expect `200` — previously this returned `400`.

[APIM-14077]: https://gravitee.atlassian.net/browse/APIM-14077?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ