### PR TITLE
feat/APIM-13569: payload data masking

### DIFF
--- a/gravitee-apim-console-webui/src/entities/management-api-v2/api/v4/index.ts
+++ b/gravitee-apim-console-webui/src/entities/management-api-v2/api/v4/index.ts
@@ -50,5 +50,6 @@ export * from './stepV4';
 export * from './subscriptionListener';
 export * from './tcpListener';
 export * from './McpSelector';
+export * from './payloadMaskingV4';
 export * from './redactionV4';
 export * from './tracingV4';

--- a/gravitee-apim-console-webui/src/entities/management-api-v2/api/v4/payloadMaskingV4.ts
+++ b/gravitee-apim-console-webui/src/entities/management-api-v2/api/v4/payloadMaskingV4.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { MaskingStrategy } from './redactionV4';
+
+export type PayloadFormat = 'JSON' | 'XML' | 'AUTO';
+export type PayloadPhase = 'REQUEST' | 'RESPONSE' | 'BOTH';
+
+export interface PayloadMaskingRule {
+  /** JSONPath (e.g. "$.password") or XPath (e.g. "//password") */
+  path: string;
+  maskingStrategy?: MaskingStrategy;
+  /** Which traffic direction(s) this rule applies to. Default: BOTH */
+  phase?: PayloadPhase;
+  /** Body format. AUTO detects from Content-Type and body heuristics. Default: AUTO */
+  format?: PayloadFormat;
+}
+
+export interface PayloadMaskingConfig {
+  /** Fallback replacement text for FULL rules with no per-rule replacement. */
+  defaultReplacement?: string;
+  rules: PayloadMaskingRule[];
+}

--- a/gravitee-apim-console-webui/src/management/api/reporter-settings/reporter-settings-proxy/api-payload-masking-rules/api-payload-masking-rules.component.html
+++ b/gravitee-apim-console-webui/src/management/api/reporter-settings/reporter-settings-proxy/api-payload-masking-rules/api-payload-masking-rules.component.html
@@ -1,0 +1,103 @@
+<!--
+
+    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<div class="payloadMaskingRules">
+  <div class="payloadMaskingRules__header">
+    <div class="payloadMaskingRules__header__title">Payload Masking</div>
+    @if (!isReadOnly()) {
+      <button mat-stroked-button color="primary" class="payloadMaskingRules__header__btn" (click)="addRule()">
+        <mat-icon svgIcon="gio:plus"></mat-icon>
+        Add rule
+      </button>
+    }
+  </div>
+
+  <div class="payloadMaskingRules__banner">
+    <gio-banner-info>
+      <span
+        >Rules mask field values inside request/response bodies before they are exported to your tracing backend. Global rules defined in
+        <code>gravitee.yml</code> are always applied first.</span
+      >
+    </gio-banner-info>
+  </div>
+
+  <table mat-table [dataSource]="rows()" class="payloadMaskingRules__table">
+    <ng-container matColumnDef="index">
+      <th mat-header-cell *matHeaderCellDef>#</th>
+      <td mat-cell *matCellDef="let row; let i = index">
+        <span class="gio-badge-neutral">{{ i + 1 }}</span>
+      </td>
+    </ng-container>
+
+    <ng-container matColumnDef="path">
+      <th mat-header-cell *matHeaderCellDef>Path</th>
+      <td mat-cell *matCellDef="let row">
+        <code class="payloadMaskingRules__code">{{ row.path }}</code>
+      </td>
+    </ng-container>
+
+    <ng-container matColumnDef="format">
+      <th mat-header-cell *matHeaderCellDef>Format</th>
+      <td mat-cell *matCellDef="let row">
+        <span class="gio-badge-neutral">{{ row.format ?? 'AUTO' }}</span>
+      </td>
+    </ng-container>
+
+    <ng-container matColumnDef="phase">
+      <th mat-header-cell *matHeaderCellDef>Phase</th>
+      <td mat-cell *matCellDef="let row">
+        {{ row.phase ?? 'BOTH' }}
+      </td>
+    </ng-container>
+
+    <ng-container matColumnDef="masking">
+      <th mat-header-cell *matHeaderCellDef>Masking</th>
+      <td mat-cell *matCellDef="let row">
+        <span [class]="row.maskingStrategy?.type === 'PARTIAL' ? 'gio-badge-accent' : 'gio-badge-neutral'">{{ maskingLabel(row) }}</span>
+        <span class="payloadMaskingRules__detail">{{ maskingDetail(row) }}</span>
+      </td>
+    </ng-container>
+
+    <ng-container matColumnDef="actions">
+      <th mat-header-cell *matHeaderCellDef></th>
+      <td mat-cell *matCellDef="let row">
+        @if (!isReadOnly()) {
+          <div class="payloadMaskingRules__actionsCell">
+            <button mat-icon-button (click)="editRule(row._id)" matTooltip="Edit rule" aria-label="Edit rule">
+              <mat-icon svgIcon="gio:edit-pencil"></mat-icon>
+            </button>
+            <button mat-icon-button (click)="removeRule(row._id)" matTooltip="Delete rule" aria-label="Delete rule">
+              <mat-icon svgIcon="gio:trash"></mat-icon>
+            </button>
+          </div>
+        }
+      </td>
+    </ng-container>
+
+    <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+    <tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
+
+    <tr class="mat-row" *matNoDataRow>
+      <td class="mat-cell" [attr.colspan]="displayedColumns.length">
+        <div class="payloadMaskingRules__emptyState">
+          <mat-icon svgIcon="gio:lock"></mat-icon>
+          No payload masking rules — body fields are exported as-is.
+        </div>
+      </td>
+    </tr>
+  </table>
+</div>

--- a/gravitee-apim-console-webui/src/management/api/reporter-settings/reporter-settings-proxy/api-payload-masking-rules/api-payload-masking-rules.component.scss
+++ b/gravitee-apim-console-webui/src/management/api/reporter-settings/reporter-settings-proxy/api-payload-masking-rules/api-payload-masking-rules.component.scss
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+.payloadMaskingRules {
+  padding: 16px;
+
+  &__header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 12px;
+
+    &__title {
+      font-size: 1rem;
+      font-weight: 500;
+    }
+  }
+
+  &__banner {
+    margin-bottom: 12px;
+  }
+
+  &__table {
+    width: 100%;
+  }
+
+  &__code {
+    background: #f5f5f5;
+    border-radius: 3px;
+    padding: 1px 4px;
+    font-family: monospace;
+    font-size: 0.85em;
+  }
+
+  &__detail {
+    margin-left: 6px;
+    font-size: 0.8em;
+    color: #666;
+  }
+
+  &__actionsCell {
+    display: flex;
+    gap: 4px;
+    justify-content: flex-end;
+  }
+
+  &__emptyState {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    justify-content: center;
+    padding: 24px;
+    color: #999;
+  }
+}

--- a/gravitee-apim-console-webui/src/management/api/reporter-settings/reporter-settings-proxy/api-payload-masking-rules/api-payload-masking-rules.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/reporter-settings/reporter-settings-proxy/api-payload-masking-rules/api-payload-masking-rules.component.spec.ts
@@ -1,0 +1,211 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { MatIconTestingModule } from '@angular/material/icon/testing';
+import { MatDialog } from '@angular/material/dialog';
+import { of } from 'rxjs';
+
+import { ApiPayloadMaskingRulesComponent } from './api-payload-masking-rules.component';
+import { PayloadMaskingRuleDialogComponent } from './payload-masking-rule-dialog/payload-masking-rule-dialog.component';
+
+import { fakeProxyApiV4, PayloadMaskingRule } from '../../../../../entities/management-api-v2';
+
+describe('ApiPayloadMaskingRulesComponent', () => {
+  let fixture: ComponentFixture<ApiPayloadMaskingRulesComponent>;
+  let component: ApiPayloadMaskingRulesComponent;
+  const mockDialog = { open: jest.fn() };
+
+  const baseApi = fakeProxyApiV4({
+    analytics: {
+      enabled: true,
+      tracing: {
+        enabled: true,
+        verbose: false,
+        payloadMasking: {
+          rules: [
+            { path: '$.password', maskingStrategy: { type: 'FULL' }, phase: 'BOTH', format: 'JSON' },
+            {
+              path: '$.creditCard',
+              maskingStrategy: { type: 'PARTIAL', prefixLength: 0, suffixLength: 4, replacement: '*' },
+              phase: 'REQUEST',
+              format: 'JSON',
+            },
+          ],
+        },
+      },
+    },
+  });
+
+  async function setup(api = baseApi, resetTrigger = 0) {
+    await TestBed.configureTestingModule({
+      imports: [ApiPayloadMaskingRulesComponent, NoopAnimationsModule, MatIconTestingModule],
+      providers: [{ provide: MatDialog, useValue: mockDialog }],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ApiPayloadMaskingRulesComponent);
+    component = fixture.componentInstance;
+    fixture.componentRef.setInput('api', api);
+    fixture.componentRef.setInput('resetTrigger', resetTrigger);
+    fixture.detectChanges();
+  }
+
+  afterEach(() => jest.clearAllMocks());
+
+  describe('initialisation', () => {
+    it('should display rows from existing API payload masking rules', async () => {
+      await setup();
+
+      const rows = component['rows']();
+      expect(rows).toHaveLength(2);
+      expect(rows[0].path).toBe('$.password');
+      expect(rows[1].path).toBe('$.creditCard');
+    });
+
+    it('should display empty table when API has no payload masking rules', async () => {
+      await setup(fakeProxyApiV4({ analytics: { enabled: true, tracing: { enabled: true, verbose: false } } }));
+
+      expect(component['rows']()).toHaveLength(0);
+    });
+
+    it('should mark as read-only for Kubernetes-origin APIs', async () => {
+      await setup(fakeProxyApiV4({ definitionContext: { origin: 'KUBERNETES' } }));
+
+      expect(component['isReadOnly']()).toBe(true);
+    });
+
+    it('should not be read-only for management-origin APIs', async () => {
+      await setup(baseApi);
+
+      expect(component['isReadOnly']()).toBe(false);
+    });
+  });
+
+  describe('addRule', () => {
+    it('should add a row and emit rulesChange when dialog confirms', async () => {
+      await setup();
+      const emitted: PayloadMaskingRule[][] = [];
+      component.rulesChange.subscribe(rules => emitted.push(rules));
+
+      const newRule: PayloadMaskingRule = { path: '$.token', maskingStrategy: { type: 'FULL' }, phase: 'BOTH', format: 'JSON' };
+      mockDialog.open.mockReturnValue({ afterClosed: () => of(newRule) });
+
+      component['addRule']();
+      fixture.detectChanges();
+
+      expect(component['rows']()).toHaveLength(3);
+      expect(component['rows']()[2].path).toBe('$.token');
+      expect(emitted).toHaveLength(1);
+      expect(emitted[0]).toHaveLength(3);
+    });
+
+    it('should not change rows when dialog is cancelled', async () => {
+      await setup();
+      const emitted: PayloadMaskingRule[][] = [];
+      component.rulesChange.subscribe(rules => emitted.push(rules));
+
+      mockDialog.open.mockReturnValue({ afterClosed: () => of(undefined) });
+
+      component['addRule']();
+      fixture.detectChanges();
+
+      expect(component['rows']()).toHaveLength(2);
+      expect(emitted).toHaveLength(0);
+    });
+
+    it('should open dialog with PayloadMaskingRuleDialogComponent', async () => {
+      await setup();
+      mockDialog.open.mockReturnValue({ afterClosed: () => of(undefined) });
+
+      component['addRule']();
+
+      expect(mockDialog.open).toHaveBeenCalledWith(PayloadMaskingRuleDialogComponent, expect.objectContaining({ data: { rule: null } }));
+    });
+  });
+
+  describe('removeRule', () => {
+    it('should remove the row and emit rulesChange', async () => {
+      await setup();
+      const emitted: PayloadMaskingRule[][] = [];
+      component.rulesChange.subscribe(rules => emitted.push(rules));
+
+      const idToRemove = component['rows']()[0]._id;
+      component['removeRule'](idToRemove);
+      fixture.detectChanges();
+
+      expect(component['rows']()).toHaveLength(1);
+      expect(component['rows']()[0].path).toBe('$.creditCard');
+      expect(emitted).toHaveLength(1);
+      expect(emitted[0]).toHaveLength(1);
+    });
+  });
+
+  describe('editRule', () => {
+    it('should update the row in place and emit rulesChange when dialog confirms', async () => {
+      await setup();
+      const emitted: PayloadMaskingRule[][] = [];
+      component.rulesChange.subscribe(rules => emitted.push(rules));
+
+      const idToEdit = component['rows']()[0]._id;
+      const updatedRule: PayloadMaskingRule = {
+        path: '$.password',
+        maskingStrategy: { type: 'FULL', replacement: '[SECRET]' },
+        phase: 'REQUEST',
+        format: 'JSON',
+      };
+      mockDialog.open.mockReturnValue({ afterClosed: () => of(updatedRule) });
+
+      component['editRule'](idToEdit);
+      fixture.detectChanges();
+
+      expect(component['rows']()).toHaveLength(2);
+      expect(component['rows']()[0]._id).toBe(idToEdit);
+      expect(component['rows']()[0].maskingStrategy?.replacement).toBe('[SECRET]');
+      expect(emitted).toHaveLength(1);
+    });
+  });
+
+  describe('resetTrigger', () => {
+    it('should reset rows to API state when resetTrigger increments', async () => {
+      await setup(baseApi, 0);
+
+      component['rows'].update(rows => [...rows, { ...rows[0], _id: 'new', path: '$.extra' }]);
+      expect(component['rows']()).toHaveLength(3);
+
+      fixture.componentRef.setInput('resetTrigger', 1);
+      fixture.detectChanges();
+
+      expect(component['rows']()).toHaveLength(2);
+      expect(component['rows']()[0].path).toBe('$.password');
+    });
+  });
+
+  describe('emitted rules strip display-only fields', () => {
+    it('should not include _id in emitted rules', async () => {
+      await setup();
+      const emitted: PayloadMaskingRule[][] = [];
+      component.rulesChange.subscribe(rules => emitted.push(rules));
+
+      const idToRemove = component['rows']()[1]._id;
+      component['removeRule'](idToRemove);
+
+      const emittedRule = emitted[0][0] as any;
+      expect(emittedRule._id).toBeUndefined();
+      expect(emittedRule.path).toBe('$.password');
+    });
+  });
+});

--- a/gravitee-apim-console-webui/src/management/api/reporter-settings/reporter-settings-proxy/api-payload-masking-rules/api-payload-masking-rules.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/reporter-settings/reporter-settings-proxy/api-payload-masking-rules/api-payload-masking-rules.component.ts
@@ -1,0 +1,134 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Component, computed, DestroyRef, effect, inject, input, output, signal } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MatButtonModule } from '@angular/material/button';
+import { MatDialog } from '@angular/material/dialog';
+import { MatIconModule } from '@angular/material/icon';
+import { MatTableModule } from '@angular/material/table';
+import { MatTooltipModule } from '@angular/material/tooltip';
+import { GioBannerModule, GIO_DIALOG_WIDTH, GioIconsModule } from '@gravitee/ui-particles-angular';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+
+import {
+  PayloadMaskingRuleDialogComponent,
+  PayloadMaskingRuleDialogData,
+  PayloadMaskingRuleDialogResult,
+} from './payload-masking-rule-dialog/payload-masking-rule-dialog.component';
+
+import { ApiV4, PayloadMaskingRule } from '../../../../../entities/management-api-v2';
+
+type PayloadMaskingRuleRow = PayloadMaskingRule & { _id: string };
+
+function buildRow(rule: PayloadMaskingRule, id?: string): PayloadMaskingRuleRow {
+  return { ...rule, _id: id ?? crypto.randomUUID() };
+}
+
+function stripDisplayFields({ _id, ...rule }: PayloadMaskingRuleRow): PayloadMaskingRule {
+  return rule;
+}
+
+@Component({
+  selector: 'api-payload-masking-rules',
+  templateUrl: './api-payload-masking-rules.component.html',
+  styleUrls: ['./api-payload-masking-rules.component.scss'],
+  imports: [CommonModule, MatButtonModule, MatIconModule, MatTableModule, MatTooltipModule, GioBannerModule, GioIconsModule],
+})
+export class ApiPayloadMaskingRulesComponent {
+  private readonly matDialog = inject(MatDialog);
+  private readonly destroyRef = inject(DestroyRef);
+
+  api = input.required<ApiV4>();
+  resetTrigger = input(0);
+
+  rulesChange = output<PayloadMaskingRule[]>();
+
+  protected readonly displayedColumns = ['index', 'path', 'format', 'phase', 'masking', 'actions'];
+  protected rows = signal<PayloadMaskingRuleRow[]>([]);
+  protected isReadOnly = computed(() => this.api().definitionContext?.origin === 'KUBERNETES');
+
+  private readonly resetEffect = effect(() => {
+    this.resetTrigger();
+    this.resetToApiState();
+  });
+
+  protected addRule(): void {
+    this.matDialog
+      .open<PayloadMaskingRuleDialogComponent, PayloadMaskingRuleDialogData, PayloadMaskingRuleDialogResult>(
+        PayloadMaskingRuleDialogComponent,
+        {
+          width: GIO_DIALOG_WIDTH.MEDIUM,
+          data: { rule: null },
+        },
+      )
+      .afterClosed()
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe(result => {
+        if (result) {
+          this.rows.update(rows => [...rows, buildRow(result)]);
+          this.emitRulesChange();
+        }
+      });
+  }
+
+  protected editRule(id: string): void {
+    const row = this.rows().find(r => r._id === id);
+    if (!row) return;
+    this.matDialog
+      .open<PayloadMaskingRuleDialogComponent, PayloadMaskingRuleDialogData, PayloadMaskingRuleDialogResult>(
+        PayloadMaskingRuleDialogComponent,
+        {
+          width: GIO_DIALOG_WIDTH.MEDIUM,
+          data: { rule: row },
+        },
+      )
+      .afterClosed()
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe(result => {
+        if (result) {
+          this.rows.update(rows => rows.map(r => (r._id === id ? buildRow(result, id) : r)));
+          this.emitRulesChange();
+        }
+      });
+  }
+
+  protected removeRule(id: string): void {
+    this.rows.update(rows => rows.filter(r => r._id !== id));
+    this.emitRulesChange();
+  }
+
+  protected maskingLabel(rule: PayloadMaskingRule): string {
+    return rule.maskingStrategy?.type === 'PARTIAL' ? 'PARTIAL' : 'FULL';
+  }
+
+  protected maskingDetail(rule: PayloadMaskingRule): string {
+    const s = rule.maskingStrategy;
+    if (!s || s.type !== 'PARTIAL') {
+      return `→ "${s?.replacement ?? '[REDACTED]'}"`;
+    }
+    return `prefix ${s.prefixLength ?? 0} · suffix ${s.suffixLength ?? 0} · char "${s.replacement ?? '*'}"`;
+  }
+
+  private emitRulesChange(): void {
+    this.rulesChange.emit(this.rows().map(stripDisplayFields));
+  }
+
+  private resetToApiState(): void {
+    const existing = this.api().analytics?.tracing?.payloadMasking?.rules ?? [];
+    this.rows.set(existing.map(rule => buildRow(rule)));
+  }
+}

--- a/gravitee-apim-console-webui/src/management/api/reporter-settings/reporter-settings-proxy/api-payload-masking-rules/payload-masking-rule-dialog/payload-masking-rule-dialog.component.html
+++ b/gravitee-apim-console-webui/src/management/api/reporter-settings/reporter-settings-proxy/api-payload-masking-rules/payload-masking-rule-dialog/payload-masking-rule-dialog.component.html
@@ -1,0 +1,93 @@
+<!--
+
+    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<div class="title">
+  <h2 mat-dialog-title>{{ isEdit ? 'Edit payload masking rule' : 'New payload masking rule' }}</h2>
+  <button mat-icon-button (click)="onCancel()" aria-label="Close dialog">
+    <mat-icon svgIcon="gio:cancel"></mat-icon>
+  </button>
+</div>
+
+<mat-dialog-content [formGroup]="form">
+  <mat-form-field class="field">
+    <mat-label>Path<span aria-hidden="true"> *</span></mat-label>
+    <input matInput formControlName="path" placeholder="e.g. $.password or //CreditCard/Number" />
+    <mat-hint>JSONPath (e.g. <code>$.creditCard.number</code>) or XPath (e.g. <code>//password</code>)</mat-hint>
+  </mat-form-field>
+
+  <mat-form-field class="field">
+    <mat-label>Format</mat-label>
+    <mat-select formControlName="format">
+      <mat-option value="AUTO">AUTO — detect from Content-Type and body</mat-option>
+      <mat-option value="JSON">JSON</mat-option>
+      <mat-option value="XML">XML</mat-option>
+    </mat-select>
+  </mat-form-field>
+
+  <mat-form-field class="field">
+    <mat-label>Phase</mat-label>
+    <mat-select formControlName="phase">
+      <mat-option value="BOTH">BOTH — request and response</mat-option>
+      <mat-option value="REQUEST">REQUEST only</mat-option>
+      <mat-option value="RESPONSE">RESPONSE only</mat-option>
+    </mat-select>
+  </mat-form-field>
+
+  <mat-form-field class="field">
+    <mat-label>Masking Type</mat-label>
+    <mat-select formControlName="maskingType">
+      <mat-option value="FULL">Full Mask — replace entire value</mat-option>
+      <mat-option value="PARTIAL">Partial Mask — keep prefix / suffix visible</mat-option>
+    </mat-select>
+  </mat-form-field>
+
+  @if (!isPartial()) {
+    <mat-form-field class="field">
+      <mat-label>Replacement Text</mat-label>
+      <input matInput formControlName="fullReplacement" placeholder="[REDACTED]" />
+      <mat-hint>Leave blank to use the default: [REDACTED]</mat-hint>
+    </mat-form-field>
+  }
+
+  @if (isPartial()) {
+    <div class="partialMask">
+      <mat-form-field class="partialMask__field">
+        <mat-label>Visible Prefix (chars)</mat-label>
+        <input matInput type="number" min="0" formControlName="prefixLength" />
+      </mat-form-field>
+      <mat-form-field class="partialMask__field">
+        <mat-label>Visible Suffix (chars)</mat-label>
+        <input matInput type="number" min="0" formControlName="suffixLength" />
+      </mat-form-field>
+      <mat-form-field class="partialMask__field">
+        <mat-label>Mask Character</mat-label>
+        <input matInput formControlName="maskChar" maxlength="1" placeholder="*" />
+        <mat-hint>Single character</mat-hint>
+      </mat-form-field>
+    </div>
+    <div class="partialMask__preview">
+      Preview: <code class="payloadMaskingRules__code">{{ partialPreview() }}</code>
+    </div>
+  }
+</mat-dialog-content>
+
+<mat-dialog-actions align="end">
+  <button mat-button (click)="onCancel()">Cancel</button>
+  <button mat-flat-button color="primary" [disabled]="form.invalid" (click)="onSave()">
+    {{ isEdit ? 'Save' : 'Add' }}
+  </button>
+</mat-dialog-actions>

--- a/gravitee-apim-console-webui/src/management/api/reporter-settings/reporter-settings-proxy/api-payload-masking-rules/payload-masking-rule-dialog/payload-masking-rule-dialog.component.scss
+++ b/gravitee-apim-console-webui/src/management/api/reporter-settings/reporter-settings-proxy/api-payload-masking-rules/payload-masking-rule-dialog/payload-masking-rule-dialog.component.scss
@@ -14,12 +14,36 @@
  * limitations under the License.
  */
 
-import { RedactionConfig } from './redactionV4';
-import { PayloadMaskingConfig } from './payloadMaskingV4';
+.title {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
 
-export interface TracingV4 {
-  enabled: boolean;
-  verbose: boolean;
-  redaction?: RedactionConfig;
-  payloadMasking?: PayloadMaskingConfig;
+.field {
+  display: block;
+  width: 100%;
+  margin-bottom: 8px;
+}
+
+.partialMask {
+  display: flex;
+  gap: 12px;
+  margin-bottom: 8px;
+
+  &__field {
+    flex: 1;
+  }
+
+  &__preview {
+    margin-bottom: 12px;
+    font-size: 0.85em;
+  }
+}
+
+.payloadMaskingRules__code {
+  background: #f5f5f5;
+  border-radius: 3px;
+  padding: 1px 4px;
+  font-family: monospace;
 }

--- a/gravitee-apim-console-webui/src/management/api/reporter-settings/reporter-settings-proxy/api-payload-masking-rules/payload-masking-rule-dialog/payload-masking-rule-dialog.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/reporter-settings/reporter-settings-proxy/api-payload-masking-rules/payload-masking-rule-dialog/payload-masking-rule-dialog.component.spec.ts
@@ -1,0 +1,219 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { MatIconTestingModule } from '@angular/material/icon/testing';
+import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+
+import { PayloadMaskingRuleDialogComponent, PayloadMaskingRuleDialogData } from './payload-masking-rule-dialog.component';
+
+import { PayloadMaskingRule } from '../../../../../../entities/management-api-v2';
+
+describe('PayloadMaskingRuleDialogComponent', () => {
+  let fixture: ComponentFixture<PayloadMaskingRuleDialogComponent>;
+  let component: PayloadMaskingRuleDialogComponent;
+  const mockDialogRef = { close: jest.fn() };
+
+  async function setup(data: PayloadMaskingRuleDialogData) {
+    await TestBed.configureTestingModule({
+      imports: [PayloadMaskingRuleDialogComponent, NoopAnimationsModule, MatIconTestingModule],
+      providers: [
+        { provide: MatDialogRef, useValue: mockDialogRef },
+        { provide: MAT_DIALOG_DATA, useValue: data },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(PayloadMaskingRuleDialogComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  }
+
+  afterEach(() => jest.clearAllMocks());
+
+  describe('New rule mode', () => {
+    beforeEach(async () => setup({ rule: null }));
+
+    it('should show "New payload masking rule" title', () => {
+      const title: HTMLElement = fixture.nativeElement.querySelector('[mat-dialog-title]');
+      expect(title.textContent?.trim()).toBe('New payload masking rule');
+    });
+
+    it('should show "Add" submit button label', () => {
+      const btn: HTMLElement = fixture.nativeElement.querySelector('[mat-flat-button]');
+      expect(btn.textContent?.trim()).toBe('Add');
+    });
+
+    it('should default to FULL masking type, AUTO format, BOTH phase', () => {
+      const value = component['form'].getRawValue();
+      expect(value.maskingType).toBe('FULL');
+      expect(value.format).toBe('AUTO');
+      expect(value.phase).toBe('BOTH');
+    });
+
+    it('should have invalid form when path is empty', () => {
+      expect(component['form'].invalid).toBe(true);
+    });
+
+    it('should close with undefined when cancelled', () => {
+      component.onCancel();
+      expect(mockDialogRef.close).toHaveBeenCalledWith(undefined);
+    });
+
+    it('should not close on save when form is invalid', () => {
+      component.onSave();
+      expect(mockDialogRef.close).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Edit rule mode', () => {
+    const existingRule: PayloadMaskingRule & { _id: string } = {
+      _id: 'test-id',
+      path: '$.password',
+      maskingStrategy: { type: 'FULL', replacement: '[HIDDEN]' },
+      phase: 'REQUEST',
+      format: 'JSON',
+    };
+
+    beforeEach(async () => setup({ rule: existingRule }));
+
+    it('should show "Edit payload masking rule" title', () => {
+      const title: HTMLElement = fixture.nativeElement.querySelector('[mat-dialog-title]');
+      expect(title.textContent?.trim()).toBe('Edit payload masking rule');
+    });
+
+    it('should show "Save" submit button label', () => {
+      const btn: HTMLElement = fixture.nativeElement.querySelector('[mat-flat-button]');
+      expect(btn.textContent?.trim()).toBe('Save');
+    });
+
+    it('should pre-populate form values from existing rule', () => {
+      const value = component['form'].getRawValue();
+      expect(value.path).toBe('$.password');
+      expect(value.maskingType).toBe('FULL');
+      expect(value.fullReplacement).toBe('[HIDDEN]');
+      expect(value.phase).toBe('REQUEST');
+      expect(value.format).toBe('JSON');
+    });
+  });
+
+  describe('FULL masking save', () => {
+    beforeEach(async () => setup({ rule: null }));
+
+    it('should close with correct PayloadMaskingRule for FULL masking with replacement', () => {
+      component['form'].patchValue({ path: '$.password', maskingType: 'FULL', fullReplacement: '[MASKED]', format: 'JSON', phase: 'BOTH' });
+      component.onSave();
+
+      expect(mockDialogRef.close).toHaveBeenCalledWith<[PayloadMaskingRule]>({
+        path: '$.password',
+        format: 'JSON',
+        phase: 'BOTH',
+        maskingStrategy: { type: 'FULL', replacement: '[MASKED]' },
+      });
+    });
+
+    it('should omit replacement when fullReplacement is blank (uses server default)', () => {
+      component['form'].patchValue({ path: '$.password', maskingType: 'FULL', fullReplacement: '', format: 'AUTO', phase: 'BOTH' });
+      component.onSave();
+
+      const result = mockDialogRef.close.mock.calls[0][0] as PayloadMaskingRule;
+      expect(result.maskingStrategy?.replacement).toBeUndefined();
+    });
+  });
+
+  describe('PARTIAL masking save', () => {
+    beforeEach(async () => setup({ rule: null }));
+
+    it('should close with correct PayloadMaskingRule for PARTIAL masking', () => {
+      component['form'].patchValue({
+        path: '$.creditCard',
+        maskingType: 'PARTIAL',
+        prefixLength: 0,
+        suffixLength: 4,
+        maskChar: '*',
+        format: 'JSON',
+        phase: 'REQUEST',
+      });
+      component.onSave();
+
+      expect(mockDialogRef.close).toHaveBeenCalledWith<[PayloadMaskingRule]>({
+        path: '$.creditCard',
+        format: 'JSON',
+        phase: 'REQUEST',
+        maskingStrategy: { type: 'PARTIAL', prefixLength: 0, suffixLength: 4, replacement: '*' },
+      });
+    });
+
+    it('should default maskChar to * when left blank', () => {
+      component['form'].patchValue({
+        path: '$.creditCard',
+        maskingType: 'PARTIAL',
+        prefixLength: 0,
+        suffixLength: 4,
+        maskChar: '',
+        format: 'AUTO',
+        phase: 'BOTH',
+      });
+      component.onSave();
+
+      const result = mockDialogRef.close.mock.calls[0][0] as PayloadMaskingRule;
+      expect(result.maskingStrategy?.replacement).toBe('*');
+    });
+
+    it('should be invalid when prefixLength is negative', () => {
+      component['form'].patchValue({ path: '$.creditCard', maskingType: 'PARTIAL', prefixLength: -1 });
+      expect(component['form'].controls.prefixLength.hasError('min')).toBe(true);
+    });
+  });
+
+  describe('isPartial signal', () => {
+    beforeEach(async () => setup({ rule: null }));
+
+    it('should be false when maskingType is FULL', () => {
+      component['form'].patchValue({ maskingType: 'FULL' });
+      fixture.detectChanges();
+      expect(component['isPartial']()).toBe(false);
+    });
+
+    it('should be true when maskingType is PARTIAL', () => {
+      component['form'].patchValue({ maskingType: 'PARTIAL' });
+      fixture.detectChanges();
+      expect(component['isPartial']()).toBe(true);
+    });
+  });
+
+  describe('partialPreview', () => {
+    beforeEach(async () => setup({ rule: null }));
+
+    it('should show masked middle for 0 prefix 4 suffix', () => {
+      component['form'].patchValue({ maskingType: 'PARTIAL', prefixLength: 0, suffixLength: 4, maskChar: '*' });
+      fixture.detectChanges();
+      expect(component['partialPreview']()).toBe('**********1234');
+    });
+
+    it('should show masked middle for 3 prefix 3 suffix', () => {
+      component['form'].patchValue({ maskingType: 'PARTIAL', prefixLength: 3, suffixLength: 3, maskChar: 'X' });
+      fixture.detectChanges();
+      expect(component['partialPreview']()).toBe('ABCXXXXXXXX234');
+    });
+
+    it('should show original sample when prefix + suffix covers the full length', () => {
+      component['form'].patchValue({ maskingType: 'PARTIAL', prefixLength: 7, suffixLength: 7, maskChar: '*' });
+      fixture.detectChanges();
+      expect(component['partialPreview']()).toBe('ABCDEFGHIJ1234');
+    });
+  });
+});

--- a/gravitee-apim-console-webui/src/management/api/reporter-settings/reporter-settings-proxy/api-payload-masking-rules/payload-masking-rule-dialog/payload-masking-rule-dialog.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/reporter-settings/reporter-settings-proxy/api-payload-masking-rules/payload-masking-rule-dialog/payload-masking-rule-dialog.component.ts
@@ -1,0 +1,143 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Component, computed, inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { toSignal } from '@angular/core/rxjs-interop';
+import { FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
+import { MatButtonModule } from '@angular/material/button';
+import { MAT_DIALOG_DATA, MatDialogModule, MatDialogRef } from '@angular/material/dialog';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatIconModule } from '@angular/material/icon';
+import { MatInputModule } from '@angular/material/input';
+import { MatSelectModule } from '@angular/material/select';
+import { GioIconsModule } from '@gravitee/ui-particles-angular';
+
+import { MaskingType, PayloadFormat, PayloadMaskingRule, PayloadPhase } from '../../../../../../entities/management-api-v2';
+
+export type PayloadMaskingRuleDialogData = {
+  rule: (PayloadMaskingRule & { _id: string }) | null;
+};
+
+export type PayloadMaskingRuleDialogResult = PayloadMaskingRule | undefined;
+
+type DialogFormControls = {
+  path: FormControl<string>;
+  format: FormControl<PayloadFormat>;
+  phase: FormControl<PayloadPhase>;
+  maskingType: FormControl<MaskingType>;
+  fullReplacement: FormControl<string>;
+  prefixLength: FormControl<number>;
+  suffixLength: FormControl<number>;
+  maskChar: FormControl<string>;
+};
+
+const PREVIEW_SAMPLE = 'ABCDEFGHIJ1234';
+
+@Component({
+  selector: 'payload-masking-rule-dialog',
+  templateUrl: './payload-masking-rule-dialog.component.html',
+  styleUrls: ['./payload-masking-rule-dialog.component.scss'],
+  standalone: true,
+  imports: [
+    CommonModule,
+    ReactiveFormsModule,
+    MatButtonModule,
+    MatDialogModule,
+    MatFormFieldModule,
+    MatIconModule,
+    MatInputModule,
+    MatSelectModule,
+    GioIconsModule,
+  ],
+})
+export class PayloadMaskingRuleDialogComponent {
+  private readonly dialogRef = inject<MatDialogRef<PayloadMaskingRuleDialogComponent, PayloadMaskingRuleDialogResult>>(MatDialogRef);
+  protected readonly data = inject<PayloadMaskingRuleDialogData>(MAT_DIALOG_DATA);
+
+  protected readonly isEdit = this.data.rule !== null;
+
+  protected readonly form = new FormGroup<DialogFormControls>({
+    path: new FormControl<string>(this.data.rule?.path ?? '', {
+      nonNullable: true,
+      validators: [Validators.required],
+    }),
+    format: new FormControl<PayloadFormat>(this.data.rule?.format ?? 'AUTO', { nonNullable: true }),
+    phase: new FormControl<PayloadPhase>(this.data.rule?.phase ?? 'BOTH', { nonNullable: true }),
+    maskingType: new FormControl<MaskingType>((this.data.rule?.maskingStrategy?.type as MaskingType) ?? 'FULL', { nonNullable: true }),
+    fullReplacement: new FormControl<string>(
+      this.data.rule?.maskingStrategy?.type !== 'PARTIAL' ? (this.data.rule?.maskingStrategy?.replacement ?? '') : '',
+      { nonNullable: true },
+    ),
+    prefixLength: new FormControl<number>(this.data.rule?.maskingStrategy?.prefixLength ?? 0, {
+      nonNullable: true,
+      validators: [Validators.min(0)],
+    }),
+    suffixLength: new FormControl<number>(this.data.rule?.maskingStrategy?.suffixLength ?? 0, {
+      nonNullable: true,
+      validators: [Validators.min(0)],
+    }),
+    maskChar: new FormControl<string>(
+      this.data.rule?.maskingStrategy?.type === 'PARTIAL' ? (this.data.rule?.maskingStrategy?.replacement ?? '*') : '*',
+      { nonNullable: true, validators: [Validators.maxLength(1)] },
+    ),
+  });
+
+  private readonly formValue = toSignal(this.form.valueChanges, { initialValue: this.form.getRawValue() });
+
+  protected readonly isPartial = computed(() => this.formValue().maskingType === 'PARTIAL');
+
+  protected readonly partialPreview = computed(() => {
+    const { prefixLength, suffixLength, maskChar } = this.formValue();
+    const prefix = Math.max(0, prefixLength ?? 0);
+    const suffix = Math.max(0, suffixLength ?? 0);
+    const char = maskChar || '*';
+    const sample = PREVIEW_SAMPLE;
+    const len = sample.length;
+    if (prefix + suffix >= len) {
+      return sample;
+    }
+    return sample.slice(0, prefix) + char.repeat(len - prefix - suffix) + sample.slice(len - suffix);
+  });
+
+  onSave(): void {
+    if (this.form.invalid) return;
+
+    const { path, format, phase, maskingType, fullReplacement, prefixLength, suffixLength, maskChar } = this.form.getRawValue();
+
+    const rule: PayloadMaskingRule = { path, format, phase };
+
+    if (maskingType === 'PARTIAL') {
+      rule.maskingStrategy = {
+        type: 'PARTIAL',
+        prefixLength,
+        suffixLength,
+        replacement: maskChar || '*',
+      };
+    } else {
+      rule.maskingStrategy = {
+        type: 'FULL',
+        ...(fullReplacement ? { replacement: fullReplacement } : {}),
+      };
+    }
+
+    this.dialogRef.close(rule);
+  }
+
+  onCancel(): void {
+    this.dialogRef.close(undefined);
+  }
+}

--- a/gravitee-apim-console-webui/src/management/api/reporter-settings/reporter-settings-proxy/reporter-settings-proxy.component.html
+++ b/gravitee-apim-console-webui/src/management/api/reporter-settings/reporter-settings-proxy/reporter-settings-proxy.component.html
@@ -116,6 +116,14 @@
         (rulesChange)="onRedactionRulesChange($event)"
       ></api-redaction-rules>
     }
+
+    @if (form.get('tracingEnabled').value && form.get('tracingVerbose').value) {
+      <api-payload-masking-rules
+        [api]="effectiveApi()"
+        [resetTrigger]="resetTriggerCounter()"
+        (rulesChange)="onPayloadMaskingRulesChange($event)"
+      ></api-payload-masking-rules>
+    }
   </mat-card>
   <gio-save-bar
     [form]="form"

--- a/gravitee-apim-console-webui/src/management/api/reporter-settings/reporter-settings-proxy/reporter-settings-proxy.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/reporter-settings/reporter-settings-proxy/reporter-settings-proxy.component.spec.ts
@@ -24,6 +24,7 @@ import { By } from '@angular/platform-browser';
 
 import { ReporterSettingsProxyHarness } from './reporter-settings-proxy.harness';
 import { ReporterSettingsProxyComponent } from './reporter-settings-proxy.component';
+import { ApiPayloadMaskingRulesComponent } from './api-payload-masking-rules/api-payload-masking-rules.component';
 
 import { CONSTANTS_TESTING, GioTestingModule } from '../../../../shared/testing';
 import { ApiV4, fakeProxyApiV4 } from '../../../../entities/management-api-v2';
@@ -559,6 +560,99 @@ describe('ApiRuntimeLogsProxySettingsComponent', () => {
 
       expect((proxyInstance as any).pendingRedactionRules()).toBeNull();
       expect((proxyInstance as any).resetTriggerCounter()).toBe(counterBefore + 1);
+    });
+
+    it('should include pending payload masking rules when saving', async () => {
+      const apiWithPayloadMasking = fakeProxyApiV4({
+        id: API_ID,
+        analytics: {
+          enabled: true,
+          tracing: {
+            enabled: true,
+            verbose: false,
+            payloadMasking: {
+              rules: [{ path: '$.password', maskingStrategy: { type: 'FULL' }, phase: 'BOTH', format: 'JSON' }],
+            },
+          },
+        },
+      });
+      await initComponent(apiWithPayloadMasking);
+
+      const proxyInstance = fixture.debugElement.query(By.directive(ReporterSettingsProxyComponent))
+        .componentInstance as ReporterSettingsProxyComponent;
+      proxyInstance.onPayloadMaskingRulesChange([
+        { path: '$.password', maskingStrategy: { type: 'FULL' }, phase: 'BOTH', format: 'JSON' },
+        { path: '$.token', maskingStrategy: { type: 'FULL' }, phase: 'REQUEST', format: 'AUTO' },
+      ]);
+      fixture.detectChanges();
+
+      await componentHarness.clickOnSaveButton();
+
+      expectApiGetRequest(apiWithPayloadMasking);
+      expectApiPutRequest({
+        ...apiWithPayloadMasking,
+        analytics: {
+          ...apiWithPayloadMasking.analytics,
+          logging: {
+            condition: undefined,
+            mode: { entrypoint: undefined, endpoint: undefined },
+            phase: { request: undefined, response: undefined },
+            content: { headers: undefined, payload: undefined },
+          },
+          tracing: {
+            enabled: true,
+            verbose: false,
+            payloadMasking: {
+              defaultReplacement: undefined,
+              rules: [
+                { path: '$.password', maskingStrategy: { type: 'FULL' }, phase: 'BOTH', format: 'JSON' },
+                { path: '$.token', maskingStrategy: { type: 'FULL' }, phase: 'REQUEST', format: 'AUTO' },
+              ],
+            },
+          },
+        },
+      });
+    });
+
+    it('should clear pending payload masking rules on discard', async () => {
+      const proxyInstance = fixture.debugElement.query(By.directive(ReporterSettingsProxyComponent))
+        .componentInstance as ReporterSettingsProxyComponent;
+
+      proxyInstance.onPayloadMaskingRulesChange([{ path: '$.password', maskingStrategy: { type: 'FULL' }, phase: 'BOTH', format: 'JSON' }]);
+      fixture.detectChanges();
+
+      expect((proxyInstance as any).pendingPayloadMaskingRules()).toHaveLength(1);
+
+      await componentHarness.clickOnResetButton();
+
+      expect((proxyInstance as any).pendingPayloadMaskingRules()).toBeNull();
+    });
+
+    describe('Payload Masking section visibility', () => {
+      it('should show payload masking section when tracing is enabled (regardless of verbose)', async () => {
+        await initComponent(apiWithTracingEnabledAndVerboseFalse);
+        expect(fixture.debugElement.query(By.directive(ApiPayloadMaskingRulesComponent))).not.toBeNull();
+      });
+
+      it('should show payload masking section when tracing and verbose are both enabled', async () => {
+        await initComponent(apiWithTracingEnabled);
+        expect(fixture.debugElement.query(By.directive(ApiPayloadMaskingRulesComponent))).not.toBeNull();
+      });
+
+      it('should hide payload masking section when tracing is disabled', async () => {
+        await initComponent(apiWithTracingDisabled);
+        expect(fixture.debugElement.query(By.directive(ApiPayloadMaskingRulesComponent))).toBeNull();
+      });
+
+      it('should hide payload masking section after toggling tracing off', async () => {
+        await initComponent(apiWithTracingEnabled);
+        expect(fixture.debugElement.query(By.directive(ApiPayloadMaskingRulesComponent))).not.toBeNull();
+
+        await componentHarness.toggleTracingEnabled();
+        fixture.detectChanges();
+
+        expect(fixture.debugElement.query(By.directive(ApiPayloadMaskingRulesComponent))).toBeNull();
+      });
     });
   });
 });

--- a/gravitee-apim-console-webui/src/management/api/reporter-settings/reporter-settings-proxy/reporter-settings-proxy.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/reporter-settings/reporter-settings-proxy/reporter-settings-proxy.component.ts
@@ -30,9 +30,10 @@ import { MatSlideToggle } from '@angular/material/slide-toggle';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
 import { ApiRedactionRulesComponent } from './api-redaction-rules/api-redaction-rules.component';
+import { ApiPayloadMaskingRulesComponent } from './api-payload-masking-rules/api-payload-masking-rules.component';
 
 import { ApiV2Service } from '../../../../services-ngx/api-v2.service';
-import { ApiV4, RedactionRule } from '../../../../entities/management-api-v2';
+import { ApiV4, PayloadMaskingRule, RedactionRule } from '../../../../entities/management-api-v2';
 import { SnackBarService } from '../../../../services-ngx/snack-bar.service';
 
 type DefaultConfiguration = {
@@ -68,6 +69,7 @@ type DefaultConfiguration = {
     GioFormSlideToggleModule,
     MatSlideToggle,
     ApiRedactionRulesComponent,
+    ApiPayloadMaskingRulesComponent,
   ],
 })
 export class ReporterSettingsProxyComponent implements OnInit {
@@ -77,6 +79,7 @@ export class ReporterSettingsProxyComponent implements OnInit {
   private destroyRef = inject(DestroyRef);
 
   protected pendingRedactionRules = signal<RedactionRule[] | null>(null);
+  protected pendingPayloadMaskingRules = signal<PayloadMaskingRule[] | null>(null);
   protected resetTriggerCounter = signal(0);
   protected savedApiState = signal<ApiV4 | null>(null);
   protected effectiveApi = computed(() => this.savedApiState() ?? this.api());
@@ -93,6 +96,7 @@ export class ReporterSettingsProxyComponent implements OnInit {
 
   submit() {
     const pendingRules = this.pendingRedactionRules();
+    const pendingPayloadRules = this.pendingPayloadMaskingRules();
     this.apiService
       .get(this.activatedRoute.snapshot.params.apiId)
       .pipe(
@@ -131,6 +135,14 @@ export class ReporterSettingsProxyComponent implements OnInit {
                       },
                     }
                   : {}),
+                ...(configurationValues.tracingEnabled && (pendingPayloadRules !== null || existingTracing?.payloadMasking != null)
+                  ? {
+                      payloadMasking: {
+                        defaultReplacement: existingTracing?.payloadMasking?.defaultReplacement,
+                        rules: pendingPayloadRules ?? existingTracing?.payloadMasking?.rules ?? [],
+                      },
+                    }
+                  : {}),
               },
             },
           };
@@ -140,6 +152,7 @@ export class ReporterSettingsProxyComponent implements OnInit {
         tap((savedApi: ApiV4) => {
           this.snackBarService.success('Configuration successfully saved!');
           this.pendingRedactionRules.set(null);
+          this.pendingPayloadMaskingRules.set(null);
           this.savedApiState.set(savedApi);
         }),
         catchError(({ error }) => {
@@ -162,7 +175,13 @@ export class ReporterSettingsProxyComponent implements OnInit {
 
   onDiscardRedactionRules(): void {
     this.pendingRedactionRules.set(null);
+    this.pendingPayloadMaskingRules.set(null);
     this.resetTriggerCounter.update(counter => counter + 1);
+  }
+
+  onPayloadMaskingRulesChange(rules: PayloadMaskingRule[]): void {
+    this.pendingPayloadMaskingRules.set(rules);
+    this.form.markAsDirty();
   }
 
   private initForm(api: ApiV4) {

--- a/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/analytics/tracing/TracingPayloadFormat.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/analytics/tracing/TracingPayloadFormat.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.definition.model.v4.analytics.tracing;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+
+public enum TracingPayloadFormat {
+    JSON,
+    XML,
+    AUTO;
+
+    @JsonCreator
+    public static TracingPayloadFormat fromValue(final String value) {
+        if (value == null) return null;
+        return TracingPayloadFormat.valueOf(value.toUpperCase());
+    }
+}

--- a/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/analytics/tracing/TracingPayloadMaskingConfig.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/analytics/tracing/TracingPayloadMaskingConfig.java
@@ -16,35 +16,27 @@
 package io.gravitee.definition.model.v4.analytics.tracing;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
 import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
 
-/**
- * @author David BRASSELY (david.brassely at graviteesource.com)
- * @author GraviteeSource Team
- */
 @NoArgsConstructor
 @Getter
 @Setter
 @ToString
 @EqualsAndHashCode
-@Schema(name = "TracingV4")
-public class Tracing implements Serializable {
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class TracingPayloadMaskingConfig implements Serializable {
 
-    private boolean enabled;
-    private boolean verbose;
-
-    @Valid
-    @JsonInclude(JsonInclude.Include.NON_NULL)
-    private TracingRedactionConfig redaction;
+    private String defaultReplacement;
 
     @Valid
-    @JsonInclude(JsonInclude.Include.NON_NULL)
-    private TracingPayloadMaskingConfig payloadMasking;
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    private List<TracingPayloadMaskingRule> rules = new ArrayList<>();
 }

--- a/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/analytics/tracing/TracingPayloadMaskingRule.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/analytics/tracing/TracingPayloadMaskingRule.java
@@ -16,8 +16,7 @@
 package io.gravitee.definition.model.v4.analytics.tracing;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
 import java.io.Serializable;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -25,26 +24,20 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
 
-/**
- * @author David BRASSELY (david.brassely at graviteesource.com)
- * @author GraviteeSource Team
- */
 @NoArgsConstructor
 @Getter
 @Setter
 @ToString
 @EqualsAndHashCode
-@Schema(name = "TracingV4")
-public class Tracing implements Serializable {
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class TracingPayloadMaskingRule implements Serializable {
 
-    private boolean enabled;
-    private boolean verbose;
+    @NotBlank
+    private String path;
 
-    @Valid
-    @JsonInclude(JsonInclude.Include.NON_NULL)
-    private TracingRedactionConfig redaction;
+    private TracingMaskingStrategy maskingStrategy;
 
-    @Valid
-    @JsonInclude(JsonInclude.Include.NON_NULL)
-    private TracingPayloadMaskingConfig payloadMasking;
+    private TracingPayloadPhase phase = TracingPayloadPhase.BOTH;
+
+    private TracingPayloadFormat format = TracingPayloadFormat.AUTO;
 }

--- a/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/analytics/tracing/TracingPayloadPhase.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/analytics/tracing/TracingPayloadPhase.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.definition.model.v4.analytics.tracing;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+
+public enum TracingPayloadPhase {
+    REQUEST,
+    RESPONSE,
+    BOTH;
+
+    @JsonCreator
+    public static TracingPayloadPhase fromValue(final String value) {
+        if (value == null) return null;
+        return TracingPayloadPhase.valueOf(value.toUpperCase());
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/reactive/core/v4/analytics/AnalyticsContext.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/reactive/core/v4/analytics/AnalyticsContext.java
@@ -41,7 +41,7 @@ public class AnalyticsContext {
     }
 
     private void initLoggingContext(final LoggingContext loggingContext) {
-        if (AnalyticsUtils.isLoggingEnabled(analytics)) {
+        if (loggingContext != null && (AnalyticsUtils.isLoggingEnabled(analytics) || loggingContext.isTracingVerbose())) {
             this.loggingContext = loggingContext;
         }
     }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/reactive/core/v4/analytics/LoggingContext.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/reactive/core/v4/analytics/LoggingContext.java
@@ -25,6 +25,7 @@ import lombok.CustomLog;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.Setter;
+import lombok.experimental.Accessors;
 
 /**
  * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
@@ -42,6 +43,14 @@ public class LoggingContext implements ConditionSupplier {
     @Setter
     private LogGuardService logGuardService;
 
+    /**
+     * When {@code true}, payload capture is enabled for OTel verbose tracing even when regular
+     * logging (analytics.logging) is not configured. Set by the reactor when {@code tracing.verbose = true}.
+     */
+    @Getter
+    @Setter
+    private boolean tracingVerbose = false;
+
     private final LoggableContentType loggableContentType;
 
     public LoggingContext(Logging logging) {
@@ -55,11 +64,11 @@ public class LoggingContext implements ConditionSupplier {
     }
 
     public boolean entrypointRequest() {
-        return logging.getMode().isEntrypoint() && logging.getPhase().isRequest();
+        return tracingVerbose || (logging.getMode().isEntrypoint() && logging.getPhase().isRequest());
     }
 
     public boolean entrypointResponse() {
-        return logging.getMode().isEntrypoint() && logging.getPhase().isResponse();
+        return tracingVerbose || (logging.getMode().isEntrypoint() && logging.getPhase().isResponse());
     }
 
     public boolean endpointRequest() {
@@ -75,7 +84,7 @@ public class LoggingContext implements ConditionSupplier {
     }
 
     public boolean entrypointRequestPayload() {
-        return logging.getMode().isEntrypoint() && logging.getPhase().isRequest() && logging.getContent().isPayload();
+        return tracingVerbose || (logging.getMode().isEntrypoint() && logging.getPhase().isRequest() && logging.getContent().isPayload());
     }
 
     public boolean endpointRequestHeaders() {
@@ -91,7 +100,7 @@ public class LoggingContext implements ConditionSupplier {
     }
 
     public boolean entrypointResponsePayload() {
-        return logging.getMode().isEntrypoint() && logging.getPhase().isResponse() && logging.getContent().isPayload();
+        return tracingVerbose || (logging.getMode().isEntrypoint() && logging.getPhase().isResponse() && logging.getContent().isPayload());
     }
 
     public boolean endpointResponseHeaders() {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-core/src/test/java/io/gravitee/gateway/reactive/core/v4/analytics/AnalyticsContextTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-core/src/test/java/io/gravitee/gateway/reactive/core/v4/analytics/AnalyticsContextTest.java
@@ -18,9 +18,11 @@ package io.gravitee.gateway.reactive.core.v4.analytics;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
 import io.gravitee.definition.model.v4.analytics.Analytics;
+import io.gravitee.definition.model.v4.analytics.logging.Logging;
 import io.gravitee.gateway.opentelemetry.TracingContext;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -44,5 +46,33 @@ class AnalyticsContextTest {
         analytics.setEnabled(true);
         AnalyticsContext analyticsContext = new AnalyticsContext(analytics, null, TracingContext.noop());
         assertThat(analyticsContext.isEnabled()).isTrue();
+    }
+
+    @Nested
+    class TracingVerbose {
+
+        @Test
+        void should_enable_logging_context_when_tracingVerbose_is_true() {
+            var analytics = new Analytics();
+            analytics.setEnabled(true);
+            var loggingContext = new LoggingContext(Logging.builder().build());
+            loggingContext.setTracingVerbose(true);
+
+            var ctx = new AnalyticsContext(analytics, loggingContext, TracingContext.noop());
+
+            assertThat(ctx.isLoggingEnabled()).isTrue();
+        }
+
+        @Test
+        void should_not_enable_logging_context_when_tracingVerbose_is_false_and_no_logging_configured() {
+            var analytics = new Analytics();
+            analytics.setEnabled(true);
+            var loggingContext = new LoggingContext(Logging.builder().build());
+            // tracingVerbose defaults to false, no logging mode set
+
+            var ctx = new AnalyticsContext(analytics, loggingContext, TracingContext.noop());
+
+            assertThat(ctx.isLoggingEnabled()).isFalse();
+        }
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-core/src/test/java/io/gravitee/gateway/reactive/core/v4/analytics/LoggingContextTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-core/src/test/java/io/gravitee/gateway/reactive/core/v4/analytics/LoggingContextTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.reactive.core.v4.analytics;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.definition.model.v4.analytics.logging.Logging;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author GraviteeSource Team
+ */
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class LoggingContextTest {
+
+    @Nested
+    class TracingVerbose {
+
+        @Test
+        void entrypointRequest_returns_true_when_tracingVerbose_set() {
+            var ctx = new LoggingContext(Logging.builder().build());
+            ctx.setTracingVerbose(true);
+            assertThat(ctx.entrypointRequest()).isTrue();
+        }
+
+        @Test
+        void entrypointResponse_returns_true_when_tracingVerbose_set() {
+            var ctx = new LoggingContext(Logging.builder().build());
+            ctx.setTracingVerbose(true);
+            assertThat(ctx.entrypointResponse()).isTrue();
+        }
+
+        @Test
+        void entrypointRequestPayload_returns_true_when_tracingVerbose_set() {
+            var ctx = new LoggingContext(Logging.builder().build());
+            ctx.setTracingVerbose(true);
+            assertThat(ctx.entrypointRequestPayload()).isTrue();
+        }
+
+        @Test
+        void entrypointResponsePayload_returns_true_when_tracingVerbose_set() {
+            var ctx = new LoggingContext(Logging.builder().build());
+            ctx.setTracingVerbose(true);
+            assertThat(ctx.entrypointResponsePayload()).isTrue();
+        }
+
+        @Test
+        void entrypointRequest_returns_false_when_tracingVerbose_false_and_logging_disabled() {
+            var ctx = new LoggingContext(Logging.builder().build());
+            assertThat(ctx.entrypointRequest()).isFalse();
+        }
+
+        @Test
+        void entrypointRequestPayload_returns_false_when_tracingVerbose_false_and_logging_disabled() {
+            var ctx = new LoggingContext(Logging.builder().build());
+            assertThat(ctx.entrypointRequestPayload()).isFalse();
+        }
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/DefaultApiReactor.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/DefaultApiReactor.java
@@ -743,6 +743,10 @@ public class DefaultApiReactor extends AbstractApiReactor {
                 context.setMaxSizeLogMessage(loggingMaxSize);
                 context.setExcludedResponseTypes(loggingExcludedResponseType);
                 context.setLogGuardService(logGuardService);
+                var tracing = analytics.getTracing();
+                if (tracing != null && tracing.isEnabled() && tracing.isVerbose()) {
+                    context.setTracingVerbose(true);
+                }
                 return context;
             })
             .orElse(null);

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/DefaultApiReactorFactory.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/DefaultApiReactorFactory.java
@@ -428,7 +428,8 @@ public class DefaultApiReactorFactory extends AbstractReactorFactory<Api> {
                 serviceNameSpace,
                 api.getApiVersion(),
                 instrumenterTracerFactories,
-                TracingRedactionMapper.toRedactionConfig(api)
+                TracingRedactionMapper.toRedactionConfig(api),
+                TracingPayloadMaskingMapper.toPayloadMaskingConfig(api)
             );
             return new TracingContext(tracer, true, isApiTracingVerboseEnabled(api));
         }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/TracingPayloadMaskingMapper.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/TracingPayloadMaskingMapper.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.reactive.handlers.api.v4;
+
+import com.google.common.annotations.VisibleForTesting;
+import io.gravitee.definition.model.v4.analytics.tracing.MaskingType;
+import io.gravitee.definition.model.v4.analytics.tracing.TracingPayloadFormat;
+import io.gravitee.definition.model.v4.analytics.tracing.TracingPayloadMaskingRule;
+import io.gravitee.definition.model.v4.analytics.tracing.TracingPayloadPhase;
+import io.gravitee.node.api.opentelemetry.redaction.MaskingStrategy;
+import io.gravitee.node.api.opentelemetry.redaction.PayloadFormat;
+import io.gravitee.node.api.opentelemetry.redaction.PayloadMaskingConfig;
+import io.gravitee.node.api.opentelemetry.redaction.PayloadMaskingRule;
+import io.gravitee.node.api.opentelemetry.redaction.PayloadPhase;
+import java.util.Optional;
+import lombok.CustomLog;
+
+@CustomLog
+final class TracingPayloadMaskingMapper {
+
+    private TracingPayloadMaskingMapper() {}
+
+    static PayloadMaskingConfig toPayloadMaskingConfig(final Api api) {
+        return Optional.ofNullable(api.getDefinition())
+            .map(definition -> definition.getAnalytics())
+            .map(analytics -> analytics.getTracing())
+            .map(tracing -> tracing.getPayloadMasking())
+            .filter(config -> config.getRules() != null && !config.getRules().isEmpty())
+            .map(config -> {
+                var mappedRules = config
+                    .getRules()
+                    .stream()
+                    .filter(rule -> rule.getPath() != null && !rule.getPath().isBlank())
+                    .map(rule ->
+                        new PayloadMaskingRule(
+                            rule.getPath(),
+                            toMaskingStrategy(rule),
+                            toPayloadPhase(rule.getPhase()),
+                            toPayloadFormat(rule.getFormat())
+                        )
+                    )
+                    .toList();
+                return mappedRules.isEmpty()
+                    ? PayloadMaskingConfig.EMPTY
+                    : new PayloadMaskingConfig(mappedRules, config.getDefaultReplacement());
+            })
+            .orElse(PayloadMaskingConfig.EMPTY);
+    }
+
+    @VisibleForTesting
+    static MaskingStrategy toMaskingStrategy(final TracingPayloadMaskingRule rule) {
+        var maskingStrategy = rule.getMaskingStrategy();
+        if (maskingStrategy == null) return MaskingStrategy.DEFAULT;
+        MaskingType maskingType = maskingStrategy.getType();
+        if (maskingType == null) return MaskingStrategy.DEFAULT;
+        return switch (maskingType) {
+            case FULL -> maskingStrategy.getReplacement() != null
+                ? MaskingStrategy.fullMask(maskingStrategy.getReplacement())
+                : MaskingStrategy.DEFAULT;
+            case PARTIAL -> {
+                var maskChar = maskingStrategy.getReplacement() != null ? maskingStrategy.getReplacement() : "*";
+                if (maskChar.length() != 1) {
+                    log.warn("PARTIAL masking strategy replacement must be a single character, got '{}' — defaulting to '*'", maskChar);
+                    maskChar = "*";
+                }
+                int prefix = Math.max(0, maskingStrategy.getPrefixLength() != null ? maskingStrategy.getPrefixLength() : 0);
+                int suffix = Math.max(0, maskingStrategy.getSuffixLength() != null ? maskingStrategy.getSuffixLength() : 0);
+                yield MaskingStrategy.partialMask(prefix, suffix, maskChar);
+            }
+        };
+    }
+
+    @VisibleForTesting
+    static PayloadPhase toPayloadPhase(final TracingPayloadPhase phase) {
+        if (phase == null) return PayloadPhase.BOTH;
+        return switch (phase) {
+            case REQUEST -> PayloadPhase.REQUEST;
+            case RESPONSE -> PayloadPhase.RESPONSE;
+            case BOTH -> PayloadPhase.BOTH;
+        };
+    }
+
+    @VisibleForTesting
+    static PayloadFormat toPayloadFormat(final TracingPayloadFormat format) {
+        if (format == null) return PayloadFormat.AUTO;
+        return switch (format) {
+            case JSON -> PayloadFormat.JSON;
+            case XML -> PayloadFormat.XML;
+            case AUTO -> PayloadFormat.AUTO;
+        };
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/analytics/logging/request/LogEndpointRequest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/analytics/logging/request/LogEndpointRequest.java
@@ -46,7 +46,11 @@ public class LogEndpointRequest extends LogRequest {
                 if (loggingContext.isBodyLoggable()) {
                     chunks = chunks
                         .doOnNext(chunk -> BufferUtils.appendBuffer(buffer, chunk, loggingContext.getMaxSizeLogMessage()))
-                        .doFinally(() -> this.setBody(buffer.toString()));
+                        .doFinally(() -> {
+                            String capturedBody = buffer.toString();
+                            this.setBody(capturedBody);
+                            emitPayloadSpanEvent(ctx, capturedBody);
+                        });
                 } else {
                     this.setBody("BODY NOT CAPTURED");
                 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/analytics/logging/request/LogEntrypointRequest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/analytics/logging/request/LogEntrypointRequest.java
@@ -45,7 +45,11 @@ public class LogEntrypointRequest extends LogRequest {
                     request
                         .chunks()
                         .doOnNext(chunk -> BufferUtils.appendBuffer(buffer, chunk, loggingContext.getMaxSizeLogMessage()))
-                        .doOnComplete(() -> this.setBody(buffer.toString()))
+                        .doOnComplete(() -> {
+                            String capturedBody = buffer.toString();
+                            this.setBody(capturedBody);
+                            emitPayloadSpanEvent(ctx, capturedBody);
+                        })
                 );
             } else {
                 this.setBody("BODY NOT CAPTURED");

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/analytics/logging/request/LogRequest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/analytics/logging/request/LogRequest.java
@@ -18,6 +18,7 @@ package io.gravitee.gateway.reactive.handlers.api.v4.analytics.logging.request;
 import io.gravitee.gateway.api.buffer.Buffer;
 import io.gravitee.gateway.api.http.HttpHeaderNames;
 import io.gravitee.gateway.api.http.HttpHeaders;
+import io.gravitee.gateway.reactive.api.context.InternalContextAttributes;
 import io.gravitee.gateway.reactive.api.context.base.BaseExecutionContext;
 import io.gravitee.gateway.reactive.api.context.http.HttpPlainExecutionContext;
 import io.gravitee.gateway.reactive.api.context.http.HttpPlainRequest;
@@ -25,6 +26,8 @@ import io.gravitee.gateway.reactive.core.context.HttpExecutionContextInternal;
 import io.gravitee.gateway.reactive.core.context.HttpRequestInternal;
 import io.gravitee.gateway.reactive.core.v4.analytics.BufferUtils;
 import io.gravitee.gateway.reactive.core.v4.analytics.LoggingContext;
+import io.gravitee.node.api.opentelemetry.Span;
+import java.util.Map;
 
 /**
  * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)
@@ -45,4 +48,29 @@ abstract class LogRequest extends io.gravitee.reporter.api.common.Request {
     protected abstract boolean isLogPayload();
 
     protected abstract boolean isLogHeaders();
+
+    /**
+     * Adds a {@code "payload"} span event to the root OTel span for the current request.
+     * No-op when OTel tracing is disabled or no root span exists in the context.
+     */
+    protected void emitPayloadSpanEvent(HttpExecutionContextInternal ctx, String body) {
+        Span span = ctx.getInternalAttribute(InternalContextAttributes.ATTR_INTERNAL_TRACING_ROOT_SPAN);
+        if (span == null) {
+            return;
+        }
+        String contentType = request.headers().get(HttpHeaderNames.CONTENT_TYPE);
+        span.addEvent(
+            "payload",
+            Map.of("payload.body", body, "payload.format", resolvePayloadFormat(contentType), "payload.phase", "REQUEST")
+        );
+    }
+
+    // NOTE: mirrored in LogResponse — both will be replaced by PayloadFormat enum from gravitee-node (APIM-13580)
+    private static String resolvePayloadFormat(String contentType) {
+        if (contentType == null) return "UNKNOWN";
+        String ct = contentType.toLowerCase();
+        if (ct.contains("json")) return "JSON";
+        if (ct.contains("xml")) return "XML";
+        return "UNKNOWN";
+    }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/analytics/logging/response/LogEndpointResponse.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/analytics/logging/response/LogEndpointResponse.java
@@ -49,7 +49,11 @@ public class LogEndpointResponse extends LogResponse {
                 if (loggingContext.isBodyLoggable()) {
                     chunks = chunks
                         .doOnNext(chunk -> BufferUtils.appendBuffer(buffer, chunk, loggingContext.getMaxSizeLogMessage()))
-                        .doFinally(() -> this.setBody(buffer.toString()));
+                        .doFinally(() -> {
+                            String capturedBody = buffer.toString();
+                            this.setBody(capturedBody);
+                            emitPayloadSpanEvent(ctx, capturedBody);
+                        });
                 } else {
                     this.setBody("BODY NOT CAPTURED");
                 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/analytics/logging/response/LogEntrypointResponse.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/analytics/logging/response/LogEntrypointResponse.java
@@ -42,7 +42,11 @@ public class LogEntrypointResponse extends LogResponse {
                     response
                         .chunks()
                         .doOnNext(chunk -> BufferUtils.appendBuffer(buffer, chunk, loggingContext.getMaxSizeLogMessage()))
-                        .doOnComplete(() -> this.setBody(buffer.toString()))
+                        .doOnComplete(() -> {
+                            String capturedBody = buffer.toString();
+                            this.setBody(capturedBody);
+                            emitPayloadSpanEvent(ctx, capturedBody);
+                        })
                 );
             } else {
                 this.setBody("BODY NOT CAPTURED");

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/analytics/logging/response/LogResponse.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/analytics/logging/response/LogResponse.java
@@ -18,12 +18,16 @@ package io.gravitee.gateway.reactive.handlers.api.v4.analytics.logging.response;
 import io.gravitee.gateway.api.buffer.Buffer;
 import io.gravitee.gateway.api.http.HttpHeaderNames;
 import io.gravitee.gateway.api.http.HttpHeaders;
+import io.gravitee.gateway.reactive.api.context.InternalContextAttributes;
 import io.gravitee.gateway.reactive.api.context.base.BaseExecutionContext;
 import io.gravitee.gateway.reactive.api.context.http.HttpPlainResponse;
+import io.gravitee.gateway.reactive.core.context.HttpExecutionContextInternal;
 import io.gravitee.gateway.reactive.core.context.HttpResponseInternal;
 import io.gravitee.gateway.reactive.core.v4.analytics.BufferUtils;
 import io.gravitee.gateway.reactive.core.v4.analytics.LoggingContext;
 import io.gravitee.gateway.reactive.handlers.api.v4.analytics.logging.LogHeadersCaptor;
+import io.gravitee.node.api.opentelemetry.Span;
+import java.util.Map;
 
 /**
  * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)
@@ -56,4 +60,29 @@ abstract class LogResponse extends io.gravitee.reporter.api.common.Response {
     protected abstract boolean isLogPayload();
 
     protected abstract boolean isLogHeaders();
+
+    /**
+     * Adds a {@code "payload"} span event to the root OTel span for the current response.
+     * No-op when OTel tracing is disabled or no root span exists in the context.
+     */
+    protected void emitPayloadSpanEvent(HttpExecutionContextInternal ctx, String body) {
+        Span span = ctx.getInternalAttribute(InternalContextAttributes.ATTR_INTERNAL_TRACING_ROOT_SPAN);
+        if (span == null) {
+            return;
+        }
+        String contentType = response.headers().get(HttpHeaderNames.CONTENT_TYPE);
+        span.addEvent(
+            "payload",
+            Map.of("payload.body", body, "payload.format", resolvePayloadFormat(contentType), "payload.phase", "RESPONSE")
+        );
+    }
+
+    // NOTE: mirrored in LogRequest — both will be replaced by PayloadFormat enum from gravitee-node (APIM-13580)
+    private static String resolvePayloadFormat(String contentType) {
+        if (contentType == null) return "UNKNOWN";
+        String ct = contentType.toLowerCase();
+        if (ct.contains("json")) return "JSON";
+        if (ct.contains("xml")) return "XML";
+        return "UNKNOWN";
+    }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/processor/ApiProcessorChainFactory.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/processor/ApiProcessorChainFactory.java
@@ -20,6 +20,7 @@ import static io.gravitee.gateway.reactive.handlers.api.processor.subscription.S
 import io.gravitee.definition.model.Cors;
 import io.gravitee.definition.model.RequestValidation;
 import io.gravitee.definition.model.v4.analytics.Analytics;
+import io.gravitee.definition.model.v4.analytics.tracing.Tracing;
 import io.gravitee.definition.model.v4.listener.ListenerType;
 import io.gravitee.definition.model.v4.listener.http.HttpListener;
 import io.gravitee.gateway.opentelemetry.TracingContext;
@@ -91,7 +92,7 @@ public class ApiProcessorChainFactory {
 
         io.gravitee.definition.model.v4.Api apiDefinition = api.getDefinition();
         Analytics analytics = apiDefinition.getAnalytics();
-        if (AnalyticsUtils.isLoggingEnabled(analytics)) {
+        if (AnalyticsUtils.isLoggingEnabled(analytics) || isTracingVerbose(analytics)) {
             processors.add(LogInitProcessor.instance());
             processors.add(LogRequestProcessor.instance());
         }
@@ -219,7 +220,7 @@ public class ApiProcessorChainFactory {
 
         final io.gravitee.definition.model.v4.Api apiDefinition = api.getDefinition();
         final Analytics analytics = apiDefinition.getAnalytics();
-        if (AnalyticsUtils.isLoggingEnabled(analytics)) {
+        if (AnalyticsUtils.isLoggingEnabled(analytics) || isTracingVerbose(analytics)) {
             processors.add(LogResponseProcessor.instance());
         }
         return processors;
@@ -245,5 +246,11 @@ public class ApiProcessorChainFactory {
 
     private <T> Stream<T> stream(Iterable<T> iterable) {
         return iterable == null ? Stream.empty() : StreamSupport.stream(iterable.spliterator(), false);
+    }
+
+    private boolean isTracingVerbose(final Analytics analytics) {
+        if (analytics == null) return false;
+        Tracing tracing = analytics.getTracing();
+        return tracing != null && tracing.isEnabled() && tracing.isVerbose();
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/v4/DefaultApiReactorFactoryTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/v4/DefaultApiReactorFactoryTest.java
@@ -33,6 +33,10 @@ import io.gravitee.definition.model.v4.analytics.Analytics;
 import io.gravitee.definition.model.v4.analytics.tracing.MaskingType;
 import io.gravitee.definition.model.v4.analytics.tracing.Tracing;
 import io.gravitee.definition.model.v4.analytics.tracing.TracingMaskingStrategy;
+import io.gravitee.definition.model.v4.analytics.tracing.TracingPayloadFormat;
+import io.gravitee.definition.model.v4.analytics.tracing.TracingPayloadMaskingConfig;
+import io.gravitee.definition.model.v4.analytics.tracing.TracingPayloadMaskingRule;
+import io.gravitee.definition.model.v4.analytics.tracing.TracingPayloadPhase;
 import io.gravitee.definition.model.v4.analytics.tracing.TracingRedactionConfig;
 import io.gravitee.definition.model.v4.analytics.tracing.TracingRedactionRule;
 import io.gravitee.definition.model.v4.listener.http.HttpListener;
@@ -69,6 +73,8 @@ import io.gravitee.node.api.Node;
 import io.gravitee.node.api.configuration.Configuration;
 import io.gravitee.node.api.opentelemetry.Tracer;
 import io.gravitee.node.api.opentelemetry.redaction.FullMaskingStrategy;
+import io.gravitee.node.api.opentelemetry.redaction.PartialMaskingStrategy;
+import io.gravitee.node.api.opentelemetry.redaction.PayloadMaskingConfig;
 import io.gravitee.node.api.opentelemetry.redaction.RedactionConfig;
 import io.gravitee.node.container.spring.SpringEnvironmentConfiguration;
 import io.gravitee.node.opentelemetry.OpenTelemetryFactory;
@@ -438,17 +444,81 @@ class DefaultApiReactorFactoryTest {
             when(api.getName()).thenReturn("api-name");
             when(api.getApiVersion()).thenReturn("1.0");
             when(openTelemetryConfiguration.isTracesEnabled()).thenReturn(true);
-            when(openTelemetryFactory.createTracer(any(), any(), any(), any(), any(), any(RedactionConfig.class))).thenReturn(
-                mock(Tracer.class)
-            );
+            when(
+                openTelemetryFactory.createTracer(
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(RedactionConfig.class),
+                    any(PayloadMaskingConfig.class)
+                )
+            ).thenReturn(mock(Tracer.class));
 
             cut.createTracingContext(api, "test-namespace");
 
             ArgumentCaptor<RedactionConfig> captor = ArgumentCaptor.forClass(RedactionConfig.class);
-            verify(openTelemetryFactory).createTracer(any(), any(), any(), any(), any(), captor.capture());
+            verify(openTelemetryFactory).createTracer(any(), any(), any(), any(), any(), captor.capture(), any(PayloadMaskingConfig.class));
             assertThat(captor.getValue().rules()).hasSize(1);
             assertThat(captor.getValue().rules().get(0).attributeNamePattern()).isEqualTo("enduser.id");
             assertThat(captor.getValue().rules().get(0).maskingStrategy()).isInstanceOf(FullMaskingStrategy.class);
+        }
+
+        @Test
+        void should_pass_payload_masking_config_to_createTracer() {
+            var strategy = new TracingMaskingStrategy();
+            strategy.setType(MaskingType.PARTIAL);
+            strategy.setPrefixLength(2);
+            strategy.setSuffixLength(4);
+            strategy.setReplacement("*");
+            var rule = new TracingPayloadMaskingRule();
+            rule.setPath("$.creditCard");
+            rule.setMaskingStrategy(strategy);
+            rule.setPhase(TracingPayloadPhase.REQUEST);
+            rule.setFormat(TracingPayloadFormat.JSON);
+            var maskingConfig = new TracingPayloadMaskingConfig();
+            maskingConfig.setRules(List.of(rule));
+            var tracing = new Tracing();
+            tracing.setEnabled(true);
+            tracing.setPayloadMasking(maskingConfig);
+            var analytics = new Analytics();
+            analytics.setEnabled(true);
+            analytics.setTracing(tracing);
+            var def = new io.gravitee.definition.model.v4.Api();
+            def.setAnalytics(analytics);
+
+            Api api = mock(Api.class);
+            when(api.getDefinition()).thenReturn(def);
+            when(api.getId()).thenReturn("api-id");
+            when(api.getName()).thenReturn("api-name");
+            when(api.getApiVersion()).thenReturn("1.0");
+            when(openTelemetryConfiguration.isTracesEnabled()).thenReturn(true);
+            when(
+                openTelemetryFactory.createTracer(
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(RedactionConfig.class),
+                    any(PayloadMaskingConfig.class)
+                )
+            ).thenReturn(mock(Tracer.class));
+
+            cut.createTracingContext(api, "test-namespace");
+
+            ArgumentCaptor<PayloadMaskingConfig> captor = ArgumentCaptor.forClass(PayloadMaskingConfig.class);
+            verify(openTelemetryFactory).createTracer(any(), any(), any(), any(), any(), any(RedactionConfig.class), captor.capture());
+            assertThat(captor.getValue().rules()).hasSize(1);
+            assertThat(captor.getValue().rules().get(0).path()).isEqualTo("$.creditCard");
+            assertThat(captor.getValue().rules().get(0).maskingStrategy()).isInstanceOf(PartialMaskingStrategy.class);
+            assertThat(captor.getValue().rules().get(0).phase()).isEqualTo(
+                io.gravitee.node.api.opentelemetry.redaction.PayloadPhase.REQUEST
+            );
+            assertThat(captor.getValue().rules().get(0).format()).isEqualTo(
+                io.gravitee.node.api.opentelemetry.redaction.PayloadFormat.JSON
+            );
         }
     }
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/v4/TracingPayloadMaskingMapperTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/v4/TracingPayloadMaskingMapperTest.java
@@ -1,0 +1,245 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.reactive.handlers.api.v4;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.definition.model.v4.analytics.Analytics;
+import io.gravitee.definition.model.v4.analytics.tracing.MaskingType;
+import io.gravitee.definition.model.v4.analytics.tracing.Tracing;
+import io.gravitee.definition.model.v4.analytics.tracing.TracingMaskingStrategy;
+import io.gravitee.definition.model.v4.analytics.tracing.TracingPayloadFormat;
+import io.gravitee.definition.model.v4.analytics.tracing.TracingPayloadMaskingConfig;
+import io.gravitee.definition.model.v4.analytics.tracing.TracingPayloadMaskingRule;
+import io.gravitee.definition.model.v4.analytics.tracing.TracingPayloadPhase;
+import io.gravitee.node.api.opentelemetry.redaction.FullMaskingStrategy;
+import io.gravitee.node.api.opentelemetry.redaction.MaskingStrategy;
+import io.gravitee.node.api.opentelemetry.redaction.PartialMaskingStrategy;
+import io.gravitee.node.api.opentelemetry.redaction.PayloadMaskingConfig;
+import java.util.List;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class TracingPayloadMaskingMapperTest {
+
+    @Nested
+    class ToPayloadMaskingConfig {
+
+        @Test
+        void should_return_empty_when_definition_is_null() {
+            Api api = mock(Api.class);
+            when(api.getDefinition()).thenReturn(null);
+
+            assertThat(TracingPayloadMaskingMapper.toPayloadMaskingConfig(api)).isSameAs(PayloadMaskingConfig.EMPTY);
+        }
+
+        @Test
+        void should_return_empty_when_analytics_is_null() {
+            assertThat(TracingPayloadMaskingMapper.toPayloadMaskingConfig(apiWithPayloadMasking(null))).isSameAs(
+                PayloadMaskingConfig.EMPTY
+            );
+        }
+
+        @Test
+        void should_return_empty_when_rules_list_is_null() {
+            var config = new TracingPayloadMaskingConfig();
+            config.setRules(null);
+            assertThat(TracingPayloadMaskingMapper.toPayloadMaskingConfig(apiWithPayloadMasking(config))).isSameAs(
+                PayloadMaskingConfig.EMPTY
+            );
+        }
+
+        @Test
+        void should_return_empty_when_rules_list_is_empty() {
+            var config = new TracingPayloadMaskingConfig();
+            config.setRules(List.of());
+            assertThat(TracingPayloadMaskingMapper.toPayloadMaskingConfig(apiWithPayloadMasking(config))).isSameAs(
+                PayloadMaskingConfig.EMPTY
+            );
+        }
+
+        @Test
+        void should_return_empty_when_all_rules_have_null_path() {
+            var rule = new TracingPayloadMaskingRule();
+            rule.setPath(null);
+            var config = new TracingPayloadMaskingConfig();
+            config.setRules(List.of(rule));
+            assertThat(TracingPayloadMaskingMapper.toPayloadMaskingConfig(apiWithPayloadMasking(config))).isSameAs(
+                PayloadMaskingConfig.EMPTY
+            );
+        }
+
+        @Test
+        void should_return_empty_when_all_rules_have_blank_path() {
+            var rule = new TracingPayloadMaskingRule();
+            rule.setPath("  ");
+            var config = new TracingPayloadMaskingConfig();
+            config.setRules(List.of(rule));
+            assertThat(TracingPayloadMaskingMapper.toPayloadMaskingConfig(apiWithPayloadMasking(config))).isSameAs(
+                PayloadMaskingConfig.EMPTY
+            );
+        }
+
+        @Test
+        void should_map_full_masking_with_explicit_replacement() {
+            var strategy = new TracingMaskingStrategy();
+            strategy.setType(MaskingType.FULL);
+            strategy.setReplacement("[HIDDEN]");
+            var config = TracingPayloadMaskingMapper.toPayloadMaskingConfig(apiWithRules(rule("$.password", strategy)));
+
+            assertThat(config.rules()).hasSize(1);
+            assertThat(config.rules().get(0).maskingStrategy()).isInstanceOf(FullMaskingStrategy.class);
+            assertThat(((FullMaskingStrategy) config.rules().get(0).maskingStrategy()).replacement()).isEqualTo("[HIDDEN]");
+        }
+
+        @Test
+        void should_map_full_masking_with_no_replacement_to_default() {
+            var strategy = new TracingMaskingStrategy();
+            strategy.setType(MaskingType.FULL);
+            strategy.setReplacement(null);
+            var config = TracingPayloadMaskingMapper.toPayloadMaskingConfig(apiWithRules(rule("$.password", strategy)));
+
+            assertThat(config.rules().get(0).maskingStrategy()).isSameAs(MaskingStrategy.DEFAULT);
+        }
+
+        @Test
+        void should_map_null_masking_strategy_to_default() {
+            var config = TracingPayloadMaskingMapper.toPayloadMaskingConfig(apiWithRules(rule("$.password", null)));
+
+            assertThat(config.rules().get(0).maskingStrategy()).isSameAs(MaskingStrategy.DEFAULT);
+        }
+
+        @Test
+        void should_map_partial_masking_strategy() {
+            var strategy = new TracingMaskingStrategy();
+            strategy.setType(MaskingType.PARTIAL);
+            strategy.setPrefixLength(2);
+            strategy.setSuffixLength(4);
+            strategy.setReplacement("X");
+            var config = TracingPayloadMaskingMapper.toPayloadMaskingConfig(apiWithRules(rule("$.card.number", strategy)));
+
+            assertThat(config.rules().get(0).maskingStrategy()).isInstanceOf(PartialMaskingStrategy.class);
+            var partial = (PartialMaskingStrategy) config.rules().get(0).maskingStrategy();
+            assertThat(partial.prefixLength()).isEqualTo(2);
+            assertThat(partial.suffixLength()).isEqualTo(4);
+            assertThat(partial.maskChar()).isEqualTo("X");
+        }
+
+        @Test
+        void should_map_phase_request() {
+            var r = rule("$.password", null);
+            r.setPhase(TracingPayloadPhase.REQUEST);
+            var config = TracingPayloadMaskingMapper.toPayloadMaskingConfig(apiWithRules(r));
+
+            assertThat(config.rules().get(0).phase()).isEqualTo(io.gravitee.node.api.opentelemetry.redaction.PayloadPhase.REQUEST);
+        }
+
+        @Test
+        void should_map_phase_response() {
+            var r = rule("$.password", null);
+            r.setPhase(TracingPayloadPhase.RESPONSE);
+            var config = TracingPayloadMaskingMapper.toPayloadMaskingConfig(apiWithRules(r));
+
+            assertThat(config.rules().get(0).phase()).isEqualTo(io.gravitee.node.api.opentelemetry.redaction.PayloadPhase.RESPONSE);
+        }
+
+        @Test
+        void should_default_null_phase_to_both() {
+            var r = rule("$.password", null);
+            r.setPhase(null);
+            var config = TracingPayloadMaskingMapper.toPayloadMaskingConfig(apiWithRules(r));
+
+            assertThat(config.rules().get(0).phase()).isEqualTo(io.gravitee.node.api.opentelemetry.redaction.PayloadPhase.BOTH);
+        }
+
+        @Test
+        void should_map_format_json() {
+            var r = rule("$.password", null);
+            r.setFormat(TracingPayloadFormat.JSON);
+            var config = TracingPayloadMaskingMapper.toPayloadMaskingConfig(apiWithRules(r));
+
+            assertThat(config.rules().get(0).format()).isEqualTo(io.gravitee.node.api.opentelemetry.redaction.PayloadFormat.JSON);
+        }
+
+        @Test
+        void should_map_format_xml() {
+            var r = rule("//password", null);
+            r.setFormat(TracingPayloadFormat.XML);
+            var config = TracingPayloadMaskingMapper.toPayloadMaskingConfig(apiWithRules(r));
+
+            assertThat(config.rules().get(0).format()).isEqualTo(io.gravitee.node.api.opentelemetry.redaction.PayloadFormat.XML);
+        }
+
+        @Test
+        void should_default_null_format_to_auto() {
+            var r = rule("$.password", null);
+            r.setFormat(null);
+            var config = TracingPayloadMaskingMapper.toPayloadMaskingConfig(apiWithRules(r));
+
+            assertThat(config.rules().get(0).format()).isEqualTo(io.gravitee.node.api.opentelemetry.redaction.PayloadFormat.AUTO);
+        }
+
+        @Test
+        void should_preserve_config_default_replacement() {
+            var maskingConfig = new TracingPayloadMaskingConfig();
+            maskingConfig.setDefaultReplacement("[MASKED]");
+            maskingConfig.setRules(List.of(rule("$.password", null)));
+            var config = TracingPayloadMaskingMapper.toPayloadMaskingConfig(apiWithPayloadMasking(maskingConfig));
+
+            assertThat(config.defaultReplacement()).isEqualTo("[MASKED]");
+        }
+
+        @Test
+        void should_preserve_rule_ordering() {
+            var r1 = rule("$.password", null);
+            var r2 = rule("$.creditCard", null);
+            var config = TracingPayloadMaskingMapper.toPayloadMaskingConfig(apiWithRules(r1, r2));
+
+            assertThat(config.rules()).hasSize(2);
+            assertThat(config.rules().get(0).path()).isEqualTo("$.password");
+            assertThat(config.rules().get(1).path()).isEqualTo("$.creditCard");
+        }
+
+        private Api apiWithPayloadMasking(TracingPayloadMaskingConfig payloadMasking) {
+            var def = new io.gravitee.definition.model.v4.Api();
+            if (payloadMasking != null) {
+                var tracing = new Tracing();
+                tracing.setPayloadMasking(payloadMasking);
+                var analytics = new Analytics();
+                analytics.setTracing(tracing);
+                def.setAnalytics(analytics);
+            }
+            Api api = mock(Api.class);
+            when(api.getDefinition()).thenReturn(def);
+            return api;
+        }
+
+        private Api apiWithRules(TracingPayloadMaskingRule... rules) {
+            var config = new TracingPayloadMaskingConfig();
+            config.setRules(List.of(rules));
+            return apiWithPayloadMasking(config);
+        }
+
+        private TracingPayloadMaskingRule rule(String path, TracingMaskingStrategy strategy) {
+            var r = new TracingPayloadMaskingRule();
+            r.setPath(path);
+            r.setMaskingStrategy(strategy);
+            return r;
+        }
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/v4/analytics/logging/request/LogEndpointRequestTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/v4/analytics/logging/request/LogEndpointRequestTest.java
@@ -26,15 +26,19 @@ import io.gravitee.gateway.api.buffer.Buffer;
 import io.gravitee.gateway.api.http.HttpHeaderNames;
 import io.gravitee.gateway.api.http.HttpHeaders;
 import io.gravitee.gateway.http.vertx.VertxHttpHeaders;
+import io.gravitee.gateway.reactive.api.context.InternalContextAttributes;
 import io.gravitee.gateway.reactive.core.context.HttpExecutionContextInternal;
 import io.gravitee.gateway.reactive.core.context.HttpRequestInternal;
 import io.gravitee.gateway.reactive.core.v4.analytics.LoggingContext;
+import io.gravitee.node.api.opentelemetry.Span;
 import io.gravitee.reporter.api.v4.metric.Metrics;
 import io.reactivex.rxjava3.core.Flowable;
 import io.reactivex.rxjava3.core.FlowableTransformer;
 import io.vertx.core.http.impl.headers.HeadersMultiMap;
 import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -238,5 +242,49 @@ class LogEndpointRequestTest {
 
     private void initializeHeaders(HttpHeaders initialHeaders) {
         when(request.headers()).thenReturn(initialHeaders);
+    }
+
+    @Nested
+    class PayloadSpanEvent {
+
+        @Mock
+        private Span rootSpan;
+
+        @Test
+        void should_emit_payload_span_event_when_body_captured_and_tracing_enabled() {
+            final HttpHeaders headers = HttpHeaders.create();
+            headers.set(HttpHeaderNames.CONTENT_TYPE, "application/json");
+            initializeHeaders(headers);
+            when(loggingContext.endpointRequestHeaders()).thenReturn(false);
+            when(loggingContext.endpointRequestPayload()).thenReturn(true);
+            when(loggingContext.getMaxSizeLogMessage()).thenReturn(-1);
+            when(loggingContext.isBodyLoggable()).thenReturn(true);
+            when(loggingContext.isContentTypeLoggable(any(), any())).thenReturn(true);
+            when(ctx.getInternalAttribute(InternalContextAttributes.ATTR_INTERNAL_TRACING_ROOT_SPAN)).thenReturn(rootSpan);
+
+            cut.setupCapture(ctx);
+            triggerRequestToBackend(null, true);
+
+            verify(rootSpan).addEvent(
+                eq("payload"),
+                eq(Map.of("payload.body", BODY_CONTENT, "payload.format", "JSON", "payload.phase", "REQUEST"))
+            );
+        }
+
+        @Test
+        void should_not_emit_payload_span_event_when_no_root_span() {
+            initializeHeaders(HttpHeaders.create());
+            when(loggingContext.endpointRequestHeaders()).thenReturn(false);
+            when(loggingContext.endpointRequestPayload()).thenReturn(true);
+            when(loggingContext.getMaxSizeLogMessage()).thenReturn(-1);
+            when(loggingContext.isBodyLoggable()).thenReturn(true);
+            when(loggingContext.isContentTypeLoggable(any(), any())).thenReturn(true);
+            when(ctx.getInternalAttribute(InternalContextAttributes.ATTR_INTERNAL_TRACING_ROOT_SPAN)).thenReturn(null);
+
+            cut.setupCapture(ctx);
+            triggerRequestToBackend(null, true);
+
+            verify(rootSpan, never()).addEvent(any(), any());
+        }
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/v4/analytics/logging/request/LogEntrypointRequestTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/v4/analytics/logging/request/LogEntrypointRequestTest.java
@@ -20,6 +20,7 @@ import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -29,13 +30,17 @@ import io.gravitee.gateway.api.buffer.Buffer;
 import io.gravitee.gateway.api.http.HttpHeaderNames;
 import io.gravitee.gateway.api.http.HttpHeaders;
 import io.gravitee.gateway.http.vertx.VertxHttpHeaders;
+import io.gravitee.gateway.reactive.api.context.InternalContextAttributes;
 import io.gravitee.gateway.reactive.core.context.HttpExecutionContextInternal;
 import io.gravitee.gateway.reactive.core.context.HttpRequestInternal;
 import io.gravitee.gateway.reactive.core.v4.analytics.LoggingContext;
+import io.gravitee.node.api.opentelemetry.Span;
 import io.reactivex.rxjava3.core.Flowable;
 import io.reactivex.rxjava3.subscribers.TestSubscriber;
 import io.vertx.core.http.impl.headers.HeadersMultiMap;
 import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -180,5 +185,109 @@ class LogEntrypointRequestTest {
 
         assertNull(logRequest.getHeaders());
         assertThat(logRequest.getBody()).isEqualTo("BODY NOT CAPTURED");
+    }
+
+    @Nested
+    class PayloadSpanEvent {
+
+        @Mock
+        private Span rootSpan;
+
+        @Test
+        void should_emit_payload_span_event_when_body_captured_and_tracing_enabled() {
+            final Flowable<Buffer> body = Flowable.just(Buffer.buffer(BODY_CONTENT));
+            final HttpHeaders headers = HttpHeaders.create();
+            headers.set(HttpHeaderNames.CONTENT_TYPE, "application/json");
+
+            when(request.chunks()).thenReturn(body);
+            when(request.headers()).thenReturn(headers);
+            when(loggingContext.entrypointRequestHeaders()).thenReturn(false);
+            when(loggingContext.entrypointRequestPayload()).thenReturn(true);
+            when(loggingContext.getMaxSizeLogMessage()).thenReturn(-1);
+            when(loggingContext.isBodyLoggable()).thenReturn(true);
+            when(loggingContext.isContentTypeLoggable(any(), any())).thenReturn(true);
+            when(ctx.getInternalAttribute(InternalContextAttributes.ATTR_INTERNAL_TRACING_ROOT_SPAN)).thenReturn(rootSpan);
+
+            final var logRequest = new LogEntrypointRequest(loggingContext, request);
+            logRequest.capture(ctx);
+            verify(request).chunks(chunksCaptor.capture());
+            chunksCaptor.getValue().test().assertComplete();
+
+            verify(rootSpan).addEvent(
+                eq("payload"),
+                eq(Map.of("payload.body", BODY_CONTENT, "payload.format", "JSON", "payload.phase", "REQUEST"))
+            );
+        }
+
+        @Test
+        void should_not_emit_payload_span_event_when_no_root_span() {
+            final Flowable<Buffer> body = Flowable.just(Buffer.buffer(BODY_CONTENT));
+
+            when(request.chunks()).thenReturn(body);
+            when(request.headers()).thenReturn(HttpHeaders.create());
+            when(loggingContext.entrypointRequestHeaders()).thenReturn(false);
+            when(loggingContext.entrypointRequestPayload()).thenReturn(true);
+            when(loggingContext.getMaxSizeLogMessage()).thenReturn(-1);
+            when(loggingContext.isBodyLoggable()).thenReturn(true);
+            when(loggingContext.isContentTypeLoggable(any(), any())).thenReturn(true);
+            when(ctx.getInternalAttribute(InternalContextAttributes.ATTR_INTERNAL_TRACING_ROOT_SPAN)).thenReturn(null);
+
+            final var logRequest = new LogEntrypointRequest(loggingContext, request);
+            logRequest.capture(ctx);
+            verify(request).chunks(chunksCaptor.capture());
+            chunksCaptor.getValue().test().assertComplete();
+
+            verify(rootSpan, never()).addEvent(any(), any());
+        }
+
+        @Test
+        void should_resolve_xml_format_from_content_type() {
+            final Flowable<Buffer> body = Flowable.just(Buffer.buffer(BODY_CONTENT));
+            final HttpHeaders headers = HttpHeaders.create();
+            headers.set(HttpHeaderNames.CONTENT_TYPE, "application/xml");
+
+            when(request.chunks()).thenReturn(body);
+            when(request.headers()).thenReturn(headers);
+            when(loggingContext.entrypointRequestHeaders()).thenReturn(false);
+            when(loggingContext.entrypointRequestPayload()).thenReturn(true);
+            when(loggingContext.getMaxSizeLogMessage()).thenReturn(-1);
+            when(loggingContext.isBodyLoggable()).thenReturn(true);
+            when(loggingContext.isContentTypeLoggable(any(), any())).thenReturn(true);
+            when(ctx.getInternalAttribute(InternalContextAttributes.ATTR_INTERNAL_TRACING_ROOT_SPAN)).thenReturn(rootSpan);
+
+            final var logRequest = new LogEntrypointRequest(loggingContext, request);
+            logRequest.capture(ctx);
+            verify(request).chunks(chunksCaptor.capture());
+            chunksCaptor.getValue().test().assertComplete();
+
+            verify(rootSpan).addEvent(
+                eq("payload"),
+                eq(Map.of("payload.body", BODY_CONTENT, "payload.format", "XML", "payload.phase", "REQUEST"))
+            );
+        }
+
+        @Test
+        void should_use_unknown_format_when_content_type_absent() {
+            final Flowable<Buffer> body = Flowable.just(Buffer.buffer(BODY_CONTENT));
+
+            when(request.chunks()).thenReturn(body);
+            when(request.headers()).thenReturn(HttpHeaders.create());
+            when(loggingContext.entrypointRequestHeaders()).thenReturn(false);
+            when(loggingContext.entrypointRequestPayload()).thenReturn(true);
+            when(loggingContext.getMaxSizeLogMessage()).thenReturn(-1);
+            when(loggingContext.isBodyLoggable()).thenReturn(true);
+            when(loggingContext.isContentTypeLoggable(any(), any())).thenReturn(true);
+            when(ctx.getInternalAttribute(InternalContextAttributes.ATTR_INTERNAL_TRACING_ROOT_SPAN)).thenReturn(rootSpan);
+
+            final var logRequest = new LogEntrypointRequest(loggingContext, request);
+            logRequest.capture(ctx);
+            verify(request).chunks(chunksCaptor.capture());
+            chunksCaptor.getValue().test().assertComplete();
+
+            verify(rootSpan).addEvent(
+                eq("payload"),
+                eq(Map.of("payload.body", BODY_CONTENT, "payload.format", "UNKNOWN", "payload.phase", "REQUEST"))
+            );
+        }
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/v4/analytics/logging/response/LogEndpointResponseTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/v4/analytics/logging/response/LogEndpointResponseTest.java
@@ -24,24 +24,30 @@ import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.gravitee.gateway.api.buffer.Buffer;
 import io.gravitee.gateway.api.http.HttpHeaderNames;
 import io.gravitee.gateway.api.http.HttpHeaders;
 import io.gravitee.gateway.http.vertx.VertxHttpHeaders;
+import io.gravitee.gateway.reactive.api.context.InternalContextAttributes;
 import io.gravitee.gateway.reactive.core.context.HttpExecutionContextInternal;
 import io.gravitee.gateway.reactive.core.context.HttpResponseInternal;
 import io.gravitee.gateway.reactive.core.v4.analytics.LoggingContext;
+import io.gravitee.node.api.opentelemetry.Span;
 import io.reactivex.rxjava3.core.Flowable;
 import io.reactivex.rxjava3.core.FlowableTransformer;
 import io.vertx.core.http.impl.headers.HeadersMultiMap;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -302,5 +308,49 @@ class LogEndpointResponseTest {
                 headersRef.set(invocation.getArgument(0));
                 return response;
             });
+    }
+
+    @Nested
+    class PayloadSpanEvent {
+
+        @Mock
+        private Span rootSpan;
+
+        @Test
+        void should_emit_payload_span_event_when_body_captured_and_tracing_enabled() {
+            final HttpHeaders headers = HttpHeaders.create();
+            headers.set(HttpHeaderNames.CONTENT_TYPE, "application/json");
+            initializeHeaders(headers);
+            when(loggingContext.endpointResponseHeaders()).thenReturn(false);
+            when(loggingContext.endpointResponsePayload()).thenReturn(true);
+            when(loggingContext.getMaxSizeLogMessage()).thenReturn(-1);
+            when(loggingContext.isBodyLoggable()).thenReturn(true);
+            when(loggingContext.isContentTypeLoggable(any(), any())).thenReturn(true);
+            when(ctx.getInternalAttribute(InternalContextAttributes.ATTR_INTERNAL_TRACING_ROOT_SPAN)).thenReturn(rootSpan);
+
+            cut.setupCapture(ctx);
+            triggerResponseFromBackend(null);
+
+            verify(rootSpan).addEvent(
+                eq("payload"),
+                eq(Map.of("payload.body", BODY_CONTENT, "payload.format", "JSON", "payload.phase", "RESPONSE"))
+            );
+        }
+
+        @Test
+        void should_not_emit_payload_span_event_when_no_root_span() {
+            initializeHeaders(HttpHeaders.create());
+            when(loggingContext.endpointResponseHeaders()).thenReturn(false);
+            when(loggingContext.endpointResponsePayload()).thenReturn(true);
+            when(loggingContext.getMaxSizeLogMessage()).thenReturn(-1);
+            when(loggingContext.isBodyLoggable()).thenReturn(true);
+            when(loggingContext.isContentTypeLoggable(any(), any())).thenReturn(true);
+            when(ctx.getInternalAttribute(InternalContextAttributes.ATTR_INTERNAL_TRACING_ROOT_SPAN)).thenReturn(null);
+
+            cut.setupCapture(ctx);
+            triggerResponseFromBackend(null);
+
+            verify(rootSpan, never()).addEvent(any(), any());
+        }
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/v4/analytics/logging/response/LogEntrypointResponseTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/v4/analytics/logging/response/LogEntrypointResponseTest.java
@@ -30,13 +30,17 @@ import io.gravitee.gateway.api.buffer.Buffer;
 import io.gravitee.gateway.api.http.HttpHeaderNames;
 import io.gravitee.gateway.api.http.HttpHeaders;
 import io.gravitee.gateway.http.vertx.VertxHttpHeaders;
+import io.gravitee.gateway.reactive.api.context.InternalContextAttributes;
 import io.gravitee.gateway.reactive.core.context.HttpExecutionContextInternal;
 import io.gravitee.gateway.reactive.core.context.HttpResponseInternal;
 import io.gravitee.gateway.reactive.core.v4.analytics.LoggingContext;
+import io.gravitee.node.api.opentelemetry.Span;
 import io.reactivex.rxjava3.core.Flowable;
 import io.reactivex.rxjava3.subscribers.TestSubscriber;
 import io.vertx.core.http.impl.headers.HeadersMultiMap;
 import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -178,5 +182,109 @@ class LogEntrypointResponseTest {
 
         assertNull(logResponse.getHeaders());
         assertThat(logResponse.getBody()).isEqualTo("BODY NOT CAPTURED");
+    }
+
+    @Nested
+    class PayloadSpanEvent {
+
+        @Mock
+        private Span rootSpan;
+
+        @Test
+        void should_emit_payload_span_event_when_body_captured_and_tracing_enabled() {
+            final Flowable<Buffer> body = Flowable.just(Buffer.buffer(BODY_CONTENT));
+            final HttpHeaders headers = HttpHeaders.create();
+            headers.set(HttpHeaderNames.CONTENT_TYPE, "application/json");
+
+            when(response.chunks()).thenReturn(body);
+            when(response.headers()).thenReturn(headers);
+            when(loggingContext.entrypointResponseHeaders()).thenReturn(false);
+            when(loggingContext.entrypointResponsePayload()).thenReturn(true);
+            when(loggingContext.getMaxSizeLogMessage()).thenReturn(-1);
+            when(loggingContext.isBodyLoggable()).thenReturn(true);
+            when(loggingContext.isContentTypeLoggable(any(), any())).thenReturn(true);
+            when(ctx.getInternalAttribute(InternalContextAttributes.ATTR_INTERNAL_TRACING_ROOT_SPAN)).thenReturn(rootSpan);
+
+            final var logResponse = new LogEntrypointResponse(loggingContext, response);
+            logResponse.capture(ctx);
+            verify(response).chunks(chunksCaptor.capture());
+            chunksCaptor.getValue().test().assertComplete();
+
+            verify(rootSpan).addEvent(
+                eq("payload"),
+                eq(Map.of("payload.body", BODY_CONTENT, "payload.format", "JSON", "payload.phase", "RESPONSE"))
+            );
+        }
+
+        @Test
+        void should_not_emit_payload_span_event_when_no_root_span() {
+            final Flowable<Buffer> body = Flowable.just(Buffer.buffer(BODY_CONTENT));
+
+            when(response.chunks()).thenReturn(body);
+            when(response.headers()).thenReturn(HttpHeaders.create());
+            when(loggingContext.entrypointResponseHeaders()).thenReturn(false);
+            when(loggingContext.entrypointResponsePayload()).thenReturn(true);
+            when(loggingContext.getMaxSizeLogMessage()).thenReturn(-1);
+            when(loggingContext.isBodyLoggable()).thenReturn(true);
+            when(loggingContext.isContentTypeLoggable(any(), any())).thenReturn(true);
+            when(ctx.getInternalAttribute(InternalContextAttributes.ATTR_INTERNAL_TRACING_ROOT_SPAN)).thenReturn(null);
+
+            final var logResponse = new LogEntrypointResponse(loggingContext, response);
+            logResponse.capture(ctx);
+            verify(response).chunks(chunksCaptor.capture());
+            chunksCaptor.getValue().test().assertComplete();
+
+            verify(rootSpan, never()).addEvent(any(), any());
+        }
+
+        @Test
+        void should_resolve_xml_format_from_content_type() {
+            final Flowable<Buffer> body = Flowable.just(Buffer.buffer(BODY_CONTENT));
+            final HttpHeaders headers = HttpHeaders.create();
+            headers.set(HttpHeaderNames.CONTENT_TYPE, "application/xml");
+
+            when(response.chunks()).thenReturn(body);
+            when(response.headers()).thenReturn(headers);
+            when(loggingContext.entrypointResponseHeaders()).thenReturn(false);
+            when(loggingContext.entrypointResponsePayload()).thenReturn(true);
+            when(loggingContext.getMaxSizeLogMessage()).thenReturn(-1);
+            when(loggingContext.isBodyLoggable()).thenReturn(true);
+            when(loggingContext.isContentTypeLoggable(any(), any())).thenReturn(true);
+            when(ctx.getInternalAttribute(InternalContextAttributes.ATTR_INTERNAL_TRACING_ROOT_SPAN)).thenReturn(rootSpan);
+
+            final var logResponse = new LogEntrypointResponse(loggingContext, response);
+            logResponse.capture(ctx);
+            verify(response).chunks(chunksCaptor.capture());
+            chunksCaptor.getValue().test().assertComplete();
+
+            verify(rootSpan).addEvent(
+                eq("payload"),
+                eq(Map.of("payload.body", BODY_CONTENT, "payload.format", "XML", "payload.phase", "RESPONSE"))
+            );
+        }
+
+        @Test
+        void should_use_unknown_format_when_content_type_absent() {
+            final Flowable<Buffer> body = Flowable.just(Buffer.buffer(BODY_CONTENT));
+
+            when(response.chunks()).thenReturn(body);
+            when(response.headers()).thenReturn(HttpHeaders.create());
+            when(loggingContext.entrypointResponseHeaders()).thenReturn(false);
+            when(loggingContext.entrypointResponsePayload()).thenReturn(true);
+            when(loggingContext.getMaxSizeLogMessage()).thenReturn(-1);
+            when(loggingContext.isBodyLoggable()).thenReturn(true);
+            when(loggingContext.isContentTypeLoggable(any(), any())).thenReturn(true);
+            when(ctx.getInternalAttribute(InternalContextAttributes.ATTR_INTERNAL_TRACING_ROOT_SPAN)).thenReturn(rootSpan);
+
+            final var logResponse = new LogEntrypointResponse(loggingContext, response);
+            logResponse.capture(ctx);
+            verify(response).chunks(chunksCaptor.capture());
+            chunksCaptor.getValue().test().assertComplete();
+
+            verify(rootSpan).addEvent(
+                eq("payload"),
+                eq(Map.of("payload.body", BODY_CONTENT, "payload.format", "UNKNOWN", "payload.phase", "RESPONSE"))
+            );
+        }
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/v4/processor/ApiProcessorChainFactoryTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/v4/processor/ApiProcessorChainFactoryTest.java
@@ -24,6 +24,7 @@ import io.gravitee.definition.model.flow.Operator;
 import io.gravitee.definition.model.v4.analytics.Analytics;
 import io.gravitee.definition.model.v4.analytics.logging.Logging;
 import io.gravitee.definition.model.v4.analytics.logging.LoggingMode;
+import io.gravitee.definition.model.v4.analytics.tracing.Tracing;
 import io.gravitee.definition.model.v4.flow.Flow;
 import io.gravitee.definition.model.v4.flow.selector.HttpSelector;
 import io.gravitee.definition.model.v4.listener.http.HttpListener;
@@ -130,6 +131,66 @@ class ApiProcessorChainFactoryTest {
             .assertValueCount(2)
             .assertValueAt(0, processor -> processor instanceof LogInitProcessor)
             .assertValueAt(1, processor -> processor instanceof LogRequestProcessor);
+    }
+
+    @Test
+    void shouldReturnBeforeHandleProcessorChainWithTracingVerbose() {
+        var apiModel = new io.gravitee.definition.model.v4.Api();
+        var analytics = new Analytics();
+        analytics.setEnabled(true);
+        var tracing = new Tracing();
+        tracing.setEnabled(true);
+        tracing.setVerbose(true);
+        analytics.setTracing(tracing);
+        apiModel.setAnalytics(analytics);
+        Api api = new Api(apiModel);
+        ProcessorChain processorChain = apiProcessorChainFactory.beforeHandle(api);
+        assertThat(processorChain.getId()).isEqualTo("before-api-handle");
+        Flowable<Processor> processors = extractProcessorChain(processorChain);
+        processors
+            .test()
+            .assertComplete()
+            .assertValueCount(2)
+            .assertValueAt(0, processor -> processor instanceof LogInitProcessor)
+            .assertValueAt(1, processor -> processor instanceof LogRequestProcessor);
+    }
+
+    @Test
+    void shouldReturnEmptyBeforeHandleProcessorChainWhenTracingEnabledButNotVerbose() {
+        var apiModel = new io.gravitee.definition.model.v4.Api();
+        var analytics = new Analytics();
+        analytics.setEnabled(true);
+        var tracing = new Tracing();
+        tracing.setEnabled(true);
+        tracing.setVerbose(false);
+        analytics.setTracing(tracing);
+        apiModel.setAnalytics(analytics);
+        Api api = new Api(apiModel);
+        ProcessorChain processorChain = apiProcessorChainFactory.beforeHandle(api);
+        assertThat(processorChain.getId()).isEqualTo("before-api-handle");
+        Flowable<Processor> processors = extractProcessorChain(processorChain);
+        processors.test().assertNoValues();
+    }
+
+    @Test
+    void shouldReturnAfterHandleProcessorChainWithTracingVerbose() {
+        var apiModel = new io.gravitee.definition.model.v4.Api();
+        var analytics = new Analytics();
+        analytics.setEnabled(true);
+        var tracing = new Tracing();
+        tracing.setEnabled(true);
+        tracing.setVerbose(true);
+        analytics.setTracing(tracing);
+        apiModel.setAnalytics(analytics);
+        Api api = new Api(apiModel);
+        ProcessorChain processorChain = apiProcessorChainFactory.afterHandle(api);
+        assertThat(processorChain.getId()).isEqualTo("after-api-handle");
+        Flowable<Processor> processors = extractProcessorChain(processorChain);
+        processors
+            .test()
+            .assertComplete()
+            .assertValueCount(1)
+            .assertValueAt(0, processor -> processor instanceof LogResponseProcessor);
     }
 
     @Test

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/main/java/io/gravitee/gateway/reactive/debug/DebugReactorEventListener.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/main/java/io/gravitee/gateway/reactive/debug/DebugReactorEventListener.java
@@ -268,7 +268,12 @@ public class DebugReactorEventListener extends ReactorEventListener {
         if (host == null) {
             List<ReactableAccessPoint> accessPoints = accessPointManager.getByEnvironmentId(debugApi.getEnvironmentId());
             if (accessPoints != null && !accessPoints.isEmpty()) {
-                host = accessPoints.getFirst().getHost();
+                host = accessPoints
+                    .stream()
+                    .filter(ap -> ap.getTarget() == ReactableAccessPoint.Target.GATEWAY)
+                    .findFirst()
+                    .map(ReactableAccessPoint::getHost)
+                    .orElseGet(() -> accessPoints.getFirst().getHost());
             }
         }
         if (host != null) {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/test/java/io/gravitee/gateway/reactive/debug/DebugReactorEventListenerTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/test/java/io/gravitee/gateway/reactive/debug/DebugReactorEventListenerTest.java
@@ -791,5 +791,50 @@ class DebugReactorEventListenerTest {
             final MultiMap result = debugReactorEventListener.buildHeaders(new DebugApiV2("eventId", debugApiModel), httpRequest);
             assertThat(result.get("host")).isNull();
         }
+
+        @Test
+        void should_enforce_host_from_gateway_access_point_not_kafka_when_v4_api_has_no_virtual_host() {
+            var httpRequest = new HttpRequest("/demo-api/example", "GET", (String) null);
+            var debugApiV4 = new io.gravitee.gateway.debug.definition.DebugApiV4(
+                "1dc3b6b9-0fcd-4d26-83b6-b90fcd2d26ec",
+                aDebugApiV4Definition(httpRequest)
+            );
+
+            when(accessPointManager.getByEnvironmentId(any())).thenReturn(
+                List.of(
+                    ReactableAccessPoint.builder()
+                        .host("{apiHost}.dev-org-softco-poc.{geo}-{provider}-{region}.kafka-gateway.gravitee.io:9092")
+                        .target(ReactableAccessPoint.Target.KAFKA_GATEWAY)
+                        .build(),
+                    ReactableAccessPoint.builder().host("apigw.ipaas.softco.com").target(ReactableAccessPoint.Target.GATEWAY).build()
+                )
+            );
+
+            var result = debugReactorEventListener.buildHeaders(debugApiV4, httpRequest);
+
+            assertThat(result.get("host")).isEqualTo("apigw.ipaas.softco.com");
+        }
+
+        @Test
+        void should_fallback_to_first_access_point_when_no_gateway_target_found() {
+            var httpRequest = new HttpRequest("/demo-api/example", "GET", (String) null);
+            var debugApiV4 = new io.gravitee.gateway.debug.definition.DebugApiV4(
+                "1dc3b6b9-0fcd-4d26-83b6-b90fcd2d26ec",
+                aDebugApiV4Definition(httpRequest)
+            );
+
+            when(accessPointManager.getByEnvironmentId(any())).thenReturn(
+                List.of(
+                    ReactableAccessPoint.builder()
+                        .host("kafka-only.gravitee.io:9092")
+                        .target(ReactableAccessPoint.Target.KAFKA_GATEWAY)
+                        .build()
+                )
+            );
+
+            var result = debugReactorEventListener.buildHeaders(debugApiV4, httpRequest);
+
+            assertThat(result.get("host")).isEqualTo("kafka-only.gravitee.io:9092");
+        }
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-apis.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-apis.yaml
@@ -4951,6 +4951,45 @@ components:
                     description: Enable technical tracing to get more details on request execution. Be careful this settings would generate more noise and would impact performance.
                 redaction:
                     $ref: "#/components/schemas/TracingRedactionConfig"
+                payloadMasking:
+                    $ref: "#/components/schemas/TracingPayloadMaskingConfig"
+        TracingPayloadMaskingConfig:
+            type: object
+            properties:
+                defaultReplacement:
+                    type: string
+                    description: >
+                        Fallback replacement text for FULL masking rules with no per-rule
+                        replacement. Defaults to [REDACTED].
+                    example: "[REDACTED]"
+                rules:
+                    type: array
+                    items:
+                        $ref: "#/components/schemas/TracingPayloadMaskingRule"
+        TracingPayloadMaskingRule:
+            type: object
+            required:
+                - path
+            properties:
+                path:
+                    type: string
+                    description: >
+                        JSONPath expression (e.g. $.creditCard.number) or XPath expression
+                        (e.g. //CreditCard/Number) identifying the field to mask.
+                    example: "$.password"
+                maskingStrategy:
+                    $ref: "#/components/schemas/TracingMaskingStrategy"
+                phase:
+                    type: string
+                    enum: [REQUEST, RESPONSE, BOTH]
+                    default: BOTH
+                    description: Which traffic direction(s) this rule applies to.
+                format:
+                    type: string
+                    enum: [JSON, XML, AUTO]
+                    default: AUTO
+                    description: >
+                        Body format. AUTO detects from Content-Type header and body heuristics.
         TracingRedactionConfig:
             type: object
             properties:


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-13577
https://gravitee.atlassian.net/browse/APIM-13580
https://gravitee.atlassian.net/browse/APIM-13581

## Description

Implements OTel payload masking for verbose tracing (APIM-13569).

When verbose tracing is enabled on a V4 proxy API, the gateway captures request and response bodies as span events. This PR adds the ability to define masking rules that redact sensitive fields inside those bodies before they are exported to the tracing backend (Jaeger/Tempo).

  ### What's included

  **APIM-13577 - Payload span event capture**
Captures request/response bodies at 4 points in the pipeline (entrypoint/endpoint × request/response) and attaches each as a `payload` span event with `payload.body`, `payload.format`, and `payload.phase` attributes. Capture is gated by `tracing.verbose = true`- the log processor chain (`LogInitProcessor`, `LogRequestProcessor`,
  `LogResponseProcessor`) is now also activated when verbose mode is on, without requiring logging to be separately configured.

  **APIM-13580 - Per-API rules wiring**
Adds `TracingPayloadMaskingRule/Config` to the V4 API definition model and a `TracingPayloadMaskingMapper` that converts per-API rules and passes them to the OTel tracer factory alongside the existing redaction config. Global rules from `gravitee.yml` are always merged in first.

  **APIM-13581 - Console UI**
Adds a Payload Masking section in API → Reporter Settings, visible only when both Tracing and Verbose are enabled. API owners can add/edit/delete rules with path (JSONPath or XPath), format (JSON/XML/AUTO), phase (REQUEST/RESPONSE/BOTH), and masking type (FULL or PARTIAL with live preview). OpenAPI schema updated accordingly.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

