### PR TITLE
Feat/v4 wsdl import

### DIFF
--- a/gravitee-apim-console-webui/src/entities/management-api-v2/api/v4/importWsdlDescriptor.ts
+++ b/gravitee-apim-console-webui/src/entities/management-api-v2/api/v4/importWsdlDescriptor.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export interface ImportWsdlDescriptor {
+  /** The raw WSDL content (INLINE) or the URL to fetch it from (URL). */
+  payload: string;
+  /** Whether the payload is an inline WSDL string or a remote URL. Defaults to INLINE. */
+  type?: 'INLINE' | 'URL';
+  /** Generate a Swagger documentation page from the converted OpenAPI spec. */
+  withDocumentation?: boolean;
+  /** Add an OAS Validation policy to every flow. */
+  withOASValidationPolicy?: boolean;
+  /** Policy visitor IDs to apply (e.g. 'rest-to-soap', 'json-validation'). */
+  withPolicies?: string[];
+}

--- a/gravitee-apim-console-webui/src/management/api/import-v4/api-import-v4-form/api-import-v4-form.component.html
+++ b/gravitee-apim-console-webui/src/management/api/import-v4/api-import-v4-form/api-import-v4-form.component.html
@@ -79,11 +79,7 @@
             <h3>API format</h3>
             <gio-form-selection-inline formControlName="format">
               @for (format of formats; track format.value) {
-                <gio-form-selection-inline-card
-                  [value]="format.value"
-                  [disabled]="format.value === 'wsdl'"
-                  [matTooltip]="format.value === 'wsdl' ? 'Coming soon' : null"
-                >
+                <gio-form-selection-inline-card [value]="format.value">
                   <gio-form-selection-inline-card-content [icon]="format.icon">
                     <gio-card-content-title>{{ format.label }}</gio-card-content-title>
                   </gio-form-selection-inline-card-content>

--- a/gravitee-apim-console-webui/src/management/api/import-v4/api-import-v4-form/api-import-v4-form.component.html
+++ b/gravitee-apim-console-webui/src/management/api/import-v4/api-import-v4-form/api-import-v4-form.component.html
@@ -195,6 +195,18 @@
             <ng-template matStepLabel>Options</ng-template>
             <div class="options-step__body">
               <h3>Options</h3>
+              @if (importFormat() === 'wsdl' && hasRestToSoapPolicy()) {
+                <gio-form-slide-toggle>
+                  <gio-form-label>Apply REST to SOAP Transformer policy</gio-form-label>
+                  This will overwrite all the existing policy.
+                  <mat-slide-toggle
+                    gioFormSlideToggle
+                    formControlName="withRestToSoap"
+                    aria-label="Toggle REST to SOAP Transformer policy"
+                    name="withRestToSoap"
+                  ></mat-slide-toggle>
+                </gio-form-slide-toggle>
+              }
               <gio-form-slide-toggle>
                 <gio-form-label>Create documentation page from spec</gio-form-label>
                 This will add a documentation page for this API using the OpenAPI spec used during the import. This page will be published
@@ -270,6 +282,16 @@
             <mat-card class="review-import-step__section">
               <mat-card-content>
                 <h3>Options</h3>
+                @if (importFormat() === 'wsdl' && hasRestToSoapPolicy()) {
+                  <div class="review-import-step__row">
+                    <span>REST to SOAP Transformer:</span>
+                    @if (optionsForm.controls.withRestToSoap.value) {
+                      <span class="gio-badge-success">Enabled</span>
+                    } @else {
+                      <span class="gio-badge-neutral">Disabled</span>
+                    }
+                  </div>
+                }
                 <div class="review-import-step__row">
                   <span>Documentation page:</span>
                   @if (optionsForm.controls.withDocumentation.value) {

--- a/gravitee-apim-console-webui/src/management/api/import-v4/api-import-v4-form/api-import-v4-form.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/import-v4/api-import-v4-form/api-import-v4-form.component.spec.ts
@@ -325,54 +325,7 @@ describe('ApiImportV4FormComponent', () => {
   it('should show the options step for WSDL', async () => {
     fixture.componentInstance.selectApiFormatForm.patchValue({ format: 'wsdl' });
     fixture.detectChanges();
-    const showOptions = (fixture.componentInstance as unknown as { showImportOptionsStep: () => boolean }).showImportOptionsStep;
-    expect(showOptions()).toBe(true);
-  });
-
-  it('should POST WSDL from a local file', async () => {
-    const httpMock = TestBed.inject(HttpTestingController);
-    const wsdlContent = '<definitions name="CalculatorService"/>';
-
-    await harness.selectFormat('wsdl');
-    fixture.detectChanges();
-    await harness.clickNext();
-    await harness.pickFiles([new File([wsdlContent], 'calculator.wsdl', { type: 'text/xml' })]);
-    fixture.detectChanges();
-    await harness.clickNext();
-    await harness.clickNext();
-    await harness.clickImport();
-
-    const req = httpMock.expectOne(r => r.method === 'POST' && r.url === `${CONSTANTS_TESTING.env.v2BaseURL}/apis/_import/wsdl`);
-    expect(req.request.body).toEqual(
-      expect.objectContaining({
-        payload: wsdlContent,
-        type: 'INLINE',
-      }),
-    );
-    req.flush(fakeApiV4({ id: 'imported-wsdl' }));
-    httpMock.verify();
-  });
-
-  it('should call importWsdlApi with remote URL for WSDL', async () => {
-    const apiV2 = TestBed.inject(ApiV2Service);
-    jest.spyOn(apiV2, 'importWsdlApi').mockReturnValue(of({ id: 'new-api' } as ApiV4));
-
-    await harness.selectFormat('wsdl');
-    fixture.detectChanges();
-    await harness.clickNext();
-    await harness.selectSource('remote');
-    await harness.setRemoteUrl('https://example.com/calculator.wsdl');
-    fixture.detectChanges();
-    await harness.clickNext();
-    await harness.clickNext();
-    await harness.clickImport();
-
-    expect(apiV2.importWsdlApi).toHaveBeenCalledWith(
-      expect.objectContaining({
-        payload: 'https://example.com/calculator.wsdl',
-        type: 'URL',
-      }),
-    );
+    expect(await harness.hasOptionsStep()).toBe(true);
   });
 
   it('should show actionable message when remote fetch fails with status 0', async () => {
@@ -479,7 +432,7 @@ describe('ApiImportV4FormComponent (oas-validation policy installed)', () => {
     expect(await harness.getPickedFilesCount()).toBe(1);
   });
 
-  it('should expose documentation and OAS validation toggles for WSDL when oas-validation policy is installed', async () => {
+  it('should expose documentation and OAS validation toggles for WSDL but disabled without rest-to-soap policy', async () => {
     await harness.selectFormat('wsdl');
     fixture.detectChanges();
     await harness.clickNext();
@@ -488,11 +441,12 @@ describe('ApiImportV4FormComponent (oas-validation policy installed)', () => {
     fixture.detectChanges();
     await harness.clickNext();
 
-    expect(await harness.isDocumentationImportSelected()).toBe(true);
-    expect(await harness.isDocumentationImportDisabled()).toBe(false);
+    // Without rest-to-soap policy, documentation and OAS validation are disabled for WSDL
+    expect(await harness.isDocumentationImportSelected()).toBe(false);
+    expect(await harness.isDocumentationImportDisabled()).toBe(true);
     expect(await harness.isOasValidationPolicyImportPresent()).toBe(true);
-    expect(await harness.isOasValidationPolicyImportSelected()).toBe(true);
-    expect(await harness.isOasValidationPolicyImportDisabled()).toBe(false);
+    expect(await harness.isOasValidationPolicyImportSelected()).toBe(false);
+    expect(await harness.isOasValidationPolicyImportDisabled()).toBe(true);
   });
 
   it('should still skip the options step for Gravitee definition when policy is installed', async () => {
@@ -506,5 +460,174 @@ describe('ApiImportV4FormComponent (oas-validation policy installed)', () => {
     fixture.detectChanges();
 
     expect(await harness.hasOptionsStep()).toBe(false);
+  });
+});
+
+describe('ApiImportV4FormComponent (rest-to-soap policy installed)', () => {
+  let fixture: ComponentFixture<ApiImportV4FormComponent>;
+  let harness: ApiImportV4FormHarness;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [NoopAnimationsModule, ApiImportV4FormComponent, GioTestingModule],
+      providers: [
+        {
+          provide: PolicyV2Service,
+          useValue: {
+            list: () => of([fakePolicyPlugin({ id: 'rest-to-soap' }), fakePolicyPlugin({ id: 'oas-validation' })]),
+          },
+        },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ApiImportV4FormComponent);
+    harness = await TestbedHarnessEnvironment.harnessForFixture(fixture, ApiImportV4FormHarness);
+    fixture.detectChanges();
+  });
+
+  async function navigateToWsdlOptionsStep(): Promise<void> {
+    await harness.selectFormat('wsdl');
+    fixture.detectChanges();
+    await harness.clickNext();
+    await harness.pickFiles([new File(['<definitions/>'], 'service.wsdl', { type: 'text/xml' })]);
+    await fixture.whenStable();
+    fixture.detectChanges();
+    await harness.clickNext();
+    fixture.detectChanges();
+  }
+
+  it('should show REST to SOAP toggle for WSDL when rest-to-soap policy is installed', async () => {
+    await navigateToWsdlOptionsStep();
+    expect(await harness.isRestToSoapTogglePresent()).toBe(true);
+  });
+
+  it('should have REST to SOAP toggle ON by default for WSDL', async () => {
+    await navigateToWsdlOptionsStep();
+    expect(await harness.isRestToSoapToggleSelected()).toBe(true);
+  });
+
+  it('should enable documentation and OAS validation when REST to SOAP is ON', async () => {
+    await navigateToWsdlOptionsStep();
+    expect(await harness.isDocumentationImportSelected()).toBe(true);
+    expect(await harness.isDocumentationImportDisabled()).toBe(false);
+    expect(await harness.isOasValidationPolicyImportSelected()).toBe(true);
+    expect(await harness.isOasValidationPolicyImportDisabled()).toBe(false);
+  });
+
+  it('should disable and uncheck documentation and OAS validation when REST to SOAP is toggled OFF', async () => {
+    await navigateToWsdlOptionsStep();
+    await harness.toggleRestToSoap();
+    fixture.detectChanges();
+
+    expect(await harness.isRestToSoapToggleSelected()).toBe(false);
+    expect(await harness.isDocumentationImportSelected()).toBe(false);
+    expect(await harness.isDocumentationImportDisabled()).toBe(true);
+    expect(await harness.isOasValidationPolicyImportSelected()).toBe(false);
+    expect(await harness.isOasValidationPolicyImportDisabled()).toBe(true);
+  });
+
+  it('should re-enable and check documentation and OAS validation when REST to SOAP is toggled back ON', async () => {
+    await navigateToWsdlOptionsStep();
+    await harness.toggleRestToSoap();
+    fixture.detectChanges();
+    await harness.toggleRestToSoap();
+    fixture.detectChanges();
+
+    expect(await harness.isRestToSoapToggleSelected()).toBe(true);
+    expect(await harness.isDocumentationImportSelected()).toBe(true);
+    expect(await harness.isDocumentationImportDisabled()).toBe(false);
+    expect(await harness.isOasValidationPolicyImportSelected()).toBe(true);
+    expect(await harness.isOasValidationPolicyImportDisabled()).toBe(false);
+  });
+
+  it('should not show REST to SOAP toggle for OpenAPI format', async () => {
+    await harness.selectFormat('openapi');
+    fixture.detectChanges();
+    await harness.clickNext();
+    await harness.pickFiles([new File(['openapi: 3.1.0'], 'openapi.yml', { type: 'application/x-yaml' })]);
+    await fixture.whenStable();
+    fixture.detectChanges();
+    await harness.clickNext();
+    fixture.detectChanges();
+
+    expect(await harness.isRestToSoapTogglePresent()).toBe(false);
+  });
+
+  it('should send withPolicies containing rest-to-soap when toggle is ON', async () => {
+    const apiV2 = TestBed.inject(ApiV2Service);
+    jest.spyOn(apiV2, 'importWsdlApi').mockReturnValue(of(fakeApiV4({ id: 'new-api' })));
+
+    await navigateToWsdlOptionsStep();
+    expect(await harness.isRestToSoapToggleSelected()).toBe(true);
+    await harness.clickNext();
+    await harness.clickImport();
+
+    expect(apiV2.importWsdlApi).toHaveBeenCalledWith(
+      expect.objectContaining({
+        withPolicies: ['rest-to-soap'],
+      }),
+    );
+  });
+
+  it('should send empty withPolicies when REST to SOAP toggle is OFF', async () => {
+    const apiV2 = TestBed.inject(ApiV2Service);
+    jest.spyOn(apiV2, 'importWsdlApi').mockReturnValue(of(fakeApiV4({ id: 'new-api' })));
+
+    await navigateToWsdlOptionsStep();
+    await harness.toggleRestToSoap();
+    fixture.detectChanges();
+    await harness.clickNext();
+    await harness.clickImport();
+
+    expect(apiV2.importWsdlApi).toHaveBeenCalledWith(
+      expect.objectContaining({
+        withPolicies: [],
+      }),
+    );
+  });
+
+  it('should call importWsdlApi with remote URL for WSDL', async () => {
+    const apiV2 = TestBed.inject(ApiV2Service);
+    jest.spyOn(apiV2, 'importWsdlApi').mockReturnValue(of(fakeApiV4({ id: 'new-api' })));
+
+    await harness.selectFormat('wsdl');
+    fixture.detectChanges();
+    await harness.clickNext();
+    await harness.selectSource('remote');
+    await harness.setRemoteUrl('https://example.com/calculator.wsdl');
+    fixture.detectChanges();
+    await harness.clickNext();
+    fixture.detectChanges();
+    await harness.clickNext();
+    await harness.clickImport();
+
+    expect(apiV2.importWsdlApi).toHaveBeenCalledWith(
+      expect.objectContaining({
+        payload: 'https://example.com/calculator.wsdl',
+        type: 'URL',
+        withPolicies: ['rest-to-soap'],
+      }),
+    );
+  });
+
+  it('should call updateApiFromWsdl when updateTargetApiId is set', async () => {
+    const apiV2 = TestBed.inject(ApiV2Service);
+    jest.spyOn(apiV2, 'importWsdlApi');
+    jest.spyOn(apiV2, 'updateApiFromWsdl').mockReturnValue(of(fakeApiV4({ id: 'existing-api' })));
+    fixture.componentRef.setInput('updateTargetApiId', 'existing-api');
+    fixture.detectChanges();
+
+    await navigateToWsdlOptionsStep();
+    expect(await harness.isRestToSoapToggleSelected()).toBe(true);
+    await harness.clickNext();
+    await harness.clickImport();
+
+    expect(apiV2.updateApiFromWsdl).toHaveBeenCalledWith(
+      'existing-api',
+      expect.objectContaining({
+        withPolicies: ['rest-to-soap'],
+      }),
+    );
+    expect(apiV2.importWsdlApi).not.toHaveBeenCalled();
   });
 });

--- a/gravitee-apim-console-webui/src/management/api/import-v4/api-import-v4-form/api-import-v4-form.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/import-v4/api-import-v4-form/api-import-v4-form.component.spec.ts
@@ -322,6 +322,59 @@ describe('ApiImportV4FormComponent', () => {
     httpMock.verify();
   });
 
+  it('should show the options step for WSDL', async () => {
+    fixture.componentInstance.selectApiFormatForm.patchValue({ format: 'wsdl' });
+    fixture.detectChanges();
+    const showOptions = (fixture.componentInstance as unknown as { showImportOptionsStep: () => boolean }).showImportOptionsStep;
+    expect(showOptions()).toBe(true);
+  });
+
+  it('should POST WSDL from a local file', async () => {
+    const httpMock = TestBed.inject(HttpTestingController);
+    const wsdlContent = '<definitions name="CalculatorService"/>';
+
+    await harness.selectFormat('wsdl');
+    fixture.detectChanges();
+    await harness.clickNext();
+    await harness.pickFiles([new File([wsdlContent], 'calculator.wsdl', { type: 'text/xml' })]);
+    fixture.detectChanges();
+    await harness.clickNext();
+    await harness.clickNext();
+    await harness.clickImport();
+
+    const req = httpMock.expectOne(r => r.method === 'POST' && r.url === `${CONSTANTS_TESTING.env.v2BaseURL}/apis/_import/wsdl`);
+    expect(req.request.body).toEqual(
+      expect.objectContaining({
+        payload: wsdlContent,
+        type: 'INLINE',
+      }),
+    );
+    req.flush(fakeApiV4({ id: 'imported-wsdl' }));
+    httpMock.verify();
+  });
+
+  it('should call importWsdlApi with remote URL for WSDL', async () => {
+    const apiV2 = TestBed.inject(ApiV2Service);
+    jest.spyOn(apiV2, 'importWsdlApi').mockReturnValue(of({ id: 'new-api' } as ApiV4));
+
+    await harness.selectFormat('wsdl');
+    fixture.detectChanges();
+    await harness.clickNext();
+    await harness.selectSource('remote');
+    await harness.setRemoteUrl('https://example.com/calculator.wsdl');
+    fixture.detectChanges();
+    await harness.clickNext();
+    await harness.clickNext();
+    await harness.clickImport();
+
+    expect(apiV2.importWsdlApi).toHaveBeenCalledWith(
+      expect.objectContaining({
+        payload: 'https://example.com/calculator.wsdl',
+        type: 'URL',
+      }),
+    );
+  });
+
   it('should show actionable message when remote fetch fails with status 0', async () => {
     const snackBarService = TestBed.inject(SnackBarService);
     const snackBarErrorSpy = jest.spyOn(snackBarService, 'error');
@@ -424,6 +477,22 @@ describe('ApiImportV4FormComponent (oas-validation policy installed)', () => {
 
     expect(await harness.isConfigureSourceNextDisabled()).toBe(false);
     expect(await harness.getPickedFilesCount()).toBe(1);
+  });
+
+  it('should expose documentation and OAS validation toggles for WSDL when oas-validation policy is installed', async () => {
+    await harness.selectFormat('wsdl');
+    fixture.detectChanges();
+    await harness.clickNext();
+    await harness.pickFiles([new File(['<definitions/>'], 'service.wsdl', { type: 'text/xml' })]);
+    await fixture.whenStable();
+    fixture.detectChanges();
+    await harness.clickNext();
+
+    expect(await harness.isDocumentationImportSelected()).toBe(true);
+    expect(await harness.isDocumentationImportDisabled()).toBe(false);
+    expect(await harness.isOasValidationPolicyImportPresent()).toBe(true);
+    expect(await harness.isOasValidationPolicyImportSelected()).toBe(true);
+    expect(await harness.isOasValidationPolicyImportDisabled()).toBe(false);
   });
 
   it('should still skip the options step for Gravitee definition when policy is installed', async () => {

--- a/gravitee-apim-console-webui/src/management/api/import-v4/api-import-v4-form/api-import-v4-form.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/import-v4/api-import-v4-form/api-import-v4-form.component.ts
@@ -133,11 +133,13 @@ export class ApiImportV4FormComponent {
   );
 
   public readonly optionsForm = this.formBuilder.group({
+    withRestToSoap: [{ value: false, disabled: false }],
     withDocumentation: [{ value: false, disabled: false }],
     withOASValidationPolicy: [{ value: false, disabled: false }],
   });
 
   protected readonly hasOasValidationPolicy = signal(false);
+  protected readonly hasRestToSoapPolicy = signal(false);
 
   protected readonly importFormat = toSignal(
     this.selectApiFormatForm.controls.format.valueChanges.pipe(
@@ -236,10 +238,36 @@ export class ApiImportV4FormComponent {
   private readonly syncPolicyOptionsEffect = effect(() => {
     const [format, policies] = this.formatAndPolicies();
     const hasOas = policies.some(policy => policy.id === 'oas-validation');
+    const hasRestToSoap = policies.some(policy => policy.id === 'rest-to-soap');
     this.hasOasValidationPolicy.set(hasOas);
-    this.syncImportOptionsFromFormat(format, hasOas);
+    this.hasRestToSoapPolicy.set(hasRestToSoap);
+    this.syncImportOptionsFromFormat(format, hasOas, hasRestToSoap);
     this.configureFileSourceForm.updateValueAndValidity({ emitEvent: true });
     this.optionsForm.updateValueAndValidity({ emitEvent: true });
+  });
+
+  private readonly restToSoapValue = toSignal(
+    this.optionsForm.controls.withRestToSoap.valueChanges.pipe(startWith(this.optionsForm.controls.withRestToSoap.value)),
+    { initialValue: this.optionsForm.controls.withRestToSoap.value },
+  );
+
+  private readonly syncRestToSoapDependentsEffect = effect(() => {
+    const format = this.importFormat();
+    if (format !== 'wsdl') return;
+    const restToSoapOn = this.restToSoapValue();
+    if (restToSoapOn) {
+      this.optionsForm.controls.withDocumentation.setValue(true, { emitEvent: false });
+      this.optionsForm.controls.withDocumentation.enable({ emitEvent: false });
+      if (this.hasOasValidationPolicy()) {
+        this.optionsForm.controls.withOASValidationPolicy.setValue(true, { emitEvent: false });
+        this.optionsForm.controls.withOASValidationPolicy.enable({ emitEvent: false });
+      }
+    } else {
+      this.optionsForm.controls.withDocumentation.setValue(false, { emitEvent: false });
+      this.optionsForm.controls.withDocumentation.disable({ emitEvent: false });
+      this.optionsForm.controls.withOASValidationPolicy.setValue(false, { emitEvent: false });
+      this.optionsForm.controls.withOASValidationPolicy.disable({ emitEvent: false });
+    }
   });
 
   private readonly applyFileSourceModeEffect = effect(() => {
@@ -334,13 +362,16 @@ export class ApiImportV4FormComponent {
     this.configureFileSourceForm.updateValueAndValidity({ emitEvent: true });
   }
 
-  private syncImportOptionsFromFormat(format: string | null, hasOasValidationPolicyInstalled: boolean): void {
-    if (format === 'openapi' || format === 'wsdl') {
+  private syncImportOptionsFromFormat(
+    format: string | null,
+    hasOasValidationPolicyInstalled: boolean,
+    hasRestToSoapPolicyInstalled: boolean,
+  ): void {
+    if (format === 'openapi') {
+      this.optionsForm.controls.withRestToSoap.setValue(false, { emitEvent: false });
+      this.optionsForm.controls.withRestToSoap.disable({ emitEvent: false });
       this.optionsForm.patchValue(
-        {
-          withDocumentation: true,
-          withOASValidationPolicy: hasOasValidationPolicyInstalled,
-        },
+        { withDocumentation: true, withOASValidationPolicy: hasOasValidationPolicyInstalled },
         { emitEvent: false },
       );
       this.optionsForm.controls.withDocumentation.enable();
@@ -352,6 +383,23 @@ export class ApiImportV4FormComponent {
       }
       return;
     }
+    if (format === 'wsdl') {
+      if (hasRestToSoapPolicyInstalled) {
+        // Intentionally emits event so `restToSoapValue` signal updates and `syncRestToSoapDependentsEffect` sets documentation/OAS controls.
+        this.optionsForm.controls.withRestToSoap.setValue(true);
+        this.optionsForm.controls.withRestToSoap.enable({ emitEvent: false });
+      } else {
+        this.optionsForm.controls.withRestToSoap.setValue(false, { emitEvent: false });
+        this.optionsForm.controls.withRestToSoap.disable({ emitEvent: false });
+        this.optionsForm.controls.withDocumentation.setValue(false, { emitEvent: false });
+        this.optionsForm.controls.withDocumentation.disable({ emitEvent: false });
+        this.optionsForm.controls.withOASValidationPolicy.setValue(false, { emitEvent: false });
+        this.optionsForm.controls.withOASValidationPolicy.disable({ emitEvent: false });
+      }
+      return;
+    }
+    this.optionsForm.controls.withRestToSoap.setValue(false, { emitEvent: false });
+    this.optionsForm.controls.withRestToSoap.disable({ emitEvent: false });
     this.optionsForm.patchValue({ withDocumentation: false, withOASValidationPolicy: false });
     this.optionsForm.controls.withDocumentation.enable();
     this.optionsForm.controls.withOASValidationPolicy.enable();
@@ -435,46 +483,48 @@ export class ApiImportV4FormComponent {
       return null;
     }
 
-    const updateId = this.updateTargetApiId();
     const source = this.configureFileSourceForm.controls.source.value;
+    return source === 'remote' ? this.resolveRemoteImport$() : this.resolveFileImport$();
+  }
+
+  private resolveRemoteImport$(): Observable<ApiV4> | null {
+    const updateId = this.updateTargetApiId();
     const format = this.selectApiFormatForm.controls.format.value;
+    const url = this.configureFileSourceForm.controls.remoteUrl.value?.trim() as string;
 
-    if (source === 'remote') {
-      const url = this.configureFileSourceForm.controls.remoteUrl.value?.trim() as string;
-      if (format === 'gravitee') {
-        return this.importGraviteeDefinitionFromRemoteUrl$(url, updateId);
-      }
-      if (format === 'wsdl') {
-        return updateId
-          ? this.apiV2Service.updateApiFromWsdl(updateId, this.buildImportWsdlDescriptor(url, 'URL'))
-          : this.apiV2Service.importWsdlApi(this.buildImportWsdlDescriptor(url, 'URL'));
-      }
-      return updateId
-        ? this.apiV2Service.updateApiFromSwagger(updateId, this.buildImportSwaggerDescriptor(url))
-        : this.apiV2Service.importSwaggerApi(this.buildImportSwaggerDescriptor(url));
+    if (format === 'gravitee') {
+      return this.importGraviteeDefinitionFromRemoteUrl$(url, updateId);
     }
+    if (format === 'wsdl') {
+      return updateId
+        ? this.apiV2Service.updateApiFromWsdl(updateId, this.buildImportWsdlDescriptor(url, 'URL'))
+        : this.apiV2Service.importWsdlApi(this.buildImportWsdlDescriptor(url, 'URL'));
+    }
+    return updateId
+      ? this.apiV2Service.updateApiFromSwagger(updateId, this.buildImportSwaggerDescriptor(url))
+      : this.apiV2Service.importSwaggerApi(this.buildImportSwaggerDescriptor(url));
+  }
 
+  private resolveFileImport$(): Observable<ApiV4> | null {
+    const updateId = this.updateTargetApiId();
+    const format = this.selectApiFormatForm.controls.format.value;
     const pickedType = this.importType();
-    const fileContent = this.importFileContent();
+    const fileContent = this.importFileContent() as string;
 
     if (format === 'gravitee' && pickedType === 'MAPI_V2') {
-      if (updateId) {
-        return defer(() => {
-          const definition = this.parseGraviteeDefinitionJson(fileContent as string);
-          return this.apiV2Service.updateApiFromDefinition(updateId, definition);
-        });
-      }
-      return this.apiV2Service.import(fileContent as string);
+      return updateId
+        ? defer(() => this.apiV2Service.updateApiFromDefinition(updateId, this.parseGraviteeDefinitionJson(fileContent)))
+        : this.apiV2Service.import(fileContent);
     }
     if (format === 'openapi' && pickedType === 'SWAGGER') {
       return updateId
-        ? this.apiV2Service.updateApiFromSwagger(updateId, this.buildImportSwaggerDescriptor(fileContent as string))
-        : this.apiV2Service.importSwaggerApi(this.buildImportSwaggerDescriptor(fileContent as string));
+        ? this.apiV2Service.updateApiFromSwagger(updateId, this.buildImportSwaggerDescriptor(fileContent))
+        : this.apiV2Service.importSwaggerApi(this.buildImportSwaggerDescriptor(fileContent));
     }
     if (format === 'wsdl' && pickedType === 'WSDL') {
       return updateId
-        ? this.apiV2Service.updateApiFromWsdl(updateId, this.buildImportWsdlDescriptor(fileContent as string, 'INLINE'))
-        : this.apiV2Service.importWsdlApi(this.buildImportWsdlDescriptor(fileContent as string, 'INLINE'));
+        ? this.apiV2Service.updateApiFromWsdl(updateId, this.buildImportWsdlDescriptor(fileContent, 'INLINE'))
+        : this.apiV2Service.importWsdlApi(this.buildImportWsdlDescriptor(fileContent, 'INLINE'));
     }
     return null;
   }
@@ -497,6 +547,7 @@ export class ApiImportV4FormComponent {
       type,
       withDocumentation: rawOptions.withDocumentation,
       withOASValidationPolicy: rawOptions.withOASValidationPolicy,
+      withPolicies: rawOptions.withRestToSoap ? ['rest-to-soap'] : [],
     };
   }
 

--- a/gravitee-apim-console-webui/src/management/api/import-v4/api-import-v4-form/api-import-v4-form.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/import-v4/api-import-v4-form/api-import-v4-form.component.ts
@@ -445,7 +445,9 @@ export class ApiImportV4FormComponent {
         return this.importGraviteeDefinitionFromRemoteUrl$(url, updateId);
       }
       if (format === 'wsdl') {
-        return this.apiV2Service.importWsdlApi(this.buildImportWsdlDescriptor(url, 'URL'));
+        return updateId
+          ? this.apiV2Service.updateApiFromWsdl(updateId, this.buildImportWsdlDescriptor(url, 'URL'))
+          : this.apiV2Service.importWsdlApi(this.buildImportWsdlDescriptor(url, 'URL'));
       }
       return updateId
         ? this.apiV2Service.updateApiFromSwagger(updateId, this.buildImportSwaggerDescriptor(url))
@@ -470,7 +472,9 @@ export class ApiImportV4FormComponent {
         : this.apiV2Service.importSwaggerApi(this.buildImportSwaggerDescriptor(fileContent as string));
     }
     if (format === 'wsdl' && pickedType === 'WSDL') {
-      return this.apiV2Service.importWsdlApi(this.buildImportWsdlDescriptor(fileContent as string, 'INLINE'));
+      return updateId
+        ? this.apiV2Service.updateApiFromWsdl(updateId, this.buildImportWsdlDescriptor(fileContent as string, 'INLINE'))
+        : this.apiV2Service.importWsdlApi(this.buildImportWsdlDescriptor(fileContent as string, 'INLINE'));
     }
     return null;
   }

--- a/gravitee-apim-console-webui/src/management/api/import-v4/api-import-v4-form/api-import-v4-form.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/import-v4/api-import-v4-form/api-import-v4-form.component.ts
@@ -34,6 +34,7 @@ import { catchError, distinctUntilChanged, finalize, map, startWith, switchMap, 
 import { ApiImportFilePickerComponent } from '../../component/api-import-file-picker/api-import-file-picker.component';
 import { ApiV4, PolicyPlugin } from '../../../../entities/management-api-v2';
 import { ImportSwaggerDescriptor } from '../../../../entities/management-api-v2/api/v4/importSwaggerDescriptor';
+import { ImportWsdlDescriptor } from '../../../../entities/management-api-v2/api/v4/importWsdlDescriptor';
 import { ApiV2Service } from '../../../../services-ngx/api-v2.service';
 import { PolicyV2Service } from '../../../../services-ngx/policy-v2.service';
 import { SnackBarService } from '../../../../services-ngx/snack-bar.service';
@@ -413,7 +414,7 @@ export class ApiImportV4FormComponent {
       if (!url || this.configureFileSourceForm.controls.remoteUrl.invalid) {
         return false;
       }
-      return format === 'gravitee' || format === 'openapi';
+      return format === 'gravitee' || format === 'openapi' || format === 'wsdl';
     }
 
     const type = this.importType();
@@ -422,7 +423,11 @@ export class ApiImportV4FormComponent {
       return false;
     }
 
-    return (format === 'gravitee' && type === 'MAPI_V2') || (format === 'openapi' && type === 'SWAGGER');
+    return (
+      (format === 'gravitee' && type === 'MAPI_V2') ||
+      (format === 'openapi' && type === 'SWAGGER') ||
+      (format === 'wsdl' && type === 'WSDL')
+    );
   }
 
   private resolveImportRequest$(): Observable<ApiV4> | null {
@@ -438,6 +443,9 @@ export class ApiImportV4FormComponent {
       const url = this.configureFileSourceForm.controls.remoteUrl.value?.trim() as string;
       if (format === 'gravitee') {
         return this.importGraviteeDefinitionFromRemoteUrl$(url, updateId);
+      }
+      if (format === 'wsdl') {
+        return this.apiV2Service.importWsdlApi(this.buildImportWsdlDescriptor(url, 'URL'));
       }
       return updateId
         ? this.apiV2Service.updateApiFromSwagger(updateId, this.buildImportSwaggerDescriptor(url))
@@ -461,6 +469,9 @@ export class ApiImportV4FormComponent {
         ? this.apiV2Service.updateApiFromSwagger(updateId, this.buildImportSwaggerDescriptor(fileContent as string))
         : this.apiV2Service.importSwaggerApi(this.buildImportSwaggerDescriptor(fileContent as string));
     }
+    if (format === 'wsdl' && pickedType === 'WSDL') {
+      return this.apiV2Service.importWsdlApi(this.buildImportWsdlDescriptor(fileContent as string, 'INLINE'));
+    }
     return null;
   }
 
@@ -469,6 +480,17 @@ export class ApiImportV4FormComponent {
     const rawOptions = this.optionsForm.getRawValue();
     return {
       payload,
+      withDocumentation: rawOptions.withDocumentation,
+      withOASValidationPolicy: rawOptions.withOASValidationPolicy,
+    };
+  }
+
+  /** Builds the WSDL import descriptor sent to the Management API. */
+  private buildImportWsdlDescriptor(payload: string, type: 'INLINE' | 'URL'): ImportWsdlDescriptor {
+    const rawOptions = this.optionsForm.getRawValue();
+    return {
+      payload,
+      type,
       withDocumentation: rawOptions.withDocumentation,
       withOASValidationPolicy: rawOptions.withOASValidationPolicy,
     };

--- a/gravitee-apim-console-webui/src/management/api/import-v4/api-import-v4-form/api-import-v4-form.harness.ts
+++ b/gravitee-apim-console-webui/src/management/api/import-v4/api-import-v4-form/api-import-v4-form.harness.ts
@@ -41,6 +41,9 @@ export class ApiImportV4FormHarness extends ComponentHarness {
   private readonly getOasValidationToggleOptional = this.locatorForOptional(
     MatSlideToggleHarness.with({ selector: '[formControlName="withOASValidationPolicy"]' }),
   );
+  private readonly getRestToSoapToggleOptional = this.locatorForOptional(
+    MatSlideToggleHarness.with({ selector: '[formControlName="withRestToSoap"]' }),
+  );
 
   public async hasRoot(): Promise<boolean> {
     return (await this.getRoot()) !== null;
@@ -175,6 +178,34 @@ export class ApiImportV4FormHarness extends ComponentHarness {
     const toggle = await this.getOasValidationToggleOptional();
     if (!toggle) {
       throw new Error('OpenAPI validation toggle is not in the DOM');
+    }
+    return toggle.toggle();
+  }
+
+  public async isRestToSoapTogglePresent(): Promise<boolean> {
+    return (await this.getRestToSoapToggleOptional()) !== null;
+  }
+
+  public async isRestToSoapToggleSelected(): Promise<boolean> {
+    const toggle = await this.getRestToSoapToggleOptional();
+    if (!toggle) {
+      throw new Error('REST to SOAP toggle is not in the DOM');
+    }
+    return toggle.isChecked();
+  }
+
+  public async isRestToSoapToggleDisabled(): Promise<boolean> {
+    const toggle = await this.getRestToSoapToggleOptional();
+    if (!toggle) {
+      throw new Error('REST to SOAP toggle is not in the DOM');
+    }
+    return toggle.isDisabled();
+  }
+
+  public async toggleRestToSoap(): Promise<void> {
+    const toggle = await this.getRestToSoapToggleOptional();
+    if (!toggle) {
+      throw new Error('REST to SOAP toggle is not in the DOM');
     }
     return toggle.toggle();
   }

--- a/gravitee-apim-console-webui/src/services-ngx/api-v2.service.spec.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/api-v2.service.spec.ts
@@ -625,6 +625,41 @@ describe('ApiV2Service', () => {
     });
   });
 
+  describe('importWsdlApi', () => {
+    it('should POST to the WSDL import endpoint', done => {
+      const descriptor = { payload: '<definitions/>', type: 'INLINE' as const, withDocumentation: false, withPolicies: ['rest-to-soap'] };
+
+      apiV2Service.importWsdlApi(descriptor).subscribe(() => {
+        done();
+      });
+
+      const req = httpTestingController.expectOne({
+        url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis/_import/wsdl`,
+        method: 'POST',
+      });
+      expect(req.request.body).toEqual(descriptor);
+      req.flush(null);
+    });
+  });
+
+  describe('updateApiFromWsdl', () => {
+    it('should PUT to the API-scoped WSDL import endpoint', done => {
+      const apiId = 'existing-api';
+      const descriptor = { payload: '<definitions/>', type: 'INLINE' as const, withDocumentation: true, withPolicies: [] };
+
+      apiV2Service.updateApiFromWsdl(apiId, descriptor).subscribe(() => {
+        done();
+      });
+
+      const req = httpTestingController.expectOne({
+        url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${apiId}/_import/wsdl`,
+        method: 'PUT',
+      });
+      expect(req.request.body).toEqual(descriptor);
+      req.flush(null);
+    });
+  });
+
   describe('updateApiFromDefinition', () => {
     it('should PUT to the API-scoped definition import endpoint', done => {
       const apiId = 'existing-api';

--- a/gravitee-apim-console-webui/src/services-ngx/api-v2.service.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/api-v2.service.ts
@@ -38,6 +38,7 @@ import {
 import { PathToVerify, VerifyApiPathResponse } from '../entities/management-api-v2/api/verifyApiPath';
 import { VerifyApiHostsResponse } from '../entities/management-api-v2/api/verifyApiHosts';
 import { ImportSwaggerDescriptor } from '../entities/management-api-v2/api/v4/importSwaggerDescriptor';
+import { ImportWsdlDescriptor } from '../entities/management-api-v2/api/v4/importWsdlDescriptor';
 import { MigrateToV4Response } from '../entities/management-api-v2/api/v2/migrateToV4Response';
 import { ApiProductInfo } from '../entities/management-api-v2/api-product/apiProductInfo';
 
@@ -154,6 +155,14 @@ export class ApiV2Service {
 
   importSwaggerApi(descriptor: ImportSwaggerDescriptor) {
     return this.http.post<ApiV4>(`${this.constants.env.v2BaseURL}/apis/_import/swagger`, descriptor, {
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    });
+  }
+
+  importWsdlApi(descriptor: ImportWsdlDescriptor): Observable<ApiV4> {
+    return this.http.post<ApiV4>(`${this.constants.env.v2BaseURL}/apis/_import/wsdl`, descriptor, {
       headers: {
         'Content-Type': 'application/json',
       },

--- a/gravitee-apim-console-webui/src/services-ngx/api-v2.service.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/api-v2.service.ts
@@ -169,6 +169,14 @@ export class ApiV2Service {
     });
   }
 
+  updateApiFromWsdl(apiId: string, descriptor: ImportWsdlDescriptor): Observable<ApiV4> {
+    return this.http.put<ApiV4>(`${this.constants.env.v2BaseURL}/apis/${apiId}/_import/wsdl`, descriptor, {
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    });
+  }
+
   /**
    * Updates an existing v4 API from a Gravitee export document (same shape as {@link export}).
    */

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/spring/ResourceContextConfiguration.java
@@ -62,6 +62,7 @@ import io.gravitee.apim.core.api.domain_service.UpdateApiDomainService;
 import io.gravitee.apim.core.api.domain_service.ValidateApiCRDDomainService;
 import io.gravitee.apim.core.api.domain_service.ValidateApiDomainService;
 import io.gravitee.apim.core.api.domain_service.VerifyApiPathDomainService;
+import io.gravitee.apim.core.api.domain_service.WsdlParserDomainService;
 import io.gravitee.apim.core.api.query_service.ApiEventQueryService;
 import io.gravitee.apim.core.api.query_service.ApiQueryService;
 import io.gravitee.apim.core.api.service_provider.ApiTemplateModelProvider;
@@ -73,6 +74,7 @@ import io.gravitee.apim.core.api.use_case.ImportApiCRDUseCase;
 import io.gravitee.apim.core.api.use_case.PatchApiUseCase.FlowListDeserializer;
 import io.gravitee.apim.core.api.use_case.PatchApiUseCase.FlowListSerializer;
 import io.gravitee.apim.core.api.use_case.RollbackApiUseCase;
+import io.gravitee.apim.core.api.use_case.WsdlToImportApiUseCase;
 import io.gravitee.apim.core.api_key.domain_service.ReconcileApiKeysDomainService;
 import io.gravitee.apim.core.apim.service_provider.ApimProductInfo;
 import io.gravitee.apim.core.application.domain_service.ValidateApplicationCRDDomainService;
@@ -647,6 +649,17 @@ public class ResourceContextConfiguration {
     @Bean
     public OAIDomainService oaiDomainService() {
         return mock(OAIDomainService.class);
+    }
+
+    @Bean
+    public WsdlParserDomainService wsdlParserDomainService() {
+        return mock(WsdlParserDomainService.class);
+    }
+
+    @Bean
+    @Primary
+    public WsdlToImportApiUseCase wsdlToImportApiUseCase() {
+        return mock(WsdlToImportApiUseCase.class);
     }
 
     @Bean

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource.java
@@ -40,6 +40,7 @@ import io.gravitee.apim.core.api.use_case.UpdateApiDefinitionFromImportUseCase;
 import io.gravitee.apim.core.api.use_case.UpdateApiGroupsUseCase;
 import io.gravitee.apim.core.api.use_case.UpdateFederatedApiUseCase;
 import io.gravitee.apim.core.api.use_case.UpdateNativeApiUseCase;
+import io.gravitee.apim.core.api.use_case.WsdlToUpdateApiUseCase;
 import io.gravitee.apim.core.audit.model.AuditActor;
 import io.gravitee.apim.core.audit.model.AuditInfo;
 import io.gravitee.apim.core.audit.model.Excludable;
@@ -71,6 +72,7 @@ import io.gravitee.rest.api.management.v2.rest.model.DuplicateApiOptions;
 import io.gravitee.rest.api.management.v2.rest.model.Error;
 import io.gravitee.rest.api.management.v2.rest.model.ExportApiV4;
 import io.gravitee.rest.api.management.v2.rest.model.ImportSwaggerDescriptor;
+import io.gravitee.rest.api.management.v2.rest.model.ImportWsdlDescriptor;
 import io.gravitee.rest.api.management.v2.rest.model.MigrationReportResponses;
 import io.gravitee.rest.api.management.v2.rest.model.MigrationReportResponsesIssuesInner;
 import io.gravitee.rest.api.management.v2.rest.model.MigrationStateType;
@@ -278,6 +280,9 @@ public class ApiResource extends AbstractResource {
     private OAIToUpdateApiUseCase oaiToUpdateApiUseCase;
 
     @Inject
+    private WsdlToUpdateApiUseCase wsdlToUpdateApiUseCase;
+
+    @Inject
     private UpdateApiGroupsUseCase updateApiGroupsUseCase;
 
     @Context
@@ -401,6 +406,31 @@ public class ApiResource extends AbstractResource {
                 .withPolicyPaths(Boolean.TRUE.equals(descriptor.getWithPolicyPaths()))
                 .auditInfo(audit)
                 .build()
+        );
+
+        boolean isSynchronized = apiStateService.isSynchronized(
+            GraviteeContext.getExecutionContext(),
+            getGenericApiEntityById(apiId, false)
+        );
+        return Response.ok().entity(ApiMapper.INSTANCE.map(output.apiWithFlows(), uriInfo, isSynchronized)).build();
+    }
+
+    @PUT
+    @Path("/_import/wsdl")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    @Permissions({ @Permission(value = RolePermission.API_DEFINITION, acls = RolePermissionAction.UPDATE) })
+    public Response updateApiFromWsdl(@PathParam("apiId") String apiId, @Valid @NotNull ImportWsdlDescriptor descriptor) {
+        var audit = getAuditInfo();
+        var output = wsdlToUpdateApiUseCase.execute(
+            WsdlToUpdateApiUseCase.Input.of(
+                apiId,
+                descriptor.getPayload(),
+                ImportWsdlDescriptor.TypeEnum.URL.equals(descriptor.getType()),
+                Boolean.TRUE.equals(descriptor.getWithDocumentation()),
+                Boolean.TRUE.equals(descriptor.getWithOASValidationPolicy()),
+                audit
+            )
         );
 
         boolean isSynchronized = apiStateService.isSynchronized(

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource.java
@@ -174,6 +174,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -429,6 +430,7 @@ public class ApiResource extends AbstractResource {
                 ImportWsdlDescriptor.TypeEnum.URL.equals(descriptor.getType()),
                 Boolean.TRUE.equals(descriptor.getWithDocumentation()),
                 Boolean.TRUE.equals(descriptor.getWithOASValidationPolicy()),
+                Optional.ofNullable(descriptor.getWithPolicies()).map(ArrayList::new).orElse(null),
                 audit
             )
         );

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApisResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApisResource.java
@@ -104,7 +104,9 @@ import jakarta.ws.rs.container.ResourceContext;
 import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.UriInfo;
+import java.util.ArrayList;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -286,6 +288,7 @@ public class ApisResource extends AbstractResource {
                     ImportWsdlDescriptor.TypeEnum.URL.equals(descriptor.getType()),
                     Boolean.TRUE.equals(descriptor.getWithDocumentation()),
                     Boolean.TRUE.equals(descriptor.getWithOASValidationPolicy()),
+                    Optional.ofNullable(descriptor.getWithPolicies()).map(ArrayList::new).orElse(null),
                     audit
                 )
             );

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApisResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApisResource.java
@@ -42,6 +42,7 @@ import io.gravitee.apim.core.api.use_case.OAIToImportApiUseCase;
 import io.gravitee.apim.core.api.use_case.ValidateApiCRDUseCase;
 import io.gravitee.apim.core.api.use_case.VerifyApiHostsUseCase;
 import io.gravitee.apim.core.api.use_case.VerifyApiPathsUseCase;
+import io.gravitee.apim.core.api.use_case.WsdlToImportApiUseCase;
 import io.gravitee.apim.core.audit.model.AuditInfo;
 import io.gravitee.apim.core.utils.CollectionUtils;
 import io.gravitee.common.data.domain.Page;
@@ -59,6 +60,7 @@ import io.gravitee.rest.api.management.v2.rest.model.CreateApiV4;
 import io.gravitee.rest.api.management.v2.rest.model.ExportApiV4;
 import io.gravitee.rest.api.management.v2.rest.model.GenericApi;
 import io.gravitee.rest.api.management.v2.rest.model.ImportSwaggerDescriptor;
+import io.gravitee.rest.api.management.v2.rest.model.ImportWsdlDescriptor;
 import io.gravitee.rest.api.management.v2.rest.model.VerifyApiHosts;
 import io.gravitee.rest.api.management.v2.rest.model.VerifyApiHostsResponse;
 import io.gravitee.rest.api.management.v2.rest.model.VerifyApiPaths;
@@ -163,6 +165,9 @@ public class ApisResource extends AbstractResource {
     private OAIToImportApiUseCase oaiToImportApiUseCase;
 
     @Inject
+    private WsdlToImportApiUseCase wsdlToImportApiUseCase;
+
+    @Inject
     private ImportConfiguration importConfiguration;
 
     @Inject
@@ -261,6 +266,34 @@ public class ApisResource extends AbstractResource {
 
             return Response.created(this.getLocationHeader(importOutput.apiWithFlows().getId()))
                 .entity(ApiMapper.INSTANCE.map(importOutput.apiWithFlows(), uriInfo, isSynchronized))
+                .build();
+        } catch (InvalidPathsException e) {
+            throw new InvalidPathException("Cannot import API with invalid paths", e);
+        }
+    }
+
+    @POST
+    @Path("/_import/wsdl")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    @Permissions({ @Permission(value = RolePermission.ENVIRONMENT_API, acls = RolePermissionAction.CREATE) })
+    public Response createApiFromWsdl(@Valid @NotNull ImportWsdlDescriptor descriptor) {
+        try {
+            var audit = getAuditInfo();
+            var output = wsdlToImportApiUseCase.execute(
+                WsdlToImportApiUseCase.Input.of(
+                    descriptor.getPayload(),
+                    ImportWsdlDescriptor.TypeEnum.URL.equals(descriptor.getType()),
+                    Boolean.TRUE.equals(descriptor.getWithDocumentation()),
+                    Boolean.TRUE.equals(descriptor.getWithOASValidationPolicy()),
+                    audit
+                )
+            );
+
+            boolean isSynchronized = apiStateDomainService.isSynchronized(output.apiWithFlows(), audit);
+
+            return Response.created(this.getLocationHeader(output.apiWithFlows().getId()))
+                .entity(ApiMapper.INSTANCE.map(output.apiWithFlows(), uriInfo, isSynchronized))
                 .build();
         } catch (InvalidPathsException e) {
             throw new InvalidPathException("Cannot import API with invalid paths", e);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-apis.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-apis.yaml
@@ -700,6 +700,36 @@ paths:
                 default:
                     $ref: "#/components/responses/Error"
 
+    /environments/{envId}/apis/{apiId}/_import/wsdl:
+        parameters:
+            - $ref: "#/components/parameters/envIdParam"
+            - $ref: "#/components/parameters/apiIdParam"
+        put:
+            tags:
+                - APIs
+            summary: Update API from WSDL descriptor
+            description: |-
+                Update an existing API by importing a WSDL descriptor.<br>
+                The descriptor payload must be a valid WSDL 1.1 document, either as inline content or a remote URL.
+
+                User must have the API_DEFINITION[UPDATE] permission.
+            operationId: updateApiFromWsdl
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: "#/components/schemas/ImportWsdlDescriptor"
+                required: true
+            responses:
+                "200":
+                    description: API successfully updated
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/ApiV4"
+                default:
+                    $ref: "#/components/responses/Error"
+
     /environments/{envId}/apis/{apiId}/_import/swagger:
         parameters:
             - $ref: "#/components/parameters/envIdParam"

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-apis.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-apis.yaml
@@ -133,6 +133,36 @@ paths:
                 default:
                     $ref: "#/components/responses/Error"
 
+    /environments/{envId}/apis/_import/wsdl:
+        parameters:
+            - $ref: "#/components/parameters/envIdParam"
+        post:
+            tags:
+                - APIs
+            summary: Create API from WSDL
+            description: |-
+                Create a v4 HTTP Proxy API from a WSDL descriptor. The WSDL is converted to OpenAPI
+                and processed through the v4 OAI import pipeline. Payload can be inline WSDL (type: INLINE)
+                or a remote URL (type: URL).
+
+                User must have the ENVIRONMENT_API[CREATE] permission.
+            operationId: createApiFromWsdl
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: "#/components/schemas/ImportWsdlDescriptor"
+                required: true
+            responses:
+                "201":
+                    description: API successfully created
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/ApiV4"
+                default:
+                    $ref: "#/components/responses/Error"
+
     /environments/{envId}/apis/_import/definition:
         parameters:
             - $ref: "#/components/parameters/envIdParam"
@@ -3886,6 +3916,34 @@ components:
                     description: The list of API's media used in pages.
                     items:
                         $ref: "#/components/schemas/Media"
+
+        ImportWsdlDescriptor:
+            type: object
+            required:
+                - payload
+            properties:
+                payload:
+                    type: string
+                    description: Inline WSDL content (when type is INLINE) or a remote URL (when type is URL).
+                type:
+                    type: string
+                    description: Whether the payload is inline WSDL or a remote URL.
+                    enum:
+                        - INLINE
+                        - URL
+                    default: INLINE
+                withDocumentation:
+                    type: boolean
+                    description: Generate a Swagger documentation page from the converted OpenAPI spec.
+                withOASValidationPolicy:
+                    type: boolean
+                    description: Add an OAS Validation policy to every flow.
+                withPolicies:
+                    type: array
+                    description: Policy visitor IDs to apply (e.g. rest-to-soap, json-validation, mock, validate-request, xml-validation).
+                    items:
+                        type: string
+                    uniqueItems: true
 
         ImportSwaggerDescriptor:
             type: object

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/AbstractResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/AbstractResourceTest.java
@@ -45,6 +45,7 @@ import io.gravitee.apim.core.api.domain_service.VerifyApiPathDomainService;
 import io.gravitee.apim.core.api.use_case.ExportApiUseCase;
 import io.gravitee.apim.core.api.use_case.OAIToUpdateApiUseCase;
 import io.gravitee.apim.core.api.use_case.UpdateApiDefinitionFromImportUseCase;
+import io.gravitee.apim.core.api.use_case.WsdlToUpdateApiUseCase;
 import io.gravitee.apim.core.group.model.Group;
 import io.gravitee.apim.core.specgen.use_case.SpecGenRequestUseCase;
 import io.gravitee.apim.core.user.model.BaseUserEntity;
@@ -138,6 +139,9 @@ public abstract class AbstractResourceTest extends JerseySpringTest {
 
     @Autowired
     protected OAIToUpdateApiUseCase oaiToUpdateApiUseCase;
+
+    @Autowired
+    protected WsdlToUpdateApiUseCase wsdlToUpdateApiUseCase;
 
     @Autowired
     protected PermissionService permissionService;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResourceTest.java
@@ -55,7 +55,8 @@ public abstract class ApiResourceTest extends AbstractResourceTest {
             apiDuplicatorService,
             apiDuplicateService,
             updateApiDefinitionUseCase,
-            oaiToUpdateApiUseCase
+            oaiToUpdateApiUseCase,
+            wsdlToUpdateApiUseCase
         );
         GraviteeContext.cleanContext();
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource_UpdateApiFromWsdlTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource_UpdateApiFromWsdlTest.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.management.v2.rest.resource.api;
+
+import static io.gravitee.common.http.HttpStatusCode.BAD_REQUEST_400;
+import static io.gravitee.common.http.HttpStatusCode.FORBIDDEN_403;
+import static io.gravitee.common.http.HttpStatusCode.NOT_FOUND_404;
+import static io.gravitee.common.http.HttpStatusCode.OK_200;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import fixtures.core.model.ApiFixtures;
+import io.gravitee.apim.core.api.exception.ApiNotFoundException;
+import io.gravitee.apim.core.api.exception.InvalidApiDefinitionException;
+import io.gravitee.apim.core.api.exception.InvalidPathsException;
+import io.gravitee.apim.core.api.model.ApiWithFlows;
+import io.gravitee.apim.core.api.use_case.WsdlToUpdateApiUseCase;
+import io.gravitee.rest.api.management.v2.rest.model.ApiV4;
+import io.gravitee.rest.api.management.v2.rest.model.ImportWsdlDescriptor;
+import io.gravitee.rest.api.model.permissions.RolePermission;
+import io.gravitee.rest.api.model.permissions.RolePermissionAction;
+import io.gravitee.rest.api.service.common.GraviteeContext;
+import jakarta.ws.rs.client.Entity;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import org.junit.jupiter.api.Test;
+
+class ApiResource_UpdateApiFromWsdlTest extends ApiResourceTest {
+
+    @Override
+    protected String contextPath() {
+        return "/environments/" + ENVIRONMENT + "/apis/" + API + "/_import/wsdl";
+    }
+
+    @Test
+    void should_return_403_when_no_definition_update_permission() {
+        when(
+            permissionService.hasPermission(
+                GraviteeContext.getExecutionContext(),
+                RolePermission.API_DEFINITION,
+                API,
+                RolePermissionAction.UPDATE
+            )
+        ).thenReturn(false);
+
+        Response response = rootTarget().request().put(Entity.json(new ImportWsdlDescriptor()));
+
+        assertThat(response.getStatus()).isEqualTo(FORBIDDEN_403);
+    }
+
+    @Test
+    void should_return_404_when_api_not_found() {
+        when(wsdlToUpdateApiUseCase.execute(any())).thenThrow(new ApiNotFoundException(API));
+
+        Response response = rootTarget().request().put(Entity.entity(buildDescriptor("<definitions/>"), MediaType.APPLICATION_JSON));
+
+        assertThat(response.getStatus()).isEqualTo(NOT_FOUND_404);
+    }
+
+    @Test
+    void should_return_200_and_updated_api_on_success() {
+        var existingApi = ApiFixtures.aProxyApiV4().toBuilder().id(API).environmentId(ENVIRONMENT).build();
+        var apiWithFlows = new ApiWithFlows(existingApi, java.util.List.of());
+
+        when(wsdlToUpdateApiUseCase.execute(any())).thenReturn(new WsdlToUpdateApiUseCase.Output(apiWithFlows));
+        when(apiSearchServiceV4.findById(GraviteeContext.getExecutionContext(), API)).thenReturn(
+            io.gravitee.rest.api.model.v4.api.ApiEntity.builder().id(API).name("CalculatorService").apiVersion("1.0").build()
+        );
+
+        Response response = rootTarget().request().put(Entity.entity(buildDescriptor("<definitions/>"), MediaType.APPLICATION_JSON));
+
+        assertThat(response.getStatus()).isEqualTo(OK_200);
+        var body = response.readEntity(ApiV4.class);
+        assertThat(body).isNotNull();
+        assertThat(body.getId()).isEqualTo(API);
+    }
+
+    @Test
+    void should_return_400_when_wsdl_cannot_be_converted() {
+        when(wsdlToUpdateApiUseCase.execute(any())).thenThrow(
+            new InvalidApiDefinitionException("Unable to read the swagger specification")
+        );
+
+        Response response = rootTarget().request().put(Entity.entity(buildDescriptor("<definitions/>"), MediaType.APPLICATION_JSON));
+
+        assertThat(response.getStatus()).isEqualTo(BAD_REQUEST_400);
+    }
+
+    @Test
+    void should_return_400_when_invalid_paths() {
+        when(wsdlToUpdateApiUseCase.execute(any())).thenThrow(new InvalidPathsException("Path [/foo] already exists"));
+
+        Response response = rootTarget().request().put(Entity.entity(buildDescriptor("<definitions/>"), MediaType.APPLICATION_JSON));
+
+        assertThat(response.getStatus()).isEqualTo(BAD_REQUEST_400);
+    }
+
+    private ImportWsdlDescriptor buildDescriptor(String payload) {
+        return new ImportWsdlDescriptor().payload(payload).withDocumentation(false).withOASValidationPolicy(false);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource_UpdateApiFromWsdlTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource_UpdateApiFromWsdlTest.java
@@ -21,6 +21,7 @@ import static io.gravitee.common.http.HttpStatusCode.NOT_FOUND_404;
 import static io.gravitee.common.http.HttpStatusCode.OK_200;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import fixtures.core.model.ApiFixtures;
@@ -37,7 +38,10 @@ import io.gravitee.rest.api.service.common.GraviteeContext;
 import jakarta.ws.rs.client.Entity;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
+import java.util.List;
+import java.util.Set;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 
 class ApiResource_UpdateApiFromWsdlTest extends ApiResourceTest {
 
@@ -74,7 +78,7 @@ class ApiResource_UpdateApiFromWsdlTest extends ApiResourceTest {
     @Test
     void should_return_200_and_updated_api_on_success() {
         var existingApi = ApiFixtures.aProxyApiV4().toBuilder().id(API).environmentId(ENVIRONMENT).build();
-        var apiWithFlows = new ApiWithFlows(existingApi, java.util.List.of());
+        var apiWithFlows = new ApiWithFlows(existingApi, List.of());
 
         when(wsdlToUpdateApiUseCase.execute(any())).thenReturn(new WsdlToUpdateApiUseCase.Output(apiWithFlows));
         when(apiSearchServiceV4.findById(GraviteeContext.getExecutionContext(), API)).thenReturn(
@@ -107,6 +111,29 @@ class ApiResource_UpdateApiFromWsdlTest extends ApiResourceTest {
         Response response = rootTarget().request().put(Entity.entity(buildDescriptor("<definitions/>"), MediaType.APPLICATION_JSON));
 
         assertThat(response.getStatus()).isEqualTo(BAD_REQUEST_400);
+    }
+
+    @Test
+    void should_forward_with_policies_to_use_case() {
+        var existingApi = ApiFixtures.aProxyApiV4().toBuilder().id(API).environmentId(ENVIRONMENT).build();
+        var apiWithFlows = new ApiWithFlows(existingApi, List.of());
+
+        when(wsdlToUpdateApiUseCase.execute(any())).thenReturn(new WsdlToUpdateApiUseCase.Output(apiWithFlows));
+        when(apiSearchServiceV4.findById(GraviteeContext.getExecutionContext(), API)).thenReturn(
+            io.gravitee.rest.api.model.v4.api.ApiEntity.builder().id(API).name("CalculatorService").apiVersion("1.0").build()
+        );
+
+        var descriptor = new ImportWsdlDescriptor()
+            .payload("<definitions/>")
+            .withDocumentation(false)
+            .withOASValidationPolicy(false)
+            .withPolicies(Set.of("rest-to-soap"));
+
+        rootTarget().request().put(Entity.entity(descriptor, MediaType.APPLICATION_JSON));
+
+        var captor = ArgumentCaptor.forClass(WsdlToUpdateApiUseCase.Input.class);
+        verify(wsdlToUpdateApiUseCase).execute(captor.capture());
+        assertThat(captor.getValue().withPolicies()).containsExactly("rest-to-soap");
     }
 
     private ImportWsdlDescriptor buildDescriptor(String payload) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApisResource_CreateApiFromWsdlTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApisResource_CreateApiFromWsdlTest.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.management.v2.rest.resource.api;
+
+import static io.gravitee.common.http.HttpStatusCode.BAD_REQUEST_400;
+import static io.gravitee.common.http.HttpStatusCode.CREATED_201;
+import static io.gravitee.common.http.HttpStatusCode.FORBIDDEN_403;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.apim.core.api.exception.InvalidPathsException;
+import io.gravitee.apim.core.api.model.Api;
+import io.gravitee.apim.core.api.model.ApiWithFlows;
+import io.gravitee.apim.core.api.use_case.WsdlToImportApiUseCase;
+import io.gravitee.definition.model.DefinitionVersion;
+import io.gravitee.definition.model.v4.ApiType;
+import io.gravitee.repository.exceptions.TechnicalException;
+import io.gravitee.rest.api.management.v2.rest.model.ApiV4;
+import io.gravitee.rest.api.management.v2.rest.model.Error;
+import io.gravitee.rest.api.management.v2.rest.model.ImportWsdlDescriptor;
+import io.gravitee.rest.api.management.v2.rest.resource.AbstractResourceTest;
+import io.gravitee.rest.api.model.EnvironmentEntity;
+import io.gravitee.rest.api.model.permissions.RolePermission;
+import io.gravitee.rest.api.model.permissions.RolePermissionAction;
+import io.gravitee.rest.api.service.common.GraviteeContext;
+import jakarta.ws.rs.client.Entity;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+public class ApisResource_CreateApiFromWsdlTest extends AbstractResourceTest {
+
+    private static final String ENVIRONMENT_ID = "my-env";
+
+    @Autowired
+    private WsdlToImportApiUseCase wsdlToImportApiUseCase;
+
+    @Override
+    protected String contextPath() {
+        return "/environments/" + ENVIRONMENT_ID + "/apis/_import/wsdl";
+    }
+
+    @BeforeEach
+    public void init() throws TechnicalException {
+        reset(wsdlToImportApiUseCase);
+        GraviteeContext.cleanContext();
+        GraviteeContext.setCurrentEnvironment(ENVIRONMENT_ID);
+        GraviteeContext.setCurrentOrganization(ORGANIZATION);
+
+        EnvironmentEntity environmentEntity = new EnvironmentEntity();
+        environmentEntity.setId(ENVIRONMENT_ID);
+        environmentEntity.setOrganizationId(ORGANIZATION);
+        when(environmentService.findById(ENVIRONMENT_ID)).thenReturn(environmentEntity);
+        when(environmentService.findByOrgAndIdOrHrid(ORGANIZATION, ENVIRONMENT_ID)).thenReturn(environmentEntity);
+    }
+
+    @Test
+    public void should_return_403_when_no_permission() {
+        when(
+            permissionService.hasPermission(
+                GraviteeContext.getExecutionContext(),
+                RolePermission.ENVIRONMENT_API,
+                ENVIRONMENT_ID,
+                RolePermissionAction.CREATE
+            )
+        ).thenReturn(false);
+
+        var response = rootTarget().request().post(null);
+
+        assertThat(response.getStatus()).isEqualTo(FORBIDDEN_403);
+    }
+
+    @Test
+    public void should_return_201_with_created_api() {
+        var createdApi = Api.builder()
+            .id("wsdl-api-id")
+            .name("CalculatorService")
+            .environmentId(ENVIRONMENT_ID)
+            .definitionVersion(DefinitionVersion.V4)
+            .type(ApiType.PROXY)
+            .build();
+        when(wsdlToImportApiUseCase.execute(any())).thenReturn(new WsdlToImportApiUseCase.Output(new ApiWithFlows(createdApi, List.of())));
+
+        var descriptor = new ImportWsdlDescriptor().payload("<definitions/>").withDocumentation(false).withOASValidationPolicy(false);
+
+        var response = rootTarget().request().post(Entity.json(descriptor));
+
+        assertThat(response.getStatus()).isEqualTo(CREATED_201);
+        var api = response.readEntity(ApiV4.class);
+        assertThat(api.getId()).isEqualTo("wsdl-api-id");
+        assertThat(api.getName()).isEqualTo("CalculatorService");
+    }
+
+    @Test
+    public void should_return_400_when_invalid_paths() {
+        when(wsdlToImportApiUseCase.execute(any())).thenThrow(new InvalidPathsException("Invalid paths"));
+
+        var descriptor = new ImportWsdlDescriptor().payload("<definitions/>");
+
+        var response = rootTarget().request().post(Entity.json(descriptor));
+
+        assertThat(response.getStatus()).isEqualTo(BAD_REQUEST_400);
+        var error = response.readEntity(Error.class);
+        assertThat(error.getHttpStatus()).isEqualTo(BAD_REQUEST_400);
+        assertThat(error.getMessage()).isEqualTo("Cannot import API with invalid paths (Invalid paths)");
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/spring/ResourceContextConfiguration.java
@@ -88,6 +88,7 @@ import io.gravitee.apim.core.api.use_case.UpdateApiDefinitionFromImportUseCase;
 import io.gravitee.apim.core.api.use_case.UpdateApiGroupsUseCase;
 import io.gravitee.apim.core.api.use_case.ValidateApiCRDUseCase;
 import io.gravitee.apim.core.api.use_case.WsdlToImportApiUseCase;
+import io.gravitee.apim.core.api.use_case.WsdlToUpdateApiUseCase;
 import io.gravitee.apim.core.api_key.domain_service.ReconcileApiKeysDomainService;
 import io.gravitee.apim.core.api_product.use_case.CreateApiProductUseCase;
 import io.gravitee.apim.core.api_product.use_case.DeleteApiProductUseCase;
@@ -723,6 +724,12 @@ public class ResourceContextConfiguration {
     @Primary
     public WsdlToImportApiUseCase wsdlToImportApiUseCase() {
         return mock(WsdlToImportApiUseCase.class);
+    }
+
+    @Bean
+    @Primary
+    public WsdlToUpdateApiUseCase wsdlToUpdateApiUseCase() {
+        return mock(WsdlToUpdateApiUseCase.class);
     }
 
     @Bean

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/spring/ResourceContextConfiguration.java
@@ -72,6 +72,7 @@ import io.gravitee.apim.core.api.domain_service.ValidateApiCRDDomainService;
 import io.gravitee.apim.core.api.domain_service.ValidateApiDomainService;
 import io.gravitee.apim.core.api.domain_service.VerifyApiHostsDomainService;
 import io.gravitee.apim.core.api.domain_service.VerifyApiPathDomainService;
+import io.gravitee.apim.core.api.domain_service.WsdlParserDomainService;
 import io.gravitee.apim.core.api.query_service.ApiEventQueryService;
 import io.gravitee.apim.core.api.service_provider.ApiTemplateModelProvider;
 import io.gravitee.apim.core.api.use_case.ExportApiUseCase;
@@ -86,6 +87,7 @@ import io.gravitee.apim.core.api.use_case.RollbackApiUseCase;
 import io.gravitee.apim.core.api.use_case.UpdateApiDefinitionFromImportUseCase;
 import io.gravitee.apim.core.api.use_case.UpdateApiGroupsUseCase;
 import io.gravitee.apim.core.api.use_case.ValidateApiCRDUseCase;
+import io.gravitee.apim.core.api.use_case.WsdlToImportApiUseCase;
 import io.gravitee.apim.core.api_key.domain_service.ReconcileApiKeysDomainService;
 import io.gravitee.apim.core.api_product.use_case.CreateApiProductUseCase;
 import io.gravitee.apim.core.api_product.use_case.DeleteApiProductUseCase;
@@ -710,6 +712,17 @@ public class ResourceContextConfiguration {
     @Primary
     public OAIToUpdateApiUseCase oaiToUpdateApiUseCase() {
         return mock(OAIToUpdateApiUseCase.class);
+    }
+
+    @Bean
+    public WsdlParserDomainService wsdlParserDomainService() {
+        return mock(WsdlParserDomainService.class);
+    }
+
+    @Bean
+    @Primary
+    public WsdlToImportApiUseCase wsdlToImportApiUseCase() {
+        return mock(WsdlToImportApiUseCase.class);
     }
 
     @Bean

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/spring/ResourceContextConfiguration.java
@@ -58,6 +58,7 @@ import io.gravitee.apim.core.api.domain_service.OAIDomainService;
 import io.gravitee.apim.core.api.domain_service.UpdateApiDomainService;
 import io.gravitee.apim.core.api.domain_service.ValidateApiDomainService;
 import io.gravitee.apim.core.api.domain_service.VerifyApiPathDomainService;
+import io.gravitee.apim.core.api.domain_service.WsdlParserDomainService;
 import io.gravitee.apim.core.api.query_service.ApiEventQueryService;
 import io.gravitee.apim.core.api.query_service.ApiMetadataQueryService;
 import io.gravitee.apim.core.api.query_service.ApiQueryService;
@@ -66,6 +67,7 @@ import io.gravitee.apim.core.api.use_case.GetExposedEntrypointsUseCase;
 import io.gravitee.apim.core.api.use_case.PatchApiUseCase.FlowListDeserializer;
 import io.gravitee.apim.core.api.use_case.PatchApiUseCase.FlowListSerializer;
 import io.gravitee.apim.core.api.use_case.RollbackApiUseCase;
+import io.gravitee.apim.core.api.use_case.WsdlToImportApiUseCase;
 import io.gravitee.apim.core.api_key.domain_service.ReconcileApiKeysDomainService;
 import io.gravitee.apim.core.api_product.use_case.GetApiProductsUseCase;
 import io.gravitee.apim.core.api_product.use_case.TransferApiProductOwnershipUseCase;
@@ -912,6 +914,17 @@ public class ResourceContextConfiguration {
     @Bean
     public OAIDomainService oaiDomainService() {
         return mock(OAIDomainService.class);
+    }
+
+    @Bean
+    public WsdlParserDomainService wsdlParserDomainService() {
+        return mock(WsdlParserDomainService.class);
+    }
+
+    @Bean
+    @Primary
+    public WsdlToImportApiUseCase wsdlToImportApiUseCase() {
+        return mock(WsdlToImportApiUseCase.class);
     }
 
     @Bean

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/ImportSwaggerDescriptorEntity.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/ImportSwaggerDescriptorEntity.java
@@ -21,7 +21,9 @@ import jakarta.validation.constraints.NotNull;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
@@ -57,6 +59,10 @@ public class ImportSwaggerDescriptorEntity {
 
     @JsonProperty("with_policies")
     private List<String> withPolicies;
+
+    @Getter
+    @Setter
+    private boolean skipFlows;
 
     public Type getType() {
         return type;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/spring/ResourceContextConfiguration.java
@@ -61,6 +61,7 @@ import io.gravitee.apim.core.api.domain_service.OAIDomainService;
 import io.gravitee.apim.core.api.domain_service.UpdateApiDomainService;
 import io.gravitee.apim.core.api.domain_service.ValidateApiDomainService;
 import io.gravitee.apim.core.api.domain_service.VerifyApiPathDomainService;
+import io.gravitee.apim.core.api.domain_service.WsdlParserDomainService;
 import io.gravitee.apim.core.api.query_service.ApiEventQueryService;
 import io.gravitee.apim.core.api.query_service.ApiMetadataQueryService;
 import io.gravitee.apim.core.api.query_service.ApiQueryService;
@@ -69,6 +70,7 @@ import io.gravitee.apim.core.api.use_case.GetExposedEntrypointsUseCase;
 import io.gravitee.apim.core.api.use_case.PatchApiUseCase.FlowListDeserializer;
 import io.gravitee.apim.core.api.use_case.PatchApiUseCase.FlowListSerializer;
 import io.gravitee.apim.core.api.use_case.RollbackApiUseCase;
+import io.gravitee.apim.core.api.use_case.WsdlToImportApiUseCase;
 import io.gravitee.apim.core.api_key.domain_service.ReconcileApiKeysDomainService;
 import io.gravitee.apim.core.api_product.use_case.TransferApiProductOwnershipUseCase;
 import io.gravitee.apim.core.apim.service_provider.ApimProductInfo;
@@ -280,6 +282,7 @@ import java.util.List;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Primary;
 import org.springframework.context.annotation.PropertySource;
 import org.springframework.mock.env.MockEnvironment;
 
@@ -842,6 +845,17 @@ public class ResourceContextConfiguration {
     @Bean
     public OAIDomainService oaiDomainService() {
         return mock(OAIDomainService.class);
+    }
+
+    @Bean
+    public WsdlParserDomainService wsdlParserDomainService() {
+        return mock(WsdlParserDomainService.class);
+    }
+
+    @Bean
+    @Primary
+    public WsdlToImportApiUseCase wsdlToImportApiUseCase() {
+        return mock(WsdlToImportApiUseCase.class);
     }
 
     @Bean

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/domain_service/WsdlParserDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/domain_service/WsdlParserDomainService.java
@@ -22,7 +22,8 @@ package io.gravitee.apim.core.api.domain_service;
 public interface WsdlParserDomainService {
     /**
      * @param content inline WSDL XML content or a remote URL
-     * @return OpenAPI 3.x YAML string, or {@code null} if parsing failed
+     * @return OpenAPI 3.x YAML string
+     * @throws io.gravitee.rest.api.service.exceptions.SwaggerDescriptorException if parsing fails
      */
     String toOpenApiYaml(String content);
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/domain_service/WsdlParserDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/domain_service/WsdlParserDomainService.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.api.domain_service;
+
+/**
+ * Converts a WSDL descriptor into an OpenAPI YAML string
+ * that can be fed into the standard v4 OAI import pipeline.
+ */
+public interface WsdlParserDomainService {
+    /**
+     * @param content inline WSDL XML content or a remote URL
+     * @return OpenAPI 3.x YAML string, or {@code null} if parsing failed
+     */
+    String toOpenApiYaml(String content);
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/use_case/WsdlToImportApiUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/use_case/WsdlToImportApiUseCase.java
@@ -23,23 +23,47 @@ import io.gravitee.apim.core.api.model.ApiWithFlows;
 import io.gravitee.apim.core.audit.model.AuditInfo;
 import io.gravitee.rest.api.model.ImportSwaggerDescriptorEntity;
 import io.gravitee.rest.api.service.exceptions.SwaggerDescriptorException;
+import java.util.List;
+import java.util.stream.Stream;
+import lombok.RequiredArgsConstructor;
 
 @UseCase
+@RequiredArgsConstructor
 public class WsdlToImportApiUseCase {
 
     public sealed interface Input permits Input.Inline, Input.Url {
         boolean withDocumentation();
         boolean withOASValidationPolicy();
+        List<String> withPolicies();
         AuditInfo auditInfo();
 
-        record Inline(String payload, boolean withDocumentation, boolean withOASValidationPolicy, AuditInfo auditInfo) implements Input {}
+        record Inline(
+            String payload,
+            boolean withDocumentation,
+            boolean withOASValidationPolicy,
+            List<String> withPolicies,
+            AuditInfo auditInfo
+        ) implements Input {}
 
-        record Url(String url, boolean withDocumentation, boolean withOASValidationPolicy, AuditInfo auditInfo) implements Input {}
+        record Url(
+            String url,
+            boolean withDocumentation,
+            boolean withOASValidationPolicy,
+            List<String> withPolicies,
+            AuditInfo auditInfo
+        ) implements Input {}
 
-        static Input of(String payload, boolean isUrl, boolean withDocumentation, boolean withOASValidationPolicy, AuditInfo auditInfo) {
+        static Input of(
+            String payload,
+            boolean isUrl,
+            boolean withDocumentation,
+            boolean withOASValidationPolicy,
+            List<String> withPolicies,
+            AuditInfo auditInfo
+        ) {
             return isUrl
-                ? new Url(payload, withDocumentation, withOASValidationPolicy, auditInfo)
-                : new Inline(payload, withDocumentation, withOASValidationPolicy, auditInfo);
+                ? new Url(payload, withDocumentation, withOASValidationPolicy, withPolicies, auditInfo)
+                : new Inline(payload, withDocumentation, withOASValidationPolicy, withPolicies, auditInfo);
         }
     }
 
@@ -49,16 +73,6 @@ public class WsdlToImportApiUseCase {
     private final OAIDomainService oaiDomainService;
     private final ImportDefinitionCreateDomainService importDefinitionCreateDomainService;
 
-    public WsdlToImportApiUseCase(
-        WsdlParserDomainService wsdlParserDomainService,
-        OAIDomainService oaiDomainService,
-        ImportDefinitionCreateDomainService importDefinitionCreateDomainService
-    ) {
-        this.wsdlParserDomainService = wsdlParserDomainService;
-        this.oaiDomainService = oaiDomainService;
-        this.importDefinitionCreateDomainService = importDefinitionCreateDomainService;
-    }
-
     public Output execute(Input input) {
         String content = switch (input) {
             case Input.Url u -> u.url();
@@ -66,13 +80,14 @@ public class WsdlToImportApiUseCase {
         };
         String openApiYaml = wsdlParserDomainService.toOpenApiYaml(content);
 
-        if (openApiYaml == null) {
-            throw new SwaggerDescriptorException("Failed to convert WSDL to OpenAPI specification");
-        }
+        var policies = addDependentPolicies(input.withPolicies());
 
         var importSwaggerDescriptor = ImportSwaggerDescriptorEntity.builder()
             .payload(openApiYaml)
+            .format(ImportSwaggerDescriptorEntity.Format.WSDL)
             .withDocumentation(input.withDocumentation())
+            .withPolicies(policies)
+            .skipFlows(policies != null && policies.isEmpty())
             .build();
 
         var importDefinition = oaiDomainService.convert(
@@ -89,5 +104,12 @@ public class WsdlToImportApiUseCase {
 
         ApiWithFlows apiWithFlows = importDefinitionCreateDomainService.create(input.auditInfo(), importDefinition);
         return new Output(apiWithFlows);
+    }
+
+    private static List<String> addDependentPolicies(List<String> policies) {
+        if (policies == null || !policies.contains("rest-to-soap")) {
+            return policies;
+        }
+        return Stream.concat(policies.stream(), Stream.of("xml-json")).distinct().toList();
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/use_case/WsdlToImportApiUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/use_case/WsdlToImportApiUseCase.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.api.use_case;
+
+import io.gravitee.apim.core.UseCase;
+import io.gravitee.apim.core.api.domain_service.OAIDomainService;
+import io.gravitee.apim.core.api.domain_service.WsdlParserDomainService;
+import io.gravitee.apim.core.api.domain_service.import_definition.ImportDefinitionCreateDomainService;
+import io.gravitee.apim.core.api.model.ApiWithFlows;
+import io.gravitee.apim.core.audit.model.AuditInfo;
+import io.gravitee.rest.api.model.ImportSwaggerDescriptorEntity;
+import io.gravitee.rest.api.service.exceptions.SwaggerDescriptorException;
+
+@UseCase
+public class WsdlToImportApiUseCase {
+
+    public sealed interface Input permits Input.Inline, Input.Url {
+        boolean withDocumentation();
+        boolean withOASValidationPolicy();
+        AuditInfo auditInfo();
+
+        record Inline(String payload, boolean withDocumentation, boolean withOASValidationPolicy, AuditInfo auditInfo) implements Input {}
+
+        record Url(String url, boolean withDocumentation, boolean withOASValidationPolicy, AuditInfo auditInfo) implements Input {}
+
+        static Input of(String payload, boolean isUrl, boolean withDocumentation, boolean withOASValidationPolicy, AuditInfo auditInfo) {
+            return isUrl
+                ? new Url(payload, withDocumentation, withOASValidationPolicy, auditInfo)
+                : new Inline(payload, withDocumentation, withOASValidationPolicy, auditInfo);
+        }
+    }
+
+    public record Output(ApiWithFlows apiWithFlows) {}
+
+    private final WsdlParserDomainService wsdlParserDomainService;
+    private final OAIDomainService oaiDomainService;
+    private final ImportDefinitionCreateDomainService importDefinitionCreateDomainService;
+
+    public WsdlToImportApiUseCase(
+        WsdlParserDomainService wsdlParserDomainService,
+        OAIDomainService oaiDomainService,
+        ImportDefinitionCreateDomainService importDefinitionCreateDomainService
+    ) {
+        this.wsdlParserDomainService = wsdlParserDomainService;
+        this.oaiDomainService = oaiDomainService;
+        this.importDefinitionCreateDomainService = importDefinitionCreateDomainService;
+    }
+
+    public Output execute(Input input) {
+        String content = switch (input) {
+            case Input.Url u -> u.url();
+            case Input.Inline i -> i.payload();
+        };
+        String openApiYaml = wsdlParserDomainService.toOpenApiYaml(content);
+
+        if (openApiYaml == null) {
+            throw new SwaggerDescriptorException("Failed to convert WSDL to OpenAPI specification");
+        }
+
+        var importSwaggerDescriptor = ImportSwaggerDescriptorEntity.builder()
+            .payload(openApiYaml)
+            .withDocumentation(input.withDocumentation())
+            .build();
+
+        var importDefinition = oaiDomainService.convert(
+            input.auditInfo().organizationId(),
+            input.auditInfo().environmentId(),
+            importSwaggerDescriptor,
+            input.withDocumentation(),
+            input.withOASValidationPolicy()
+        );
+
+        if (importDefinition == null) {
+            throw new SwaggerDescriptorException("Failed to convert OpenAPI specification to API definition");
+        }
+
+        ApiWithFlows apiWithFlows = importDefinitionCreateDomainService.create(input.auditInfo(), importDefinition);
+        return new Output(apiWithFlows);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/use_case/WsdlToUpdateApiUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/use_case/WsdlToUpdateApiUseCase.java
@@ -20,15 +20,19 @@ import io.gravitee.apim.core.api.domain_service.WsdlParserDomainService;
 import io.gravitee.apim.core.api.model.ApiWithFlows;
 import io.gravitee.apim.core.audit.model.AuditInfo;
 import io.gravitee.rest.api.model.ImportSwaggerDescriptorEntity;
-import io.gravitee.rest.api.service.exceptions.SwaggerDescriptorException;
+import java.util.List;
+import java.util.stream.Stream;
+import lombok.RequiredArgsConstructor;
 
 @UseCase
+@RequiredArgsConstructor
 public class WsdlToUpdateApiUseCase {
 
     public sealed interface Input permits Input.Inline, Input.Url {
         String apiId();
         boolean withDocumentation();
         boolean withOASValidationPolicy();
+        List<String> withPolicies();
         AuditInfo auditInfo();
 
         record Inline(
@@ -36,11 +40,18 @@ public class WsdlToUpdateApiUseCase {
             String payload,
             boolean withDocumentation,
             boolean withOASValidationPolicy,
+            List<String> withPolicies,
             AuditInfo auditInfo
         ) implements Input {}
 
-        record Url(String apiId, String url, boolean withDocumentation, boolean withOASValidationPolicy, AuditInfo auditInfo) implements
-            Input {}
+        record Url(
+            String apiId,
+            String url,
+            boolean withDocumentation,
+            boolean withOASValidationPolicy,
+            List<String> withPolicies,
+            AuditInfo auditInfo
+        ) implements Input {}
 
         static Input of(
             String apiId,
@@ -48,11 +59,12 @@ public class WsdlToUpdateApiUseCase {
             boolean isUrl,
             boolean withDocumentation,
             boolean withOASValidationPolicy,
+            List<String> withPolicies,
             AuditInfo auditInfo
         ) {
             return isUrl
-                ? new Url(apiId, payload, withDocumentation, withOASValidationPolicy, auditInfo)
-                : new Inline(apiId, payload, withDocumentation, withOASValidationPolicy, auditInfo);
+                ? new Url(apiId, payload, withDocumentation, withOASValidationPolicy, withPolicies, auditInfo)
+                : new Inline(apiId, payload, withDocumentation, withOASValidationPolicy, withPolicies, auditInfo);
         }
     }
 
@@ -61,11 +73,6 @@ public class WsdlToUpdateApiUseCase {
     private final WsdlParserDomainService wsdlParserDomainService;
     private final OAIToUpdateApiUseCase oaiToUpdateApiUseCase;
 
-    public WsdlToUpdateApiUseCase(WsdlParserDomainService wsdlParserDomainService, OAIToUpdateApiUseCase oaiToUpdateApiUseCase) {
-        this.wsdlParserDomainService = wsdlParserDomainService;
-        this.oaiToUpdateApiUseCase = oaiToUpdateApiUseCase;
-    }
-
     public Output execute(Input input) {
         String content = switch (input) {
             case Input.Url u -> u.url();
@@ -73,13 +80,14 @@ public class WsdlToUpdateApiUseCase {
         };
         String openApiYaml = wsdlParserDomainService.toOpenApiYaml(content);
 
-        if (openApiYaml == null) {
-            throw new SwaggerDescriptorException("Failed to convert WSDL to OpenAPI specification");
-        }
+        var policies = addDependentPolicies(input.withPolicies());
 
         var importSwaggerDescriptor = ImportSwaggerDescriptorEntity.builder()
             .payload(openApiYaml)
+            .format(ImportSwaggerDescriptorEntity.Format.WSDL)
             .withDocumentation(input.withDocumentation())
+            .withPolicies(policies)
+            .skipFlows(policies != null && policies.isEmpty())
             .build();
 
         var output = oaiToUpdateApiUseCase.execute(
@@ -94,5 +102,12 @@ public class WsdlToUpdateApiUseCase {
         );
 
         return new Output(output.apiWithFlows());
+    }
+
+    private static List<String> addDependentPolicies(List<String> policies) {
+        if (policies == null || !policies.contains("rest-to-soap")) {
+            return policies;
+        }
+        return Stream.concat(policies.stream(), Stream.of("xml-json")).distinct().toList();
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/use_case/WsdlToUpdateApiUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/use_case/WsdlToUpdateApiUseCase.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.api.use_case;
+
+import io.gravitee.apim.core.UseCase;
+import io.gravitee.apim.core.api.domain_service.WsdlParserDomainService;
+import io.gravitee.apim.core.api.model.ApiWithFlows;
+import io.gravitee.apim.core.audit.model.AuditInfo;
+import io.gravitee.rest.api.model.ImportSwaggerDescriptorEntity;
+import io.gravitee.rest.api.service.exceptions.SwaggerDescriptorException;
+
+@UseCase
+public class WsdlToUpdateApiUseCase {
+
+    public sealed interface Input permits Input.Inline, Input.Url {
+        String apiId();
+        boolean withDocumentation();
+        boolean withOASValidationPolicy();
+        AuditInfo auditInfo();
+
+        record Inline(
+            String apiId,
+            String payload,
+            boolean withDocumentation,
+            boolean withOASValidationPolicy,
+            AuditInfo auditInfo
+        ) implements Input {}
+
+        record Url(String apiId, String url, boolean withDocumentation, boolean withOASValidationPolicy, AuditInfo auditInfo) implements
+            Input {}
+
+        static Input of(
+            String apiId,
+            String payload,
+            boolean isUrl,
+            boolean withDocumentation,
+            boolean withOASValidationPolicy,
+            AuditInfo auditInfo
+        ) {
+            return isUrl
+                ? new Url(apiId, payload, withDocumentation, withOASValidationPolicy, auditInfo)
+                : new Inline(apiId, payload, withDocumentation, withOASValidationPolicy, auditInfo);
+        }
+    }
+
+    public record Output(ApiWithFlows apiWithFlows) {}
+
+    private final WsdlParserDomainService wsdlParserDomainService;
+    private final OAIToUpdateApiUseCase oaiToUpdateApiUseCase;
+
+    public WsdlToUpdateApiUseCase(WsdlParserDomainService wsdlParserDomainService, OAIToUpdateApiUseCase oaiToUpdateApiUseCase) {
+        this.wsdlParserDomainService = wsdlParserDomainService;
+        this.oaiToUpdateApiUseCase = oaiToUpdateApiUseCase;
+    }
+
+    public Output execute(Input input) {
+        String content = switch (input) {
+            case Input.Url u -> u.url();
+            case Input.Inline i -> i.payload();
+        };
+        String openApiYaml = wsdlParserDomainService.toOpenApiYaml(content);
+
+        if (openApiYaml == null) {
+            throw new SwaggerDescriptorException("Failed to convert WSDL to OpenAPI specification");
+        }
+
+        var importSwaggerDescriptor = ImportSwaggerDescriptorEntity.builder()
+            .payload(openApiYaml)
+            .withDocumentation(input.withDocumentation())
+            .build();
+
+        var output = oaiToUpdateApiUseCase.execute(
+            OAIToUpdateApiUseCase.Input.builder()
+                .apiId(input.apiId())
+                .importSwaggerDescriptor(importSwaggerDescriptor)
+                .withDocumentation(input.withDocumentation())
+                .withOASValidationPolicy(input.withOASValidationPolicy())
+                .withPolicyPaths(false)
+                .auditInfo(input.auditInfo())
+                .build()
+        );
+
+        return new Output(output.apiWithFlows());
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/converter/oai/OAIToImportDefinitionConverter.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/converter/oai/OAIToImportDefinitionConverter.java
@@ -25,9 +25,11 @@ import io.gravitee.rest.api.model.Visibility;
 import io.gravitee.rest.api.service.impl.swagger.visitor.v3.OAIOperationVisitor;
 import io.gravitee.rest.api.service.swagger.converter.extension.XGraviteeIODefinition;
 import io.swagger.v3.oas.models.OpenAPI;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
 import org.apache.commons.lang3.StringUtils;
 
 public class OAIToImportDefinitionConverter {
@@ -37,6 +39,14 @@ public class OAIToImportDefinitionConverter {
     private static final String PICTURE_REGEX = "^data:image/[\\w]+;base64,.*$";
 
     public ImportDefinition toImportDefinition(OpenAPI specification, Collection<? extends OAIOperationVisitor> visitors) {
+        return toImportDefinition(specification, visitors, false);
+    }
+
+    public ImportDefinition toImportDefinition(
+        OpenAPI specification,
+        Collection<? extends OAIOperationVisitor> visitors,
+        boolean skipFlows
+    ) {
         var xGraviteeIODefinition = getXGraviteeIODefinition(specification);
         var serverUrls = OAIServersConverter.INSTANCE.convert(specification.getServers());
         var importDefinitionBuilder = ImportDefinition.builder();
@@ -50,7 +60,7 @@ public class OAIToImportDefinitionConverter {
             .definitionVersion(DefinitionVersion.V4)
             .apiVersion(specification.getInfo().getVersion())
             .type(ApiType.PROXY)
-            .flows(OAIToFlowsConverter.INSTANCE.convert(specification, visitors))
+            .flows(skipFlows ? new ArrayList<>() : OAIToFlowsConverter.INSTANCE.convert(specification, visitors))
             .listeners(
                 OAIToListenersConverter.INSTANCE.convert(
                     xGraviteeIODefinition,

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/api/OAIDomainServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/api/OAIDomainServiceImpl.java
@@ -75,14 +75,19 @@ public class OAIDomainServiceImpl implements OAIDomainService {
         var descriptor = toOAIDescriptor(payload);
         var visitors = getVisitors(importSwaggerDescriptor);
 
-        var importDefinition = OAIToImportDefinitionConverter.INSTANCE.toImportDefinition(descriptor.getSpecification(), visitors);
+        var importDefinition = OAIToImportDefinitionConverter.INSTANCE.toImportDefinition(
+            descriptor.getSpecification(),
+            visitors,
+            importSwaggerDescriptor.isSkipFlows()
+        );
 
         if (importDefinition != null) {
             var importWithEndpointGroupsSharedConfiguration = addEndpointGroupSharedConfiguration(importDefinition);
             var importWithGroups = replaceGroupNamesWithIds(environmentId, importWithEndpointGroupsSharedConfiguration);
             var importWithTags = replaceTagsNamesWithIds(organizationId, importWithGroups);
             var importWithDocumentation = addOAIDocumentation(withDocumentation, payload, importWithTags);
-            return addOASValidationPolicy(withOASValidationPolicy, payload, importWithDocumentation);
+            boolean deferResponseValidation = shouldDeferResponseValidation(importSwaggerDescriptor);
+            return addOASValidationPolicy(withOASValidationPolicy, payload, importWithDocumentation, deferResponseValidation);
         }
 
         return null;
@@ -215,7 +220,12 @@ public class OAIDomainServiceImpl implements OAIDomainService {
         return importWithTags.toBuilder().pages(List.of(page)).build();
     }
 
-    private ImportDefinition addOASValidationPolicy(boolean withOASValidationPolicy, String payload, ImportDefinition importDefinition) {
+    private ImportDefinition addOASValidationPolicy(
+        boolean withOASValidationPolicy,
+        String payload,
+        ImportDefinition importDefinition,
+        boolean deferResponseValidation
+    ) {
         if (!withOASValidationPolicy) {
             return importDefinition;
         }
@@ -233,7 +243,6 @@ public class OAIDomainServiceImpl implements OAIDomainService {
                 .build();
             importDefinition.getApiExport().setResources(List.of(resource));
 
-            // Add Flow with OAS validation policy to API flows
             var step = Step.builder()
                 .policy(oasValidationPolicy.getId())
                 .name(oasValidationPolicy.getName())
@@ -246,11 +255,20 @@ public class OAIDomainServiceImpl implements OAIDomainService {
                 .name("OpenAPI Specification Validation")
                 .selectors(List.of(httpSelector))
                 .request(List.of(step))
-                .response(List.of(step))
+                .response(deferResponseValidation ? List.of() : List.of(step))
                 .build();
 
             List<Flow> apiExportFlows = (List<Flow>) importDefinition.getApiExport().getFlows();
             apiExportFlows.addFirst(flow);
+
+            if (deferResponseValidation) {
+                var responseFlow = Flow.builder()
+                    .name("OpenAPI Specification Validation")
+                    .selectors(List.of(httpSelector))
+                    .response(List.of(step))
+                    .build();
+                apiExportFlows.addLast(responseFlow);
+            }
 
             importDefinition.getApiExport().setFlows(apiExportFlows);
 
@@ -258,5 +276,13 @@ public class OAIDomainServiceImpl implements OAIDomainService {
         } catch (JsonProcessingException e) {
             throw new TechnicalManagementException("Error while serializing OpenAPI Specification", e);
         }
+    }
+
+    private static boolean shouldDeferResponseValidation(ImportSwaggerDescriptorEntity importSwaggerDescriptor) {
+        return (
+            ImportSwaggerDescriptorEntity.Format.WSDL.equals(importSwaggerDescriptor.getFormat()) &&
+            importSwaggerDescriptor.getWithPolicies() != null &&
+            !importSwaggerDescriptor.getWithPolicies().isEmpty()
+        );
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/api/WsdlParserDomainServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/api/WsdlParserDomainServiceImpl.java
@@ -16,6 +16,7 @@
 package io.gravitee.apim.infra.domain_service.api;
 
 import io.gravitee.apim.core.api.domain_service.WsdlParserDomainService;
+import io.gravitee.rest.api.service.exceptions.SwaggerDescriptorException;
 import io.gravitee.rest.api.service.impl.swagger.parser.WsdlParser;
 import io.gravitee.rest.api.service.sanitizer.UrlSanitizerUtils;
 import io.gravitee.rest.api.service.spring.ImportConfiguration;
@@ -45,7 +46,7 @@ public class WsdlParserDomainServiceImpl implements WsdlParserDomainService {
         }
         OpenAPI openAPI = new WsdlParser().parse(content);
         if (openAPI == null) {
-            return null;
+            throw new SwaggerDescriptorException("Failed to convert WSDL to OpenAPI specification");
         }
         return Yaml.pretty(openAPI);
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/api/WsdlParserDomainServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/api/WsdlParserDomainServiceImpl.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.infra.domain_service.api;
+
+import io.gravitee.apim.core.api.domain_service.WsdlParserDomainService;
+import io.gravitee.rest.api.service.impl.swagger.parser.WsdlParser;
+import io.gravitee.rest.api.service.sanitizer.UrlSanitizerUtils;
+import io.gravitee.rest.api.service.spring.ImportConfiguration;
+import io.swagger.v3.core.util.Yaml;
+import io.swagger.v3.oas.models.OpenAPI;
+import lombok.CustomLog;
+import org.springframework.stereotype.Service;
+
+@Service
+@CustomLog
+public class WsdlParserDomainServiceImpl implements WsdlParserDomainService {
+
+    private final ImportConfiguration importConfiguration;
+
+    public WsdlParserDomainServiceImpl(ImportConfiguration importConfiguration) {
+        this.importConfiguration = importConfiguration;
+    }
+
+    @Override
+    public String toOpenApiYaml(String content) {
+        if (UrlSanitizerUtils.isUrl(content)) {
+            UrlSanitizerUtils.checkAllowed(
+                content,
+                importConfiguration.getImportWhitelist(),
+                importConfiguration.isAllowImportFromPrivate()
+            );
+        }
+        OpenAPI openAPI = new WsdlParser().parse(content);
+        if (openAPI == null) {
+            return null;
+        }
+        return Yaml.pretty(openAPI);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/sanitizer/UrlSanitizerUtils.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/sanitizer/UrlSanitizerUtils.java
@@ -20,21 +20,26 @@ import io.gravitee.rest.api.service.exceptions.UrlForbiddenException;
 import java.net.Inet6Address;
 import java.net.InetAddress;
 import java.net.URI;
-import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
+import lombok.CustomLog;
 
 /**
  * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)
  * @author GraviteeSource Team
  */
+@CustomLog
 public class UrlSanitizerUtils {
 
     public static boolean isUrl(String content) {
+        if (content == null || content.isBlank()) {
+            return false;
+        }
         try {
-            new URL(content);
-            return true;
+            var uri = new URI(content);
+            return uri.getScheme() != null && uri.getHost() != null;
         } catch (Exception e) {
+            log.debug("Content is not a valid URL: {}", e.getMessage());
             return false;
         }
     }
@@ -61,7 +66,7 @@ public class UrlSanitizerUtils {
 
     public static boolean isPrivate(String url) {
         try {
-            InetAddress inetAddress = Inet6Address.getByName(new URL(url).getHost());
+            InetAddress inetAddress = Inet6Address.getByName(URI.create(url).toURL().getHost());
 
             return (
                 inetAddress.isSiteLocalAddress() ||

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/sanitizer/UrlSanitizerUtils.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/sanitizer/UrlSanitizerUtils.java
@@ -30,6 +30,15 @@ import java.util.List;
  */
 public class UrlSanitizerUtils {
 
+    public static boolean isUrl(String content) {
+        try {
+            new URL(content);
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
     public static void checkAllowed(String url, List<String> whitelist, boolean allowPrivate) {
         checkUrlForbiddenCharacters(url);
         checkUriSyntax(url);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/WsdlToImportApiUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/WsdlToImportApiUseCaseTest.java
@@ -146,13 +146,12 @@ class WsdlToImportApiUseCaseTest {
     }
 
     @Test
-    void should_create_flows_for_each_wsdl_operation() {
+    void should_not_create_flows_when_no_policies_are_requested() {
         var output = useCase.execute(buildInput(loadWsdl(), false, false));
         var apiDefinition = (Api) output.apiWithFlows().getApiDefinitionValue();
 
         assertThat(output).isNotNull();
-        // calculator.wsdl has 4 operations × 2 bindings (SOAP 1.1 + SOAP 1.2) = 8 flows
-        assertThat(apiDefinition.getFlows()).hasSize(8);
+        assertThat(apiDefinition.getFlows()).isEmpty();
     }
 
     @Test
@@ -203,18 +202,18 @@ class WsdlToImportApiUseCaseTest {
                 "http://localhost:" + wm.getHttpPort() + "/calculator.wsdl",
                 false,
                 false,
+                List.of(),
                 AUDIT_INFO
             );
             var output = useCase.execute(input);
 
             assertThat(output).isNotNull();
             assertThat(output.apiWithFlows().getName()).isEqualTo("CalculatorService");
-            assertThat(((Api) output.apiWithFlows().getApiDefinitionValue()).getFlows()).hasSize(8);
         }
 
         @Test
         void should_throw_when_remote_url_is_unreachable() {
-            var input = new WsdlToImportApiUseCase.Input.Url("http://localhost:1/nonexistent.wsdl", false, false, AUDIT_INFO);
+            var input = new WsdlToImportApiUseCase.Input.Url("http://localhost:1/nonexistent.wsdl", false, false, List.of(), AUDIT_INFO);
 
             var throwable = catchThrowable(() -> useCase.execute(input));
 
@@ -229,6 +228,7 @@ class WsdlToImportApiUseCaseTest {
                 "http://localhost:" + wm.getHttpPort() + "/bad.wsdl",
                 false,
                 false,
+                List.of(),
                 AUDIT_INFO
             );
             var throwable = catchThrowable(() -> useCase.execute(input));
@@ -237,12 +237,22 @@ class WsdlToImportApiUseCaseTest {
         }
     }
 
+    @Test
+    void should_create_flows_when_rest_to_soap_policy_is_requested() {
+        var input = new WsdlToImportApiUseCase.Input.Inline(loadWsdl(), false, false, List.of("rest-to-soap"), AUDIT_INFO);
+        var output = useCase.execute(input);
+        var apiDefinition = (Api) output.apiWithFlows().getApiDefinitionValue();
+
+        // Flows are generated (not skipped) when policies are requested
+        assertThat(apiDefinition.getFlows()).isNotEmpty();
+    }
+
     @SneakyThrows
     private String loadWsdl() {
         return Resources.toString(Resources.getResource("wsdl/calculator.wsdl"), Charsets.UTF_8);
     }
 
     private WsdlToImportApiUseCase.Input buildInput(String payload, boolean withDocumentation, boolean withOASValidationPolicy) {
-        return new WsdlToImportApiUseCase.Input.Inline(payload, withDocumentation, withOASValidationPolicy, AUDIT_INFO);
+        return new WsdlToImportApiUseCase.Input.Inline(payload, withDocumentation, withOASValidationPolicy, List.of(), AUDIT_INFO);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/WsdlToImportApiUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/WsdlToImportApiUseCaseTest.java
@@ -1,0 +1,248 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.api.use_case;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.catchThrowable;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
+import com.github.tomakehurst.wiremock.junit5.WireMockTest;
+import com.google.common.base.Charsets;
+import com.google.common.io.Resources;
+import fixtures.core.model.AuditInfoFixtures;
+import initializers.ImportDefinitionCreateDomainServiceTestInitializer;
+import inmemory.ApiCrudServiceInMemory;
+import inmemory.GroupQueryServiceInMemory;
+import inmemory.PolicyPluginCrudServiceInMemory;
+import inmemory.TagQueryServiceInMemory;
+import io.gravitee.apim.core.audit.model.AuditInfo;
+import io.gravitee.apim.core.plugin.domain_service.EndpointConnectorPluginDomainService;
+import io.gravitee.apim.core.user.model.BaseUserEntity;
+import io.gravitee.apim.infra.domain_service.api.OAIDomainServiceImpl;
+import io.gravitee.apim.infra.domain_service.api.WsdlParserDomainServiceImpl;
+import io.gravitee.definition.model.v4.Api;
+import io.gravitee.repository.management.model.Parameter;
+import io.gravitee.repository.management.model.ParameterReferenceType;
+import io.gravitee.rest.api.model.parameters.Key;
+import io.gravitee.rest.api.model.settings.ApiPrimaryOwnerMode;
+import io.gravitee.rest.api.service.exceptions.SwaggerDescriptorException;
+import io.gravitee.rest.api.service.impl.swagger.policy.impl.PolicyOperationVisitorManagerImpl;
+import io.gravitee.rest.api.service.spring.ImportConfiguration;
+import java.util.List;
+import lombok.SneakyThrows;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class WsdlToImportApiUseCaseTest {
+
+    private static final String ORGANIZATION_ID = "organization-id";
+    private static final String ENVIRONMENT_ID = "environment-id";
+    private static final String USER_ID = "user-id";
+    private static final String SHARED_CONFIGURATION = """
+            { "description": "shared config" }
+        """;
+    private static final AuditInfo AUDIT_INFO = AuditInfoFixtures.anAuditInfo(ORGANIZATION_ID, ENVIRONMENT_ID, USER_ID);
+
+    private final EndpointConnectorPluginDomainService endpointConnectorPluginService = mock(EndpointConnectorPluginDomainService.class);
+    private final PolicyPluginCrudServiceInMemory policyPluginCrudService = new PolicyPluginCrudServiceInMemory();
+    private final ApiCrudServiceInMemory apiCrudService = new ApiCrudServiceInMemory();
+
+    private WsdlToImportApiUseCase useCase;
+    private ImportDefinitionCreateDomainServiceTestInitializer importDefinitionCreateDomainServiceTestInitializer;
+
+    @BeforeEach
+    void setUp() {
+        importDefinitionCreateDomainServiceTestInitializer = new ImportDefinitionCreateDomainServiceTestInitializer(apiCrudService);
+
+        when(endpointConnectorPluginService.getDefaultSharedConfiguration(anyString())).thenReturn(SHARED_CONFIGURATION);
+
+        importDefinitionCreateDomainServiceTestInitializer.parametersQueryService.initWith(
+            List.of(
+                new Parameter(
+                    Key.API_PRIMARY_OWNER_MODE.key(),
+                    ENVIRONMENT_ID,
+                    ParameterReferenceType.ENVIRONMENT,
+                    ApiPrimaryOwnerMode.USER.name()
+                ),
+                new Parameter(Key.PLAN_SECURITY_KEYLESS_ENABLED.key(), ENVIRONMENT_ID, ParameterReferenceType.ENVIRONMENT, "true")
+            )
+        );
+        importDefinitionCreateDomainServiceTestInitializer.userCrudService.initWith(
+            List.of(BaseUserEntity.builder().id(USER_ID).firstname("Jane").lastname("Doe").email("jane@gravitee.io").build())
+        );
+        when(
+            importDefinitionCreateDomainServiceTestInitializer.validateApiDomainService.validateAndSanitizeForCreation(
+                any(),
+                any(),
+                any(),
+                any()
+            )
+        ).thenAnswer(invocation -> invocation.getArgument(0));
+
+        ImportConfiguration importConfiguration = mock(ImportConfiguration.class);
+        when(importConfiguration.isAllowImportFromPrivate()).thenReturn(true);
+        when(importConfiguration.getImportWhitelist()).thenReturn(List.of());
+
+        useCase = new WsdlToImportApiUseCase(
+            new WsdlParserDomainServiceImpl(importConfiguration),
+            new OAIDomainServiceImpl(
+                new PolicyOperationVisitorManagerImpl(),
+                new GroupQueryServiceInMemory(),
+                new TagQueryServiceInMemory(),
+                endpointConnectorPluginService,
+                policyPluginCrudService
+            ),
+            importDefinitionCreateDomainServiceTestInitializer.initialize()
+        );
+    }
+
+    @Test
+    void should_create_api_with_name_from_wsdl_service_element() {
+        var output = useCase.execute(buildInput(loadWsdl(), false, false));
+
+        assertThat(output).isNotNull();
+        assertThat(output.apiWithFlows().getName()).isEqualTo("CalculatorService");
+    }
+
+    @Test
+    void should_create_api_with_endpoint_url_from_wsdl_soap_address() {
+        var output = useCase.execute(buildInput(loadWsdl(), false, false));
+        var apiDefinition = (Api) output.apiWithFlows().getApiDefinitionValue();
+
+        assertThat(output).isNotNull();
+        assertThat(apiDefinition.getEndpointGroups())
+            .isNotEmpty()
+            .first()
+            .satisfies(endpointGroup ->
+                assertThat(endpointGroup.getEndpoints())
+                    .isNotEmpty()
+                    .first()
+                    .satisfies(endpoint -> assertThat(endpoint.getConfiguration()).contains("http://localhost:8080/calculator"))
+            );
+    }
+
+    @Test
+    void should_create_flows_for_each_wsdl_operation() {
+        var output = useCase.execute(buildInput(loadWsdl(), false, false));
+        var apiDefinition = (Api) output.apiWithFlows().getApiDefinitionValue();
+
+        assertThat(output).isNotNull();
+        // calculator.wsdl has 4 operations × 2 bindings (SOAP 1.1 + SOAP 1.2) = 8 flows
+        assertThat(apiDefinition.getFlows()).hasSize(8);
+    }
+
+    @Test
+    void should_throw_when_wsdl_payload_is_invalid() {
+        var throwable = catchThrowable(() -> useCase.execute(buildInput("not valid wsdl content", false, false)));
+
+        assertThat(throwable).isInstanceOf(SwaggerDescriptorException.class);
+    }
+
+    @Nested
+    class WithDocumentation {
+
+        @Test
+        void should_add_documentation_page_with_openapi_yaml_content() {
+            var output = useCase.execute(buildInput(loadWsdl(), true, false));
+
+            assertThat(output).isNotNull();
+            assertThat(importDefinitionCreateDomainServiceTestInitializer.pageCrudService.storage())
+                .hasSize(1)
+                .first()
+                .satisfies(page -> {
+                    assertThat(page.getReferenceId()).isEqualTo(output.apiWithFlows().getId());
+                    assertThat(page.getName()).isEqualTo("Swagger");
+                    // Content must be the converted OpenAPI YAML, not the raw WSDL XML
+                    assertThat(page.getContent()).startsWith("openapi:");
+                    assertThat(page.getContent()).doesNotStartWith("<");
+                });
+        }
+
+        @Test
+        void should_not_add_documentation_page_when_disabled() {
+            useCase.execute(buildInput(loadWsdl(), false, false));
+
+            assertThat(importDefinitionCreateDomainServiceTestInitializer.pageCrudService.storage()).isEmpty();
+        }
+    }
+
+    @Nested
+    @WireMockTest
+    class WithUrlImport {
+
+        @Test
+        void should_create_api_from_remote_wsdl_url(WireMockRuntimeInfo wm) {
+            var wsdlContent = loadWsdl();
+            wm.getWireMock().register(get(urlEqualTo("/calculator.wsdl")).willReturn(aResponse().withStatus(200).withBody(wsdlContent)));
+
+            var input = new WsdlToImportApiUseCase.Input.Url(
+                "http://localhost:" + wm.getHttpPort() + "/calculator.wsdl",
+                false,
+                false,
+                AUDIT_INFO
+            );
+            var output = useCase.execute(input);
+
+            assertThat(output).isNotNull();
+            assertThat(output.apiWithFlows().getName()).isEqualTo("CalculatorService");
+            assertThat(((Api) output.apiWithFlows().getApiDefinitionValue()).getFlows()).hasSize(8);
+        }
+
+        @Test
+        void should_throw_when_remote_url_is_unreachable() {
+            var input = new WsdlToImportApiUseCase.Input.Url("http://localhost:1/nonexistent.wsdl", false, false, AUDIT_INFO);
+
+            var throwable = catchThrowable(() -> useCase.execute(input));
+
+            assertThat(throwable).isInstanceOf(SwaggerDescriptorException.class);
+        }
+
+        @Test
+        void should_throw_when_remote_url_returns_invalid_wsdl(WireMockRuntimeInfo wm) {
+            wm.getWireMock().register(get(urlEqualTo("/bad.wsdl")).willReturn(aResponse().withStatus(200).withBody("not valid wsdl")));
+
+            var input = new WsdlToImportApiUseCase.Input.Url(
+                "http://localhost:" + wm.getHttpPort() + "/bad.wsdl",
+                false,
+                false,
+                AUDIT_INFO
+            );
+            var throwable = catchThrowable(() -> useCase.execute(input));
+
+            assertThat(throwable).isInstanceOf(SwaggerDescriptorException.class);
+        }
+    }
+
+    @SneakyThrows
+    private String loadWsdl() {
+        return Resources.toString(Resources.getResource("wsdl/calculator.wsdl"), Charsets.UTF_8);
+    }
+
+    private WsdlToImportApiUseCase.Input buildInput(String payload, boolean withDocumentation, boolean withOASValidationPolicy) {
+        return new WsdlToImportApiUseCase.Input.Inline(payload, withDocumentation, withOASValidationPolicy, AUDIT_INFO);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/WsdlToUpdateApiUseCaseIntegrationTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/WsdlToUpdateApiUseCaseIntegrationTest.java
@@ -1,0 +1,194 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.api.use_case;
+
+import static fixtures.core.model.ApiFixtures.aProxyApiV4;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.catchThrowable;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.common.base.Charsets;
+import com.google.common.io.Resources;
+import fixtures.core.model.AuditInfoFixtures;
+import inmemory.ApiCrudServiceInMemory;
+import inmemory.FlowCrudServiceInMemory;
+import inmemory.GroupQueryServiceInMemory;
+import inmemory.InMemoryAlternative;
+import inmemory.PolicyPluginCrudServiceInMemory;
+import inmemory.TagQueryServiceInMemory;
+import io.gravitee.apim.core.api.domain_service.import_definition.ImportDefinitionUpdateDomainServiceTestInitializer;
+import io.gravitee.apim.core.audit.model.AuditInfo;
+import io.gravitee.apim.core.plugin.domain_service.EndpointConnectorPluginDomainService;
+import io.gravitee.apim.infra.domain_service.api.OAIDomainServiceImpl;
+import io.gravitee.apim.infra.domain_service.api.WsdlParserDomainServiceImpl;
+import io.gravitee.rest.api.model.v4.api.ApiEntity;
+import io.gravitee.rest.api.service.exceptions.SwaggerDescriptorException;
+import io.gravitee.rest.api.service.impl.swagger.policy.impl.PolicyOperationVisitorManagerImpl;
+import io.gravitee.rest.api.service.spring.ImportConfiguration;
+import java.util.List;
+import java.util.stream.Stream;
+import lombok.SneakyThrows;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class WsdlToUpdateApiUseCaseIntegrationTest {
+
+    private static final String API_ID = "existing-api-id";
+    private static final String ORGANIZATION_ID = "organization-id";
+    private static final String ENVIRONMENT_ID = "environment-id";
+    private static final String USER_ID = "user-id";
+    private static final String SHARED_CONFIGURATION = """
+            { "description": "shared config" }
+        """;
+    private static final AuditInfo AUDIT_INFO = AuditInfoFixtures.anAuditInfo(ORGANIZATION_ID, ENVIRONMENT_ID, USER_ID);
+
+    private final EndpointConnectorPluginDomainService endpointConnectorPluginService = mock(EndpointConnectorPluginDomainService.class);
+    private final PolicyPluginCrudServiceInMemory policyPluginCrudService = new PolicyPluginCrudServiceInMemory();
+    private final ApiCrudServiceInMemory apiCrudService = new ApiCrudServiceInMemory();
+    private final FlowCrudServiceInMemory flowCrudService = new FlowCrudServiceInMemory();
+
+    private WsdlToUpdateApiUseCase useCase;
+    private ImportDefinitionUpdateDomainServiceTestInitializer updateInitializer;
+
+    @BeforeEach
+    void setUp() {
+        updateInitializer = new ImportDefinitionUpdateDomainServiceTestInitializer(apiCrudService);
+
+        when(endpointConnectorPluginService.getDefaultSharedConfiguration(anyString())).thenReturn(SHARED_CONFIGURATION);
+
+        when(updateInitializer.validateApiDomainService.validateAndSanitizeForUpdate(any(), any(), any(), any(), any())).thenAnswer(inv ->
+            inv.getArgument(1)
+        );
+
+        when(updateInitializer.apiService.update(any(), any(), any(), anyBoolean(), any())).thenAnswer(inv -> {
+            io.gravitee.rest.api.model.v4.api.UpdateApiEntity updateApi = inv.getArgument(2);
+            return ApiEntity.builder().id(API_ID).name(updateApi.getName()).apiVersion(updateApi.getApiVersion()).build();
+        });
+
+        ImportConfiguration importConfiguration = mock(ImportConfiguration.class);
+        when(importConfiguration.isAllowImportFromPrivate()).thenReturn(true);
+        when(importConfiguration.getImportWhitelist()).thenReturn(List.of());
+
+        var oaiDomainService = new OAIDomainServiceImpl(
+            new PolicyOperationVisitorManagerImpl(),
+            new GroupQueryServiceInMemory(),
+            new TagQueryServiceInMemory(),
+            endpointConnectorPluginService,
+            policyPluginCrudService
+        );
+
+        var updateApiDefinitionUseCase = new UpdateApiDefinitionFromImportUseCase(
+            apiCrudService,
+            updateInitializer.initialize(ENVIRONMENT_ID),
+            flowCrudService
+        );
+
+        var oaiToUpdateApiUseCase = new OAIToUpdateApiUseCase(oaiDomainService, flowCrudService, updateApiDefinitionUseCase);
+
+        useCase = new WsdlToUpdateApiUseCase(new WsdlParserDomainServiceImpl(importConfiguration), oaiToUpdateApiUseCase);
+    }
+
+    @AfterEach
+    void tearDown() {
+        updateInitializer.tearDown();
+        Stream.of(apiCrudService, flowCrudService).forEach(InMemoryAlternative::reset);
+    }
+
+    @Test
+    void should_preserve_api_id_when_updating_from_wsdl() {
+        givenExistingApi(API_ID);
+
+        var output = useCase.execute(buildInput(loadWsdl(), false, false));
+
+        assertThat(output).isNotNull();
+        assertThat(output.apiWithFlows().getId()).isEqualTo(API_ID);
+    }
+
+    @Test
+    void should_update_api_name_from_wsdl_service_element() {
+        givenExistingApi(API_ID);
+
+        useCase.execute(buildInput(loadWsdl(), false, false));
+
+        var captor = ArgumentCaptor.forClass(io.gravitee.rest.api.model.v4.api.UpdateApiEntity.class);
+        verify(updateInitializer.apiService).update(any(), any(), captor.capture(), anyBoolean(), any());
+        assertThat(captor.getValue().getName()).isEqualTo("CalculatorService");
+    }
+
+    @Test
+    void should_replace_flows_with_wsdl_operations() {
+        givenExistingApi(API_ID);
+
+        useCase.execute(buildInput(loadWsdl(), false, false));
+
+        var captor = ArgumentCaptor.forClass(io.gravitee.rest.api.model.v4.api.UpdateApiEntity.class);
+        verify(updateInitializer.apiService).update(any(), any(), captor.capture(), anyBoolean(), any());
+        // calculator.wsdl has 4 operations × 2 bindings (SOAP 1.1 + SOAP 1.2) = 8 flows
+        assertThat(captor.getValue().getFlows()).hasSize(8);
+    }
+
+    @Test
+    void should_update_endpoint_url_from_wsdl_soap_address() {
+        givenExistingApi(API_ID);
+
+        useCase.execute(buildInput(loadWsdl(), false, false));
+
+        var captor = ArgumentCaptor.forClass(io.gravitee.rest.api.model.v4.api.UpdateApiEntity.class);
+        verify(updateInitializer.apiService).update(any(), any(), captor.capture(), anyBoolean(), any());
+        assertThat(captor.getValue().getEndpointGroups())
+            .isNotEmpty()
+            .first()
+            .satisfies(endpointGroup ->
+                assertThat(endpointGroup.getEndpoints())
+                    .isNotEmpty()
+                    .first()
+                    .satisfies(endpoint -> assertThat(endpoint.getConfiguration()).contains("http://localhost:8080/calculator"))
+            );
+    }
+
+    @Test
+    void should_throw_when_wsdl_payload_is_invalid() {
+        givenExistingApi(API_ID);
+
+        var throwable = catchThrowable(() -> useCase.execute(buildInput("not valid wsdl content", false, false)));
+
+        assertThat(throwable).isInstanceOf(SwaggerDescriptorException.class);
+    }
+
+    private void givenExistingApi(String apiId) {
+        var existingApi = aProxyApiV4().toBuilder().id(apiId).environmentId(ENVIRONMENT_ID).build();
+        apiCrudService.initWith(List.of(existingApi));
+    }
+
+    @SneakyThrows
+    private String loadWsdl() {
+        return Resources.toString(Resources.getResource("wsdl/calculator.wsdl"), Charsets.UTF_8);
+    }
+
+    private WsdlToUpdateApiUseCase.Input buildInput(String payload, boolean withDocumentation, boolean withOASValidationPolicy) {
+        return new WsdlToUpdateApiUseCase.Input.Inline(API_ID, payload, withDocumentation, withOASValidationPolicy, AUDIT_INFO);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/WsdlToUpdateApiUseCaseIntegrationTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/WsdlToUpdateApiUseCaseIntegrationTest.java
@@ -15,6 +15,9 @@
  */
 package io.gravitee.apim.core.api.use_case;
 
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static fixtures.core.model.ApiFixtures.aProxyApiV4;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.catchThrowable;
@@ -25,6 +28,8 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
+import com.github.tomakehurst.wiremock.junit5.WireMockTest;
 import com.google.common.base.Charsets;
 import com.google.common.io.Resources;
 import fixtures.core.model.AuditInfoFixtures;
@@ -50,6 +55,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
@@ -139,15 +145,14 @@ class WsdlToUpdateApiUseCaseIntegrationTest {
     }
 
     @Test
-    void should_replace_flows_with_wsdl_operations() {
+    void should_have_no_flows_when_no_policies_are_requested() {
         givenExistingApi(API_ID);
 
         useCase.execute(buildInput(loadWsdl(), false, false));
 
         var captor = ArgumentCaptor.forClass(io.gravitee.rest.api.model.v4.api.UpdateApiEntity.class);
         verify(updateInitializer.apiService).update(any(), any(), captor.capture(), anyBoolean(), any());
-        // calculator.wsdl has 4 operations × 2 bindings (SOAP 1.1 + SOAP 1.2) = 8 flows
-        assertThat(captor.getValue().getFlows()).hasSize(8);
+        assertThat(captor.getValue().getFlows()).isEmpty();
     }
 
     @Test
@@ -178,6 +183,31 @@ class WsdlToUpdateApiUseCaseIntegrationTest {
         assertThat(throwable).isInstanceOf(SwaggerDescriptorException.class);
     }
 
+    @Nested
+    @WireMockTest
+    class WithUrlUpdate {
+
+        @Test
+        void should_update_api_from_remote_wsdl_url(WireMockRuntimeInfo wm) {
+            givenExistingApi(API_ID);
+            var wsdlContent = loadWsdl();
+            wm.getWireMock().register(get(urlEqualTo("/calculator.wsdl")).willReturn(aResponse().withStatus(200).withBody(wsdlContent)));
+
+            var input = new WsdlToUpdateApiUseCase.Input.Url(
+                API_ID,
+                "http://localhost:" + wm.getHttpPort() + "/calculator.wsdl",
+                false,
+                false,
+                List.of(),
+                AUDIT_INFO
+            );
+            var output = useCase.execute(input);
+
+            assertThat(output).isNotNull();
+            assertThat(output.apiWithFlows().getId()).isEqualTo(API_ID);
+        }
+    }
+
     private void givenExistingApi(String apiId) {
         var existingApi = aProxyApiV4().toBuilder().id(apiId).environmentId(ENVIRONMENT_ID).build();
         apiCrudService.initWith(List.of(existingApi));
@@ -189,6 +219,6 @@ class WsdlToUpdateApiUseCaseIntegrationTest {
     }
 
     private WsdlToUpdateApiUseCase.Input buildInput(String payload, boolean withDocumentation, boolean withOASValidationPolicy) {
-        return new WsdlToUpdateApiUseCase.Input.Inline(API_ID, payload, withDocumentation, withOASValidationPolicy, AUDIT_INFO);
+        return new WsdlToUpdateApiUseCase.Input.Inline(API_ID, payload, withDocumentation, withOASValidationPolicy, List.of(), AUDIT_INFO);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/WsdlToUpdateApiUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/WsdlToUpdateApiUseCaseTest.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.api.use_case;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import fixtures.core.model.ApiFixtures;
+import fixtures.core.model.AuditInfoFixtures;
+import io.gravitee.apim.core.api.domain_service.WsdlParserDomainService;
+import io.gravitee.apim.core.api.model.ApiWithFlows;
+import io.gravitee.apim.core.audit.model.AuditInfo;
+import io.gravitee.rest.api.model.ImportSwaggerDescriptorEntity;
+import io.gravitee.rest.api.service.exceptions.SwaggerDescriptorException;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class WsdlToUpdateApiUseCaseTest {
+
+    private static final String API_ID = "my-api-id";
+    private static final String ORGANIZATION_ID = "organization-id";
+    private static final String ENVIRONMENT_ID = "environment-id";
+    private static final String USER_ID = "user-id";
+    private static final AuditInfo AUDIT_INFO = AuditInfoFixtures.anAuditInfo(ORGANIZATION_ID, ENVIRONMENT_ID, USER_ID);
+    private static final String OPENAPI_YAML = "openapi: 3.0.0\ninfo:\n  title: CalculatorService\n";
+
+    private WsdlParserDomainService wsdlParserDomainService;
+    private OAIToUpdateApiUseCase oaiToUpdateApiUseCase;
+    private WsdlToUpdateApiUseCase useCase;
+
+    @BeforeEach
+    void setUp() {
+        wsdlParserDomainService = mock(WsdlParserDomainService.class);
+        oaiToUpdateApiUseCase = mock(OAIToUpdateApiUseCase.class);
+        useCase = new WsdlToUpdateApiUseCase(wsdlParserDomainService, oaiToUpdateApiUseCase);
+    }
+
+    @Test
+    void should_throw_when_wsdl_conversion_returns_null() {
+        when(wsdlParserDomainService.toOpenApiYaml(any())).thenReturn(null);
+
+        assertThatThrownBy(() ->
+            useCase.execute(new WsdlToUpdateApiUseCase.Input.Inline(API_ID, "<definitions/>", false, false, AUDIT_INFO))
+        )
+            .isInstanceOf(SwaggerDescriptorException.class)
+            .hasMessage("Failed to convert WSDL to OpenAPI specification");
+    }
+
+    @Test
+    void should_pass_openapi_yaml_to_oai_update_use_case() {
+        when(wsdlParserDomainService.toOpenApiYaml(any())).thenReturn(OPENAPI_YAML);
+        var existingApi = ApiFixtures.aProxyApiV4().toBuilder().id(API_ID).build();
+        when(oaiToUpdateApiUseCase.execute(any())).thenReturn(new OAIToUpdateApiUseCase.Output(new ApiWithFlows(existingApi, List.of())));
+
+        useCase.execute(new WsdlToUpdateApiUseCase.Input.Inline(API_ID, "<definitions/>", false, false, AUDIT_INFO));
+
+        var captor = ArgumentCaptor.forClass(OAIToUpdateApiUseCase.Input.class);
+        verify(oaiToUpdateApiUseCase).execute(captor.capture());
+        assertThat(captor.getValue().apiId()).isEqualTo(API_ID);
+        assertThat(captor.getValue().importSwaggerDescriptor().getPayload()).isEqualTo(OPENAPI_YAML);
+        assertThat(captor.getValue().withPolicyPaths()).isFalse();
+    }
+
+    @Test
+    void should_forward_withDocumentation_flag_to_oai_use_case() {
+        when(wsdlParserDomainService.toOpenApiYaml(any())).thenReturn(OPENAPI_YAML);
+        var existingApi = ApiFixtures.aProxyApiV4().toBuilder().id(API_ID).build();
+        when(oaiToUpdateApiUseCase.execute(any())).thenReturn(new OAIToUpdateApiUseCase.Output(new ApiWithFlows(existingApi, List.of())));
+
+        useCase.execute(new WsdlToUpdateApiUseCase.Input.Inline(API_ID, "<definitions/>", true, false, AUDIT_INFO));
+
+        var captor = ArgumentCaptor.forClass(OAIToUpdateApiUseCase.Input.class);
+        verify(oaiToUpdateApiUseCase).execute(captor.capture());
+        assertThat(captor.getValue().withDocumentation()).isTrue();
+    }
+
+    @Test
+    void should_return_api_from_oai_use_case_output() {
+        when(wsdlParserDomainService.toOpenApiYaml(any())).thenReturn(OPENAPI_YAML);
+        var existingApi = ApiFixtures.aProxyApiV4().toBuilder().id(API_ID).build();
+        var apiWithFlows = new ApiWithFlows(existingApi, List.of());
+        when(oaiToUpdateApiUseCase.execute(any())).thenReturn(new OAIToUpdateApiUseCase.Output(apiWithFlows));
+
+        var output = useCase.execute(new WsdlToUpdateApiUseCase.Input.Inline(API_ID, "<definitions/>", false, false, AUDIT_INFO));
+
+        assertThat(output.apiWithFlows().getId()).isEqualTo(API_ID);
+    }
+
+    @Nested
+    class WithUrlInput {
+
+        @Test
+        void should_pass_url_string_to_parser() {
+            when(wsdlParserDomainService.toOpenApiYaml(any())).thenReturn(OPENAPI_YAML);
+            var existingApi = ApiFixtures.aProxyApiV4().toBuilder().id(API_ID).build();
+            when(oaiToUpdateApiUseCase.execute(any())).thenReturn(
+                new OAIToUpdateApiUseCase.Output(new ApiWithFlows(existingApi, List.of()))
+            );
+
+            useCase.execute(new WsdlToUpdateApiUseCase.Input.Url(API_ID, "http://example.com/service.wsdl", false, false, AUDIT_INFO));
+
+            verify(wsdlParserDomainService).toOpenApiYaml(eq("http://example.com/service.wsdl"));
+        }
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/WsdlToUpdateApiUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/WsdlToUpdateApiUseCaseTest.java
@@ -62,11 +62,13 @@ class WsdlToUpdateApiUseCaseTest {
     }
 
     @Test
-    void should_throw_when_wsdl_conversion_returns_null() {
-        when(wsdlParserDomainService.toOpenApiYaml(any())).thenReturn(null);
+    void should_throw_when_wsdl_conversion_fails() {
+        when(wsdlParserDomainService.toOpenApiYaml(any())).thenThrow(
+            new SwaggerDescriptorException("Failed to convert WSDL to OpenAPI specification")
+        );
 
         assertThatThrownBy(() ->
-            useCase.execute(new WsdlToUpdateApiUseCase.Input.Inline(API_ID, "<definitions/>", false, false, AUDIT_INFO))
+            useCase.execute(new WsdlToUpdateApiUseCase.Input.Inline(API_ID, "<definitions/>", false, false, List.of(), AUDIT_INFO))
         )
             .isInstanceOf(SwaggerDescriptorException.class)
             .hasMessage("Failed to convert WSDL to OpenAPI specification");
@@ -78,12 +80,13 @@ class WsdlToUpdateApiUseCaseTest {
         var existingApi = ApiFixtures.aProxyApiV4().toBuilder().id(API_ID).build();
         when(oaiToUpdateApiUseCase.execute(any())).thenReturn(new OAIToUpdateApiUseCase.Output(new ApiWithFlows(existingApi, List.of())));
 
-        useCase.execute(new WsdlToUpdateApiUseCase.Input.Inline(API_ID, "<definitions/>", false, false, AUDIT_INFO));
+        useCase.execute(new WsdlToUpdateApiUseCase.Input.Inline(API_ID, "<definitions/>", false, false, List.of(), AUDIT_INFO));
 
         var captor = ArgumentCaptor.forClass(OAIToUpdateApiUseCase.Input.class);
         verify(oaiToUpdateApiUseCase).execute(captor.capture());
         assertThat(captor.getValue().apiId()).isEqualTo(API_ID);
         assertThat(captor.getValue().importSwaggerDescriptor().getPayload()).isEqualTo(OPENAPI_YAML);
+        assertThat(captor.getValue().importSwaggerDescriptor().getFormat()).isEqualTo(ImportSwaggerDescriptorEntity.Format.WSDL);
         assertThat(captor.getValue().withPolicyPaths()).isFalse();
     }
 
@@ -93,7 +96,7 @@ class WsdlToUpdateApiUseCaseTest {
         var existingApi = ApiFixtures.aProxyApiV4().toBuilder().id(API_ID).build();
         when(oaiToUpdateApiUseCase.execute(any())).thenReturn(new OAIToUpdateApiUseCase.Output(new ApiWithFlows(existingApi, List.of())));
 
-        useCase.execute(new WsdlToUpdateApiUseCase.Input.Inline(API_ID, "<definitions/>", true, false, AUDIT_INFO));
+        useCase.execute(new WsdlToUpdateApiUseCase.Input.Inline(API_ID, "<definitions/>", true, false, List.of(), AUDIT_INFO));
 
         var captor = ArgumentCaptor.forClass(OAIToUpdateApiUseCase.Input.class);
         verify(oaiToUpdateApiUseCase).execute(captor.capture());
@@ -107,9 +110,53 @@ class WsdlToUpdateApiUseCaseTest {
         var apiWithFlows = new ApiWithFlows(existingApi, List.of());
         when(oaiToUpdateApiUseCase.execute(any())).thenReturn(new OAIToUpdateApiUseCase.Output(apiWithFlows));
 
-        var output = useCase.execute(new WsdlToUpdateApiUseCase.Input.Inline(API_ID, "<definitions/>", false, false, AUDIT_INFO));
+        var output = useCase.execute(
+            new WsdlToUpdateApiUseCase.Input.Inline(API_ID, "<definitions/>", false, false, List.of(), AUDIT_INFO)
+        );
 
         assertThat(output.apiWithFlows().getId()).isEqualTo(API_ID);
+    }
+
+    @Test
+    void should_forward_withPolicies_to_import_swagger_descriptor() {
+        when(wsdlParserDomainService.toOpenApiYaml(any())).thenReturn(OPENAPI_YAML);
+        var existingApi = ApiFixtures.aProxyApiV4().toBuilder().id(API_ID).build();
+        when(oaiToUpdateApiUseCase.execute(any())).thenReturn(new OAIToUpdateApiUseCase.Output(new ApiWithFlows(existingApi, List.of())));
+
+        useCase.execute(
+            new WsdlToUpdateApiUseCase.Input.Inline(API_ID, "<definitions/>", false, false, List.of("rest-to-soap"), AUDIT_INFO)
+        );
+
+        var captor = ArgumentCaptor.forClass(OAIToUpdateApiUseCase.Input.class);
+        verify(oaiToUpdateApiUseCase).execute(captor.capture());
+        assertThat(captor.getValue().importSwaggerDescriptor().getWithPolicies()).containsExactly("rest-to-soap", "xml-json");
+        assertThat(captor.getValue().importSwaggerDescriptor().isSkipFlows()).isFalse();
+    }
+
+    @Test
+    void should_set_skipFlows_when_empty_policies_list_is_provided() {
+        when(wsdlParserDomainService.toOpenApiYaml(any())).thenReturn(OPENAPI_YAML);
+        var existingApi = ApiFixtures.aProxyApiV4().toBuilder().id(API_ID).build();
+        when(oaiToUpdateApiUseCase.execute(any())).thenReturn(new OAIToUpdateApiUseCase.Output(new ApiWithFlows(existingApi, List.of())));
+
+        useCase.execute(new WsdlToUpdateApiUseCase.Input.Inline(API_ID, "<definitions/>", false, false, List.of(), AUDIT_INFO));
+
+        var captor = ArgumentCaptor.forClass(OAIToUpdateApiUseCase.Input.class);
+        verify(oaiToUpdateApiUseCase).execute(captor.capture());
+        assertThat(captor.getValue().importSwaggerDescriptor().isSkipFlows()).isTrue();
+    }
+
+    @Test
+    void should_not_skip_flows_when_withPolicies_is_not_provided() {
+        when(wsdlParserDomainService.toOpenApiYaml(any())).thenReturn(OPENAPI_YAML);
+        var existingApi = ApiFixtures.aProxyApiV4().toBuilder().id(API_ID).build();
+        when(oaiToUpdateApiUseCase.execute(any())).thenReturn(new OAIToUpdateApiUseCase.Output(new ApiWithFlows(existingApi, List.of())));
+
+        useCase.execute(new WsdlToUpdateApiUseCase.Input.Inline(API_ID, "<definitions/>", false, false, null, AUDIT_INFO));
+
+        var captor = ArgumentCaptor.forClass(OAIToUpdateApiUseCase.Input.class);
+        verify(oaiToUpdateApiUseCase).execute(captor.capture());
+        assertThat(captor.getValue().importSwaggerDescriptor().isSkipFlows()).isFalse();
     }
 
     @Nested
@@ -123,7 +170,9 @@ class WsdlToUpdateApiUseCaseTest {
                 new OAIToUpdateApiUseCase.Output(new ApiWithFlows(existingApi, List.of()))
             );
 
-            useCase.execute(new WsdlToUpdateApiUseCase.Input.Url(API_ID, "http://example.com/service.wsdl", false, false, AUDIT_INFO));
+            useCase.execute(
+                new WsdlToUpdateApiUseCase.Input.Url(API_ID, "http://example.com/service.wsdl", false, false, List.of(), AUDIT_INFO)
+            );
 
             verify(wsdlParserDomainService).toOpenApiYaml(eq("http://example.com/service.wsdl"));
         }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/api/OAIDomainServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/api/OAIDomainServiceImplTest.java
@@ -15,14 +15,26 @@
  */
 package io.gravitee.apim.infra.domain_service.api;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
+import inmemory.GroupQueryServiceInMemory;
+import inmemory.PolicyPluginCrudServiceInMemory;
+import inmemory.TagQueryServiceInMemory;
+import io.gravitee.apim.core.plugin.domain_service.EndpointConnectorPluginDomainService;
+import io.gravitee.apim.core.plugin.model.PolicyPlugin;
+import io.gravitee.definition.model.v4.flow.Flow;
 import io.gravitee.rest.api.model.ImportSwaggerDescriptorEntity;
 import io.gravitee.rest.api.service.exceptions.SwaggerDescriptorException;
 import io.gravitee.rest.api.service.impl.swagger.policy.impl.PolicyOperationVisitorManagerImpl;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EmptySource;
@@ -66,5 +78,83 @@ class OAIDomainServiceImplTest {
         assertThatThrownBy(() ->
             oaiDomainService.convert(ORGANIZATION_ID, ENVIRONMENT_ID, importSwaggerDescriptor, false, false)
         ).isExactlyInstanceOf(SwaggerDescriptorException.class);
+    }
+
+    @Nested
+    @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+    class DeferredResponseValidation {
+
+        private static final String VALID_OPENAPI = """
+            {
+              "openapi": "3.0.0",
+              "info": { "title": "Test", "version": "1.0" },
+              "paths": {
+                "/test": {
+                  "get": {
+                    "responses": { "200": { "description": "OK" } }
+                  }
+                }
+              }
+            }
+            """;
+
+        private OAIDomainServiceImpl service;
+        private PolicyPluginCrudServiceInMemory policyPluginCrudService;
+
+        @BeforeEach
+        void setUp() {
+            policyPluginCrudService = new PolicyPluginCrudServiceInMemory();
+            policyPluginCrudService.initWith(List.of(PolicyPlugin.builder().id("oas-validation").name("OAS Validation").build()));
+            var endpointConnectorPluginService = mock(EndpointConnectorPluginDomainService.class);
+            when(endpointConnectorPluginService.getDefaultSharedConfiguration(anyString())).thenReturn("{}");
+            service = new OAIDomainServiceImpl(
+                new PolicyOperationVisitorManagerImpl(),
+                new GroupQueryServiceInMemory(),
+                new TagQueryServiceInMemory(),
+                endpointConnectorPluginService,
+                policyPluginCrudService
+            );
+        }
+
+        @Test
+        void should_place_oas_response_validation_last_when_wsdl_format_with_policies() {
+            var descriptor = ImportSwaggerDescriptorEntity.builder()
+                .payload(VALID_OPENAPI)
+                .format(ImportSwaggerDescriptorEntity.Format.WSDL)
+                .withPolicies(List.of("rest-to-soap"))
+                .build();
+
+            var result = service.convert(ORGANIZATION_ID, ENVIRONMENT_ID, descriptor, false, true);
+
+            assertThat(result).isNotNull();
+            var flows = (List<Flow>) result.getApiExport().getFlows();
+            assertThat(flows).hasSizeGreaterThanOrEqualTo(2);
+
+            var firstFlow = flows.getFirst();
+            assertThat(firstFlow.getName()).isEqualTo("OpenAPI Specification Validation");
+            assertThat(firstFlow.getRequest()).hasSize(1);
+            assertThat(firstFlow.getResponse()).isEmpty();
+
+            var lastFlow = flows.getLast();
+            assertThat(lastFlow.getName()).isEqualTo("OpenAPI Specification Validation");
+            assertThat(lastFlow.getResponse()).hasSize(1);
+        }
+
+        @Test
+        void should_not_defer_response_validation_for_non_wsdl_format() {
+            var descriptor = ImportSwaggerDescriptorEntity.builder().payload(VALID_OPENAPI).build();
+
+            var result = service.convert(ORGANIZATION_ID, ENVIRONMENT_ID, descriptor, false, true);
+
+            assertThat(result).isNotNull();
+            var flows = (List<Flow>) result.getApiExport().getFlows();
+            var oasFlows = flows
+                .stream()
+                .filter(f -> "OpenAPI Specification Validation".equals(f.getName()))
+                .toList();
+            assertThat(oasFlows).hasSize(1);
+            assertThat(oasFlows.getFirst().getRequest()).hasSize(1);
+            assertThat(oasFlows.getFirst().getResponse()).hasSize(1);
+        }
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/api/WsdlParserDomainServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/api/WsdlParserDomainServiceImplTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.infra.domain_service.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.catchThrowable;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.google.common.base.Charsets;
+import com.google.common.io.Resources;
+import io.gravitee.rest.api.service.exceptions.UrlForbiddenException;
+import io.gravitee.rest.api.service.spring.ImportConfiguration;
+import java.util.List;
+import lombok.SneakyThrows;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class WsdlParserDomainServiceImplTest {
+
+    private final ImportConfiguration importConfiguration = mock(ImportConfiguration.class);
+    private final WsdlParserDomainServiceImpl service = new WsdlParserDomainServiceImpl(importConfiguration);
+
+    @Test
+    void should_parse_inline_wsdl_content() {
+        when(importConfiguration.isAllowImportFromPrivate()).thenReturn(false);
+        when(importConfiguration.getImportWhitelist()).thenReturn(List.of());
+
+        var result = service.toOpenApiYaml(loadWsdl());
+
+        assertThat(result).isNotNull().startsWith("openapi:");
+    }
+
+    @Test
+    void should_throw_when_url_points_to_private_address() {
+        when(importConfiguration.isAllowImportFromPrivate()).thenReturn(false);
+        when(importConfiguration.getImportWhitelist()).thenReturn(List.of());
+
+        var throwable = catchThrowable(() -> service.toOpenApiYaml("http://192.168.1.1/spec.wsdl"));
+
+        assertThat(throwable).isInstanceOf(UrlForbiddenException.class);
+    }
+
+    @SneakyThrows
+    private String loadWsdl() {
+        return Resources.toString(Resources.getResource("wsdl/calculator.wsdl"), Charsets.UTF_8);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/api/WsdlParserDomainServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/api/WsdlParserDomainServiceImplTest.java
@@ -20,15 +20,17 @@ import static org.assertj.core.api.AssertionsForClassTypes.catchThrowable;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import com.google.common.base.Charsets;
 import com.google.common.io.Resources;
 import io.gravitee.rest.api.service.exceptions.UrlForbiddenException;
 import io.gravitee.rest.api.service.spring.ImportConfiguration;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import lombok.SneakyThrows;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 class WsdlParserDomainServiceImplTest {
@@ -46,18 +48,34 @@ class WsdlParserDomainServiceImplTest {
         assertThat(result).isNotNull().startsWith("openapi:");
     }
 
-    @Test
-    void should_throw_when_url_points_to_private_address() {
+    @ParameterizedTest
+    @ValueSource(
+        strings = {
+            "http://localhost:8080/spec.wsdl", "http://127.0.0.1/spec.wsdl", "http://169.254.1.2/spec.wsdl", "http://192.168.1.1/spec.wsdl",
+        }
+    )
+    void should_block_ssrf_attack_vectors(String url) {
         when(importConfiguration.isAllowImportFromPrivate()).thenReturn(false);
         when(importConfiguration.getImportWhitelist()).thenReturn(List.of());
 
-        var throwable = catchThrowable(() -> service.toOpenApiYaml("http://192.168.1.1/spec.wsdl"));
+        var throwable = catchThrowable(() -> service.toOpenApiYaml(url));
 
         assertThat(throwable).isInstanceOf(UrlForbiddenException.class);
     }
 
+    @ParameterizedTest
+    @ValueSource(strings = { "file:///etc/passwd", "not-a-valid-url-or-wsdl", "ftp://example.com/spec.wsdl" })
+    void should_fail_parsing_non_url_inputs(String content) {
+        when(importConfiguration.isAllowImportFromPrivate()).thenReturn(false);
+        when(importConfiguration.getImportWhitelist()).thenReturn(List.of());
+
+        var throwable = catchThrowable(() -> service.toOpenApiYaml(content));
+
+        assertThat(throwable).isNotInstanceOf(UrlForbiddenException.class);
+    }
+
     @SneakyThrows
     private String loadWsdl() {
-        return Resources.toString(Resources.getResource("wsdl/calculator.wsdl"), Charsets.UTF_8);
+        return Resources.toString(Resources.getResource("wsdl/calculator.wsdl"), StandardCharsets.UTF_8);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/sanitizer/UrlSanitizerUtilsTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/sanitizer/UrlSanitizerUtilsTest.java
@@ -34,12 +34,12 @@ import org.junit.jupiter.params.provider.ValueSource;
 public class UrlSanitizerUtilsTest {
 
     @Test
-    public void isUrl_returnsTrue_forHttpUrl() {
+    public void is_url_returns_true_for_http_url() {
         assertTrue(UrlSanitizerUtils.isUrl("https://www.gravitee.io/spec.wsdl"));
     }
 
     @Test
-    public void isUrl_returnsFalse_forInlineContent() {
+    public void is_url_returns_false_for_inline_content() {
         assertFalse(UrlSanitizerUtils.isUrl("<definitions xmlns=\"http://schemas.xmlsoap.org/wsdl/\"/>"));
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/sanitizer/UrlSanitizerUtilsTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/sanitizer/UrlSanitizerUtilsTest.java
@@ -34,6 +34,16 @@ import org.junit.jupiter.params.provider.ValueSource;
 public class UrlSanitizerUtilsTest {
 
     @Test
+    public void isUrl_returnsTrue_forHttpUrl() {
+        assertTrue(UrlSanitizerUtils.isUrl("https://www.gravitee.io/spec.wsdl"));
+    }
+
+    @Test
+    public void isUrl_returnsFalse_forInlineContent() {
+        assertFalse(UrlSanitizerUtils.isUrl("<definitions xmlns=\"http://schemas.xmlsoap.org/wsdl/\"/>"));
+    }
+
+    @Test
     public void checkAllowed_allowPrivate() {
         UrlSanitizerUtils.checkAllowed("http://localhost:8080", Collections.emptyList(), true);
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/wsdl/calculator.wsdl
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/wsdl/calculator.wsdl
@@ -1,0 +1,187 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions
+    xmlns="http://schemas.xmlsoap.org/wsdl/"
+    xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+    xmlns:soap12="http://schemas.xmlsoap.org/wsdl/soap12/"
+    xmlns:tns="http://gravitee.io/wsdl/calculator"
+    xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+    targetNamespace="http://gravitee.io/wsdl/calculator"
+    name="CalculatorService">
+
+    <types>
+        <xsd:schema targetNamespace="http://gravitee.io/wsdl/calculator">
+
+            <xsd:element name="AddRequest">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="a" type="xsd:double"/>
+                        <xsd:element name="b" type="xsd:double"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="AddResponse">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="result" type="xsd:double"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+
+            <xsd:element name="SubtractRequest">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="a" type="xsd:double"/>
+                        <xsd:element name="b" type="xsd:double"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="SubtractResponse">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="result" type="xsd:double"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+
+            <xsd:element name="MultiplyRequest">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="a" type="xsd:double"/>
+                        <xsd:element name="b" type="xsd:double"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="MultiplyResponse">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="result" type="xsd:double"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+
+            <xsd:element name="DivideRequest">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="a" type="xsd:double"/>
+                        <xsd:element name="b" type="xsd:double"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="DivideResponse">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="result" type="xsd:double"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+
+        </xsd:schema>
+    </types>
+
+    <!-- Messages -->
+    <message name="AddRequest">
+        <part name="parameters" element="tns:AddRequest"/>
+    </message>
+    <message name="AddResponse">
+        <part name="parameters" element="tns:AddResponse"/>
+    </message>
+    <message name="SubtractRequest">
+        <part name="parameters" element="tns:SubtractRequest"/>
+    </message>
+    <message name="SubtractResponse">
+        <part name="parameters" element="tns:SubtractResponse"/>
+    </message>
+    <message name="MultiplyRequest">
+        <part name="parameters" element="tns:MultiplyRequest"/>
+    </message>
+    <message name="MultiplyResponse">
+        <part name="parameters" element="tns:MultiplyResponse"/>
+    </message>
+    <message name="DivideRequest">
+        <part name="parameters" element="tns:DivideRequest"/>
+    </message>
+    <message name="DivideResponse">
+        <part name="parameters" element="tns:DivideResponse"/>
+    </message>
+
+    <!-- Port Type -->
+    <portType name="CalculatorPortType">
+        <operation name="Add">
+            <input message="tns:AddRequest"/>
+            <output message="tns:AddResponse"/>
+        </operation>
+        <operation name="Subtract">
+            <input message="tns:SubtractRequest"/>
+            <output message="tns:SubtractResponse"/>
+        </operation>
+        <operation name="Multiply">
+            <input message="tns:MultiplyRequest"/>
+            <output message="tns:MultiplyResponse"/>
+        </operation>
+        <operation name="Divide">
+            <input message="tns:DivideRequest"/>
+            <output message="tns:DivideResponse"/>
+        </operation>
+    </portType>
+
+    <!-- SOAP 1.1 Binding -->
+    <binding name="CalculatorSoap11Binding" type="tns:CalculatorPortType">
+        <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+        <operation name="Add">
+            <soap:operation soapAction="http://gravitee.io/wsdl/calculator/Add"/>
+            <input><soap:body use="literal"/></input>
+            <output><soap:body use="literal"/></output>
+        </operation>
+        <operation name="Subtract">
+            <soap:operation soapAction="http://gravitee.io/wsdl/calculator/Subtract"/>
+            <input><soap:body use="literal"/></input>
+            <output><soap:body use="literal"/></output>
+        </operation>
+        <operation name="Multiply">
+            <soap:operation soapAction="http://gravitee.io/wsdl/calculator/Multiply"/>
+            <input><soap:body use="literal"/></input>
+            <output><soap:body use="literal"/></output>
+        </operation>
+        <operation name="Divide">
+            <soap:operation soapAction="http://gravitee.io/wsdl/calculator/Divide"/>
+            <input><soap:body use="literal"/></input>
+            <output><soap:body use="literal"/></output>
+        </operation>
+    </binding>
+
+    <!-- SOAP 1.2 Binding -->
+    <binding name="CalculatorSoap12Binding" type="tns:CalculatorPortType">
+        <soap12:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+        <operation name="Add">
+            <soap12:operation soapAction="http://gravitee.io/wsdl/calculator/Add"/>
+            <input><soap12:body use="literal"/></input>
+            <output><soap12:body use="literal"/></output>
+        </operation>
+        <operation name="Subtract">
+            <soap12:operation soapAction="http://gravitee.io/wsdl/calculator/Subtract"/>
+            <input><soap12:body use="literal"/></input>
+            <output><soap12:body use="literal"/></output>
+        </operation>
+        <operation name="Multiply">
+            <soap12:operation soapAction="http://gravitee.io/wsdl/calculator/Multiply"/>
+            <input><soap12:body use="literal"/></input>
+            <output><soap12:body use="literal"/></output>
+        </operation>
+        <operation name="Divide">
+            <soap12:operation soapAction="http://gravitee.io/wsdl/calculator/Divide"/>
+            <input><soap12:body use="literal"/></input>
+            <output><soap12:body use="literal"/></output>
+        </operation>
+    </binding>
+
+    <!-- Service -->
+    <service name="CalculatorService">
+        <port name="CalculatorSoap11Port" binding="tns:CalculatorSoap11Binding">
+            <soap:address location="http://localhost:8080/calculator"/>
+        </port>
+        <port name="CalculatorSoap12Port" binding="tns:CalculatorSoap12Binding">
+            <soap12:address location="http://localhost:8080/calculator"/>
+        </port>
+    </service>
+
+</definitions>

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-spec-converter/src/main/java/io/gravitee/rest/api/spec/converter/wsdl/SoapMessageBuilder.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-spec-converter/src/main/java/io/gravitee/rest/api/spec/converter/wsdl/SoapMessageBuilder.java
@@ -21,6 +21,7 @@ import static io.gravitee.rest.api.spec.converter.wsdl.WSDLUtils.formatQName;
 import io.gravitee.rest.api.spec.converter.wsdl.binding.SoapVersion;
 import io.gravitee.rest.api.spec.converter.wsdl.soap.SoapBodyBuilder;
 import io.gravitee.rest.api.spec.converter.wsdl.soap.SoapHeadersBuilder;
+import io.gravitee.rest.api.spec.converter.wsdl.utils.ElPlaceholderXmlUtil;
 import io.gravitee.rest.api.spec.converter.wsdl.utils.SampleXmlUtil;
 import java.io.IOException;
 import java.io.StringWriter;
@@ -48,8 +49,14 @@ public class SoapMessageBuilder {
     private List<XmlObject> schemas = new ArrayList<>();
     private SchemaTypeSystem schemaTypeSystem;
     private boolean compiled = false;
+    private final boolean useElPlaceholders;
 
     public SoapMessageBuilder(Map<String, String> namespaceMappings) {
+        this(namespaceMappings, false);
+    }
+
+    public SoapMessageBuilder(Map<String, String> namespaceMappings, boolean useElPlaceholders) {
+        this.useElPlaceholders = useElPlaceholders;
         this.namespaceMappings = namespaceMappings;
         this.namespaceMappings.put(SampleXmlUtil.XSI_TYPE.getNamespaceURI(), SampleXmlUtil.XSI_TYPE.getPrefix());
         this.namespaceMappings.put(XMLSCHEMA, XSD_PREFIX);
@@ -76,6 +83,13 @@ public class SoapMessageBuilder {
                 e
             );
         }
+    }
+
+    public SchemaTypeSystem getSchemaTypeSystem() {
+        if (!compiled) {
+            compileSchemas();
+        }
+        return schemaTypeSystem;
     }
 
     public void compileSchemas() {
@@ -134,13 +148,17 @@ public class SoapMessageBuilder {
             envelopeCursor.toBookmark(bookmark);
             envelopeCursor.toLastChild();
 
-            new SoapBodyBuilder()
+            SoapBodyBuilder bodyBuilder = new SoapBodyBuilder();
+            bodyBuilder
                 .withBindingOperation(bindingOperation)
                 .withCursor(envelopeCursor)
                 .withNamespaceMappings(namespaceMappings)
                 .withShemaTypeSystem(schemaTypeSystem)
-                .withVersion(version)
-                .build();
+                .withVersion(version);
+            if (useElPlaceholders) {
+                bodyBuilder.withTypeContentWriter(ElPlaceholderXmlUtil.typeContentWriter());
+            }
+            bodyBuilder.build();
 
             envelopeCursor.dispose();
             soapEnvelope.save(writer, options);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-spec-converter/src/main/java/io/gravitee/rest/api/spec/converter/wsdl/WSDLToOpenAPIConverter.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-spec-converter/src/main/java/io/gravitee/rest/api/spec/converter/wsdl/WSDLToOpenAPIConverter.java
@@ -24,10 +24,12 @@ import io.gravitee.common.http.MediaType;
 import io.gravitee.rest.api.spec.converter.OpenAPIConverter;
 import io.gravitee.rest.api.spec.converter.wsdl.exception.WsdlDescriptorException;
 import io.gravitee.rest.api.spec.converter.wsdl.reader.GraviteeWSDLReaderImpl;
+import io.gravitee.rest.api.spec.converter.wsdl.utils.XsdToJsonSchemaConverter;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.PathItem;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.media.Content;
+import io.swagger.v3.oas.models.parameters.RequestBody;
 import io.swagger.v3.oas.models.responses.ApiResponse;
 import io.swagger.v3.oas.models.responses.ApiResponses;
 import io.swagger.v3.oas.models.servers.Server;
@@ -39,6 +41,8 @@ import javax.wsdl.*;
 import javax.wsdl.extensions.schema.Schema;
 import javax.xml.namespace.QName;
 import lombok.CustomLog;
+import org.apache.xmlbeans.SchemaType;
+import org.apache.xmlbeans.SchemaTypeSystem;
 import org.w3c.dom.Element;
 import org.xml.sax.InputSource;
 
@@ -68,7 +72,7 @@ public class WSDLToOpenAPIConverter implements OpenAPIConverter {
         this.wsdlDefinition = loadWSDL(stream);
         // create the SoapBuilder with namespaces declared in the Definition element
         // this allows Apache XmlBeans to load additional Namespaces if required to parse the XSDs
-        this.soapBuilder = new SoapMessageBuilder(wsdlDefinition.getNamespaces());
+        this.soapBuilder = new SoapMessageBuilder(wsdlDefinition.getNamespaces(), true);
 
         this.openAPI = new OpenAPI();
         buildInfo();
@@ -161,6 +165,7 @@ public class WSDLToOpenAPIConverter implements OpenAPIConverter {
                     this.soapBuilder.generateSoapEnvelop(wsdlDefinition, binding, bindingOperation).ifPresent(envelope ->
                         openApiOperation.addExtension(SOAP_EXTENSION_ENVELOPE, envelope)
                     );
+                    buildRequestBody(input).ifPresent(openApiOperation::setRequestBody);
                 }
 
                 // create an empty Content definition used by each response description
@@ -243,5 +248,36 @@ public class WSDLToOpenAPIConverter implements OpenAPIConverter {
             openAPI.addServersItem(server);
             serverCache.add(address);
         }
+    }
+
+    @SuppressWarnings("unchecked")
+    private Optional<RequestBody> buildRequestBody(Input input) {
+        SchemaTypeSystem sts = soapBuilder.getSchemaTypeSystem();
+        if (sts == null || input.getMessage() == null) {
+            return Optional.empty();
+        }
+
+        return ((Collection<Part>) input.getMessage().getParts().values()).stream()
+            .findFirst()
+            .map(Part::getElementName)
+            .flatMap(elementName -> {
+                QName rootName = new QName(elementName.getNamespaceURI(), elementName.getLocalPart());
+                return Arrays.stream(sts.documentTypes())
+                    .filter(dt -> rootName.equals(dt.getDocumentElementName()))
+                    .findFirst();
+            })
+            .map(docType -> {
+                io.swagger.v3.oas.models.media.Schema<?> jsonSchema = XsdToJsonSchemaConverter.convert(docType);
+                io.swagger.v3.oas.models.media.MediaType mediaType = new io.swagger.v3.oas.models.media.MediaType();
+                mediaType.setSchema(jsonSchema);
+
+                Content content = new Content();
+                content.addMediaType(MediaType.APPLICATION_JSON, mediaType);
+
+                RequestBody requestBody = new RequestBody();
+                requestBody.setRequired(true);
+                requestBody.setContent(content);
+                return requestBody;
+            });
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-spec-converter/src/main/java/io/gravitee/rest/api/spec/converter/wsdl/soap/AbstractSoapBuilder.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-spec-converter/src/main/java/io/gravitee/rest/api/spec/converter/wsdl/soap/AbstractSoapBuilder.java
@@ -18,6 +18,7 @@ package io.gravitee.rest.api.spec.converter.wsdl.soap;
 import io.gravitee.rest.api.spec.converter.wsdl.binding.SoapVersion;
 import io.gravitee.rest.api.spec.converter.wsdl.utils.SampleXmlUtil;
 import java.util.Map;
+import java.util.function.BiConsumer;
 import javax.wsdl.BindingOperation;
 import javax.wsdl.Part;
 import javax.xml.namespace.QName;
@@ -34,6 +35,7 @@ public abstract class AbstractSoapBuilder {
 
     private SchemaTypeSystem schemaTypeSystem;
     private Map<String, String> namespaceMappings;
+    private BiConsumer<SchemaType, XmlCursor> typeContentWriter;
 
     protected SoapVersion version;
     protected BindingOperation bindingOperation;
@@ -64,6 +66,11 @@ public abstract class AbstractSoapBuilder {
         return this;
     }
 
+    public AbstractSoapBuilder withTypeContentWriter(BiConsumer<SchemaType, XmlCursor> typeContentWriter) {
+        this.typeContentWriter = typeContentWriter;
+        return this;
+    }
+
     public abstract XmlCursor build();
 
     protected void generateXml(Part part, XmlCursor cursor, boolean encoded) {
@@ -84,7 +91,7 @@ public abstract class AbstractSoapBuilder {
                 cursor.insertAttributeWithValue(SampleXmlUtil.XSI_TYPE, buildPrefixedName(elem));
             }
 
-            new SampleXmlUtil(encoded).createSampleForType(elem, cursor);
+            resolveTypeContentWriter(encoded).accept(elem, cursor);
         } else {
             SchemaType type = schemaTypeSystem.findType(part.getTypeName());
             if (type == null) {
@@ -94,9 +101,15 @@ public abstract class AbstractSoapBuilder {
                 if (encoded) {
                     cursor.insertAttributeWithValue(SampleXmlUtil.XSI_TYPE, buildPrefixedName(type));
                 }
-                new SampleXmlUtil(encoded).createSampleForType(type, cursor);
+                resolveTypeContentWriter(encoded).accept(type, cursor);
             }
         }
+    }
+
+    private BiConsumer<SchemaType, XmlCursor> resolveTypeContentWriter(boolean encoded) {
+        return typeContentWriter != null
+            ? typeContentWriter
+            : (type, cursor) -> new SampleXmlUtil(encoded).createSampleForType(type, cursor);
     }
 
     protected String buildPrefixedName(SchemaType type) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-spec-converter/src/main/java/io/gravitee/rest/api/spec/converter/wsdl/utils/ElPlaceholderXmlUtil.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-spec-converter/src/main/java/io/gravitee/rest/api/spec/converter/wsdl/utils/ElPlaceholderXmlUtil.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.spec.converter.wsdl.utils;
+
+import java.util.function.BiConsumer;
+import org.apache.xmlbeans.SchemaLocalElement;
+import org.apache.xmlbeans.SchemaParticle;
+import org.apache.xmlbeans.SchemaType;
+import org.apache.xmlbeans.XmlCursor;
+
+/**
+ * Generates EL placeholder expressions instead of sample values for SOAP envelope elements.
+ * Leaf elements get {@code {#xmlEscape(#jsonPath(#request.content, '$.path'))}} while
+ * complex types are traversed recursively, building the JSON path from the element hierarchy.
+ */
+public class ElPlaceholderXmlUtil {
+
+    private static final Runnable SKIP_NON_COMPLEX_CONTENT = () -> {};
+    private static final Runnable SKIP_UNSUPPORTED_PARTICLE_TYPE = () -> {};
+
+    private ElPlaceholderXmlUtil() {}
+
+    /**
+     * Returns a {@link BiConsumer} that writes EL expressions for leaf elements
+     * and traverses complex types recursively. The JSON path starts at {@code $}
+     * and skips the root XML element name (the WSDL operation wrapper).
+     */
+    public static BiConsumer<SchemaType, XmlCursor> typeContentWriter() {
+        return (stype, xmlc) -> {
+            // The document type wraps a root element (e.g. AddRequest).
+            // Insert the root element in XML but start the JSON path at "$"
+            // so children get "$.a", "$.b" instead of "$.AddRequest.a".
+            if (stype.getContentModel() != null && stype.getContentModel().getParticleType() == SchemaParticle.ELEMENT) {
+                SchemaLocalElement rootElement = (SchemaLocalElement) stype.getContentModel();
+                xmlc.insertElement(rootElement.getName().getLocalPart(), rootElement.getName().getNamespaceURI());
+                xmlc.toPrevToken();
+                createPlaceholderForType(rootElement.getType(), xmlc, "$");
+                xmlc.toNextToken();
+            } else {
+                createPlaceholderForType(stype, xmlc, "$");
+            }
+        };
+    }
+
+    private static void createPlaceholderForType(SchemaType stype, XmlCursor xmlc, String jsonPath) {
+        if (stype.isSimpleType() || stype.isURType()) {
+            writeElPlaceholder(xmlc, jsonPath);
+            return;
+        }
+
+        switch (stype.getContentType()) {
+            case SchemaType.SIMPLE_CONTENT -> writeElPlaceholder(xmlc, jsonPath);
+            case SchemaType.ELEMENT_CONTENT, SchemaType.MIXED_CONTENT -> {
+                if (stype.getContentModel() != null) {
+                    processParticle(stype.getContentModel(), xmlc, jsonPath);
+                }
+            }
+            default -> SKIP_NON_COMPLEX_CONTENT.run();
+        }
+    }
+
+    private static void processParticle(SchemaParticle sp, XmlCursor xmlc, String jsonPath) {
+        switch (sp.getParticleType()) {
+            case SchemaParticle.ELEMENT -> processElement(sp, xmlc, jsonPath);
+            case SchemaParticle.SEQUENCE, SchemaParticle.CHOICE, SchemaParticle.ALL -> {
+                for (SchemaParticle child : sp.getParticleChildren()) {
+                    processParticle(child, xmlc, jsonPath);
+                }
+            }
+            default -> SKIP_UNSUPPORTED_PARTICLE_TYPE.run();
+        }
+    }
+
+    private static void processElement(SchemaParticle sp, XmlCursor xmlc, String parentPath) {
+        SchemaLocalElement element = (SchemaLocalElement) sp;
+        String elementName = element.getName().getLocalPart();
+        String currentPath = parentPath + "." + elementName;
+
+        xmlc.insertElement(elementName, element.getName().getNamespaceURI());
+        xmlc.toPrevToken();
+        createPlaceholderForType(element.getType(), xmlc, currentPath);
+        xmlc.toNextToken();
+    }
+
+    private static void writeElPlaceholder(XmlCursor xmlc, String jsonPath) {
+        xmlc.insertChars("{#xmlEscape(#jsonPath(#request.content, '" + jsonPath + "'))}");
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-spec-converter/src/main/java/io/gravitee/rest/api/spec/converter/wsdl/utils/XsdToJsonSchemaConverter.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-spec-converter/src/main/java/io/gravitee/rest/api/spec/converter/wsdl/utils/XsdToJsonSchemaConverter.java
@@ -1,0 +1,182 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.spec.converter.wsdl.utils;
+
+import io.swagger.v3.oas.models.media.Schema;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.apache.xmlbeans.SchemaLocalElement;
+import org.apache.xmlbeans.SchemaParticle;
+import org.apache.xmlbeans.SchemaType;
+
+/**
+ * Converts XSD schema types to OpenAPI JSON Schema representations.
+ * Used to generate request body schemas from WSDL input message parts.
+ */
+public class XsdToJsonSchemaConverter {
+
+    private static final String TYPE_OBJECT = "object";
+    private static final String TYPE_STRING = "string";
+    private static final String TYPE_BOOLEAN = "boolean";
+    private static final String TYPE_NUMBER = "number";
+    private static final String TYPE_INTEGER = "integer";
+    private static final String FORMAT_DATE = "date";
+    private static final String FORMAT_DATE_TIME = "date-time";
+
+    private static final Set<Integer> BOOLEAN_TYPES = Set.of(SchemaType.BTC_BOOLEAN);
+
+    private static final Set<Integer> NUMBER_TYPES = Set.of(SchemaType.BTC_FLOAT, SchemaType.BTC_DOUBLE, SchemaType.BTC_DECIMAL);
+
+    private static final Set<Integer> INTEGER_TYPES = Set.of(
+        SchemaType.BTC_INTEGER,
+        SchemaType.BTC_LONG,
+        SchemaType.BTC_INT,
+        SchemaType.BTC_SHORT,
+        SchemaType.BTC_BYTE,
+        SchemaType.BTC_NON_NEGATIVE_INTEGER,
+        SchemaType.BTC_POSITIVE_INTEGER,
+        SchemaType.BTC_NON_POSITIVE_INTEGER,
+        SchemaType.BTC_NEGATIVE_INTEGER,
+        SchemaType.BTC_UNSIGNED_LONG,
+        SchemaType.BTC_UNSIGNED_INT,
+        SchemaType.BTC_UNSIGNED_SHORT,
+        SchemaType.BTC_UNSIGNED_BYTE
+    );
+
+    private static final Set<Integer> DATE_TYPES = Set.of(SchemaType.BTC_DATE);
+
+    private static final Set<Integer> DATE_TIME_TYPES = Set.of(SchemaType.BTC_DATE_TIME);
+
+    private XsdToJsonSchemaConverter() {}
+
+    /**
+     * Converts an XSD document type (wrapping a complex type) to an OpenAPI JSON Schema.
+     */
+    @SuppressWarnings("rawtypes")
+    public static Schema<?> convert(SchemaType documentType) {
+        if (documentType == null) {
+            return new Schema().type(TYPE_OBJECT);
+        }
+
+        SchemaType contentType = documentType;
+        if (documentType.getContentModel() != null && documentType.getContentModel().getParticleType() == SchemaParticle.ELEMENT) {
+            contentType = ((SchemaLocalElement) documentType.getContentModel()).getType();
+        }
+
+        return convertType(contentType);
+    }
+
+    @SuppressWarnings("rawtypes")
+    private static Schema<?> convertType(SchemaType stype) {
+        if (stype == null) {
+            return new Schema().type(TYPE_OBJECT);
+        }
+
+        if (stype.isSimpleType() || stype.isURType()) {
+            return mapSimpleType(stype);
+        }
+
+        return switch (stype.getContentType()) {
+            case SchemaType.SIMPLE_CONTENT -> mapSimpleType(stype);
+            case SchemaType.ELEMENT_CONTENT, SchemaType.MIXED_CONTENT -> stype.getContentModel() != null
+                ? convertParticle(stype.getContentModel())
+                : new Schema().type(TYPE_OBJECT);
+            default -> new Schema().type(TYPE_OBJECT);
+        };
+    }
+
+    @SuppressWarnings({ "rawtypes", "unchecked" })
+    private static Schema<?> convertParticle(SchemaParticle sp) {
+        return switch (sp.getParticleType()) {
+            case SchemaParticle.SEQUENCE, SchemaParticle.ALL, SchemaParticle.CHOICE -> buildObjectSchema(sp);
+            case SchemaParticle.ELEMENT -> convertType(((SchemaLocalElement) sp).getType());
+            default -> new Schema().type(TYPE_OBJECT);
+        };
+    }
+
+    @SuppressWarnings({ "rawtypes", "unchecked" })
+    private static Schema<?> buildObjectSchema(SchemaParticle sp) {
+        Schema schema = new Schema().type(TYPE_OBJECT);
+        schema.setProperties(collectElementProperties(sp));
+
+        List<String> required = collectRequiredProperties(sp);
+        if (!required.isEmpty()) {
+            schema.setRequired(required);
+        }
+
+        return schema;
+    }
+
+    @SuppressWarnings("rawtypes")
+    private static Map<String, Schema> collectElementProperties(SchemaParticle sp) {
+        return Arrays.stream(sp.getParticleChildren())
+            .filter(child -> child.getParticleType() == SchemaParticle.ELEMENT)
+            .collect(
+                Collectors.toMap(
+                    child -> ((SchemaLocalElement) child).getName().getLocalPart(),
+                    child -> convertType(((SchemaLocalElement) child).getType()),
+                    (a, b) -> a,
+                    LinkedHashMap::new
+                )
+            );
+    }
+
+    private static List<String> collectRequiredProperties(SchemaParticle sp) {
+        return Arrays.stream(sp.getParticleChildren())
+            .filter(child -> child.getParticleType() == SchemaParticle.ELEMENT)
+            .filter(child -> child.getIntMinOccurs() >= 1)
+            .map(child -> ((SchemaLocalElement) child).getName().getLocalPart())
+            .collect(Collectors.toCollection(ArrayList::new));
+    }
+
+    @SuppressWarnings("rawtypes")
+    private static Schema<?> mapSimpleType(SchemaType stype) {
+        if (stype == null) {
+            return new Schema().type(TYPE_STRING);
+        }
+
+        int typeCode = getBuiltinTypeCode(stype);
+        if (BOOLEAN_TYPES.contains(typeCode)) {
+            return new Schema().type(TYPE_BOOLEAN);
+        }
+        if (NUMBER_TYPES.contains(typeCode)) {
+            return new Schema().type(TYPE_NUMBER);
+        }
+        if (INTEGER_TYPES.contains(typeCode)) {
+            return new Schema().type(TYPE_INTEGER);
+        }
+        if (DATE_TYPES.contains(typeCode)) {
+            return new Schema().type(TYPE_STRING).format(FORMAT_DATE);
+        }
+        if (DATE_TIME_TYPES.contains(typeCode)) {
+            return new Schema().type(TYPE_STRING).format(FORMAT_DATE_TIME);
+        }
+        return new Schema().type(TYPE_STRING);
+    }
+
+    private static int getBuiltinTypeCode(SchemaType stype) {
+        SchemaType current = stype;
+        while (current != null && !current.isBuiltinType()) {
+            current = current.getBaseType();
+        }
+        return current != null ? current.getBuiltinTypeCode() : SchemaType.BTC_STRING;
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-spec-converter/src/test/java/io/gravitee/rest/api/spec/converter/wsdl/WSDLToOpenAPIConverterElPlaceholderTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-spec-converter/src/test/java/io/gravitee/rest/api/spec/converter/wsdl/WSDLToOpenAPIConverterElPlaceholderTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.spec.converter.wsdl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.Operation;
+import io.swagger.v3.oas.models.PathItem;
+import io.swagger.v3.oas.models.media.Schema;
+import java.util.Map;
+import org.junit.Test;
+
+public class WSDLToOpenAPIConverterElPlaceholderTest {
+
+    private final WSDLToOpenAPIConverter converter = new WSDLToOpenAPIConverter();
+
+    @Test
+    public void should_generate_json_path_el_placeholders_in_soap_envelope() {
+        OpenAPI openApi = converter.toOpenAPI(getClass().getResourceAsStream("/calculator.asmx"));
+
+        // The Add operation has two integer parameters: intA and intB
+        // Multiple ports exist, so path includes the port name
+        PathItem addPath = openApi.getPaths().get("/Calculator/CalculatorSoap/Add");
+        assertThat(addPath).isNotNull();
+
+        Operation addOp = addPath.getPost();
+        assertThat(addOp).isNotNull();
+
+        String envelope = (String) addOp.getExtensions().get(WSDLToOpenAPIConverter.SOAP_EXTENSION_ENVELOPE);
+        assertThat(envelope).isNotNull();
+        assertThat(envelope).contains("{#xmlEscape(#jsonPath(#request.content, '$.intA'))}");
+        assertThat(envelope).contains("{#xmlEscape(#jsonPath(#request.content, '$.intB'))}");
+        assertThat(envelope).doesNotContain("1.051732E7");
+        assertThat(envelope).doesNotContain("#request.params");
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void should_generate_request_body_schema_from_wsdl() {
+        OpenAPI openApi = converter.toOpenAPI(getClass().getResourceAsStream("/calculator.asmx"));
+
+        PathItem addPath = openApi.getPaths().get("/Calculator/CalculatorSoap/Add");
+        assertThat(addPath).isNotNull();
+
+        Operation addOp = addPath.getPost();
+        assertThat(addOp).isNotNull();
+        assertThat(addOp.getRequestBody()).isNotNull();
+        assertThat(addOp.getRequestBody().getRequired()).isTrue();
+
+        Schema<?> schema = addOp.getRequestBody().getContent().get("application/json").getSchema();
+        assertThat(schema).isNotNull();
+        assertThat(schema.getType()).isEqualTo("object");
+
+        Map<String, Schema> properties = schema.getProperties();
+        assertThat(properties).isNotNull();
+        assertThat(properties).containsKey("intA");
+        assertThat(properties).containsKey("intB");
+        assertThat(properties.get("intA").getType()).isEqualTo("integer");
+        assertThat(properties.get("intB").getType()).isEqualTo("integer");
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-spec-converter/src/test/java/io/gravitee/rest/api/spec/converter/wsdl/utils/ElPlaceholderXmlUtilTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-spec-converter/src/test/java/io/gravitee/rest/api/spec/converter/wsdl/utils/ElPlaceholderXmlUtilTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.spec.converter.wsdl.utils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.rest.api.spec.converter.wsdl.WSDLToOpenAPIConverter;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.Operation;
+import org.junit.Test;
+
+/**
+ * Tests {@link ElPlaceholderXmlUtil} through the WSDL converter which uses it
+ * to generate EL placeholders in SOAP envelopes.
+ */
+public class ElPlaceholderXmlUtilTest {
+
+    private final WSDLToOpenAPIConverter converter = new WSDLToOpenAPIConverter();
+
+    @Test
+    public void should_generate_json_path_for_integer_params() {
+        OpenAPI api = converter.toOpenAPI(getClass().getResourceAsStream("/calculator.asmx"));
+        String envelope = getEnvelope(api, "/Calculator/CalculatorSoap/Add");
+
+        assertThat(envelope).contains("{#xmlEscape(#jsonPath(#request.content, '$.intA'))}");
+        assertThat(envelope).contains("{#xmlEscape(#jsonPath(#request.content, '$.intB'))}");
+    }
+
+    @Test
+    public void should_generate_json_path_for_string_params() {
+        OpenAPI api = converter.toOpenAPI(getClass().getResourceAsStream("/tempconvert.wsdl"));
+        String envelope = getEnvelope(api, "/TempConvert/TempConvertSoap/FahrenheitToCelsius");
+
+        assertThat(envelope).contains("{#xmlEscape(#jsonPath(#request.content, '$.Fahrenheit'))}");
+    }
+
+    private String getEnvelope(OpenAPI api, String path) {
+        Operation op = api.getPaths().get(path).getPost();
+        assertThat(op).isNotNull();
+        return (String) op.getExtensions().get(WSDLToOpenAPIConverter.SOAP_EXTENSION_ENVELOPE);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-spec-converter/src/test/java/io/gravitee/rest/api/spec/converter/wsdl/utils/XsdToJsonSchemaConverterTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-spec-converter/src/test/java/io/gravitee/rest/api/spec/converter/wsdl/utils/XsdToJsonSchemaConverterTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.spec.converter.wsdl.utils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.rest.api.spec.converter.wsdl.WSDLToOpenAPIConverter;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.Operation;
+import io.swagger.v3.oas.models.media.Schema;
+import java.util.Map;
+import org.junit.Test;
+
+/**
+ * Tests {@link XsdToJsonSchemaConverter} through the WSDL converter which uses it
+ * to generate JSON request body schemas from WSDL input messages.
+ */
+public class XsdToJsonSchemaConverterTest {
+
+    private final WSDLToOpenAPIConverter converter = new WSDLToOpenAPIConverter();
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void should_map_integer_params_to_integer_schema_with_required() {
+        OpenAPI api = converter.toOpenAPI(getClass().getResourceAsStream("/calculator.asmx"));
+        Schema<?> schema = getRequestBodySchema(api, "/Calculator/CalculatorSoap/Add");
+
+        assertThat(schema.getType()).isEqualTo("object");
+        Map<String, Schema> props = schema.getProperties();
+        assertThat(props).containsKeys("intA", "intB");
+        assertThat(props.get("intA").getType()).isEqualTo("integer");
+        assertThat(props.get("intB").getType()).isEqualTo("integer");
+        assertThat(schema.getRequired()).containsExactly("intA", "intB");
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void should_generate_schema_for_multiple_operations() {
+        OpenAPI api = converter.toOpenAPI(getClass().getResourceAsStream("/calculator.asmx"));
+        Schema<?> subtractSchema = getRequestBodySchema(api, "/Calculator/CalculatorSoap/Subtract");
+
+        assertThat(subtractSchema.getType()).isEqualTo("object");
+        Map<String, Schema> props = subtractSchema.getProperties();
+        assertThat(props).containsKeys("intA", "intB");
+    }
+
+    @Test
+    public void should_set_request_body_as_required_with_json_content() {
+        OpenAPI api = converter.toOpenAPI(getClass().getResourceAsStream("/calculator.asmx"));
+        Operation op = api.getPaths().get("/Calculator/CalculatorSoap/Add").getPost();
+
+        assertThat(op.getRequestBody()).isNotNull();
+        assertThat(op.getRequestBody().getRequired()).isTrue();
+        assertThat(op.getRequestBody().getContent()).containsKey("application/json");
+        assertThat(op.getRequestBody().getContent().get("application/json").getSchema()).isNotNull();
+        assertThat(op.getRequestBody().getContent().get("application/json").getSchema().getType()).isEqualTo("object");
+    }
+
+    private Schema<?> getRequestBodySchema(OpenAPI api, String path) {
+        Operation op = api.getPaths().get(path).getPost();
+        assertThat(op).isNotNull();
+        assertThat(op.getRequestBody()).isNotNull();
+        return op.getRequestBody().getContent().get("application/json").getSchema();
+    }
+}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/EXT-103

## Description

  These commits introduce WSDL import support for v4 APIs, enabling both creating and updating APIs from WSDL definitions. Two import modes are available — raw SOAP (passthrough) and REST-to-SOAP (protocol translation) — with optional OpenAPI documentation and OAS validation, following the   
  same functional scope as the existing v2 implementation.
                                                                                                                                                                                                                                                                                                     
  Functional                                                                                                                                                                                                                                                                                       

  - Two import modes: raw SOAP (passthrough, no flows generated) and REST-to-SOAP (protocol translation with per-operation rest-to-soap + xml-json flows)
  - Two operations: create or update a v4 API from WSDL
  - REST-to-SOAP optional features: OpenAPI documentation page and OAS validation policy — only available in REST-to-SOAP mode
  - EL expressions in SOAP envelopes — leaf values use {#xmlEscape(#jsonPath(#request.content, '$.path'))} to extract from incoming JSON with XML escaping
  - Conditional flows — skipFlows=true in raw SOAP mode (no policies); flows only built for REST-to-SOAP
  - Deferred response validation — OAS validation on response is placed last so that xml-json converts the SOAP XML to JSON first, before validation against the OpenAPI schema can apply
  - Auto-added dependency — selecting rest-to-soap automatically appends xml-json policy
  - Validate Request / Apply XML Validation not ported — these v2 policies appear dead (never added during v2 WSDL import) and were omitted to keep WSDL import aligned with other import formats

  Technical

  - New endpoints: POST /v2/apis/_import/wsdl (create) and PUT /v2/apis/{apiId}/_import/wsdl (update)
  - New use cases: WsdlToImportApiUseCase and WsdlToUpdateApiUseCase — orchestrate WSDL parsing → OAI conversion → API create/update
  - New domain service: WsdlParserDomainService — wraps WSDLToOpenAPIConverter to parse WSDL into OpenAPI YAML

  Design decisions and constraints

  - XSD → JSON Schema (XsdToJsonSchemaConverter) — maps basic XSD primitives and nested structures; advanced constraints (patterns, enumerations, unions) not supported — same scope as v2
  - maxOccurs / arrays — converter does not produce JSON array types for maxOccurs > 1; known v2 limitation carried over
  - EL expression builder (ElPlaceholderXmlUtil) — supports flat/nested hierarchies; same v2 limitations for complex XSD constructs (choices, extensions, substitution groups)
  - v4 always uses EL placeholders — SoapMessageBuilder flag useElPlaceholders is always true for v4, replacing v2's hardcoded sample values with safe #xmlEscape expressions
  - Deferred validation trigger — only when format is WSDL and policies are present, preventing OAS validation from running against unconverted XML


## Rules compliant report

[rules-compliance-report.md](https://github.com/user-attachments/files/28090716/rules-compliance-report.md)

## Demonstration

https://github.com/user-attachments/assets/8c5fb6d7-fb6f-4a35-8343-c4209bc11167


