### PR TITLE
feat(portal): add route for configuring consumer subscription

### DIFF
--- a/gravitee-apim-portal-webui-next/src/app/app.routes.ts
+++ b/gravitee-apim-portal-webui-next/src/app/app.routes.ts
@@ -172,6 +172,13 @@ export const routes: Routes = [
         loadComponent: () => import('./dashboard/subscription-details/subscription-details.component'),
       },
       {
+        path: 'subscriptions/:subscriptionId/configure',
+        loadComponent: () =>
+          import('../components/subscription/webhook/configure-consumer/configure-consumer.component').then(
+            m => m.ConfigureConsumerComponent,
+          ),
+      },
+      {
         path: 'applications',
         loadComponent: () => import('./dashboard/applications/applications.component'),
       },


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-14020

## Description

- Fixes a 404 when opening **Advanced configuration** for push-plan (webhook) subscriptions from the new developer portal dashboard.
- After subscribing, users are redirected to `/dashboard/subscriptions/:subscriptionId`. The **Advanced configuration** button uses a relative `configure` link, but no dashboard route existed for that path. The configure UI (`ConfigureConsumerComponent`) was already implemented and wired for the catalog path only (`/catalog/api/:apiId/subscriptions/:subscriptionId/configure`).

## Root cause
- `subscription-consumer-configuration.component.html` links to `[routerLink]="'configure'"`.
- Post-subscribe navigation targets `/dashboard/subscriptions/:subscriptionId` (`subscribe-to-api.component.ts`).
- Dashboard routing defined `subscriptions/:subscriptionId` (details) but not `subscriptions/:subscriptionId/configure`.

## Solution
Add a dashboard route for consumer configuration that lazy-loads the existing `ConfigureConsumerComponent`:

https://github.com/user-attachments/assets/098dae78-10d1-4461-a35f-e537cda258ca


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

