### PR TITLE
feat(repository): add TracingRepository SPI

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/tracing/api/TracingRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/tracing/api/TracingRepository.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.tracing.api;
+
+import io.gravitee.repository.common.query.QueryContext;
+import io.gravitee.repository.tracing.model.Trace;
+import io.gravitee.repository.tracing.model.TraceSearchCriteria;
+import io.reactivex.rxjava3.core.Maybe;
+import io.reactivex.rxjava3.core.Single;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Backend-agnostic port for querying stored traces. Implementations adapt this contract to a specific tracing backend
+ * (Grafana Tempo today; Jaeger / direct OTLP could follow).
+ * <p>
+ * {@link QueryContext} carries the caller's org/env tenancy and is used to resolve tenant-aware indices / headers
+ * (e.g. {@code X-Scope-OrgID} on Tempo, the {@code {orgId}} placeholder substituted into the Elasticsearch index
+ * template). All other query scoping — environment, module, region, anything attached to the producer's OTel
+ * resource — flows through {@link TraceSearchCriteria#resourceAttributeFilters()} (for {@code searchTraces}) or
+ * the equivalent map argument on {@link #getTrace(QueryContext, String, Map)}. Implementations apply the map
+ * uniformly; they have no built-in knowledge of which keys belong on the resource.
+ *
+ * @author GraviteeSource Team
+ */
+public interface TracingRepository {
+    /**
+     * List traces matching the given filter. The returned {@link Trace} entries carry summary fields only;
+     * {@code spans} is always empty — call {@link #getTrace(QueryContext, String, Map)} to fetch a trace's spans.
+     *
+     * @param queryContext caller's org/env, used to resolve tenant-aware indices/headers
+     * @param criteria filter (attribute filters, resource-attribute filters, time window, limit)
+     * @return list of matching traces; emits an empty list when no trace matches
+     */
+    Single<List<Trace>> searchTraces(QueryContext queryContext, TraceSearchCriteria criteria);
+
+    /**
+     * Fetch a single trace by id, including its full span tree.
+     *
+     * @param queryContext caller's org/env, used to resolve tenant-aware indices/headers
+     * @param traceId the trace identifier
+     * @param resourceAttributeFilters resource-attribute scope (env, module, …) the trace must match. Empty map
+     *                                 means "no resource scoping" — the caller is responsible for adding
+     *                                 isolation filters (env, module) so a known trace id from another scope
+     *                                 isn't returned. Same shape as
+     *                                 {@link TraceSearchCriteria#resourceAttributeFilters()}.
+     * @return the trace; completes empty when the backend has no trace for that id, or when the trace exists
+     *         but doesn't satisfy the resource filter
+     */
+    Maybe<Trace> getTrace(QueryContext queryContext, String traceId, Map<String, String> resourceAttributeFilters);
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/tracing/model/Trace.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/tracing/model/Trace.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.tracing.model;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Aggregated view of a distributed trace returned by a {@link io.gravitee.repository.tracing.api.TracingRepository}.
+ * <p>
+ * In list responses {@code spans} is empty (the backend only carries summary attributes); {@code spans} is populated when the
+ * trace is fetched by id. {@code hasError} may be {@code null} when the backend cannot determine the error status.
+ *
+ * @author GraviteeSource Team
+ */
+public record Trace(
+    String traceId,
+    Instant startTime,
+    long durationNanos,
+    String rootService,
+    String rootOperation,
+    Boolean hasError,
+    List<TraceSpan> spans
+) {
+    public Trace {
+        if (spans == null) {
+            spans = new ArrayList<>();
+        }
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/tracing/model/TraceSearchCriteria.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/tracing/model/TraceSearchCriteria.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.tracing.model;
+
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Filter passed to {@link io.gravitee.repository.tracing.api.TracingRepository#searchTraces}.
+ * <p>
+ * Two separate equality-filter maps matching the OTel attribute split:
+ * <ul>
+ *   <li>{@code attributeFilters} — span-attribute filters. The backend encodes each entry against the per-span
+ *       attribute store (e.g. {@code attributes.<key>} in Elasticsearch, {@code span.<key>} in TraceQL).</li>
+ *   <li>{@code resourceAttributeFilters} — resource-attribute filters. The backend encodes each entry against
+ *       the resource-level attribute store (e.g. {@code resource.attributes.<key>} in Elasticsearch,
+ *       {@code resource.<key>} in TraceQL). Use this for properties set by the producer's OTel SDK once per
+ *       process — service identity, environment, deployment module, region, etc. — rather than per-span tags.</li>
+ * </ul>
+ * Separating the two avoids the impl having to guess (by prefix or hardcoded key list) where each entry
+ * belongs, and lines up with how the backends actually store attributes.
+ *
+ * @author GraviteeSource Team
+ */
+public record TraceSearchCriteria(
+    Map<String, String> attributeFilters,
+    Integer limit,
+    Instant start,
+    Instant end,
+    Map<String, String> resourceAttributeFilters
+) {
+    public TraceSearchCriteria {
+        if (limit == null || limit <= 0) {
+            limit = 20;
+        }
+        if (attributeFilters == null) {
+            attributeFilters = new HashMap<>();
+        }
+        if (resourceAttributeFilters == null) {
+            resourceAttributeFilters = new HashMap<>();
+        }
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/tracing/model/TraceSpan.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/tracing/model/TraceSpan.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.tracing.model;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * A single span inside a {@link Trace}. {@code children} is a tree-projection field reserved for callers that want to rebuild
+ * the parent/child hierarchy locally — backends return spans flat and leave it empty (see {@link #of}).
+ *
+ * @author GraviteeSource Team
+ */
+public record TraceSpan(
+    String traceId,
+    String spanId,
+    String parentSpanId,
+    String operationName,
+    String serviceName,
+    Instant startTime,
+    long durationNanos,
+    Map<String, String> attributes,
+    List<TraceSpanEvent> events,
+    List<TraceSpan> children
+) {
+    public TraceSpan {
+        if (children == null) {
+            children = new ArrayList<>();
+        }
+        if (attributes == null) {
+            attributes = new HashMap<>();
+        }
+        if (events == null) {
+            events = new ArrayList<>();
+        }
+    }
+
+    public static TraceSpan of(
+        String traceId,
+        String spanId,
+        String parentSpanId,
+        String operationName,
+        String serviceName,
+        Instant startTime,
+        long durationNanos,
+        Map<String, String> attributes,
+        List<TraceSpanEvent> events
+    ) {
+        return new TraceSpan(
+            traceId,
+            spanId,
+            parentSpanId,
+            operationName,
+            serviceName,
+            startTime,
+            durationNanos,
+            attributes,
+            events,
+            new ArrayList<>()
+        );
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/tracing/model/TraceSpanEvent.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/tracing/model/TraceSpanEvent.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.tracing.model;
+
+import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * A timestamped event attached to a {@link TraceSpan} (e.g. {@code exception}, {@code gravitee.policy.pre},
+ * {@code gravitee.policy.post}).
+ *
+ * @author GraviteeSource Team
+ */
+public record TraceSpanEvent(String name, Instant time, Map<String, String> attributes) {
+    public TraceSpanEvent {
+        if (attributes == null) {
+            attributes = new LinkedHashMap<>();
+        }
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/tracing/TracingRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/tracing/TracingRepositoryTest.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.tracing;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.repository.common.query.QueryContext;
+import io.gravitee.repository.config.AbstractRepositoryTest;
+import io.gravitee.repository.tracing.api.TracingRepository;
+import io.gravitee.repository.tracing.model.Trace;
+import io.gravitee.repository.tracing.model.TraceSearchCriteria;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * Shared contract for {@link TracingRepository} implementations. Traces aren't writable through the SPI, so this test
+ * doesn't drive a JSON-based create flow — implementations must seed the {@link Fixtures fixture} traces into their
+ * backend from {@code TestRepositoryInitializer.setUp()} before each test.
+ *
+ * @author GraviteeSource Team
+ */
+public abstract class TracingRepositoryTest extends AbstractRepositoryTest {
+
+    @Autowired
+    @SuppressWarnings("SpringJavaInjectionPointsAutowiringInspection")
+    protected TracingRepository tracingRepository;
+
+    /**
+     * Fixed query context used by every assertion. Implementations whose backend is tenant-aware (Elasticsearch index
+     * template substitution; future Tempo {@code X-Scope-OrgID}) must wire their fixture-seeding pipeline so the
+     * fixtures land where this org/env resolves to.
+     */
+    protected static final QueryContext QUERY_CONTEXT = new QueryContext(Fixtures.ORG_ID, Fixtures.ENV_ID);
+
+    /**
+     * Tracing has no write-side SPI, so the standard JSON-driven {@code createModel} flow doesn't apply. Implementations
+     * push the {@link Fixtures} traces into the backend from their {@code TestRepositoryInitializer.setUp()} instead.
+     */
+    @Override
+    protected String getTestCasesPath() {
+        return null;
+    }
+
+    @Override
+    protected String getModelPackage() {
+        return null;
+    }
+
+    @Override
+    protected void createModel(Object object) {
+        // no-op: see class-level Javadoc
+    }
+
+    @Test
+    public void should_search_traces_matching_service_tag() {
+        List<Trace> traces = tracingRepository
+            .searchTraces(QUERY_CONTEXT, new TraceSearchCriteria(Map.of("service.name", Fixtures.SERVICE_NAME), 20, null, null, Map.of()))
+            .blockingGet();
+
+        assertThat(traces).extracting(Trace::traceId).containsExactlyInAnyOrder(Fixtures.TRACE_OK_ID, Fixtures.TRACE_ERROR_ID);
+    }
+
+    @Test
+    public void should_return_empty_list_when_no_trace_matches() {
+        List<Trace> traces = tracingRepository
+            .searchTraces(
+                QUERY_CONTEXT,
+                new TraceSearchCriteria(Map.of("service.name", "service-that-does-not-exist"), 20, null, null, Map.of())
+            )
+            .blockingGet();
+
+        assertThat(traces).isEmpty();
+    }
+
+    @Test
+    public void should_get_trace_by_id_with_full_span_tree() {
+        Trace trace = tracingRepository.getTrace(QUERY_CONTEXT, Fixtures.TRACE_OK_ID, Map.of()).blockingGet();
+
+        assertThat(trace).isNotNull();
+        assertThat(trace.traceId()).isEqualTo(Fixtures.TRACE_OK_ID);
+        assertThat(trace.rootService()).isEqualTo(Fixtures.SERVICE_NAME);
+        assertThat(trace.rootOperation()).isEqualTo(Fixtures.TRACE_OK_ROOT_OPERATION);
+        assertThat(trace.spans()).hasSize(1);
+        assertThat(trace.spans().get(0).attributes()).containsEntry("http.status_code", "200");
+    }
+
+    @Test
+    public void should_complete_empty_when_trace_id_is_unknown() {
+        Trace trace = tracingRepository.getTrace(QUERY_CONTEXT, Fixtures.UNKNOWN_TRACE_ID, Map.of()).blockingGet();
+
+        assertThat(trace).isNull();
+    }
+
+    /**
+     * Trace fixtures the implementation's {@code TestRepositoryInitializer.setUp()} must seed in the backend before each
+     * test runs. Defined as a single source of truth so impl-side seeding and assertion expectations stay aligned.
+     * <p>
+     * Trace IDs are 32-character lowercase hex with a non-zero leading byte: some backends (Tempo) strip leading-zero
+     * bytes when echoing IDs back through their search API, which would break exact-match assertions on round-trip.
+     */
+    public static final class Fixtures {
+
+        /**
+         * Tenancy values used by {@link #QUERY_CONTEXT}. Implementations whose backend resolves indices/tenants from
+         * the org id ({@code traces-apim.otel-{orgId}} for Elasticsearch; {@code X-Scope-OrgID} for Tempo) must seed
+         * fixtures under this org so the contract tests find them.
+         */
+        public static final String ORG_ID = "test-org";
+        public static final String ENV_ID = "test-env";
+
+        public static final String SERVICE_NAME = "test-service";
+
+        public static final String TRACE_OK_ID = "a1b2c3d4e5f60718293a4b5c6d7e8f01";
+        public static final String TRACE_OK_ROOT_OPERATION = "GET /ok";
+        public static final Instant TRACE_OK_START_TIME = Instant.parse("2026-04-30T10:00:00Z");
+
+        public static final String TRACE_ERROR_ID = "a1b2c3d4e5f60718293a4b5c6d7e8f02";
+        public static final String TRACE_ERROR_ROOT_OPERATION = "GET /error";
+        public static final Instant TRACE_ERROR_START_TIME = Instant.parse("2026-04-30T10:01:00Z");
+
+        /** Valid-shape trace id (32-hex) that no fixture seeds — used by the not-found test. */
+        public static final String UNKNOWN_TRACE_ID = "deadbeef0000000000000000beefdead";
+
+        private Fixtures() {}
+    }
+}


### PR DESCRIPTION
## Issue

N/A — foundational SPI addition, no JIRA ticket.

## Description

Introduces a backend-agnostic read-side SPI for stored traces. Ships only the contract and a shared contract test — Elasticsearch and Tempo implementations follow in separate PRs.

**Contract**
- `searchTraces(QueryContext, TraceSearchCriteria)` returns a list of trace summaries (no spans) for listing UIs.
- `getTrace(QueryContext, traceId, resourceAttributeFilters)` returns the full span tree for a single trace, or empty when the resource scope doesn't match.

**Scoping model is explicit**
- `QueryContext.orgId` partitions hard (per-tenant index / header — backend-defined).
- `resourceAttributeFilters` (passed either via the criteria or the `getTrace` arg) scopes by OTel resource attributes (env, module, region, …). The repository emits each entry uniformly; it has no built-in knowledge of which keys are APIM concepts. That keeps the SPI reusable by other Gravitee modules.

**Shared contract test**
`TracingRepositoryTest` is abstract — implementations subclass from their integration test module and seed fixtures from their own `TestRepositoryInitializer` (tracing has no write-side SPI, so fixtures land via the impl's collector / ingestion pipeline).

## Additional context

This is **PR 1 of 5** in the tracing read-side rollout. Subsequent PRs:
1. ✅ This PR — TracingRepository SPI + shared contract test
2. Gateway producer enrichment (gravitee.module / api.id / env.id span attributes)
3. ElasticsearchTracingRepository impl + OTEL_TRACES scope wiring in rest-api
4. TempoTracingRepository plugin + gravitee-node bump to 9.0.0-alpha.12
5. gamma-module-apim TracingResource consuming the SPI

🤖 Generated with [Claude Code](https://claude.com/claude-code)