### PR TITLE
feat: update existing v4 API via URL

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource.java
@@ -32,6 +32,7 @@ import io.gravitee.apim.core.api.use_case.ExportApiCRDUseCase;
 import io.gravitee.apim.core.api.use_case.ExportApiUseCase;
 import io.gravitee.apim.core.api.use_case.GetApiDefinitionUseCase;
 import io.gravitee.apim.core.api.use_case.GetExposedEntrypointsUseCase;
+import io.gravitee.apim.core.api.use_case.ImportApiDefinitionFromUrlUseCase;
 import io.gravitee.apim.core.api.use_case.MigrateApiUseCase;
 import io.gravitee.apim.core.api.use_case.OAIToUpdateApiUseCase;
 import io.gravitee.apim.core.api.use_case.PatchApiUseCase;
@@ -137,6 +138,7 @@ import io.gravitee.rest.api.service.exceptions.InvalidLicenseException;
 import io.gravitee.rest.api.service.exceptions.PreconditionFailedException;
 import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
 import io.gravitee.rest.api.service.exceptions.TransferOwnershipNotAllowedException;
+import io.gravitee.rest.api.service.spring.ImportConfiguration;
 import io.gravitee.rest.api.service.v4.ApiDuplicateService;
 import io.gravitee.rest.api.service.v4.ApiImagesService;
 import io.gravitee.rest.api.service.v4.ApiLicenseService;
@@ -278,6 +280,15 @@ public class ApiResource extends AbstractResource {
     private UpdateApiDefinitionFromImportUseCase updateApiDefinitionUseCase;
 
     @Inject
+    private ImportApiDefinitionFromUrlUseCase importApiDefinitionFromUrlUseCase;
+
+    @Inject
+    private ImportConfiguration importConfiguration;
+
+    @Inject
+    private RemoteApiDefinitionParser remoteApiDefinitionParser;
+
+    @Inject
     private OAIToUpdateApiUseCase oaiToUpdateApiUseCase;
 
     @Inject
@@ -383,6 +394,23 @@ public class ApiResource extends AbstractResource {
         );
 
         return Response.ok().entity(ApiMapper.INSTANCE.map(output.apiWithFlows(), uriInfo, isSynchronized)).build();
+    }
+
+    @PUT
+    @Path("/_import/definition-url")
+    @Consumes(MediaType.TEXT_PLAIN)
+    @Produces(MediaType.APPLICATION_JSON)
+    @Permissions({ @Permission(value = RolePermission.API_DEFINITION, acls = RolePermissionAction.UPDATE) })
+    public Response updateApiWithDefinitionFromUrl(@PathParam("apiId") String apiId, @NotNull String apiDefinitionUrl) {
+        var input = new ImportApiDefinitionFromUrlUseCase.Input(
+            apiDefinitionUrl,
+            importConfiguration.getImportWhitelist(),
+            importConfiguration.isAllowImportFromPrivate()
+        );
+        var output = importApiDefinitionFromUrlUseCase.execute(input);
+
+        ExportApiV4 apiToImport = remoteApiDefinitionParser.parseAndValidate(output.apiDefinitionContent());
+        return updateApiWithDefinition(apiId, apiToImport);
     }
 
     @PUT

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApisResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApisResource.java
@@ -27,8 +27,6 @@ import static io.gravitee.rest.api.service.impl.search.lucene.transformer.ApiDoc
 import static io.gravitee.rest.api.service.impl.search.lucene.transformer.ApiDocumentTransformer.FIELD_TYPE_VALUE;
 import static io.gravitee.rest.api.service.impl.search.lucene.transformer.ApiDocumentTransformer.FIELD_VISIBILITY;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Strings;
 import io.gravitee.apim.core.api.domain_service.ApiStateDomainService;
 import io.gravitee.apim.core.api.exception.InvalidPathsException;
@@ -84,11 +82,7 @@ import io.gravitee.rest.api.service.spring.ImportConfiguration;
 import io.gravitee.rest.api.service.v4.ApiStateService;
 import io.gravitee.rest.api.service.v4.exception.InvalidPathException;
 import jakarta.inject.Inject;
-import jakarta.validation.ConstraintViolation;
-import jakarta.validation.ConstraintViolationException;
 import jakarta.validation.Valid;
-import jakarta.validation.Validation;
-import jakarta.validation.Validator;
 import jakarta.validation.constraints.NotNull;
 import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.BeanParam;
@@ -173,9 +167,7 @@ public class ApisResource extends AbstractResource {
     private ImportConfiguration importConfiguration;
 
     @Inject
-    private ObjectMapper objectMapper;
-
-    private static final Validator VALIDATOR = Validation.buildDefaultValidatorFactory().getValidator();
+    private RemoteApiDefinitionParser remoteApiDefinitionParser;
 
     @POST
     @Produces(MediaType.APPLICATION_JSON)
@@ -342,21 +334,8 @@ public class ApisResource extends AbstractResource {
         );
         var output = importApiDefinitionFromUrlUseCase.execute(input);
 
-        ExportApiV4 apiToImport = parseApiDefinition(output.apiDefinitionContent());
-        Set<ConstraintViolation<ExportApiV4>> violations = VALIDATOR.validate(apiToImport);
-        if (!violations.isEmpty()) {
-            throw new ConstraintViolationException(violations);
-        }
+        ExportApiV4 apiToImport = remoteApiDefinitionParser.parseAndValidate(output.apiDefinitionContent());
         return createApiWithDefinition(apiToImport);
-    }
-
-    private ExportApiV4 parseApiDefinition(String apiDefinitionContent) {
-        try {
-            return objectMapper.readValue(apiDefinitionContent, ExportApiV4.class);
-        } catch (JsonProcessingException e) {
-            log.warn("Failed to parse API definition fetched from URL", e);
-            throw new BadRequestException("Invalid API definition format");
-        }
     }
 
     private static void verifyImage(String imageContent, String imageUsage) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api/RemoteApiDefinitionParser.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api/RemoteApiDefinitionParser.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.management.v2.rest.resource.api;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.gravitee.rest.api.management.v2.rest.model.ExportApiV4;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.ConstraintViolationException;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.ws.rs.BadRequestException;
+import java.util.Set;
+import lombok.CustomLog;
+
+/**
+ * Parses and validates a Gravitee {@link ExportApiV4} definition fetched from a remote URL.
+ *
+ * <p>Shared between {@code ApisResource} (create-from-URL) and {@code ApiResource} (update-from-URL).
+ * The post-fetch parse + validate path is identical across both endpoints, so it lives here rather than
+ * being duplicated in each resource. Registered as a Spring bean by {@code RestManagementConfiguration}
+ * (and the test counterpart) — no {@code @Component} annotation, following the explicit-bean convention
+ * used throughout the v2 rest module.
+ */
+@CustomLog
+public class RemoteApiDefinitionParser {
+
+    private static final Validator VALIDATOR = Validation.buildDefaultValidatorFactory().getValidator();
+
+    private final ObjectMapper objectMapper;
+
+    public RemoteApiDefinitionParser(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    /**
+     * Deserializes the JSON content into an {@link ExportApiV4} and runs Bean Validation against it.
+     *
+     * <p>Bean Validation is run explicitly because the caller invokes the existing JSON import methods as
+     * plain Java methods (not via JAX-RS dispatch), which would otherwise bypass {@code @Valid} constraints
+     * on those endpoint parameters.
+     *
+     * @throws BadRequestException if the content is not parseable JSON. The Jackson exception detail is
+     *     logged at warn level but never returned to the caller, to avoid leaking internal class paths or
+     *     fragments of the remote body through the error message.
+     * @throws ConstraintViolationException if the parsed definition fails Bean Validation.
+     */
+    public ExportApiV4 parseAndValidate(String apiDefinitionContent) {
+        ExportApiV4 apiToImport;
+        try {
+            apiToImport = objectMapper.readValue(apiDefinitionContent, ExportApiV4.class);
+        } catch (JsonProcessingException e) {
+            log.warn("Failed to parse API definition fetched from URL", e);
+            throw new BadRequestException("Invalid API definition format");
+        }
+        Set<ConstraintViolation<ExportApiV4>> violations = VALIDATOR.validate(apiToImport);
+        if (!violations.isEmpty()) {
+            throw new ConstraintViolationException(violations);
+        }
+        return apiToImport;
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/spring/RestManagementConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/spring/RestManagementConfiguration.java
@@ -36,6 +36,7 @@ import io.gravitee.repository.management.api.ApiRepository;
 import io.gravitee.rest.api.kafkaexplorer.spring.KafkaExplorerSpringConfiguration;
 import io.gravitee.rest.api.management.v2.rest.mapper.FlowMapper;
 import io.gravitee.rest.api.management.v2.rest.model.FlowV4;
+import io.gravitee.rest.api.management.v2.rest.resource.api.RemoteApiDefinitionParser;
 import io.gravitee.rest.api.management.v2.rest.utils.SubscriptionExpandHelper;
 import io.gravitee.rest.api.service.ApplicationService;
 import io.gravitee.rest.api.service.UserService;
@@ -71,6 +72,11 @@ public class RestManagementConfiguration {
     @Bean
     public ExpressionLanguageInitializer expressionLanguageInitializer() {
         return new ExpressionLanguageInitializer();
+    }
+
+    @Bean
+    public RemoteApiDefinitionParser remoteApiDefinitionParser(ObjectMapper objectMapper) {
+        return new RemoteApiDefinitionParser(objectMapper);
     }
 
     @Bean

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-apis.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-apis.yaml
@@ -730,6 +730,39 @@ paths:
                 default:
                     $ref: "#/components/responses/Error"
 
+    /environments/{envId}/apis/{apiId}/_import/definition-url:
+        parameters:
+            - $ref: "#/components/parameters/envIdParam"
+            - $ref: "#/components/parameters/apiIdParam"
+        put:
+            tags:
+                - APIs
+            summary: Update API from a definition fetched from a remote URL
+            description: |-
+                ⚠️ Support only v4 API for the moment. ⚠️<br>
+                Update an existing API by fetching a Gravitee API definition from a remote URL.<br>
+                The URL must be permitted by the configured import whitelist.
+
+                User must have the API_DEFINITION[UPDATE] permission.
+            operationId: updateApiWithDefinitionFromUrl
+            requestBody:
+                content:
+                    text/plain:
+                        schema:
+                            type: string
+                            format: uri
+                            example: https://example.com/api-definition.json
+                required: true
+            responses:
+                "200":
+                    description: API successfully updated
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/ApiV4"
+                default:
+                    $ref: "#/components/responses/Error"
+
     /environments/{envId}/apis/{apiId}/_import/swagger:
         parameters:
             - $ref: "#/components/parameters/envIdParam"

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource_UpdateApiWithDefinitionFromUrlTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource_UpdateApiWithDefinitionFromUrlTest.java
@@ -1,0 +1,263 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.management.v2.rest.resource.api;
+
+import static io.gravitee.common.http.HttpStatusCode.BAD_REQUEST_400;
+import static io.gravitee.common.http.HttpStatusCode.FORBIDDEN_403;
+import static io.gravitee.common.http.HttpStatusCode.INTERNAL_SERVER_ERROR_500;
+import static io.gravitee.common.http.HttpStatusCode.OK_200;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import fixtures.core.model.ApiFixtures;
+import io.gravitee.apim.core.api.model.ApiWithFlows;
+import io.gravitee.apim.core.api.use_case.UpdateApiDefinitionFromImportUseCase;
+import io.gravitee.common.http.HttpMethod;
+import io.gravitee.rest.api.model.permissions.RolePermission;
+import io.gravitee.rest.api.model.permissions.RolePermissionAction;
+import io.gravitee.rest.api.service.HttpClientService;
+import io.gravitee.rest.api.service.common.GraviteeContext;
+import io.gravitee.rest.api.service.spring.ImportConfiguration;
+import io.vertx.core.buffer.Buffer;
+import jakarta.ws.rs.client.Entity;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+
+class ApiResource_UpdateApiWithDefinitionFromUrlTest extends ApiResourceTest {
+
+    private static final String TEST_URL = "https://example.com/api-definition.json";
+
+    /**
+     * The {@code api.id} in this fixture intentionally differs from the path {@link #API}: the contract is that the path
+     * parameter wins (the use case receives the path apiId), so the body's id must be ignored.
+     */
+    private static final String BODY_API_ID = "id-from-body-should-be-ignored";
+    private static final String VALID_API_DEFINITION_JSON = """
+        {
+          "api": {
+            "id": "%s",
+            "name": "Test API",
+            "description": "Test API Description",
+            "version": "1.0.0",
+            "definitionVersion": "V4",
+            "type": "PROXY",
+            "apiVersion": "1.0.0",
+            "listeners": [
+              {
+                "type": "HTTP",
+                "paths": [
+                  {
+                    "path": "/test"
+                  }
+                ],
+                "entrypoints": [
+                  {
+                    "type": "http-proxy"
+                  }
+                ]
+              }
+            ],
+            "endpointGroups": [
+              {
+                "name": "default-group",
+                "type": "http-proxy",
+                "endpoints": [
+                  {
+                    "name": "default",
+                    "type": "http-proxy",
+                    "weight": 1,
+                    "inheritConfiguration": false,
+                    "configuration": {
+                      "target": "http://localhost:8080/endpoint"
+                    }
+                  }
+                ]
+              }
+            ],
+            "flowExecution": {
+              "mode": "DEFAULT",
+              "matchRequired": false
+            },
+            "flows": [],
+            "responseTemplates": {},
+            "analytics": {
+              "enabled": false
+            },
+            "lifecycleState": "CREATED"
+          },
+          "plans": []
+        }
+        """.formatted(BODY_API_ID);
+
+    @Autowired
+    private HttpClientService httpClientService;
+
+    @Autowired
+    private ImportConfiguration importConfiguration;
+
+    @Override
+    protected String contextPath() {
+        return "/environments/" + ENVIRONMENT + "/apis/" + API + "/_import/definition-url";
+    }
+
+    @BeforeEach
+    public void initUrlImportMocks() {
+        reset(httpClientService, importConfiguration);
+        when(importConfiguration.getImportWhitelist()).thenReturn(Collections.emptyList());
+        when(importConfiguration.isAllowImportFromPrivate()).thenReturn(false);
+    }
+
+    @Test
+    public void should_return_403_when_no_definition_update_permission() {
+        when(
+            permissionService.hasPermission(
+                GraviteeContext.getExecutionContext(),
+                RolePermission.API_DEFINITION,
+                API,
+                RolePermissionAction.UPDATE
+            )
+        ).thenReturn(false);
+
+        Response response = rootTarget().request().put(Entity.text(TEST_URL));
+
+        assertThat(response.getStatus()).isEqualTo(FORBIDDEN_403);
+    }
+
+    @Test
+    public void should_update_api_from_url_when_url_is_valid() {
+        when(
+            permissionService.hasPermission(
+                GraviteeContext.getExecutionContext(),
+                RolePermission.API_DEFINITION,
+                API,
+                RolePermissionAction.UPDATE
+            )
+        ).thenReturn(true);
+
+        Buffer buffer = Buffer.buffer(VALID_API_DEFINITION_JSON);
+        when(httpClientService.request(eq(HttpMethod.GET), eq(TEST_URL), any(), any(), any())).thenReturn(buffer);
+
+        var existingApi = ApiFixtures.aProxyApiV4().toBuilder().id(API).environmentId(ENVIRONMENT).build();
+        var apiWithFlows = new ApiWithFlows(existingApi, List.of());
+        when(updateApiDefinitionUseCase.execute(any())).thenReturn(new UpdateApiDefinitionFromImportUseCase.Output(apiWithFlows));
+        when(apiSearchServiceV4.findById(GraviteeContext.getExecutionContext(), API)).thenReturn(
+            io.gravitee.rest.api.model.v4.api.ApiEntity.builder().id(API).name("Test API").apiVersion("1.0").build()
+        );
+
+        Response response = rootTarget().request().put(Entity.text(TEST_URL));
+
+        assertThat(response.getStatus()).isEqualTo(OK_200);
+        verify(httpClientService).request(eq(HttpMethod.GET), eq(TEST_URL), any(), any(), any());
+
+        ArgumentCaptor<UpdateApiDefinitionFromImportUseCase.Input> inputCaptor = ArgumentCaptor.forClass(
+            UpdateApiDefinitionFromImportUseCase.Input.class
+        );
+        verify(updateApiDefinitionUseCase).execute(inputCaptor.capture());
+        assertThat(inputCaptor.getValue().apiId())
+            .as("Path apiId must win over body id; got %s", inputCaptor.getValue().apiId())
+            .isEqualTo(API)
+            .isNotEqualTo(BODY_API_ID);
+    }
+
+    @Test
+    public void should_return_bad_request_when_url_is_private_and_private_not_allowed() {
+        when(
+            permissionService.hasPermission(
+                GraviteeContext.getExecutionContext(),
+                RolePermission.API_DEFINITION,
+                API,
+                RolePermissionAction.UPDATE
+            )
+        ).thenReturn(true);
+
+        String privateUrl = "http://localhost:8080/api-definition.json";
+        Response response = rootTarget().request().put(Entity.text(privateUrl));
+
+        assertThat(response.getStatus()).isEqualTo(BAD_REQUEST_400);
+    }
+
+    @Test
+    public void should_return_bad_request_when_url_returns_invalid_json() {
+        when(
+            permissionService.hasPermission(
+                GraviteeContext.getExecutionContext(),
+                RolePermission.API_DEFINITION,
+                API,
+                RolePermissionAction.UPDATE
+            )
+        ).thenReturn(true);
+
+        Buffer buffer = Buffer.buffer("not valid json");
+        when(httpClientService.request(eq(HttpMethod.GET), eq(TEST_URL), any(), any(), any())).thenReturn(buffer);
+
+        Response response = rootTarget().request().put(Entity.text(TEST_URL));
+
+        assertThat(response.getStatus()).isEqualTo(BAD_REQUEST_400);
+
+        // Guard against leaking Jackson internals back to the caller (review feedback on PR #16844).
+        String body = response.readEntity(String.class);
+        assertThat(body).contains("Invalid API definition format").doesNotContain("io.gravitee", "fasterxml", "JsonProcessingException");
+    }
+
+    @Test
+    public void should_return_internal_server_error_when_http_client_throws() {
+        when(
+            permissionService.hasPermission(
+                GraviteeContext.getExecutionContext(),
+                RolePermission.API_DEFINITION,
+                API,
+                RolePermissionAction.UPDATE
+            )
+        ).thenReturn(true);
+
+        when(httpClientService.request(eq(HttpMethod.GET), eq(TEST_URL), any(), any(), any())).thenThrow(
+            new RuntimeException("Connection refused")
+        );
+
+        Response response = rootTarget().request().put(Entity.text(TEST_URL));
+
+        assertThat(response.getStatus()).isEqualTo(INTERNAL_SERVER_ERROR_500);
+    }
+
+    @Test
+    public void should_reject_url_not_in_whitelist() {
+        when(
+            permissionService.hasPermission(
+                GraviteeContext.getExecutionContext(),
+                RolePermission.API_DEFINITION,
+                API,
+                RolePermissionAction.UPDATE
+            )
+        ).thenReturn(true);
+
+        when(importConfiguration.getImportWhitelist()).thenReturn(List.of("https://allowed.example.com"));
+
+        String notWhitelistedUrl = "https://other.example.com/api-definition.json";
+        Response response = rootTarget().request().put(Entity.text(notWhitelistedUrl));
+
+        assertThat(response.getStatus()).isEqualTo(BAD_REQUEST_400);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/spring/ResourceContextConfiguration.java
@@ -335,6 +335,13 @@ public class ResourceContextConfiguration {
     }
 
     @Bean
+    public io.gravitee.rest.api.management.v2.rest.resource.api.RemoteApiDefinitionParser remoteApiDefinitionParser(
+        ObjectMapper objectMapper
+    ) {
+        return new io.gravitee.rest.api.management.v2.rest.resource.api.RemoteApiDefinitionParser(objectMapper);
+    }
+
+    @Bean
     public ApiRepository apiRepository() {
         return mock(ApiRepository.class);
     }


### PR DESCRIPTION
## Issue

Subtask: https://gravitee.atlassian.net/browse/APIM-14116
Parent: https://gravitee.atlassian.net/browse/APIM-12142

## Description

  - Add PUT /environments/{envId}/apis/{apiId}/_import/definition-url — fetches a Gravitee API definition from a remote URL and updates the target API in one call. The path apiId is authoritative.
  - Reuses ImportApiDefinitionFromUrlUseCase (URL fetch + sanitize) and delegates to the existing updateApiWithDefinition after parsing + validating the body — same pattern as createApiWithDefinitionFromUrl.
  - Honors the same imports.whitelist / imports.allow-from-private config as the create endpoint.

  Test plan

  - mvn test on gravitee-apim-rest-api-management-v2-rest — 6/6 pass on ApiResource_UpdateApiWithDefinitionFromUrlTest covering: 403 no permission, success (with ArgumentCaptor asserting path apiId beats body id),
  private URL forbidden, invalid JSON (with body assertions that no Jackson internals leak), HTTP client throws → 500, URL not in whitelist
  - mvn prettier:check on the module — clean
  - Neighboring tests unaffected (ApisResource_CreateApiWithDefinitionFromUrlTest, ApiResource_UpdateApiWithDefinitionTest)
  - Manual smoke test: PUT a URL serving a Gravitee export to an existing API, confirm the update lands

  Notes for reviewers

  - Targets master. Companion frontend work for APIM-12142 will be a separate PR.
  - Code review checks from PR #16844 (APIM-12140) are pre-applied: explicit Validator.validate(apiToImport), bare BadRequestException("Invalid API definition format") with detail logged only, @CustomLog already on
   ApiResource.
  - Followups (deferred, not blockers): (1) parseApiDefinition + VALIDATOR are now duplicated between ApisResource and ApiResource — worth extracting when APIM-12143 (OpenAPI create-from-URL) lands a third copy.
  (2) ImportApiDefinitionFromUrlUseCase is misnamed (it only fetches); rename in a follow-up.
## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

