### PR TITLE
ci: adapt pr workflow for gamma apim

### DIFF
--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-gateway-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-gateway-only.yml
@@ -332,6 +332,7 @@ workflows:
       - job-validate-workflow-status:
           name: Validate workflow status
           requires:
+            - Build backend
             - Test gateway
             - Integration tests
 orbs:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-integration-tests-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-integration-tests-only.yml
@@ -250,6 +250,7 @@ workflows:
       - job-validate-workflow-status:
           name: Validate workflow status
           requires:
+            - Build backend
             - Integration tests
 orbs:
   keeper: gravitee-io/keeper@0.7.0

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-only.yml
@@ -562,6 +562,7 @@ workflows:
       - job-validate-workflow-status:
           name: Validate workflow status
           requires:
+            - Build backend
             - Test definition
             - Test gateway
             - Test rest-api

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-plugin-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-plugin-only.yml
@@ -333,6 +333,7 @@ workflows:
       - job-validate-workflow-status:
           name: Validate workflow status
           requires:
+            - Build backend
             - Integration tests
             - Test plugins
 orbs:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-reporter-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-reporter-only.yml
@@ -333,6 +333,7 @@ workflows:
       - job-validate-workflow-status:
           name: Validate workflow status
           requires:
+            - Build backend
             - Integration tests
             - Test reporters
 orbs:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-rest-api-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-rest-api-only.yml
@@ -280,6 +280,7 @@ workflows:
       - job-validate-workflow-status:
           name: Validate workflow status
           requires:
+            - Build backend
             - Test rest-api
 orbs:
   keeper: gravitee-io/keeper@0.7.0

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-gamma-console-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-gamma-console-only.yml
@@ -309,6 +309,7 @@ workflows:
       - job-validate-workflow-status:
           name: Validate workflow status
           requires:
+            - Build backend
             - Check prettier formatting for nx projects
             - Lint & test Gamma Console
             - Build Gamma Console

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch.yml
@@ -1010,6 +1010,7 @@ workflows:
           name: Validate workflow status
           requires:
             - Helm Chart - Lint & Test
+            - Build backend
             - Test definition
             - Test gateway
             - Test rest-api

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-mergify.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-mergify.yml
@@ -1010,6 +1010,7 @@ workflows:
           name: Validate workflow status
           requires:
             - Helm Chart - Lint & Test
+            - Build backend
             - Test definition
             - Test gateway
             - Test rest-api

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-run-e2e.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-run-e2e.yml
@@ -1327,6 +1327,7 @@ workflows:
           name: Validate workflow status
           requires:
             - Helm Chart - Lint & Test
+            - Build backend
             - Test definition
             - Test gateway
             - Test rest-api

--- a/.circleci/ci/src/workflows/workflow-pull-requests.ts
+++ b/.circleci/ci/src/workflows/workflow-pull-requests.ts
@@ -152,6 +152,7 @@ export class PullRequestsWorkflow {
           requires: ['Validate backend'],
         }),
       );
+      requires.push('Build backend');
 
       if (!filterJobs || shouldTestDefinition(environment.changedFiles)) {
         const testDefinitionJob = TestDefinitionJob.create(dynamicConfig, environment);
@@ -548,7 +549,7 @@ export class PullRequestsWorkflow {
     }
 
     // Force validation workflow in case only distribution pom.xml has changed
-    if (environment.changedFiles.some((file) => file.includes('gravitee-apim-distribution'))) {
+    if (!requires.includes('Build backend') && environment.changedFiles.some((file) => file.includes('gravitee-apim-distribution'))) {
       addValidationJob = true;
       requires.push('Build backend');
     }


### PR DESCRIPTION
Add at least the build-backend job in the validation workflow job so that gamma apim module can have the validation step.