### PR TITLE
fix: shared API key renewal now syncs to gateway

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiKeyServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiKeyServiceImpl.java
@@ -194,7 +194,7 @@ public class ApiKeyServiceImpl extends TransactionalService implements ApiKeySer
         try {
             LOGGER.debug("Renew API Key for application {}", application.getId());
 
-            ApiKey newApiKey = generateForApplication(application);
+            ApiKey newApiKey = generateForApplication(application, executionContext.getEnvironmentId());
             newApiKey = apiKeyRepository.create(newApiKey);
 
             // Expire previously generated keys
@@ -313,9 +313,8 @@ public class ApiKeyServiceImpl extends TransactionalService implements ApiKeySer
             throw new SubscriptionClosedException(subscription.getId());
         }
 
-        ApiKey apiKey = generateForApplication(subscription.getApplication(), customApiKey);
+        ApiKey apiKey = generateForApplication(subscription.getApplication(), customApiKey, executionContext.getEnvironmentId());
         apiKey.setSubscriptions(List.of(subscription.getId()));
-        apiKey.setEnvironmentId(executionContext.getEnvironmentId());
 
         // By default, the API Key will expire when subscription is closed
         apiKey.setExpireAt(subscription.getEndingAt());
@@ -327,10 +326,11 @@ public class ApiKeyServiceImpl extends TransactionalService implements ApiKeySer
      * Generate an {@link ApiKey} for an application. Generates a new random key value.
      *
      * @param application
+     * @param environmentId
      * @return An API Key
      */
-    private ApiKey generateForApplication(ApplicationEntity application) {
-        return generateForApplication(application.getId(), null);
+    private ApiKey generateForApplication(ApplicationEntity application, String environmentId) {
+        return generateForApplication(application.getId(), null, environmentId);
     }
 
     /**
@@ -338,13 +338,14 @@ public class ApiKeyServiceImpl extends TransactionalService implements ApiKeySer
      *
      * @param application
      * @param customApiKey
+     * @param environmentId
      * @return An API Key
      */
-    private ApiKey generateForApplication(String application, String customApiKey) {
+    private ApiKey generateForApplication(String application, String customApiKey, String environmentId) {
         ApiKey apiKey = new ApiKey();
         apiKey.setId(UuidString.generateRandom());
         apiKey.setApplication(application);
-        apiKey.setEnvironmentId(apiKey.getEnvironmentId());
+        apiKey.setEnvironmentId(environmentId);
         apiKey.setCreatedAt(new Date());
         apiKey.setUpdatedAt(apiKey.getCreatedAt());
         apiKey.setKey(isNotEmpty(customApiKey) ? customApiKey : apiKeyGenerator.generate());

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiKeyServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiKeyServiceTest.java
@@ -1083,6 +1083,8 @@ public class ApiKeyServiceTest {
 
         apiKeyService.renew(GraviteeContext.getExecutionContext(), application);
 
+        verify(apiKeyRepository, times(1)).create(argThat(apiKey -> ENVIRONMENT_ID.equals(apiKey.getEnvironmentId())));
+
         // 3 old keys have been expired, but not the new one
         verify(apiKeyRepository, times(1)).update(argThat(apiKey -> apiKey.getId().equals("apiKey-2") && apiKey.getExpireAt() != null));
         verify(apiKeyRepository, times(1)).update(argThat(apiKey -> apiKey.getId().equals("apiKey-3") && apiKey.getExpireAt() != null));


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-14094

## Description

Shared-mode renewals were persisted without environmentId, so the gateway sync filter excluded them and every request with the new key returned 401.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

