### PR TITLE
fix(deps): Bumping up the version for policy-oas-validation to fix vulnerability

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -210,7 +210,7 @@
         <gravitee-policy-mock.version>1.15.0</gravitee-policy-mock.version>
         <gravitee-policy-mtls.version>1.0.0</gravitee-policy-mtls.version>
         <gravitee-policy-oauth2.version>5.2.1</gravitee-policy-oauth2.version>
-        <gravitee-policy-oas-validation.version>1.2.2</gravitee-policy-oas-validation.version>
+        <gravitee-policy-oas-validation.version>2.0.0</gravitee-policy-oas-validation.version>
         <gravitee-policy-openid-connect-userinfo.version>1.7.0</gravitee-policy-openid-connect-userinfo.version>
         <gravitee-policy-override-http-method.version>2.2.1</gravitee-policy-override-http-method.version>
         <!--    Version of policy-ratelimit is also used for policy-quota, policy-spikearrest and gateway-services-ratelimit    -->


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-13243

## Description

Bumping up the gravitee-bom version.
Fix for vulnerability GHSA 72hv-8253 57qq

## Additional context

