### PR TITLE
fix: remove invalid invitation search SQL escape clause

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcInvitationRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcInvitationRepository.java
@@ -162,7 +162,7 @@ public class JdbcInvitationRepository extends JdbcAbstractCrudRepository<Invitat
                 clauses.add("reference_type = ?");
             }
             if (StringUtils.hasText(criteria.email())) {
-                clauses.add("lower(email) like ? escape '\\'");
+                clauses.add("lower(email) like ?");
             }
         }
 
@@ -184,12 +184,8 @@ public class JdbcInvitationRepository extends JdbcAbstractCrudRepository<Invitat
             ps.setString(index++, criteria.referenceType().name());
         }
         if (StringUtils.hasText(criteria.email())) {
-            ps.setString(index, "%" + escapeLike(criteria.email().toLowerCase(Locale.ROOT)) + "%");
+            ps.setString(index, "%" + criteria.email().toLowerCase(Locale.ROOT) + "%");
         }
-    }
-
-    private String escapeLike(String value) {
-        return value.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_");
     }
 
     private void applySortable(Sortable sortable, StringBuilder query) {


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-14102

## Description

https://app.circleci.com/pipelines/github/gravitee-io/gravitee-api-management/81400/workflows/5a1f4679-0187-4b47-8594-325e2087bf94/jobs/1710695/tests#failed-test-0


fix for mariadb and mysql8  regarding 

```
Caused by: org.springframework.jdbc.BadSqlGrammarException: PreparedStatementCallback; bad SQL grammar [select * from `test_gio_invitations` where reference_id = ? and reference_type = ? and lower(email) like ? escape '\' order by case when email is null then 1 else 0 end, lower(email) desc ]

```


