### PR TITLE
feat(gamma-apim): add API notifications management page, consumer page

### DIFF
--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/app/AppRoutes.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/app/AppRoutes.tsx
@@ -26,12 +26,18 @@ import { ApiDetailIndexRedirect, ApiDetailLayout } from '../features/apis/compon
 import { AlertFormPage } from '../pages/AlertFormPage';
 import { AnalyticsPage } from '../pages/AnalyticsPage';
 import { ApiAlertsPage } from '../pages/ApiAlertsPage';
+import { ApiBroadcastsPage } from '../pages/ApiBroadcastsPage';
+import { ApiConsumerDetailPage } from '../pages/ApiConsumerDetailPage';
+import { ApiConsumersPage } from '../pages/ApiConsumersPage';
 import { ApiCorsPage } from '../pages/ApiCorsPage';
 import { ApiDetailOverviewPage } from '../pages/ApiDetailOverviewPage';
 import { ApiDetailPlaceholderPage } from '../pages/ApiDetailPlaceholderPage';
 import { ApiEntrypointsPage } from '../pages/ApiEntrypointsPage';
 import { ApiGeneralPage } from '../pages/ApiGeneralPage';
+import { ApiNotificationsPage } from '../pages/ApiNotificationsPage';
 import { ApiProductApisPage } from '../pages/ApiProductApisPage';
+import { ApiProductConsumerDetailPage } from '../pages/ApiProductConsumerDetailPage';
+import { ApiProductConsumersPage } from '../pages/ApiProductConsumersPage';
 import { ApiProductGeneralPage } from '../pages/ApiProductGeneralPage';
 import { ApiProductOverviewPage } from '../pages/ApiProductOverviewPage';
 import { ApiProductPlaceholderPage } from '../pages/ApiProductPlaceholderPage';
@@ -94,7 +100,7 @@ export function AppRoutes() {
                             <Route path="general" element={<ApiGeneralPage />} />
                             <Route path="properties" element={<ApiPropertiesPage />} />
                             <Route path="resources" element={<ApiDetailPlaceholderPage title="Resources" />} />
-                            <Route path="notifications" element={<ApiDetailPlaceholderPage title="Notifications" />} />
+                            <Route path="notifications" element={<ApiNotificationsPage />} />
                             <Route path="api-score" element={<ApiDetailPlaceholderPage title="API Score" />} />
                             <Route path="response-templates" element={<ApiDetailPlaceholderPage title="Response Templates" />} />
                             <Route path="entrypoints" element={<ApiEntrypointsPage />} />
@@ -112,8 +118,11 @@ export function AppRoutes() {
                             <Route path="policy-studio" element={<ApiDetailPlaceholderPage title="Policy Studio" />} />
                             <Route path="documentation" element={<ApiDetailPlaceholderPage title="Documentation" />} />
                             <Route path="plans" element={<ApiDetailPlaceholderPage title="Plans" />} />
-                            <Route path="consumers" element={<ApiDetailPlaceholderPage title="Consumers" />} />
-                            <Route path="broadcasts" element={<ApiDetailPlaceholderPage title="Broadcasts" />} />
+                            <Route path="consumers">
+                                <Route index element={<ApiConsumersPage />} />
+                                <Route path=":subscriptionId" element={<ApiConsumerDetailPage />} />
+                            </Route>
+                            <Route path="broadcasts" element={<ApiBroadcastsPage />} />
                             <Route path="authorization" element={<ApiDetailPlaceholderPage title="Authorization" />} />
                             <Route path="user-permissions" element={<UserPermissionsPage />} />
                             <Route path="alerts">
@@ -139,7 +148,10 @@ export function AppRoutes() {
                             <Route path="general" element={<ApiProductGeneralPage />} />
                             <Route path="apis" element={<ApiProductApisPage />} />
                             <Route path="plans" element={<ApiProductPlaceholderPage title="Plans" />} />
-                            <Route path="consumers" element={<ApiProductPlaceholderPage title="Consumers" />} />
+                            <Route path="consumers">
+                                <Route index element={<ApiProductConsumersPage />} />
+                                <Route path=":subscriptionId" element={<ApiProductConsumerDetailPage />} />
+                            </Route>
                             <Route path="user-permissions" element={<ApiProductUserPermissionsPage />} />
                             <Route path="*" element={<Navigate to="overview" replace />} />
                         </Route>

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/api-products/components/detail/ApiProductDetailLayout.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/api-products/components/detail/ApiProductDetailLayout.tsx
@@ -18,6 +18,7 @@ import { Navigate, Outlet, useNavigate, useParams } from 'react-router-dom';
 
 import { ApiProductDetailContext } from '../../context/ApiProductDetailContext';
 import { useApiProductDetail } from '../../hooks/useApiProductDetail';
+import { useApiProductPermissions } from '../../hooks/useApiProductPermissions';
 import type { ApiProductListItem } from '../../types/apiProduct';
 import { SyncStatusBadge } from '../SyncStatusBadge';
 import { ApiProductSidebarNav } from './ApiProductSidebarNav';
@@ -88,6 +89,7 @@ export function ApiProductDetailLayout() {
     const navigate = useNavigate();
     const basePath = useDetailBasePath('api-products', productId);
     const { data: product, isLoading, isError } = useApiProductDetail(productId);
+    const { permissionsReady } = useApiProductPermissions(productId);
 
     if (isError) {
         return (
@@ -103,17 +105,14 @@ export function ApiProductDetailLayout() {
     }
 
     return (
-        <ApiProductDetailContext.Provider value={{ product: product ?? null, isLoading }}>
-            <div className="flex" style={{ minHeight: '100vh' }}>
-                <aside
-                    className="shrink-0 min-w-0 overflow-y-auto overflow-x-hidden pb-4 sticky top-0 self-start w-56"
-                    style={{ maxHeight: '100dvh', maxWidth: '14rem' }}
-                >
+        <ApiProductDetailContext.Provider value={{ product: product ?? null, isLoading, permissionsReady }}>
+            <div className="flex" style={{ height: 'calc(100dvh - 5rem)' }}>
+                <aside className="shrink-0 min-w-0 w-56 overflow-y-auto overflow-x-hidden pb-4" style={{ maxWidth: '14rem' }}>
                     <ProductInfoHeader product={product ?? null} isLoading={isLoading} />
                     <ApiProductSidebarNav basePath={basePath} />
                 </aside>
-                <div className="w-px bg-border shrink-0 self-stretch" />
-                <main className="min-w-0 flex-1 pl-6">
+                <div className="w-px bg-border shrink-0" />
+                <main className="min-w-0 flex-1 pl-6 overflow-y-auto">
                     <Outlet />
                 </main>
             </div>

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/api-products/components/detail/ApiProductSidebarNav.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/api-products/components/detail/ApiProductSidebarNav.tsx
@@ -29,6 +29,7 @@ interface NavItem {
     path: string;
     label: string;
     icon: ComponentType<{ className?: string }>;
+    end?: boolean;
 }
 
 interface NavGroup {
@@ -49,7 +50,7 @@ const API_PRODUCT_NAV_GROUPS: NavGroup[] = [
         label: 'Consumer Access',
         items: [
             { path: 'plans', label: 'Plans', icon: ShieldIcon },
-            { path: 'consumers', label: 'Consumers', icon: UsersRoundIcon },
+            { path: 'consumers', label: 'Consumers', icon: UsersRoundIcon, end: false },
         ],
     },
     {
@@ -72,7 +73,7 @@ export function ApiProductSidebarNav({ basePath }: ApiProductSidebarNavProps) {
                         const Icon = item.icon;
                         return (
                             <NavLink
-                                end
+                                end={item.end ?? true}
                                 key={item.path}
                                 to={`${basePath}/${item.path}`}
                                 className={({ isActive }) =>

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/api-products/hooks/useApiProductPermissions.ts
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/api-products/hooks/useApiProductPermissions.ts
@@ -1,0 +1,48 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { type PermissionScope, permissionService, useEnvironment } from '@gravitee/gamma-modules-sdk';
+import { useQuery } from '@tanstack/react-query';
+import { useEffect } from 'react';
+
+import { getApiProductPermissions } from '../services/apiProductMembers';
+import { apiProductKeys } from '../utils/queryKeys';
+
+/**
+ * Fetches the current user's API-product-scoped permissions and loads them into
+ * the shared `permissionService` singleton for the duration of the product detail view.
+ *
+ * Mirrors the `useApiPermissions` pattern: load on enter, clear on leave.
+ */
+export function useApiProductPermissions(productId: string | undefined): { permissionsReady: boolean } {
+    const env = useEnvironment();
+
+    const { data: permissions, isSuccess } = useQuery({
+        queryKey: apiProductKeys.permissions(env?.id ?? '', productId ?? ''),
+        queryFn: () => getApiProductPermissions(env!.id, productId!),
+        enabled: Boolean(env && productId),
+        staleTime: 60_000,
+    });
+
+    useEffect(() => {
+        if (!permissions) return;
+        // 'api_product' is not yet in the alpha SDK's PermissionScope union — cast until SDK is updated
+        const scope = 'api_product' as PermissionScope;
+        permissionService.load(scope, permissions);
+        return () => permissionService.clear(scope);
+    }, [permissions]);
+
+    return { permissionsReady: isSuccess };
+}

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/api-products/services/apiProductMembers.ts
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/api-products/services/apiProductMembers.ts
@@ -73,3 +73,11 @@ export async function transferApiProductOwnership(
 export async function getApiProductRoles(): Promise<ApiRole[]> {
     return apimFetchJsonOrg<ApiRole[]>(`/configuration/rolescopes/API_PRODUCT/roles`);
 }
+
+export async function getApiProductPermissions(environmentId: string, productId: string): Promise<string[]> {
+    const raw = await apimFetchJsonV2<Record<string, string | string[]>>(environmentId, `/api-products/${productId}/members/permissions`);
+    return Object.entries(raw).flatMap(([resource, ops]) => {
+        const letters = Array.isArray(ops) ? ops : ops.split('');
+        return letters.map(op => `api_product-${resource.toLowerCase()}-${op.toLowerCase()}`);
+    });
+}

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/api-products/utils/queryKeys.ts
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/api-products/utils/queryKeys.ts
@@ -29,4 +29,5 @@ export const apiProductKeys = {
     groupMembers: (envId: string, productId: string, groupId: string) =>
         [...apiProductKeys.all, 'group-members', envId, productId, groupId] as const,
     roles: () => [...apiProductKeys.all, 'roles'] as const,
+    permissions: (envId: string, productId: string) => [...apiProductKeys.all, 'permissions', envId, productId] as const,
 } as const;

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/components/detail/ApiDetailLayout.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/components/detail/ApiDetailLayout.tsx
@@ -136,15 +136,13 @@ export function ApiDetailLayout() {
 
     return (
         <ApiDetailContext.Provider value={{ api: api ?? null, isLoading, permissionsReady }}>
-            <div className="flex gap-6">
-                <aside
-                    className="sticky top-0 self-start w-56 min-w-0 shrink-0 overflow-y-auto overflow-x-hidden pb-4"
-                    style={{ maxHeight: '100dvh', maxWidth: '14rem' }}
-                >
+            <div className="flex" style={{ height: 'calc(100dvh - 5rem)' }}>
+                <aside className="w-56 min-w-0 shrink-0 overflow-y-auto overflow-x-hidden pb-4" style={{ maxWidth: '14rem' }}>
                     <ApiInfoHeader api={api ?? null} isLoading={isLoading} />
                     <ApiDetailSidebarNav groups={API_PROXY_NAV_GROUPS} basePath={basePath} permissionsReady={permissionsReady} />
                 </aside>
-                <main className="min-w-0 flex-1">
+                <div className="w-px bg-border shrink-0" />
+                <main className="min-w-0 flex-1 overflow-y-auto">
                     <Outlet />
                 </main>
             </div>

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/components/detail/ApiDetailSidebarNav.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/components/detail/ApiDetailSidebarNav.tsx
@@ -53,6 +53,8 @@ export interface DetailNavItem {
     path: string;
     label: string;
     icon: ComponentType<{ className?: string }>;
+    /** When false, matches any sub-path (prefix match). Defaults to true (exact match). */
+    end?: boolean;
     children?: DetailNavChild[];
 }
 
@@ -105,7 +107,7 @@ export const API_PROXY_NAV_GROUPS: DetailNavGroup[] = [
         label: 'Consumer Access',
         items: [
             { path: 'plans', label: 'Plans', icon: ShieldIcon },
-            { path: 'consumers', label: 'Consumers', icon: UsersRoundIcon },
+            { path: 'consumers', label: 'Consumers', icon: UsersRoundIcon, end: false },
             { path: 'broadcasts', label: 'Broadcasts', icon: MessageSquareIcon },
         ],
     },
@@ -240,7 +242,7 @@ export function ApiDetailSidebarNav({ groups, basePath, permissionsReady = true 
                         const Icon = item.icon;
                         return (
                             <NavLink
-                                end
+                                end={item.end !== false}
                                 key={item.path}
                                 to={`${basePath}/${item.path}`}
                                 className={({ isActive }) =>

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/hooks/useApiBroadcast.ts
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/hooks/useApiBroadcast.ts
@@ -1,0 +1,60 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useEnvironment } from '@gravitee/gamma-modules-sdk';
+import { useMutation, useQuery } from '@tanstack/react-query';
+import { useMemo } from 'react';
+
+import { listApplicationRoles, sendBroadcast } from '../../../services/apis/broadcasts';
+import type { BroadcastPayload, RecipientOption } from '../types/broadcast';
+import { apiBroadcastKeys } from '../utils/queryKeys';
+
+/**
+ * Fetches APPLICATION-scoped roles and builds the recipients dropdown options.
+ * API_SUBSCRIBERS is always prepended as the first option.
+ */
+export function useApplicationRoles() {
+    const rolesQuery = useQuery({
+        queryKey: apiBroadcastKeys.applicationRoles(),
+        queryFn: listApplicationRoles,
+        staleTime: 5 * 60_000,
+    });
+
+    const recipientOptions = useMemo<RecipientOption[]>(() => {
+        const sorted = [...(rolesQuery.data ?? [])].sort((a, b) => a.name.localeCompare(b.name));
+        return [
+            { name: 'API_SUBSCRIBERS', displayName: 'API subscribers' },
+            ...sorted.map(role => ({
+                name: role.name,
+                displayName: `Members with the ${role.name} role on applications subscribed to this API`,
+            })),
+        ];
+    }, [rolesQuery.data]);
+
+    return {
+        recipientOptions,
+        isLoading: rolesQuery.isLoading,
+        isError: rolesQuery.isError,
+    };
+}
+
+export function useSendBroadcast(apiId: string) {
+    const env = useEnvironment();
+    const envId = env?.id ?? '';
+
+    return useMutation({
+        mutationFn: (payload: BroadcastPayload) => sendBroadcast(envId, apiId, payload),
+    });
+}

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/hooks/useApiNotifications.ts
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/hooks/useApiNotifications.ts
@@ -1,0 +1,163 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useEnvironment } from '@gravitee/gamma-modules-sdk';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useMemo } from 'react';
+
+import {
+    createNotification,
+    deleteNotification,
+    listHooks,
+    listNotifiers,
+    listNotifications,
+    updateNotification,
+} from '../../../services/apis/notifications';
+import type {
+    ApiHook,
+    ApiNotifier,
+    CreateNotificationPayload,
+    HookCategory,
+    NotificationChannel,
+    NotificationSettings,
+    UpdateNotificationPayload,
+} from '../types/notification';
+import { apiNotificationKeys } from '../utils/queryKeys';
+
+export type { HookCategory, NotificationChannel };
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+/** Derive display channel from a notification + its notifier plugin. */
+export function resolveChannel(notification: NotificationSettings, notifier: ApiNotifier | undefined): NotificationChannel {
+    if (notification.config_type === 'PORTAL') return 'CONSOLE';
+    if (notifier?.type === 'EMAIL') return 'EMAIL';
+    if (notifier?.type === 'WEBHOOK') return 'WEBHOOK';
+    return 'CONSOLE';
+}
+
+/** Group a flat hooks array by category, preserving backend order. */
+export function groupHooksByCategory(hooks: ApiHook[]): HookCategory[] {
+    const seen = new Map<string, ApiHook[]>();
+    for (const hook of hooks) {
+        const group = seen.get(hook.category) ?? [];
+        group.push(hook);
+        seen.set(hook.category, group);
+    }
+    return [...seen.entries()].map(([name, hs]) => ({ name, hooks: hs }));
+}
+
+// ─── Data hook ────────────────────────────────────────────────────────────────
+
+export interface NotificationRow {
+    /** 'PORTAL' for the default console notification; the notification ID otherwise. */
+    key: string;
+    notification: NotificationSettings;
+    notifier: ApiNotifier | undefined;
+    channel: NotificationChannel;
+    /** True when managed by Kubernetes — editing not allowed. */
+    isReadonly: boolean;
+    /** PORTAL notification cannot be deleted. */
+    canDelete: boolean;
+}
+
+export function useApiNotifications(apiId: string | undefined) {
+    const env = useEnvironment();
+    const envId = env?.id ?? '';
+    const enabled = Boolean(env && apiId);
+
+    const notificationsQuery = useQuery({
+        queryKey: apiNotificationKeys.list(envId, apiId ?? ''),
+        queryFn: () => listNotifications(envId, apiId!),
+        enabled,
+        staleTime: 30_000,
+    });
+
+    const notifiersQuery = useQuery({
+        queryKey: apiNotificationKeys.notifiers(envId, apiId ?? ''),
+        queryFn: () => listNotifiers(envId, apiId!),
+        enabled,
+        staleTime: 60_000,
+    });
+
+    const hooksQuery = useQuery({
+        queryKey: apiNotificationKeys.hooks(envId),
+        queryFn: () => listHooks(envId),
+        enabled,
+        staleTime: 5 * 60_000,
+    });
+
+    // Build enriched rows only when all data is available
+    const rows = useMemo<NotificationRow[]>(() => {
+        const notifications = notificationsQuery.data ?? [];
+        const notifiers = notifiersQuery.data ?? [];
+        return notifications.map(n => {
+            const notifier = notifiers.find(nr => nr.id === n.notifier);
+            const channel = resolveChannel(n, notifier);
+            return {
+                key: n.id ?? 'PORTAL',
+                notification: n,
+                notifier,
+                channel,
+                isReadonly: Boolean(n.origin && n.origin !== 'MANAGEMENT'),
+                canDelete: n.config_type !== 'PORTAL',
+            };
+        });
+    }, [notificationsQuery.data, notifiersQuery.data]);
+
+    const hookCategories = useMemo<HookCategory[]>(() => groupHooksByCategory(hooksQuery.data ?? []), [hooksQuery.data]);
+
+    return {
+        rows,
+        notifiers: notifiersQuery.data ?? [],
+        hookCategories,
+        isLoading: notificationsQuery.isLoading || notifiersQuery.isLoading,
+        isLoadingHooks: hooksQuery.isLoading,
+        isError: notificationsQuery.isError || hooksQuery.isError || notifiersQuery.isError,
+    };
+}
+
+export function useCreateNotification(apiId: string) {
+    const env = useEnvironment();
+    const queryClient = useQueryClient();
+    const envId = env?.id ?? '';
+
+    return useMutation({
+        mutationFn: (payload: CreateNotificationPayload) => createNotification(envId, apiId, payload),
+        onSuccess: () => queryClient.invalidateQueries({ queryKey: apiNotificationKeys.list(envId, apiId) }),
+    });
+}
+
+export function useUpdateNotification(apiId: string) {
+    const env = useEnvironment();
+    const queryClient = useQueryClient();
+    const envId = env?.id ?? '';
+
+    return useMutation({
+        mutationFn: (payload: UpdateNotificationPayload) => updateNotification(envId, apiId, payload),
+        onSuccess: () => queryClient.invalidateQueries({ queryKey: apiNotificationKeys.list(envId, apiId) }),
+    });
+}
+
+export function useDeleteNotification(apiId: string) {
+    const env = useEnvironment();
+    const queryClient = useQueryClient();
+    const envId = env?.id ?? '';
+
+    return useMutation({
+        mutationFn: (notificationId: string) => deleteNotification(envId, apiId, notificationId),
+        onSuccess: () => queryClient.invalidateQueries({ queryKey: apiNotificationKeys.list(envId, apiId) }),
+    });
+}

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/hooks/useEnv.ts
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/hooks/useEnv.ts
@@ -13,22 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { createContext, useContext } from 'react';
+import { useEnvironment } from '@gravitee/gamma-modules-sdk';
 
-import type { ApiProductListItem } from '../types/apiProduct';
-
-export interface ApiProductDetailContextValue {
-    readonly product: ApiProductListItem | null;
-    readonly isLoading: boolean;
-    readonly permissionsReady: boolean;
-}
-
-export const ApiProductDetailContext = createContext<ApiProductDetailContextValue>({
-    product: null,
-    isLoading: true,
-    permissionsReady: false,
-});
-
-export function useApiProductDetailContext(): ApiProductDetailContextValue {
-    return useContext(ApiProductDetailContext);
+export function useEnv() {
+    const env = useEnvironment();
+    return env?.id ?? '';
 }

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/hooks/useSubscriptionActions.ts
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/hooks/useSubscriptionActions.ts
@@ -1,0 +1,104 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { useEnv } from './useEnv';
+import {
+    closeSubscription,
+    createSubscription,
+    pauseSubscription,
+    resumeSubscription,
+    transferSubscription,
+    updateSubscriptionEndDate,
+} from '../services/subscriptions';
+import type { CreateSubscriptionPayload, SubscriptionContext } from '../types/subscription';
+import { apiSubscriptionKeys } from '../utils/queryKeys';
+
+export function useCreateSubscription(ctx: SubscriptionContext) {
+    const envId = useEnv();
+    const qc = useQueryClient();
+
+    return useMutation({
+        mutationFn: (payload: CreateSubscriptionPayload) => createSubscription(envId, ctx, payload),
+        onSuccess: () => {
+            qc.invalidateQueries({ queryKey: [...apiSubscriptionKeys.all, ctx.type, ctx.entityId, 'list'] });
+        },
+    });
+}
+
+export function useTransferSubscription(ctx: SubscriptionContext, subscriptionId: string) {
+    const envId = useEnv();
+    const qc = useQueryClient();
+
+    return useMutation({
+        mutationFn: (planId: string) => transferSubscription(envId, ctx, subscriptionId, planId),
+        onSuccess: sub => {
+            qc.setQueryData(apiSubscriptionKeys.detail(envId, ctx, subscriptionId), sub);
+            qc.invalidateQueries({ queryKey: [...apiSubscriptionKeys.all, ctx.type, ctx.entityId, 'list'] });
+        },
+    });
+}
+
+export function usePauseSubscription(ctx: SubscriptionContext, subscriptionId: string) {
+    const envId = useEnv();
+    const qc = useQueryClient();
+
+    return useMutation({
+        mutationFn: () => pauseSubscription(envId, ctx, subscriptionId),
+        onSuccess: sub => {
+            qc.setQueryData(apiSubscriptionKeys.detail(envId, ctx, subscriptionId), sub);
+            qc.invalidateQueries({ queryKey: [...apiSubscriptionKeys.all, ctx.type, ctx.entityId, 'list'] });
+        },
+    });
+}
+
+export function useResumeSubscription(ctx: SubscriptionContext, subscriptionId: string) {
+    const envId = useEnv();
+    const qc = useQueryClient();
+
+    return useMutation({
+        mutationFn: () => resumeSubscription(envId, ctx, subscriptionId),
+        onSuccess: sub => {
+            qc.setQueryData(apiSubscriptionKeys.detail(envId, ctx, subscriptionId), sub);
+            qc.invalidateQueries({ queryKey: [...apiSubscriptionKeys.all, ctx.type, ctx.entityId, 'list'] });
+        },
+    });
+}
+
+export function useCloseSubscription(ctx: SubscriptionContext, subscriptionId: string) {
+    const envId = useEnv();
+    const qc = useQueryClient();
+
+    return useMutation({
+        mutationFn: () => closeSubscription(envId, ctx, subscriptionId),
+        onSuccess: sub => {
+            qc.setQueryData(apiSubscriptionKeys.detail(envId, ctx, subscriptionId), sub);
+            qc.invalidateQueries({ queryKey: [...apiSubscriptionKeys.all, ctx.type, ctx.entityId, 'list'] });
+        },
+    });
+}
+
+export function useUpdateSubscriptionEndDate(ctx: SubscriptionContext, subscriptionId: string) {
+    const envId = useEnv();
+    const qc = useQueryClient();
+
+    return useMutation({
+        mutationFn: (endingAt: string | null) => updateSubscriptionEndDate(envId, ctx, subscriptionId, endingAt),
+        onSuccess: sub => {
+            qc.setQueryData(apiSubscriptionKeys.detail(envId, ctx, subscriptionId), sub);
+        },
+    });
+}

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/hooks/useSubscriptionApiKeys.ts
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/hooks/useSubscriptionApiKeys.ts
@@ -1,0 +1,69 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
+import { useEnv } from './useEnv';
+import { expireApiKey, listApiKeys, renewApiKey, revokeApiKey } from '../services/subscriptions';
+import type { SubscriptionContext } from '../types/subscription';
+import { apiSubscriptionKeys } from '../utils/queryKeys';
+
+export function useApiKeyList(ctx: SubscriptionContext, subscriptionId: string, page: number, perPage = 5) {
+    const envId = useEnv();
+
+    return useQuery({
+        queryKey: apiSubscriptionKeys.apiKeys(envId, ctx, subscriptionId, page),
+        queryFn: () => listApiKeys(envId, ctx, subscriptionId, page, perPage),
+        enabled: Boolean(envId && ctx.entityId && subscriptionId),
+        staleTime: 30_000,
+    });
+}
+
+export function useRenewApiKey(ctx: SubscriptionContext, subscriptionId: string) {
+    const envId = useEnv();
+    const qc = useQueryClient();
+
+    return useMutation({
+        mutationFn: () => renewApiKey(envId, ctx, subscriptionId),
+        onSuccess: () => {
+            qc.invalidateQueries({ queryKey: [...apiSubscriptionKeys.all, ctx.type, ctx.entityId, 'api-keys', envId, subscriptionId] });
+        },
+    });
+}
+
+export function useRevokeApiKey(ctx: SubscriptionContext, subscriptionId: string) {
+    const envId = useEnv();
+    const qc = useQueryClient();
+
+    return useMutation({
+        mutationFn: (apiKeyId: string) => revokeApiKey(envId, ctx, subscriptionId, apiKeyId),
+        onSuccess: () => {
+            qc.invalidateQueries({ queryKey: [...apiSubscriptionKeys.all, ctx.type, ctx.entityId, 'api-keys', envId, subscriptionId] });
+        },
+    });
+}
+
+export function useExpireApiKey(ctx: SubscriptionContext, subscriptionId: string) {
+    const envId = useEnv();
+    const qc = useQueryClient();
+
+    return useMutation({
+        mutationFn: ({ apiKeyId, expireAt }: { apiKeyId: string; expireAt: string }) =>
+            expireApiKey(envId, ctx, subscriptionId, apiKeyId, expireAt),
+        onSuccess: () => {
+            qc.invalidateQueries({ queryKey: [...apiSubscriptionKeys.all, ctx.type, ctx.entityId, 'api-keys', envId, subscriptionId] });
+        },
+    });
+}

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/hooks/useSubscriptions.ts
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/hooks/useSubscriptions.ts
@@ -1,0 +1,107 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useEnvironment } from '@gravitee/gamma-modules-sdk';
+import { useQuery } from '@tanstack/react-query';
+
+import { getSubscription, listApiPlans, listSubscriptions, searchApplications } from '../services/subscriptions';
+import type { SubscriptionContext, SubscriptionFilters, SubscriptionStatus } from '../types/subscription';
+import { apiSubscriptionKeys } from '../utils/queryKeys';
+
+export function isSubscriptionFiltersDirty(filters: SubscriptionFilters): boolean {
+    return (
+        filters.statuses.length > 0 || filters.planIds.length > 0 || filters.applicationIds.length > 0 || filters.apiKey.trim().length > 0
+    );
+}
+
+export const DEFAULT_STATUSES = ['ACCEPTED', 'PAUSED', 'PENDING'] as const;
+
+const SAFE_CTX: SubscriptionContext = { type: 'api', entityId: '' };
+
+export function useSubscriptionList(ctx: SubscriptionContext | null, filters: Partial<SubscriptionFilters>, page: number, perPage = 10) {
+    const env = useEnvironment();
+    const envId = env?.id ?? '';
+    const safeCtx = ctx ?? SAFE_CTX;
+    const filtersKey = { ...filters, page, perPage };
+
+    return useQuery({
+        queryKey: apiSubscriptionKeys.list(envId, safeCtx, filtersKey),
+        queryFn: () =>
+            listSubscriptions(envId, ctx!, {
+                statuses: filters.statuses?.length ? filters.statuses : [...DEFAULT_STATUSES],
+                planIds: filters.planIds,
+                applicationIds: filters.applicationIds,
+                apiKey: filters.apiKey,
+                page,
+                perPage,
+            }),
+        enabled: Boolean(env && ctx?.entityId),
+        staleTime: 30_000,
+    });
+}
+
+export function useSubscriptionDetail(ctx: SubscriptionContext | null, subscriptionId: string | undefined) {
+    const env = useEnvironment();
+    const envId = env?.id ?? '';
+    const safeCtx = ctx ?? SAFE_CTX;
+
+    return useQuery({
+        queryKey: apiSubscriptionKeys.detail(envId, safeCtx, subscriptionId ?? ''),
+        queryFn: () => getSubscription(envId, ctx!, subscriptionId!),
+        enabled: Boolean(env && ctx?.entityId && subscriptionId),
+        staleTime: 30_000,
+    });
+}
+
+export function useApiPlans(ctx: SubscriptionContext | null) {
+    const env = useEnvironment();
+    const envId = env?.id ?? '';
+    const safeCtx = ctx ?? SAFE_CTX;
+
+    return useQuery({
+        queryKey: apiSubscriptionKeys.plans(envId, safeCtx),
+        queryFn: () => listApiPlans(envId, ctx!),
+        enabled: Boolean(env && ctx?.entityId),
+        staleTime: 5 * 60_000,
+        select: data => data.data.filter(p => p.security?.type !== 'KEY_LESS'),
+    });
+}
+
+export function useSubscriptionCount(ctx: SubscriptionContext | null, statuses: SubscriptionStatus[]) {
+    const env = useEnvironment();
+    const envId = env?.id ?? '';
+    const safeCtx = ctx ?? SAFE_CTX;
+    return useQuery({
+        queryKey: apiSubscriptionKeys.list(envId, safeCtx, { statuses, page: 1, perPage: 1 }),
+        queryFn: () => listSubscriptions(envId, ctx!, { statuses, page: 1, perPage: 1 }),
+        enabled: Boolean(env && ctx?.entityId),
+        staleTime: 30_000,
+        select: data => data.pagination.totalCount,
+    });
+}
+
+export function useApplicationSearch(query: string) {
+    const env = useEnvironment();
+    const envId = env?.id ?? '';
+    const trimmed = query.trim();
+
+    return useQuery({
+        queryKey: apiSubscriptionKeys.applications(envId, trimmed),
+        queryFn: () => searchApplications(envId, trimmed),
+        enabled: Boolean(env && trimmed.length > 0),
+        staleTime: 30_000,
+        select: data => data.data,
+    });
+}

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/services/subscriptions.ts
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/services/subscriptions.ts
@@ -1,0 +1,158 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { apimFetchJsonV1Env, apimFetchJsonV2 } from '../../../shared/api/apimClient';
+import type {
+    ApiKey,
+    ApiKeyPage,
+    Application,
+    ApplicationPage,
+    CreateSubscriptionPayload,
+    PlanPage,
+    Subscription,
+    SubscriptionContext,
+    SubscriptionPage,
+    SubscriptionStatus,
+} from '../types/subscription';
+
+function buildQuery(params: Record<string, string | string[] | number | boolean | undefined>): string {
+    const p = new URLSearchParams();
+    for (const [k, v] of Object.entries(params)) {
+        if (v === undefined || (Array.isArray(v) && v.length === 0)) continue;
+        p.set(k, Array.isArray(v) ? v.join(',') : String(v));
+    }
+    const s = p.toString();
+    return s ? `?${s}` : '';
+}
+
+const entityBase = (ctx: SubscriptionContext) =>
+    ctx.type === 'api' ? `/apis/${encodeURIComponent(ctx.entityId)}` : `/api-products/${encodeURIComponent(ctx.entityId)}`;
+
+const sub = (ctx: SubscriptionContext, subId: string) => `${entityBase(ctx)}/subscriptions/${encodeURIComponent(subId)}`;
+
+export async function listSubscriptions(
+    envId: string,
+    ctx: SubscriptionContext,
+    filters: {
+        statuses?: SubscriptionStatus[];
+        planIds?: string[];
+        applicationIds?: string[];
+        apiKey?: string;
+        page?: number;
+        perPage?: number;
+    },
+): Promise<SubscriptionPage> {
+    const q = buildQuery({
+        statuses: filters.statuses,
+        planIds: filters.planIds,
+        applicationIds: filters.applicationIds,
+        apiKey: filters.apiKey,
+        page: filters.page ?? 1,
+        perPage: filters.perPage ?? 10,
+        expands: 'plan,application',
+    });
+    return apimFetchJsonV2<SubscriptionPage>(envId, `${entityBase(ctx)}/subscriptions${q}`);
+}
+
+export async function getSubscription(envId: string, ctx: SubscriptionContext, subscriptionId: string): Promise<Subscription> {
+    return apimFetchJsonV2<Subscription>(envId, `${sub(ctx, subscriptionId)}?expands=plan,application,subscribedBy`);
+}
+
+export async function createSubscription(
+    envId: string,
+    ctx: SubscriptionContext,
+    payload: CreateSubscriptionPayload,
+): Promise<Subscription> {
+    return apimFetchJsonV2<Subscription>(envId, `${entityBase(ctx)}/subscriptions`, { method: 'POST', body: JSON.stringify(payload) });
+}
+
+export async function transferSubscription(
+    envId: string,
+    ctx: SubscriptionContext,
+    subscriptionId: string,
+    planId: string,
+): Promise<Subscription> {
+    return apimFetchJsonV2<Subscription>(envId, `${sub(ctx, subscriptionId)}/_transfer`, {
+        method: 'POST',
+        body: JSON.stringify({ planId }),
+    });
+}
+
+export async function pauseSubscription(envId: string, ctx: SubscriptionContext, subscriptionId: string): Promise<Subscription> {
+    return apimFetchJsonV2<Subscription>(envId, `${sub(ctx, subscriptionId)}/_pause`, { method: 'POST', body: JSON.stringify({}) });
+}
+
+export async function resumeSubscription(envId: string, ctx: SubscriptionContext, subscriptionId: string): Promise<Subscription> {
+    return apimFetchJsonV2<Subscription>(envId, `${sub(ctx, subscriptionId)}/_resume`, { method: 'POST', body: JSON.stringify({}) });
+}
+
+export async function closeSubscription(envId: string, ctx: SubscriptionContext, subscriptionId: string): Promise<Subscription> {
+    return apimFetchJsonV2<Subscription>(envId, `${sub(ctx, subscriptionId)}/_close`, { method: 'POST', body: JSON.stringify({}) });
+}
+
+export async function updateSubscriptionEndDate(
+    envId: string,
+    ctx: SubscriptionContext,
+    subscriptionId: string,
+    endingAt: string | null,
+): Promise<Subscription> {
+    return apimFetchJsonV2<Subscription>(envId, sub(ctx, subscriptionId), { method: 'PUT', body: JSON.stringify({ endingAt }) });
+}
+
+export async function listApiKeys(
+    envId: string,
+    ctx: SubscriptionContext,
+    subscriptionId: string,
+    page = 1,
+    perPage = 10,
+): Promise<ApiKeyPage> {
+    return apimFetchJsonV2<ApiKeyPage>(envId, `${sub(ctx, subscriptionId)}/api-keys${buildQuery({ page, perPage })}`);
+}
+
+export async function renewApiKey(envId: string, ctx: SubscriptionContext, subscriptionId: string): Promise<ApiKey> {
+    return apimFetchJsonV2<ApiKey>(envId, `${sub(ctx, subscriptionId)}/api-keys/_renew`, { method: 'POST', body: JSON.stringify({}) });
+}
+
+export async function revokeApiKey(envId: string, ctx: SubscriptionContext, subscriptionId: string, apiKeyId: string): Promise<void> {
+    return apimFetchJsonV2<void>(envId, `${sub(ctx, subscriptionId)}/api-keys/${encodeURIComponent(apiKeyId)}/_revoke`, {
+        method: 'POST',
+        body: JSON.stringify({}),
+    });
+}
+
+export async function expireApiKey(
+    envId: string,
+    ctx: SubscriptionContext,
+    subscriptionId: string,
+    apiKeyId: string,
+    expireAt: string,
+): Promise<ApiKey> {
+    return apimFetchJsonV2<ApiKey>(envId, `${sub(ctx, subscriptionId)}/api-keys/${encodeURIComponent(apiKeyId)}`, {
+        method: 'PUT',
+        body: JSON.stringify({ expireAt }),
+    });
+}
+
+export async function listApiPlans(envId: string, ctx: SubscriptionContext): Promise<PlanPage> {
+    return apimFetchJsonV2<PlanPage>(envId, `${entityBase(ctx)}/plans${buildQuery({ statuses: 'PUBLISHED', perPage: 100 })}`);
+}
+
+export async function searchApplications(envId: string, query: string): Promise<ApplicationPage> {
+    const res = await apimFetchJsonV1Env<{ data: Application[]; metadata?: { pagination?: { total?: number } } }>(
+        envId,
+        `/applications/_paged${buildQuery({ query: query.trim(), status: 'ACTIVE', page: 1, size: 20, order: 'name' })}`,
+    );
+    return { data: res.data ?? [], pagination: { totalCount: res.metadata?.pagination?.total ?? 0 } };
+}

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/types/broadcast.ts
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/types/broadcast.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export type BroadcastChannel = 'PORTAL' | 'MAIL' | 'HTTP';
+
+export interface BroadcastTextPayload {
+    channel: 'PORTAL' | 'MAIL';
+    title: string;
+    text: string;
+    recipient: {
+        role_scope: 'APPLICATION';
+        role_value: string[];
+    };
+}
+
+export interface BroadcastHttpPayload {
+    channel: 'HTTP';
+    text: string;
+    recipient: { url: string };
+    params: Record<string, string>;
+    useSystemProxy: boolean;
+}
+
+export type BroadcastPayload = BroadcastTextPayload | BroadcastHttpPayload;
+
+export interface ApplicationRole {
+    name: string;
+    description?: string;
+}
+
+export interface RecipientOption {
+    name: string;
+    displayName: string;
+}

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/types/notification.ts
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/types/notification.ts
@@ -1,0 +1,76 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/** A configured notification subscription on an API. */
+export interface NotificationSettings {
+    /** Present for GENERIC notifications; absent for PORTAL (default console) notification. */
+    id?: string;
+    name: string;
+    referenceType: string;
+    referenceId: string;
+    /** Notifier plugin ID (e.g. 'default-email', 'default-webhook'). Absent for PORTAL. */
+    notifier?: string;
+    hooks: string[];
+    /** Hooks inherited from the API's group — displayed but not editable. */
+    groupHooks?: string[];
+    /** Email address(es) or webhook URL. Only relevant for EMAIL and WEBHOOK channels. */
+    config?: string;
+    useSystemProxy?: boolean;
+    /** 'PORTAL' = default in-app console notification; 'GENERIC' = user-created. */
+    config_type: 'PORTAL' | 'GENERIC';
+    /** 'MANAGEMENT' (editable) | 'KUBERNETES' (read-only). */
+    origin?: string;
+}
+
+/** A notifier plugin available for this API (returned by /notifiers endpoint). */
+export interface ApiNotifier {
+    id: string;
+    /** 'EMAIL' | 'WEBHOOK' | 'DEFAULT' (console). */
+    type: string;
+    name: string;
+}
+
+/** A single hookable event returned by /apis/hooks. */
+export interface ApiHook {
+    id: string;
+    label: string;
+    description: string;
+    scope: string;
+    category: string;
+}
+
+/** Hooks grouped by their category label. */
+export interface HookCategory {
+    name: string;
+    hooks: ApiHook[];
+}
+
+/** Derived channel type used only in the UI for display and filtering. */
+export type NotificationChannel = 'CONSOLE' | 'EMAIL' | 'WEBHOOK';
+
+/** Payload sent to POST /notificationsettings to create a notification. */
+export interface CreateNotificationPayload {
+    name: string;
+    /** Notifier plugin ID. */
+    notifier: string;
+    config_type: 'GENERIC';
+    hooks: string[];
+    referenceType: 'API';
+    referenceId: string;
+}
+
+/** Payload sent to PUT /notificationsettings/{id} to update a notification. */
+export type UpdateNotificationPayload = NotificationSettings;

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/types/subscription.ts
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/types/subscription.ts
@@ -1,0 +1,121 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export type SubscriptionStatus = 'PENDING' | 'ACCEPTED' | 'REJECTED' | 'CLOSED' | 'PAUSED' | 'RESUMED';
+export type SubscriptionSecurityType = 'API_KEY' | 'OAUTH2' | 'JWT' | 'KEY_LESS' | 'MTLS';
+export type ApiKeyMode = 'SHARED' | 'EXCLUSIVE' | 'UNSPECIFIED';
+export type SubscriptionConsumerStatus = 'STARTED' | 'STOPPED' | 'FAILURE';
+
+export interface SubscriptionPlan {
+    id: string;
+    name: string;
+    security?: { type: SubscriptionSecurityType; configuration?: unknown };
+    mode?: 'STANDARD' | 'PUSH';
+}
+
+export interface SubscriptionApplication {
+    id: string;
+    name: string;
+    description?: string;
+    domain?: string;
+    primaryOwner?: { displayName: string };
+    apiKeyMode?: ApiKeyMode;
+    type?: string;
+}
+
+export interface Subscription {
+    id: string;
+    status: SubscriptionStatus;
+    consumerStatus?: SubscriptionConsumerStatus;
+    origin?: 'KUBERNETES' | 'MANAGEMENT';
+    plan: SubscriptionPlan;
+    application: SubscriptionApplication;
+    subscribedBy?: { displayName: string };
+    createdAt?: string;
+    updatedAt?: string;
+    processedAt?: string;
+    startingAt?: string;
+    endingAt?: string;
+    closedAt?: string;
+    pausedAt?: string;
+    publisherMessage?: string;
+    consumerMessage?: string;
+    failureCause?: string;
+    metadata?: Record<string, string>;
+}
+
+export interface SubscriptionPage {
+    data: Subscription[];
+    pagination: { totalCount: number; pageIndex: number; pageSize: number };
+}
+
+export interface ApiKey {
+    id: string;
+    key: string;
+    createdAt?: string;
+    expireAt?: string;
+    revokedAt?: string;
+    revoked?: boolean;
+    expired?: boolean;
+}
+
+export interface ApiKeyPage {
+    data: ApiKey[];
+    pagination: { totalCount: number; pageIndex: number; pageSize: number };
+}
+
+export interface Plan {
+    id: string;
+    name: string;
+    description?: string;
+    security?: { type: SubscriptionSecurityType };
+    mode?: 'STANDARD' | 'PUSH';
+    status?: string;
+}
+
+export interface PlanPage {
+    data: Plan[];
+    pagination: { totalCount: number };
+}
+
+export interface Application {
+    id: string;
+    name: string;
+    description?: string;
+    primaryOwner?: { displayName: string };
+    type?: string;
+    apiKeyMode?: ApiKeyMode;
+}
+
+export interface ApplicationPage {
+    data: Application[];
+    pagination: { totalCount: number };
+}
+
+export interface SubscriptionFilters {
+    statuses: SubscriptionStatus[];
+    planIds: string[];
+    applicationIds: string[];
+    apiKey: string;
+}
+
+export interface CreateSubscriptionPayload {
+    planId: string;
+    applicationId: string;
+    customApiKey?: string;
+}
+
+export type SubscriptionContext = { type: 'api'; entityId: string } | { type: 'api-product'; entityId: string };

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/utils/formatDate.ts
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/utils/formatDate.ts
@@ -1,0 +1,40 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+function parts(value: string): { d: Date; day: string; month: string; year: number } {
+    const d = new Date(value);
+    return {
+        d,
+        day: d.getDate().toString().padStart(2, '0'),
+        month: d.toLocaleString('en-US', { month: 'short' }),
+        year: d.getFullYear(),
+    };
+}
+
+export function formatDate(value: string | undefined): string {
+    if (!value) return '—';
+    const { day, month, year } = parts(value);
+    return `${day} ${month} ${year}`;
+}
+
+export function formatDateTime(value: string | undefined): string {
+    if (!value) return '—';
+    const { d, day, month, year } = parts(value);
+    const hh = d.getHours().toString().padStart(2, '0');
+    const mm = d.getMinutes().toString().padStart(2, '0');
+    const ss = d.getSeconds().toString().padStart(2, '0');
+    return `${day} ${month} ${year} ${hh}:${mm}:${ss}`;
+}

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/utils/notificationFormatters.ts
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/utils/notificationFormatters.ts
@@ -13,22 +13,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { createContext, useContext } from 'react';
+import { MailIcon, MessageSquareIcon, WebhookIcon } from '@gravitee/graphene-core/icons';
+import type { ComponentType } from 'react';
 
-import type { ApiProductListItem } from '../types/apiProduct';
+import type { NotificationChannel } from '../types/notification';
 
-export interface ApiProductDetailContextValue {
-    readonly product: ApiProductListItem | null;
-    readonly isLoading: boolean;
-    readonly permissionsReady: boolean;
-}
+export const CHANNEL_ICON: Record<NotificationChannel, ComponentType<{ className?: string }>> = {
+    CONSOLE: MessageSquareIcon,
+    EMAIL: MailIcon,
+    WEBHOOK: WebhookIcon,
+};
 
-export const ApiProductDetailContext = createContext<ApiProductDetailContextValue>({
-    product: null,
-    isLoading: true,
-    permissionsReady: false,
-});
-
-export function useApiProductDetailContext(): ApiProductDetailContextValue {
-    return useContext(ApiProductDetailContext);
-}
+export const CHANNEL_LABEL: Record<NotificationChannel, string> = {
+    CONSOLE: 'Console',
+    EMAIL: 'Email',
+    WEBHOOK: 'Webhook',
+};

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/utils/queryKeys.ts
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/utils/queryKeys.ts
@@ -90,3 +90,29 @@ export const apiAnalyticsKeys = {
     statusRanges: (envId: string, apiId: string, window: string) =>
         [...apiAnalyticsKeys.all, 'status-ranges', envId, apiId, window] as const,
 };
+
+export const apiBroadcastKeys = {
+    all: ['api-broadcasts'] as const,
+    applicationRoles: () => [...apiBroadcastKeys.all, 'application-roles'] as const,
+};
+
+export const apiNotificationKeys = {
+    all: ['api-notifications'] as const,
+    list: (envId: string, apiId: string) => [...apiNotificationKeys.all, 'list', envId, apiId] as const,
+    notifiers: (envId: string, apiId: string) => [...apiNotificationKeys.all, 'notifiers', envId, apiId] as const,
+    hooks: (envId: string) => [...apiNotificationKeys.all, 'hooks', envId] as const,
+};
+
+import type { SubscriptionContext } from '../types/subscription';
+
+export const apiSubscriptionKeys = {
+    all: ['api-subscriptions'] as const,
+    list: (envId: string, ctx: SubscriptionContext, filters: object) =>
+        [...apiSubscriptionKeys.all, ctx.type, ctx.entityId, 'list', envId, filters] as const,
+    detail: (envId: string, ctx: SubscriptionContext, subscriptionId: string) =>
+        [...apiSubscriptionKeys.all, ctx.type, ctx.entityId, 'detail', envId, subscriptionId] as const,
+    apiKeys: (envId: string, ctx: SubscriptionContext, subscriptionId: string, page: number) =>
+        [...apiSubscriptionKeys.all, ctx.type, ctx.entityId, 'api-keys', envId, subscriptionId, page] as const,
+    plans: (envId: string, ctx: SubscriptionContext) => [...apiSubscriptionKeys.all, ctx.type, ctx.entityId, 'plans', envId] as const,
+    applications: (envId: string, query: string) => [...apiSubscriptionKeys.all, 'applications', envId, query] as const,
+};

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/pages/ApiBroadcastsPage.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/pages/ApiBroadcastsPage.spec.tsx
@@ -1,0 +1,398 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useHasPermission } from '@gravitee/gamma-modules-sdk';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { ReactNode } from 'react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+
+import { ApiBroadcastsPage } from './ApiBroadcastsPage';
+import { useApplicationRoles, useSendBroadcast } from '../features/apis/hooks/useApiBroadcast';
+import type { BroadcastPayload } from '../features/apis/types/broadcast';
+
+// ─── SDK / icon mocks ─────────────────────────────────────────────────────────
+
+jest.mock('@gravitee/gamma-modules-sdk', () => ({
+    useEnvironment: jest.fn(() => ({ id: 'DEFAULT' })),
+    useHasPermission: jest.fn(() => true),
+}));
+
+jest.mock('@gravitee/graphene-core/icons', () => new Proxy({}, { get: () => () => null }));
+
+// ─── Hook mocks ───────────────────────────────────────────────────────────────
+
+jest.mock('../features/apis/hooks/useApiBroadcast', () => ({
+    useApplicationRoles: jest.fn(),
+    useSendBroadcast: jest.fn(),
+}));
+
+// ─── Graphene UI mock — renders semantic HTML so behaviour tests work reliably ─
+
+jest.mock('@gravitee/graphene-core', () => {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires, @typescript-eslint/no-require-imports
+    const React = require('react');
+
+    return {
+        Alert: ({ children }: { children: ReactNode }) => <div role="alert">{children}</div>,
+        AlertDescription: ({ children }: { children: ReactNode }) => <span>{children}</span>,
+        Badge: ({ children }: { children: ReactNode }) => <span>{children}</span>,
+        Button: ({
+            children,
+            disabled,
+            onClick,
+            type,
+        }: {
+            children: ReactNode;
+            disabled?: boolean;
+            onClick?: () => void;
+            type?: React.ButtonHTMLAttributes<HTMLButtonElement>['type'];
+        }) => (
+            <button type={type ?? 'button'} disabled={disabled} onClick={onClick}>
+                {children}
+            </button>
+        ),
+        Card: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+        CardContent: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+        CardHeader: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+        CardTitle: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+        Checkbox: ({
+            checked,
+            onCheckedChange,
+            'aria-label': ariaLabel,
+        }: {
+            checked?: boolean;
+            onCheckedChange?: (v: boolean) => void;
+            'aria-label'?: string;
+        }) => <input type="checkbox" checked={!!checked} onChange={e => onCheckedChange?.(e.target.checked)} aria-label={ariaLabel} />,
+        Input: ({
+            id,
+            value,
+            onChange,
+            placeholder,
+            type,
+        }: {
+            id?: string;
+            value?: string;
+            onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
+            placeholder?: string;
+            type?: string;
+        }) => <input id={id} value={value} onChange={onChange} placeholder={placeholder} type={type ?? 'text'} />,
+        Label: ({ children, htmlFor }: { children: ReactNode; htmlFor?: string }) => <label htmlFor={htmlFor}>{children}</label>,
+        Select: ({ value, onValueChange, children }: { value?: string; onValueChange?: (v: string) => void; children: ReactNode }) => (
+            <select aria-label="channel-select" value={value} onChange={e => onValueChange?.(e.target.value)}>
+                {children}
+            </select>
+        ),
+        SelectContent: ({ children }: { children: ReactNode }) => <>{children}</>,
+        SelectItem: ({ value, children }: { value: string; children: ReactNode }) => <option value={value}>{children}</option>,
+        SelectTrigger: ({ children }: { children: ReactNode }) => <>{children}</>,
+        SelectValue: () => null,
+        Separator: () => <hr />,
+        Skeleton: () => <div aria-busy="true" />,
+        Switch: ({ id, checked, onCheckedChange }: { id?: string; checked?: boolean; onCheckedChange?: (v: boolean) => void }) => (
+            <input id={id} type="checkbox" role="switch" checked={!!checked} onChange={e => onCheckedChange?.(e.target.checked)} />
+        ),
+        Textarea: ({
+            id,
+            value,
+            onChange,
+            maxLength,
+        }: {
+            id?: string;
+            value?: string;
+            onChange?: (e: React.ChangeEvent<HTMLTextAreaElement>) => void;
+            maxLength?: number;
+        }) => <textarea id={id} value={value} onChange={onChange} maxLength={maxLength} />,
+    };
+});
+
+// ─── Test data ────────────────────────────────────────────────────────────────
+
+const RECIPIENT_OPTIONS = [
+    { name: 'API_SUBSCRIBERS', displayName: 'API subscribers' },
+    { name: 'ADMIN', displayName: 'Members with the ADMIN role on applications subscribed to this API' },
+    { name: 'USER', displayName: 'Members with the USER role on applications subscribed to this API' },
+];
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+const mockUseHasPermission = useHasPermission as jest.Mock;
+const mockUseApplicationRoles = useApplicationRoles as jest.Mock;
+const mockUseSendBroadcast = useSendBroadcast as jest.Mock;
+
+function buildMutateMock(reach = 3) {
+    return jest.fn((_payload: BroadcastPayload, opts?: { onSuccess?: (data: number) => void }) => {
+        opts?.onSuccess?.(reach);
+    });
+}
+
+function setupDefaults(overrides: { mutateFn?: jest.Mock } = {}) {
+    const mutateFn = overrides.mutateFn ?? jest.fn();
+
+    mockUseApplicationRoles.mockReturnValue({ recipientOptions: RECIPIENT_OPTIONS, isLoading: false, isError: false });
+    mockUseSendBroadcast.mockReturnValue({ mutate: mutateFn, isPending: false, error: null, reset: jest.fn() });
+
+    return { mutateFn };
+}
+
+function renderPage() {
+    render(
+        <MemoryRouter initialEntries={['/apis/api-1/broadcasts']}>
+            <Routes>
+                <Route path="apis/:apiId/broadcasts" element={<ApiBroadcastsPage />} />
+            </Routes>
+        </MemoryRouter>,
+    );
+}
+
+async function openComposeForm() {
+    renderPage();
+    const user = userEvent.setup();
+    await user.click(screen.getByRole('button', { name: /compose broadcast/i }));
+    return user;
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseHasPermission.mockReturnValue(true);
+});
+
+// ─── 1. Permission gating ─────────────────────────────────────────────────────
+
+it('hides Compose broadcast button when user lacks api-message-c', () => {
+    setupDefaults();
+    mockUseHasPermission.mockReturnValue(false);
+    renderPage();
+    expect(screen.queryByRole('button', { name: /compose broadcast/i })).toBeNull();
+});
+
+// ─── 2. Empty / learning state ────────────────────────────────────────────────
+
+it('shows learning card on initial render', () => {
+    setupDefaults();
+    renderPage();
+    expect(screen.getByText(/why send broadcasts/i)).not.toBeNull();
+});
+
+it('hides learning card while compose form is open', async () => {
+    setupDefaults();
+    await openComposeForm();
+    expect(screen.queryByText(/why send broadcasts/i)).toBeNull();
+});
+
+// ─── 3. Send button disabled until all required fields are filled ─────────────
+
+it('keeps Send disabled until channel, recipients, title, and text are all provided', async () => {
+    setupDefaults();
+    const user = await openComposeForm();
+
+    const sendBtn = screen.getByRole('button', { name: /^send$/i });
+    expect(sendBtn).toBeDisabled();
+
+    // Select a recipient — still missing title + text
+    await user.click(screen.getByRole('checkbox', { name: /api subscribers/i }));
+    expect(sendBtn).toBeDisabled();
+
+    // Type a title — still missing text
+    await user.type(screen.getByLabelText(/title/i), 'Maintenance notice');
+    expect(sendBtn).toBeDisabled();
+
+    // Type text — now all required fields are filled
+    await user.type(screen.getByLabelText(/message/i), 'Planned downtime this Sunday.');
+    expect(sendBtn).not.toBeDisabled();
+});
+
+// ─── 4. Channel switching — PORTAL → HTTP ────────────────────────────────────
+
+it('shows URL field and hides Title when channel is switched to HTTP', async () => {
+    setupDefaults();
+    const user = await openComposeForm();
+
+    // Default (PORTAL): Title visible, URL hidden
+    expect(screen.getByLabelText(/title/i)).not.toBeNull();
+    expect(screen.queryByLabelText(/url/i)).toBeNull();
+
+    await user.selectOptions(screen.getByRole('combobox'), 'HTTP');
+
+    await waitFor(() => {
+        expect(screen.queryByLabelText(/title/i)).toBeNull();
+        expect(screen.getByLabelText(/url/i)).not.toBeNull();
+    });
+});
+
+// ─── 5. Channel switching — HTTP → MAIL ──────────────────────────────────────
+
+it('restores Title and hides URL when switching from HTTP back to MAIL', async () => {
+    setupDefaults();
+    const user = await openComposeForm();
+
+    await user.selectOptions(screen.getByRole('combobox'), 'HTTP');
+    await waitFor(() => expect(screen.getByLabelText(/url/i)).not.toBeNull());
+
+    await user.selectOptions(screen.getByRole('combobox'), 'MAIL');
+    await waitFor(() => {
+        expect(screen.queryByLabelText(/url/i)).toBeNull();
+        expect(screen.getByLabelText(/title/i)).not.toBeNull();
+    });
+});
+
+// ─── 6. Character counter ─────────────────────────────────────────────────────
+
+it('shows remaining character count as user types in the message field', async () => {
+    setupDefaults();
+    const user = await openComposeForm();
+
+    const textarea = screen.getByLabelText(/message/i);
+    await user.type(textarea, 'a'.repeat(100));
+
+    expect(screen.getByText('150 / 250')).not.toBeNull();
+});
+
+it('send enabled at exactly 250 characters', async () => {
+    setupDefaults();
+    const user = await openComposeForm();
+
+    await user.click(screen.getByRole('checkbox', { name: /api subscribers/i }));
+    await user.type(screen.getByLabelText(/title/i), 'T');
+    const textarea = screen.getByLabelText(/message/i);
+    fireEvent.change(textarea, { target: { value: 'a'.repeat(250) } });
+
+    expect(screen.getByText('0 / 250')).not.toBeNull();
+    expect(screen.getByRole('button', { name: /^send$/i })).not.toBeDisabled();
+});
+
+// ─── 7. Recipients order ──────────────────────────────────────────────────────
+
+it('lists API_SUBSCRIBERS before role-based recipients', () => {
+    setupDefaults();
+    renderPage();
+    const options = RECIPIENT_OPTIONS;
+    expect(options[0].name).toBe('API_SUBSCRIBERS');
+    expect(options[1].name).toBe('ADMIN');
+    expect(options[2].name).toBe('USER');
+});
+
+// ─── 8. PORTAL payload shape ──────────────────────────────────────────────────
+
+it('sends a correctly structured PORTAL payload with selected recipients', async () => {
+    const mutateFn = jest.fn();
+    setupDefaults({ mutateFn });
+    const user = await openComposeForm();
+
+    await user.click(screen.getByRole('checkbox', { name: /api subscribers/i }));
+    fireEvent.change(screen.getByLabelText(/title/i), { target: { value: 'API deprecation notice' } });
+    fireEvent.change(screen.getByLabelText(/message/i), { target: { value: 'The v1 endpoint is deprecated.' } });
+
+    await user.click(screen.getByRole('button', { name: /^send$/i }));
+
+    expect(mutateFn).toHaveBeenCalledWith(
+        {
+            channel: 'PORTAL',
+            title: 'API deprecation notice',
+            text: 'The v1 endpoint is deprecated.',
+            recipient: {
+                role_scope: 'APPLICATION',
+                role_value: ['API_SUBSCRIBERS'],
+            },
+        },
+        expect.any(Object),
+    );
+});
+
+// ─── 9. HTTP payload shape ────────────────────────────────────────────────────
+
+it('sends a correctly structured HTTP payload with URL and no title', async () => {
+    const mutateFn = jest.fn();
+    setupDefaults({ mutateFn });
+    const user = await openComposeForm();
+
+    await user.selectOptions(screen.getByRole('combobox'), 'HTTP');
+    await waitFor(() => expect(screen.getByLabelText(/url/i)).not.toBeNull());
+
+    await user.click(screen.getByRole('checkbox', { name: /api subscribers/i }));
+    await user.type(screen.getByLabelText(/url/i), 'https://hooks.example.com/notify');
+    await user.type(screen.getByLabelText(/message/i), 'System going offline for maintenance.');
+
+    await user.click(screen.getByRole('button', { name: /^send$/i }));
+
+    expect(mutateFn).toHaveBeenCalledWith(
+        {
+            channel: 'HTTP',
+            text: 'System going offline for maintenance.',
+            recipient: { url: 'https://hooks.example.com/notify' },
+            params: {},
+            useSystemProxy: false,
+        },
+        expect.any(Object),
+    );
+});
+
+// ─── 10. Success: inline banner shown with reach count ────────────────────────
+
+it('shows success banner with reach count after a successful send', async () => {
+    const mutateFn = buildMutateMock(7);
+    setupDefaults({ mutateFn });
+    const user = await openComposeForm();
+
+    await user.click(screen.getByRole('checkbox', { name: /api subscribers/i }));
+    await user.type(screen.getByLabelText(/title/i), 'Test broadcast');
+    await user.type(screen.getByLabelText(/message/i), 'Hello consumers.');
+
+    await user.click(screen.getByRole('button', { name: /^send$/i }));
+
+    await waitFor(() => {
+        expect(screen.getByText(/broadcast sent/i)).not.toBeNull();
+        expect(screen.getByText(/7 recipients/i)).not.toBeNull();
+    });
+});
+
+it('returns to learning state when Compose another is clicked from success banner', async () => {
+    const mutateFn = buildMutateMock();
+    setupDefaults({ mutateFn });
+    const user = await openComposeForm();
+
+    await user.click(screen.getByRole('checkbox', { name: /api subscribers/i }));
+    await user.type(screen.getByLabelText(/title/i), 'Test broadcast');
+    await user.type(screen.getByLabelText(/message/i), 'Hello consumers.');
+    await user.click(screen.getByRole('button', { name: /^send$/i }));
+
+    await waitFor(() => expect(screen.getByText(/broadcast sent/i)).not.toBeNull());
+
+    await user.click(screen.getByRole('button', { name: /compose another/i }));
+
+    await waitFor(() => {
+        expect(screen.queryByText(/broadcast sent/i)).toBeNull();
+        expect(screen.getByText(/why send broadcasts/i)).not.toBeNull();
+    });
+});
+
+// ─── 11. Error from backend shown inline ─────────────────────────────────────
+
+it('displays an error alert in the form when the send request fails', async () => {
+    setupDefaults();
+    mockUseSendBroadcast.mockReturnValue({
+        mutate: jest.fn(),
+        isPending: false,
+        error: new Error('Server rejected the message'),
+    });
+
+    await openComposeForm();
+
+    await waitFor(() => expect(screen.getByRole('alert')).not.toBeNull());
+    expect(screen.getByText(/server rejected the message/i)).not.toBeNull();
+});

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/pages/ApiBroadcastsPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/pages/ApiBroadcastsPage.tsx
@@ -1,0 +1,100 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useHasPermission } from '@gravitee/gamma-modules-sdk';
+import { Alert, AlertDescription, Button } from '@gravitee/graphene-core';
+import { RadioIcon } from '@gravitee/graphene-core/icons';
+import { useCallback, useState } from 'react';
+import { useParams } from 'react-router-dom';
+
+import { BroadcastEmptyState } from './api-broadcasts/BroadcastEmptyState';
+import { BroadcastForm } from './api-broadcasts/BroadcastForm';
+import { BroadcastSuccessBanner } from './api-broadcasts/BroadcastSuccessBanner';
+import { useApplicationRoles, useSendBroadcast } from '../features/apis/hooks/useApiBroadcast';
+import type { BroadcastPayload } from '../features/apis/types/broadcast';
+
+type PageState = 'idle' | 'composing' | 'sent';
+
+export function ApiBroadcastsPage() {
+    const { apiId } = useParams<{ apiId: string }>();
+
+    const canSend = useHasPermission({ anyOf: ['api-message-c'] });
+
+    const { recipientOptions, isLoading: isLoadingRecipients, isError: isRolesError } = useApplicationRoles();
+    const sendMutation = useSendBroadcast(apiId ?? '');
+
+    const [pageState, setPageState] = useState<PageState>('idle');
+    const [reachCount, setReachCount] = useState(0);
+
+    const handleSend = useCallback(
+        (payload: BroadcastPayload) => {
+            sendMutation.mutate(payload, {
+                onSuccess: reach => {
+                    setReachCount(reach);
+                    setPageState('sent');
+                },
+            });
+        },
+        [sendMutation],
+    );
+
+    const handleComposeAnother = useCallback(() => {
+        sendMutation.reset();
+        setPageState('idle');
+    }, [sendMutation]);
+
+    return (
+        <div className="flex flex-col gap-6 p-6">
+            {/* Header */}
+            <div className="flex items-center justify-between gap-4">
+                <div>
+                    <h1 className="text-2xl font-semibold tracking-tight">Broadcasts</h1>
+                    <p className="text-sm text-muted-foreground">Send announcements to your API consumers.</p>
+                </div>
+                {canSend && pageState === 'idle' && (
+                    <Button type="button" size="sm" onClick={() => setPageState('composing')}>
+                        <RadioIcon className="size-4" aria-hidden="true" />
+                        Compose broadcast
+                    </Button>
+                )}
+            </div>
+
+            {/* Recipient-load error — show regardless of page state */}
+            {isRolesError && (
+                <Alert variant="destructive">
+                    <AlertDescription>Failed to load recipient options. Please refresh the page and try again.</AlertDescription>
+                </Alert>
+            )}
+
+            {/* Learning state */}
+            {pageState === 'idle' && <BroadcastEmptyState />}
+
+            {/* Success banner */}
+            {pageState === 'sent' && <BroadcastSuccessBanner reach={reachCount} onComposeAnother={handleComposeAnother} />}
+
+            {/* Compose form */}
+            {pageState === 'composing' && (
+                <BroadcastForm
+                    recipientOptions={recipientOptions}
+                    isLoadingRecipients={isLoadingRecipients}
+                    isPending={sendMutation.isPending}
+                    error={sendMutation.error?.message ?? null}
+                    onSend={handleSend}
+                    onCancel={() => setPageState('idle')}
+                />
+            )}
+        </div>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/pages/ApiConsumerDetailPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/pages/ApiConsumerDetailPage.tsx
@@ -1,0 +1,28 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useHasPermission } from '@gravitee/gamma-modules-sdk';
+import { useParams } from 'react-router-dom';
+
+import { ConsumerDetailPage } from './api-consumers/ConsumerDetailPage';
+import type { SubscriptionContext } from '../features/apis/types/subscription';
+
+export function ApiConsumerDetailPage() {
+    const { apiId, subscriptionId } = useParams<{ apiId: string; subscriptionId: string }>();
+    const ctx: SubscriptionContext = { type: 'api', entityId: apiId ?? '' };
+    const canUpdate = useHasPermission({ anyOf: ['api-subscription-u'] });
+    const canDelete = useHasPermission({ anyOf: ['api-subscription-d'] });
+    return <ConsumerDetailPage ctx={ctx} subscriptionId={subscriptionId} canUpdate={canUpdate} canDelete={canDelete} />;
+}

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/pages/ApiConsumersPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/pages/ApiConsumersPage.tsx
@@ -1,0 +1,28 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useHasPermission } from '@gravitee/gamma-modules-sdk';
+import { useParams } from 'react-router-dom';
+
+import { ConsumersPage } from './api-consumers/ConsumersPage';
+import type { SubscriptionContext } from '../features/apis/types/subscription';
+
+export function ApiConsumersPage() {
+    const { apiId } = useParams<{ apiId: string }>();
+    const ctx: SubscriptionContext = { type: 'api', entityId: apiId ?? '' };
+    const canCreate = useHasPermission({ anyOf: ['api-subscription-c'] });
+    const canRead = useHasPermission({ anyOf: ['api-subscription-r'] });
+    return <ConsumersPage ctx={ctx} canCreate={canCreate} canRead={canRead} />;
+}

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/pages/ApiGeneralPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/pages/ApiGeneralPage.tsx
@@ -292,7 +292,7 @@ export function ApiGeneralPage() {
                         {/* ─ Left: form ─ */}
                         <div className="flex-1 min-w-0 space-y-4">
                             <div className="flex gap-4">
-                                <div className="flex-[4] min-w-0 space-y-1">
+                                <div className="flex-1 min-w-0 space-y-1">
                                     <Label htmlFor="api-name">
                                         Name <span className="text-destructive">*</span>
                                     </Label>
@@ -304,7 +304,7 @@ export function ApiGeneralPage() {
                                         disabled={isReadOnly}
                                     />
                                 </div>
-                                <div className="flex-1 space-y-1" style={{ minWidth: '120px' }}>
+                                <div className="space-y-1 w-32">
                                     <Label htmlFor="api-version">
                                         Version <span className="text-destructive">*</span>
                                     </Label>

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/pages/ApiNotificationsPage.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/pages/ApiNotificationsPage.spec.tsx
@@ -1,0 +1,265 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useHasPermission } from '@gravitee/gamma-modules-sdk';
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+
+import { ApiNotificationsPage } from './ApiNotificationsPage';
+import {
+    useApiNotifications,
+    useCreateNotification,
+    useDeleteNotification,
+    useUpdateNotification,
+} from '../features/apis/hooks/useApiNotifications';
+
+// ─── SDK mocks ────────────────────────────────────────────────────────────────
+
+jest.mock('@gravitee/gamma-modules-sdk', () => ({
+    useEnvironment: jest.fn(() => ({ id: 'DEFAULT' })),
+    useHasPermission: jest.fn(() => true),
+}));
+
+jest.mock('@gravitee/graphene-core/icons', () => new Proxy({}, { get: () => () => null }));
+
+// ─── Hook mocks ───────────────────────────────────────────────────────────────
+
+jest.mock('../features/apis/hooks/useApiNotifications', () => ({
+    useApiNotifications: jest.fn(),
+    useCreateNotification: jest.fn(),
+    useUpdateNotification: jest.fn(),
+    useDeleteNotification: jest.fn(),
+}));
+
+// ─── Test data ────────────────────────────────────────────────────────────────
+
+const PORTAL_ROW = {
+    key: 'PORTAL',
+    notification: { name: 'Default console', config_type: 'PORTAL' as const, hooks: [], referenceType: 'API', referenceId: 'api-1' },
+    notifier: undefined,
+    channel: 'CONSOLE' as const,
+    isReadonly: false,
+    canDelete: false,
+};
+
+const EMAIL_ROW = {
+    key: 'notif-email-1',
+    notification: {
+        id: 'notif-email-1',
+        name: 'Ops email',
+        config_type: 'GENERIC' as const,
+        notifier: 'email-notifier',
+        hooks: ['API_STARTED'],
+        config: 'ops@example.com',
+        referenceType: 'API',
+        referenceId: 'api-1',
+    },
+    notifier: { id: 'email-notifier', type: 'EMAIL', name: 'Default email' },
+    channel: 'EMAIL' as const,
+    isReadonly: false,
+    canDelete: true,
+};
+
+const NOTIFIERS = [{ id: 'email-notifier', type: 'EMAIL', name: 'Default email' }];
+
+const HOOK_CATEGORIES = [
+    {
+        name: 'Lifecycle',
+        hooks: [
+            { id: 'API_STARTED', label: 'API started', description: '', scope: 'API', category: 'Lifecycle' },
+            { id: 'API_STOPPED', label: 'API stopped', description: '', scope: 'API', category: 'Lifecycle' },
+        ],
+    },
+];
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+const mockUseHasPermission = useHasPermission as jest.Mock;
+const mockUseApiNotifications = useApiNotifications as jest.Mock;
+const mockUseCreateNotification = useCreateNotification as jest.Mock;
+const mockUseUpdateNotification = useUpdateNotification as jest.Mock;
+const mockUseDeleteNotification = useDeleteNotification as jest.Mock;
+
+function buildMutationMock(overrides?: Partial<{ mutate: jest.Mock; isPending: boolean }>) {
+    return { mutate: jest.fn(), isPending: false, ...overrides };
+}
+
+function renderPage() {
+    render(
+        <MemoryRouter initialEntries={['/apis/api-1/notifications']}>
+            <Routes>
+                <Route path="apis/:apiId/notifications" element={<ApiNotificationsPage />} />
+            </Routes>
+        </MemoryRouter>,
+    );
+}
+
+beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseHasPermission.mockReturnValue(true);
+    mockUseApiNotifications.mockReturnValue({
+        rows: [PORTAL_ROW],
+        notifiers: NOTIFIERS,
+        hookCategories: HOOK_CATEGORIES,
+        isLoading: false,
+        isLoadingHooks: false,
+        isError: false,
+    });
+    mockUseCreateNotification.mockReturnValue(buildMutationMock());
+    mockUseUpdateNotification.mockReturnValue(buildMutationMock());
+    mockUseDeleteNotification.mockReturnValue(buildMutationMock());
+});
+
+// ─── 1. Error state ───────────────────────────────────────────────────────────
+
+it('renders an error alert when the notifications query fails', () => {
+    mockUseApiNotifications.mockReturnValue({
+        rows: [],
+        notifiers: [],
+        hookCategories: [],
+        isLoading: false,
+        isLoadingHooks: false,
+        isError: true,
+    });
+    renderPage();
+    expect(screen.getByText(/failed to load notifications/i)).not.toBeNull();
+});
+
+// ─── 2. Empty state: shows learning card when no rows ─────────────────────────
+
+it('shows the learning card when there are no configured notifications', () => {
+    mockUseApiNotifications.mockReturnValue({
+        rows: [],
+        notifiers: [],
+        hookCategories: [],
+        isLoading: false,
+        isLoadingHooks: false,
+        isError: false,
+    });
+    renderPage();
+    expect(screen.getByText(/why configure notifications/i)).not.toBeNull();
+});
+
+// ─── 3. Table renders rows ────────────────────────────────────────────────────
+
+it('renders notification rows in the table', () => {
+    mockUseApiNotifications.mockReturnValue({
+        rows: [PORTAL_ROW, EMAIL_ROW],
+        notifiers: NOTIFIERS,
+        hookCategories: HOOK_CATEGORIES,
+        isLoading: false,
+        isLoadingHooks: false,
+        isError: false,
+    });
+    renderPage();
+    expect(screen.getByText('Default console')).not.toBeNull();
+    expect(screen.getByText('Ops email')).not.toBeNull();
+});
+
+// ─── 4. Permissions: no Add button when canCreate is false ───────────────────
+
+it('hides Add notification button when user lacks api-notification-c', () => {
+    mockUseHasPermission.mockImplementation(({ anyOf }: { anyOf: string[] }) => anyOf.some(p => p !== 'api-notification-c'));
+    renderPage();
+    expect(screen.queryByRole('button', { name: /add notification/i })).toBeNull();
+});
+
+// ─── 5. Inline editor opens on Edit click ────────────────────────────────────
+
+it('opens the inline event editor when Edit events is selected from the dropdown', async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    await user.click(screen.getByRole('button', { name: /actions for default console/i }));
+    await user.click(screen.getByText(/edit events/i));
+
+    // The editor renders a Save/Close button when the editor is open
+    await waitFor(() => expect(screen.getByRole('button', { name: /save events/i })).not.toBeNull());
+});
+
+// ─── 6. Save events calls updateMutation ─────────────────────────────────────
+
+it('calls updateNotification with the selected hooks when Save events is clicked', async () => {
+    const mutateFn = jest.fn((_payload: unknown, opts: { onSuccess?: () => void }) => opts.onSuccess?.());
+    mockUseUpdateNotification.mockReturnValue({ mutate: mutateFn, isPending: false });
+    const user = userEvent.setup();
+    renderPage();
+
+    // Open editor
+    await user.click(screen.getByRole('button', { name: /actions for default console/i }));
+    await user.click(screen.getByText(/edit events/i));
+
+    // Toggle a hook checkbox
+    await user.click(screen.getByLabelText(/api started/i));
+    await user.click(screen.getByRole('button', { name: /save events/i }));
+
+    await waitFor(() => expect(mutateFn).toHaveBeenCalledTimes(1));
+    const [payload] = mutateFn.mock.calls[0];
+    expect(payload.hooks).toContain('API_STARTED');
+});
+
+// ─── 7. Delete: PORTAL row shows no Delete option ────────────────────────────
+
+it('does not show a Delete option for the PORTAL (console) notification', async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    await user.click(screen.getByRole('button', { name: /actions for default console/i }));
+    expect(screen.queryByText(/^delete$/i)).toBeNull();
+});
+
+// ─── 8. Delete confirmation flow ─────────────────────────────────────────────
+
+it('calls deleteNotification with the notification id after confirming deletion', async () => {
+    const mutateFn = jest.fn((_id: unknown, opts: { onSuccess?: () => void }) => opts.onSuccess?.());
+    mockUseDeleteNotification.mockReturnValue({ mutate: mutateFn, isPending: false });
+    mockUseApiNotifications.mockReturnValue({
+        rows: [EMAIL_ROW],
+        notifiers: NOTIFIERS,
+        hookCategories: HOOK_CATEGORIES,
+        isLoading: false,
+        isLoadingHooks: false,
+        isError: false,
+    });
+    const user = userEvent.setup();
+    renderPage();
+
+    await user.click(screen.getByRole('button', { name: /actions for ops email/i }));
+    await user.click(screen.getByText(/^delete$/i));
+
+    const dialog = screen.getByRole('dialog');
+    await user.click(within(dialog).getByRole('button', { name: /^delete$/i }));
+
+    await waitFor(() => expect(mutateFn).toHaveBeenCalledWith('notif-email-1', expect.any(Object)));
+});
+
+// ─── 9. Summary cards show correct counts ────────────────────────────────────
+
+it('renders summary cards with correct counts per channel', () => {
+    mockUseApiNotifications.mockReturnValue({
+        rows: [PORTAL_ROW, EMAIL_ROW],
+        notifiers: NOTIFIERS,
+        hookCategories: HOOK_CATEGORIES,
+        isLoading: false,
+        isLoadingHooks: false,
+        isError: false,
+    });
+    renderPage();
+
+    // CONSOLE count = 1, EMAIL count = 1, WEBHOOK count = 0
+    const cards = screen.getAllByText(/notifiers/i);
+    expect(cards.length).toBeGreaterThanOrEqual(3);
+});

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/pages/ApiNotificationsPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/pages/ApiNotificationsPage.tsx
@@ -1,0 +1,265 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useHasPermission } from '@gravitee/gamma-modules-sdk';
+import {
+    Alert,
+    AlertDescription,
+    Button,
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+} from '@gravitee/graphene-core';
+import { PlusIcon } from '@gravitee/graphene-core/icons';
+import { useCallback, useState } from 'react';
+import { useParams } from 'react-router-dom';
+
+import { AddNotificationDialog } from './api-notifications/AddNotificationDialog';
+import { NotificationEventEditor } from './api-notifications/NotificationEventEditor';
+import { NotificationsEmptyState } from './api-notifications/NotificationsEmptyState';
+import { NotificationsSummaryCards } from './api-notifications/NotificationsSummaryCards';
+import { NotificationsTable } from './api-notifications/NotificationsTable';
+import type { NotificationRow } from '../features/apis/hooks/useApiNotifications';
+import {
+    useApiNotifications,
+    useCreateNotification,
+    useDeleteNotification,
+    useUpdateNotification,
+} from '../features/apis/hooks/useApiNotifications';
+
+// ─── Delete confirm dialog ────────────────────────────────────────────────────
+
+interface DeleteConfirmDialogProps {
+    row: NotificationRow | null;
+    isPending: boolean;
+    onConfirm: () => void;
+    onCancel: () => void;
+}
+
+function DeleteConfirmDialog({ row, isPending, onConfirm, onCancel }: Readonly<DeleteConfirmDialogProps>) {
+    return (
+        <Dialog
+            open={row !== null}
+            onOpenChange={open => {
+                if (!open) onCancel();
+            }}
+        >
+            <DialogContent style={{ maxWidth: '24rem' }}>
+                <DialogHeader>
+                    <DialogTitle>Delete notification</DialogTitle>
+                    <DialogDescription>
+                        <strong>{row?.notification.name}</strong> will be permanently deleted. This cannot be undone.
+                    </DialogDescription>
+                </DialogHeader>
+                <DialogFooter>
+                    <Button type="button" variant="outline" onClick={onCancel} disabled={isPending}>
+                        Cancel
+                    </Button>
+                    <Button type="button" variant="destructive" onClick={onConfirm} disabled={isPending}>
+                        {isPending ? 'Deleting…' : 'Delete'}
+                    </Button>
+                </DialogFooter>
+            </DialogContent>
+        </Dialog>
+    );
+}
+
+// ─── Page ─────────────────────────────────────────────────────────────────────
+
+export function ApiNotificationsPage() {
+    const { apiId } = useParams<{ apiId: string }>();
+
+    const canCreate = useHasPermission({ anyOf: ['api-notification-c'] });
+    const canUpdate = useHasPermission({ anyOf: ['api-notification-u'] });
+    const canDelete = useHasPermission({ anyOf: ['api-notification-d'] });
+
+    const { rows, notifiers, hookCategories, isLoading, isLoadingHooks, isError } = useApiNotifications(apiId);
+
+    const createMutation = useCreateNotification(apiId ?? '');
+    const updateMutation = useUpdateNotification(apiId ?? '');
+    const deleteMutation = useDeleteNotification(apiId ?? '');
+
+    const [addDialogOpen, setAddDialogOpen] = useState(false);
+    const [editingKey, setEditingKey] = useState<string | null>(null);
+    const [deletingRow, setDeletingRow] = useState<NotificationRow | null>(null);
+    const [saveError, setSaveError] = useState<string | null>(null);
+
+    const editingRow = editingKey !== null ? (rows.find(r => r.key === editingKey) ?? null) : null;
+
+    // ─── Handlers ──────────────────────────────────────────────────────────────
+
+    const handleAdd = useCallback(
+        (name: string, notifierId: string) => {
+            if (!apiId) return;
+            const isPortal = notifierId === '__PORTAL__';
+
+            if (isPortal) {
+                // The PORTAL notification always exists — just open the editor
+                const portalRow = rows.find(r => r.notification.config_type === 'PORTAL');
+                setAddDialogOpen(false);
+                if (portalRow && canUpdate) setEditingKey(portalRow.key);
+                return;
+            }
+
+            createMutation.mutate(
+                {
+                    name,
+                    notifier: notifierId,
+                    config_type: 'GENERIC',
+                    hooks: [],
+                    referenceType: 'API',
+                    referenceId: apiId,
+                },
+                {
+                    onSuccess: created => {
+                        setAddDialogOpen(false);
+                        setSaveError(null);
+                        if (canUpdate) setEditingKey(created.id ?? 'PORTAL');
+                    },
+                    onError: (err: unknown) => {
+                        const message = err instanceof Error ? err.message : 'Failed to create notification.';
+                        setSaveError(message);
+                    },
+                },
+            );
+        },
+        [apiId, rows, canUpdate, createMutation],
+    );
+
+    const handleSaveEvents = useCallback(
+        (hooks: string[], config: string) => {
+            if (!editingRow) return;
+            updateMutation.mutate(
+                { ...editingRow.notification, hooks, config },
+                {
+                    onSuccess: () => {
+                        setSaveError(null);
+                        setEditingKey(null);
+                    },
+                    onError: (err: unknown) => {
+                        const message = err instanceof Error ? err.message : 'Failed to save notification events.';
+                        setSaveError(message);
+                    },
+                },
+            );
+        },
+        [editingRow, updateMutation],
+    );
+
+    const handleDeleteConfirm = useCallback(() => {
+        if (!deletingRow?.notification.id) return;
+        deleteMutation.mutate(deletingRow.notification.id, {
+            onSuccess: () => {
+                setSaveError(null);
+                setDeletingRow(null);
+            },
+            onError: (err: unknown) => {
+                const message = err instanceof Error ? err.message : 'Failed to delete notification.';
+                setSaveError(message);
+            },
+        });
+    }, [deletingRow, deleteMutation]);
+
+    // ─── Render ────────────────────────────────────────────────────────────────
+
+    if (isError) {
+        return (
+            <div className="p-6">
+                <Alert variant="destructive">
+                    <AlertDescription>Failed to load notifications. Please refresh the page.</AlertDescription>
+                </Alert>
+            </div>
+        );
+    }
+
+    const isEmpty = !isLoading && rows.every(r => r.notification.config_type === 'PORTAL');
+
+    return (
+        <div className="flex flex-col gap-6 p-6">
+            {/* Header */}
+            <div className="flex items-center justify-between gap-4">
+                <div>
+                    <h1 className="text-2xl font-semibold tracking-tight">Notifications</h1>
+                    <p className="text-sm text-muted-foreground">
+                        Get alerted when key API events occur — deployments, subscription changes, or policy errors.
+                    </p>
+                </div>
+                {canCreate && (
+                    <Button type="button" size="sm" onClick={() => setAddDialogOpen(true)}>
+                        <PlusIcon className="size-4" aria-hidden="true" />
+                        Add notification
+                    </Button>
+                )}
+            </div>
+
+            {/* Mutation error banner */}
+            {saveError && (
+                <div className="rounded-lg border border-destructive/30 bg-destructive/5 px-4 py-3">
+                    <p className="text-sm text-destructive">{saveError}</p>
+                </div>
+            )}
+
+            {/* Summary cards — always visible (shows 0 when empty) */}
+            <NotificationsSummaryCards rows={rows} isLoading={isLoading} />
+
+            {/* Empty learning state */}
+            {isEmpty && <NotificationsEmptyState />}
+
+            {/* Table — always visible when rows exist or loading */}
+            {(isLoading || rows.length > 0) && (
+                <NotificationsTable
+                    rows={rows}
+                    isLoading={isLoading}
+                    editingKey={editingKey}
+                    canUpdate={canUpdate}
+                    canDelete={canDelete}
+                    onEdit={setEditingKey}
+                    onDelete={setDeletingRow}
+                />
+            )}
+
+            {/* Inline event editor */}
+            {editingRow && (
+                <NotificationEventEditor
+                    key={editingRow.key}
+                    row={editingRow}
+                    hookCategories={hookCategories}
+                    isLoadingHooks={isLoadingHooks}
+                    isPending={updateMutation.isPending}
+                    onSave={handleSaveEvents}
+                    onCancel={() => setEditingKey(null)}
+                />
+            )}
+
+            {/* Dialogs */}
+            <AddNotificationDialog
+                open={addDialogOpen}
+                notifiers={notifiers}
+                isPending={createMutation.isPending}
+                onClose={() => setAddDialogOpen(false)}
+                onAdd={handleAdd}
+            />
+            <DeleteConfirmDialog
+                row={deletingRow}
+                isPending={deleteMutation.isPending}
+                onConfirm={handleDeleteConfirm}
+                onCancel={() => setDeletingRow(null)}
+            />
+        </div>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/pages/ApiProductConsumerDetailPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/pages/ApiProductConsumerDetailPage.tsx
@@ -1,0 +1,28 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useHasPermission } from '@gravitee/gamma-modules-sdk';
+import { useParams } from 'react-router-dom';
+
+import { ConsumerDetailPage } from './api-consumers/ConsumerDetailPage';
+import type { SubscriptionContext } from '../features/apis/types/subscription';
+
+export function ApiProductConsumerDetailPage() {
+    const { productId, subscriptionId } = useParams<{ productId: string; subscriptionId: string }>();
+    const ctx: SubscriptionContext = { type: 'api-product', entityId: productId ?? '' };
+    const canUpdate = useHasPermission({ anyOf: ['api_product-subscription-u'] });
+    const canDelete = useHasPermission({ anyOf: ['api_product-subscription-d'] });
+    return <ConsumerDetailPage ctx={ctx} subscriptionId={subscriptionId} canUpdate={canUpdate} canDelete={canDelete} />;
+}

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/pages/ApiProductConsumersPage.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/pages/ApiProductConsumersPage.spec.tsx
@@ -1,0 +1,251 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useHasPermission } from '@gravitee/gamma-modules-sdk';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { ReactNode } from 'react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+
+import { ApiProductConsumersPage } from './ApiProductConsumersPage';
+import { useCreateSubscription } from '../features/apis/hooks/useSubscriptionActions';
+import { useApiPlans, useSubscriptionList } from '../features/apis/hooks/useSubscriptions';
+import type { SubscriptionPage } from '../features/apis/types/subscription';
+
+// ─── SDK / icon mocks ─────────────────────────────────────────────────────────
+
+jest.mock('@gravitee/gamma-modules-sdk', () => ({
+    useEnvironment: jest.fn(() => ({ id: 'DEFAULT' })),
+    useHasPermission: jest.fn(() => true),
+}));
+
+jest.mock('@gravitee/graphene-core/icons', () => new Proxy({}, { get: () => () => null }));
+
+// ─── Hook mocks ───────────────────────────────────────────────────────────────
+
+jest.mock('../features/apis/hooks/useSubscriptionActions', () => ({
+    useCreateSubscription: jest.fn(),
+}));
+
+jest.mock('../features/apis/hooks/useSubscriptions', () => ({
+    useSubscriptionList: jest.fn(),
+    useApiPlans: jest.fn(),
+    useSubscriptionCount: jest.fn(() => ({ data: 0, isLoading: false })),
+    useApplicationSearch: jest.fn(() => ({ data: [], isLoading: false })),
+    isSubscriptionFiltersDirty: jest.fn(() => false),
+}));
+
+// ─── Graphene UI mock ─────────────────────────────────────────────────────────
+
+jest.mock('@gravitee/graphene-core', () => {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires, @typescript-eslint/no-require-imports
+    const React = require('react');
+
+    return {
+        Badge: ({ children }: { children: ReactNode }) => <span>{children}</span>,
+        Button: ({
+            children,
+            disabled,
+            onClick,
+            type,
+        }: {
+            children: ReactNode;
+            disabled?: boolean;
+            onClick?: () => void;
+            type?: React.ButtonHTMLAttributes<HTMLButtonElement>['type'];
+        }) => (
+            <button type={type ?? 'button'} disabled={disabled} onClick={onClick}>
+                {children}
+            </button>
+        ),
+        Card: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+        CardContent: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+        CardHeader: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+        CardTitle: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+        DataTablePagination: () => null,
+        Dialog: ({ open, children }: { open?: boolean; children: ReactNode }) => (open ? <div role="dialog">{children}</div> : null),
+        DialogContent: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+        DialogFooter: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+        DialogHeader: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+        DialogTitle: ({ children }: { children: ReactNode }) => <h2>{children}</h2>,
+        Input: ({
+            id,
+            value,
+            onChange,
+            placeholder,
+            type,
+        }: {
+            id?: string;
+            value?: string;
+            onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
+            placeholder?: string;
+            type?: string;
+        }) => <input id={id} value={value} onChange={onChange} placeholder={placeholder} type={type ?? 'text'} />,
+        Label: ({ children, htmlFor }: { children: ReactNode; htmlFor?: string }) => <label htmlFor={htmlFor}>{children}</label>,
+        Select: ({ value, onValueChange, children }: { value?: string; onValueChange?: (v: string) => void; children: ReactNode }) => (
+            <select value={value} onChange={e => onValueChange?.(e.target.value)}>
+                {children}
+            </select>
+        ),
+        SelectContent: ({ children }: { children: ReactNode }) => <>{children}</>,
+        SelectItem: ({ value, children }: { value: string; children: ReactNode }) => <option value={value}>{children}</option>,
+        SelectTrigger: ({ children }: { children: ReactNode }) => <>{children}</>,
+        SelectValue: () => null,
+        Separator: () => <hr />,
+        Skeleton: () => <div aria-busy="true" />,
+        Table: ({ children }: { children: ReactNode }) => <table>{children}</table>,
+        TableBody: ({ children }: { children: ReactNode }) => <tbody>{children}</tbody>,
+        TableCell: ({ children }: { children: ReactNode }) => <td>{children}</td>,
+        TableHead: ({ children }: { children: ReactNode }) => <th>{children}</th>,
+        TableHeader: ({ children }: { children: ReactNode }) => <thead>{children}</thead>,
+        TableRow: ({ children, onClick }: { children: ReactNode; onClick?: () => void }) => <tr onClick={onClick}>{children}</tr>,
+    };
+});
+
+// ─── Test data ────────────────────────────────────────────────────────────────
+
+const EMPTY_PAGE: SubscriptionPage = {
+    data: [],
+    pagination: { totalCount: 0, pageIndex: 1, pageSize: 10 },
+};
+
+const SUBSCRIPTION_PAGE: SubscriptionPage = {
+    data: [
+        {
+            id: 'sub-1',
+            status: 'ACCEPTED',
+            plan: { id: 'plan-1', name: 'Default Plan', security: { type: 'API_KEY' } },
+            application: { id: 'app-1', name: 'My App', primaryOwner: { displayName: 'Alice' } },
+            createdAt: '2024-01-01T00:00:00Z',
+        },
+    ],
+    pagination: { totalCount: 1, pageIndex: 1, pageSize: 10 },
+};
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+const mockUseHasPermission = useHasPermission as jest.Mock;
+const mockUseSubscriptionList = useSubscriptionList as jest.Mock;
+const mockUseApiPlans = useApiPlans as jest.Mock;
+const mockUseCreateSubscription = useCreateSubscription as jest.Mock;
+
+function setupDefaults() {
+    mockUseSubscriptionList.mockReturnValue({ data: EMPTY_PAGE, isLoading: false });
+    mockUseApiPlans.mockReturnValue({ data: [], isLoading: false });
+    mockUseCreateSubscription.mockReturnValue({ mutate: jest.fn(), isPending: false, error: null, reset: jest.fn() });
+}
+
+function renderPage() {
+    render(
+        <MemoryRouter initialEntries={['/api-products/product-1/consumers']}>
+            <Routes>
+                <Route path="api-products/:productId/consumers" element={<ApiProductConsumersPage />} />
+            </Routes>
+        </MemoryRouter>,
+    );
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseHasPermission.mockReturnValue(true);
+});
+
+// ─── 1. Permission gating ─────────────────────────────────────────────────────
+
+it('shows permission denied message when user lacks api_product-subscription-r', () => {
+    setupDefaults();
+    mockUseHasPermission.mockImplementation(({ anyOf }: { anyOf: string[] }) => {
+        return !anyOf.includes('api_product-subscription-r');
+    });
+    renderPage();
+    expect(screen.getByText(/you don't have permission to view subscriptions/i)).not.toBeNull();
+});
+
+it('hides Create subscription button when user lacks api_product-subscription-c', () => {
+    setupDefaults();
+    mockUseHasPermission.mockImplementation(({ anyOf }: { anyOf: string[] }) => {
+        return !anyOf.includes('api_product-subscription-c');
+    });
+    renderPage();
+    expect(screen.queryByRole('button', { name: /create subscription/i })).toBeNull();
+});
+
+it('shows Create subscription button when user has api_product-subscription-c', () => {
+    setupDefaults();
+    renderPage();
+    expect(screen.getByRole('button', { name: /create subscription/i })).not.toBeNull();
+});
+
+// ─── 2. Empty state ──────────────────────────────────────────────────────────
+
+it('renders empty state when there are no subscriptions', () => {
+    setupDefaults();
+    renderPage();
+    expect(screen.queryByRole('table')).toBeNull();
+});
+
+// ─── 3. Subscription list ─────────────────────────────────────────────────────
+
+it('renders subscriptions table when data is present', () => {
+    setupDefaults();
+    mockUseSubscriptionList.mockReturnValue({ data: SUBSCRIPTION_PAGE, isLoading: false });
+    renderPage();
+    expect(screen.getByText('My App')).not.toBeNull();
+    expect(screen.getByText('Default Plan')).not.toBeNull();
+});
+
+// ─── 4. Loading state ─────────────────────────────────────────────────────────
+
+it('renders skeletons while loading', () => {
+    setupDefaults();
+    mockUseSubscriptionList.mockReturnValue({ data: undefined, isLoading: true });
+    renderPage();
+    expect(screen.getAllByRole('cell').some(el => el.querySelector('[aria-busy="true"]') !== null)).toBe(true);
+});
+
+// ─── 5. Context isolation — ctx.type is api-product ──────────────────────────
+
+it('calls useSubscriptionList with api-product context for the resolved productId', () => {
+    setupDefaults();
+    renderPage();
+    const [ctx] = mockUseSubscriptionList.mock.calls[0];
+    expect(ctx).toEqual({ type: 'api-product', entityId: 'product-1' });
+});
+
+it('calls useApiPlans with api-product context', () => {
+    setupDefaults();
+    renderPage();
+    const [ctx] = mockUseApiPlans.mock.calls[0];
+    expect(ctx).toEqual({ type: 'api-product', entityId: 'product-1' });
+});
+
+it('calls useCreateSubscription with api-product context', () => {
+    setupDefaults();
+    renderPage();
+    const [ctx] = mockUseCreateSubscription.mock.calls[0];
+    expect(ctx).toEqual({ type: 'api-product', entityId: 'product-1' });
+});
+
+// ─── 6. Create dialog opens ───────────────────────────────────────────────────
+
+it('opens the create subscription dialog when the button is clicked', async () => {
+    setupDefaults();
+    const user = userEvent.setup();
+    renderPage();
+    await user.click(screen.getByRole('button', { name: /create subscription/i }));
+    await waitFor(() => expect(screen.getByRole('dialog')).not.toBeNull());
+});

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/pages/ApiProductConsumersPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/pages/ApiProductConsumersPage.tsx
@@ -1,0 +1,28 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useHasPermission } from '@gravitee/gamma-modules-sdk';
+import { useParams } from 'react-router-dom';
+
+import { ConsumersPage } from './api-consumers/ConsumersPage';
+import type { SubscriptionContext } from '../features/apis/types/subscription';
+
+export function ApiProductConsumersPage() {
+    const { productId } = useParams<{ productId: string }>();
+    const ctx: SubscriptionContext = { type: 'api-product', entityId: productId ?? '' };
+    const canCreate = useHasPermission({ anyOf: ['api_product-subscription-c'] });
+    const canRead = useHasPermission({ anyOf: ['api_product-subscription-r'] });
+    return <ConsumersPage ctx={ctx} canCreate={canCreate} canRead={canRead} />;
+}

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/pages/ApiProductGeneralPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/pages/ApiProductGeneralPage.tsx
@@ -163,7 +163,7 @@ export function ApiProductGeneralPage() {
                                             value={version}
                                             onChange={e => setVersion(e.target.value)}
                                             placeholder="1.0.0"
-                                            maxLength={32}
+                                            maxLength={64}
                                         />
                                     </div>
                                 </div>

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/pages/ApiPropertiesPage.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/pages/ApiPropertiesPage.spec.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import { useHasPermission } from '@gravitee/gamma-modules-sdk';
-import { render, screen, waitFor, within } from '@testing-library/react';
+import { render, screen, waitFor, within, fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 
@@ -130,8 +130,8 @@ it('adds a plain-text property and calls updateApiProperties with the new key/va
     await user.click(screen.getByRole('button', { name: /add property/i }));
 
     const dialog = screen.getByRole('dialog');
-    await user.type(within(dialog).getByLabelText(/key/i), 'my.key');
-    await user.type(within(dialog).getByLabelText(/value/i), 'my-value');
+    fireEvent.change(within(dialog).getByLabelText(/key/i), { target: { value: 'my.key' } });
+    fireEvent.change(within(dialog).getByLabelText(/value/i), { target: { value: 'my-value' } });
     await user.click(within(dialog).getByRole('button', { name: /add property/i }));
 
     await waitFor(() => expect(mockUpdateApiProperties).toHaveBeenCalledTimes(1));

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/pages/api-broadcasts/BroadcastEmptyState.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/pages/api-broadcasts/BroadcastEmptyState.tsx
@@ -1,0 +1,87 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Card, CardContent } from '@gravitee/graphene-core';
+import { ArrowRightIcon, CircleCheckIcon, RadioIcon, UserIcon, UsersIcon } from '@gravitee/graphene-core/icons';
+import type { ComponentType } from 'react';
+
+function FlowNode({
+    icon: Icon,
+    label,
+    active = false,
+}: Readonly<{ icon: ComponentType<{ className?: string }>; label: string; active?: boolean }>) {
+    return (
+        <div
+            className="flex flex-col items-center gap-1.5"
+            style={active ? { border: '1px solid var(--color-border)', borderRadius: '0.5rem', padding: '0.5rem 0.75rem' } : undefined}
+        >
+            <div
+                className="rounded-lg p-2"
+                style={{ backgroundColor: active ? 'color-mix(in oklab, var(--color-primary) 10%, transparent)' : 'var(--color-muted)' }}
+            >
+                <Icon className={active ? 'size-4 text-primary' : 'size-4 text-muted-foreground'} />
+            </div>
+            <p className={active ? 'text-xs font-semibold text-center' : 'text-xs text-muted-foreground text-center'}>{label}</p>
+        </div>
+    );
+}
+
+const BENEFITS = [
+    'Announce deprecations and breaking changes to all subscribers',
+    'Schedule maintenance notifications in advance',
+    'Target broadcasts by plan or subscription status',
+] as const;
+
+export function BroadcastEmptyState() {
+    return (
+        <Card>
+            <CardContent className="p-6 space-y-6">
+                <div className="space-y-1">
+                    <p className="text-sm font-semibold">Why send broadcasts?</p>
+                    <p className="text-sm text-muted-foreground">
+                        Broadcasts let you communicate directly with API consumers — announce breaking changes, scheduled maintenance
+                        windows, or new endpoint availability.
+                    </p>
+                </div>
+
+                <div
+                    className="rounded-xl p-5 space-y-3"
+                    style={{
+                        border: '2px solid color-mix(in oklab, var(--color-primary) 20%, transparent)',
+                        backgroundColor: 'color-mix(in oklab, var(--color-primary) 4%, transparent)',
+                    }}
+                >
+                    <p className="text-xs font-semibold text-primary">How it works</p>
+                    <div className="flex items-center justify-center gap-3">
+                        <FlowNode icon={UserIcon} label="Admin" />
+                        <ArrowRightIcon className="size-4 shrink-0 text-muted-foreground" aria-hidden />
+                        <FlowNode icon={RadioIcon} label="Broadcast" active />
+                        <ArrowRightIcon className="size-4 shrink-0 text-muted-foreground" aria-hidden />
+                        <FlowNode icon={UsersIcon} label="Subscribers" />
+                    </div>
+                </div>
+
+                <ul className="space-y-2">
+                    {BENEFITS.map(b => (
+                        <li key={b} className="flex items-start gap-2">
+                            <CircleCheckIcon className="size-3.5 shrink-0 mt-0.5 text-success" aria-hidden />
+                            <span className="text-xs text-muted-foreground">{b}</span>
+                        </li>
+                    ))}
+                </ul>
+            </CardContent>
+        </Card>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/pages/api-broadcasts/BroadcastForm.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/pages/api-broadcasts/BroadcastForm.tsx
@@ -1,0 +1,309 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+    Alert,
+    AlertDescription,
+    Button,
+    Card,
+    CardContent,
+    CardHeader,
+    CardTitle,
+    Checkbox,
+    Input,
+    Label,
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+    Separator,
+    Skeleton,
+    Switch,
+    Textarea,
+} from '@gravitee/graphene-core';
+import { MessageSquareIcon } from '@gravitee/graphene-core/icons';
+import { useCallback, useState } from 'react';
+
+import type { BroadcastChannel, BroadcastPayload, RecipientOption } from '../../features/apis/types/broadcast';
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+const TEXT_MAX = 250;
+
+function isValidHttpUrl(value: string): boolean {
+    try {
+        const { protocol } = new URL(value);
+        return protocol === 'https:' || protocol === 'http:';
+    } catch {
+        return false;
+    }
+}
+
+const CHANNELS: { id: BroadcastChannel; label: string }[] = [
+    { id: 'PORTAL', label: 'Portal Notifications' },
+    { id: 'MAIL', label: 'Email' },
+    { id: 'HTTP', label: 'POST HTTP Message' },
+];
+
+// ─── Recipients list ──────────────────────────────────────────────────────────
+
+interface RecipientsListProps {
+    options: RecipientOption[];
+    selected: string[];
+    isLoading: boolean;
+    onToggle: (name: string) => void;
+}
+
+function RecipientsList({ options, selected, isLoading, onToggle }: Readonly<RecipientsListProps>) {
+    if (isLoading) {
+        return (
+            <div className="border rounded-md p-2 space-y-2">
+                {[1, 2, 3].map(i => (
+                    <Skeleton key={i} className="h-6 w-full rounded" />
+                ))}
+            </div>
+        );
+    }
+    return (
+        <div className="border rounded-md max-h-52 overflow-y-auto" role="group" aria-label="Recipients">
+            {options.map((opt, idx) => (
+                <label
+                    key={opt.name}
+                    className="flex items-center gap-3 px-3 py-2 cursor-pointer hover:bg-muted transition-colors"
+                    style={idx > 0 ? { borderTop: '1px solid var(--color-border)' } : undefined}
+                >
+                    <Checkbox
+                        checked={selected.includes(opt.name)}
+                        onCheckedChange={() => onToggle(opt.name)}
+                        aria-label={opt.displayName}
+                    />
+                    <span className="text-sm">{opt.displayName}</span>
+                </label>
+            ))}
+        </div>
+    );
+}
+
+// ─── Props ────────────────────────────────────────────────────────────────────
+
+interface BroadcastFormProps {
+    recipientOptions: RecipientOption[];
+    isLoadingRecipients: boolean;
+    isPending: boolean;
+    error: string | null;
+    onSend: (payload: BroadcastPayload) => void;
+    onCancel: () => void;
+}
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+export function BroadcastForm({ recipientOptions, isLoadingRecipients, isPending, error, onSend, onCancel }: Readonly<BroadcastFormProps>) {
+    const [channel, setChannel] = useState<BroadcastChannel>('PORTAL');
+    const [selectedRecipients, setSelectedRecipients] = useState<string[]>([]);
+    const [title, setTitle] = useState('');
+    const [url, setUrl] = useState('');
+    const [text, setText] = useState('');
+    const [useSystemProxy, setUseSystemProxy] = useState(false);
+
+    const isHttp = channel === 'HTTP';
+    const charsLeft = TEXT_MAX - text.length;
+
+    const isValid =
+        selectedRecipients.length > 0 &&
+        (isHttp ? isValidHttpUrl(url) : title.trim().length > 0) &&
+        text.trim().length > 0 &&
+        text.length <= TEXT_MAX;
+
+    const handleChannelChange = useCallback((value: string) => {
+        setChannel(value as BroadcastChannel);
+        setTitle('');
+        setUrl('');
+    }, []);
+
+    const toggleRecipient = useCallback((name: string) => {
+        setSelectedRecipients(prev => (prev.includes(name) ? prev.filter(r => r !== name) : [...prev, name]));
+    }, []);
+
+    const handleSend = useCallback(() => {
+        if (!isValid || isPending) return;
+
+        if (isHttp) {
+            onSend({
+                channel: 'HTTP',
+                text: text.trim(),
+                recipient: { url: url.trim() },
+                params: {},
+                useSystemProxy,
+            });
+        } else {
+            onSend({
+                channel,
+                title: title.trim(),
+                text: text.trim(),
+                recipient: {
+                    role_scope: 'APPLICATION',
+                    role_value: selectedRecipients,
+                },
+            });
+        }
+    }, [isValid, isPending, isHttp, selectedRecipients, channel, title, text, url, useSystemProxy, onSend]);
+
+    return (
+        <Card style={{ border: '2px solid color-mix(in oklab, var(--color-primary) 25%, transparent)' }}>
+            <CardHeader className="pb-2">
+                <CardTitle className="text-sm">Compose broadcast</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+                {/* Info banner */}
+                <div
+                    className="flex items-start gap-3 rounded-lg p-3"
+                    style={{
+                        backgroundColor: 'color-mix(in oklab, var(--color-primary) 6%, transparent)',
+                        border: '1px solid color-mix(in oklab, var(--color-primary) 20%, transparent)',
+                    }}
+                >
+                    <MessageSquareIcon className="size-4 shrink-0 mt-0.5 text-primary" aria-hidden />
+                    <p className="text-sm text-muted-foreground">
+                        Send a one-way message to specified recipients to inform them of any changes or updates.
+                    </p>
+                </div>
+
+                {/* Channel */}
+                <div className="space-y-2">
+                    <Label htmlFor="broadcast-channel">
+                        Channel <span className="text-destructive">*</span>
+                    </Label>
+                    <Select value={channel} onValueChange={handleChannelChange}>
+                        <SelectTrigger id="broadcast-channel" className="w-full">
+                            <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                            {CHANNELS.map(c => (
+                                <SelectItem key={c.id} value={c.id}>
+                                    {c.label}
+                                </SelectItem>
+                            ))}
+                        </SelectContent>
+                    </Select>
+                </div>
+
+                {/* Recipients */}
+                <div className="space-y-2">
+                    <Label>
+                        Recipients <span className="text-destructive">*</span>
+                    </Label>
+                    <RecipientsList
+                        options={recipientOptions}
+                        selected={selectedRecipients}
+                        isLoading={isLoadingRecipients}
+                        onToggle={toggleRecipient}
+                    />
+                    {selectedRecipients.length > 0 && (
+                        <p className="text-xs text-muted-foreground">
+                            {selectedRecipients.length} recipient{selectedRecipients.length !== 1 ? 's' : ''} selected
+                        </p>
+                    )}
+                </div>
+
+                {/* Title — PORTAL / MAIL only */}
+                {!isHttp && (
+                    <div className="space-y-2">
+                        <Label htmlFor="broadcast-title">
+                            Title <span className="text-destructive">*</span>
+                        </Label>
+                        <Input
+                            id="broadcast-title"
+                            value={title}
+                            onChange={e => setTitle(e.target.value)}
+                            placeholder="e.g. Scheduled maintenance — 2 Jun"
+                            required
+                        />
+                    </div>
+                )}
+
+                {/* URL + system proxy — HTTP only */}
+                {isHttp && (
+                    <>
+                        <div className="space-y-2">
+                            <Label htmlFor="broadcast-url">
+                                URL <span className="text-destructive">*</span>
+                            </Label>
+                            <Input
+                                id="broadcast-url"
+                                type="url"
+                                value={url}
+                                onChange={e => setUrl(e.target.value)}
+                                placeholder="https://hooks.example.com/notify"
+                                required
+                            />
+                        </div>
+                        <div className="flex items-center gap-3">
+                            <Switch
+                                id="broadcast-proxy"
+                                checked={useSystemProxy}
+                                onCheckedChange={setUseSystemProxy}
+                                aria-label="Use system proxy"
+                            />
+                            <Label htmlFor="broadcast-proxy" className="cursor-pointer font-normal">
+                                Use system proxy
+                            </Label>
+                        </div>
+                    </>
+                )}
+
+                {/* Text */}
+                <div className="flex flex-col gap-2">
+                    <Label htmlFor="broadcast-text">
+                        Message <span className="text-destructive">*</span>
+                    </Label>
+                    <Textarea
+                        id="broadcast-text"
+                        value={text}
+                        onChange={e => setText(e.target.value)}
+                        placeholder="Describe the change, maintenance window, or update…"
+                        rows={4}
+                        maxLength={TEXT_MAX}
+                    />
+                    <p
+                        className="text-xs text-right"
+                        style={{ color: charsLeft <= 20 ? 'var(--color-destructive)' : 'var(--color-muted-foreground)' }}
+                    >
+                        {charsLeft} / {TEXT_MAX}
+                    </p>
+                </div>
+
+                {/* Error */}
+                {error && (
+                    <Alert variant="destructive">
+                        <AlertDescription>{error}</AlertDescription>
+                    </Alert>
+                )}
+
+                <Separator />
+
+                {/* Actions */}
+                <div className="flex items-center justify-end gap-3">
+                    <Button type="button" variant="outline" size="sm" onClick={onCancel} disabled={isPending}>
+                        Cancel
+                    </Button>
+                    <Button type="button" size="sm" onClick={handleSend} disabled={!isValid || isPending}>
+                        {isPending ? 'Sending…' : 'Send'}
+                    </Button>
+                </div>
+            </CardContent>
+        </Card>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/pages/api-broadcasts/BroadcastSuccessBanner.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/pages/api-broadcasts/BroadcastSuccessBanner.tsx
@@ -1,0 +1,55 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Button } from '@gravitee/graphene-core';
+import { CircleCheckIcon, RadioIcon } from '@gravitee/graphene-core/icons';
+
+interface BroadcastSuccessBannerProps {
+    reach: number;
+    onComposeAnother: () => void;
+}
+
+export function BroadcastSuccessBanner({ reach, onComposeAnother }: Readonly<BroadcastSuccessBannerProps>) {
+    return (
+        <div
+            className="flex flex-col items-center gap-6 rounded-xl p-8 text-center"
+            style={{
+                backgroundColor: 'color-mix(in oklab, var(--color-success) 8%, transparent)',
+                border: '1px solid color-mix(in oklab, var(--color-success) 25%, transparent)',
+            }}
+        >
+            <div
+                className="flex size-14 items-center justify-center rounded-full"
+                style={{ backgroundColor: 'color-mix(in oklab, var(--color-success) 15%, transparent)' }}
+            >
+                <CircleCheckIcon className="size-7 text-success" aria-hidden />
+            </div>
+
+            <div className="space-y-1">
+                <h2 className="text-lg font-semibold">Broadcast sent</h2>
+                <p className="text-sm text-muted-foreground">
+                    {reach > 0
+                        ? `Your message was delivered to ${reach} recipient${reach !== 1 ? 's' : ''}.`
+                        : 'Your message has been sent.'}
+                </p>
+            </div>
+
+            <Button type="button" variant="outline" size="sm" onClick={onComposeAnother}>
+                <RadioIcon className="size-4" aria-hidden />
+                Compose another broadcast
+            </Button>
+        </div>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/pages/api-consumers/ApplicationSearchList.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/pages/api-consumers/ApplicationSearchList.tsx
@@ -1,0 +1,107 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Badge, Input, Skeleton } from '@gravitee/graphene-core';
+import { CircleCheckIcon, MonitorIcon, SearchIcon } from '@gravitee/graphene-core/icons';
+import { useCallback, useEffect, useState } from 'react';
+
+import { useApplicationSearch } from '../../features/apis/hooks/useSubscriptions';
+import type { Application } from '../../features/apis/types/subscription';
+
+interface ApplicationSearchListProps {
+    selected: Application | null;
+    onSelect: (app: Application) => void;
+}
+
+export function ApplicationSearchList({ selected, onSelect }: Readonly<ApplicationSearchListProps>) {
+    const [query, setQuery] = useState('');
+    const [debouncedQuery, setDebouncedQuery] = useState('');
+
+    useEffect(() => {
+        const timer = setTimeout(() => setDebouncedQuery(query), 300);
+        return () => clearTimeout(timer);
+    }, [query]);
+
+    const { data: apps = [], isLoading } = useApplicationSearch(debouncedQuery);
+    const hasQuery = debouncedQuery.trim().length > 0;
+
+    const handleQuery = useCallback((e: React.ChangeEvent<HTMLInputElement>) => setQuery(e.target.value), []);
+
+    return (
+        <div className="space-y-2">
+            <div className="relative">
+                <SearchIcon
+                    className="pointer-events-none absolute left-2.5 top-1/2 size-3.5 -translate-y-1/2 text-muted-foreground"
+                    aria-hidden
+                />
+                <Input className="pl-8" placeholder="Type to search applications…" value={query} onChange={handleQuery} />
+            </div>
+
+            <div className="rounded-md border overflow-y-auto" style={{ maxHeight: '14rem' }}>
+                {!hasQuery && (
+                    <div className="flex flex-col items-center gap-2 py-8 text-center">
+                        <SearchIcon className="size-5 text-muted-foreground" style={{ opacity: 0.4 }} aria-hidden />
+                        <p className="text-sm text-muted-foreground">Type a name to find applications</p>
+                    </div>
+                )}
+
+                {hasQuery && isLoading && (
+                    <div className="p-2 space-y-1.5">
+                        {[1, 2, 3].map(i => (
+                            <Skeleton key={i} className="h-12 w-full rounded" />
+                        ))}
+                    </div>
+                )}
+
+                {hasQuery && !isLoading && apps.length === 0 && (
+                    <p className="py-6 text-center text-sm text-muted-foreground">
+                        No applications found for &ldquo;{debouncedQuery}&rdquo;.
+                    </p>
+                )}
+
+                {hasQuery && !isLoading && apps.length > 0 && (
+                    <div>
+                        {apps.map((app, idx) => {
+                            const isSelected = selected?.id === app.id;
+                            return (
+                                <button
+                                    key={app.id}
+                                    type="button"
+                                    onClick={() => onSelect(app)}
+                                    className="flex w-full items-center gap-3 px-3 py-2.5 text-left text-sm transition-colors hover:bg-muted"
+                                    style={idx > 0 ? { borderTop: '1px solid var(--color-border)' } : undefined}
+                                >
+                                    <MonitorIcon className="size-4 shrink-0 text-muted-foreground" aria-hidden />
+                                    <div className="min-w-0 flex-1">
+                                        <p className="font-medium truncate">{app.name}</p>
+                                        {app.primaryOwner?.displayName && (
+                                            <p className="text-xs text-muted-foreground truncate">{app.primaryOwner.displayName}</p>
+                                        )}
+                                    </div>
+                                    {app.type && (
+                                        <Badge variant="secondary" className="text-xs shrink-0">
+                                            {app.type}
+                                        </Badge>
+                                    )}
+                                    {isSelected && <CircleCheckIcon className="size-4 shrink-0 text-primary" aria-hidden />}
+                                </button>
+                            );
+                        })}
+                    </div>
+                )}
+            </div>
+        </div>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/pages/api-consumers/ConsumerDetailPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/pages/api-consumers/ConsumerDetailPage.tsx
@@ -1,0 +1,80 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Button, Skeleton } from '@gravitee/graphene-core';
+import { ArrowLeftIcon } from '@gravitee/graphene-core/icons';
+import { useNavigate } from 'react-router-dom';
+
+import { SubscriptionActionsBar } from './subscription-detail/SubscriptionActionsBar';
+import { SubscriptionApiKeysCard } from './subscription-detail/SubscriptionApiKeysCard';
+import { SubscriptionInfoCard } from './subscription-detail/SubscriptionInfoCard';
+import { useSubscriptionDetail } from '../../features/apis/hooks/useSubscriptions';
+import type { SubscriptionContext } from '../../features/apis/types/subscription';
+
+interface ConsumerDetailPageProps {
+    ctx: SubscriptionContext;
+    subscriptionId: string | undefined;
+    canUpdate: boolean;
+    canDelete: boolean;
+}
+
+export function ConsumerDetailPage({ ctx, subscriptionId, canUpdate, canDelete }: ConsumerDetailPageProps) {
+    const navigate = useNavigate();
+    const { data: subscription, isLoading, isError } = useSubscriptionDetail(ctx, subscriptionId);
+
+    return (
+        <div className="flex flex-col gap-6 p-6">
+            <div className="flex items-center gap-3">
+                <Button type="button" variant="ghost" size="sm" className="gap-1.5" onClick={() => navigate(-1)}>
+                    <ArrowLeftIcon className="size-4" aria-hidden />
+                    Go back to your subscriptions
+                </Button>
+            </div>
+
+            {isError && (
+                <p className="text-sm text-muted-foreground">
+                    Failed to load subscription. It may have been deleted or you may not have access.
+                </p>
+            )}
+
+            {isLoading && (
+                <div className="space-y-4">
+                    <Skeleton className="h-6 w-48 rounded" />
+                    <Skeleton className="h-64 w-full rounded-xl" />
+                </div>
+            )}
+
+            {subscription && (
+                <>
+                    <div className="space-y-1">
+                        <h1 className="text-2xl font-semibold tracking-tight">{subscription.application.name}</h1>
+                        <p className="text-sm text-muted-foreground">
+                            Plan: {subscription.plan.name}
+                            {subscription.plan.security?.type ? ` (${subscription.plan.security.type})` : ''}
+                        </p>
+                    </div>
+
+                    {(canUpdate || canDelete) && (
+                        <SubscriptionActionsBar ctx={ctx} subscription={subscription} canUpdate={canUpdate} canDelete={canDelete} />
+                    )}
+
+                    <SubscriptionInfoCard subscription={subscription} isLoading={false} />
+
+                    <SubscriptionApiKeysCard ctx={ctx} subscription={subscription} canUpdate={canUpdate} />
+                </>
+            )}
+        </div>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/pages/api-consumers/ConsumersEmptyState.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/pages/api-consumers/ConsumersEmptyState.tsx
@@ -1,0 +1,87 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Card, CardContent } from '@gravitee/graphene-core';
+import { ArrowRightIcon, CircleCheckIcon, CreditCardIcon, KeyRoundIcon, MonitorIcon, UsersRoundIcon } from '@gravitee/graphene-core/icons';
+import type { ComponentType } from 'react';
+
+function FlowNode({
+    icon: Icon,
+    label,
+    active = false,
+}: Readonly<{ icon: ComponentType<{ className?: string }>; label: string; active?: boolean }>) {
+    return (
+        <div
+            className="flex flex-col items-center gap-1.5"
+            style={active ? { border: '1px solid var(--color-border)', borderRadius: '0.5rem', padding: '0.5rem 0.75rem' } : undefined}
+        >
+            <div
+                className="rounded-lg p-2"
+                style={{ backgroundColor: active ? 'color-mix(in oklab, var(--color-primary) 10%, transparent)' : 'var(--color-muted)' }}
+            >
+                <Icon className={active ? 'size-4 text-primary' : 'size-4 text-muted-foreground'} />
+            </div>
+            <p className={active ? 'text-xs font-semibold text-center' : 'text-xs text-muted-foreground text-center'}>{label}</p>
+        </div>
+    );
+}
+
+const BENEFITS = [
+    { icon: UsersRoundIcon, text: 'Track which applications are consuming your API' },
+    { icon: KeyRoundIcon, text: 'Manage API keys — issue, revoke, and rotate per consumer' },
+    { icon: CircleCheckIcon, text: 'Monitor per-consumer request volume and error rates' },
+] as const;
+
+export function ConsumersEmptyState() {
+    return (
+        <Card>
+            <CardContent className="p-6 space-y-6">
+                <div className="space-y-1">
+                    <p className="text-sm font-semibold">Why manage consumers?</p>
+                    <p className="text-sm text-muted-foreground">
+                        Consumers are the applications subscribed to your API through plans. Track who&apos;s calling your API, manage their
+                        API keys, and monitor per-consumer usage and health.
+                    </p>
+                </div>
+
+                <div
+                    className="rounded-xl p-5 space-y-3"
+                    style={{
+                        border: '2px solid color-mix(in oklab, var(--color-primary) 20%, transparent)',
+                        backgroundColor: 'color-mix(in oklab, var(--color-primary) 4%, transparent)',
+                    }}
+                >
+                    <p className="text-xs font-semibold text-primary">How it works</p>
+                    <div className="flex items-center justify-center gap-3">
+                        <FlowNode icon={MonitorIcon} label="Application" />
+                        <ArrowRightIcon className="size-4 shrink-0 text-muted-foreground" aria-hidden />
+                        <FlowNode icon={CreditCardIcon} label="Subscription" active />
+                        <ArrowRightIcon className="size-4 shrink-0 text-muted-foreground" aria-hidden />
+                        <FlowNode icon={UsersRoundIcon} label="API Proxy" />
+                    </div>
+                </div>
+
+                <ul className="space-y-2">
+                    {BENEFITS.map(({ text }) => (
+                        <li key={text} className="flex items-start gap-2">
+                            <CircleCheckIcon className="size-3.5 shrink-0 mt-0.5 text-success" aria-hidden />
+                            <span className="text-xs text-muted-foreground">{text}</span>
+                        </li>
+                    ))}
+                </ul>
+            </CardContent>
+        </Card>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/pages/api-consumers/ConsumersFilterBar.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/pages/api-consumers/ConsumersFilterBar.tsx
@@ -1,0 +1,132 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+    Button,
+    Card,
+    CardContent,
+    Input,
+    Label,
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from '@gravitee/graphene-core';
+import { XIcon } from '@gravitee/graphene-core/icons';
+import { useCallback } from 'react';
+
+import { isSubscriptionFiltersDirty } from '../../features/apis/hooks/useSubscriptions';
+import type { Plan, SubscriptionFilters, SubscriptionStatus } from '../../features/apis/types/subscription';
+
+const ALL_STATUSES: SubscriptionStatus[] = ['PENDING', 'ACCEPTED', 'REJECTED', 'CLOSED', 'PAUSED', 'RESUMED'];
+
+interface ConsumersFilterBarProps {
+    filters: SubscriptionFilters;
+    plans: Plan[];
+    onChange: (filters: SubscriptionFilters) => void;
+}
+
+export function ConsumersFilterBar({ filters, plans, onChange }: Readonly<ConsumersFilterBarProps>) {
+    const isDirty = isSubscriptionFiltersDirty(filters);
+
+    const handleStatus = useCallback(
+        (value: string) => {
+            if (value === '__all__') {
+                onChange({ ...filters, statuses: [] });
+            } else {
+                onChange({ ...filters, statuses: [value as SubscriptionStatus] });
+            }
+        },
+        [filters, onChange],
+    );
+
+    const handlePlan = useCallback(
+        (value: string) => {
+            onChange({ ...filters, planIds: value === '__all__' ? [] : [value] });
+        },
+        [filters, onChange],
+    );
+
+    const handleApiKey = useCallback(
+        (e: React.ChangeEvent<HTMLInputElement>) => {
+            onChange({ ...filters, apiKey: e.target.value });
+        },
+        [filters, onChange],
+    );
+
+    const handleReset = useCallback(() => {
+        onChange({ statuses: [], planIds: [], applicationIds: [], apiKey: '' });
+    }, [onChange]);
+
+    const currentStatus = filters.statuses.length === 1 ? filters.statuses[0] : '__all__';
+    const currentPlan = filters.planIds.length === 1 ? filters.planIds[0] : '__all__';
+
+    return (
+        <Card>
+            <CardContent className="pt-4 pb-4">
+                <div className="flex flex-wrap gap-4">
+                    <div className="flex-1 space-y-1.5" style={{ minWidth: '140px' }}>
+                        <Label className="text-xs">Status</Label>
+                        <Select value={currentStatus} onValueChange={handleStatus}>
+                            <SelectTrigger className="w-full">
+                                <SelectValue placeholder="All statuses" />
+                            </SelectTrigger>
+                            <SelectContent>
+                                <SelectItem value="__all__">All statuses</SelectItem>
+                                {ALL_STATUSES.map(s => (
+                                    <SelectItem key={s} value={s}>
+                                        {s.charAt(0) + s.slice(1).toLowerCase()}
+                                    </SelectItem>
+                                ))}
+                            </SelectContent>
+                        </Select>
+                    </div>
+
+                    <div className="flex-1 space-y-1.5" style={{ minWidth: '140px' }}>
+                        <Label className="text-xs">Plan</Label>
+                        <Select value={currentPlan} onValueChange={handlePlan}>
+                            <SelectTrigger className="w-full">
+                                <SelectValue placeholder="All plans" />
+                            </SelectTrigger>
+                            <SelectContent>
+                                <SelectItem value="__all__">All plans</SelectItem>
+                                {plans.map(p => (
+                                    <SelectItem key={p.id} value={p.id}>
+                                        {p.name}
+                                    </SelectItem>
+                                ))}
+                            </SelectContent>
+                        </Select>
+                    </div>
+
+                    <div className="flex-1 space-y-1.5" style={{ minWidth: '160px' }}>
+                        <Label className="text-xs">API Key</Label>
+                        <Input className="w-full" placeholder="Search by key…" value={filters.apiKey} onChange={handleApiKey} />
+                    </div>
+
+                    {isDirty && (
+                        <div className="flex items-end">
+                            <Button type="button" variant="ghost" size="sm" className="gap-1.5 text-muted-foreground" onClick={handleReset}>
+                                <XIcon className="size-3.5" aria-hidden />
+                                Reset
+                            </Button>
+                        </div>
+                    )}
+                </div>
+            </CardContent>
+        </Card>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/pages/api-consumers/ConsumersPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/pages/api-consumers/ConsumersPage.tsx
@@ -1,0 +1,146 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Button } from '@gravitee/graphene-core';
+import { PlusIcon } from '@gravitee/graphene-core/icons';
+import { useCallback, useState } from 'react';
+
+import { ConsumersEmptyState } from './ConsumersEmptyState';
+import { ConsumersFilterBar } from './ConsumersFilterBar';
+import { ConsumersSummaryCards } from './ConsumersSummaryCards';
+import { ConsumersTable } from './ConsumersTable';
+import { CreateSubscriptionDialog } from './CreateSubscriptionDialog';
+import { useCreateSubscription } from '../../features/apis/hooks/useSubscriptionActions';
+import {
+    isSubscriptionFiltersDirty,
+    useApiPlans,
+    useSubscriptionCount,
+    useSubscriptionList,
+} from '../../features/apis/hooks/useSubscriptions';
+import type { SubscriptionContext, SubscriptionFilters } from '../../features/apis/types/subscription';
+
+const EMPTY_FILTERS: SubscriptionFilters = {
+    statuses: [],
+    planIds: [],
+    applicationIds: [],
+    apiKey: '',
+};
+
+interface ConsumersPageProps {
+    ctx: SubscriptionContext;
+    canCreate: boolean;
+    canRead: boolean;
+}
+
+export function ConsumersPage({ ctx, canCreate, canRead }: ConsumersPageProps) {
+    const [filters, setFilters] = useState<SubscriptionFilters>(EMPTY_FILTERS);
+    const [page, setPage] = useState(1);
+    const [perPage, setPerPage] = useState(10);
+    const [dialogOpen, setDialogOpen] = useState(false);
+
+    const entityLabel = ctx.type === 'api-product' ? 'API Product' : 'API';
+    const { data, isLoading: isLoadingList } = useSubscriptionList(ctx, filters, page, perPage);
+    const { data: acceptedCount = 0, isLoading: isLoadingAccepted } = useSubscriptionCount(ctx, ['ACCEPTED']);
+    const { data: pendingCount = 0, isLoading: isLoadingPending } = useSubscriptionCount(ctx, ['PENDING']);
+    const isLoading = isLoadingList || isLoadingAccepted || isLoadingPending;
+    const { data: plans = [] } = useApiPlans(ctx);
+    const createMutation = useCreateSubscription(ctx);
+
+    const handleFilterChange = useCallback((next: SubscriptionFilters) => {
+        setFilters(next);
+        setPage(1);
+    }, []);
+
+    const handlePerPageChange = useCallback((next: number) => {
+        setPerPage(next);
+        setPage(1);
+    }, []);
+
+    const handleCreate = useCallback(
+        (applicationId: string, planId: string) => {
+            createMutation.mutate({ applicationId, planId }, { onSuccess: () => setDialogOpen(false) });
+        },
+        [createMutation],
+    );
+
+    const totalCount = data?.pagination.totalCount ?? 0;
+    const hasAnySubscriptions = totalCount > 0 || isLoading;
+    const isFiltered = isSubscriptionFiltersDirty(filters);
+
+    if (!canRead) {
+        return (
+            <div className="flex flex-col gap-6 p-6">
+                <h1 className="text-2xl font-semibold tracking-tight">Consumers</h1>
+                <p className="text-sm text-muted-foreground">You don&apos;t have permission to view subscriptions.</p>
+            </div>
+        );
+    }
+
+    return (
+        <div className="flex flex-col gap-6 p-6">
+            <div className="flex items-center justify-between gap-4">
+                <div>
+                    <h1 className="text-2xl font-semibold tracking-tight">Consumers</h1>
+                    <p className="text-sm text-muted-foreground">View and manage {entityLabel} consumers and their usage.</p>
+                </div>
+                {canCreate && (
+                    <Button type="button" size="sm" onClick={() => setDialogOpen(true)}>
+                        <PlusIcon className="size-4" aria-hidden />
+                        Create subscription
+                    </Button>
+                )}
+            </div>
+
+            {!hasAnySubscriptions && !isFiltered ? (
+                <ConsumersEmptyState />
+            ) : (
+                <>
+                    <ConsumersSummaryCards
+                        totalCount={totalCount}
+                        acceptedCount={acceptedCount}
+                        pendingCount={pendingCount}
+                        isLoading={isLoading}
+                    />
+
+                    <ConsumersFilterBar filters={filters} plans={plans} onChange={handleFilterChange} />
+
+                    <ConsumersTable
+                        subscriptions={data?.data ?? []}
+                        totalCount={data?.pagination.totalCount ?? 0}
+                        page={page}
+                        perPage={perPage}
+                        isLoading={isLoading}
+                        onPage={setPage}
+                        onPerPageChange={handlePerPageChange}
+                    />
+                </>
+            )}
+
+            {canCreate && (
+                <CreateSubscriptionDialog
+                    ctx={ctx}
+                    open={dialogOpen}
+                    isPending={createMutation.isPending}
+                    error={createMutation.error?.message ?? null}
+                    onConfirm={handleCreate}
+                    onClose={() => {
+                        setDialogOpen(false);
+                        createMutation.reset();
+                    }}
+                />
+            )}
+        </div>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/pages/api-consumers/ConsumersSummaryCards.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/pages/api-consumers/ConsumersSummaryCards.tsx
@@ -1,0 +1,59 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Card, CardContent, Skeleton } from '@gravitee/graphene-core';
+
+interface StatCardProps {
+    value: number | string;
+    label: string;
+    isLoading: boolean;
+}
+
+function StatCard({ value, label, isLoading }: StatCardProps) {
+    return (
+        <Card>
+            <CardContent className="pt-5 pb-5">
+                {isLoading ? (
+                    <div className="space-y-2">
+                        <Skeleton className="h-7 w-10 rounded" />
+                        <Skeleton className="h-4 w-24 rounded" />
+                    </div>
+                ) : (
+                    <div className="space-y-1">
+                        <p className="text-2xl font-bold">{value}</p>
+                        <p className="text-sm text-muted-foreground">{label}</p>
+                    </div>
+                )}
+            </CardContent>
+        </Card>
+    );
+}
+
+interface ConsumersSummaryCardsProps {
+    totalCount: number;
+    acceptedCount: number;
+    pendingCount: number;
+    isLoading: boolean;
+}
+
+export function ConsumersSummaryCards({ totalCount, acceptedCount, pendingCount, isLoading }: Readonly<ConsumersSummaryCardsProps>) {
+    return (
+        <div className="grid gap-4" style={{ gridTemplateColumns: 'repeat(3, minmax(0, 1fr))' }}>
+            <StatCard value={totalCount} label="Total consumers" isLoading={isLoading} />
+            <StatCard value={acceptedCount} label="Accepted" isLoading={isLoading} />
+            <StatCard value={pendingCount} label="Pending" isLoading={isLoading} />
+        </div>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/pages/api-consumers/ConsumersTable.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/pages/api-consumers/ConsumersTable.tsx
@@ -1,0 +1,133 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+    Badge,
+    DataTablePagination,
+    Skeleton,
+    Table,
+    TableBody,
+    TableCell,
+    TableHead,
+    TableHeader,
+    TableRow,
+} from '@gravitee/graphene-core';
+import { useNavigate } from 'react-router-dom';
+
+import { SubscriptionStatusBadge } from './SubscriptionStatusBadge';
+import type { Subscription } from '../../features/apis/types/subscription';
+import { formatDate } from '../../features/apis/utils/formatDate';
+
+interface ConsumersTableProps {
+    subscriptions: Subscription[];
+    totalCount: number;
+    page: number;
+    perPage: number;
+    isLoading: boolean;
+    onPage: (p: number) => void;
+    onPerPageChange: (perPage: number) => void;
+}
+
+export function ConsumersTable({
+    subscriptions,
+    totalCount,
+    page,
+    perPage,
+    isLoading,
+    onPage,
+    onPerPageChange,
+}: Readonly<ConsumersTableProps>) {
+    const navigate = useNavigate();
+
+    return (
+        <div className="space-y-2">
+            <DataTablePagination
+                page={page}
+                pageSize={perPage}
+                totalCount={totalCount}
+                pageSizeOptions={[10, 25, 50, 100]}
+                onPageChange={onPage}
+                onPageSizeChange={onPerPageChange}
+            />
+            <div className="rounded-md border">
+                <Table>
+                    <TableHeader>
+                        <TableRow>
+                            <TableHead>Application</TableHead>
+                            <TableHead>Plan</TableHead>
+                            <TableHead>Security</TableHead>
+                            <TableHead>Status</TableHead>
+                            <TableHead>Created</TableHead>
+                        </TableRow>
+                    </TableHeader>
+                    <TableBody>
+                        {isLoading &&
+                            Array.from({ length: perPage }).map((_, i) => (
+                                <TableRow key={i}>
+                                    {Array.from({ length: 5 }).map((__, j) => (
+                                        <TableCell key={j}>
+                                            <Skeleton className="h-4 w-full rounded" />
+                                        </TableCell>
+                                    ))}
+                                </TableRow>
+                            ))}
+
+                        {!isLoading && subscriptions.length === 0 && (
+                            <TableRow>
+                                <TableCell colSpan={5} className="py-10 text-center text-sm text-muted-foreground">
+                                    No subscriptions match the current filters.
+                                </TableCell>
+                            </TableRow>
+                        )}
+
+                        {!isLoading &&
+                            subscriptions.map(sub => (
+                                <TableRow key={sub.id} className="cursor-pointer hover:bg-muted" onClick={() => navigate(sub.id)}>
+                                    <TableCell>
+                                        <div className="font-medium">{sub.application.name}</div>
+                                        {sub.application.primaryOwner?.displayName && (
+                                            <div className="text-xs text-muted-foreground">{sub.application.primaryOwner.displayName}</div>
+                                        )}
+                                    </TableCell>
+                                    <TableCell>{sub.plan.name}</TableCell>
+                                    <TableCell>
+                                        {sub.plan.security?.type ? (
+                                            <Badge variant="secondary" className="text-xs font-mono">
+                                                {sub.plan.security.type === 'KEY_LESS' ? 'Keyless' : sub.plan.security.type}
+                                            </Badge>
+                                        ) : (
+                                            <span className="text-muted-foreground">—</span>
+                                        )}
+                                    </TableCell>
+                                    <TableCell>
+                                        <SubscriptionStatusBadge status={sub.status} />
+                                    </TableCell>
+                                    <TableCell className="text-muted-foreground text-sm">{formatDate(sub.createdAt)}</TableCell>
+                                </TableRow>
+                            ))}
+                    </TableBody>
+                </Table>
+            </div>
+            <DataTablePagination
+                page={page}
+                pageSize={perPage}
+                totalCount={totalCount}
+                pageSizeOptions={[10, 25, 50, 100]}
+                onPageChange={onPage}
+                onPageSizeChange={onPerPageChange}
+            />
+        </div>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/pages/api-consumers/CreateSubscriptionDialog.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/pages/api-consumers/CreateSubscriptionDialog.tsx
@@ -1,0 +1,181 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+    Alert,
+    AlertDescription,
+    Badge,
+    Button,
+    Dialog,
+    DialogContent,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+    Label,
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+    Separator,
+} from '@gravitee/graphene-core';
+import { PlusIcon } from '@gravitee/graphene-core/icons';
+import { useCallback, useState } from 'react';
+
+import { ApplicationSearchList } from './ApplicationSearchList';
+import { useApiPlans } from '../../features/apis/hooks/useSubscriptions';
+import type { Application, Plan, SubscriptionContext } from '../../features/apis/types/subscription';
+
+interface CreateSubscriptionDialogProps {
+    ctx: SubscriptionContext;
+    open: boolean;
+    isPending: boolean;
+    error: string | null;
+    onConfirm: (applicationId: string, planId: string) => void;
+    onClose: () => void;
+}
+
+function SubscriptionSummary({ app, plan }: { app: Application; plan: Plan }) {
+    return (
+        <div className="rounded-lg border p-4 space-y-3">
+            <p className="text-sm font-medium">Subscription Summary</p>
+            <div className="grid grid-cols-2 gap-x-6 gap-y-2 text-sm">
+                <div>
+                    <p className="text-xs text-muted-foreground">Application</p>
+                    <p className="font-medium">{app.name}</p>
+                </div>
+                <div>
+                    <p className="text-xs text-muted-foreground">Plan</p>
+                    <div className="flex items-center gap-1.5">
+                        <p className="font-medium">{plan.name}</p>
+                        {plan.security?.type && (
+                            <Badge variant="secondary" className="text-xs">
+                                {plan.security.type}
+                            </Badge>
+                        )}
+                    </div>
+                </div>
+                {app.primaryOwner?.displayName && (
+                    <div>
+                        <p className="text-xs text-muted-foreground">Owner</p>
+                        <p>{app.primaryOwner.displayName}</p>
+                    </div>
+                )}
+                {app.type && (
+                    <div>
+                        <p className="text-xs text-muted-foreground">Type</p>
+                        <Badge variant="secondary" className="text-xs">
+                            {app.type}
+                        </Badge>
+                    </div>
+                )}
+            </div>
+        </div>
+    );
+}
+
+export function CreateSubscriptionDialog({ ctx, open, isPending, error, onConfirm, onClose }: Readonly<CreateSubscriptionDialogProps>) {
+    const [selectedApp, setSelectedApp] = useState<Application | null>(null);
+    const [selectedPlanId, setSelectedPlanId] = useState('');
+
+    const entityLabel = ctx.type === 'api-product' ? 'API product' : 'API';
+    const { data: plans = [], isLoading: isLoadingPlans } = useApiPlans(ctx);
+
+    const onlyKeyless = !isLoadingPlans && plans.length === 0;
+    const selectedPlan = plans.find(p => p.id === selectedPlanId) ?? null;
+    const canSubmit = Boolean(selectedApp && selectedPlanId && !onlyKeyless);
+
+    const handleClose = useCallback(() => {
+        setSelectedApp(null);
+        setSelectedPlanId('');
+        onClose();
+    }, [onClose]);
+
+    const handleConfirm = useCallback(() => {
+        if (!canSubmit || !selectedApp) return;
+        onConfirm(selectedApp.id, selectedPlanId);
+    }, [canSubmit, selectedApp, selectedPlanId, onConfirm]);
+
+    return (
+        <Dialog open={open} onOpenChange={open ? handleClose : undefined}>
+            <DialogContent style={{ maxWidth: '480px', width: '90vw', maxHeight: '85vh', display: 'flex', flexDirection: 'column' }}>
+                <DialogHeader>
+                    <DialogTitle>Create Subscription</DialogTitle>
+                    <p className="text-sm text-muted-foreground">
+                        Select an environment-level application and assign a plan to subscribe it to this {entityLabel}.
+                    </p>
+                </DialogHeader>
+
+                <div className="space-y-5 py-2" style={{ overflowY: 'auto', flex: 1, minHeight: 0 }}>
+                    <div className="space-y-2">
+                        <Label>Select Application</Label>
+                        <ApplicationSearchList selected={selectedApp} onSelect={setSelectedApp} />
+                    </div>
+
+                    <Separator />
+
+                    <div className="space-y-2">
+                        <Label htmlFor="sub-plan">Subscription Plan</Label>
+                        <Select value={selectedPlanId} onValueChange={setSelectedPlanId} disabled={isLoadingPlans || onlyKeyless}>
+                            <SelectTrigger id="sub-plan" className="w-full">
+                                <SelectValue
+                                    placeholder={
+                                        isLoadingPlans ? 'Loading plans…' : onlyKeyless ? 'No subscribable plans' : 'Select a plan'
+                                    }
+                                />
+                            </SelectTrigger>
+                            <SelectContent>
+                                {plans.map(p => (
+                                    <SelectItem key={p.id} value={p.id}>
+                                        {p.name}
+                                        {p.description ? ` — ${p.description}` : ''}
+                                    </SelectItem>
+                                ))}
+                            </SelectContent>
+                        </Select>
+                        {onlyKeyless && (
+                            <p className="text-xs text-muted-foreground">
+                                This API only offers keyless plans. Subscriptions are not required.
+                            </p>
+                        )}
+                        {!onlyKeyless && (
+                            <p className="text-xs text-muted-foreground">
+                                Plans define rate limits, quotas, and access policies for this subscription.
+                            </p>
+                        )}
+                    </div>
+
+                    {selectedApp && selectedPlan && <SubscriptionSummary app={selectedApp} plan={selectedPlan} />}
+
+                    {error && (
+                        <Alert variant="destructive">
+                            <AlertDescription>{error}</AlertDescription>
+                        </Alert>
+                    )}
+                </div>
+
+                <DialogFooter>
+                    <Button type="button" variant="outline" onClick={handleClose} disabled={isPending}>
+                        Cancel
+                    </Button>
+                    <Button type="button" onClick={handleConfirm} disabled={!canSubmit || isPending}>
+                        {!isPending && <PlusIcon className="size-4" aria-hidden />}
+                        {isPending ? 'Creating…' : 'Create subscription'}
+                    </Button>
+                </DialogFooter>
+            </DialogContent>
+        </Dialog>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/pages/api-consumers/SubscriptionStatusBadge.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/pages/api-consumers/SubscriptionStatusBadge.tsx
@@ -1,0 +1,44 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Badge } from '@gravitee/graphene-core';
+
+import type { SubscriptionStatus } from '../../features/apis/types/subscription';
+
+type BadgeVariant = 'default' | 'secondary' | 'destructive' | 'outline';
+
+interface StatusConfig {
+    label: string;
+    variant?: BadgeVariant;
+    className?: string;
+}
+
+const STATUS_CONFIG: Record<SubscriptionStatus, StatusConfig> = {
+    ACCEPTED: { label: 'Accepted', className: 'bg-success/10 text-success border-transparent' },
+    RESUMED: { label: 'Resumed', className: 'bg-success/10 text-success border-transparent' },
+    PENDING: { label: 'Pending', variant: 'outline', className: 'border-warning/30 text-warning' },
+    PAUSED: { label: 'Paused', variant: 'outline', className: 'border-warning/30 text-warning' },
+    REJECTED: { label: 'Rejected', variant: 'destructive' },
+    CLOSED: { label: 'Closed', variant: 'secondary' },
+};
+
+export function SubscriptionStatusBadge({ status }: { status: SubscriptionStatus }) {
+    const config = STATUS_CONFIG[status] ?? { label: status, variant: 'outline' as BadgeVariant };
+    return (
+        <Badge variant={config.variant} className={config.className}>
+            {config.label}
+        </Badge>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/pages/api-consumers/subscription-detail/SubscriptionActionsBar.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/pages/api-consumers/subscription-detail/SubscriptionActionsBar.tsx
@@ -1,0 +1,243 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+    Alert,
+    AlertDescription,
+    Button,
+    Dialog,
+    DialogContent,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+    Input,
+    Label,
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from '@gravitee/graphene-core';
+import { ArrowRightIcon, CalendarIcon, CircleStopIcon, CircleXIcon, PlayIcon } from '@gravitee/graphene-core/icons';
+import { useCallback, useMemo, useState } from 'react';
+
+import {
+    useCloseSubscription,
+    usePauseSubscription,
+    useResumeSubscription,
+    useTransferSubscription,
+    useUpdateSubscriptionEndDate,
+} from '../../../features/apis/hooks/useSubscriptionActions';
+import { useApiPlans } from '../../../features/apis/hooks/useSubscriptions';
+import type { Subscription, SubscriptionContext } from '../../../features/apis/types/subscription';
+
+type PendingAction = 'pause' | 'resume' | 'close' | null;
+
+interface SubscriptionActionsBarProps {
+    ctx: SubscriptionContext;
+    subscription: Subscription;
+    canUpdate: boolean;
+    canDelete: boolean;
+}
+
+export function SubscriptionActionsBar({ ctx, subscription, canUpdate, canDelete }: Readonly<SubscriptionActionsBarProps>) {
+    const [pending, setPending] = useState<PendingAction>(null);
+    const [transferOpen, setTransferOpen] = useState(false);
+    const [endDateOpen, setEndDateOpen] = useState(false);
+    const [selectedPlanId, setSelectedPlanId] = useState('');
+    const [endDate, setEndDate] = useState('');
+
+    const { data: plans = [] } = useApiPlans(ctx);
+    const transferPlans = useMemo(
+        () => plans.filter(p => p.id !== subscription.plan.id && p.security?.type === subscription.plan.security?.type),
+        [plans, subscription.plan.id, subscription.plan.security?.type],
+    );
+
+    const pauseMutation = usePauseSubscription(ctx, subscription.id);
+    const resumeMutation = useResumeSubscription(ctx, subscription.id);
+    const closeMutation = useCloseSubscription(ctx, subscription.id);
+    const transferMutation = useTransferSubscription(ctx, subscription.id);
+    const endDateMutation = useUpdateSubscriptionEndDate(ctx, subscription.id);
+
+    const isKubernetes = subscription.origin === 'KUBERNETES';
+    const { status } = subscription;
+
+    const confirmAction = useCallback(() => {
+        if (pending === 'pause') pauseMutation.mutate(undefined, { onSuccess: () => setPending(null) });
+        else if (pending === 'resume') resumeMutation.mutate(undefined, { onSuccess: () => setPending(null) });
+        else if (pending === 'close') closeMutation.mutate(undefined, { onSuccess: () => setPending(null) });
+    }, [pending, pauseMutation, resumeMutation, closeMutation]);
+
+    const handleTransfer = useCallback(() => {
+        if (!selectedPlanId) return;
+        transferMutation.mutate(selectedPlanId, {
+            onSuccess: () => {
+                setTransferOpen(false);
+                setSelectedPlanId('');
+            },
+        });
+    }, [selectedPlanId, transferMutation]);
+
+    const handleEndDate = useCallback(() => {
+        endDateMutation.mutate(endDate || null, {
+            onSuccess: () => {
+                setEndDateOpen(false);
+                setEndDate('');
+            },
+        });
+    }, [endDate, endDateMutation]);
+
+    const actionError =
+        pauseMutation.error ?? resumeMutation.error ?? closeMutation.error ?? transferMutation.error ?? endDateMutation.error;
+
+    if (isKubernetes) {
+        return (
+            <Alert>
+                <AlertDescription>This subscription is managed by Kubernetes and cannot be modified here.</AlertDescription>
+            </Alert>
+        );
+    }
+
+    return (
+        <div className="space-y-3">
+            <div className="flex flex-wrap gap-2">
+                {canUpdate && status === 'ACCEPTED' && (
+                    <Button type="button" variant="outline" size="sm" onClick={() => setTransferOpen(true)}>
+                        <ArrowRightIcon className="size-3.5" aria-hidden />
+                        Transfer
+                    </Button>
+                )}
+                {canUpdate && (status === 'ACCEPTED' || status === 'PAUSED') && (
+                    <Button type="button" variant="outline" size="sm" onClick={() => setEndDateOpen(true)}>
+                        <CalendarIcon className="size-3.5" aria-hidden />
+                        Change end date
+                    </Button>
+                )}
+                {canUpdate && status === 'ACCEPTED' && (
+                    <Button type="button" variant="outline" size="sm" onClick={() => setPending('pause')}>
+                        <CircleStopIcon className="size-3.5" aria-hidden />
+                        Pause
+                    </Button>
+                )}
+                {canUpdate && status === 'PAUSED' && (
+                    <Button type="button" variant="outline" size="sm" onClick={() => setPending('resume')}>
+                        <PlayIcon className="size-3.5" aria-hidden />
+                        Resume
+                    </Button>
+                )}
+                {canDelete && (status === 'ACCEPTED' || status === 'PAUSED' || status === 'PENDING') && (
+                    <Button type="button" variant="destructive" size="sm" onClick={() => setPending('close')}>
+                        <CircleXIcon className="size-3.5" aria-hidden />
+                        Close subscription
+                    </Button>
+                )}
+            </div>
+
+            {pending && (
+                <div
+                    className="flex items-center gap-3 rounded-lg px-4 py-3 text-sm"
+                    style={{
+                        backgroundColor:
+                            pending === 'close'
+                                ? 'color-mix(in oklab, var(--color-destructive) 8%, transparent)'
+                                : 'color-mix(in oklab, var(--color-muted) 60%, transparent)',
+                        border: `1px solid ${pending === 'close' ? 'color-mix(in oklab, var(--color-destructive) 20%, transparent)' : 'var(--color-border)'}`,
+                    }}
+                >
+                    <p className="flex-1">
+                        {pending === 'pause' && 'Pausing will suspend access for this consumer. Confirm?'}
+                        {pending === 'resume' && 'The consumer will regain access to the API. Confirm?'}
+                        {pending === 'close' &&
+                            'This will permanently close the subscription and invalidate all associated API keys. Confirm?'}
+                    </p>
+                    <Button type="button" variant="ghost" size="sm" onClick={() => setPending(null)}>
+                        Cancel
+                    </Button>
+                    <Button
+                        type="button"
+                        variant={pending === 'close' ? 'destructive' : 'default'}
+                        size="sm"
+                        onClick={confirmAction}
+                        disabled={pauseMutation.isPending || resumeMutation.isPending || closeMutation.isPending}
+                    >
+                        Confirm
+                    </Button>
+                </div>
+            )}
+
+            {actionError && (
+                <Alert variant="destructive">
+                    <AlertDescription>{actionError?.message}</AlertDescription>
+                </Alert>
+            )}
+
+            {/* Transfer dialog */}
+            <Dialog open={transferOpen} onOpenChange={setTransferOpen}>
+                <DialogContent style={{ maxWidth: '384px', width: '90vw' }}>
+                    <DialogHeader>
+                        <DialogTitle>Transfer Subscription</DialogTitle>
+                    </DialogHeader>
+                    <div className="space-y-2 py-2">
+                        <Label htmlFor="transfer-plan">New Plan</Label>
+                        <Select value={selectedPlanId} onValueChange={setSelectedPlanId}>
+                            <SelectTrigger id="transfer-plan">
+                                <SelectValue placeholder="Select a plan" />
+                            </SelectTrigger>
+                            <SelectContent>
+                                {transferPlans.map(p => (
+                                    <SelectItem key={p.id} value={p.id}>
+                                        {p.name}
+                                    </SelectItem>
+                                ))}
+                            </SelectContent>
+                        </Select>
+                        {transferPlans.length === 0 && (
+                            <p className="text-xs text-muted-foreground">No compatible plans available for transfer.</p>
+                        )}
+                    </div>
+                    <DialogFooter>
+                        <Button type="button" variant="outline" onClick={() => setTransferOpen(false)}>
+                            Cancel
+                        </Button>
+                        <Button type="button" onClick={handleTransfer} disabled={!selectedPlanId || transferMutation.isPending}>
+                            {transferMutation.isPending ? 'Transferring…' : 'Transfer'}
+                        </Button>
+                    </DialogFooter>
+                </DialogContent>
+            </Dialog>
+
+            {/* Change end date dialog */}
+            <Dialog open={endDateOpen} onOpenChange={setEndDateOpen}>
+                <DialogContent style={{ maxWidth: '384px', width: '90vw' }}>
+                    <DialogHeader>
+                        <DialogTitle>Change End Date</DialogTitle>
+                    </DialogHeader>
+                    <div className="space-y-2 py-2">
+                        <Label htmlFor="end-date">End date (leave empty to remove)</Label>
+                        <Input id="end-date" type="date" value={endDate} onChange={e => setEndDate(e.target.value)} />
+                    </div>
+                    <DialogFooter>
+                        <Button type="button" variant="outline" onClick={() => setEndDateOpen(false)}>
+                            Cancel
+                        </Button>
+                        <Button type="button" onClick={handleEndDate} disabled={endDateMutation.isPending}>
+                            {endDateMutation.isPending ? 'Saving…' : 'Save'}
+                        </Button>
+                    </DialogFooter>
+                </DialogContent>
+            </Dialog>
+        </div>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/pages/api-consumers/subscription-detail/SubscriptionApiKeysCard.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/pages/api-consumers/subscription-detail/SubscriptionApiKeysCard.tsx
@@ -1,0 +1,274 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+    Alert,
+    AlertDescription,
+    Button,
+    Card,
+    CardContent,
+    CardHeader,
+    CardTitle,
+    DataTablePagination,
+    Input,
+    Skeleton,
+    Table,
+    TableBody,
+    TableCell,
+    TableHead,
+    TableHeader,
+    TableRow,
+    Tooltip,
+    TooltipContent,
+    TooltipTrigger,
+} from '@gravitee/graphene-core';
+import { CalendarIcon, CircleCheckIcon, CircleXIcon, CopyIcon, RefreshCwIcon, XIcon } from '@gravitee/graphene-core/icons';
+import { useCallback, useState } from 'react';
+
+import { useApiKeyList, useExpireApiKey, useRenewApiKey, useRevokeApiKey } from '../../../features/apis/hooks/useSubscriptionApiKeys';
+import type { ApiKey, Subscription, SubscriptionContext } from '../../../features/apis/types/subscription';
+import { formatDate } from '../../../features/apis/utils/formatDate';
+
+function InfoBanner({ children }: { children: React.ReactNode }) {
+    return (
+        <div
+            className="rounded-lg px-4 py-3 text-sm text-muted-foreground"
+            style={{ backgroundColor: 'color-mix(in oklab, var(--color-muted) 40%, transparent)', border: '1px solid var(--color-border)' }}
+        >
+            {children}
+        </div>
+    );
+}
+
+interface ApiKeyRowActionsProps {
+    apiKey: ApiKey;
+    subscriptionAccepted: boolean;
+    canUpdate: boolean;
+    onRevoke: (id: string) => void;
+    onExpire: (id: string) => void;
+    isRevoking: boolean;
+}
+
+function ApiKeyRowActions({ apiKey, subscriptionAccepted, canUpdate, onRevoke, onExpire, isRevoking }: ApiKeyRowActionsProps) {
+    if (!canUpdate || !subscriptionAccepted || apiKey.revoked || apiKey.expired) return null;
+    return (
+        <div className="flex items-center gap-1 justify-end">
+            <Tooltip>
+                <TooltipTrigger asChild>
+                    <Button
+                        type="button"
+                        variant="ghost"
+                        size="icon"
+                        className="size-7"
+                        onClick={() => navigator.clipboard.writeText(apiKey.key).catch(() => {})}
+                    >
+                        <CopyIcon className="size-3.5" aria-hidden />
+                        <span className="sr-only">Copy key</span>
+                    </Button>
+                </TooltipTrigger>
+                <TooltipContent>Copy key</TooltipContent>
+            </Tooltip>
+            <Tooltip>
+                <TooltipTrigger asChild>
+                    <Button
+                        type="button"
+                        variant="ghost"
+                        size="icon"
+                        className="size-7 text-destructive hover:text-destructive"
+                        disabled={isRevoking}
+                        onClick={() => onRevoke(apiKey.id)}
+                    >
+                        <XIcon className="size-3.5" aria-hidden />
+                        <span className="sr-only">Revoke key</span>
+                    </Button>
+                </TooltipTrigger>
+                <TooltipContent>Revoke key</TooltipContent>
+            </Tooltip>
+            <Tooltip>
+                <TooltipTrigger asChild>
+                    <Button type="button" variant="ghost" size="icon" className="size-7" onClick={() => onExpire(apiKey.id)}>
+                        <CalendarIcon className="size-3.5" aria-hidden />
+                        <span className="sr-only">Set expiry date</span>
+                    </Button>
+                </TooltipTrigger>
+                <TooltipContent>Set expiry date</TooltipContent>
+            </Tooltip>
+        </div>
+    );
+}
+
+interface SubscriptionApiKeysCardProps {
+    ctx: SubscriptionContext;
+    subscription: Subscription;
+    canUpdate: boolean;
+}
+
+export function SubscriptionApiKeysCard({ ctx, subscription, canUpdate }: Readonly<SubscriptionApiKeysCardProps>) {
+    const [page, setPage] = useState(1);
+    const [expiringKeyId, setExpiringKeyId] = useState<string | null>(null);
+    const [expireDate, setExpireDate] = useState('');
+    const PER_PAGE = 5;
+
+    const { data, isLoading } = useApiKeyList(ctx, subscription.id, page, PER_PAGE);
+    const renewMutation = useRenewApiKey(ctx, subscription.id);
+    const revokeMutation = useRevokeApiKey(ctx, subscription.id);
+    const expireMutation = useExpireApiKey(ctx, subscription.id);
+
+    const handleRevoke = useCallback((keyId: string) => revokeMutation.mutate(keyId), [revokeMutation]);
+    const handleExpireConfirm = useCallback(() => {
+        if (!expiringKeyId || !expireDate) return;
+        expireMutation.mutate(
+            { apiKeyId: expiringKeyId, expireAt: new Date(expireDate + 'T23:59:59').toISOString() },
+            {
+                onSuccess: () => {
+                    setExpiringKeyId(null);
+                    setExpireDate('');
+                },
+            },
+        );
+    }, [expiringKeyId, expireDate, expireMutation]);
+
+    const securityType = subscription.plan.security?.type;
+    const isShared = subscription.application.apiKeyMode === 'SHARED' && securityType === 'API_KEY';
+    const subscriptionAccepted = subscription.status === 'ACCEPTED';
+
+    const totalCount = data?.pagination.totalCount ?? 0;
+
+    if (securityType === 'KEY_LESS') return null;
+    if (securityType === 'OAUTH2' || securityType === 'JWT') {
+        return (
+            <Card>
+                <CardHeader>
+                    <CardTitle className="text-base">Credentials</CardTitle>
+                </CardHeader>
+                <CardContent>
+                    <InfoBanner>OAuth2 / JWT credentials are managed via your application&apos;s security settings.</InfoBanner>
+                </CardContent>
+            </Card>
+        );
+    }
+
+    return (
+        <Card>
+            <CardHeader className="flex flex-row items-center justify-between pb-2">
+                <CardTitle className="text-base">{isShared ? 'Shared API Keys' : 'API Keys'}</CardTitle>
+                {canUpdate && subscriptionAccepted && !isShared && (
+                    <Button
+                        type="button"
+                        variant="outline"
+                        size="sm"
+                        onClick={() => renewMutation.mutate()}
+                        disabled={renewMutation.isPending}
+                    >
+                        <RefreshCwIcon className="size-3.5" aria-hidden />
+                        {renewMutation.isPending ? 'Renewing…' : 'Renew'}
+                    </Button>
+                )}
+            </CardHeader>
+            <CardContent className="space-y-3">
+                {isShared && (
+                    <InfoBanner>This subscription uses a shared API Key. You can renew or revoke it at the application level.</InfoBanner>
+                )}
+
+                {(renewMutation.error || revokeMutation.error || expireMutation.error) && (
+                    <Alert variant="destructive">
+                        <AlertDescription>
+                            {(renewMutation.error ?? revokeMutation.error ?? expireMutation.error)?.message}
+                        </AlertDescription>
+                    </Alert>
+                )}
+
+                <div className="rounded-md border">
+                    <Table>
+                        <TableHeader>
+                            <TableRow>
+                                <TableHead className="w-8" />
+                                <TableHead>Key</TableHead>
+                                <TableHead>Created</TableHead>
+                                <TableHead>Revoked / Expired</TableHead>
+                                <TableHead />
+                            </TableRow>
+                        </TableHeader>
+                        <TableBody>
+                            {isLoading &&
+                                Array.from({ length: 2 }).map((_, i) => (
+                                    <TableRow key={i}>
+                                        {Array.from({ length: 5 }).map((__, j) => (
+                                            <TableCell key={j}>
+                                                <Skeleton className="h-4 w-full rounded" />
+                                            </TableCell>
+                                        ))}
+                                    </TableRow>
+                                ))}
+                            {!isLoading &&
+                                (data?.data ?? []).map(key => (
+                                    <TableRow key={key.id}>
+                                        <TableCell>
+                                            {key.revoked || key.expired ? (
+                                                <CircleXIcon className="size-4 text-muted-foreground" aria-hidden />
+                                            ) : (
+                                                <CircleCheckIcon className="size-4 text-success" aria-hidden />
+                                            )}
+                                        </TableCell>
+                                        <TableCell className="font-mono text-xs max-w-xs truncate">{key.key}</TableCell>
+                                        <TableCell className="text-sm text-muted-foreground">{formatDate(key.createdAt)}</TableCell>
+                                        <TableCell className="text-sm text-muted-foreground">
+                                            {formatDate(key.revokedAt ?? key.expireAt)}
+                                        </TableCell>
+                                        <TableCell>
+                                            <ApiKeyRowActions
+                                                apiKey={key}
+                                                subscriptionAccepted={subscriptionAccepted}
+                                                canUpdate={canUpdate}
+                                                onRevoke={handleRevoke}
+                                                onExpire={id => {
+                                                    setExpiringKeyId(id);
+                                                    setExpireDate('');
+                                                }}
+                                                isRevoking={revokeMutation.isPending}
+                                            />
+                                        </TableCell>
+                                    </TableRow>
+                                ))}
+                        </TableBody>
+                    </Table>
+                </div>
+
+                {expiringKeyId && (
+                    <div className="flex items-center gap-3 rounded-lg border px-4 py-3 text-sm">
+                        <label htmlFor="expire-date" className="shrink-0 text-muted-foreground">
+                            Set expiry date:
+                        </label>
+                        <Input
+                            id="expire-date"
+                            type="date"
+                            className="flex-1"
+                            value={expireDate}
+                            onChange={e => setExpireDate(e.target.value)}
+                        />
+                        <Button type="button" variant="ghost" size="sm" onClick={() => setExpiringKeyId(null)}>
+                            Cancel
+                        </Button>
+                        <Button type="button" size="sm" disabled={!expireDate || expireMutation.isPending} onClick={handleExpireConfirm}>
+                            {expireMutation.isPending ? 'Saving…' : 'Set'}
+                        </Button>
+                    </div>
+                )}
+
+                <DataTablePagination page={page} pageSize={PER_PAGE} totalCount={totalCount} onPageChange={setPage} />
+            </CardContent>
+        </Card>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/pages/api-consumers/subscription-detail/SubscriptionInfoCard.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/pages/api-consumers/subscription-detail/SubscriptionInfoCard.tsx
@@ -1,0 +1,146 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Badge, Card, CardContent, CardHeader, CardTitle, Skeleton } from '@gravitee/graphene-core';
+
+import type { Subscription } from '../../../features/apis/types/subscription';
+import { formatDateTime } from '../../../features/apis/utils/formatDate';
+import { SubscriptionStatusBadge } from '../SubscriptionStatusBadge';
+
+function Row({ label, children }: { label: string; children: React.ReactNode }) {
+    return (
+        <div style={{ display: 'grid', gridTemplateColumns: '180px 1fr', gap: '1rem' }} className="py-2.5 border-b last:border-0">
+            <span className="text-sm text-muted-foreground shrink-0">{label}</span>
+            <span className="text-sm min-w-0 break-words">{children}</span>
+        </div>
+    );
+}
+
+function DateCell({ value }: { value?: string }) {
+    return <span className={value ? undefined : 'text-muted-foreground'}>{formatDateTime(value)}</span>;
+}
+
+interface SubscriptionInfoCardProps {
+    subscription: Subscription;
+    isLoading: boolean;
+}
+
+export function SubscriptionInfoCard({ subscription: sub, isLoading }: Readonly<SubscriptionInfoCardProps>) {
+    if (isLoading) {
+        return (
+            <Card>
+                <CardHeader>
+                    <Skeleton className="h-5 w-40 rounded" />
+                </CardHeader>
+                <CardContent className="space-y-3">
+                    {Array.from({ length: 8 }).map((_, i) => (
+                        <Skeleton key={i} className="h-4 w-full rounded" />
+                    ))}
+                </CardContent>
+            </Card>
+        );
+    }
+
+    const isSharedKey = sub.application.apiKeyMode === 'SHARED' && sub.plan.security?.type === 'API_KEY';
+
+    return (
+        <Card>
+            <CardHeader className="pb-0">
+                <CardTitle className="text-base">Subscription details</CardTitle>
+            </CardHeader>
+            <CardContent className="pt-2">
+                <Row label="ID">
+                    <span className="font-mono text-xs break-all">{sub.id}</span>
+                </Row>
+                <Row label="Plan">
+                    <div className="flex items-center gap-2">
+                        <span>{sub.plan.name}</span>
+                        {sub.plan.security?.type && (
+                            <Badge variant="secondary" className="text-xs">
+                                {sub.plan.security.type}
+                            </Badge>
+                        )}
+                        {isSharedKey && (
+                            <Badge variant="outline" className="text-xs">
+                                Shared
+                            </Badge>
+                        )}
+                    </div>
+                </Row>
+                <Row label="Status">
+                    <SubscriptionStatusBadge status={sub.status} />
+                </Row>
+                {sub.consumerStatus && (
+                    <Row label="Consumer status">
+                        {sub.consumerStatus === 'STARTED' ? (
+                            <Badge className="bg-success/10 text-success border-transparent">Started</Badge>
+                        ) : sub.consumerStatus === 'FAILURE' ? (
+                            <Badge variant="destructive">Failure</Badge>
+                        ) : (
+                            <Badge variant="secondary">Stopped</Badge>
+                        )}
+                    </Row>
+                )}
+                {sub.subscribedBy?.displayName && <Row label="Subscribed by">{sub.subscribedBy.displayName}</Row>}
+                <Row label="Application">
+                    <div>
+                        <p>{sub.application.name}</p>
+                        {sub.application.primaryOwner?.displayName && (
+                            <p className="text-xs text-muted-foreground">{sub.application.primaryOwner.displayName}</p>
+                        )}
+                    </div>
+                </Row>
+                {sub.publisherMessage && <Row label="Publisher message">{sub.publisherMessage}</Row>}
+                {sub.consumerMessage && <Row label="Subscriber message">{sub.consumerMessage}</Row>}
+                <Row label="Created at">
+                    <DateCell value={sub.createdAt} />
+                </Row>
+                <Row label="Updated at">
+                    <DateCell value={sub.updatedAt} />
+                </Row>
+                <Row label="Processed at">
+                    <DateCell value={sub.processedAt} />
+                </Row>
+                <Row label="Starting at">
+                    <DateCell value={sub.startingAt} />
+                </Row>
+                {sub.pausedAt && (
+                    <Row label="Paused at">
+                        <DateCell value={sub.pausedAt} />
+                    </Row>
+                )}
+                <Row label="Ending at">
+                    <DateCell value={sub.endingAt} />
+                </Row>
+                {sub.closedAt && (
+                    <Row label="Closed at">
+                        <DateCell value={sub.closedAt} />
+                    </Row>
+                )}
+                {sub.metadata && Object.keys(sub.metadata).length > 0 && (
+                    <Row label="Metadata">
+                        <div className="space-y-1">
+                            {Object.entries(sub.metadata).map(([k, v]) => (
+                                <p key={k} className="text-xs">
+                                    <span className="font-mono text-muted-foreground">{k}:</span> {v}
+                                </p>
+                            ))}
+                        </div>
+                    </Row>
+                )}
+            </CardContent>
+        </Card>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/pages/api-notifications/AddNotificationDialog.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/pages/api-notifications/AddNotificationDialog.tsx
@@ -1,0 +1,152 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+    Button,
+    Dialog,
+    DialogContent,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+    Input,
+    Label,
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from '@gravitee/graphene-core';
+import { type FormEvent, useCallback, useEffect, useMemo, useState } from 'react';
+
+import type { ApiNotifier } from '../../features/apis/types/notification';
+import { CHANNEL_ICON } from '../../features/apis/utils/notificationFormatters';
+
+// ─── Channel options ──────────────────────────────────────────────────────────
+
+interface ChannelOption {
+    notifierId: string;
+    label: string;
+    type: 'CONSOLE' | 'EMAIL' | 'WEBHOOK';
+}
+
+/** Derives channel options from available notifiers; CONSOLE is always added first. */
+function buildChannelOptions(notifiers: ApiNotifier[]): ChannelOption[] {
+    const options: ChannelOption[] = [{ notifierId: '__PORTAL__', label: 'Console', type: 'CONSOLE' }];
+    for (const n of notifiers) {
+        if (n.type === 'EMAIL') {
+            options.push({ notifierId: n.id, label: n.name || 'Email', type: 'EMAIL' });
+        } else if (n.type === 'WEBHOOK') {
+            options.push({ notifierId: n.id, label: n.name || 'Webhook', type: 'WEBHOOK' });
+        }
+    }
+    return options;
+}
+
+// ─── Props ────────────────────────────────────────────────────────────────────
+
+interface AddNotificationDialogProps {
+    open: boolean;
+    notifiers: ApiNotifier[];
+    isPending: boolean;
+    onClose: () => void;
+    onAdd: (name: string, notifierId: string) => void;
+}
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+export function AddNotificationDialog({ open, notifiers, isPending, onClose, onAdd }: Readonly<AddNotificationDialogProps>) {
+    const [name, setName] = useState('');
+    const [selectedNotifierId, setSelectedNotifierId] = useState('__PORTAL__');
+
+    const channelOptions = useMemo(() => buildChannelOptions(notifiers), [notifiers]);
+
+    // Reset state each time the dialog opens
+    useEffect(() => {
+        if (open) {
+            setName('');
+            setSelectedNotifierId('__PORTAL__');
+        }
+    }, [open]);
+
+    const isValid = name.trim().length > 0;
+
+    const handleSubmit = useCallback(
+        (e: FormEvent) => {
+            e.preventDefault();
+            if (!isValid || isPending) return;
+            onAdd(name.trim(), selectedNotifierId);
+        },
+        [isValid, isPending, onAdd, name, selectedNotifierId],
+    );
+
+    return (
+        <Dialog
+            open={open}
+            onOpenChange={isOpen => {
+                if (!isOpen) onClose();
+            }}
+        >
+            <DialogContent style={{ maxWidth: '28rem' }}>
+                <DialogHeader>
+                    <DialogTitle>Add notification</DialogTitle>
+                </DialogHeader>
+
+                <form onSubmit={handleSubmit} className="space-y-4 pt-2">
+                    <div className="space-y-2">
+                        <Label htmlFor="notif-name">Name</Label>
+                        <Input
+                            id="notif-name"
+                            value={name}
+                            onChange={e => setName(e.target.value)}
+                            placeholder="e.g. Ops webhook"
+                            required
+                        />
+                    </div>
+
+                    <div className="space-y-2">
+                        <Label htmlFor="notif-channel">Channel</Label>
+                        <Select value={selectedNotifierId} onValueChange={setSelectedNotifierId}>
+                            <SelectTrigger id="notif-channel" className="w-full">
+                                <SelectValue />
+                            </SelectTrigger>
+                            <SelectContent>
+                                {channelOptions.map(opt => {
+                                    const Icon = CHANNEL_ICON[opt.type];
+                                    return (
+                                        <SelectItem key={opt.notifierId} value={opt.notifierId}>
+                                            <span className="flex items-center gap-2">
+                                                <Icon className="size-3.5" />
+                                                {opt.label}
+                                            </span>
+                                        </SelectItem>
+                                    );
+                                })}
+                            </SelectContent>
+                        </Select>
+                    </div>
+
+                    <DialogFooter>
+                        <Button type="button" variant="outline" onClick={onClose} disabled={isPending}>
+                            Cancel
+                        </Button>
+                        <Button type="submit" disabled={!isValid || isPending}>
+                            {isPending ? 'Adding…' : 'Add'}
+                        </Button>
+                    </DialogFooter>
+                </form>
+            </DialogContent>
+        </Dialog>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/pages/api-notifications/NotificationEventEditor.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/pages/api-notifications/NotificationEventEditor.tsx
@@ -1,0 +1,191 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Button, Card, CardContent, CardHeader, CardTitle, Checkbox, Input, Label, Separator, Skeleton } from '@gravitee/graphene-core';
+import { Fragment, useCallback, useMemo, useState } from 'react';
+
+import type { HookCategory, NotificationRow } from '../../features/apis/hooks/useApiNotifications';
+
+// ─── Loading skeleton ─────────────────────────────────────────────────────────
+
+function EditorSkeleton() {
+    return (
+        <div className="space-y-4">
+            {[1, 2, 3].map(i => (
+                <div key={i} className="space-y-2">
+                    <Skeleton className="h-4 w-24 rounded" />
+                    <div className="grid grid-cols-2 gap-2">
+                        {[1, 2, 3, 4].map(j => (
+                            <Skeleton key={j} className="h-5 w-full rounded" />
+                        ))}
+                    </div>
+                </div>
+            ))}
+        </div>
+    );
+}
+
+// ─── Category section ─────────────────────────────────────────────────────────
+
+interface CategorySectionProps {
+    category: HookCategory;
+    selected: Set<string>;
+    groupHookIds: Set<string>;
+    onToggle: (hookId: string) => void;
+    readonly: boolean;
+}
+
+function CategorySection({ category, selected, groupHookIds, onToggle, readonly }: Readonly<CategorySectionProps>) {
+    return (
+        <div className="space-y-2">
+            <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wide">{category.name}</p>
+            <div className="grid grid-cols-2 gap-1.5">
+                {category.hooks.map(hook => {
+                    const isGroupHook = groupHookIds.has(hook.id);
+                    const isDisabled = readonly || isGroupHook;
+                    return (
+                        <label
+                            key={hook.id}
+                            className="flex items-start gap-2 rounded-md p-2 transition-colors"
+                            style={isDisabled ? { opacity: 0.6 } : { cursor: 'pointer' }}
+                        >
+                            <Checkbox
+                                checked={selected.has(hook.id)}
+                                onCheckedChange={() => !isDisabled && onToggle(hook.id)}
+                                disabled={isDisabled}
+                                className="mt-0.5 shrink-0"
+                            />
+                            <div className="min-w-0">
+                                <p className="text-sm font-medium leading-snug">{hook.label}</p>
+                                {hook.description ? <p className="text-xs text-muted-foreground">{hook.description}</p> : null}
+                            </div>
+                        </label>
+                    );
+                })}
+            </div>
+        </div>
+    );
+}
+
+// ─── Props ────────────────────────────────────────────────────────────────────
+
+interface NotificationEventEditorProps {
+    row: NotificationRow;
+    hookCategories: HookCategory[];
+    isLoadingHooks: boolean;
+    isPending: boolean;
+    onSave: (hooks: string[], config: string) => void;
+    onCancel: () => void;
+}
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+export function NotificationEventEditor({
+    row,
+    hookCategories,
+    isLoadingHooks,
+    isPending,
+    onSave,
+    onCancel,
+}: Readonly<NotificationEventEditorProps>) {
+    const groupHookIds = useMemo(() => new Set(row.notification.groupHooks ?? []), [row.notification.groupHooks]);
+
+    // Initial state only — parent passes key={row.key} so component remounts on row change
+    const [selectedHooks, setSelectedHooks] = useState<Set<string>>(
+        new Set([...(row.notification.hooks ?? []), ...(row.notification.groupHooks ?? [])]),
+    );
+    const [config, setConfig] = useState(row.notification.config ?? '');
+
+    const needsTarget = row.channel === 'EMAIL' || row.channel === 'WEBHOOK';
+    const targetLabel = row.channel === 'EMAIL' ? 'Email address(es)' : 'Webhook URL';
+    const targetPlaceholder = row.channel === 'EMAIL' ? 'e.g. user@example.com' : 'e.g. https://hooks.example.com/notify';
+
+    const toggleHook = useCallback((hookId: string) => {
+        setSelectedHooks(prev => {
+            const next = new Set(prev);
+            if (next.has(hookId)) next.delete(hookId);
+            else next.add(hookId);
+            return next;
+        });
+    }, []);
+
+    const handleSave = useCallback(() => {
+        // Strip groupHooks before saving — they are not user-owned
+        const userHooks = [...selectedHooks].filter(h => !groupHookIds.has(h));
+        onSave(userHooks, config);
+    }, [onSave, selectedHooks, groupHookIds, config]);
+
+    const isReadonly = row.isReadonly;
+
+    return (
+        <Card style={{ border: '2px solid color-mix(in oklab, var(--color-primary) 25%, transparent)' }}>
+            <CardHeader className="pb-2">
+                <CardTitle className="text-sm">
+                    Edit events — <span className="font-normal text-muted-foreground">{row.notification.name}</span>
+                </CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-5">
+                {/* Target field (email / webhook) */}
+                {needsTarget && (
+                    <>
+                        <div className="space-y-2">
+                            <Label htmlFor="editor-target">{targetLabel}</Label>
+                            <Input
+                                id="editor-target"
+                                value={config}
+                                onChange={e => setConfig(e.target.value)}
+                                placeholder={targetPlaceholder}
+                                disabled={isReadonly || isPending}
+                            />
+                        </div>
+                        <Separator />
+                    </>
+                )}
+
+                {/* Event checkboxes */}
+                {isLoadingHooks ? (
+                    <EditorSkeleton />
+                ) : (
+                    <div className="space-y-4">
+                        {hookCategories.map((cat, idx) => (
+                            <Fragment key={cat.name}>
+                                {idx > 0 && <Separator />}
+                                <CategorySection
+                                    category={cat}
+                                    selected={selectedHooks}
+                                    groupHookIds={groupHookIds}
+                                    onToggle={toggleHook}
+                                    readonly={isReadonly}
+                                />
+                            </Fragment>
+                        ))}
+                    </div>
+                )}
+
+                {/* Actions */}
+                <div className="flex items-center justify-end gap-3 pt-2">
+                    <Button type="button" variant="outline" size="sm" onClick={onCancel} disabled={!isReadonly && isPending}>
+                        {isReadonly ? 'Close' : 'Cancel'}
+                    </Button>
+                    {!isReadonly && (
+                        <Button type="button" size="sm" onClick={handleSave} disabled={isPending || isLoadingHooks}>
+                            {isPending ? 'Saving…' : 'Save events'}
+                        </Button>
+                    )}
+                </div>
+            </CardContent>
+        </Card>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/pages/api-notifications/NotificationsEmptyState.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/pages/api-notifications/NotificationsEmptyState.tsx
@@ -1,0 +1,114 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Card, CardContent } from '@gravitee/graphene-core';
+import {
+    ActivityIcon,
+    ArrowRightIcon,
+    BellIcon,
+    CircleCheckIcon,
+    MailIcon,
+    MessageSquareIcon,
+    WebhookIcon,
+} from '@gravitee/graphene-core/icons';
+import type { ComponentType } from 'react';
+
+// ─── Flow diagram (reuses Alerts empty-state pattern) ─────────────────────────
+
+function FlowNode({
+    icon: Icon,
+    label,
+    active = false,
+}: Readonly<{ icon: ComponentType<{ className?: string }>; label: string; active?: boolean }>) {
+    return (
+        <div
+            className="flex flex-col items-center gap-1.5"
+            style={active ? { border: '1px solid var(--color-border)', borderRadius: '0.5rem', padding: '0.5rem 0.75rem' } : undefined}
+        >
+            <div
+                className="rounded-lg p-2"
+                style={{ backgroundColor: active ? 'color-mix(in oklab, var(--color-primary) 10%, transparent)' : 'var(--color-muted)' }}
+            >
+                <Icon className={active ? 'size-4 text-primary' : 'size-4 text-muted-foreground'} />
+            </div>
+            <p className={active ? 'text-xs font-semibold text-center' : 'text-xs text-muted-foreground text-center'}>{label}</p>
+        </div>
+    );
+}
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+const BENEFITS = [
+    'Alert on deployments, subscription requests, or policy errors',
+    'Route to multiple channels — console, email, or webhooks',
+    'Filter by event type to reduce alert fatigue',
+] as const;
+
+export function NotificationsEmptyState() {
+    return (
+        <Card>
+            <CardContent className="p-6 space-y-6">
+                <div className="space-y-1">
+                    <p className="text-sm font-semibold">Why configure notifications?</p>
+                    <p className="text-sm text-muted-foreground">
+                        Get alerted when key API events happen — deployments, subscription requests, policy violations — without polling the
+                        dashboard.
+                    </p>
+                </div>
+
+                {/* How it works flow */}
+                <div
+                    className="rounded-xl p-5 space-y-3"
+                    style={{
+                        border: '2px solid color-mix(in oklab, var(--color-primary) 20%, transparent)',
+                        backgroundColor: 'color-mix(in oklab, var(--color-primary) 4%, transparent)',
+                    }}
+                >
+                    <p className="text-xs font-semibold text-primary">How it works</p>
+                    <div className="flex items-center justify-center gap-3">
+                        <FlowNode icon={ActivityIcon} label="API Event" />
+                        <ArrowRightIcon className="size-4 shrink-0 text-muted-foreground" aria-hidden="true" />
+                        <FlowNode icon={BellIcon} label="Notification rule" active />
+                        <ArrowRightIcon className="size-4 shrink-0 text-muted-foreground" aria-hidden="true" />
+                        <div className="flex flex-col items-center gap-1.5">
+                            <div className="flex gap-1.5">
+                                <div className="rounded-lg bg-muted p-1.5">
+                                    <MailIcon className="size-3 text-muted-foreground" />
+                                </div>
+                                <div className="rounded-lg bg-muted p-1.5">
+                                    <MessageSquareIcon className="size-3 text-muted-foreground" />
+                                </div>
+                                <div className="rounded-lg bg-muted p-1.5">
+                                    <WebhookIcon className="size-3 text-muted-foreground" />
+                                </div>
+                            </div>
+                            <p className="text-xs text-muted-foreground">Email · Console · Webhook</p>
+                        </div>
+                    </div>
+                </div>
+
+                {/* Benefits list */}
+                <ul className="space-y-2">
+                    {BENEFITS.map(b => (
+                        <li key={b} className="flex items-start gap-2">
+                            <CircleCheckIcon className="size-3.5 shrink-0 mt-0.5 text-success" aria-hidden="true" />
+                            <span className="text-xs text-muted-foreground">{b}</span>
+                        </li>
+                    ))}
+                </ul>
+            </CardContent>
+        </Card>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/pages/api-notifications/NotificationsSummaryCards.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/pages/api-notifications/NotificationsSummaryCards.tsx
@@ -1,0 +1,82 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Card, CardContent, Skeleton } from '@gravitee/graphene-core';
+
+import type { NotificationChannel, NotificationRow } from '../../features/apis/hooks/useApiNotifications';
+import { CHANNEL_ICON } from '../../features/apis/utils/notificationFormatters';
+
+// ─── Colour tokens for each channel (inline to stay MF-safe) ─────────────────
+
+const CHANNEL_CONFIG: Record<NotificationChannel, { label: string; iconBg: string; iconCls: string }> = {
+    CONSOLE: {
+        label: 'Console notifiers',
+        iconBg: 'color-mix(in oklab, var(--color-primary) 10%, transparent)',
+        iconCls: 'size-5 text-primary',
+    },
+    EMAIL: {
+        label: 'Email notifiers',
+        iconBg: 'color-mix(in oklab, var(--color-success) 10%, transparent)',
+        iconCls: 'size-5 text-success',
+    },
+    WEBHOOK: {
+        label: 'Webhook notifiers',
+        iconBg: 'color-mix(in oklab, var(--color-warning) 10%, transparent)',
+        iconCls: 'size-5 text-warning',
+    },
+};
+
+function SummaryCard({ channel, count, isLoading }: Readonly<{ channel: NotificationChannel; count: number; isLoading: boolean }>) {
+    const { label, iconBg, iconCls } = CHANNEL_CONFIG[channel];
+    const Icon = CHANNEL_ICON[channel];
+    return (
+        <Card className="flex-1">
+            <CardContent className="p-5">
+                <div className="flex items-center gap-3">
+                    <div className="flex size-10 shrink-0 items-center justify-center rounded-lg" style={{ backgroundColor: iconBg }}>
+                        <Icon className={iconCls} />
+                    </div>
+                    <div>
+                        {isLoading ? (
+                            <Skeleton className="h-7 w-10 rounded" />
+                        ) : (
+                            <p className="text-2xl font-semibold tracking-tight">{count}</p>
+                        )}
+                        <p className="text-xs text-muted-foreground">{label}</p>
+                    </div>
+                </div>
+            </CardContent>
+        </Card>
+    );
+}
+
+interface NotificationsSummaryCardsProps {
+    rows: NotificationRow[];
+    isLoading: boolean;
+}
+
+export function NotificationsSummaryCards({ rows, isLoading }: Readonly<NotificationsSummaryCardsProps>) {
+    const consoleCount = rows.filter(r => r.channel === 'CONSOLE').length;
+    const emailCount = rows.filter(r => r.channel === 'EMAIL').length;
+    const webhookCount = rows.filter(r => r.channel === 'WEBHOOK').length;
+
+    return (
+        <div className="flex gap-4">
+            <SummaryCard channel="CONSOLE" count={consoleCount} isLoading={isLoading} />
+            <SummaryCard channel="EMAIL" count={emailCount} isLoading={isLoading} />
+            <SummaryCard channel="WEBHOOK" count={webhookCount} isLoading={isLoading} />
+        </div>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/pages/api-notifications/NotificationsTable.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/pages/api-notifications/NotificationsTable.tsx
@@ -1,0 +1,216 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+    Badge,
+    Button,
+    Card,
+    CardContent,
+    CardHeader,
+    CardTitle,
+    DropdownMenu,
+    DropdownMenuContent,
+    DropdownMenuItem,
+    DropdownMenuSeparator,
+    DropdownMenuTrigger,
+    Skeleton,
+    Table,
+    TableBody,
+    TableCell,
+    TableHead,
+    TableHeader,
+    TableRow,
+} from '@gravitee/graphene-core';
+import { MoreHorizontalIcon, PencilIcon, Trash2Icon } from '@gravitee/graphene-core/icons';
+import { useCallback } from 'react';
+
+import type { NotificationChannel, NotificationRow } from '../../features/apis/hooks/useApiNotifications';
+import { CHANNEL_ICON, CHANNEL_LABEL } from '../../features/apis/utils/notificationFormatters';
+
+// ─── Channel badge ────────────────────────────────────────────────────────────
+
+function ChannelBadge({ channel }: Readonly<{ channel: NotificationChannel }>) {
+    const Icon = CHANNEL_ICON[channel];
+    return (
+        <Badge variant="outline" className="gap-1">
+            <Icon className="size-3" />
+            {CHANNEL_LABEL[channel]}
+        </Badge>
+    );
+}
+
+// ─── Event count badge ────────────────────────────────────────────────────────
+
+function EventCountBadge({ count }: Readonly<{ count: number }>) {
+    if (count === 0) return <span className="text-xs text-muted-foreground italic">None</span>;
+    return (
+        <Badge variant="secondary" className="text-xs">
+            {count} event{count !== 1 ? 's' : ''}
+        </Badge>
+    );
+}
+
+// ─── Loading rows ─────────────────────────────────────────────────────────────
+
+function LoadingRows({ hasActionsColumn }: Readonly<{ hasActionsColumn: boolean }>) {
+    return (
+        <>
+            {[1, 2, 3].map(i => (
+                <TableRow key={i}>
+                    <TableCell>
+                        <Skeleton className="h-4 w-36 rounded" />
+                    </TableCell>
+                    <TableCell>
+                        <Skeleton className="h-5 w-20 rounded-full" />
+                    </TableCell>
+                    <TableCell>
+                        <Skeleton className="h-5 w-16 rounded-full" />
+                    </TableCell>
+                    <TableCell>
+                        <Skeleton className="h-4 w-48 rounded" />
+                    </TableCell>
+                    {hasActionsColumn && <TableCell />}
+                </TableRow>
+            ))}
+        </>
+    );
+}
+
+// ─── Main component ───────────────────────────────────────────────────────────
+
+interface NotificationsTableProps {
+    rows: NotificationRow[];
+    isLoading: boolean;
+    editingKey: string | null;
+    canUpdate: boolean;
+    canDelete: boolean;
+    onEdit: (key: string) => void;
+    onDelete: (row: NotificationRow) => void;
+}
+
+export function NotificationsTable({
+    rows,
+    isLoading,
+    editingKey,
+    canUpdate,
+    canDelete,
+    onEdit,
+    onDelete,
+}: Readonly<NotificationsTableProps>) {
+    const hasActionsColumn = canUpdate || canDelete;
+    const rowHasActions = useCallback(
+        (row: NotificationRow) => (canUpdate && !row.isReadonly) || (canDelete && row.canDelete),
+        [canUpdate, canDelete],
+    );
+    return (
+        <Card>
+            <CardHeader className="pb-0">
+                <CardTitle className="text-base">Configured notifications</CardTitle>
+            </CardHeader>
+            <CardContent className="p-0 pt-2">
+                <Table>
+                    <TableHeader>
+                        <TableRow>
+                            <TableHead>Name</TableHead>
+                            <TableHead>Channel</TableHead>
+                            <TableHead>Events</TableHead>
+                            <TableHead>Target</TableHead>
+                            {hasActionsColumn && <TableHead className="w-12" />}
+                        </TableRow>
+                    </TableHeader>
+                    <TableBody>
+                        {isLoading ? (
+                            <LoadingRows hasActionsColumn={hasActionsColumn} />
+                        ) : (
+                            rows.map(row => (
+                                <TableRow
+                                    key={row.key}
+                                    style={
+                                        editingKey === row.key
+                                            ? { backgroundColor: 'color-mix(in oklab, var(--color-accent) 30%, transparent)' }
+                                            : undefined
+                                    }
+                                >
+                                    <TableCell className="font-medium">{row.notification.name}</TableCell>
+                                    <TableCell>
+                                        <ChannelBadge channel={row.channel} />
+                                    </TableCell>
+                                    <TableCell>
+                                        <EventCountBadge
+                                            count={row.notification.hooks.length + (row.notification.groupHooks?.length ?? 0)}
+                                        />
+                                    </TableCell>
+                                    <TableCell>
+                                        <span
+                                            className="text-xs text-muted-foreground font-mono"
+                                            style={{
+                                                overflow: 'hidden',
+                                                textOverflow: 'ellipsis',
+                                                whiteSpace: 'nowrap',
+                                                display: 'block',
+                                                maxWidth: '18rem',
+                                            }}
+                                        >
+                                            {row.notification.config ?? '—'}
+                                        </span>
+                                    </TableCell>
+                                    {hasActionsColumn && (
+                                        <TableCell onClick={e => e.stopPropagation()}>
+                                            {rowHasActions(row) && (
+                                                <DropdownMenu>
+                                                    <DropdownMenuTrigger asChild>
+                                                        <Button
+                                                            type="button"
+                                                            variant="ghost"
+                                                            size="icon"
+                                                            className="size-8"
+                                                            aria-label={`Actions for ${row.notification.name}`}
+                                                        >
+                                                            <MoreHorizontalIcon className="size-4" />
+                                                        </Button>
+                                                    </DropdownMenuTrigger>
+                                                    <DropdownMenuContent align="end">
+                                                        {canUpdate && !row.isReadonly && (
+                                                            <DropdownMenuItem onSelect={() => onEdit(row.key)}>
+                                                                <PencilIcon className="size-4" />
+                                                                Edit events
+                                                            </DropdownMenuItem>
+                                                        )}
+                                                        {canDelete && row.canDelete && (
+                                                            <>
+                                                                {canUpdate && !row.isReadonly && <DropdownMenuSeparator />}
+                                                                <DropdownMenuItem
+                                                                    onSelect={() => onDelete(row)}
+                                                                    className="text-destructive focus:text-destructive"
+                                                                >
+                                                                    <Trash2Icon className="size-4" />
+                                                                    Delete
+                                                                </DropdownMenuItem>
+                                                            </>
+                                                        )}
+                                                    </DropdownMenuContent>
+                                                </DropdownMenu>
+                                            )}
+                                        </TableCell>
+                                    )}
+                                </TableRow>
+                            ))
+                        )}
+                    </TableBody>
+                </Table>
+            </CardContent>
+        </Card>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/services/apis/broadcasts.ts
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/services/apis/broadcasts.ts
@@ -1,0 +1,30 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import type { ApplicationRole, BroadcastPayload } from '../../features/apis/types/broadcast';
+import { apimFetchJsonOrg, apimFetchJsonV1Env } from '../../shared/api/apimClient';
+
+/** Fetch APPLICATION-scoped roles — used to build the recipients dropdown. */
+export async function listApplicationRoles(): Promise<ApplicationRole[]> {
+    return apimFetchJsonOrg<ApplicationRole[]>('/configuration/rolescopes/APPLICATION/roles');
+}
+
+/** POST a broadcast message to all API consumers. Returns the number of recipients reached. */
+export async function sendBroadcast(envId: string, apiId: string, payload: BroadcastPayload): Promise<number> {
+    return apimFetchJsonV1Env<number>(envId, `/apis/${encodeURIComponent(apiId)}/messages`, {
+        method: 'POST',
+        body: JSON.stringify(payload),
+    });
+}

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/services/apis/notifications.ts
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/services/apis/notifications.ts
@@ -1,0 +1,68 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import type {
+    ApiHook,
+    ApiNotifier,
+    CreateNotificationPayload,
+    NotificationSettings,
+    UpdateNotificationPayload,
+} from '../../features/apis/types/notification';
+import { apimFetchJsonV1Env } from '../../shared/api/apimClient';
+
+const apiPath = (apiId: string) => `/apis/${encodeURIComponent(apiId)}`;
+
+export async function listNotifications(envId: string, apiId: string): Promise<NotificationSettings[]> {
+    return apimFetchJsonV1Env<NotificationSettings[]>(envId, `${apiPath(apiId)}/notificationsettings`);
+}
+
+export async function listNotifiers(envId: string, apiId: string): Promise<ApiNotifier[]> {
+    return apimFetchJsonV1Env<ApiNotifier[]>(envId, `${apiPath(apiId)}/notifiers`);
+}
+
+/** Global hook catalog — same for every API in the env. */
+export async function listHooks(envId: string): Promise<ApiHook[]> {
+    return apimFetchJsonV1Env<ApiHook[]>(envId, '/apis/hooks');
+}
+
+export async function createNotification(envId: string, apiId: string, payload: CreateNotificationPayload): Promise<NotificationSettings> {
+    return apimFetchJsonV1Env<NotificationSettings>(envId, `${apiPath(apiId)}/notificationsettings`, {
+        method: 'POST',
+        body: JSON.stringify(payload),
+    });
+}
+
+/**
+ * Update a notification. PORTAL notification has no id and uses the bare
+ * collection URL (classic console behaviour).
+ */
+export async function updateNotification(
+    envId: string,
+    apiId: string,
+    notification: UpdateNotificationPayload,
+): Promise<NotificationSettings> {
+    const isPortal = notification.config_type === 'PORTAL';
+    const suffix = isPortal ? '/' : `/${encodeURIComponent(notification.id!)}`;
+    return apimFetchJsonV1Env<NotificationSettings>(envId, `${apiPath(apiId)}/notificationsettings${suffix}`, {
+        method: 'PUT',
+        body: JSON.stringify(notification),
+    });
+}
+
+export async function deleteNotification(envId: string, apiId: string, notificationId: string): Promise<void> {
+    await apimFetchJsonV1Env<void>(envId, `${apiPath(apiId)}/notificationsettings/${encodeURIComponent(notificationId)}`, {
+        method: 'DELETE',
+    });
+}

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/shared/api/apimClient.ts
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/shared/api/apimClient.ts
@@ -58,6 +58,9 @@ export class ApimApiError extends Error {
 async function doFetch<T>(url: string, path: string, init?: RequestInit): Promise<T> {
     const headers = new Headers(init?.headers);
     headers.set('X-Requested-With', 'XMLHttpRequest');
+    if (init?.body !== undefined && init.body !== null) {
+        headers.set('Content-Type', 'application/json');
+    }
     const csrf = localStorage.getItem('XSRF-TOKEN');
     if (csrf) headers.set('X-Xsrf-Token', csrf);
 


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/GMA-227

## Description

## Summary

- Introduces a `SubscriptionContext` discriminated union (`{ type: 'api' | 'api-product'; entityId: string }`) to share all consumer/subscription UI logic between APIs and API Products
- Rewrites `ApiConsumersPage` and `ApiConsumerDetailPage` as thin adapters; extracts shared `ConsumersPage` and `ConsumerDetailPage` components
- Adds `ApiProductConsumersPage` and `ApiProductConsumerDetailPage` wired into the API Product sidebar navigation
- Adds API notifications management page and broadcast page
- Fixes expiry date timezone bug (now uses local end-of-day `T23:59:59`)
- Fixes date format to `DD MMM YYYY HH:MM:SS` using locale-independent construction
- Fixes summary cards loading state to OR all query loading flags
- Fixes `ApiBroadcastsPage.spec.tsx` and `ApiPropertiesPage.spec.tsx` flaky tests by replacing `userEvent.type` with `fireEvent.change` for controlled inputs

## Test plan

- [ ] API consumers list renders and filters correctly
- [ ] API Product consumers list renders with correct permission guards
- [ ] Subscription detail actions (pause, resume, close, transfer) work for both API and API Product
- [ ] API Key renew/revoke/expire work correctly; expiry date is saved as local end-of-day

https://github.com/user-attachments/assets/a67c1110-6129-4097-be5b-17f75ea6f6e7



https://github.com/user-attachments/assets/f515f911-b4c3-4d10-b08f-751037630ff8




## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

