### PR TITLE
fix(portal): scope user permissions to current environment (APIM-13995)

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/mapper/UserMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/mapper/UserMapper.java
@@ -21,11 +21,16 @@ import io.gravitee.rest.api.idp.api.identity.SearchableUser;
 import io.gravitee.rest.api.model.*;
 import io.gravitee.rest.api.model.permissions.RoleScope;
 import io.gravitee.rest.api.portal.rest.model.*;
+import io.gravitee.rest.api.service.common.GraviteeContext;
+import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.springframework.stereotype.Component;
 
 /**
@@ -57,10 +62,19 @@ public class UserMapper {
         userItem.setId(user.getId());
         userItem.setEditableProfile(IDP_SOURCE_GRAVITEE.equals(user.getSource()) || IDP_SOURCE_MEMORY.equalsIgnoreCase(user.getSource()));
         if (user.getRoles() != null) {
-            Map<String, List<String>> userPermissions = user
+            Stream<UserRoleEntity> orgRoles = user
                 .getRoles()
                 .stream()
-                .filter(role -> RoleScope.ENVIRONMENT.equals(role.getScope()) || RoleScope.ORGANIZATION.equals(role.getScope()))
+                .filter(role -> RoleScope.ORGANIZATION.equals(role.getScope()));
+
+            Map<String, Set<UserRoleEntity>> envRolesMap = user.getEnvRoles();
+            String environmentId = GraviteeContext.getCurrentEnvironment();
+
+            Set<UserRoleEntity> currentEnvironmentRoles = (envRolesMap == null || environmentId == null)
+                ? Set.of()
+                : envRolesMap.getOrDefault(environmentId, Set.of());
+
+            Map<String, List<String>> userPermissions = Stream.concat(orgRoles, currentEnvironmentRoles.stream())
                 .map(UserRoleEntity::getPermissions)
                 .map(rolePermissions ->
                     rolePermissions
@@ -77,7 +91,13 @@ public class UserMapper {
                         )
                 )
                 .reduce(new HashMap<>(), (acc, rolePermissions) -> {
-                    acc.putAll(rolePermissions);
+                    rolePermissions.forEach((key, permissionChars) ->
+                        acc.merge(key, new ArrayList<>(permissionChars), (existing, incoming) -> {
+                            LinkedHashSet<String> merged = new LinkedHashSet<>(existing);
+                            merged.addAll(incoming);
+                            return new ArrayList<>(merged);
+                        })
+                    );
                     return acc;
                 });
             userItem.setPermissions(objectMapper.convertValue(userPermissions, UserPermissions.class));

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/mapper/UserMapperTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/mapper/UserMapperTest.java
@@ -27,11 +27,15 @@ import io.gravitee.rest.api.portal.rest.model.FinalizeRegistrationInput;
 import io.gravitee.rest.api.portal.rest.model.RegisterUserInput;
 import io.gravitee.rest.api.portal.rest.model.User;
 import io.gravitee.rest.api.portal.rest.model.UserLinks;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import java.time.Instant;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import org.junit.After;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
@@ -59,8 +63,16 @@ public class UserMapperTest {
     private static final String SEARCHABLE_USER_DISPLAY_NAME = "my-searchable-user-display-name";
     private static final String SEARCHABLE_USER_REFERENCE = "my-searchable-user-reference";
 
+    private static final String DEV_ENVIRONMENT_ID = "dev-environment-id";
+    private static final String TEST_ENVIRONMENT_ID = "test-environment-id";
+
     @InjectMocks
     private UserMapper userMapper;
+
+    @After
+    public void tearDown() {
+        GraviteeContext.cleanContext();
+    }
 
     @Test
     public void testConvertUserEntity() {
@@ -125,6 +137,8 @@ public class UserMapperTest {
         userEntity.setPassword(USER_PASSWORD);
         userEntity.setPicture(USER_PICTURE);
         userEntity.setRoles(new HashSet<>(Arrays.asList(userRoleEntityOrganization, userRoleEntityEnvironment)));
+        GraviteeContext.setCurrentEnvironment(DEV_ENVIRONMENT_ID);
+        userEntity.setEnvRoles(Map.of(DEV_ENVIRONMENT_ID, Set.of(userRoleEntityEnvironment)));
         userEntity.setSource(USER_SOURCE);
         userEntity.setSourceId(USER_SOURCE_ID);
         userEntity.setStatus(USER_STATUS);
@@ -139,6 +153,112 @@ public class UserMapperTest {
         assertEquals(USER_LASTNAME, responseUser.getLastName());
         assertEquals(USER_FIRSTNAME + ' ' + USER_LASTNAME, responseUser.getDisplayName());
         assertTrue(responseUser.getPermissions().getAPPLICATION().containsAll(Arrays.asList("C")));
+    }
+
+    @Test
+    public void should_not_apply_flat_environment_roles_when_env_roles_is_not_populated() {
+        UserRoleEntity environmentRole = environmentRole("env-role-id", Map.of("APPLICATION", new char[] { 'C' }));
+
+        UserEntity userEntity = baseUserEntity();
+        userEntity.setRoles(new HashSet<>(Set.of(environmentRole)));
+        userEntity.setEnvRoles(null);
+        GraviteeContext.setCurrentEnvironment(DEV_ENVIRONMENT_ID);
+
+        User user = userMapper.convert(userEntity);
+        assertNull(user.getPermissions().getAPPLICATION());
+    }
+
+    @Test
+    public void should_not_apply_environment_roles_when_current_environment_is_not_set() {
+        UserRoleEntity flatRole = environmentRole("flat-role-id", Map.of("APPLICATION", new char[] { 'C' }));
+        UserRoleEntity defaultEnvRole = environmentRole("default-env-role-id", Map.of("APPLICATION", new char[] { 'R' }));
+
+        UserEntity userEntity = baseUserEntity();
+        userEntity.setRoles(new HashSet<>(Set.of(flatRole)));
+        userEntity.setEnvRoles(Map.of(GraviteeContext.getDefaultEnvironment(), Set.of(defaultEnvRole)));
+
+        GraviteeContext.setCurrentEnvironment(null);
+        User user = userMapper.convert(userEntity);
+        assertNull(user.getPermissions().getAPPLICATION());
+    }
+
+    @Test
+    public void should_not_apply_environment_roles_when_current_environment_absent_from_env_roles() {
+        UserRoleEntity devRole = environmentRole("le-group-role-id", Map.of("APPLICATION", new char[] { 'C', 'R' }));
+
+        UserEntity userEntity = baseUserEntity();
+        userEntity.setRoles(new HashSet<>(Set.of(devRole)));
+        // envRoles is populated but has no entry for the current environment.
+        userEntity.setEnvRoles(Map.of(DEV_ENVIRONMENT_ID, Set.of(devRole)));
+
+        GraviteeContext.setCurrentEnvironment(TEST_ENVIRONMENT_ID);
+        User testUser = userMapper.convert(userEntity);
+        assertNull(testUser.getPermissions().getAPPLICATION());
+    }
+
+    @Test
+    public void should_not_apply_environment_permissions_from_flat_roles_when_env_roles_has_current_environment_entry() {
+        UserRoleEntity devRole = environmentRole("le-group-role-id", Map.of("APPLICATION", new char[] { 'C', 'R' }));
+        UserRoleEntity testRole = environmentRole("ue-group-role-id", Map.of("APPLICATION", new char[] { 'R' }));
+
+        UserEntity userEntity = baseUserEntity();
+        userEntity.setRoles(new HashSet<>(Set.of(devRole, testRole)));
+        userEntity.setEnvRoles(Map.of(DEV_ENVIRONMENT_ID, Set.of(devRole), TEST_ENVIRONMENT_ID, Set.of()));
+
+        GraviteeContext.setCurrentEnvironment(TEST_ENVIRONMENT_ID);
+        User testUser = userMapper.convert(userEntity);
+        assertNull(testUser.getPermissions().getAPPLICATION());
+    }
+
+    @Test
+    public void should_include_organization_and_current_environment_permissions() {
+        UserRoleEntity orgRole = organizationRole("org-role-id", Map.of("USER", new char[] { 'R' }));
+        UserRoleEntity envRole = environmentRole("env-role-id", Map.of("APPLICATION", new char[] { 'C' }));
+
+        UserEntity userEntity = baseUserEntity();
+        userEntity.setRoles(new HashSet<>(Set.of(orgRole, envRole)));
+        userEntity.setEnvRoles(Map.of(DEV_ENVIRONMENT_ID, Set.of(envRole)));
+
+        GraviteeContext.setCurrentEnvironment(DEV_ENVIRONMENT_ID);
+        User user = userMapper.convert(userEntity);
+
+        assertTrue(user.getPermissions().getUSER().contains("R"));
+        assertTrue(user.getPermissions().getAPPLICATION().contains("C"));
+    }
+
+    @Test
+    public void should_union_permissions_from_multiple_roles_in_same_environment() {
+        UserRoleEntity createRole = environmentRole("create-role-id", Map.of("APPLICATION", new char[] { 'C' }));
+        UserRoleEntity readRole = environmentRole("read-role-id", Map.of("APPLICATION", new char[] { 'R' }));
+
+        UserEntity userEntity = baseUserEntity();
+        userEntity.setRoles(new HashSet<>(Set.of(createRole, readRole)));
+        userEntity.setEnvRoles(Map.of(DEV_ENVIRONMENT_ID, Set.of(createRole, readRole)));
+
+        GraviteeContext.setCurrentEnvironment(DEV_ENVIRONMENT_ID);
+        User user = userMapper.convert(userEntity);
+
+        assertTrue(user.getPermissions().getAPPLICATION().contains("C"));
+        assertTrue(user.getPermissions().getAPPLICATION().contains("R"));
+    }
+
+    @Test
+    public void should_use_only_current_environment_roles_when_user_has_multiple_environment_memberships() {
+        UserRoleEntity devRole = environmentRole("le-group-role-id", Map.of("APPLICATION", new char[] { 'C', 'R' }));
+        UserRoleEntity testRole = environmentRole("ue-group-role-id", Map.of("APPLICATION", new char[] { 'R' }));
+
+        UserEntity userEntity = baseUserEntity();
+        userEntity.setRoles(new HashSet<>(Set.of(devRole, testRole)));
+        userEntity.setEnvRoles(Map.of(DEV_ENVIRONMENT_ID, Set.of(devRole), TEST_ENVIRONMENT_ID, Set.of(testRole)));
+
+        GraviteeContext.setCurrentEnvironment(DEV_ENVIRONMENT_ID);
+        User devUser = userMapper.convert(userEntity);
+        assertTrue(devUser.getPermissions().getAPPLICATION().contains("C"));
+
+        GraviteeContext.setCurrentEnvironment(TEST_ENVIRONMENT_ID);
+        User testUser = userMapper.convert(userEntity);
+        assertFalse(testUser.getPermissions().getAPPLICATION().contains("C"));
+        assertTrue(testUser.getPermissions().getAPPLICATION().contains("R"));
     }
 
     @Test
@@ -212,5 +332,41 @@ public class UserMapperTest {
         assertEquals(basePath + "/avatar?", links.getAvatar());
         assertEquals(basePath + "/notifications", links.getNotifications());
         assertEquals(basePath, links.getSelf());
+    }
+
+    private static UserEntity baseUserEntity() {
+        Instant now = Instant.now();
+        Date nowDate = Date.from(now);
+
+        UserEntity userEntity = new UserEntity();
+        userEntity.setCreatedAt(nowDate);
+        userEntity.setEmail(USER_EMAIL);
+        userEntity.setFirstname(USER_FIRSTNAME);
+        userEntity.setId(USER_ID);
+        userEntity.setLastConnectionAt(nowDate);
+        userEntity.setLastname(USER_LASTNAME);
+        userEntity.setPassword(USER_PASSWORD);
+        userEntity.setPicture(USER_PICTURE);
+        userEntity.setSource(USER_SOURCE);
+        userEntity.setSourceId(USER_SOURCE_ID);
+        userEntity.setStatus(USER_STATUS);
+        userEntity.setUpdatedAt(nowDate);
+        return userEntity;
+    }
+
+    private static UserRoleEntity environmentRole(String roleId, Map<String, char[]> permissions) {
+        UserRoleEntity role = new UserRoleEntity();
+        role.setId(roleId);
+        role.setScope(RoleScope.ENVIRONMENT);
+        role.setPermissions(permissions);
+        return role;
+    }
+
+    private static UserRoleEntity organizationRole(String roleId, Map<String, char[]> permissions) {
+        UserRoleEntity role = new UserRoleEntity();
+        role.setId(roleId);
+        role.setScope(RoleScope.ORGANIZATION);
+        role.setPermissions(permissions);
+        return role;
     }
 }


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-13995

**Description**

Fixes environment role permissions leaking across Developer Portal environments.

UserMapper was building the user permissions payload by merging all environment roles from user.getRoles(). When a user had different roles per environment (e.g. create access in DEV, read-only in TEST), putAll could overwrite permissions so DEV lost APPLICATION: C after TEST was assigned.

The mapper now:

Keeps organization roles from user.getRoles()
Uses only roles from user.getEnvRoles() for GraviteeContext.getCurrentEnvironment()
Falls back to the previous flat user.getRoles() behavior when envRoles is not populated
A unit test covers the multi-environment scenario from the ticket.

**Additional context**

Reproduction (before fix):

Create two environments (e.g. DEV and TEST).
Create environment roles:
LE_GROUP — APPLICATION create enabled
UE_GROUP — APPLICATION read-only
Assign a user LE_GROUP on DEV only → they can create applications in the portal for DEV.
Also assign UE_GROUP on TEST → they can no longer create applications in DEV (UI hides create; permissions merged incorrectly).

**Expected**: Permissions in the portal reflect only the current environment (plus org roles).

**Root cause**: UserServiceImpl already exposes per-environment roles via envRoles, but UserMapper ignored that map and merged every environment role into one permission set.

**UI impact**: Portal Next Gen (canCreate from permissions.APPLICATION) and classic portal use this API response for the create-application action.

**Server-side note**: PermissionServiceImpl.hasPermission() already checks the current environment for API calls; this change aligns the returned user permissions with that behavior.


Pre-fix behaviour  : 

https://github.com/user-attachments/assets/3cc49d0d-a13e-47c8-9b75-857ae8ee2132

Post fix behaviour: 

https://github.com/user-attachments/assets/838d5c6a-f9af-48f3-8638-46428616f428
