### PR TITLE
fix: api product access resolution

### DIFF
--- a/gravitee-apim-console-webui/src/management/api-products/api-products.routes.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/api-products.routes.ts
@@ -71,6 +71,12 @@ export const API_PRODUCTS_ROUTES: Routes = [
       {
         path: 'apis',
         loadComponent: () => import('./apis/api-product-apis.component').then(m => m.ApiProductApisComponent),
+        data: {
+          permissions: {
+            anyOf: ['api_product-definition-r'],
+            unauthorizedFallbackTo: 'configuration/general',
+          },
+        },
       },
       {
         path: 'consumers',

--- a/gravitee-apim-console-webui/src/management/api-products/api-products.routes.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/api-products.routes.ts
@@ -71,12 +71,6 @@ export const API_PRODUCTS_ROUTES: Routes = [
       {
         path: 'apis',
         loadComponent: () => import('./apis/api-product-apis.component').then(m => m.ApiProductApisComponent),
-        data: {
-          permissions: {
-            anyOf: ['api_product-definition-r'],
-            unauthorizedFallbackTo: 'configuration/general',
-          },
-        },
       },
       {
         path: 'consumers',

--- a/gravitee-apim-console-webui/src/management/api-products/configuration/api-product-configuration.component.html
+++ b/gravitee-apim-console-webui/src/management/api-products/configuration/api-product-configuration.component.html
@@ -55,6 +55,7 @@
       <api-product-danger-zone
         [apiProduct]="product"
         [isReadOnly]="isReadOnly"
+        [canDelete]="canDeleteApiProduct"
         (removeApisClick)="onRemoveApis()"
         (deleteApiProductClick)="onDeleteApiProduct()"
       ></api-product-danger-zone>

--- a/gravitee-apim-console-webui/src/management/api-products/configuration/api-product-configuration.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/configuration/api-product-configuration.component.spec.ts
@@ -57,7 +57,7 @@ describe('ApiProductConfigurationComponent', () => {
       providers: [
         { provide: Constants, useValue: CONSTANTS_TESTING },
         { provide: SnackBarService, useValue: fakeSnackBarService },
-        { provide: GioTestingPermissionProvider, useValue: ['api_product-definition-u'] },
+        { provide: GioTestingPermissionProvider, useValue: ['api_product-definition-u', 'api_product-definition-d'] },
         {
           provide: ActivatedRoute,
           useValue: {
@@ -135,8 +135,46 @@ describe('ApiProductConfigurationComponent', () => {
     expect(await versionInput.isDisabled()).toBe(true);
     expect(await descriptionInput.isDisabled()).toBe(true);
 
-    const deleteButton = await loader.getHarness(MatButtonHarness.with({ selector: '[data-testid="api_product_dangerzone_delete"]' }));
-    expect(await deleteButton.isDisabled()).toBe(true);
+    const deleteButton = await loader.getHarnessOrNull(
+      MatButtonHarness.with({ selector: '[data-testid="api_product_dangerzone_delete"]' }),
+    );
+    expect(deleteButton).toBeNull();
+  });
+
+  it('should hide delete when user has definition-u but not definition-d', async () => {
+    TestBed.resetTestingModule();
+    await TestBed.configureTestingModule({
+      imports: [ApiProductConfigurationComponent, GioTestingModule, MatIconTestingModule, NoopAnimationsModule],
+      providers: [
+        { provide: Constants, useValue: CONSTANTS_TESTING },
+        { provide: SnackBarService, useValue: fakeSnackBarService },
+        { provide: GioTestingPermissionProvider, useValue: ['api_product-definition-u'] },
+        {
+          provide: ActivatedRoute,
+          useValue: {
+            params: of({ apiProductId: API_PRODUCT_ID }),
+            snapshot: { params: { apiProductId: API_PRODUCT_ID } },
+          },
+        },
+      ],
+    }).compileComponents();
+    fixture = TestBed.createComponent(ApiProductConfigurationComponent);
+    loader = TestbedHarnessEnvironment.loader(fixture);
+    httpTestingController = TestBed.inject(HttpTestingController);
+    fixture.detectChanges();
+
+    const req = httpTestingController.expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/api-products/${API_PRODUCT_ID}`);
+    req.flush(fakeApiProduct);
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    const nameInput = await loader.getHarness(MatInputHarness.with({ selector: '[formControlName="name"]' }));
+    expect(await nameInput.isDisabled()).toBe(false);
+
+    const deleteButton = await loader.getHarnessOrNull(
+      MatButtonHarness.with({ selector: '[data-testid="api_product_dangerzone_delete"]' }),
+    );
+    expect(deleteButton).toBeNull();
   });
 
   it('should validate required fields', async () => {

--- a/gravitee-apim-console-webui/src/management/api-products/configuration/api-product-configuration.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/configuration/api-product-configuration.component.spec.ts
@@ -22,6 +22,7 @@ import { MatIconTestingModule } from '@angular/material/icon/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { HttpTestingController } from '@angular/common/http/testing';
 import { ActivatedRoute, Router } from '@angular/router';
+import { fakeAsync, flush, tick } from '@angular/core/testing';
 import { of } from 'rxjs';
 import { GioConfirmAndValidateDialogHarness, GioConfirmDialogHarness } from '@gravitee/ui-particles-angular';
 
@@ -56,7 +57,7 @@ describe('ApiProductConfigurationComponent', () => {
       providers: [
         { provide: Constants, useValue: CONSTANTS_TESTING },
         { provide: SnackBarService, useValue: fakeSnackBarService },
-        { provide: GioTestingPermissionProvider, useValue: ['environment-api_product-u'] },
+        { provide: GioTestingPermissionProvider, useValue: ['api_product-definition-u'] },
         {
           provide: ActivatedRoute,
           useValue: {
@@ -98,6 +99,44 @@ describe('ApiProductConfigurationComponent', () => {
     expect(form).toBeTruthy();
     expect(form?.getRawValue().name).toBe('Test API Product');
     expect(form?.getRawValue().version).toBe('1.0');
+  });
+
+  it('should disable form fields and danger zone when user lacks api_product-definition-u', async () => {
+    TestBed.resetTestingModule();
+    await TestBed.configureTestingModule({
+      imports: [ApiProductConfigurationComponent, GioTestingModule, MatIconTestingModule, NoopAnimationsModule],
+      providers: [
+        { provide: Constants, useValue: CONSTANTS_TESTING },
+        { provide: SnackBarService, useValue: fakeSnackBarService },
+        { provide: GioTestingPermissionProvider, useValue: ['api_product-definition-r'] },
+        {
+          provide: ActivatedRoute,
+          useValue: {
+            params: of({ apiProductId: API_PRODUCT_ID }),
+            snapshot: { params: { apiProductId: API_PRODUCT_ID } },
+          },
+        },
+      ],
+    }).compileComponents();
+    fixture = TestBed.createComponent(ApiProductConfigurationComponent);
+    loader = TestbedHarnessEnvironment.loader(fixture);
+    httpTestingController = TestBed.inject(HttpTestingController);
+    fixture.detectChanges();
+
+    const req = httpTestingController.expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/api-products/${API_PRODUCT_ID}`);
+    req.flush(fakeApiProduct);
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    const nameInput = await loader.getHarness(MatInputHarness.with({ selector: '[formControlName="name"]' }));
+    const versionInput = await loader.getHarness(MatInputHarness.with({ selector: '[formControlName="version"]' }));
+    const descriptionInput = await loader.getHarness(MatInputHarness.with({ selector: '[formControlName="description"]' }));
+    expect(await nameInput.isDisabled()).toBe(true);
+    expect(await versionInput.isDisabled()).toBe(true);
+    expect(await descriptionInput.isDisabled()).toBe(true);
+
+    const deleteButton = await loader.getHarness(MatButtonHarness.with({ selector: '[data-testid="api_product_dangerzone_delete"]' }));
+    expect(await deleteButton.isDisabled()).toBe(true);
   });
 
   it('should validate required fields', async () => {
@@ -151,6 +190,42 @@ describe('ApiProductConfigurationComponent', () => {
 
     expect(fakeSnackBarService.success).toHaveBeenCalledWith('Configuration successfully saved!');
   });
+
+  it('should verify renamed product name before save', fakeAsync(async () => {
+    const req = httpTestingController.expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/api-products/${API_PRODUCT_ID}`);
+    req.flush(fakeApiProduct);
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    const nameInput = await loader.getHarness(MatInputHarness.with({ selector: '[formControlName="name"]' }));
+    await nameInput.setValue('Renamed API Product');
+    tick(250);
+    fixture.detectChanges();
+
+    const verifyReq = httpTestingController.expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/api-products/_verify`);
+    expect(verifyReq.request.body).toEqual({ name: 'Renamed API Product' });
+    verifyReq.flush({ ok: true });
+    flush();
+    await fixture.whenStable();
+
+    const form = fixture.componentInstance.form;
+    form!.markAsDirty();
+    fixture.componentInstance.onSubmit();
+
+    const updateReq = httpTestingController.expectOne({
+      method: 'PUT',
+      url: `${CONSTANTS_TESTING.env.v2BaseURL}/api-products/${API_PRODUCT_ID}`,
+    });
+    expect(updateReq.request.body.name).toBe('Renamed API Product');
+    updateReq.flush({ ...fakeApiProduct, name: 'Renamed API Product' });
+
+    const refetchReq = httpTestingController.expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/api-products/${API_PRODUCT_ID}`);
+    refetchReq.flush({ ...fakeApiProduct, name: 'Renamed API Product' });
+    flush();
+    await fixture.whenStable();
+
+    expect(fakeSnackBarService.success).toHaveBeenCalledWith('Configuration successfully saved!');
+  }));
 
   it('should show snackbar on load error', async () => {
     const req = httpTestingController.expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/api-products/${API_PRODUCT_ID}`);

--- a/gravitee-apim-console-webui/src/management/api-products/configuration/api-product-configuration.component.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/configuration/api-product-configuration.component.ts
@@ -78,7 +78,7 @@ export class ApiProductConfigurationComponent {
   private readonly snackBarService = inject(SnackBarService);
   private readonly matDialog = inject(MatDialog);
 
-  protected readonly isReadOnly = !this.permissionService.hasAnyMatching(['environment-api_product-u']);
+  protected readonly isReadOnly = !this.permissionService.hasAnyMatching(['api_product-definition-u']);
 
   readonly nameMaxLength = 512;
   readonly versionMaxLength = 64;
@@ -121,6 +121,11 @@ export class ApiProductConfigurationComponent {
       version: p.version ?? '',
       description: p.description ?? '',
     });
+    if (this.isReadOnly) {
+      this.form.disable({ emitEvent: false });
+    } else {
+      this.form.enable({ emitEvent: false });
+    }
     this.initialFormValue.set(this.form.getRawValue());
   });
 

--- a/gravitee-apim-console-webui/src/management/api-products/configuration/api-product-configuration.component.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/configuration/api-product-configuration.component.ts
@@ -79,6 +79,7 @@ export class ApiProductConfigurationComponent {
   private readonly matDialog = inject(MatDialog);
 
   protected readonly isReadOnly = !this.permissionService.hasAnyMatching(['api_product-definition-u']);
+  protected readonly canDeleteApiProduct = this.permissionService.hasAnyMatching(['api_product-definition-d']);
 
   readonly nameMaxLength = 512;
   readonly versionMaxLength = 64;

--- a/gravitee-apim-console-webui/src/management/api-products/configuration/danger-zone/api-product-danger-zone.component.html
+++ b/gravitee-apim-console-webui/src/management/api-products/configuration/danger-zone/api-product-danger-zone.component.html
@@ -27,18 +27,14 @@
         </button>
       </div>
 
-      <div class="danger-card__actions__action">
-        <span class="gv-form-danger-text"> Delete this API Product. </span>
-        <button
-          mat-button
-          color="warn"
-          [disabled]="isReadOnly()"
-          [attr.data-testid]="'api_product_dangerzone_delete'"
-          (click)="onDeleteApiProduct()"
-        >
-          Delete API Product
-        </button>
-      </div>
+      @if (canDelete()) {
+        <div class="danger-card__actions__action">
+          <span class="gv-form-danger-text"> Delete this API Product. </span>
+          <button mat-button color="warn" [attr.data-testid]="'api_product_dangerzone_delete'" (click)="onDeleteApiProduct()">
+            Delete API Product
+          </button>
+        </div>
+      }
     </div>
   </mat-card-content>
 </mat-card>

--- a/gravitee-apim-console-webui/src/management/api-products/configuration/danger-zone/api-product-danger-zone.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/configuration/danger-zone/api-product-danger-zone.component.spec.ts
@@ -31,6 +31,7 @@ import { ApiProduct } from '../../../../entities/management-api-v2/api-product';
   template: `<api-product-danger-zone
     [apiProduct]="apiProduct()"
     [isReadOnly]="isReadOnly()"
+    [canDelete]="canDelete()"
     (removeApisClick)="onRemoveApis()"
     (deleteApiProductClick)="onDeleteApiProduct()"
   ></api-product-danger-zone>`,
@@ -44,6 +45,7 @@ class TestHostComponent {
     apiIds: ['api-1', 'api-2'],
   });
   isReadOnly = signal(false);
+  canDelete = signal(true);
   removeApisEmitted = false;
   deleteApiProductEmitted = false;
 
@@ -93,6 +95,17 @@ describe('ApiProductDangerZoneComponent', () => {
   it('should always show Remove APIs button', async () => {
     const removeButtons = await loader.getAllHarnesses(MatButtonHarness.with({ text: /Remove APIs/i }));
     expect(removeButtons.length).toBe(1);
+  });
+
+  it('should hide Delete API Product button when canDelete is false', async () => {
+    hostComponent.canDelete.set(false);
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    const deleteButton = await loader.getHarnessOrNull(
+      MatButtonHarness.with({ selector: '[data-testid="api_product_dangerzone_delete"]' }),
+    );
+    expect(deleteButton).toBeNull();
   });
 
   it('should show Remove APIs button even when product has no APIs', async () => {

--- a/gravitee-apim-console-webui/src/management/api-products/configuration/danger-zone/api-product-danger-zone.component.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/configuration/danger-zone/api-product-danger-zone.component.ts
@@ -30,6 +30,7 @@ import { ApiProduct } from '../../../../entities/management-api-v2/api-product';
 export class ApiProductDangerZoneComponent {
   apiProduct = input.required<ApiProduct>();
   isReadOnly = input<boolean>(false);
+  canDelete = input<boolean>(false);
 
   removeApisClick = output<void>();
   deleteApiProductClick = output<void>();

--- a/gravitee-apim-console-webui/src/management/api-products/navigation/api-product-navigation.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/navigation/api-product-navigation.component.spec.ts
@@ -260,6 +260,28 @@ describe('ApiProductNavigationComponent', () => {
     });
   });
 
+  describe('APIs menu item visibility', () => {
+    it('should show APIs menu item when user has api product definition read permission', async () => {
+      await configureNavigationTestBed(['api_product-definition-r']);
+      createFixture();
+      flushRequests(fakeApiProduct);
+      await fixture.whenStable();
+      fixture.detectChanges();
+
+      expect(fixture.nativeElement.textContent).toContain('APIs');
+    });
+
+    it('should hide APIs menu item when user lacks api product definition read permission', async () => {
+      await configureNavigationTestBed(['api_product-member-r']);
+      createFixture();
+      flushRequests(fakeApiProduct);
+      await fixture.whenStable();
+      fixture.detectChanges();
+
+      expect(fixture.nativeElement.textContent).not.toContain('APIs');
+    });
+  });
+
   describe('Consumers menu item visibility', () => {
     it('should show consumers menu item when user has api product plan read permission', async () => {
       await configureNavigationTestBed(['api_product-plan-r']);

--- a/gravitee-apim-console-webui/src/management/api-products/navigation/api-product-navigation.component.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/navigation/api-product-navigation.component.ts
@@ -255,8 +255,11 @@ export class ApiProductNavigationComponent {
         header: { title: 'Configuration', subtitle: 'Manage general settings and user permissions.' },
         tabs: configurationTabs,
       },
-      { displayName: 'APIs', routerLink: 'apis', icon: 'gio:cloud-settings' },
     ];
+
+    if (this.canAccessApiProductDefinition()) {
+      items.push({ displayName: 'APIs', routerLink: 'apis', icon: 'gio:cloud-settings' });
+    }
 
     const hasPlanRead = this.permissionService.hasAnyMatching(['api_product-plan-r']);
     const hasSubscriptionRead = this.permissionService.hasAnyMatching(['api_product-subscription-r']);
@@ -285,6 +288,10 @@ export class ApiProductNavigationComponent {
 
   private canAccessApiProductUserPermissions(): boolean {
     return this.permissionService.hasAnyMatching(['api_product-member-r']);
+  }
+
+  private canAccessApiProductDefinition(): boolean {
+    return this.permissionService.hasAnyMatching(['api_product-definition-r']);
   }
 
   private isItemActive(item: MenuItem): boolean {

--- a/gravitee-apim-console-webui/src/organization/configuration/user/detail/memberships/org-settings-user-detail-memberships.component.html
+++ b/gravitee-apim-console-webui/src/organization/configuration/user/detail/memberships/org-settings-user-detail-memberships.component.html
@@ -232,7 +232,16 @@
                   <th mat-header-cell *matHeaderCellDef id="api-product-name">Name</th>
                   <td mat-cell *matCellDef="let membershipApiProduct">
                     @if (membershipApiProduct.environmentId && membershipApiProduct.id) {
-                      <a [routerLink]="['/', membershipApiProduct.environmentId, 'api-products', membershipApiProduct.id]">
+                      <a
+                        [routerLink]="[
+                          '/',
+                          membershipApiProduct.environmentId,
+                          'api-products',
+                          membershipApiProduct.id,
+                          'configuration',
+                          'general',
+                        ]"
+                      >
                         {{ membershipApiProduct.name }}
                       </a>
                     } @else {

--- a/gravitee-apim-console-webui/src/organization/configuration/user/detail/org-settings-user-detail.component.spec.ts
+++ b/gravitee-apim-console-webui/src/organization/configuration/user/detail/org-settings-user-detail.component.spec.ts
@@ -429,6 +429,35 @@ describe('OrgSettingsUserDetailComponent', () => {
     ]);
   });
 
+  it('should display api product name link', async () => {
+    const user = fakeUser({
+      id: 'userId',
+      source: 'gravitee',
+      status: 'ACTIVE',
+    });
+    expectInitRequests(user, defaultEnvironments, {
+      envAlphaId: {
+        apiProducts: [
+          {
+            id: 'productAlphaId',
+            name: 'Product Alpha',
+            version: '1.0.0',
+            visibility: 'PUBLIC',
+            environmentId: 'envAlphaId',
+            environmentName: 'Environment Alpha',
+          },
+        ],
+      },
+    });
+
+    const membershipsCard = await loader.getHarness(MatCardHarness.with({ selector: '.org-settings-user-detail__memberships-card' }));
+    const apiProductsTable = await membershipsCard.getHarness(MatTableHarness.with({ selector: '[aria-label="API Products table"]' }));
+    expect(await apiProductsTable.getCellTextByIndex()).toEqual([['Product Alpha', '1.0.0', 'public Public']]);
+
+    const clickableName = fixture.debugElement.query(By.css('a[href="/envAlphaId/api-products/productAlphaId/configuration/general"]'));
+    expect(clickableName).toBeTruthy();
+  });
+
   it('should display applications user membership in environment tab', async () => {
     const user = fakeUser({
       id: 'userId',

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api_product/ApiProductsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api_product/ApiProductsResource.java
@@ -87,9 +87,7 @@ public class ApiProductsResource extends AbstractResource {
     @Path("_verify")
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
-    @Permissions(
-        { @Permission(value = RolePermission.ENVIRONMENT_API_PRODUCT, acls = { RolePermissionAction.CREATE, RolePermissionAction.UPDATE }) }
-    )
+    @Permissions({ @Permission(value = RolePermission.ENVIRONMENT_API_PRODUCT, acls = { RolePermissionAction.READ }) })
     public Response verifyApiProductName(@Valid @NotNull final VerifyApiProduct verifyApiProduct) {
         var executionContext = GraviteeContext.getExecutionContext();
         try {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api_product/ApiProductsResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api_product/ApiProductsResourceTest.java
@@ -156,8 +156,7 @@ class ApiProductsResourceTest extends AbstractResourceTest {
                     any(),
                     eq(RolePermission.ENVIRONMENT_API_PRODUCT),
                     eq(ENV_ID),
-                    eq(RolePermissionAction.CREATE),
-                    eq(RolePermissionAction.UPDATE)
+                    eq(RolePermissionAction.READ)
                 )
             ).thenReturn(false);
             VerifyApiProduct verifyApiProduct = new VerifyApiProduct();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/GroupResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/GroupResource.java
@@ -123,11 +123,15 @@ public class GroupResource extends AbstractResource {
         ) {
             updateGroupEntity.setMaxInvitation(groupEntity.getMaxInvitation());
             updateGroupEntity.setLockApiRole(groupEntity.isLockApiRole());
+            updateGroupEntity.setLockApiProductRole(groupEntity.isLockApiProductRole());
             updateGroupEntity.setLockApplicationRole(groupEntity.isLockApplicationRole());
             updateGroupEntity.setSystemInvitation(groupEntity.isSystemInvitation());
             updateGroupEntity.setEmailInvitation(groupEntity.isEmailInvitation());
             if (groupEntity.isLockApiRole()) {
                 updateGroupEntity.getRoles().put(RoleScope.API, groupEntity.getRoles().get(RoleScope.API));
+            }
+            if (groupEntity.isLockApiProductRole()) {
+                updateGroupEntity.getRoles().put(RoleScope.API_PRODUCT, groupEntity.getRoles().get(RoleScope.API_PRODUCT));
             }
             if (groupEntity.isLockApplicationRole()) {
                 updateGroupEntity.getRoles().put(RoleScope.APPLICATION, groupEntity.getRoles().get(RoleScope.APPLICATION));

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/use_case/GetApiProductApisUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/use_case/GetApiProductApisUseCase.java
@@ -26,7 +26,6 @@ import io.gravitee.rest.api.model.common.Pageable;
 import io.gravitee.rest.api.model.common.Sortable;
 import io.gravitee.rest.api.model.v4.api.GenericApiEntity;
 import io.gravitee.rest.api.service.common.ExecutionContext;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -68,7 +67,10 @@ public class GetApiProductApisUseCase {
             if (manageableIds == null || manageableIds.isEmpty()) {
                 return new Output(emptyPage(input.pageable()));
             }
-            searchIds = new ArrayList<>(manageableIds);
+            searchIds = apiIds.stream().filter(manageableIds::contains).toList();
+            if (searchIds.isEmpty()) {
+                return new Output(emptyPage(input.pageable()));
+            }
         }
 
         String query = (input.query() == null || input.query().isBlank()) ? null : input.query().trim();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api_product/use_case/GetApiProductApisUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api_product/use_case/GetApiProductApisUseCaseTest.java
@@ -20,11 +20,13 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
 import inmemory.ApiAuthorizationDomainServiceInMemory;
 import inmemory.ApiProductQueryServiceInMemory;
 import inmemory.InMemoryAlternative;
+import io.gravitee.apim.core.api.domain_service.ApiAuthorizationDomainService;
 import io.gravitee.apim.core.api_product.exception.ApiProductNotFoundException;
 import io.gravitee.apim.core.api_product.model.ApiProduct;
 import io.gravitee.apim.core.api_product.query_service.ApiProductSearchQueryService;
@@ -41,6 +43,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -151,6 +155,66 @@ class GetApiProductApisUseCaseTest {
             assertThat(output.apisPage()).isNotNull();
             assertThat(output.apisPage().getContent()).hasSize(1);
             assertThat(output.apisPage().getTotalElements()).isEqualTo(2);
+        }
+    }
+
+    @Nested
+    class NonAdminUser {
+
+        @Mock
+        private ApiAuthorizationDomainService apiAuthorizationDomainServiceMock;
+
+        @Captor
+        private ArgumentCaptor<List<String>> searchApiIdsCaptor;
+
+        @BeforeEach
+        void setUpNonAdmin() {
+            useCase = new GetApiProductApisUseCase(apiAuthorizationDomainServiceMock, apiProductSearchQueryService, apiProductQueryService);
+        }
+
+        @Test
+        void should_search_only_apis_on_product_when_user_can_manage_more_apis() {
+            apiProductQueryService.initWith(
+                List.of(
+                    ApiProduct.builder()
+                        .id(API_PRODUCT_ID)
+                        .name("Product")
+                        .environmentId(ENV_ID)
+                        .apiIds(Set.of("api-on-product", "api-not-manageable"))
+                        .build()
+                )
+            );
+            when(apiAuthorizationDomainServiceMock.findIdsByUser(any(), eq(USER_ID), any(), any(), eq(true))).thenReturn(
+                Set.of("api-on-product", "api-other-1", "api-other-2")
+            );
+
+            var apiEntity = new ApiEntity();
+            apiEntity.setId("api-on-product");
+            when(
+                apiProductSearchQueryService.searchApis(any(), anyString(), anyBoolean(), searchApiIdsCaptor.capture(), any(), any(), any())
+            ).thenReturn(new Page<>(List.of(apiEntity), 1, 10, 1));
+
+            var output = useCase.execute(input(API_PRODUCT_ID, null, new PageableImpl(1, 10), null, USER_ID, false));
+
+            assertThat(output.apisPage().getContent()).hasSize(1);
+            assertThat(searchApiIdsCaptor.getValue()).containsExactly("api-on-product");
+        }
+
+        @Test
+        void should_return_empty_page_when_user_cannot_manage_any_product_api() {
+            apiProductQueryService.initWith(
+                List.of(
+                    ApiProduct.builder().id(API_PRODUCT_ID).name("Product").environmentId(ENV_ID).apiIds(Set.of("api-on-product")).build()
+                )
+            );
+            when(apiAuthorizationDomainServiceMock.findIdsByUser(any(), eq(USER_ID), any(), any(), eq(true))).thenReturn(
+                Set.of("api-other-1")
+            );
+
+            var output = useCase.execute(input(API_PRODUCT_ID, null, new PageableImpl(1, 10), null, USER_ID, false));
+
+            assertThat(output.apisPage().getContent()).isEmpty();
+            assertThat(output.apisPage().getTotalElements()).isZero();
         }
     }
 


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-13380

## Description

1 | Backend – APIs tab list | GetApiProductApisUseCase intersects product apiIds with APIs the user can manage | Non-admin users (e.g. user-direct-owner) saw every API they belong to on the product APIs tab, not only APIs attached to the product
-- | -- | -- | --
2 | Backend – name verify | POST .../api-products/_verify requires environment-api_product READ aligns with API path verify (env read) | Now users can update API-Product with api-product-definition-u & the name uniqueness is verified with environment-api_product-R & not environment-api_product CREATE or UPDATE.
3 | Backend – groups | GroupResource preserves API_PRODUCT default role when lockApiProductRole is set on update | Updating a group dropped locked API Product role settings (same pattern as API / Application locks)
4 | Console – configuration | isReadOnly uses api_product-definition-u instead of environment-api_product-u | Form editability matched env permission instead of product-scoped definition update (e.g. OWNER/PO via membership could not edit)
5 | Console – configuration | Disable/enable form when read-only after product load | Read-only users could still edit fields when permissions loaded after the form was built
6 | Console – navigation | Show APIs menu item only if api_product-definition-r | APIs tab visible without definition read permission
7 | Console – routes | Guard APIs route with api_product-definition-r | Direct URL to /apis bypassed menu visibility


Direct owner sees API he's added not all API belonging to him
<img width="758" height="373" alt="image" src="https://github.com/user-attachments/assets/bc122a98-0b37-4dfe-a97c-ec362aca575f" />

Delete API product is gated by api-product-defination-d
<img width="1512" height="748" alt="image" src="https://github.com/user-attachments/assets/4e51bc29-95ff-413a-b742-b1ec12cdf88e" />

The button is hidden for Org User
<img width="1480" height="745" alt="image" src="https://github.com/user-attachments/assets/e44c8a94-d63e-4ead-9fb0-8293d10759ac" />


