### PR TITLE
feat: wire backend to url import

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/import-v4/api-import-v4-form/api-import-v4-form.component.html
+++ b/gravitee-apim-console-webui/src/management/api/import-v4/api-import-v4-form/api-import-v4-form.component.html
@@ -112,8 +112,12 @@
               <div class="configure-file-source__col configure-file-source__col--sources">
                 <span class="configure-file-source__col-heading">Source</span>
                 <gio-form-selection-inline formControlName="source" class="configure-file-source__source-selection">
-                  @for (source of sources; track source.value) {
-                    <gio-form-selection-inline-card [value]="source.value">
+                  @for (source of sources(); track source.value) {
+                    <gio-form-selection-inline-card
+                      [value]="source.value"
+                      [disabled]="!!source.disabledReason"
+                      [matTooltip]="source.disabledReason"
+                    >
                       <gio-form-selection-inline-card-content [icon]="source.icon">
                         <gio-card-content-title>{{ source.label }}</gio-card-content-title>
                       </gio-form-selection-inline-card-content>
@@ -163,10 +167,6 @@
                       ) {
                         <mat-error>Use a valid http(s) URL</mat-error>
                       }
-                    </mat-form-field>
-                    <mat-form-field appearance="outline" class="configure-file-source__field" subscriptSizing="dynamic">
-                      <mat-label>Authorization header (optional)</mat-label>
-                      <input matInput formControlName="authorizationHeader" type="text" autocomplete="off" />
                     </mat-form-field>
                   </div>
                 }
@@ -269,11 +269,6 @@
                   <span>URL:</span
                   ><strong class="review-import-step__value">{{ configureFileSourceForm.controls.remoteUrl.value || '—' }}</strong>
                 </div>
-                @if (configureFileSourceForm.controls.authorizationHeader.value) {
-                  <div class="review-import-step__row">
-                    <span>Authorization header:</span><strong class="review-import-step__value">Provided</strong>
-                  </div>
-                }
               }
             </mat-card-content>
           </mat-card>

--- a/gravitee-apim-console-webui/src/management/api/import-v4/api-import-v4-form/api-import-v4-form.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/import-v4/api-import-v4-form/api-import-v4-form.component.spec.ts
@@ -298,10 +298,8 @@ describe('ApiImportV4FormComponent', () => {
     expect(apiV2.importSwaggerApi).not.toHaveBeenCalled();
   });
 
-  it('should GET remote JSON then import for Gravitee remote', async () => {
-    const apiV2 = TestBed.inject(ApiV2Service);
+  it('should POST the remote URL as text/plain to the backend for Gravitee remote', async () => {
     const httpMock = TestBed.inject(HttpTestingController);
-    jest.spyOn(apiV2, 'import').mockReturnValue(of({ id: 'imported' } as ApiV4));
 
     await harness.selectFormat('gravitee');
     fixture.detectChanges();
@@ -314,11 +312,10 @@ describe('ApiImportV4FormComponent', () => {
     expect(await harness.isImportButtonDisabled()).toBe(false);
 
     await harness.clickImport();
-    const remoteReq = httpMock.expectOne(r => r.url === 'https://cdn.example/def.json');
-    expect(remoteReq.request.method).toBe('GET');
-    remoteReq.flush(JSON.stringify({ api: { definitionVersion: 'V4' } }));
-
-    expect(apiV2.import).toHaveBeenCalledWith(JSON.stringify({ api: { definitionVersion: 'V4' } }));
+    const req = httpMock.expectOne(r => r.method === 'POST' && r.url === `${CONSTANTS_TESTING.env.v2BaseURL}/apis/_import/definition-url`);
+    expect(req.request.body).toBe('https://cdn.example/def.json');
+    expect(req.request.headers.get('Content-Type')).toBe('text/plain');
+    req.flush(fakeApiV4({ id: 'imported-remote' }));
     httpMock.verify();
   });
 
@@ -328,7 +325,29 @@ describe('ApiImportV4FormComponent', () => {
     expect(await harness.hasOptionsStep()).toBe(true);
   });
 
-  it('should show actionable message when remote fetch fails with status 0', async () => {
+  it('should not GET the remote URL from the browser when Gravitee remote is selected', async () => {
+    const httpMock = TestBed.inject(HttpTestingController);
+
+    await harness.selectFormat('gravitee');
+    fixture.detectChanges();
+    await harness.clickNext();
+    await harness.selectSource('remote');
+    await harness.setRemoteUrl('https://cdn.example/def.json');
+    fixture.detectChanges();
+    await harness.clickNext();
+    await harness.clickImport();
+
+    httpMock.expectNone(r => r.method === 'GET' && r.url === 'https://cdn.example/def.json');
+    const req = httpMock.expectOne(r => r.method === 'POST' && r.url === `${CONSTANTS_TESTING.env.v2BaseURL}/apis/_import/definition-url`);
+    req.flush(fakeApiV4({ id: 'imported-remote' }));
+    httpMock.verify();
+  });
+
+  it.each([
+    [400, { message: 'Unable to reach the remote URL' }, 'Unable to reach the remote URL'],
+    [403, { message: 'You are not allowed to create APIs in this environment' }, 'You are not allowed to create APIs in this environment'],
+    [500, { message: 'Internal server error' }, 'Internal server error'],
+  ])('should surface backend message in snackbar when import-url endpoint returns %s', async (status, body, expectedMessage) => {
     const snackBarService = TestBed.inject(SnackBarService);
     const snackBarErrorSpy = jest.spyOn(snackBarService, 'error');
     const httpMock = TestBed.inject(HttpTestingController);
@@ -342,13 +361,70 @@ describe('ApiImportV4FormComponent', () => {
     await harness.clickNext();
 
     await harness.clickImport();
-    const remoteReq = httpMock.expectOne(r => r.url === 'https://cdn.example/def.json');
-    remoteReq.error(new ProgressEvent('error'));
+    const req = httpMock.expectOne(r => r.method === 'POST' && r.url === `${CONSTANTS_TESTING.env.v2BaseURL}/apis/_import/definition-url`);
+    req.flush(body, { status, statusText: 'error' });
+
+    expect(snackBarErrorSpy).toHaveBeenCalledWith(expectedMessage);
+    httpMock.verify();
+  });
+
+  it('should surface a network-error message when the import-url endpoint fails with status 0 (mAPI unreachable)', async () => {
+    const snackBarService = TestBed.inject(SnackBarService);
+    const snackBarErrorSpy = jest.spyOn(snackBarService, 'error');
+    const httpMock = TestBed.inject(HttpTestingController);
+
+    await harness.selectFormat('gravitee');
+    fixture.detectChanges();
+    await harness.clickNext();
+    await harness.selectSource('remote');
+    await harness.setRemoteUrl('https://cdn.example/def.json');
+    fixture.detectChanges();
+    await harness.clickNext();
+
+    await harness.clickImport();
+    const req = httpMock.expectOne(r => r.method === 'POST' && r.url === `${CONSTANTS_TESTING.env.v2BaseURL}/apis/_import/definition-url`);
+    req.error(new ProgressEvent('error'), { status: 0, statusText: 'Unknown Error' });
 
     expect(snackBarErrorSpy).toHaveBeenCalledWith(
-      'Could not fetch the remote URL. Check that the URL is reachable and allows CORS requests from this Console.',
+      'Unable to reach the Management API. Please check your network connection and try again.',
     );
     httpMock.verify();
+  });
+
+  describe('update mode', () => {
+    beforeEach(() => {
+      fixture.componentRef.setInput('updateTargetApiId', 'existing-api');
+      fixture.detectChanges();
+    });
+
+    it('should disable the Remote source card with a tooltip explaining the limitation', () => {
+      // `sources` is a protected signal exposed only to the template; bracket-access keeps the component API clean.
+      const sources = (
+        fixture.componentInstance as unknown as { sources: () => { value: string; disabledReason: string | null }[] }
+      ).sources();
+      const remote = sources.find(s => s.value === 'remote');
+      expect(remote?.disabledReason).toBe('Updating an API from a remote URL is not yet supported');
+      expect(sources.find(s => s.value === 'local')?.disabledReason).toBeNull();
+    });
+
+    it('should refuse to call importFromUrl when the form is forced to remote in update mode', () => {
+      const apiV2 = TestBed.inject(ApiV2Service);
+      const importFromUrlSpy = jest.spyOn(apiV2, 'importFromUrl');
+      const snackBarService = TestBed.inject(SnackBarService);
+      const snackBarErrorSpy = jest.spyOn(snackBarService, 'error');
+
+      // The UI disables the Remote card in update mode (covered above). Bypass the UI guard by forcing
+      // the form to source=remote programmatically, then trigger the import. The component layer must
+      // also refuse — otherwise we would silently create a new API via the create endpoint.
+      fixture.componentInstance.configureFileSourceForm.controls.source.setValue('remote');
+      fixture.componentInstance.configureFileSourceForm.controls.remoteUrl.setValue('https://cdn.example/def.json');
+      fixture.detectChanges();
+
+      (fixture.componentInstance as unknown as { importApi: () => void }).importApi();
+
+      expect(importFromUrlSpy).not.toHaveBeenCalled();
+      expect(snackBarErrorSpy).toHaveBeenCalled();
+    });
   });
 });
 

--- a/gravitee-apim-console-webui/src/management/api/import-v4/api-import-v4-form/api-import-v4-form.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/import-v4/api-import-v4-form/api-import-v4-form.component.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { HttpClient, HttpErrorResponse, HttpHeaders } from '@angular/common/http';
+import { HttpErrorResponse } from '@angular/common/http';
 import { StepperSelectionEvent } from '@angular/cdk/stepper';
 import { Component, computed, DestroyRef, effect, inject, input, output, signal, Signal, viewChild } from '@angular/core';
 import { takeUntilDestroyed, toSignal } from '@angular/core/rxjs-interop';
@@ -28,8 +28,8 @@ import { MatSlideToggle } from '@angular/material/slide-toggle';
 import { MatStepper, MatStepperModule } from '@angular/material/stepper';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { GioBannerModule, GioFormSelectionInlineModule, GioFormSlideToggleModule, GioIconsModule } from '@gravitee/ui-particles-angular';
-import { combineLatest, defer, EMPTY, merge, Observable, of, throwError } from 'rxjs';
-import { catchError, distinctUntilChanged, finalize, map, startWith, switchMap, tap } from 'rxjs/operators';
+import { combineLatest, defer, EMPTY, merge, Observable, of } from 'rxjs';
+import { catchError, distinctUntilChanged, finalize, map, startWith, tap } from 'rxjs/operators';
 
 import { ApiImportFilePickerComponent } from '../../component/api-import-file-picker/api-import-file-picker.component';
 import { ApiV4, PolicyPlugin } from '../../../../entities/management-api-v2';
@@ -77,7 +77,6 @@ function formValidSignal(form: AbstractControl, initialValue = form.valid): Sign
 })
 export class ApiImportV4FormComponent {
   private readonly apiV2Service = inject(ApiV2Service);
-  private readonly http = inject(HttpClient);
   private readonly snackBarService = inject(SnackBarService);
   private readonly destroyRef = inject(DestroyRef);
   private readonly router = inject(Router);
@@ -109,10 +108,23 @@ export class ApiImportV4FormComponent {
     { value: 'openapi', label: 'OpenAPI specification', icon: 'gio:open-api' },
     { value: 'wsdl', label: 'WSDL', icon: 'gio:language' },
   ];
-  protected readonly sources = [
-    { value: 'local', label: 'Local file', icon: 'gio:laptop', disabled: false },
-    { value: 'remote', label: 'Remote source', icon: 'gio:language', disabled: false },
-  ];
+
+  /**
+   * Remote source is disabled in update mode until APIM-12142 introduces a backend update-from-URL flow;
+   * the current create endpoint would silently create a new API instead of updating the target.
+   */
+  protected readonly sources = computed(() => {
+    const updateOnlySupportsLocal = !!this.updateTargetApiId();
+    return [
+      { value: 'local', label: 'Local file', icon: 'gio:laptop', disabledReason: null as string | null },
+      {
+        value: 'remote',
+        label: 'Remote source',
+        icon: 'gio:language',
+        disabledReason: updateOnlySupportsLocal ? 'Updating an API from a remote URL is not yet supported' : null,
+      },
+    ];
+  });
 
   private readonly importFileContent = signal<string | undefined>(undefined);
 
@@ -126,8 +138,6 @@ export class ApiImportV4FormComponent {
     {
       source: ['local', Validators.required],
       remoteUrl: [''],
-      /** When set, sent as the `Authorization` header on the GET to the user-entered remote URL only — not to the Gravitee Management API. */
-      authorizationHeader: [''],
     },
     { validators: [this.createConfigureFileSourceValidator()] },
   );
@@ -193,7 +203,7 @@ export class ApiImportV4FormComponent {
 
   protected readonly selectedSourceLabel = computed(() => {
     const value = this.importSourceMode();
-    return this.sources.find(s => s.value === value)?.label ?? '-';
+    return this.sources().find(s => s.value === value)?.label ?? '-';
   });
 
   protected readonly showImportOptionsStep = computed(() => {
@@ -336,15 +346,13 @@ export class ApiImportV4FormComponent {
     if (this.configureFileSourceForm.controls.source.value !== 'local') {
       this.configureFileSourceForm.controls.source.setValue('local', { emitEvent: true });
     }
-    this.configureFileSourceForm.patchValue({ remoteUrl: '', authorizationHeader: '' }, { emitEvent: false });
+    this.configureFileSourceForm.patchValue({ remoteUrl: '' }, { emitEvent: false });
     this.configureFileSourceForm.controls.remoteUrl.markAsUntouched();
-    this.configureFileSourceForm.controls.authorizationHeader.markAsUntouched();
     this.configureFileSourceForm.updateValueAndValidity({ emitEvent: true });
   }
 
   private applyFileSourceMode(source: string | null): void {
     const urlCtrl = this.configureFileSourceForm.controls.remoteUrl;
-    const authCtrl = this.configureFileSourceForm.controls.authorizationHeader;
 
     if (source === 'remote') {
       urlCtrl.setValidators([Validators.required, ApiImportV4FormComponent.remoteHttpUrlValidator]);
@@ -353,12 +361,9 @@ export class ApiImportV4FormComponent {
     } else {
       urlCtrl.clearValidators();
       urlCtrl.setValue('', { emitEvent: false });
-      authCtrl.setValue('', { emitEvent: false });
       urlCtrl.markAsUntouched();
-      authCtrl.markAsUntouched();
     }
     urlCtrl.updateValueAndValidity({ emitEvent: true });
-    authCtrl.updateValueAndValidity({ emitEvent: false });
     this.configureFileSourceForm.updateValueAndValidity({ emitEvent: true });
   }
 
@@ -493,7 +498,13 @@ export class ApiImportV4FormComponent {
     const url = this.configureFileSourceForm.controls.remoteUrl.value?.trim() as string;
 
     if (format === 'gravitee') {
-      return this.importGraviteeDefinitionFromRemoteUrl$(url, updateId);
+      // Defense-in-depth: the Remote source card is disabled in update mode (see `sources`), but if the form is
+      // forced to remote programmatically, refuse rather than silently creating a new API via the create endpoint.
+      // APIM-12142 will introduce the backend update-from-URL path.
+      if (updateId) {
+        return null;
+      }
+      return this.apiV2Service.importFromUrl(url);
     }
     if (format === 'wsdl') {
       return updateId
@@ -563,36 +574,6 @@ export class ApiImportV4FormComponent {
     }
   }
 
-  /**
-   * Fetches the Gravitee definition JSON from the URL the user typed (browser-side GET).
-   * Optional `authorizationHeader` from `configureFileSourceForm` is forwarded only on that request, not on subsequent Management API calls.
-   */
-  private importGraviteeDefinitionFromRemoteUrl$(url: string, updateApiId: string | undefined): Observable<ApiV4> {
-    const auth = this.configureFileSourceForm.controls.authorizationHeader.value?.trim();
-    let headers = new HttpHeaders();
-    if (auth) {
-      headers = headers.set('Authorization', auth);
-    }
-    return this.http.get(url, { responseType: 'text', headers }).pipe(
-      switchMap(body => {
-        const trimmed = body.trim();
-        if (!trimmed) {
-          return throwError(() => new HttpErrorResponse({ status: 0, error: 'The URL returned an empty response' }));
-        }
-        let definition: unknown;
-        try {
-          definition = JSON.parse(trimmed);
-        } catch {
-          return throwError(() => new HttpErrorResponse({ status: 0, error: 'The URL must return a Gravitee API definition as JSON' }));
-        }
-        if (updateApiId) {
-          return this.apiV2Service.updateApiFromDefinition(updateApiId, definition);
-        }
-        return this.apiV2Service.import(trimmed);
-      }),
-    );
-  }
-
   private mapImportErrorToEmpty(err: unknown): Observable<never> {
     this.snackBarService.error(this.readImportErrorMessage(err));
     return EMPTY;
@@ -600,11 +581,13 @@ export class ApiImportV4FormComponent {
 
   private readImportErrorMessage(err: unknown): string {
     if (err instanceof HttpErrorResponse) {
+      // status 0 = browser could not reach the Management API (network down, mAPI offline, DNS failure).
+      // The body is a ProgressEvent, not a JSON error, so we surface a deliberate UX message instead.
+      if (err.status === 0) {
+        return 'Unable to reach the Management API. Please check your network connection and try again.';
+      }
       if (typeof err.error === 'string') {
         return err.error;
-      }
-      if (err.status === 0) {
-        return 'Could not fetch the remote URL. Check that the URL is reachable and allows CORS requests from this Console.';
       }
       const fromBody = (err.error as { message?: string } | null | undefined)?.message;
       return fromBody ?? err.message ?? 'An error occurred while importing the API';

--- a/gravitee-apim-console-webui/src/management/api/import-v4/api-import-v4-form/api-import-v4-form.harness.ts
+++ b/gravitee-apim-console-webui/src/management/api/import-v4/api-import-v4-form/api-import-v4-form.harness.ts
@@ -32,9 +32,6 @@ export class ApiImportV4FormHarness extends ComponentHarness {
   private readonly getSourceSelectGroup = this.locatorFor(GioFormSelectionInlineHarness.with({ selector: '[formControlName="source"]' }));
   private readonly getFilePicker = this.locatorFor(GioFormFilePickerInputHarness.with({ ancestor: 'api-import-file-picker' }));
   private readonly getRemoteUrlInput = this.locatorFor(MatInputHarness.with({ selector: '[formControlName="remoteUrl"]' }));
-  private readonly getAuthorizationHeaderInput = this.locatorFor(
-    MatInputHarness.with({ selector: '[formControlName="authorizationHeader"]' }),
-  );
   private readonly getDocumentationToggle = this.locatorFor(
     MatSlideToggleHarness.with({ selector: '[formControlName="withDocumentation"]' }),
   );
@@ -74,11 +71,6 @@ export class ApiImportV4FormHarness extends ComponentHarness {
   public async setRemoteUrl(url: string): Promise<void> {
     const input = await this.getRemoteUrlInput();
     return input.setValue(url);
-  }
-
-  public async setAuthorizationHeader(value: string): Promise<void> {
-    const input = await this.getAuthorizationHeaderInput();
-    return input.setValue(value);
   }
 
   public async pickFiles(files: File[]): Promise<void> {

--- a/gravitee-apim-console-webui/src/services-ngx/api-v2.service.spec.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/api-v2.service.spec.ts
@@ -250,6 +250,27 @@ describe('ApiV2Service', () => {
     });
   });
 
+  describe('importFromUrl', () => {
+    it('should POST the URL as text/plain to the definition-url endpoint', done => {
+      const fakeApi = fakeApiV4();
+      const definitionUrl = 'https://cdn.example/def.json';
+
+      apiV2Service.importFromUrl(definitionUrl).subscribe(api => {
+        expect(api).toEqual(fakeApi);
+        done();
+      });
+
+      const req = httpTestingController.expectOne({
+        url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis/_import/definition-url`,
+        method: 'POST',
+      });
+      expect(req.request.body).toBe(definitionUrl);
+      expect(req.request.headers.get('Content-Type')).toBe('text/plain');
+
+      req.flush(fakeApi);
+    });
+  });
+
   describe('search', () => {
     it('should call the API', done => {
       const fakeApi = fakeApiV4();

--- a/gravitee-apim-console-webui/src/services-ngx/api-v2.service.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/api-v2.service.ts
@@ -153,6 +153,20 @@ export class ApiV2Service {
     });
   }
 
+  /**
+   * Creates a v4 API by asking the backend to fetch a Gravitee export from `definitionUrl` and import it.
+   * Body is the URL string itself (`text/plain`). The backend ignores any `Authorization` header.
+   *
+   * Create only — there is no update-from-URL equivalent yet (planned in APIM-12142).
+   */
+  importFromUrl(definitionUrl: string): Observable<ApiV4> {
+    return this.http.post<ApiV4>(`${this.constants.env.v2BaseURL}/apis/_import/definition-url`, definitionUrl, {
+      headers: {
+        'Content-Type': 'text/plain',
+      },
+    });
+  }
+
   importSwaggerApi(descriptor: ImportSwaggerDescriptor) {
     return this.http.post<ApiV4>(`${this.constants.env.v2BaseURL}/apis/_import/swagger`, descriptor, {
       headers: {


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-14063
## Description

- Replaces browser-side HttpClient.get(<remote URL>) + parse with a single POST /apis/_import/definition-url (text/plain, body = URL)
- Drops the now-unused Authorization header field from the Remote source panel (the backend ignores Authorization anyway; auth'd remote sources will be designed in APIM-12142).
- Disables the Remote source card in the API update dialog with a tooltip ("Updating an API from a remote URL is not yet supported") — the new endpoint is create-only, so allowing Remote in update mode would
  silently create a duplicate API.

https://github.com/user-attachments/assets/e42b7d4e-2415-44fd-9e75-8db82202ebc9


https://github.com/user-attachments/assets/335ffe46-a567-4052-99b7-ea4a7f994b18



## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

