### PR TITLE
fix(repository-jdbc): scope ratelimit PK rebuild precondition per DBMS (APIM-14096)

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v1_25_2/schema.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v1_25_2/schema.yml
@@ -67,13 +67,16 @@ databaseChangeLog:
                     MODIFY COLUMN `key` NVARCHAR(128) NOT NULL,
                     ADD CONSTRAINT pk_${gravitee_rate_limit_prefix}ratelimit PRIMARY KEY (`key`);
 
-    # Same MARK_RAN guard as the MySQL changeset above. Postgres, MSSQL, and H2
-    # all report character_maximum_length in characters (not bytes), so a
-    # single sqlCheck applies cleanly across the !mysql,!mariadb family.
+    # Same MARK_RAN guard as the MySQL changeset above. The sqlCheck MUST filter
+    # by current schema, otherwise multi-schema deployments where
+    # `${gravitee_rate_limit_prefix}ratelimit.key` is visible in >1 schema return
+    # multiple rows and Liquibase aborts with "Result set larger than one row",
+    # leaving mapi/gateway in a permanent crash loop. The current-schema function
+    # differs per DBMS, so the changeset is split into one per engine.
     - changeSet:
-        id: 1.25.2-rebuild-key-pk-other
+        id: 1.25.2-rebuild-key-pk-postgresql
         author: GraviteeSource Team
-        dbms: '!mysql, !mariadb'
+        dbms: postgresql
         preConditions:
         - onFail: MARK_RAN
         - sqlCheck:
@@ -81,7 +84,35 @@ databaseChangeLog:
             sql: |
                 SELECT character_maximum_length
                 FROM information_schema.columns
-                WHERE table_name = '${gravitee_rate_limit_prefix}ratelimit'
+                WHERE table_schema = CURRENT_SCHEMA()
+                  AND table_name = '${gravitee_rate_limit_prefix}ratelimit'
+                  AND column_name = 'key'
+        changes:
+        - dropPrimaryKey:
+            constraintName: pk_${gravitee_rate_limit_prefix}ratelimit
+            tableName: ${gravitee_rate_limit_prefix}ratelimit
+        - modifyDataType:
+            tableName: ${gravitee_rate_limit_prefix}ratelimit
+            columnName: key
+            newDataType: varchar(128)
+        - addPrimaryKey:
+             constraintName: pk_${gravitee_rate_limit_prefix}ratelimit
+             columnNames: key
+             tableName: ${gravitee_rate_limit_prefix}ratelimit
+
+    - changeSet:
+        id: 1.25.2-rebuild-key-pk-mssql
+        author: GraviteeSource Team
+        dbms: mssql
+        preConditions:
+        - onFail: MARK_RAN
+        - sqlCheck:
+            expectedResult: 64
+            sql: |
+                SELECT character_maximum_length
+                FROM information_schema.columns
+                WHERE table_schema = SCHEMA_NAME()
+                  AND table_name = '${gravitee_rate_limit_prefix}ratelimit'
                   AND column_name = 'key'
         changes:
         - dropPrimaryKey:


### PR DESCRIPTION
Fixes [APIM-14096](https://gravitee.atlassian.net/browse/APIM-14096).

## What

Liquibase changeset `1.25.2-rebuild-key-pk-other` in `gravitee-apim-repository-jdbc` runs a schema-blind `sqlCheck` against `information_schema.columns`. On Postgres/MSSQL/H2 deployments where the JDBC user can see `ratelimit.key` in more than one schema (multi-tenant shared DBs), the precondition query returns N rows and Liquibase aborts with `Result set larger than one row`. mapi + gateway then enter a permanent crash loop. The MySQL sibling changeset already filters by `(SELECT DATABASE())`; that guard was never ported to the `-other` variant.

Bug was introduced by #11401 in 4.11.6 / 4.12.0.

## How

Replace the single `1.25.2-rebuild-key-pk-other` (`dbms: '!mysql, !mariadb'`) with three per-DBMS changesets, each filtering by the engine's current-schema function:

- `1.25.2-rebuild-key-pk-postgresql` → `table_schema = CURRENT_SCHEMA()`
- `1.25.2-rebuild-key-pk-mssql` → `table_schema = SCHEMA_NAME()`
- `1.25.2-rebuild-key-pk-h2` → `table_schema = SCHEMA()`

Same `expectedResult: 64` / `onFail: MARK_RAN` guard preserved, same DDL body. `dbms:` attribute keeps Liquibase from running cross-engine variants.

## Upgrade behavior

- Fresh deploys: new changeset runs cleanly.
- Healthy single-schema deploys (already at `varchar(128)`): `expectedResult` mismatches → MARK_RAN, no DDL.
- Broken multi-schema deploys (stuck in crash loop, no `DATABASECHANGELOG` row): new changeset runs, widens `current_schema.ratelimit.key` to 128, rebuilds PK. Auto-recovery, no manual intervention.

## Verification

Postgres, empirical:
- Recreate `gravitee_resolve_14096`, pre-seed `tenant1.ratelimit` + `tenant2.ratelimit` with `key varchar(64)`. Without this fix: 36 `MigrationFailedException` retry loops, no changelog row, permanent crash.
- With the fix: `1.25.2-rebuild-key-pk-postgresql` runs cleanly, mapi reaches `Started APIM REST API`, `public.ratelimit.key` widened to 128, `tenant1`/`tenant2` untouched. Restart on migrated DB: clean, 0 failures.

MSSQL / H2 not run locally (no envs). SQL is documented standard for each engine; pattern mirrors the verified MySQL sibling.

## Out of scope

DataSource leak on Liquibase failure (companion ticket).

[APIM-14096]: https://gravitee.atlassian.net/browse/APIM-14096?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ