### PR TITLE
feat(gamma-platform-ui): Archived apps table options & general configuration

### DIFF
--- a/gravitee-gamma/gamma-ui-shared/src/api/apimClient.ts
+++ b/gravitee-gamma/gamma-ui-shared/src/api/apimClient.ts
@@ -1,0 +1,115 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export interface ApimBootstrap {
+    managementBaseURL: string;
+    organizationId: string;
+}
+
+let _bootstrap: ApimBootstrap | undefined;
+let _bootstrapPromise: Promise<ApimBootstrap> | undefined;
+
+async function resolveBootstrap(): Promise<ApimBootstrap> {
+    if (_bootstrap) return _bootstrap;
+    _bootstrapPromise ??= (async () => {
+        try {
+            const constantsRes = await fetch('/constants.json');
+            if (!constantsRes.ok) {
+                throw new ApimApiError(constantsRes.status, `Failed to fetch constants.json: ${constantsRes.status}`);
+            }
+            const constants = (await constantsRes.json()) as { gammaBaseURL: string };
+            const gammaBase = constants.gammaBaseURL.replace(/\/$/, '');
+
+            const bootstrapRes = await fetch(`${gammaBase}/ui/bootstrap`);
+            if (!bootstrapRes.ok) {
+                throw new ApimApiError(bootstrapRes.status, `Failed to fetch bootstrap config: ${bootstrapRes.status}`);
+            }
+            const bootstrap = (await bootstrapRes.json()) as { managementBaseURL: string; organizationId: string };
+
+            _bootstrap = {
+                managementBaseURL: bootstrap.managementBaseURL.replace(/\/$/, ''),
+                organizationId: bootstrap.organizationId,
+            };
+            return _bootstrap;
+        } catch (err) {
+            _bootstrapPromise = undefined;
+            throw err;
+        }
+    })();
+    return _bootstrapPromise;
+}
+
+export class ApimApiError extends Error {
+    constructor(
+        public readonly status: number,
+        message: string,
+        public readonly body?: unknown,
+    ) {
+        super(message);
+        this.name = 'ApimApiError';
+    }
+}
+
+async function doFetch<T>(url: string, path: string, init?: RequestInit): Promise<T> {
+    const headers = new Headers(init?.headers);
+    headers.set('X-Requested-With', 'XMLHttpRequest');
+    const csrf = localStorage.getItem('XSRF-TOKEN');
+    if (csrf) headers.set('X-Xsrf-Token', csrf);
+
+    const res = await fetch(url, { ...init, headers, credentials: 'include' });
+
+    const newCsrf = res.headers.get('X-Xsrf-Token');
+    if (newCsrf) localStorage.setItem('XSRF-TOKEN', newCsrf);
+
+    if (!res.ok) {
+        const text = await res.text().catch(() => '');
+        let parsed: unknown;
+        try {
+            parsed = JSON.parse(text);
+        } catch {
+            parsed = undefined;
+        }
+        const message = (parsed as Record<string, string> | undefined)?.message ?? text ?? `${path} → ${res.status}`;
+        throw new ApimApiError(res.status, message, parsed);
+    }
+    if (res.status === 204) return undefined as T;
+    const text = await res.text();
+    return text ? (JSON.parse(text) as T) : (undefined as T);
+}
+
+/** Org-scoped v1: `/organizations/{orgId}{path}` */
+export async function apimFetchJson<T>(organizationId: string, path: string, init?: RequestInit): Promise<T> {
+    const { managementBaseURL } = await resolveBootstrap();
+    return doFetch<T>(`${managementBaseURL}/organizations/${organizationId}${path}`, path, init);
+}
+
+/** v2 env-scoped: `/v2/environments/{envId}{path}` */
+export async function apimFetchJsonV2<T>(environmentId: string, path: string, init?: RequestInit): Promise<T> {
+    const { managementBaseURL } = await resolveBootstrap();
+    return doFetch<T>(`${managementBaseURL}/v2/environments/${environmentId}${path}`, path, init);
+}
+
+/** v1 env-scoped (auto-resolves orgId): `/organizations/{orgId}/environments/{envId}{path}` */
+export async function apimFetchJsonV1Env<T>(environmentId: string, path: string, init?: RequestInit): Promise<T> {
+    const { managementBaseURL, organizationId } = await resolveBootstrap();
+    return doFetch<T>(`${managementBaseURL}/organizations/${organizationId}/environments/${environmentId}${path}`, path, init);
+}
+
+/** Org-scoped v1 (auto-resolves orgId): `/organizations/{orgId}{path}` */
+export async function apimFetchJsonOrg<T>(path: string, init?: RequestInit): Promise<T> {
+    const { organizationId } = await resolveBootstrap();
+    return apimFetchJson<T>(organizationId, path, init);
+}

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/app/AppRoutes.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/app/AppRoutes.tsx
@@ -49,7 +49,6 @@ import { ApiProductsPage } from '../pages/ApiProductsPage';
 import { ApiProductUserPermissionsPage } from '../pages/ApiProductUserPermissionsPage';
 import { ApiPropertiesPage } from '../pages/ApiPropertiesPage';
 import { ApisPage } from '../pages/ApisPage';
-import { ApplicationsPage } from '../pages/ApplicationsPage';
 import { AuditLogsPage } from '../pages/AuditLogsPage';
 import { CreateApiProductPage } from '../pages/CreateApiProductPage';
 import { CreateApiProxyPage } from '../pages/CreateApiProxyPage';
@@ -168,7 +167,6 @@ export function AppRoutes() {
                             <Route path="*" element={<Navigate to="overview" replace />} />
                         </Route>
                     </Route>
-                    <Route path="applications" element={<ApplicationsPage />} />
                     <Route path="analytics" element={<AnalyticsPage />} />
                     <Route path="settings" element={<SettingsPage />} />
                 </Route>

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/config/routes.ts
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/config/routes.ts
@@ -15,7 +15,7 @@
  */
 import type { ModuleRouteConfig } from '@gravitee/gamma-modules-sdk/routing';
 
-export const ROUTE_KEYS: readonly string[] = ['dashboard', 'apis', 'api-products', 'applications', 'analytics', 'settings'];
+export const ROUTE_KEYS: readonly string[] = ['dashboard', 'apis', 'api-products', 'analytics', 'settings'];
 export type RouteKey = (typeof ROUTE_KEYS)[number];
 
 const DEFAULT_ROUTE_KEY: RouteKey = 'dashboard';
@@ -24,7 +24,6 @@ export const ROUTES: Record<RouteKey, { readonly path: string; readonly label: s
     dashboard: { path: '', label: 'Dashboard' },
     apis: { path: 'apis', label: 'API Proxies' },
     'api-products': { path: 'api-products', label: 'API Products' },
-    applications: { path: 'applications', label: 'Applications' },
     analytics: { path: 'analytics', label: 'Analytics' },
     settings: { path: 'settings', label: 'Settings' },
 };

--- a/gravitee-gamma/gravitee-gamma-module-apim/tsconfig.app.json
+++ b/gravitee-gamma/gravitee-gamma-module-apim/tsconfig.app.json
@@ -5,7 +5,9 @@
         "outDir": "../../dist/out-tsc",
         "moduleResolution": "bundler",
         "types": ["node", "@nx/react/typings/cssmodule.d.ts", "@nx/react/typings/image.d.ts"],
-        "paths": {}
+        "paths": {
+            "@gravitee/gamma-ui-shared/api": ["../gamma-ui-shared/src/api/apimClient.ts"]
+        }
     },
     "exclude": [
         "src/**/*.spec.ts",

--- a/gravitee-gamma/gravitee-gamma-module-platform/jest.config.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/jest.config.ts
@@ -14,9 +14,8 @@
  * limitations under the License.
  */
 export default {
-    displayName: 'gravitee-gamma-module-apim',
+    displayName: 'gravitee-gamma-module-platform',
     testEnvironment: 'jest-fixed-jsdom',
-    setupFilesAfterEnv: ['<rootDir>/src/main/ui/test-setup.ts'],
     transformIgnorePatterns: ['/node_modules/(?!(until-async|@gravitee/graphene-core)/)'],
     moduleNameMapper: {
         '^react$': '<rootDir>/../../node_modules/react/index.js',
@@ -29,6 +28,7 @@ export default {
         '^@gravitee/graphene-core$': '<rootDir>/../../node_modules/@gravitee/graphene-core/dist/index.js',
         '^@gravitee/graphene-core/(.*)$': '<rootDir>/../../node_modules/@gravitee/graphene-core/dist/$1',
         '^@gravitee/gamma-modules-sdk$': '<rootDir>/src/main/ui/shared/gamma-modules-sdk.ts',
+        '^@gravitee/gamma-modules-sdk/routing$': '<rootDir>/../../node_modules/@gravitee/gamma-modules-sdk/dist/routing.js',
         '^@gravitee/gamma-ui-shared/api$': '<rootDir>/../gamma-ui-shared/src/api/apimClient.ts',
     },
     transform: {

--- a/gravitee-gamma/gravitee-gamma-module-platform/package.json
+++ b/gravitee-gamma/gravitee-gamma-module-platform/package.json
@@ -4,6 +4,7 @@
     "dependencies": {
         "@gravitee/gamma-modules-sdk": "1.0.0-alpha.2",
         "@gravitee/graphene-core": "1.0.0-alpha.4",
+        "@tanstack/react-query": "5.90.12",
         "react": "19.2.4",
         "react-dom": "19.2.4",
         "react-router-dom": "7.13.1"

--- a/gravitee-gamma/gravitee-gamma-module-platform/project.json
+++ b/gravitee-gamma/gravitee-gamma-module-platform/project.json
@@ -11,6 +11,13 @@
                 "lintFilePatterns": ["{projectRoot}/**/*.ts", "{projectRoot}/**/*.tsx"]
             }
         },
-        "lint-license": {}
+        "lint-license": {},
+        "test": {
+            "executor": "@nx/jest:jest",
+            "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
+            "options": {
+                "jestConfig": "gravitee-gamma/gravitee-gamma-module-platform/jest.config.ts"
+            }
+        }
     }
 }

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/app/AppRoutes.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/app/AppRoutes.tsx
@@ -19,8 +19,19 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { useMemo } from 'react';
 import { Outlet, Route, Routes, useNavigate } from 'react-router-dom';
 
+import {
+    APPLICATION_IMPLEMENTED_DETAIL_PATHS,
+    APPLICATION_NAV_GROUPS,
+    flattenApplicationDetailNavItems,
+} from '../config/applicationDetailNavigation';
 import { NAV_GROUPS } from '../config/navigation';
 import { PLATFORM_ROUTE_CONFIG } from '../config/routes';
+import {
+    ApplicationDetailIndexRedirect,
+    ApplicationDetailLayout,
+    ApplicationDetailPlaceholderPage,
+} from '../features/applications/components/detail';
+import { ApplicationDetailGeneralPage } from '../pages/ApplicationDetailGeneralPage';
 import { ApplicationsPage } from '../pages/ApplicationsPage';
 import { DashboardPage } from '../pages/DashboardPage';
 import { RegisterApplicationPage } from '../pages/RegisterApplicationPage';
@@ -28,6 +39,15 @@ import { ConsoleSettingsProvider } from '../shared/console-settings';
 import { useEnvironmentPermissions } from '../shared/hooks/useEnvironmentPermissions';
 
 const queryClient = new QueryClient();
+
+const APPLICATION_DETAIL_TABS = flattenApplicationDetailNavItems(APPLICATION_NAV_GROUPS);
+
+function applicationDetailTabElement(path: string, label: string) {
+    if (path === 'general' && APPLICATION_IMPLEMENTED_DETAIL_PATHS.has(path)) {
+        return <ApplicationDetailGeneralPage />;
+    }
+    return <ApplicationDetailPlaceholderPage title={label} />;
+}
 
 function ModuleLayout() {
     useEnvironmentPermissions();
@@ -67,6 +87,13 @@ export function AppRoutes() {
                         <Route path="applications">
                             <Route index element={<ApplicationsPage />} />
                             <Route path="new" element={<RegisterApplicationPage />} />
+                            <Route path=":applicationId" element={<ApplicationDetailLayout />}>
+                                <Route index element={<ApplicationDetailIndexRedirect />} />
+                                {APPLICATION_DETAIL_TABS.map(tab => (
+                                    <Route key={tab.path} path={tab.path} element={applicationDetailTabElement(tab.path, tab.label)} />
+                                ))}
+                                <Route path="*" element={<ApplicationDetailIndexRedirect />} />
+                            </Route>
                         </Route>
                     </Route>
                 </Routes>

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/app/AppRoutes.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/app/AppRoutes.tsx
@@ -15,6 +15,7 @@
  */
 import { useModuleRouting } from '@gravitee/gamma-modules-sdk/routing';
 import { buildLinearBreadcrumbs, SidebarNavigation, useLayoutConfig } from '@gravitee/graphene-core';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { useMemo } from 'react';
 import { Outlet, Route, Routes, useNavigate } from 'react-router-dom';
 
@@ -22,8 +23,15 @@ import { NAV_GROUPS } from '../config/navigation';
 import { PLATFORM_ROUTE_CONFIG } from '../config/routes';
 import { ApplicationsPage } from '../pages/ApplicationsPage';
 import { DashboardPage } from '../pages/DashboardPage';
+import { RegisterApplicationPage } from '../pages/RegisterApplicationPage';
+import { ConsoleSettingsProvider } from '../shared/console-settings';
+import { useEnvironmentPermissions } from '../shared/hooks/useEnvironmentPermissions';
+
+const queryClient = new QueryClient();
 
 function ModuleLayout() {
+    useEnvironmentPermissions();
+
     const navigate = useNavigate();
     const { activeNavKey, navigateToKey, rootPath } = useModuleRouting(PLATFORM_ROUTE_CONFIG);
 
@@ -50,12 +58,19 @@ function ModuleLayout() {
 /** Route tree for this module: mounted under the host router when federated, or under the local dev root for standalone. */
 export function AppRoutes() {
     return (
-        <Routes>
-            <Route element={<ModuleLayout />}>
-                <Route index element={<DashboardPage />} />
-                <Route path="dashboard" element={<DashboardPage />} />
-                <Route path="applications" element={<ApplicationsPage />} />
-            </Route>
-        </Routes>
+        <QueryClientProvider client={queryClient}>
+            <ConsoleSettingsProvider>
+                <Routes>
+                    <Route element={<ModuleLayout />}>
+                        <Route index element={<DashboardPage />} />
+                        <Route path="dashboard" element={<DashboardPage />} />
+                        <Route path="applications">
+                            <Route index element={<ApplicationsPage />} />
+                            <Route path="new" element={<RegisterApplicationPage />} />
+                        </Route>
+                    </Route>
+                </Routes>
+            </ConsoleSettingsProvider>
+        </QueryClientProvider>
     );
 }

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/config/applicationDetailNavigation.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/config/applicationDetailNavigation.spec.ts
@@ -1,0 +1,72 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+    APPLICATION_IMPLEMENTED_DETAIL_PATHS,
+    APPLICATION_NAV_GROUPS,
+    filterApplicationDetailNavGroups,
+    getApplicationDetailTabPermissions,
+    getFirstAccessibleApplicationDetailPath,
+    getFirstAccessibleImplementedApplicationDetailPath,
+} from './applicationDetailNavigation';
+
+describe('normalizeCrudMapRecord (application permissions)', () => {
+    it('expands CRUD strings into per-letter tokens', async () => {
+        const { normalizeCrudMapRecord } = await import('../shared/gamma-modules-sdk');
+        expect(normalizeCrudMapRecord('application', { DEFINITION: 'CRUD' })).toEqual([
+            'application-definition-c',
+            'application-definition-r',
+            'application-definition-u',
+            'application-definition-d',
+        ]);
+    });
+});
+
+describe('applicationDetailNavigation permissions', () => {
+    const hasDefinitionRead = (permissions: string[]) => permissions.includes('application-definition-r');
+    const hasMemberRead = (permissions: string[]) => permissions.includes('application-member-r');
+
+    it('maps general tab to application-definition-r', () => {
+        expect(getApplicationDetailTabPermissions('general')).toEqual(['application-definition-r']);
+    });
+
+    it('filters nav groups by permission', () => {
+        const filtered = filterApplicationDetailNavGroups(APPLICATION_NAV_GROUPS, hasDefinitionRead);
+        expect(filtered.map(g => g.label)).toEqual(['General']);
+        expect(filtered[0].items.map(i => i.path)).toEqual(['overview', 'general']);
+    });
+
+    it('returns first accessible path for the user', () => {
+        expect(getFirstAccessibleApplicationDetailPath(APPLICATION_NAV_GROUPS, hasMemberRead)).toBe('user-permissions');
+        expect(getFirstAccessibleApplicationDetailPath(APPLICATION_NAV_GROUPS, hasDefinitionRead)).toBe('overview');
+    });
+
+    it('returns first accessible implemented path (skips overview placeholder)', () => {
+        expect(
+            getFirstAccessibleImplementedApplicationDetailPath(
+                APPLICATION_NAV_GROUPS,
+                APPLICATION_IMPLEMENTED_DETAIL_PATHS,
+                hasDefinitionRead,
+            ),
+        ).toBe('general');
+        expect(
+            getFirstAccessibleImplementedApplicationDetailPath(APPLICATION_NAV_GROUPS, APPLICATION_IMPLEMENTED_DETAIL_PATHS, hasMemberRead),
+        ).toBeNull();
+    });
+
+    it('returns null when user has no tab permissions', () => {
+        expect(getFirstAccessibleApplicationDetailPath(APPLICATION_NAV_GROUPS, () => false)).toBeNull();
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/config/applicationDetailNavigation.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/config/applicationDetailNavigation.ts
@@ -1,0 +1,104 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { LayoutDashboardIcon, PlugIcon, ShieldCheckIcon, SlidersHorizontalIcon } from '@gravitee/graphene-core/icons';
+import type { ComponentType } from 'react';
+
+export interface ApplicationDetailNavItem {
+    path: string;
+    label: string;
+    icon: ComponentType<{ className?: string }>;
+    /** When set, the tab is shown only if the user has any of these permissions (application scope). */
+    permissions?: string[];
+}
+
+export interface ApplicationDetailNavGroup {
+    label: string;
+    items: ApplicationDetailNavItem[];
+}
+
+/** Single source of truth for application detail sidebar labels, paths, and nested routes. */
+export const APPLICATION_NAV_GROUPS: ApplicationDetailNavGroup[] = [
+    {
+        label: 'General',
+        items: [
+            { path: 'overview', label: 'Overview', icon: LayoutDashboardIcon, permissions: ['application-definition-r'] },
+            { path: 'general', label: 'General', icon: SlidersHorizontalIcon, permissions: ['application-definition-r'] },
+        ],
+    },
+    {
+        label: 'Security',
+        items: [{ path: 'user-permissions', label: 'User Permissions', icon: ShieldCheckIcon, permissions: ['application-member-r'] }],
+    },
+    {
+        label: 'Subscriptions',
+        items: [{ path: 'subscriptions', label: 'Subscriptions', icon: PlugIcon, permissions: ['application-subscription-r'] }],
+    },
+];
+
+export function flattenApplicationDetailNavItems(groups: ApplicationDetailNavGroup[]): ApplicationDetailNavItem[] {
+    return groups.flatMap(group => group.items);
+}
+
+/** Console-aligned default landing tab (Global settings). */
+export const APPLICATION_CONSOLE_DEFAULT_DETAIL_PATH = 'general';
+
+export function filterApplicationDetailNavGroups(
+    groups: ApplicationDetailNavGroup[],
+    hasAnyPermission: (permissions: string[]) => boolean,
+): ApplicationDetailNavGroup[] {
+    return groups
+        .map(group => ({
+            ...group,
+            items: group.items.filter(item => !item.permissions || hasAnyPermission(item.permissions)),
+        }))
+        .filter(group => group.items.length > 0);
+}
+
+export function getFirstAccessibleApplicationDetailPath(
+    groups: ApplicationDetailNavGroup[],
+    hasAnyPermission: (permissions: string[]) => boolean,
+): string | null {
+    for (const item of flattenApplicationDetailNavItems(groups)) {
+        if (!item.permissions || hasAnyPermission(item.permissions)) {
+            return item.path;
+        }
+    }
+    return null;
+}
+
+/** First permission-visible tab that has a real page (skips placeholder-only routes such as overview). */
+export function getFirstAccessibleImplementedApplicationDetailPath(
+    groups: ApplicationDetailNavGroup[],
+    implementedPaths: Set<string>,
+    hasAnyPermission: (permissions: string[]) => boolean,
+): string | null {
+    for (const item of flattenApplicationDetailNavItems(groups)) {
+        if (!implementedPaths.has(item.path)) {
+            continue;
+        }
+        if (!item.permissions || hasAnyPermission(item.permissions)) {
+            return item.path;
+        }
+    }
+    return null;
+}
+
+export function getApplicationDetailTabPermissions(tabPath: string): string[] | undefined {
+    return flattenApplicationDetailNavItems(APPLICATION_NAV_GROUPS).find(item => item.path === tabPath)?.permissions;
+}
+
+/** Tab paths with a dedicated page implementation (others use the shared placeholder). */
+export const APPLICATION_IMPLEMENTED_DETAIL_PATHS = new Set<string>(['general']);

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/ApplicationsEmptyLanding.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/ApplicationsEmptyLanding.tsx
@@ -1,0 +1,145 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Card, CardContent } from '@gravitee/graphene-core';
+import { ArrowRightIcon, CircleCheckIcon, CircleXIcon, KeyIcon, MonitorIcon, ShieldIcon, UsersIcon } from '@gravitee/graphene-core/icons';
+import type { LucideIcon } from '@gravitee/graphene-core/icons';
+
+import { ApplicationsPageHeader } from './ApplicationsPageHeader';
+import { FeatureTile } from '../../shared/components';
+
+const WITHOUT_APP_CONS = [
+    'No consumer identity or subscription lifecycle',
+    'No centralized API keys or OAuth client management',
+    'Harder to track which clients call which APIs',
+] as const;
+
+const WITH_APP_PROS = [
+    'Dedicated credentials per consumer application',
+    'Subscriptions tied to plans, keys, and quotas',
+    'Clear ownership and access across environments',
+] as const;
+
+const FEATURE_TILES: { readonly Icon: LucideIcon; readonly title: string; readonly description: string }[] = [
+    {
+        Icon: UsersIcon,
+        title: 'Consumer identity',
+        description: 'Register each client app so subscriptions, owners, and credentials stay organized.',
+    },
+    {
+        Icon: KeyIcon,
+        title: 'Access management',
+        description: 'Issue API keys or OAuth clients and control how consumers authenticate.',
+    },
+    {
+        Icon: ShieldIcon,
+        title: 'Controlled access',
+        description: 'Approve subscriptions to plans and revoke access without touching backend services.',
+    },
+];
+
+function FlowNode({ Icon, label }: { Icon: LucideIcon; label: string }) {
+    return (
+        <div className="flex flex-col items-center text-center">
+            <div className="rounded-lg bg-muted p-2">
+                <Icon className="size-4 text-muted-foreground" aria-hidden />
+            </div>
+            <p className="text-xs font-medium mt-1">{label}</p>
+        </div>
+    );
+}
+
+function ComparisonLine({ label, variant }: { label: string; variant: 'positive' | 'negative' }) {
+    return (
+        <li className="flex items-center gap-1 text-xs text-muted-foreground">
+            {variant === 'positive' ? (
+                <CircleCheckIcon className="size-3 shrink-0 text-success" aria-hidden />
+            ) : (
+                <CircleXIcon className="size-3 shrink-0 text-destructive" aria-hidden />
+            )}
+            {label}
+        </li>
+    );
+}
+
+export function ApplicationsEmptyLanding({
+    onRegisterApplication,
+    canCreate = false,
+}: {
+    onRegisterApplication?: () => void;
+    canCreate?: boolean;
+}) {
+    return (
+        <div className="space-y-6">
+            <ApplicationsPageHeader canCreate={canCreate} onRegisterApplication={onRegisterApplication ?? (() => undefined)} />
+
+            <Card>
+                <CardContent className="pt-6 space-y-6">
+                    <div>
+                        <h2 className="text-base font-semibold">Why register an application?</h2>
+                        <p className="text-xs text-muted-foreground mt-1">
+                            Applications represent the consumers of your APIs. Registering them lets you manage subscriptions, credentials,
+                            and ownership in one place.
+                        </p>
+                    </div>
+
+                    <div className="flex flex-row gap-4 items-stretch">
+                        <div className="flex-1 rounded-xl border p-4 space-y-3">
+                            <p className="text-xs font-semibold text-muted-foreground">Without registered applications</p>
+                            <div className="flex items-center justify-center gap-2">
+                                <FlowNode Icon={MonitorIcon} label="Client" />
+                                <ArrowRightIcon className="size-4 text-muted-foreground shrink-0" aria-hidden />
+                                <FlowNode Icon={ShieldIcon} label="API" />
+                            </div>
+                            <ul className="space-y-1">
+                                {WITHOUT_APP_CONS.map(label => (
+                                    <ComparisonLine key={label} label={label} variant="negative" />
+                                ))}
+                            </ul>
+                        </div>
+
+                        <div className="flex items-center justify-center shrink-0">
+                            <ArrowRightIcon className="size-5 text-primary" aria-hidden />
+                        </div>
+
+                        <div className="flex-1 rounded-xl border-2 border-primary/20 bg-primary/5 p-4 space-y-3">
+                            <p className="text-xs font-semibold text-primary">With registered applications</p>
+                            <div className="flex items-center justify-center gap-2">
+                                <FlowNode Icon={MonitorIcon} label="Client" />
+                                <ArrowRightIcon className="size-4 text-primary/70 shrink-0" aria-hidden />
+                                <FlowNode Icon={UsersIcon} label="Application" />
+                                <ArrowRightIcon className="size-4 text-primary/70 shrink-0" aria-hidden />
+                                <FlowNode Icon={ShieldIcon} label="API" />
+                            </div>
+                            <ul className="space-y-1">
+                                {WITH_APP_PROS.map(label => (
+                                    <ComparisonLine key={label} label={label} variant="positive" />
+                                ))}
+                            </ul>
+                        </div>
+                    </div>
+
+                    <div className="flex flex-row gap-4 border-t pt-5">
+                        {FEATURE_TILES.map(({ Icon, title, description }) => (
+                            <div key={title} className="flex-1">
+                                <FeatureTile Icon={Icon} title={title} description={description} />
+                            </div>
+                        ))}
+                    </div>
+                </CardContent>
+            </Card>
+        </div>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/ApplicationsPageHeader.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/ApplicationsPageHeader.spec.tsx
@@ -1,0 +1,37 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import { ApplicationsPageHeader } from './ApplicationsPageHeader';
+
+describe('ApplicationsPageHeader', () => {
+    it('shows the Register Application button when canCreate is true', () => {
+        render(<ApplicationsPageHeader canCreate onRegisterApplication={jest.fn()} />);
+        expect(screen.queryByRole('button', { name: /Register Application/i })).not.toBeNull();
+    });
+
+    it('hides the Register Application button when canCreate is false', () => {
+        render(<ApplicationsPageHeader canCreate={false} onRegisterApplication={jest.fn()} />);
+        expect(screen.queryByRole('button', { name: /Register Application/i })).toBeNull();
+    });
+
+    it('calls onRegisterApplication when the create button is clicked', () => {
+        const onRegisterApplication = jest.fn();
+        render(<ApplicationsPageHeader canCreate onRegisterApplication={onRegisterApplication} />);
+        fireEvent.click(screen.getByRole('button', { name: /Register Application/i }));
+        expect(onRegisterApplication).toHaveBeenCalled();
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/ApplicationsPageHeader.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/ApplicationsPageHeader.tsx
@@ -1,0 +1,54 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Button, Tooltip, TooltipContent, TooltipTrigger } from '@gravitee/graphene-core';
+import { InfoIcon, PlusIcon } from '@gravitee/graphene-core/icons';
+
+export interface ApplicationsPageHeaderProps {
+    readonly canCreate: boolean;
+    readonly onRegisterApplication: () => void;
+    readonly showInfoTooltip?: boolean;
+}
+
+export function ApplicationsPageHeader({ canCreate, onRegisterApplication, showInfoTooltip = false }: ApplicationsPageHeaderProps) {
+    return (
+        <div className="flex items-start justify-between">
+            <div className="space-y-1">
+                <div className="flex items-center gap-2">
+                    <h1 className="text-2xl font-semibold tracking-tight">Applications</h1>
+                    {showInfoTooltip ? (
+                        <Tooltip>
+                            <TooltipTrigger asChild>
+                                <button type="button" className="text-muted-foreground" aria-label="About applications">
+                                    <InfoIcon className="size-4" aria-hidden />
+                                </button>
+                            </TooltipTrigger>
+                            <TooltipContent>Consumer applications that subscribe to your APIs and receive credentials.</TooltipContent>
+                        </Tooltip>
+                    ) : null}
+                </div>
+                <p className="text-sm text-muted-foreground">
+                    Manage consumer applications and their API subscriptions across the platform.
+                </p>
+            </div>
+            {canCreate && (
+                <Button onClick={onRegisterApplication} className="shrink-0">
+                    <PlusIcon className="size-4" aria-hidden />
+                    Register Application
+                </Button>
+            )}
+        </div>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/create/AdditionalClientMetadataField.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/create/AdditionalClientMetadataField.tsx
@@ -1,0 +1,134 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Button, Input, Label } from '@gravitee/graphene-core';
+import { XIcon } from '@gravitee/graphene-core/icons';
+import { useState } from 'react';
+
+import { rowsToAdditionalClientMetadata } from '../../utils/applicationCreateMapper';
+
+interface MetadataRow {
+    id: string;
+    key: string;
+    value: string;
+}
+
+interface AdditionalClientMetadataFieldProps {
+    readonly value: Record<string, string> | null;
+    readonly onChange: (value: Record<string, string> | null) => void;
+}
+
+function createEmptyRow(): MetadataRow {
+    return { id: crypto.randomUUID(), key: '', value: '' };
+}
+
+function recordToRows(record: Record<string, string> | null): MetadataRow[] {
+    if (!record || Object.keys(record).length === 0) {
+        return [createEmptyRow()];
+    }
+
+    return [...Object.entries(record).map(([key, value]) => ({ id: crypto.randomUUID(), key, value })), createEmptyRow()];
+}
+
+function ensureTrailingEmptyRow(rows: MetadataRow[]): MetadataRow[] {
+    if (rows.length === 0) {
+        return [createEmptyRow()];
+    }
+
+    const last = rows[rows.length - 1]!;
+    if (last.key.trim() || last.value.trim()) {
+        return [...rows, createEmptyRow()];
+    }
+
+    return rows;
+}
+
+export function AdditionalClientMetadataField({ value, onChange }: AdditionalClientMetadataFieldProps) {
+    const [rows, setRows] = useState<MetadataRow[]>(() => recordToRows(value));
+
+    const updateRows = (nextRows: MetadataRow[]) => {
+        const withTrailing = ensureTrailingEmptyRow(nextRows);
+        setRows(withTrailing);
+        onChange(rowsToAdditionalClientMetadata(withTrailing));
+    };
+
+    const handleRowChange = (rowId: string, field: 'key' | 'value', fieldValue: string) => {
+        const nextRows = rows.map(row => (row.id === rowId ? { ...row, [field]: fieldValue } : row));
+        updateRows(nextRows);
+    };
+
+    const handleDeleteRow = (rowId: string) => {
+        const nextRows = rows.filter(row => row.id !== rowId);
+        updateRows(nextRows);
+    };
+
+    return (
+        <div className="space-y-2">
+            <Label>Additional Client Metadata (optional)</Label>
+            <div className="overflow-x-auto rounded-lg border">
+                <table className="w-full min-w-[28rem] text-sm">
+                    <thead>
+                        <tr className="border-b bg-muted/40 text-left text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                            <th className="px-3 py-2">Key</th>
+                            <th className="px-3 py-2">Value</th>
+                            <th className="w-10 px-2 py-2" aria-hidden />
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {rows.map((row, index) => {
+                            const isTrailingEmpty = index === rows.length - 1 && !row.key.trim() && !row.value.trim();
+                            const showDelete = !isTrailingEmpty && rows.length > 1;
+
+                            return (
+                                <tr key={row.id} className="border-b last:border-b-0">
+                                    <td className="px-3 py-2 align-top">
+                                        <Input
+                                            value={row.key}
+                                            onChange={event => handleRowChange(row.id, 'key', event.target.value)}
+                                            placeholder="Name..."
+                                            aria-label={`Metadata key ${index + 1}`}
+                                        />
+                                    </td>
+                                    <td className="px-3 py-2 align-top">
+                                        <Input
+                                            value={row.value}
+                                            onChange={event => handleRowChange(row.id, 'value', event.target.value)}
+                                            placeholder="Value..."
+                                            aria-label={`Metadata value ${index + 1}`}
+                                        />
+                                    </td>
+                                    <td className="px-2 py-2 align-top">
+                                        {showDelete && (
+                                            <Button
+                                                type="button"
+                                                variant="ghost"
+                                                size="icon"
+                                                className="size-8 shrink-0"
+                                                aria-label={`Remove metadata row ${index + 1}`}
+                                                onClick={() => handleDeleteRow(row.id)}
+                                            >
+                                                <XIcon className="size-4" aria-hidden />
+                                            </Button>
+                                        )}
+                                    </td>
+                                </tr>
+                            );
+                        })}
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/create/ApplicationGroupsField.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/create/ApplicationGroupsField.tsx
@@ -1,0 +1,195 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+    Badge,
+    Button,
+    Checkbox,
+    cn,
+    Label,
+    Popover,
+    PopoverContent,
+    PopoverTrigger,
+    ScrollArea,
+    Tooltip,
+    TooltipContent,
+    TooltipTrigger,
+} from '@gravitee/graphene-core';
+import { ChevronsUpDownIcon, InfoIcon, XIcon } from '@gravitee/graphene-core/icons';
+import { useLayoutEffect, useMemo, useRef, useState } from 'react';
+
+import type { ApplicationGroup } from '../../types/applicationCreate';
+
+interface ApplicationGroupsFieldProps {
+    readonly groups: ApplicationGroup[];
+    readonly selectedGroupIds: string[];
+    readonly onSelectedGroupIdsChange: (groupIds: string[]) => void;
+    readonly isLoading?: boolean;
+    readonly required?: boolean;
+}
+
+export function ApplicationGroupsField({
+    groups,
+    selectedGroupIds,
+    onSelectedGroupIdsChange,
+    isLoading = false,
+    required = false,
+}: ApplicationGroupsFieldProps) {
+    const triggerRef = useRef<HTMLButtonElement>(null);
+    const [open, setOpen] = useState(false);
+    const [popoverWidth, setPopoverWidth] = useState<number>();
+
+    const sortedGroups = useMemo(() => [...groups].sort((a, b) => a.name.localeCompare(b.name)), [groups]);
+
+    const selectedGroups = useMemo(
+        () => sortedGroups.filter(group => selectedGroupIds.includes(group.id)),
+        [selectedGroupIds, sortedGroups],
+    );
+
+    const syncPopoverWidth = () => {
+        const width = triggerRef.current?.offsetWidth;
+        if (width) {
+            setPopoverWidth(width);
+        }
+    };
+
+    const handleOpenChange = (nextOpen: boolean) => {
+        if (nextOpen) {
+            syncPopoverWidth();
+        }
+        setOpen(nextOpen);
+    };
+
+    useLayoutEffect(() => {
+        if (!open) {
+            return undefined;
+        }
+
+        syncPopoverWidth();
+
+        const handleResize = () => syncPopoverWidth();
+        window.addEventListener('resize', handleResize);
+        return () => window.removeEventListener('resize', handleResize);
+    }, [open]);
+
+    const toggleGroup = (groupId: string, checked: boolean) => {
+        onSelectedGroupIdsChange(checked ? [...selectedGroupIds, groupId] : selectedGroupIds.filter(id => id !== groupId));
+    };
+
+    const removeGroup = (groupId: string) => {
+        onSelectedGroupIdsChange(selectedGroupIds.filter(id => id !== groupId));
+    };
+
+    return (
+        <div className="space-y-2">
+            <div className="flex items-center gap-1">
+                <Label htmlFor="application-groups">
+                    Groups
+                    {required && <span className="text-destructive"> *</span>}
+                </Label>
+                <Tooltip>
+                    <TooltipTrigger asChild>
+                        <button
+                            type="button"
+                            className="inline-flex items-center justify-center rounded-full text-muted-foreground/60 transition-colors hover:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                            aria-label="Groups help"
+                        >
+                            <InfoIcon className="size-4" aria-hidden />
+                        </button>
+                    </TooltipTrigger>
+                    <TooltipContent>Select user groups to add to the application</TooltipContent>
+                </Tooltip>
+            </div>
+
+            <div className="w-full">
+                <Popover open={open} onOpenChange={handleOpenChange}>
+                    <PopoverTrigger asChild>
+                        <Button
+                            ref={triggerRef}
+                            id="application-groups"
+                            type="button"
+                            variant="outline"
+                            role="combobox"
+                            disabled={isLoading}
+                            className={cn(
+                                'h-auto min-h-9 w-full justify-between gap-2 px-3 py-2 font-normal',
+                                selectedGroups.length === 0 && 'text-muted-foreground',
+                            )}
+                        >
+                            <span className="flex min-w-0 flex-1 flex-wrap items-center gap-1 text-left">
+                                {selectedGroups.length === 0 ? (
+                                    <span>{required ? 'Select groups (required)' : 'Select groups'}</span>
+                                ) : (
+                                    selectedGroups.map(group => (
+                                        <Badge
+                                            key={group.id}
+                                            variant="secondary"
+                                            className="gap-0.5 pr-1 font-normal"
+                                            onClick={event => event.stopPropagation()}
+                                        >
+                                            {group.name}
+                                            <button
+                                                type="button"
+                                                className="rounded-sm p-0.5 hover:bg-muted"
+                                                aria-label={`Remove ${group.name}`}
+                                                onClick={event => {
+                                                    event.stopPropagation();
+                                                    removeGroup(group.id);
+                                                }}
+                                            >
+                                                <XIcon className="size-3" aria-hidden />
+                                            </button>
+                                        </Badge>
+                                    ))
+                                )}
+                            </span>
+                            <ChevronsUpDownIcon className="size-4 shrink-0 opacity-50" aria-hidden />
+                        </Button>
+                    </PopoverTrigger>
+                    <PopoverContent
+                        align="start"
+                        className="gap-0 p-0"
+                        style={
+                            popoverWidth !== undefined ? { width: popoverWidth, minWidth: popoverWidth, maxWidth: popoverWidth } : undefined
+                        }
+                    >
+                        <ScrollArea className="max-h-60 w-full">
+                            <div className="w-full p-1">
+                                {sortedGroups.length === 0 ? (
+                                    <p className="px-2 py-3 text-sm text-muted-foreground">No groups available</p>
+                                ) : (
+                                    sortedGroups.map(group => (
+                                        <label
+                                            key={group.id}
+                                            className="flex w-full cursor-pointer items-center gap-2 rounded-sm px-2 py-2 text-sm hover:bg-accent"
+                                        >
+                                            <Checkbox
+                                                checked={selectedGroupIds.includes(group.id)}
+                                                onCheckedChange={checked => toggleGroup(group.id, checked === true)}
+                                            />
+                                            <span className="truncate">{group.name}</span>
+                                        </label>
+                                    ))
+                                )}
+                            </div>
+                        </ScrollArea>
+                    </PopoverContent>
+                </Popover>
+            </div>
+
+            <p className="text-xs text-muted-foreground">Select user groups to add to the application</p>
+        </div>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/create/ApplicationTypeSelector.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/create/ApplicationTypeSelector.tsx
@@ -1,0 +1,69 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { cn } from '@gravitee/graphene-core';
+import { CircleCheckIcon } from '@gravitee/graphene-core/icons';
+
+import type { ApplicationTypeConfig } from '../../types/applicationCreate';
+import { applicationTypeIcon } from '../../utils/applicationTypeIcons';
+import { isSameApplicationType } from '../../utils/applicationTypeLabels';
+
+interface ApplicationTypeSelectorProps {
+    readonly types: ApplicationTypeConfig[];
+    readonly selectedTypeId: string;
+    readonly onTypeChange: (typeId: string) => void;
+    /** When only one type is enabled, show it selected but not changeable (console hides selector; gamma keeps card visible). */
+    readonly readOnly?: boolean;
+}
+
+export function ApplicationTypeSelector({ types, selectedTypeId, onTypeChange, readOnly = false }: ApplicationTypeSelectorProps) {
+    return (
+        <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+            {types.map(type => {
+                const isSelected = isSameApplicationType(selectedTypeId, type.id);
+                const Icon = applicationTypeIcon(type.id);
+
+                return (
+                    <button
+                        key={type.id}
+                        type="button"
+                        className={cn(
+                            'relative flex items-start gap-3 rounded-xl border-2 p-4 text-left transition-all outline-none',
+                            readOnly ? 'cursor-default' : undefined,
+                            isSelected
+                                ? 'border-primary bg-primary/10 focus-visible:border-primary focus-visible:ring-2 focus-visible:ring-primary/40'
+                                : 'border-transparent bg-muted focus-visible:border-primary focus-visible:ring-2 focus-visible:ring-primary/40',
+                            !readOnly && !isSelected && 'hover:border-border',
+                        )}
+                        onClick={() => {
+                            if (!readOnly) {
+                                onTypeChange(type.id);
+                            }
+                        }}
+                        aria-pressed={isSelected}
+                        aria-disabled={readOnly || undefined}
+                    >
+                        <Icon className={cn('mt-0.5 size-5 shrink-0', isSelected ? 'text-primary' : 'text-muted-foreground')} aria-hidden />
+                        <div className="min-w-0">
+                            <span className="text-sm font-medium">{type.name}</span>
+                            {type.description && <p className="mt-0.5 text-xs leading-relaxed text-muted-foreground">{type.description}</p>}
+                        </div>
+                        {isSelected && <CircleCheckIcon className="absolute top-3 right-3 size-4 shrink-0 text-primary" aria-hidden />}
+                    </button>
+                );
+            })}
+        </div>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/create/OAuthSecurityFields.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/create/OAuthSecurityFields.tsx
@@ -1,0 +1,147 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Badge, cn, Input, Label, Textarea, Tooltip, TooltipContent, TooltipTrigger } from '@gravitee/graphene-core';
+import { CircleCheckIcon, InfoIcon } from '@gravitee/graphene-core/icons';
+
+import { AdditionalClientMetadataField } from './AdditionalClientMetadataField';
+import type { ApplicationTypeConfig } from '../../types/applicationCreate';
+import { isMandatoryGrantType } from '../../utils/applicationCreateMapper';
+
+interface OAuthSecurityFieldsProps {
+    readonly selectedType: ApplicationTypeConfig;
+    readonly grantTypes: string[];
+    readonly redirectUris: string;
+    readonly clientCertificate: string;
+    readonly additionalClientMetadata: Record<string, string> | null;
+    readonly onGrantTypesChange: (grantTypes: string[]) => void;
+    readonly onRedirectUrisChange: (value: string) => void;
+    readonly onClientCertificateChange: (value: string) => void;
+    readonly onAdditionalClientMetadataChange: (value: Record<string, string> | null) => void;
+}
+
+export function OAuthSecurityFields({
+    selectedType,
+    grantTypes,
+    redirectUris,
+    clientCertificate,
+    additionalClientMetadata,
+    onGrantTypesChange,
+    onRedirectUrisChange,
+    onClientCertificateChange,
+    onAdditionalClientMetadataChange,
+}: OAuthSecurityFieldsProps) {
+    const requiresRedirectUris = Boolean(selectedType.requires_redirect_uris);
+
+    const toggleGrantType = (grantType: string) => {
+        if (isMandatoryGrantType(selectedType, grantType)) return;
+        onGrantTypesChange(grantTypes.includes(grantType) ? grantTypes.filter(value => value !== grantType) : [...grantTypes, grantType]);
+    };
+
+    return (
+        <div className="space-y-5 pt-2">
+            <div className="space-y-2">
+                <Label className="flex items-center gap-2">
+                    Allowed grant types
+                    <Tooltip>
+                        <TooltipTrigger asChild>
+                            <button
+                                type="button"
+                                className="inline-flex items-center justify-center rounded-full text-muted-foreground/60 transition-colors hover:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                                aria-label="Grant types help"
+                            >
+                                <InfoIcon className="size-4" aria-hidden />
+                            </button>
+                        </TooltipTrigger>
+                        <TooltipContent>
+                            Grant types allowed for the client. Please set only grant types you need for security reasons.
+                        </TooltipContent>
+                    </Tooltip>
+                </Label>
+                <div className="flex flex-wrap gap-2">
+                    {selectedType.allowed_grant_types.map(grantType => {
+                        const isActive = grantTypes.includes(grantType.type);
+                        const isMandatory = isMandatoryGrantType(selectedType, grantType.type);
+
+                        return (
+                            <button
+                                key={grantType.type}
+                                type="button"
+                                className={cn(
+                                    'inline-flex items-center gap-1.5 rounded-lg border px-3 py-2 text-sm transition-colors',
+                                    isActive ? 'border-primary bg-primary/10 text-primary' : 'border-border hover:bg-accent/50',
+                                    isMandatory ? 'cursor-not-allowed opacity-80' : 'cursor-pointer',
+                                )}
+                                onClick={() => toggleGrantType(grantType.type)}
+                                disabled={isMandatory}
+                                aria-pressed={isActive}
+                            >
+                                {isActive && <CircleCheckIcon className="size-3.5" aria-hidden />}
+                                {grantType.name}
+                                {isMandatory && (
+                                    <Badge variant="secondary" className="ml-1 text-[10px]">
+                                        Mandatory
+                                    </Badge>
+                                )}
+                            </button>
+                        );
+                    })}
+                </div>
+                <p className="text-xs text-muted-foreground">
+                    Grant types allowed for the client. Please set only grant types you need for security reasons.
+                </p>
+            </div>
+
+            {requiresRedirectUris && (
+                <div className="space-y-2">
+                    <Label htmlFor="redirect-uris">
+                        Redirect URIs <span className="text-destructive">*</span>
+                    </Label>
+                    <Input
+                        id="redirect-uris"
+                        value={redirectUris}
+                        onChange={event => onRedirectUrisChange(event.target.value)}
+                        placeholder="https://app.example.com/callback"
+                    />
+                    <p className="text-xs text-muted-foreground">
+                        URIs where the authorization server will send OAuth responses. Separate multiple URIs with commas.
+                    </p>
+                </div>
+            )}
+
+            <div className="space-y-2">
+                <Label htmlFor="client-cert">Client Certificate (PEM Only)</Label>
+                <Textarea
+                    id="client-cert"
+                    value={clientCertificate}
+                    onChange={event => onClientCertificateChange(event.target.value)}
+                    placeholder={'-----BEGIN CERTIFICATE-----\n...\n-----END CERTIFICATE-----'}
+                    rows={4}
+                    className="min-h-20 font-mono text-xs"
+                />
+                <p className="text-xs text-muted-foreground">
+                    The <code className="rounded bg-muted px-1 py-0.5 text-xs">client_certificate</code> of the application. This field is
+                    required to subscribe to certain mTLS plans.
+                </p>
+            </div>
+
+            <AdditionalClientMetadataField
+                key={selectedType.id}
+                value={additionalClientMetadata}
+                onChange={onAdditionalClientMetadataChange}
+            />
+        </div>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/create/OAuthSecurityFields.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/create/OAuthSecurityFields.tsx
@@ -91,7 +91,7 @@ export function OAuthSecurityFields({
                                 {isActive && <CircleCheckIcon className="size-3.5" aria-hidden />}
                                 {grantType.name}
                                 {isMandatory && (
-                                    <Badge variant="secondary" className="ml-1 text-[10px]">
+                                    <Badge variant="secondary" className="ml-1 text-xs">
                                         Mandatory
                                     </Badge>
                                 )}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/create/RegisterApplicationForm.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/create/RegisterApplicationForm.tsx
@@ -1,0 +1,270 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+    Alert,
+    AlertDescription,
+    Button,
+    Card,
+    CardContent,
+    CardDescription,
+    CardHeader,
+    CardTitle,
+    Input,
+    Label,
+    Separator,
+    Skeleton,
+    Textarea,
+} from '@gravitee/graphene-core';
+import { Loader2Icon } from '@gravitee/graphene-core/icons';
+import { useEffect, useMemo, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+import { ApplicationGroupsField } from './ApplicationGroupsField';
+import { ApplicationTypeSelector } from './ApplicationTypeSelector';
+import { OAuthSecurityFields } from './OAuthSecurityFields';
+import { SimpleSecurityFields } from './SimpleSecurityFields';
+import { useApplicationGroups } from '../../hooks/useApplicationGroups';
+import { useApplicationTypes } from '../../hooks/useApplicationTypes';
+import { useCreateApplication } from '../../hooks/useCreateApplication';
+import { useUserGroupRequired } from '../../hooks/useUserGroupRequired';
+import type { RegisterApplicationDraft } from '../../types/applicationCreate';
+import { defaultGrantTypesForType, isOAuthApplicationType, isRegisterApplicationFormValid } from '../../utils/applicationCreateMapper';
+
+const EMPTY_DRAFT: RegisterApplicationDraft = {
+    name: '',
+    description: '',
+    domain: '',
+    typeId: 'simple',
+    groups: [],
+    appType: '',
+    appClientId: '',
+    grantTypes: [],
+    redirectUris: '',
+    clientCertificate: '',
+    additionalClientMetadata: null,
+};
+
+export function RegisterApplicationForm() {
+    const navigate = useNavigate();
+    const { data: applicationTypes = [], isLoading: isLoadingTypes } = useApplicationTypes();
+    const { data: groups = [], isLoading: isLoadingGroups } = useApplicationGroups();
+    const { requireUserGroups } = useUserGroupRequired();
+    const createApplication = useCreateApplication();
+
+    const [draft, setDraft] = useState<RegisterApplicationDraft>(EMPTY_DRAFT);
+
+    const selectedType = applicationTypes.find(type => type.id === draft.typeId) ?? applicationTypes[0];
+
+    useEffect(() => {
+        if (applicationTypes.length === 0) return;
+        if (!applicationTypes.some(type => type.id === draft.typeId)) {
+            const firstType = applicationTypes[0];
+            setDraft(current => ({
+                ...current,
+                typeId: firstType.id,
+                grantTypes: defaultGrantTypesForType(firstType),
+            }));
+        }
+    }, [draft.typeId, applicationTypes]);
+
+    const updateDraft = (patch: Partial<RegisterApplicationDraft>) => {
+        setDraft(current => ({ ...current, ...patch }));
+    };
+
+    const handleTypeChange = (typeId: string) => {
+        const nextType = applicationTypes.find(type => type.id === typeId);
+        if (!nextType) return;
+        updateDraft({
+            typeId,
+            grantTypes: defaultGrantTypesForType(nextType),
+            redirectUris: '',
+            appType: '',
+            appClientId: '',
+            additionalClientMetadata: null,
+        });
+    };
+
+    const isSimpleType = !isOAuthApplicationType(selectedType?.id ?? '');
+
+    const hasGroupsToAdd = groups.length > 0;
+    const showGroupsField = hasGroupsToAdd || requireUserGroups;
+
+    const isFormValid = useMemo(
+        () => isRegisterApplicationFormValid(draft, selectedType, { requireUserGroups }),
+        [draft, selectedType, requireUserGroups],
+    );
+
+    const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+        event.preventDefault();
+        if (!selectedType || !isFormValid) {
+            return;
+        }
+
+        createApplication.mutate(
+            { draft, selectedType },
+            {
+                onSuccess: application =>
+                    navigate('..', {
+                        state: { successMessage: `Application "${application.name}" created.` },
+                    }),
+            },
+        );
+    };
+
+    if (isLoadingTypes && applicationTypes.length === 0) {
+        return (
+            <div className="space-y-6">
+                <Skeleton className="h-10 w-full max-w-xl" />
+                <Skeleton className="h-96 w-full" />
+            </div>
+        );
+    }
+
+    return (
+        <form className="space-y-6" onSubmit={handleSubmit} noValidate>
+            {createApplication.isError && (
+                <Alert variant="destructive">
+                    <AlertDescription>{createApplication.error.message}</AlertDescription>
+                </Alert>
+            )}
+
+            <Card>
+                <CardHeader>
+                    <CardTitle className="text-lg">General</CardTitle>
+                    <CardDescription>Provide basic information about the application.</CardDescription>
+                </CardHeader>
+                <CardContent className="space-y-5">
+                    <div className="space-y-2">
+                        <Label htmlFor="application-name">
+                            Name <span className="text-destructive">*</span>
+                        </Label>
+                        <Input
+                            id="application-name"
+                            value={draft.name}
+                            onChange={event => updateDraft({ name: event.target.value })}
+                            placeholder="Application name"
+                            maxLength={512}
+                        />
+                    </div>
+
+                    <div className="space-y-2">
+                        <Label htmlFor="application-description">
+                            Description <span className="text-destructive">*</span>
+                        </Label>
+                        <Textarea
+                            id="application-description"
+                            value={draft.description}
+                            onChange={event => updateDraft({ description: event.target.value })}
+                            placeholder="Provide a description of your application, what it does, ..."
+                            maxLength={40000}
+                            rows={4}
+                        />
+                    </div>
+
+                    <div className="space-y-2">
+                        <Label htmlFor="application-domain">Domain</Label>
+                        <Input
+                            id="application-domain"
+                            value={draft.domain}
+                            onChange={event => updateDraft({ domain: event.target.value })}
+                            placeholder="e.g., app.example.com"
+                            maxLength={512}
+                        />
+                    </div>
+
+                    {showGroupsField && (
+                        <ApplicationGroupsField
+                            groups={groups}
+                            selectedGroupIds={draft.groups}
+                            onSelectedGroupIdsChange={groupIds => updateDraft({ groups: groupIds })}
+                            isLoading={isLoadingGroups}
+                            required={requireUserGroups}
+                        />
+                    )}
+
+                    {requireUserGroups && !hasGroupsToAdd && !isLoadingGroups && (
+                        <Alert variant="destructive">
+                            <AlertDescription>
+                                The current user is not associated to any groups. Add the user to one or more groups or disable the option
+                                to make group selection mandatory while creating applications.
+                            </AlertDescription>
+                        </Alert>
+                    )}
+
+                    <Separator />
+
+                    <div className="space-y-4">
+                        <h3 className="text-base font-semibold">Security</h3>
+
+                        {applicationTypes.length === 0 && (
+                            <Alert>
+                                <AlertDescription>
+                                    No application type available. Please check Client Registration configuration.
+                                </AlertDescription>
+                            </Alert>
+                        )}
+
+                        {applicationTypes.length > 0 && (
+                            <ApplicationTypeSelector
+                                types={applicationTypes}
+                                selectedTypeId={draft.typeId}
+                                onTypeChange={handleTypeChange}
+                                readOnly={applicationTypes.length === 1}
+                            />
+                        )}
+
+                        {!isSimpleType && selectedType && (
+                            <OAuthSecurityFields
+                                selectedType={selectedType}
+                                grantTypes={draft.grantTypes}
+                                redirectUris={draft.redirectUris}
+                                clientCertificate={draft.clientCertificate}
+                                additionalClientMetadata={draft.additionalClientMetadata}
+                                onGrantTypesChange={grantTypes => updateDraft({ grantTypes })}
+                                onRedirectUrisChange={redirectUris => updateDraft({ redirectUris })}
+                                onClientCertificateChange={clientCertificate => updateDraft({ clientCertificate })}
+                                onAdditionalClientMetadataChange={additionalClientMetadata => updateDraft({ additionalClientMetadata })}
+                            />
+                        )}
+
+                        {isSimpleType && (
+                            <SimpleSecurityFields
+                                appType={draft.appType}
+                                appClientId={draft.appClientId}
+                                clientCertificate={draft.clientCertificate}
+                                onAppTypeChange={appType => updateDraft({ appType })}
+                                onAppClientIdChange={appClientId => updateDraft({ appClientId })}
+                                onClientCertificateChange={clientCertificate => updateDraft({ clientCertificate })}
+                            />
+                        )}
+                    </div>
+                </CardContent>
+            </Card>
+
+            <div className="sticky bottom-0 -mx-6 mt-6 border-t bg-background/95 px-6 py-4 backdrop-blur supports-[backdrop-filter]:bg-background/80">
+                <div className="flex items-center justify-end gap-3">
+                    <Button type="button" variant="outline" onClick={() => navigate('..')}>
+                        Cancel
+                    </Button>
+                    <Button type="submit" disabled={createApplication.isPending || !isFormValid}>
+                        {createApplication.isPending && <Loader2Icon className="size-4 animate-spin" aria-hidden />}
+                        Create Application
+                    </Button>
+                </div>
+            </div>
+        </form>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/create/RegisterApplicationForm.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/create/RegisterApplicationForm.tsx
@@ -116,9 +116,9 @@ export function RegisterApplicationForm() {
         createApplication.mutate(
             { draft, selectedType },
             {
-                onSuccess: application =>
-                    navigate('..', {
-                        state: { successMessage: `Application "${application.name}" created.` },
+                onSuccess: created =>
+                    navigate(`../${created.id}/general`, {
+                        state: { created: true, applicationName: created.name },
                     }),
             },
         );

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/create/SimpleSecurityFields.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/create/SimpleSecurityFields.tsx
@@ -1,0 +1,81 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Input, Label, Textarea } from '@gravitee/graphene-core';
+
+interface SimpleSecurityFieldsProps {
+    readonly appType: string;
+    readonly appClientId: string;
+    readonly clientCertificate: string;
+    readonly onAppTypeChange: (value: string) => void;
+    readonly onAppClientIdChange: (value: string) => void;
+    readonly onClientCertificateChange: (value: string) => void;
+}
+
+export function SimpleSecurityFields({
+    appType,
+    appClientId,
+    clientCertificate,
+    onAppTypeChange,
+    onAppClientIdChange,
+    onClientCertificateChange,
+}: SimpleSecurityFieldsProps) {
+    return (
+        <div className="space-y-5 pt-2">
+            <div className="space-y-2">
+                <Label htmlFor="simple-type">Type</Label>
+                <Input
+                    id="simple-type"
+                    value={appType}
+                    onChange={event => onAppTypeChange(event.target.value)}
+                    placeholder="Type of the application (mobile, web, ...)"
+                    maxLength={64}
+                />
+                <p className="text-xs text-muted-foreground">Type of the application (mobile, web, ...)</p>
+            </div>
+
+            <div className="space-y-2">
+                <Label htmlFor="simple-client-id">Client ID</Label>
+                <Input
+                    id="simple-client-id"
+                    value={appClientId}
+                    onChange={event => onAppClientIdChange(event.target.value)}
+                    placeholder="Client ID for API Key / JWT subscriptions"
+                    maxLength={300}
+                />
+                <p className="text-xs text-muted-foreground">
+                    The <code className="rounded bg-muted px-1 py-0.5 text-xs">client_id</code> of the application. This field is required
+                    to subscribe to certain type of API Plan (OAuth2, JWT).
+                </p>
+            </div>
+
+            <div className="space-y-2">
+                <Label htmlFor="simple-client-certificate">Client Certificate (PEM Only)</Label>
+                <Textarea
+                    id="simple-client-certificate"
+                    value={clientCertificate}
+                    onChange={event => onClientCertificateChange(event.target.value)}
+                    placeholder={'-----BEGIN CERTIFICATE-----\n...\n-----END CERTIFICATE-----'}
+                    rows={4}
+                    className="min-h-20 font-mono text-xs"
+                />
+                <p className="text-xs text-muted-foreground">
+                    The <code className="rounded bg-muted px-1 py-0.5 text-xs">client_certificate</code> of the application. This field is
+                    required to subscribe to certain mTLS plans.
+                </p>
+            </div>
+        </div>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/create/index.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/create/index.ts
@@ -13,5 +13,4 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-export * from '../../../../../../gamma-ui-shared/src/api/apimClient';
+export { RegisterApplicationForm } from './RegisterApplicationForm';

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/detail/ApplicationDetailAccessDenied.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/detail/ApplicationDetailAccessDenied.tsx
@@ -1,0 +1,32 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ShieldIcon } from '@gravitee/graphene-core/icons';
+
+export function ApplicationDetailAccessDenied() {
+    return (
+        <div className="flex flex-col items-center justify-center gap-3 rounded-lg border border-dashed bg-muted/20 px-6 py-16 text-center">
+            <div className="flex size-10 items-center justify-center rounded-full bg-muted">
+                <ShieldIcon className="size-5 text-muted-foreground" aria-hidden />
+            </div>
+            <div className="space-y-1">
+                <h2 className="text-base font-semibold">Access denied</h2>
+                <p className="max-w-md text-sm text-muted-foreground">
+                    You do not have permission to view this section of the application. Contact your administrator if you need access.
+                </p>
+            </div>
+        </div>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/detail/ApplicationDetailLayout.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/detail/ApplicationDetailLayout.tsx
@@ -1,0 +1,188 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { permissionService } from '@gravitee/gamma-modules-sdk';
+import { Badge, Skeleton } from '@gravitee/graphene-core';
+import { AppWindowIcon } from '@gravitee/graphene-core/icons';
+import { useMemo } from 'react';
+import { Navigate, useParams } from 'react-router-dom';
+
+import { ApplicationDetailProtectedOutlet } from './ApplicationDetailProtectedOutlet';
+import { ApplicationDetailSidebarNav } from './ApplicationDetailSidebarNav';
+import {
+    APPLICATION_CONSOLE_DEFAULT_DETAIL_PATH,
+    APPLICATION_IMPLEMENTED_DETAIL_PATHS,
+    APPLICATION_NAV_GROUPS,
+    getFirstAccessibleApplicationDetailPath,
+    getFirstAccessibleImplementedApplicationDetailPath,
+} from '../../../../config/applicationDetailNavigation';
+import { useDetailBasePath } from '../../../shared/hooks/useDetailBasePath';
+import { usePermissionServiceSnapshot } from '../../../shared/hooks/usePermissionServiceSnapshot';
+import { ApplicationDetailContext, useApplicationDetailContext } from '../../context/ApplicationDetailContext';
+import { useApplicationDetail } from '../../hooks/useApplicationDetail';
+import { useApplicationPermissions } from '../../hooks/useApplicationPermissions';
+import type { ApplicationListItem, ApplicationStatus } from '../../types/application';
+import { formatApplicationOwnerLabel, formatApplicationSecurityTypeLabel } from '../../utils/applicationFormatters';
+
+function StatusBadge({ status }: { status: ApplicationStatus }) {
+    if (status === 'ACTIVE') {
+        return (
+            <Badge className="h-6 w-fit rounded-md border-0 bg-primary px-2.5 text-xs font-medium lowercase text-primary-foreground">
+                active
+            </Badge>
+        );
+    }
+    return (
+        <Badge className="h-6 w-fit rounded-md border-0 bg-muted px-2.5 text-xs font-medium lowercase text-muted-foreground">
+            archived
+        </Badge>
+    );
+}
+
+function ApplicationInfoHeader({ application, isLoading }: { application: ApplicationListItem | null; isLoading: boolean }) {
+    if (isLoading) {
+        return (
+            <div className="space-y-2 border-b px-3 pb-4 pt-4">
+                <div className="flex items-start gap-2.5">
+                    <Skeleton className="size-8 shrink-0 rounded-lg" />
+                    <div className="min-w-0 flex-1 space-y-1.5">
+                        <Skeleton className="h-3.5 w-32 rounded" />
+                        <Skeleton className="h-6 w-14 rounded-md" />
+                    </div>
+                </div>
+                <Skeleton className="h-3 w-full rounded" />
+                <div className="flex gap-1.5">
+                    <Skeleton className="h-5 w-14 rounded-md" />
+                    <Skeleton className="h-5 w-24 rounded-md" />
+                </div>
+            </div>
+        );
+    }
+
+    if (!application) return null;
+
+    const ownerLabel = formatApplicationOwnerLabel(application.owner);
+
+    return (
+        <div className="space-y-2 border-b px-3 pb-4 pt-4">
+            <div className="flex items-start gap-2.5">
+                <div className="flex size-8 shrink-0 items-center justify-center rounded-lg border border-primary/30 bg-primary/5">
+                    <AppWindowIcon className="size-4 text-primary" aria-hidden />
+                </div>
+                <div className="min-w-0 flex-1 space-y-1.5">
+                    <p
+                        className="text-sm font-semibold leading-snug text-foreground"
+                        style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}
+                        title={application.name}
+                    >
+                        {application.name}
+                    </p>
+                    <StatusBadge status={application.status} />
+                </div>
+            </div>
+            {application.description ? (
+                <p
+                    className="text-xs text-muted-foreground"
+                    style={{
+                        lineHeight: '1.625',
+                        wordBreak: 'break-all',
+                        overflow: 'hidden',
+                        display: '-webkit-box',
+                        WebkitBoxOrient: 'vertical',
+                        WebkitLineClamp: 2,
+                    }}
+                    title={application.description}
+                >
+                    {application.description}
+                </p>
+            ) : null}
+            <div className="flex flex-wrap items-center gap-1.5">
+                <span className="inline-flex h-5 items-center border border-border bg-background px-1.5 text-xs font-normal text-foreground">
+                    {formatApplicationSecurityTypeLabel(application)}
+                </span>
+                {ownerLabel ? (
+                    <span className="inline-flex h-5 items-center bg-muted px-1.5 text-xs font-normal text-foreground">{ownerLabel}</span>
+                ) : null}
+            </div>
+        </div>
+    );
+}
+
+export function ApplicationDetailLayout() {
+    const { applicationId } = useParams<{ applicationId: string }>();
+    const basePath = useDetailBasePath('applications', applicationId);
+    const { data: application, isLoading, isError } = useApplicationDetail(applicationId);
+    const { permissionsReady } = useApplicationPermissions(applicationId);
+
+    if (isError) {
+        return (
+            <div className="flex items-center justify-center p-8">
+                <p className="text-sm text-muted-foreground">
+                    Failed to load application. It may have been deleted or you may not have access.
+                </p>
+            </div>
+        );
+    }
+
+    return (
+        <ApplicationDetailContext.Provider value={{ application: application ?? null, isLoading, permissionsReady }}>
+            <div className="flex gap-6">
+                <aside
+                    className="sticky top-0 w-56 min-w-0 shrink-0 self-start overflow-x-hidden overflow-y-auto pb-4"
+                    style={{ maxHeight: '100dvh', maxWidth: '14rem' }}
+                >
+                    <ApplicationInfoHeader application={application ?? null} isLoading={isLoading} />
+                    <ApplicationDetailSidebarNav
+                        groups={APPLICATION_NAV_GROUPS}
+                        basePath={basePath}
+                        permissionsReady={permissionsReady && !isLoading}
+                    />
+                </aside>
+                <main className="min-w-0 flex-1">
+                    <ApplicationDetailProtectedOutlet />
+                </main>
+            </div>
+        </ApplicationDetailContext.Provider>
+    );
+}
+
+export function ApplicationDetailIndexRedirect() {
+    const { permissionsReady } = useApplicationDetailContext();
+    const permissionVersion = usePermissionServiceSnapshot();
+
+    const landingPath = useMemo(() => {
+        const hasAnyPermission = (permissions: string[]) => permissionService.hasAnyOf(permissions);
+        return (
+            getFirstAccessibleImplementedApplicationDetailPath(
+                APPLICATION_NAV_GROUPS,
+                APPLICATION_IMPLEMENTED_DETAIL_PATHS,
+                hasAnyPermission,
+            ) ??
+            getFirstAccessibleApplicationDetailPath(APPLICATION_NAV_GROUPS, hasAnyPermission) ??
+            APPLICATION_CONSOLE_DEFAULT_DETAIL_PATH
+        );
+    }, [permissionVersion]);
+
+    if (!permissionsReady) {
+        return (
+            <div className="space-y-6">
+                <Skeleton className="h-10 w-64" />
+                <Skeleton className="h-96 w-full" />
+            </div>
+        );
+    }
+
+    return <Navigate to={landingPath} replace />;
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/detail/ApplicationDetailPlaceholderPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/detail/ApplicationDetailPlaceholderPage.tsx
@@ -1,0 +1,24 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export function ApplicationDetailPlaceholderPage({ title }: { readonly title: string }) {
+    return (
+        <div className="space-y-2">
+            <h1 className="text-2xl font-semibold tracking-tight">{title}</h1>
+            <p className="text-sm text-muted-foreground">Coming soon.</p>
+        </div>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/detail/ApplicationDetailProtectedOutlet.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/detail/ApplicationDetailProtectedOutlet.tsx
@@ -1,0 +1,59 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useHasPermission } from '@gravitee/gamma-modules-sdk';
+import { Skeleton } from '@gravitee/graphene-core';
+import { Outlet, useLocation, useParams } from 'react-router-dom';
+
+import { ApplicationDetailAccessDenied } from './ApplicationDetailAccessDenied';
+import { getApplicationDetailTabPermissions } from '../../../../config/applicationDetailNavigation';
+import { useDetailBasePath } from '../../../shared/hooks/useDetailBasePath';
+import { useApplicationDetailContext } from '../../context/ApplicationDetailContext';
+
+function useApplicationDetailTabPath(): string {
+    const { applicationId } = useParams<{ applicationId: string }>();
+    const location = useLocation();
+    const basePath = useDetailBasePath('applications', applicationId);
+
+    if (!basePath || !location.pathname.startsWith(basePath)) {
+        return '';
+    }
+
+    const remainder = location.pathname.slice(basePath.length).replace(/^\//, '');
+    return remainder.split('/')[0] ?? '';
+}
+
+export function ApplicationDetailProtectedOutlet() {
+    const { permissionsReady } = useApplicationDetailContext();
+    const tabPath = useApplicationDetailTabPath();
+    const requiredPermissions = getApplicationDetailTabPermissions(tabPath);
+    const canAccessTab = useHasPermission({ anyOf: requiredPermissions ?? [] });
+    const isAccessDenied = Boolean(requiredPermissions?.length) && !canAccessTab;
+
+    if (!permissionsReady) {
+        return (
+            <div className="space-y-6">
+                <Skeleton className="h-10 w-64" />
+                <Skeleton className="h-96 w-full" />
+            </div>
+        );
+    }
+
+    if (isAccessDenied) {
+        return <ApplicationDetailAccessDenied />;
+    }
+
+    return <Outlet />;
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/detail/ApplicationDetailSidebarNav.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/detail/ApplicationDetailSidebarNav.tsx
@@ -1,0 +1,95 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { permissionService } from '@gravitee/gamma-modules-sdk';
+import { cn, Skeleton } from '@gravitee/graphene-core';
+import { useMemo } from 'react';
+import { NavLink } from 'react-router-dom';
+
+import type { ApplicationDetailNavGroup } from '../../../../config/applicationDetailNavigation';
+import { filterApplicationDetailNavGroups } from '../../../../config/applicationDetailNavigation';
+import { usePermissionServiceSnapshot } from '../../../shared/hooks/usePermissionServiceSnapshot';
+
+export type { ApplicationDetailNavGroup, ApplicationDetailNavItem } from '../../../../config/applicationDetailNavigation';
+export { APPLICATION_NAV_GROUPS } from '../../../../config/applicationDetailNavigation';
+
+interface ApplicationDetailSidebarNavProps {
+    readonly groups: ApplicationDetailNavGroup[];
+    readonly basePath: string;
+    /** When false, renders a loading skeleton in place of nav items. */
+    readonly permissionsReady?: boolean;
+}
+
+export function ApplicationDetailSidebarNav({ groups, basePath, permissionsReady = true }: ApplicationDetailSidebarNavProps) {
+    const permissionVersion = usePermissionServiceSnapshot();
+
+    const visibleGroups = useMemo(() => {
+        if (!permissionsReady) {
+            return [];
+        }
+        return filterApplicationDetailNavGroups(groups, permissions => permissionService.hasAnyOf(permissions));
+    }, [groups, permissionsReady, permissionVersion]);
+
+    if (!permissionsReady) {
+        return (
+            <div className="space-y-0.5 px-2 py-4">
+                {Array.from({ length: 5 }).map((_, index) => (
+                    <div key={index} className="px-3 py-2">
+                        <Skeleton className="h-4 rounded" />
+                    </div>
+                ))}
+            </div>
+        );
+    }
+
+    if (visibleGroups.length === 0) {
+        return (
+            <p className="px-3 py-4 text-xs text-muted-foreground">
+                No sections are available with your current permissions for this application.
+            </p>
+        );
+    }
+
+    return (
+        <div className="space-y-0.5 px-2 py-2">
+            {visibleGroups.map(group => (
+                <div key={group.label} className="pt-4 first:pt-0">
+                    <p className="mb-1 px-3 text-xs font-semibold uppercase tracking-wider text-muted-foreground">{group.label}</p>
+                    {group.items.map(item => {
+                        const Icon = item.icon;
+                        return (
+                            <NavLink
+                                end
+                                key={item.path}
+                                to={`${basePath}/${item.path}`}
+                                className={({ isActive }) =>
+                                    cn(
+                                        'flex items-center gap-2.5 rounded-lg px-3 py-2 text-sm transition-colors',
+                                        isActive
+                                            ? 'bg-accent text-foreground font-medium'
+                                            : 'text-muted-foreground hover:bg-muted hover:text-foreground',
+                                    )
+                                }
+                            >
+                                <Icon className="size-4 shrink-0" aria-hidden />
+                                {item.label}
+                            </NavLink>
+                        );
+                    })}
+                </div>
+            ))}
+        </div>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/detail/index.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/detail/index.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+export { ApplicationDetailIndexRedirect, ApplicationDetailLayout } from './ApplicationDetailLayout';
+export { ApplicationDetailPlaceholderPage } from './ApplicationDetailPlaceholderPage';

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/general/ApplicationAddCertificateDialog.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/general/ApplicationAddCertificateDialog.tsx
@@ -1,0 +1,195 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useEnvironment } from '@gravitee/gamma-modules-sdk';
+import {
+    Button,
+    Dialog,
+    DialogClose,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+    Input,
+    Label,
+    cn,
+} from '@gravitee/graphene-core';
+import { FileUpIcon, XIcon } from '@gravitee/graphene-core/icons';
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+import { findActiveCertificate, readFileAsText } from './certificateUtils';
+import { validateApplicationCertificate } from '../../services/applicationDetail';
+import type { ClientCertificate } from '../../types/applicationCertificate';
+
+export interface AddCertificateSubmit {
+    name: string;
+    certificate: string;
+    endsAt?: string;
+    gracePeriodEnd?: string;
+    activeCertificateId?: string;
+}
+
+export function ApplicationAddCertificateDialog({
+    open,
+    onOpenChange,
+    applicationId,
+    certificates,
+    onSubmit,
+    isSubmitting,
+    error,
+}: Readonly<{
+    open: boolean;
+    onOpenChange: (open: boolean) => void;
+    applicationId: string;
+    certificates: ClientCertificate[];
+    onSubmit: (payload: AddCertificateSubmit) => void;
+    isSubmitting: boolean;
+    error?: string | null;
+}>) {
+    const env = useEnvironment();
+    const fileRef = useRef<HTMLInputElement>(null);
+    const [name, setName] = useState('');
+    const [certificate, setCertificate] = useState('');
+    const [endsAt, setEndsAt] = useState('');
+    const [gracePeriodEnd, setGracePeriodEnd] = useState('');
+    const [fileError, setFileError] = useState<string | null>(null);
+    const [validating, setValidating] = useState(false);
+
+    const activeCert = findActiveCertificate(certificates);
+    const hasActive = Boolean(activeCert);
+
+    useEffect(() => {
+        if (!open) {
+            setName('');
+            setCertificate('');
+            setEndsAt('');
+            setGracePeriodEnd('');
+            setFileError(null);
+        }
+    }, [open]);
+
+    const handleFile = useCallback(
+        async (file: File | undefined) => {
+            if (!file || !env) return;
+            setFileError(null);
+            try {
+                const content = await readFileAsText(file);
+                setValidating(true);
+                await validateApplicationCertificate(env.id, applicationId, content);
+                setCertificate(content);
+            } catch (e) {
+                setCertificate('');
+                setFileError(e instanceof Error ? e.message : 'Invalid certificate.');
+            } finally {
+                setValidating(false);
+            }
+        },
+        [applicationId, env],
+    );
+
+    const handleAdd = () => {
+        if (!name.trim() || !certificate) return;
+        const endsAtIso = endsAt ? new Date(endsAt).toISOString() : undefined;
+        const graceIso = gracePeriodEnd ? new Date(gracePeriodEnd).toISOString() : undefined;
+        onSubmit({
+            name: name.trim(),
+            certificate,
+            endsAt: endsAtIso,
+            ...(hasActive && graceIso && activeCert ? { gracePeriodEnd: graceIso, activeCertificateId: activeCert.id } : {}),
+        });
+    };
+
+    const canSubmit =
+        Boolean(name.trim()) && Boolean(certificate) && !isSubmitting && !validating && (!hasActive || Boolean(gracePeriodEnd));
+
+    return (
+        <Dialog open={open} onOpenChange={onOpenChange}>
+            <DialogContent
+                className="sm:max-w-lg"
+                style={{ width: 'min(90vw, 32rem)', maxWidth: 'min(90vw, 32rem)' }}
+                showCloseButton={false}
+            >
+                <DialogHeader className="flex-row items-start justify-between gap-3 space-y-0">
+                    <div className="space-y-1.5 text-left">
+                        <DialogTitle>Add certificate</DialogTitle>
+                        <DialogDescription>Upload a PEM client certificate for mutual TLS authentication.</DialogDescription>
+                    </div>
+                    <DialogClose asChild>
+                        <Button type="button" variant="ghost" size="icon" className="size-8 shrink-0" aria-label="Close">
+                            <XIcon className="size-4" aria-hidden />
+                        </Button>
+                    </DialogClose>
+                </DialogHeader>
+
+                <div className="space-y-4 py-2">
+                    <div className="space-y-2">
+                        <Label htmlFor="cert-name">Certificate name</Label>
+                        <Input id="cert-name" value={name} onChange={e => setName(e.target.value)} placeholder="e.g. my-app-mtls-2026" />
+                    </div>
+                    <div className="space-y-2">
+                        <Label htmlFor="cert-expiry">Expiry date (optional)</Label>
+                        <Input id="cert-expiry" type="date" value={endsAt} onChange={e => setEndsAt(e.target.value)} />
+                    </div>
+                    {hasActive ? (
+                        <div className="space-y-2">
+                            <Label htmlFor="cert-grace">Grace period end (required)</Label>
+                            <Input id="cert-grace" type="date" value={gracePeriodEnd} onChange={e => setGracePeriodEnd(e.target.value)} />
+                            <p className="text-xs text-muted-foreground">
+                                Sets when the current active certificate ({activeCert?.name}) stops being used.
+                            </p>
+                        </div>
+                    ) : null}
+                    <button
+                        type="button"
+                        onClick={() => fileRef.current?.click()}
+                        disabled={validating}
+                        className={cn(
+                            'flex min-h-36 w-full flex-col items-center justify-center rounded-lg border-2 border-dashed border-border bg-muted/30 p-6 transition-colors',
+                            validating ? 'opacity-60' : 'cursor-pointer hover:border-primary',
+                        )}
+                    >
+                        <FileUpIcon className="size-7 text-muted-foreground/50" aria-hidden />
+                        <p className="mt-2 text-sm font-medium">{validating ? 'Validating…' : 'Drop PEM file or click to browse'}</p>
+                        {certificate ? <p className="mt-1 text-xs text-success">Certificate loaded</p> : null}
+                        {fileError ? <p className="mt-1 text-xs text-destructive">{fileError}</p> : null}
+                    </button>
+                    <input
+                        ref={fileRef}
+                        type="file"
+                        accept=".pem,.crt,.cer,text/plain"
+                        className="sr-only"
+                        onChange={e => {
+                            void handleFile(e.target.files?.[0]);
+                            e.target.value = '';
+                        }}
+                    />
+                    {error ? <p className="text-sm text-destructive">{error}</p> : null}
+                </div>
+
+                <DialogFooter className="sm:justify-end">
+                    <DialogClose asChild>
+                        <Button type="button" variant="outline">
+                            Cancel
+                        </Button>
+                    </DialogClose>
+                    <Button type="button" onClick={handleAdd} disabled={!canSubmit}>
+                        {isSubmitting ? 'Adding…' : 'Add certificate'}
+                    </Button>
+                </DialogFooter>
+            </DialogContent>
+        </Dialog>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/general/ApplicationCertificateDetailDialog.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/general/ApplicationCertificateDetailDialog.tsx
@@ -1,0 +1,86 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+    Badge,
+    Button,
+    Dialog,
+    DialogClose,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+} from '@gravitee/graphene-core';
+import { XIcon } from '@gravitee/graphene-core/icons';
+
+import { certificateStatusLabel, certificateStatusVariant } from './certificateUtils';
+import type { ClientCertificate } from '../../types/applicationCertificate';
+import { formatApplicationDateTime } from '../../utils/applicationFormatters';
+
+export function ApplicationCertificateDetailDialog({
+    certificate,
+    onClose,
+}: Readonly<{
+    certificate: ClientCertificate | null;
+    onClose: () => void;
+}>) {
+    return (
+        <Dialog open={certificate !== null} onOpenChange={open => !open && onClose()}>
+            <DialogContent
+                className="sm:max-w-md"
+                style={{ width: 'min(90vw, 24rem)', maxWidth: 'min(90vw, 24rem)' }}
+                showCloseButton={false}
+            >
+                <DialogHeader className="flex-row items-start justify-between gap-3 space-y-0">
+                    <div className="space-y-1.5 text-left">
+                        <DialogTitle>{certificate?.name}</DialogTitle>
+                        <DialogDescription>Certificate details</DialogDescription>
+                    </div>
+                    <DialogClose asChild>
+                        <Button type="button" variant="ghost" size="icon" className="size-8 shrink-0" aria-label="Close">
+                            <XIcon className="size-4" aria-hidden />
+                        </Button>
+                    </DialogClose>
+                </DialogHeader>
+                {certificate ? (
+                    <dl className="space-y-2 py-2 text-sm">
+                        <div className="flex justify-between gap-4">
+                            <dt className="text-muted-foreground">Uploaded</dt>
+                            <dd>{formatApplicationDateTime(certificate.createdAt)}</dd>
+                        </div>
+                        <div className="flex justify-between gap-4">
+                            <dt className="text-muted-foreground">Expiry</dt>
+                            <dd>{certificate.endsAt ? formatApplicationDateTime(certificate.endsAt) : '—'}</dd>
+                        </div>
+                        <div className="flex justify-between gap-4">
+                            <dt className="text-muted-foreground">Status</dt>
+                            <dd>
+                                <Badge variant={certificateStatusVariant(certificate.status)} className="text-xs">
+                                    {certificateStatusLabel(certificate.status)}
+                                </Badge>
+                            </dd>
+                        </div>
+                    </dl>
+                ) : null}
+                <DialogFooter className="sm:justify-end">
+                    <Button type="button" variant="outline" onClick={onClose}>
+                        Close
+                    </Button>
+                </DialogFooter>
+            </DialogContent>
+        </Dialog>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/general/ApplicationCertificatesSection.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/general/ApplicationCertificatesSection.tsx
@@ -1,0 +1,232 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+    Badge,
+    Button,
+    Card,
+    CardContent,
+    CardDescription,
+    CardHeader,
+    CardTitle,
+    Skeleton,
+    Table,
+    TableBody,
+    TableCell,
+    TableHead,
+    TableHeader,
+    TableRow,
+} from '@gravitee/graphene-core';
+import { FileUpIcon, PlusIcon } from '@gravitee/graphene-core/icons';
+import { useState } from 'react';
+
+import { ApplicationAddCertificateDialog, type AddCertificateSubmit } from './ApplicationAddCertificateDialog';
+import { ApplicationCertificateDetailDialog } from './ApplicationCertificateDetailDialog';
+import { ApplicationRevokeCertificateDialog } from './ApplicationRevokeCertificateDialog';
+import { certificateStatusLabel, certificateStatusVariant } from './certificateUtils';
+import { useApplicationCertificates } from '../../hooks/useApplicationCertificates';
+import { useApplicationGeneralMutations } from '../../hooks/useApplicationGeneralMutations';
+import type { ApplicationListItem } from '../../types/application';
+import type { ClientCertificate } from '../../types/applicationCertificate';
+import { formatApplicationDateTime } from '../../utils/applicationFormatters';
+
+export interface ApplicationCertificatesSectionProps {
+    readonly application: ApplicationListItem;
+    readonly applicationId: string;
+    readonly canManageCertificates: boolean;
+}
+
+export function ApplicationCertificatesSection({ application, applicationId, canManageCertificates }: ApplicationCertificatesSectionProps) {
+    const { data: certificates = [], isLoading: certificatesLoading } = useApplicationCertificates(applicationId);
+    const { createCertificateMutation, updateCertificateMutation } = useApplicationGeneralMutations(application, applicationId);
+
+    const [certDialogOpen, setCertDialogOpen] = useState(false);
+    const [viewCert, setViewCert] = useState<ClientCertificate | null>(null);
+    const [revokeCert, setRevokeCert] = useState<ClientCertificate | null>(null);
+    const [certError, setCertError] = useState<string | null>(null);
+    const [revokeError, setRevokeError] = useState<string | null>(null);
+
+    const openAddDialog = () => setCertDialogOpen(true);
+
+    const handleAddCertificate = (submit: AddCertificateSubmit) => {
+        setCertError(null);
+        const activeCert = submit.activeCertificateId ? certificates.find(c => c.id === submit.activeCertificateId) : undefined;
+        createCertificateMutation.mutate(
+            {
+                name: submit.name,
+                certificate: submit.certificate,
+                endsAt: submit.endsAt,
+            },
+            {
+                onSuccess: () => {
+                    if (submit.gracePeriodEnd && submit.activeCertificateId && activeCert) {
+                        updateCertificateMutation.mutate(
+                            {
+                                certificateId: submit.activeCertificateId,
+                                update: { name: activeCert.name, endsAt: submit.gracePeriodEnd },
+                            },
+                            {
+                                onSuccess: () => setCertDialogOpen(false),
+                                onError: (e: unknown) =>
+                                    setCertError(e instanceof Error ? e.message : 'Certificate added but grace period update failed.'),
+                            },
+                        );
+                    } else {
+                        setCertDialogOpen(false);
+                    }
+                },
+                onError: (e: unknown) => setCertError(e instanceof Error ? e.message : 'Failed to add certificate.'),
+            },
+        );
+    };
+
+    const handleRevokeCertificate = () => {
+        if (!revokeCert) return;
+        setRevokeError(null);
+        const revokedAt = new Date(Date.now() - 1000).toISOString();
+        updateCertificateMutation.mutate(
+            {
+                certificateId: revokeCert.id,
+                update: { name: revokeCert.name, endsAt: revokedAt },
+            },
+            {
+                onSuccess: () => {
+                    setRevokeCert(null);
+                    setRevokeError(null);
+                },
+                onError: (e: unknown) => setRevokeError(e instanceof Error ? e.message : 'Failed to revoke certificate.'),
+            },
+        );
+    };
+
+    return (
+        <>
+            <Card>
+                <CardHeader className="pb-3">
+                    <div className="flex items-center justify-between gap-4">
+                        <div className="space-y-1">
+                            <CardTitle className="text-sm">Certificates</CardTitle>
+                            <CardDescription className="text-xs">
+                                mTLS client certificates for authenticating this application to the gateway.
+                            </CardDescription>
+                        </div>
+                        {canManageCertificates ? (
+                            <Button type="button" size="sm" variant="outline" className="shrink-0" onClick={openAddDialog}>
+                                <PlusIcon className="size-3.5" aria-hidden />
+                                Add certificate
+                            </Button>
+                        ) : null}
+                    </div>
+                </CardHeader>
+                <CardContent>
+                    {certificatesLoading ? (
+                        <Skeleton className="h-24 w-full" />
+                    ) : certificates.length === 0 ? (
+                        <div className="flex flex-col items-center justify-center rounded-lg border border-dashed bg-muted/20 px-4 py-10 text-center">
+                            <FileUpIcon className="mb-2 size-8 text-muted-foreground/40" aria-hidden />
+                            <p className="text-sm font-medium">No certificates</p>
+                            <p className="mt-1 max-w-sm text-xs text-muted-foreground">
+                                Upload a client certificate to enable mutual TLS for this application.
+                            </p>
+                            {canManageCertificates ? (
+                                <Button type="button" size="sm" variant="outline" className="mt-4" onClick={openAddDialog}>
+                                    <PlusIcon className="size-3.5" aria-hidden />
+                                    Add certificate
+                                </Button>
+                            ) : null}
+                        </div>
+                    ) : (
+                        <Table>
+                            <TableHeader>
+                                <TableRow>
+                                    <TableHead>Name</TableHead>
+                                    <TableHead>Uploaded</TableHead>
+                                    <TableHead>Expiry</TableHead>
+                                    <TableHead>Status</TableHead>
+                                    <TableHead className="text-right">Actions</TableHead>
+                                </TableRow>
+                            </TableHeader>
+                            <TableBody>
+                                {certificates.map(cert => (
+                                    <TableRow key={cert.id}>
+                                        <TableCell className="font-medium">{cert.name}</TableCell>
+                                        <TableCell className="text-sm text-muted-foreground">
+                                            {formatApplicationDateTime(cert.createdAt)}
+                                        </TableCell>
+                                        <TableCell className="text-sm text-muted-foreground">
+                                            {cert.endsAt ? formatApplicationDateTime(cert.endsAt) : '—'}
+                                        </TableCell>
+                                        <TableCell>
+                                            <Badge variant={certificateStatusVariant(cert.status)} className="text-xs">
+                                                {certificateStatusLabel(cert.status)}
+                                            </Badge>
+                                        </TableCell>
+                                        <TableCell className="text-right">
+                                            <div className="flex justify-end gap-1">
+                                                <Button type="button" variant="ghost" size="sm" onClick={() => setViewCert(cert)}>
+                                                    View
+                                                </Button>
+                                                {canManageCertificates && cert.status !== 'REVOKED' ? (
+                                                    <Button
+                                                        type="button"
+                                                        variant="ghost"
+                                                        size="sm"
+                                                        className="text-destructive hover:text-destructive"
+                                                        onClick={() => {
+                                                            setRevokeError(null);
+                                                            setRevokeCert(cert);
+                                                        }}
+                                                    >
+                                                        Revoke
+                                                    </Button>
+                                                ) : null}
+                                            </div>
+                                        </TableCell>
+                                    </TableRow>
+                                ))}
+                            </TableBody>
+                        </Table>
+                    )}
+                </CardContent>
+            </Card>
+
+            <ApplicationAddCertificateDialog
+                open={certDialogOpen}
+                onOpenChange={open => {
+                    setCertDialogOpen(open);
+                    if (!open) setCertError(null);
+                }}
+                applicationId={applicationId}
+                certificates={certificates}
+                onSubmit={handleAddCertificate}
+                isSubmitting={createCertificateMutation.isPending || updateCertificateMutation.isPending}
+                error={certError}
+            />
+
+            <ApplicationCertificateDetailDialog certificate={viewCert} onClose={() => setViewCert(null)} />
+
+            <ApplicationRevokeCertificateDialog
+                certificate={revokeCert}
+                onClose={() => {
+                    setRevokeCert(null);
+                    setRevokeError(null);
+                }}
+                onConfirm={handleRevokeCertificate}
+                isLoading={updateCertificateMutation.isPending}
+                error={revokeError}
+            />
+        </>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/general/ApplicationDeleteDialog.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/general/ApplicationDeleteDialog.tsx
@@ -1,0 +1,92 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+    Button,
+    Dialog,
+    DialogClose,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+    Input,
+    Label,
+} from '@gravitee/graphene-core';
+import { Trash2Icon } from '@gravitee/graphene-core/icons';
+import { useEffect, useState } from 'react';
+
+export function ApplicationDeleteDialog({
+    open,
+    onOpenChange,
+    applicationName,
+    onDelete,
+    isLoading,
+    error,
+}: Readonly<{
+    open: boolean;
+    onOpenChange: (open: boolean) => void;
+    applicationName: string;
+    onDelete: () => void;
+    isLoading: boolean;
+    error?: string | null;
+}>) {
+    const [confirm, setConfirm] = useState('');
+
+    useEffect(() => {
+        if (!open) setConfirm('');
+    }, [open]);
+
+    return (
+        <Dialog open={open} onOpenChange={onOpenChange}>
+            <DialogContent
+                className="sm:max-w-md"
+                style={{ width: 'min(90vw, 28rem)', maxWidth: 'min(90vw, 28rem)' }}
+                showCloseButton={false}
+            >
+                <DialogHeader>
+                    <DialogTitle>Archive this application?</DialogTitle>
+                    <DialogDescription>
+                        The application <strong>{applicationName}</strong> will be archived. Active subscriptions will be closed.
+                    </DialogDescription>
+                </DialogHeader>
+                <div className="space-y-2 py-2">
+                    <Label htmlFor="application-delete-confirm" className="text-sm">
+                        Type <span className="font-mono font-semibold">{applicationName}</span> to confirm
+                    </Label>
+                    <Input
+                        id="application-delete-confirm"
+                        value={confirm}
+                        onChange={e => setConfirm(e.target.value)}
+                        placeholder={applicationName}
+                        autoComplete="off"
+                    />
+                    {error ? <p className="text-sm text-destructive">{error}</p> : null}
+                </div>
+                <DialogFooter className="sm:justify-end">
+                    <DialogClose asChild>
+                        <Button type="button" variant="outline" onClick={() => setConfirm('')}>
+                            Cancel
+                        </Button>
+                    </DialogClose>
+                    <Button type="button" variant="destructive" disabled={confirm !== applicationName || isLoading} onClick={onDelete}>
+                        <Trash2Icon className="size-4" aria-hidden />
+                        {isLoading ? 'Archiving…' : 'Archive application'}
+                    </Button>
+                </DialogFooter>
+            </DialogContent>
+        </Dialog>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/general/ApplicationDetailsSection.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/general/ApplicationDetailsSection.tsx
@@ -1,0 +1,201 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+    Button,
+    Card,
+    CardContent,
+    Input,
+    Label,
+    Separator,
+    Textarea,
+    Tooltip,
+    TooltipContent,
+    TooltipProvider,
+    TooltipTrigger,
+} from '@gravitee/graphene-core';
+import { ClockIcon, GlobeIcon, InfoIcon, KeyRoundIcon, SettingsIcon, UserIcon } from '@gravitee/graphene-core/icons';
+import type { CSSProperties } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+import { ApplicationImagePickers } from './ApplicationImagePickers';
+import { DetailRow } from './DetailRow';
+import type { ApplicationListItem } from '../../types/application';
+import {
+    formatApplicationApiKeyMode,
+    formatApplicationDateTime,
+    formatApplicationOwnerLabel,
+    formatApplicationSecurityTypeLabel,
+} from '../../utils/applicationFormatters';
+import type { ApplicationGeneralForm, ApplicationGeneralValidation } from '../../utils/applicationGeneralMapper';
+
+export interface ApplicationDetailsSectionProps {
+    readonly application: ApplicationListItem;
+    readonly form: ApplicationGeneralForm;
+    readonly validation: ApplicationGeneralValidation;
+    readonly isFormDisabled: boolean;
+    readonly showSubscribeToApis: boolean;
+    readonly subscriptionsPath: string;
+    readonly onFieldChange: <K extends keyof ApplicationGeneralForm>(key: K, value: ApplicationGeneralForm[K]) => void;
+    readonly onPictureChange: (value: string | null) => void;
+    readonly onBackgroundChange: (value: string | null) => void;
+}
+
+export function ApplicationDetailsSection({
+    application,
+    form,
+    validation,
+    isFormDisabled,
+    showSubscribeToApis,
+    subscriptionsPath,
+    onFieldChange,
+    onPictureChange,
+    onBackgroundChange,
+}: ApplicationDetailsSectionProps) {
+    const navigate = useNavigate();
+
+    return (
+        <Card>
+            <CardContent className="pt-6">
+                <div className="flex flex-row gap-8">
+                    <div className="min-w-0 flex-1 space-y-4">
+                        <div className="space-y-2">
+                            <Label htmlFor="app-name">
+                                Name <span className="text-destructive">*</span>
+                            </Label>
+                            <Input
+                                id="app-name"
+                                value={form.name}
+                                maxLength={512}
+                                onChange={e => onFieldChange('name', e.target.value)}
+                                disabled={isFormDisabled}
+                                placeholder="Application name"
+                            />
+                            {validation.name ? <p className="text-xs text-destructive">{validation.name}</p> : null}
+                        </div>
+                        <div className="space-y-2">
+                            <Label htmlFor="app-desc">
+                                Description <span className="text-destructive">*</span>
+                            </Label>
+                            <Textarea
+                                id="app-desc"
+                                rows={3}
+                                style={{ fieldSizing: 'fixed' } as CSSProperties}
+                                value={form.description}
+                                onChange={e => onFieldChange('description', e.target.value)}
+                                disabled={isFormDisabled}
+                                placeholder="Describe this application"
+                            />
+                            <p className="text-xs text-muted-foreground">
+                                A brief description of your application shown to API publishers.
+                            </p>
+                            {validation.description ? <p className="text-xs text-destructive">{validation.description}</p> : null}
+                        </div>
+                        <div className="space-y-2">
+                            <div className="flex items-center gap-1">
+                                <Label htmlFor="app-domain">Domain</Label>
+                                <TooltipProvider delayDuration={200}>
+                                    <Tooltip>
+                                        <TooltipTrigger asChild>
+                                            <button
+                                                type="button"
+                                                className="text-muted-foreground/60 transition-colors hover:text-muted-foreground"
+                                                aria-label="Domain field information"
+                                            >
+                                                <InfoIcon className="size-3.5" aria-hidden />
+                                            </button>
+                                        </TooltipTrigger>
+                                        <TooltipContent side="right" className="max-w-xs text-xs">
+                                            Optional domain used to group applications in the developer portal.
+                                        </TooltipContent>
+                                    </Tooltip>
+                                </TooltipProvider>
+                            </div>
+                            <Input
+                                id="app-domain"
+                                value={form.domain}
+                                onChange={e => onFieldChange('domain', e.target.value)}
+                                disabled={isFormDisabled}
+                                placeholder="e.g. operations.example.com"
+                            />
+                        </div>
+                    </div>
+
+                    <div className="shrink-0 space-y-5 border-l pl-8" style={{ width: '280px' }}>
+                        <ApplicationImagePickers
+                            picture={form.picture}
+                            background={form.background}
+                            disabled={isFormDisabled}
+                            onPictureChange={onPictureChange}
+                            onBackgroundChange={onBackgroundChange}
+                        />
+                        <Separator />
+                        <div className="space-y-3">
+                            <p className="text-xs font-medium uppercase tracking-wider text-muted-foreground">DETAILS</p>
+                            <dl className="space-y-2.5">
+                                <DetailRow
+                                    label={
+                                        <>
+                                            <UserIcon className="size-3" aria-hidden />
+                                            Owner
+                                        </>
+                                    }
+                                    value={formatApplicationOwnerLabel(application.owner) ?? '—'}
+                                />
+                                <DetailRow
+                                    label={
+                                        <>
+                                            <ClockIcon className="size-3" aria-hidden />
+                                            Created
+                                        </>
+                                    }
+                                    value={formatApplicationDateTime(application.created_at)}
+                                />
+                                <DetailRow
+                                    label={
+                                        <>
+                                            <SettingsIcon className="size-3" aria-hidden />
+                                            Type
+                                        </>
+                                    }
+                                    value={formatApplicationSecurityTypeLabel(application)}
+                                />
+                                <DetailRow
+                                    label={
+                                        <>
+                                            <KeyRoundIcon className="size-3" aria-hidden />
+                                            API key mode
+                                        </>
+                                    }
+                                    value={formatApplicationApiKeyMode(application.api_key_mode)}
+                                />
+                            </dl>
+                        </div>
+                    </div>
+                </div>
+
+                {showSubscribeToApis ? (
+                    <>
+                        <Separator className="my-5" />
+                        <Button type="button" variant="outline" size="sm" onClick={() => navigate(subscriptionsPath)}>
+                            <GlobeIcon className="size-3.5" aria-hidden />
+                            Subscribe to APIs
+                        </Button>
+                    </>
+                ) : null}
+            </CardContent>
+        </Card>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/general/ApplicationGeneralContent.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/general/ApplicationGeneralContent.tsx
@@ -1,0 +1,189 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useHasPermission } from '@gravitee/gamma-modules-sdk';
+import { Button, Card, Skeleton } from '@gravitee/graphene-core';
+import { CheckIcon } from '@gravitee/graphene-core/icons';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+
+import { ApplicationCertificatesSection } from './ApplicationCertificatesSection';
+import { ApplicationDetailsSection } from './ApplicationDetailsSection';
+import { ApplicationLifecycleSection } from './ApplicationLifecycleSection';
+import { ApplicationOAuthSection } from './ApplicationOAuthSection';
+import { useDetailBasePath } from '../../../shared/hooks/useDetailBasePath';
+import { useApplicationDetailContext } from '../../context/ApplicationDetailContext';
+import { useApplicationGeneralMutations } from '../../hooks/useApplicationGeneralMutations';
+import { useApplicationTypeConfiguration } from '../../hooks/useApplicationTypeConfiguration';
+import type { ApplicationListItem } from '../../types/application';
+import {
+    buildUpdatePayload,
+    formFromApplication,
+    hasApplicationGeneralValidationErrors,
+    isApplicationGeneralFormDirty,
+    isApplicationGeneralReadOnly,
+    validateApplicationGeneralForm,
+    type ApplicationGeneralForm,
+} from '../../utils/applicationGeneralMapper';
+
+export function ApplicationGeneralContent({ application }: Readonly<{ application: ApplicationListItem }>) {
+    const { applicationId } = useParams<{ applicationId: string }>();
+    const navigate = useNavigate();
+    const basePath = useDetailBasePath('applications', applicationId);
+    const { permissionsReady } = useApplicationDetailContext();
+
+    const canUpdate = useHasPermission({ anyOf: ['application-definition-u'] });
+    const canDelete = useHasPermission({ anyOf: ['application-definition-d'] });
+
+    const isSimple = application.type === 'SIMPLE';
+    const isArchivedOrKubernetes = isApplicationGeneralReadOnly(application);
+    const isFormDisabled = !permissionsReady || isArchivedOrKubernetes || !canUpdate;
+    const showSubscribeToApis = permissionsReady && !isArchivedOrKubernetes && canUpdate;
+    const canManageCertificates = permissionsReady && !isArchivedOrKubernetes && canUpdate;
+
+    const { data: typeConfig } = useApplicationTypeConfiguration(applicationId, !isSimple);
+    const { saveMutation } = useApplicationGeneralMutations(application, applicationId);
+
+    const [form, setForm] = useState<ApplicationGeneralForm | null>(null);
+    const [savedForm, setSavedForm] = useState<ApplicationGeneralForm | null>(null);
+    const [saveError, setSaveError] = useState<string | null>(null);
+
+    useEffect(() => {
+        const seed = formFromApplication(application);
+        setForm(seed);
+        setSavedForm(seed);
+        setSaveError(null);
+    }, [application]);
+
+    const validation = useMemo(() => (form ? validateApplicationGeneralForm(form) : {}), [form]);
+    const isDirty = useMemo(() => form !== null && savedForm !== null && isApplicationGeneralFormDirty(form, savedForm), [form, savedForm]);
+    const hasValidationErrors = hasApplicationGeneralValidationErrors(validation);
+    const canSave = isDirty && !hasValidationErrors && !saveMutation.isPending;
+
+    const setField = useCallback(<K extends keyof ApplicationGeneralForm>(key: K, value: ApplicationGeneralForm[K]) => {
+        setForm(prev => (prev ? { ...prev, [key]: value } : prev));
+        setSaveError(null);
+    }, []);
+
+    const handlePictureChange = useCallback((value: string | null) => {
+        setForm(prev =>
+            prev
+                ? {
+                      ...prev,
+                      picture: value,
+                      pictureRemoved: value === null,
+                  }
+                : prev,
+        );
+        setSaveError(null);
+    }, []);
+
+    const handleBackgroundChange = useCallback((value: string | null) => {
+        setForm(prev =>
+            prev
+                ? {
+                      ...prev,
+                      background: value,
+                      backgroundRemoved: value === null,
+                  }
+                : prev,
+        );
+        setSaveError(null);
+    }, []);
+
+    const copyToClipboard = (value: string) => {
+        void navigator.clipboard.writeText(value);
+    };
+
+    const handleSave = () => {
+        if (!form || isFormDisabled || !canSave) return;
+        const payload = buildUpdatePayload(application, form, typeConfig);
+        saveMutation.mutate(payload, {
+            onSuccess: () => {
+                setSavedForm(form);
+                setSaveError(null);
+            },
+            onError: (e: unknown) => setSaveError(e instanceof Error ? e.message : 'Failed to save changes.'),
+        });
+    };
+
+    if (!form || !applicationId) {
+        return (
+            <div className="space-y-5">
+                <Skeleton className="h-10 w-64" />
+                <Skeleton className="h-64 w-full" />
+            </div>
+        );
+    }
+
+    return (
+        <div className="space-y-5">
+            <div className="flex items-start justify-between gap-4">
+                <div className="space-y-1">
+                    <h1 className="text-2xl font-semibold tracking-tight">General</h1>
+                    <p className="text-sm text-muted-foreground">
+                        Application details, OAuth client configuration, certificates, and lifecycle.
+                    </p>
+                </div>
+                {!isFormDisabled ? (
+                    <Button type="button" size="sm" className="shrink-0" onClick={handleSave} disabled={!canSave}>
+                        <CheckIcon className="size-4" aria-hidden />
+                        {saveMutation.isPending ? 'Saving…' : 'Save changes'}
+                    </Button>
+                ) : null}
+            </div>
+
+            {saveError ? (
+                <Card className="border-destructive/30 bg-destructive/5 p-4">
+                    <p className="text-sm text-destructive">{saveError}</p>
+                </Card>
+            ) : null}
+
+            <ApplicationDetailsSection
+                application={application}
+                form={form}
+                validation={validation}
+                isFormDisabled={isFormDisabled}
+                showSubscribeToApis={showSubscribeToApis}
+                subscriptionsPath={`${basePath}/subscriptions`}
+                onFieldChange={setField}
+                onPictureChange={handlePictureChange}
+                onBackgroundChange={handleBackgroundChange}
+            />
+
+            <ApplicationOAuthSection
+                isSimple={isSimple}
+                form={form}
+                typeConfig={typeConfig}
+                isFormDisabled={isFormDisabled}
+                onFieldChange={setField}
+                onCopy={copyToClipboard}
+            />
+
+            <ApplicationCertificatesSection
+                application={application}
+                applicationId={applicationId}
+                canManageCertificates={canManageCertificates}
+            />
+
+            <ApplicationLifecycleSection
+                application={application}
+                applicationId={applicationId}
+                canDelete={permissionsReady && canDelete && !isArchivedOrKubernetes}
+                onDeleteSuccess={() => navigate('../..', { relative: 'route' })}
+            />
+        </div>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/general/ApplicationImagePickers.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/general/ApplicationImagePickers.tsx
@@ -1,0 +1,147 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { cn } from '@gravitee/graphene-core';
+import { UploadIcon } from '@gravitee/graphene-core/icons';
+import { useCallback, useRef, useState } from 'react';
+
+const MAX_SIZE_BYTES = 500 * 1024;
+
+function fileToDataUrl(file: File): Promise<string> {
+    return new Promise((resolve, reject) => {
+        const reader = new FileReader();
+        reader.onload = () => resolve(reader.result as string);
+        reader.onerror = reject;
+        reader.readAsDataURL(file);
+    });
+}
+
+function ImageSlot({
+    label,
+    preview,
+    width,
+    height,
+    disabled,
+    onSelect,
+    onClear,
+}: Readonly<{
+    label: string;
+    preview: string | null;
+    width: number;
+    height: number;
+    disabled?: boolean;
+    onSelect: (dataUrl: string) => void;
+    onClear: () => void;
+}>) {
+    const inputRef = useRef<HTMLInputElement>(null);
+    const [sizeError, setSizeError] = useState<string | null>(null);
+
+    const handleFile = useCallback(
+        async (file: File) => {
+            if (file.size > MAX_SIZE_BYTES) {
+                setSizeError('File exceeds 500 KB limit.');
+                return;
+            }
+            setSizeError(null);
+            onSelect(await fileToDataUrl(file));
+        },
+        [onSelect],
+    );
+
+    return (
+        <div className="space-y-1.5 text-center">
+            <button
+                type="button"
+                disabled={disabled}
+                onClick={() => !disabled && inputRef.current?.click()}
+                onContextMenu={e => {
+                    if (!disabled && preview) {
+                        e.preventDefault();
+                        onClear();
+                    }
+                }}
+                className={cn(
+                    'flex items-center justify-center overflow-hidden rounded-xl border-2 border-dashed border-border bg-muted/30 transition-colors',
+                    disabled ? 'cursor-not-allowed opacity-50 pointer-events-none' : 'cursor-pointer hover:border-primary',
+                )}
+                style={{ width, height }}
+                aria-label={`Upload ${label}`}
+                aria-disabled={disabled}
+            >
+                {preview ? (
+                    <img src={preview} alt="" className="size-full object-cover" />
+                ) : (
+                    <UploadIcon className="size-6 text-muted-foreground/40" aria-hidden />
+                )}
+            </button>
+            <p className="text-xs text-muted-foreground">{label}</p>
+            {sizeError ? <p className="text-xs text-destructive">{sizeError}</p> : null}
+            <input
+                ref={inputRef}
+                type="file"
+                accept="image/png,image/jpeg,image/svg+xml"
+                className="sr-only"
+                disabled={disabled}
+                tabIndex={-1}
+                onChange={e => {
+                    const file = e.target.files?.[0];
+                    e.target.value = '';
+                    if (file) void handleFile(file);
+                }}
+            />
+        </div>
+    );
+}
+
+export function ApplicationImagePickers({
+    picture,
+    background,
+    disabled,
+    onPictureChange,
+    onBackgroundChange,
+}: Readonly<{
+    picture: string | null;
+    background: string | null;
+    disabled?: boolean;
+    onPictureChange: (value: string | null) => void;
+    onBackgroundChange: (value: string | null) => void;
+}>) {
+    return (
+        <div className="space-y-3">
+            <p className="text-xs font-medium uppercase tracking-wider text-muted-foreground">IMAGES</p>
+            <div className="flex items-start gap-3">
+                <ImageSlot
+                    label="Picture"
+                    preview={picture}
+                    width={72}
+                    height={72}
+                    disabled={disabled}
+                    onSelect={onPictureChange}
+                    onClear={() => onPictureChange(null)}
+                />
+                <ImageSlot
+                    label="Background"
+                    preview={background}
+                    width={112}
+                    height={72}
+                    disabled={disabled}
+                    onSelect={onBackgroundChange}
+                    onClear={() => onBackgroundChange(null)}
+                />
+            </div>
+            <p className="text-xs leading-snug text-muted-foreground">Click to upload. PNG, JPG, SVG. Max 500 KB.</p>
+        </div>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/general/ApplicationLifecycleSection.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/general/ApplicationLifecycleSection.tsx
@@ -1,0 +1,82 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Button, Card, CardContent } from '@gravitee/graphene-core';
+import { AlertCircleIcon, Trash2Icon } from '@gravitee/graphene-core/icons';
+import { useState } from 'react';
+
+import { ApplicationDeleteDialog } from './ApplicationDeleteDialog';
+import { useApplicationGeneralMutations } from '../../hooks/useApplicationGeneralMutations';
+import type { ApplicationListItem } from '../../types/application';
+
+export interface ApplicationLifecycleSectionProps {
+    readonly application: ApplicationListItem;
+    readonly applicationId: string;
+    readonly canDelete: boolean;
+    readonly onDeleteSuccess: () => void;
+}
+
+export function ApplicationLifecycleSection({ application, applicationId, canDelete, onDeleteSuccess }: ApplicationLifecycleSectionProps) {
+    const [deleteOpen, setDeleteOpen] = useState(false);
+    const { deleteMutation } = useApplicationGeneralMutations(application, applicationId, { onDeleteSuccess });
+
+    if (!canDelete) {
+        return null;
+    }
+
+    const deleteError = deleteMutation.isError
+        ? deleteMutation.error instanceof Error
+            ? deleteMutation.error.message
+            : 'Failed to delete application.'
+        : null;
+
+    return (
+        <>
+            <Card className="border-primary">
+                <CardContent className="py-4">
+                    <div className="flex items-center justify-between gap-4">
+                        <div className="flex items-center gap-3">
+                            <AlertCircleIcon className="size-4 shrink-0 text-destructive" aria-hidden />
+                            <div>
+                                <p className="text-sm font-medium text-destructive">Delete this Application</p>
+                                <p className="text-xs text-muted-foreground">
+                                    Archiving closes active subscriptions and moves this application to the archived list.
+                                </p>
+                            </div>
+                        </div>
+                        <Button
+                            type="button"
+                            size="sm"
+                            className="shrink-0 bg-primary text-primary-foreground hover:bg-primary/90"
+                            onClick={() => setDeleteOpen(true)}
+                        >
+                            <Trash2Icon className="size-3.5 text-primary-foreground" aria-hidden />
+                            Delete
+                        </Button>
+                    </div>
+                </CardContent>
+            </Card>
+
+            <ApplicationDeleteDialog
+                open={deleteOpen}
+                onOpenChange={setDeleteOpen}
+                applicationName={application.name}
+                onDelete={() => deleteMutation.mutate()}
+                isLoading={deleteMutation.isPending}
+                error={deleteError}
+            />
+        </>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/general/ApplicationOAuthSection.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/general/ApplicationOAuthSection.tsx
@@ -1,0 +1,139 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Button, Card, CardContent, CardDescription, CardHeader, CardTitle, Input, Label, Textarea } from '@gravitee/graphene-core';
+import { CopyIcon } from '@gravitee/graphene-core/icons';
+
+import { GrantTypeChips } from './GrantTypeChips';
+import type { ApplicationTypeConfig } from '../../types/applicationCreate';
+import type { ApplicationGeneralForm } from '../../utils/applicationGeneralMapper';
+
+export interface ApplicationOAuthSectionProps {
+    readonly isSimple: boolean;
+    readonly form: ApplicationGeneralForm;
+    readonly typeConfig: ApplicationTypeConfig | undefined;
+    readonly isFormDisabled: boolean;
+    readonly onFieldChange: <K extends keyof ApplicationGeneralForm>(key: K, value: ApplicationGeneralForm[K]) => void;
+    readonly onCopy: (value: string) => void;
+}
+
+export function ApplicationOAuthSection({
+    isSimple,
+    form,
+    typeConfig,
+    isFormDisabled,
+    onFieldChange,
+    onCopy,
+}: ApplicationOAuthSectionProps) {
+    if (isSimple) {
+        return (
+            <Card>
+                <CardHeader className="pb-3">
+                    <CardTitle className="text-sm">OAuth2 Integration</CardTitle>
+                    <CardDescription className="text-xs">Client ID used when subscribing to OAuth2 or JWT plans.</CardDescription>
+                </CardHeader>
+                <CardContent className="max-w-xl space-y-2">
+                    <Label htmlFor="simple-client-id">Client ID</Label>
+                    <div className="flex gap-2">
+                        <Input
+                            id="simple-client-id"
+                            value={form.simpleClientId}
+                            maxLength={300}
+                            onChange={e => onFieldChange('simpleClientId', e.target.value)}
+                            disabled={isFormDisabled}
+                        />
+                        <Button
+                            type="button"
+                            variant="outline"
+                            size="icon"
+                            onClick={() => onCopy(form.simpleClientId)}
+                            disabled={!form.simpleClientId}
+                            aria-label="Copy client ID"
+                        >
+                            <CopyIcon className="size-4" aria-hidden />
+                        </Button>
+                    </div>
+                </CardContent>
+            </Card>
+        );
+    }
+
+    return (
+        <div className="space-y-3">
+            <h2 className="text-lg font-semibold">OpenID Connect Integration</h2>
+            <Card>
+                <CardContent className="max-w-2xl space-y-4 pt-6">
+                    <div className="space-y-2">
+                        <Label>Client ID</Label>
+                        <div className="flex gap-2">
+                            <Input value={form.oauthClientId} readOnly className="bg-muted/40" />
+                            <Button
+                                type="button"
+                                variant="outline"
+                                size="icon"
+                                onClick={() => onCopy(form.oauthClientId)}
+                                disabled={!form.oauthClientId}
+                                aria-label="Copy client ID"
+                            >
+                                <CopyIcon className="size-4" aria-hidden />
+                            </Button>
+                        </div>
+                    </div>
+                    <div className="space-y-2">
+                        <Label>Client secret</Label>
+                        <div className="flex gap-2">
+                            <Input value={form.oauthClientSecret} readOnly type="password" className="bg-muted/40" />
+                            <Button
+                                type="button"
+                                variant="outline"
+                                size="icon"
+                                onClick={() => onCopy(form.oauthClientSecret)}
+                                disabled={!form.oauthClientSecret}
+                                aria-label="Copy client secret"
+                            >
+                                <CopyIcon className="size-4" aria-hidden />
+                            </Button>
+                        </div>
+                    </div>
+                    {typeConfig ? (
+                        <div className="space-y-2">
+                            <Label>Authorized grant types</Label>
+                            <GrantTypeChips
+                                typeConfig={typeConfig}
+                                options={typeConfig.allowed_grant_types}
+                                values={form.grantTypes}
+                                onChange={next => onFieldChange('grantTypes', next)}
+                                disabled={isFormDisabled}
+                            />
+                        </div>
+                    ) : null}
+                    {typeConfig?.requires_redirect_uris ? (
+                        <div className="space-y-2">
+                            <Label htmlFor="redirect-uris">Redirect URIs</Label>
+                            <Textarea
+                                id="redirect-uris"
+                                value={form.redirectUrisText}
+                                onChange={e => onFieldChange('redirectUrisText', e.target.value)}
+                                disabled={isFormDisabled}
+                                placeholder="One URI per line"
+                                rows={3}
+                            />
+                        </div>
+                    ) : null}
+                </CardContent>
+            </Card>
+        </div>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/general/ApplicationRevokeCertificateDialog.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/general/ApplicationRevokeCertificateDialog.tsx
@@ -1,0 +1,70 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+    Button,
+    Dialog,
+    DialogClose,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+} from '@gravitee/graphene-core';
+
+import type { ClientCertificate } from '../../types/applicationCertificate';
+
+export function ApplicationRevokeCertificateDialog({
+    certificate,
+    onClose,
+    onConfirm,
+    isLoading,
+    error,
+}: Readonly<{
+    certificate: ClientCertificate | null;
+    onClose: () => void;
+    onConfirm: () => void;
+    isLoading: boolean;
+    error?: string | null;
+}>) {
+    return (
+        <Dialog open={certificate !== null} onOpenChange={open => !open && onClose()}>
+            <DialogContent
+                className="sm:max-w-md"
+                style={{ width: 'min(90vw, 24rem)', maxWidth: 'min(90vw, 24rem)' }}
+                showCloseButton={false}
+            >
+                <DialogHeader>
+                    <DialogTitle>Revoke certificate?</DialogTitle>
+                    <DialogDescription>
+                        Revoking <strong>{certificate?.name}</strong> cannot be undone. Active mTLS connections using this certificate will
+                        fail.
+                    </DialogDescription>
+                </DialogHeader>
+                {error ? <p className="text-sm text-destructive">{error}</p> : null}
+                <DialogFooter className="sm:justify-end">
+                    <DialogClose asChild>
+                        <Button type="button" variant="outline">
+                            Cancel
+                        </Button>
+                    </DialogClose>
+                    <Button type="button" disabled={isLoading} onClick={onConfirm}>
+                        {isLoading ? 'Revoking…' : 'Revoke'}
+                    </Button>
+                </DialogFooter>
+            </DialogContent>
+        </Dialog>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/general/DetailRow.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/general/DetailRow.tsx
@@ -1,0 +1,25 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import type { ReactNode } from 'react';
+
+export function DetailRow({ label, value }: Readonly<{ label: ReactNode; value: string }>) {
+    return (
+        <div className="flex items-start justify-between gap-2">
+            <dt className="flex shrink-0 items-center gap-1.5 text-xs text-muted-foreground">{label}</dt>
+            <dd className="truncate text-right text-xs font-medium">{value}</dd>
+        </div>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/general/GrantTypeChips.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/general/GrantTypeChips.tsx
@@ -1,0 +1,70 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Badge, cn } from '@gravitee/graphene-core';
+
+import type { ApplicationGrantType, ApplicationTypeConfig } from '../../types/applicationCreate';
+import { isMandatoryGrantType } from '../../utils/applicationCreateMapper';
+
+export function GrantTypeChips({
+    typeConfig,
+    options,
+    values,
+    onChange,
+    disabled,
+}: Readonly<{
+    typeConfig: ApplicationTypeConfig;
+    options: ApplicationGrantType[];
+    values: string[];
+    onChange: (next: string[]) => void;
+    disabled?: boolean;
+}>) {
+    const toggle = (grantType: string) => {
+        if (disabled || isMandatoryGrantType(typeConfig, grantType)) return;
+        onChange(values.includes(grantType) ? values.filter(v => v !== grantType) : [...values, grantType]);
+    };
+
+    return (
+        <div className="flex flex-wrap gap-1.5">
+            {options.map(gt => {
+                const isMandatory = isMandatoryGrantType(typeConfig, gt.type);
+                const isChipDisabled = disabled || isMandatory;
+
+                return (
+                    <button
+                        key={gt.type}
+                        type="button"
+                        disabled={isChipDisabled}
+                        onClick={() => toggle(gt.type)}
+                        className={cn(
+                            'inline-flex h-6 items-center gap-1 border px-2 text-xs transition-colors disabled:opacity-50',
+                            values.includes(gt.type)
+                                ? 'border-primary bg-primary text-primary-foreground'
+                                : 'border-border bg-background text-foreground hover:border-primary/40',
+                            isMandatory && !disabled && 'cursor-not-allowed',
+                        )}
+                    >
+                        {gt.name}
+                        {isMandatory ? (
+                            <Badge variant="secondary" className="ml-1 px-1 py-0 text-xs leading-none">
+                                Mandatory
+                            </Badge>
+                        ) : null}
+                    </button>
+                );
+            })}
+        </div>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/general/certificateUtils.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/general/certificateUtils.ts
@@ -1,0 +1,50 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import type { ClientCertificate, ClientCertificateStatus } from '../../types/applicationCertificate';
+
+export function certificateStatusLabel(status: ClientCertificateStatus): string {
+    switch (status) {
+        case 'ACTIVE':
+        case 'ACTIVE_WITH_END':
+            return 'Active';
+        case 'SCHEDULED':
+            return 'Scheduled';
+        case 'REVOKED':
+            return 'Revoked';
+        default:
+            return status;
+    }
+}
+
+export function certificateStatusVariant(status: ClientCertificateStatus): 'default' | 'secondary' | 'destructive' | 'outline' {
+    if (status === 'REVOKED') return 'destructive';
+    if (status === 'SCHEDULED') return 'outline';
+    return 'secondary';
+}
+
+export function findActiveCertificate(certificates: ClientCertificate[]): ClientCertificate | undefined {
+    const sorted = [...certificates].sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
+    return sorted.find(c => c.status === 'ACTIVE') ?? sorted.find(c => c.status === 'ACTIVE_WITH_END');
+}
+
+export function readFileAsText(file: File): Promise<string> {
+    return new Promise((resolve, reject) => {
+        const reader = new FileReader();
+        reader.onload = () => resolve(reader.result as string);
+        reader.onerror = reject;
+        reader.readAsText(file);
+    });
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/index.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/index.ts
@@ -13,5 +13,5 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-export * from '../../../../../../gamma-ui-shared/src/api/apimClient';
+export { ApplicationsEmptyLanding } from './ApplicationsEmptyLanding';
+export { ApplicationsPageHeader } from './ApplicationsPageHeader';

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/list/ApplicationListTable.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/list/ApplicationListTable.tsx
@@ -1,0 +1,86 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Badge, Skeleton, Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@gravitee/graphene-core';
+import { AppWindowIcon } from '@gravitee/graphene-core/icons';
+
+import type { ApplicationListItem } from '../../types/application';
+import { formatApplicationTypeLabel } from '../../utils/applicationFormatters';
+
+function SkeletonRow() {
+    return (
+        <TableRow>
+            <TableCell>
+                <Skeleton className="h-4 w-40 rounded" />
+            </TableCell>
+            <TableCell>
+                <Skeleton className="h-5 w-16 rounded-full" />
+            </TableCell>
+            <TableCell>
+                <Skeleton className="h-4 w-24 rounded" />
+            </TableCell>
+        </TableRow>
+    );
+}
+
+interface ApplicationListTableProps {
+    readonly applications: ApplicationListItem[];
+    readonly isLoading: boolean;
+    readonly skeletonRowCount?: number;
+}
+
+export function ApplicationListTable({ applications, isLoading, skeletonRowCount = 5 }: ApplicationListTableProps) {
+    return (
+        <div className="rounded-lg border">
+            <Table>
+                <TableHeader>
+                    <TableRow>
+                        <TableHead>Name</TableHead>
+                        <TableHead>Type</TableHead>
+                        <TableHead>Owner</TableHead>
+                    </TableRow>
+                </TableHeader>
+                <TableBody>
+                    {isLoading ? (
+                        Array.from({ length: skeletonRowCount }).map((_, i) => <SkeletonRow key={i} />)
+                    ) : applications.length === 0 ? (
+                        <TableRow>
+                            <TableCell colSpan={3} className="py-10 text-center text-sm text-muted-foreground">
+                                No applications found.
+                            </TableCell>
+                        </TableRow>
+                    ) : (
+                        applications.map(application => (
+                            <TableRow key={application.id} className="hover:bg-accent">
+                                <TableCell>
+                                    <div className="flex items-center gap-2 font-medium">
+                                        <AppWindowIcon className="size-4 text-muted-foreground shrink-0" aria-hidden />
+                                        {application.name}
+                                    </div>
+                                </TableCell>
+                                <TableCell>
+                                    <Badge variant="outline" className="border-border bg-background">
+                                        {formatApplicationTypeLabel(application)}
+                                    </Badge>
+                                </TableCell>
+                                <TableCell className="text-sm text-muted-foreground">{application.owner?.displayName ?? '—'}</TableCell>
+                            </TableRow>
+                        ))
+                    )}
+                </TableBody>
+            </Table>
+        </div>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/list/ApplicationListTable.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/list/ApplicationListTable.tsx
@@ -13,13 +13,31 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Badge, Skeleton, Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@gravitee/graphene-core';
-import { AppWindowIcon } from '@gravitee/graphene-core/icons';
+import {
+    Badge,
+    Button,
+    DropdownMenu,
+    DropdownMenuContent,
+    DropdownMenuItem,
+    DropdownMenuTrigger,
+    Skeleton,
+    Table,
+    TableBody,
+    TableCell,
+    TableHead,
+    TableHeader,
+    TableRow,
+    Tooltip,
+    TooltipContent,
+    TooltipTrigger,
+} from '@gravitee/graphene-core';
+import { AppWindowIcon, ExternalLinkIcon, MoreHorizontalIcon, PlugIcon, Wand2Icon } from '@gravitee/graphene-core/icons';
+import { useNavigate } from 'react-router-dom';
 
-import type { ApplicationListItem } from '../../types/application';
-import { formatApplicationTypeLabel } from '../../utils/applicationFormatters';
+import type { ApplicationListItem, ApplicationStatus } from '../../types/application';
+import { formatApplicationDateTime, formatApplicationTypeLabel } from '../../utils/applicationFormatters';
 
-function SkeletonRow() {
+function ActiveSkeletonRow() {
     return (
         <TableRow>
             <TableCell>
@@ -31,42 +49,136 @@ function SkeletonRow() {
             <TableCell>
                 <Skeleton className="h-4 w-24 rounded" />
             </TableCell>
+            <TableCell />
         </TableRow>
+    );
+}
+
+function ArchivedSkeletonRow() {
+    return (
+        <TableRow>
+            <TableCell>
+                <Skeleton className="h-4 w-40 rounded" />
+            </TableCell>
+            <TableCell>
+                <Skeleton className="h-4 w-32 rounded" />
+            </TableCell>
+            <TableCell />
+        </TableRow>
+    );
+}
+
+function ApplicationActionsMenu({ applicationId, onNavigate }: { applicationId: string; onNavigate: (path: string) => void }) {
+    const navigateTo = (path: string) => (event: Event) => {
+        event.preventDefault();
+        onNavigate(path);
+    };
+
+    return (
+        <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+                <Button variant="ghost" size="icon" aria-label="Application actions" onClick={event => event.stopPropagation()}>
+                    <MoreHorizontalIcon className="size-4" aria-hidden />
+                </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end" className="w-auto min-w-[12rem]" onClick={event => event.stopPropagation()}>
+                <DropdownMenuItem className="gap-2" onSelect={navigateTo(`${applicationId}/general`)}>
+                    <ExternalLinkIcon className="size-4" aria-hidden />
+                    View Details
+                </DropdownMenuItem>
+                <DropdownMenuItem className="gap-2" onSelect={navigateTo(`${applicationId}/subscriptions`)}>
+                    <PlugIcon className="size-4" aria-hidden />
+                    Manage Subscriptions
+                </DropdownMenuItem>
+            </DropdownMenuContent>
+        </DropdownMenu>
     );
 }
 
 interface ApplicationListTableProps {
     readonly applications: ApplicationListItem[];
     readonly isLoading: boolean;
+    readonly status: ApplicationStatus;
     readonly skeletonRowCount?: number;
+    readonly onRestore?: (application: ApplicationListItem) => void;
 }
 
-export function ApplicationListTable({ applications, isLoading, skeletonRowCount = 5 }: ApplicationListTableProps) {
+export function ApplicationListTable({ applications, isLoading, status, skeletonRowCount = 5, onRestore }: ApplicationListTableProps) {
+    const navigate = useNavigate();
+    const isArchived = status === 'ARCHIVED';
+
     return (
         <div className="rounded-lg border">
             <Table>
                 <TableHeader>
                     <TableRow>
                         <TableHead>Name</TableHead>
-                        <TableHead>Type</TableHead>
-                        <TableHead>Owner</TableHead>
+                        {isArchived ? (
+                            <>
+                                <TableHead>Archived at</TableHead>
+                                <TableHead className="w-12" />
+                            </>
+                        ) : (
+                            <>
+                                <TableHead>Type</TableHead>
+                                <TableHead>Owner</TableHead>
+                                <TableHead className="w-12" />
+                            </>
+                        )}
                     </TableRow>
                 </TableHeader>
                 <TableBody>
                     {isLoading ? (
-                        Array.from({ length: skeletonRowCount }).map((_, i) => <SkeletonRow key={i} />)
+                        Array.from({ length: skeletonRowCount }).map((_, index) =>
+                            isArchived ? <ArchivedSkeletonRow key={index} /> : <ActiveSkeletonRow key={index} />,
+                        )
                     ) : applications.length === 0 ? (
                         <TableRow>
-                            <TableCell colSpan={3} className="py-10 text-center text-sm text-muted-foreground">
+                            <TableCell colSpan={isArchived ? 3 : 4} className="py-10 text-center text-sm text-muted-foreground">
                                 No applications found.
                             </TableCell>
                         </TableRow>
-                    ) : (
+                    ) : isArchived ? (
                         applications.map(application => (
-                            <TableRow key={application.id} className="hover:bg-accent">
+                            <TableRow key={application.id}>
                                 <TableCell>
                                     <div className="flex items-center gap-2 font-medium">
-                                        <AppWindowIcon className="size-4 text-muted-foreground shrink-0" aria-hidden />
+                                        <AppWindowIcon className="size-4 shrink-0 text-muted-foreground" aria-hidden />
+                                        {application.name}
+                                    </div>
+                                </TableCell>
+                                <TableCell className="text-sm text-muted-foreground">
+                                    {formatApplicationDateTime(application.updated_at)}
+                                </TableCell>
+                                <TableCell className="text-right">
+                                    <Tooltip>
+                                        <TooltipTrigger asChild>
+                                            <Button
+                                                type="button"
+                                                variant="ghost"
+                                                size="icon"
+                                                className="size-8"
+                                                aria-label={`Restore ${application.name}`}
+                                                onClick={() => onRestore?.(application)}
+                                            >
+                                                <Wand2Icon className="size-4" aria-hidden />
+                                            </Button>
+                                        </TooltipTrigger>
+                                        <TooltipContent>Restore application</TooltipContent>
+                                    </Tooltip>
+                                </TableCell>
+                            </TableRow>
+                        ))
+                    ) : (
+                        applications.map(application => (
+                            <TableRow
+                                key={application.id}
+                                className="cursor-pointer hover:bg-accent"
+                                onClick={() => navigate(`${application.id}/general`)}
+                            >
+                                <TableCell>
+                                    <div className="flex items-center gap-2 font-medium">
+                                        <AppWindowIcon className="size-4 shrink-0 text-muted-foreground" aria-hidden />
                                         {application.name}
                                     </div>
                                 </TableCell>
@@ -76,6 +188,9 @@ export function ApplicationListTable({ applications, isLoading, skeletonRowCount
                                     </Badge>
                                 </TableCell>
                                 <TableCell className="text-sm text-muted-foreground">{application.owner?.displayName ?? '—'}</TableCell>
+                                <TableCell className="text-right" onClick={event => event.stopPropagation()}>
+                                    <ApplicationActionsMenu applicationId={application.id} onNavigate={navigate} />
+                                </TableCell>
                             </TableRow>
                         ))
                     )}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/list/ApplicationRestoreDialog.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/list/ApplicationRestoreDialog.tsx
@@ -1,0 +1,77 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+    Button,
+    Dialog,
+    DialogClose,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+} from '@gravitee/graphene-core';
+
+import type { ApplicationListItem } from '../../types/application';
+
+export function ApplicationRestoreDialog({
+    application,
+    onClose,
+    onConfirm,
+    isLoading,
+    error,
+}: Readonly<{
+    application: ApplicationListItem | null;
+    onClose: () => void;
+    onConfirm: () => void;
+    isLoading: boolean;
+    error?: string | null;
+}>) {
+    return (
+        <Dialog open={application !== null} onOpenChange={open => !open && onClose()}>
+            <DialogContent
+                className="sm:max-w-md"
+                style={{ width: 'min(90vw, 28rem)', maxWidth: 'min(90vw, 28rem)' }}
+                showCloseButton={false}
+            >
+                <DialogHeader>
+                    <DialogTitle className="text-lg font-semibold leading-snug">
+                        Would you like to restore the application &ldquo;{application?.name}&rdquo;?
+                    </DialogTitle>
+                    <DialogDescription>
+                        Every subscription belonging to this application will be restored in PENDING status. Subscriptions can be
+                        reactivated as per requirements.
+                    </DialogDescription>
+                </DialogHeader>
+                {error ? <p className="text-sm text-destructive">{error}</p> : null}
+                <DialogFooter className="sm:justify-end">
+                    <DialogClose asChild>
+                        <Button type="button" variant="outline">
+                            Cancel
+                        </Button>
+                    </DialogClose>
+                    <Button
+                        type="button"
+                        className="bg-primary text-primary-foreground hover:bg-primary/90"
+                        disabled={isLoading}
+                        onClick={onConfirm}
+                    >
+                        {isLoading ? 'Restoring…' : 'Restore'}
+                    </Button>
+                </DialogFooter>
+            </DialogContent>
+        </Dialog>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/list/ApplicationStatsCards.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/list/ApplicationStatsCards.tsx
@@ -1,0 +1,72 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Card, CardContent, cn, Skeleton } from '@gravitee/graphene-core';
+import { useEffect, useRef } from 'react';
+
+import type { ApplicationStats } from '../../hooks/useApplicationStats';
+
+const STAT_CARDS = [
+    { key: 'active' as const, label: 'Active applications', hint: 'in this environment' },
+    { key: 'archived' as const, label: 'Archived applications', hint: 'in this environment' },
+] as const;
+
+function StatCard({ label, hint, value, isLoading }: { label: string; hint: string; value: number | null; isLoading: boolean }) {
+    const lastKnown = useRef<number | null>(null);
+
+    useEffect(() => {
+        if (value !== null) {
+            lastKnown.current = value;
+        }
+    }, [value]);
+
+    const displayValue = value ?? lastKnown.current;
+
+    return (
+        <Card style={{ flex: 1 }}>
+            <CardContent className="pt-5 pb-4">
+                <p className="text-sm font-medium text-muted-foreground">{label}</p>
+                {displayValue === null ? (
+                    <Skeleton className="mt-1.5 h-7 w-10 rounded" />
+                ) : (
+                    <p
+                        className={cn('text-2xl font-semibold mt-0.5 transition-opacity duration-200', {
+                            'opacity-50': isLoading,
+                        })}
+                    >
+                        {displayValue}
+                    </p>
+                )}
+                <p className="text-xs text-muted-foreground mt-1">{hint}</p>
+            </CardContent>
+        </Card>
+    );
+}
+
+export function ApplicationStatsCards({ stats }: { readonly stats: ApplicationStats }) {
+    return (
+        <div className="flex gap-4">
+            {STAT_CARDS.map(({ key, label, hint }) => (
+                <StatCard
+                    key={key}
+                    label={label}
+                    hint={hint}
+                    value={stats[key]}
+                    isLoading={key === 'active' ? stats.isLoadingActive : stats.isLoadingArchived}
+                />
+            ))}
+        </div>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/list/ApplicationsListView.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/list/ApplicationsListView.tsx
@@ -1,0 +1,130 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { DataTablePagination, Input, Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@gravitee/graphene-core';
+import { SearchIcon } from '@gravitee/graphene-core/icons';
+import { useId } from 'react';
+
+import { ApplicationsPageHeader } from '../ApplicationsPageHeader';
+import { ApplicationListTable } from './ApplicationListTable';
+import { ApplicationStatsCards } from './ApplicationStatsCards';
+import type { ApplicationStats } from '../../hooks/useApplicationStats';
+import type { ApplicationListItem, ApplicationStatus } from '../../types/application';
+
+const STATUS_OPTIONS: { value: ApplicationStatus; label: string }[] = [
+    { value: 'ACTIVE', label: 'Active' },
+    { value: 'ARCHIVED', label: 'Archived' },
+];
+const PAGE_SIZE_OPTIONS = [10, 25, 50, 100];
+
+interface ApplicationsListViewProps {
+    readonly applications: ApplicationListItem[];
+    readonly totalCount: number;
+    readonly stats: ApplicationStats;
+    readonly isLoading: boolean;
+    readonly search: string;
+    readonly status: ApplicationStatus;
+    readonly page: number;
+    readonly perPage: number;
+    readonly onSearchChange: (value: string) => void;
+    readonly onStatusChange: (status: ApplicationStatus) => void;
+    readonly onPageChange: (page: number) => void;
+    readonly onPerPageChange: (perPage: number) => void;
+    readonly onRegisterApplication: () => void;
+    readonly canCreate: boolean;
+}
+
+export function ApplicationsListView({
+    applications,
+    totalCount,
+    stats,
+    isLoading,
+    search,
+    status,
+    page,
+    perPage,
+    onSearchChange,
+    onStatusChange,
+    onPageChange,
+    onPerPageChange,
+    onRegisterApplication,
+    canCreate,
+}: ApplicationsListViewProps) {
+    const searchInputId = useId();
+
+    return (
+        <div className="space-y-6">
+            <ApplicationsPageHeader canCreate={canCreate} onRegisterApplication={onRegisterApplication} showInfoTooltip />
+
+            <ApplicationStatsCards stats={stats} />
+
+            <div className="flex items-center justify-between gap-4">
+                <div className="flex min-w-0 items-center gap-3">
+                    <div className="relative w-72 shrink-0">
+                        <SearchIcon
+                            className="absolute left-3 top-1/2 -translate-y-1/2 size-4 text-muted-foreground pointer-events-none"
+                            aria-hidden
+                        />
+                        <label htmlFor={searchInputId} className="sr-only">
+                            Search applications
+                        </label>
+                        <Input
+                            id={searchInputId}
+                            placeholder="Search applications..."
+                            value={search}
+                            onChange={e => onSearchChange(e.target.value)}
+                            className="pl-9"
+                        />
+                    </div>
+
+                    <Select value={status} onValueChange={value => onStatusChange(value as ApplicationStatus)}>
+                        <SelectTrigger className="h-9 w-36 shrink-0" aria-label="Filter by status">
+                            <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                            {STATUS_OPTIONS.map(option => (
+                                <SelectItem key={option.value} value={option.value}>
+                                    {option.label}
+                                </SelectItem>
+                            ))}
+                        </SelectContent>
+                    </Select>
+                </div>
+
+                <DataTablePagination
+                    page={page}
+                    pageSize={perPage}
+                    totalCount={totalCount}
+                    pageSizeOptions={PAGE_SIZE_OPTIONS}
+                    onPageChange={onPageChange}
+                    onPageSizeChange={onPerPageChange}
+                />
+            </div>
+
+            <ApplicationListTable applications={applications} isLoading={isLoading} skeletonRowCount={perPage} />
+
+            <div className="flex justify-end">
+                <DataTablePagination
+                    page={page}
+                    pageSize={perPage}
+                    totalCount={totalCount}
+                    pageSizeOptions={PAGE_SIZE_OPTIONS}
+                    onPageChange={onPageChange}
+                    onPageSizeChange={onPerPageChange}
+                />
+            </div>
+        </div>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/list/ApplicationsListView.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/list/ApplicationsListView.tsx
@@ -15,12 +15,14 @@
  */
 import { DataTablePagination, Input, Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@gravitee/graphene-core';
 import { SearchIcon } from '@gravitee/graphene-core/icons';
-import { useId } from 'react';
+import { useId, useState } from 'react';
 
 import { ApplicationsPageHeader } from '../ApplicationsPageHeader';
 import { ApplicationListTable } from './ApplicationListTable';
+import { ApplicationRestoreDialog } from './ApplicationRestoreDialog';
 import { ApplicationStatsCards } from './ApplicationStatsCards';
 import type { ApplicationStats } from '../../hooks/useApplicationStats';
+import { useRestoreApplication } from '../../hooks/useRestoreApplication';
 import type { ApplicationListItem, ApplicationStatus } from '../../types/application';
 
 const STATUS_OPTIONS: { value: ApplicationStatus; label: string }[] = [
@@ -63,10 +65,26 @@ export function ApplicationsListView({
     canCreate,
 }: ApplicationsListViewProps) {
     const searchInputId = useId();
+    const [restoreTarget, setRestoreTarget] = useState<ApplicationListItem | null>(null);
+    const [restoreError, setRestoreError] = useState<string | null>(null);
+    const restoreMutation = useRestoreApplication();
+
+    const handleRestore = () => {
+        if (!restoreTarget) return;
+        setRestoreError(null);
+        restoreMutation.mutate(restoreTarget.id, {
+            onSuccess: () => setRestoreTarget(null),
+            onError: (e: unknown) => setRestoreError(e instanceof Error ? e.message : 'Failed to restore application.'),
+        });
+    };
 
     return (
         <div className="space-y-6">
-            <ApplicationsPageHeader canCreate={canCreate} onRegisterApplication={onRegisterApplication} showInfoTooltip />
+            <ApplicationsPageHeader
+                canCreate={canCreate && status === 'ACTIVE'}
+                onRegisterApplication={onRegisterApplication}
+                showInfoTooltip
+            />
 
             <ApplicationStatsCards stats={stats} />
 
@@ -113,7 +131,27 @@ export function ApplicationsListView({
                 />
             </div>
 
-            <ApplicationListTable applications={applications} isLoading={isLoading} skeletonRowCount={perPage} />
+            <ApplicationListTable
+                applications={applications}
+                isLoading={isLoading}
+                status={status}
+                skeletonRowCount={perPage}
+                onRestore={application => {
+                    setRestoreError(null);
+                    setRestoreTarget(application);
+                }}
+            />
+
+            <ApplicationRestoreDialog
+                application={restoreTarget}
+                onClose={() => {
+                    setRestoreTarget(null);
+                    setRestoreError(null);
+                }}
+                onConfirm={handleRestore}
+                isLoading={restoreMutation.isPending}
+                error={restoreError}
+            />
 
             <div className="flex justify-end">
                 <DataTablePagination

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/list/index.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/list/index.ts
@@ -13,5 +13,4 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-export * from '../../../../../../gamma-ui-shared/src/api/apimClient';
+export { ApplicationsListView } from './ApplicationsListView';

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/context/ApplicationDetailContext.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/context/ApplicationDetailContext.tsx
@@ -1,0 +1,34 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { createContext, useContext } from 'react';
+
+import type { ApplicationListItem } from '../types/application';
+
+export interface ApplicationDetailContextValue {
+    application: ApplicationListItem | null;
+    isLoading: boolean;
+    permissionsReady: boolean;
+}
+
+export const ApplicationDetailContext = createContext<ApplicationDetailContextValue | null>(null);
+
+export function useApplicationDetailContext(): ApplicationDetailContextValue {
+    const context = useContext(ApplicationDetailContext);
+    if (!context) {
+        throw new Error('useApplicationDetailContext must be used within ApplicationDetailLayout');
+    }
+    return context;
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/fixtures/applicationTypes.fixture.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/fixtures/applicationTypes.fixture.ts
@@ -1,0 +1,80 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import type { ApplicationTypeConfig } from '../types/applicationCreate';
+
+/**
+ * Full catalog shape from gravitee-apim-rest-api-service `applications/types.json`
+ * (filtered subset returned by GET .../configuration/applications/types per environment).
+ */
+export const APPLICATION_TYPES_FIXTURE: ApplicationTypeConfig[] = [
+    {
+        id: 'simple',
+        name: 'Simple',
+        description: 'A standalone client where you manage your own client_id. No DCR involved.',
+        requires_redirect_uris: false,
+        allowed_grant_types: [],
+        default_grant_types: [],
+        mandatory_grant_types: [],
+    },
+    {
+        id: 'browser',
+        name: 'SPA',
+        description: 'Front-end JS apps (React, Angular, Vue) using DCR for authentication.',
+        requires_redirect_uris: true,
+        allowed_grant_types: [
+            { type: 'authorization_code', name: 'Authorization Code', response_types: ['code'] },
+            { type: 'implicit', name: 'Implicit', response_types: ['token', 'id_token'] },
+        ],
+        default_grant_types: [{ type: 'authorization_code', name: 'Authorization Code', response_types: ['code'] }],
+        mandatory_grant_types: [],
+    },
+    {
+        id: 'web',
+        name: 'Web',
+        description: 'Server-side web apps (e.g., .NET, Java) that authenticate users through DCR.',
+        requires_redirect_uris: true,
+        allowed_grant_types: [
+            { type: 'authorization_code', name: 'Authorization Code', response_types: ['code'] },
+            { type: 'refresh_token', name: 'Refresh Token', response_types: [] },
+            { type: 'implicit', name: 'Implicit (Hybrid)', response_types: ['token', 'id_token'] },
+        ],
+        default_grant_types: [{ type: 'authorization_code', name: 'Authorization Code', response_types: ['code'] }],
+        mandatory_grant_types: [{ type: 'authorization_code', name: 'Authorization Code', response_types: ['code'] }],
+    },
+    {
+        id: 'native',
+        name: 'Native',
+        description: 'Mobile and desktop apps (iOS, Android) that authenticate through DCR.',
+        requires_redirect_uris: true,
+        allowed_grant_types: [
+            { type: 'authorization_code', name: 'Authorization Code', response_types: ['code'] },
+            { type: 'refresh_token', name: 'Refresh Token', response_types: [] },
+            { type: 'password', name: 'Resource Owner Password', response_types: [] },
+            { type: 'implicit', name: 'Implicit (Hybrid)', response_types: ['token', 'id_token'] },
+        ],
+        default_grant_types: [{ type: 'authorization_code', name: 'Authorization Code', response_types: ['code'] }],
+        mandatory_grant_types: [{ type: 'authorization_code', name: 'Authorization Code', response_types: ['code'] }],
+    },
+    {
+        id: 'backend_to_backend',
+        name: 'Backend to backend',
+        description: 'Machine-to-machine apps (scripts, daemons, CLIs) using DCR for API access.',
+        requires_redirect_uris: false,
+        allowed_grant_types: [{ type: 'client_credentials', name: 'Client Credentials', response_types: [] }],
+        default_grant_types: [{ type: 'client_credentials', name: 'Client Credentials', response_types: [] }],
+        mandatory_grant_types: [{ type: 'client_credentials', name: 'Client Credentials', response_types: [] }],
+    },
+];

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/hooks/useApplicationCertificates.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/hooks/useApplicationCertificates.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useEnvironment } from '@gravitee/gamma-modules-sdk';
+import { useQuery } from '@tanstack/react-query';
+
+import { listApplicationCertificates } from '../services/applicationDetail';
+import { applicationDetailKeys } from '../utils/queryKeys';
+
+export function useApplicationCertificates(applicationId: string | undefined) {
+    const env = useEnvironment();
+    return useQuery({
+        queryKey: applicationDetailKeys.certificates(env?.id ?? '', applicationId ?? ''),
+        queryFn: async () => {
+            const result = await listApplicationCertificates(env!.id, applicationId!);
+            return result.data ?? [];
+        },
+        enabled: Boolean(env && applicationId),
+        staleTime: 30_000,
+    });
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/hooks/useApplicationDetail.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/hooks/useApplicationDetail.ts
@@ -1,0 +1,30 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useEnvironment } from '@gravitee/gamma-modules-sdk';
+import { useQuery } from '@tanstack/react-query';
+
+import { getApplication } from '../services/applicationDetail';
+import { applicationDetailKeys } from '../utils/queryKeys';
+
+export function useApplicationDetail(applicationId: string | undefined) {
+    const env = useEnvironment();
+    return useQuery({
+        queryKey: applicationDetailKeys.detail(env?.id ?? '', applicationId ?? ''),
+        queryFn: () => getApplication(env!.id, applicationId!),
+        enabled: Boolean(env && applicationId),
+        staleTime: 60_000,
+    });
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/hooks/useApplicationGeneralMutations.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/hooks/useApplicationGeneralMutations.ts
@@ -1,0 +1,93 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useEnvironment } from '@gravitee/gamma-modules-sdk';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useRef } from 'react';
+
+import {
+    createApplicationCertificate,
+    deleteApplication,
+    updateApplication,
+    updateApplicationCertificate,
+    type UpdateApplicationPayload,
+} from '../services/applicationDetail';
+import type { ApplicationListItem } from '../types/application';
+import type { CreateClientCertificate, UpdateClientCertificate } from '../types/applicationCertificate';
+import { applicationDetailKeys, applicationListKeys } from '../utils/queryKeys';
+
+interface ApplicationGeneralSideEffects {
+    onDeleteSuccess?: () => void;
+}
+
+export function useApplicationGeneralMutations(
+    application: ApplicationListItem | null,
+    applicationId: string | undefined,
+    sideEffects: ApplicationGeneralSideEffects = {},
+) {
+    const env = useEnvironment();
+    const queryClient = useQueryClient();
+    const sideEffectsRef = useRef(sideEffects);
+    sideEffectsRef.current = sideEffects;
+
+    const invalidateApplicationList = () => {
+        void queryClient.invalidateQueries({ queryKey: applicationListKeys.all });
+    };
+
+    const invalidateDetail = () => {
+        void queryClient.invalidateQueries({
+            queryKey: applicationDetailKeys.detail(env?.id ?? '', applicationId ?? ''),
+        });
+        invalidateApplicationList();
+    };
+
+    const invalidateCertificates = () => {
+        void queryClient.invalidateQueries({
+            queryKey: applicationDetailKeys.certificates(env?.id ?? '', applicationId ?? ''),
+        });
+        invalidateDetail();
+    };
+
+    const saveMutation = useMutation({
+        mutationFn: (payload: UpdateApplicationPayload) => updateApplication(env!.id, application!, payload),
+        onSuccess: invalidateDetail,
+    });
+
+    const deleteMutation = useMutation({
+        mutationFn: () => deleteApplication(env!.id, applicationId!),
+        onSuccess: async () => {
+            await queryClient.invalidateQueries({ queryKey: applicationListKeys.all });
+            sideEffectsRef.current.onDeleteSuccess?.();
+        },
+    });
+
+    const createCertificateMutation = useMutation({
+        mutationFn: (certificate: CreateClientCertificate) => createApplicationCertificate(env!.id, applicationId!, certificate),
+        onSuccess: invalidateCertificates,
+    });
+
+    const updateCertificateMutation = useMutation({
+        mutationFn: ({ certificateId, update }: { certificateId: string; update: UpdateClientCertificate }) =>
+            updateApplicationCertificate(env!.id, applicationId!, certificateId, update),
+        onSuccess: invalidateCertificates,
+    });
+
+    return {
+        saveMutation,
+        deleteMutation,
+        createCertificateMutation,
+        updateCertificateMutation,
+    };
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/hooks/useApplicationGroups.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/hooks/useApplicationGroups.ts
@@ -13,5 +13,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { useEnvironment } from '@gravitee/gamma-modules-sdk';
+import { useQuery } from '@tanstack/react-query';
 
-export * from '../../../../../../gamma-ui-shared/src/api/apimClient';
+import { listApplicationGroups } from '../services/applicationConfiguration';
+import type { ApplicationGroup } from '../types/applicationCreate';
+import { applicationListKeys } from '../utils/queryKeys';
+
+export function useApplicationGroups() {
+    const env = useEnvironment();
+    return useQuery<ApplicationGroup[]>({
+        queryKey: applicationListKeys.groups(env?.id ?? ''),
+        queryFn: () => listApplicationGroups(env!.id),
+        enabled: Boolean(env),
+        staleTime: 60_000,
+    });
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/hooks/useApplicationList.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/hooks/useApplicationList.spec.tsx
@@ -1,0 +1,104 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useEnvironment } from '@gravitee/gamma-modules-sdk';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+
+import { useApplicationList } from './useApplicationList';
+import { listApplications } from '../services/applicationList';
+import { applicationListKeys } from '../utils/queryKeys';
+
+jest.mock('@gravitee/gamma-modules-sdk', () => ({ useEnvironment: jest.fn() }));
+jest.mock('../services/applicationList', () => ({ listApplications: jest.fn() }));
+
+const mockUseEnvironment = jest.mocked(useEnvironment);
+const mockListApplications = jest.mocked(listApplications);
+
+const MOCK_RESPONSE = {
+    data: [],
+    page: { current: 1, size: 0, per_page: 25, total_pages: 0, total_elements: 0 },
+};
+
+function createTestContext() {
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    function Wrapper({ children }: { children: ReactNode }) {
+        return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+    }
+    return { queryClient, Wrapper };
+}
+
+describe('useApplicationList', () => {
+    beforeEach(() => {
+        mockUseEnvironment.mockReturnValue({ id: 'env-1' });
+        mockListApplications.mockResolvedValue(MOCK_RESPONSE);
+    });
+
+    afterEach(() => jest.clearAllMocks());
+
+    it('does not call the API when the environment is unavailable', () => {
+        mockUseEnvironment.mockReturnValue(null);
+
+        const { Wrapper } = createTestContext();
+        renderHook(() => useApplicationList({ query: '', status: 'ACTIVE', page: 1, perPage: 25 }), {
+            wrapper: Wrapper,
+        });
+
+        expect(mockListApplications).not.toHaveBeenCalled();
+    });
+
+    it('calls listApplications with env id, page, and perPage', async () => {
+        const { Wrapper } = createTestContext();
+        renderHook(() => useApplicationList({ query: 'billing', status: 'ARCHIVED', page: 2, perPage: 50 }), {
+            wrapper: Wrapper,
+        });
+
+        await waitFor(() => expect(mockListApplications).toHaveBeenCalledTimes(1));
+        expect(mockListApplications).toHaveBeenCalledWith('env-1', {
+            query: 'billing',
+            page: 2,
+            size: 50,
+            status: 'ARCHIVED',
+        });
+    });
+
+    it('uses a query key scoped by env id, search, status, page, and perPage', async () => {
+        const { queryClient, Wrapper } = createTestContext();
+        renderHook(() => useApplicationList({ query: 'billing', status: 'ARCHIVED', page: 2, perPage: 50 }), {
+            wrapper: Wrapper,
+        });
+
+        await waitFor(() => expect(mockListApplications).toHaveBeenCalledTimes(1));
+
+        const expectedKey = applicationListKeys.search('env-1', 'billing', 'ARCHIVED', 2, 50);
+        expect(queryClient.getQueryCache().find({ queryKey: expectedKey })).toBeDefined();
+    });
+
+    it('maps an empty query string to undefined in the API request', async () => {
+        const { Wrapper } = createTestContext();
+        renderHook(() => useApplicationList({ query: '', status: 'ACTIVE', page: 1, perPage: 25 }), {
+            wrapper: Wrapper,
+        });
+
+        await waitFor(() => expect(mockListApplications).toHaveBeenCalledTimes(1));
+        expect(mockListApplications).toHaveBeenCalledWith('env-1', {
+            query: undefined,
+            page: 1,
+            size: 25,
+            status: 'ACTIVE',
+        });
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/hooks/useApplicationList.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/hooks/useApplicationList.ts
@@ -1,0 +1,48 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useEnvironment } from '@gravitee/gamma-modules-sdk';
+import { keepPreviousData, useQuery } from '@tanstack/react-query';
+
+import { listApplications } from '../services/applicationList';
+import type { ApplicationListResponse, ApplicationStatus } from '../types/application';
+import { applicationListKeys } from '../utils/queryKeys';
+
+export function useApplicationList({
+    query,
+    status,
+    page,
+    perPage,
+}: {
+    query: string;
+    status: ApplicationStatus;
+    page: number;
+    perPage: number;
+}) {
+    const env = useEnvironment();
+    return useQuery<ApplicationListResponse>({
+        queryKey: applicationListKeys.search(env?.id ?? '', query, status, page, perPage),
+        queryFn: () =>
+            listApplications(env!.id, {
+                query: query || undefined,
+                page,
+                size: perPage,
+                status,
+            }),
+        enabled: Boolean(env),
+        staleTime: 30_000,
+        placeholderData: keepPreviousData,
+    });
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/hooks/useApplicationPermissions.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/hooks/useApplicationPermissions.ts
@@ -1,0 +1,52 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { permissionService, useEnvironment } from '@gravitee/gamma-modules-sdk';
+import { useQuery } from '@tanstack/react-query';
+import { useLayoutEffect, useState } from 'react';
+
+import { getApplicationPermissions } from '../services/applicationPermissions';
+import { applicationPermissionKeys } from '../utils/queryKeys';
+
+/**
+ * Loads application-scoped permissions into `permissionService` for the detail view.
+ * Mirrors `useApiPermissions` and the console application detail guard.
+ */
+export function useApplicationPermissions(applicationId: string | undefined): { permissionsReady: boolean } {
+    const env = useEnvironment();
+    const [permissionsApplied, setPermissionsApplied] = useState(false);
+
+    const { data: permissions, isSuccess } = useQuery({
+        queryKey: applicationPermissionKeys.detail(env?.id ?? '', applicationId ?? ''),
+        queryFn: () => getApplicationPermissions(env!.id, applicationId!),
+        enabled: Boolean(env && applicationId),
+        staleTime: 60_000,
+    });
+
+    useLayoutEffect(() => {
+        if (!permissions) {
+            setPermissionsApplied(false);
+            return;
+        }
+        permissionService.load('application', permissions);
+        setPermissionsApplied(true);
+        return () => {
+            permissionService.clear('application');
+            setPermissionsApplied(false);
+        };
+    }, [permissions]);
+
+    return { permissionsReady: isSuccess && permissionsApplied };
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/hooks/useApplicationStats.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/hooks/useApplicationStats.ts
@@ -1,0 +1,90 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useEnvironment } from '@gravitee/gamma-modules-sdk';
+import { useQuery } from '@tanstack/react-query';
+
+import { listApplications } from '../services/applicationList';
+import { applicationListKeys } from '../utils/queryKeys';
+
+const STATS_PAGE = 1;
+const STATS_PER_PAGE = 1;
+
+export interface ApplicationStats {
+    active: number | null;
+    archived: number | null;
+    /** Sum of active + archived when both counts are known; used for empty-landing gating only. */
+    total: number | null;
+    isLoading: boolean;
+    isLoadingActive: boolean;
+    isLoadingArchived: boolean;
+}
+
+export interface UseApplicationStatsOptions {
+    readonly knownCounts?: {
+        readonly active?: number;
+        readonly archived?: number;
+    };
+}
+
+export function useApplicationStats(query?: string, options?: UseApplicationStatsOptions): ApplicationStats {
+    const env = useEnvironment();
+    const enabled = Boolean(env);
+    const envId = env?.id ?? '';
+    const knownActive = options?.knownCounts?.active;
+    const knownArchived = options?.knownCounts?.archived;
+
+    const activeQuery = useQuery({
+        queryKey: applicationListKeys.count(envId, { status: 'ACTIVE', query }),
+        queryFn: () =>
+            listApplications(envId, {
+                page: STATS_PAGE,
+                size: STATS_PER_PAGE,
+                status: 'ACTIVE',
+                query,
+            }),
+        enabled: enabled && knownActive === undefined,
+        staleTime: 60_000,
+    });
+
+    const archivedQuery = useQuery({
+        queryKey: applicationListKeys.count(envId, { status: 'ARCHIVED', query }),
+        queryFn: () =>
+            listApplications(envId, {
+                page: STATS_PAGE,
+                size: STATS_PER_PAGE,
+                status: 'ARCHIVED',
+                query,
+            }),
+        enabled: enabled && knownArchived === undefined,
+        staleTime: 60_000,
+    });
+
+    const isLoadingActive = knownActive === undefined && activeQuery.isLoading;
+    const isLoadingArchived = knownArchived === undefined && archivedQuery.isLoading;
+
+    const active = knownActive ?? activeQuery.data?.page.total_elements ?? null;
+    const archived = knownArchived ?? archivedQuery.data?.page.total_elements ?? null;
+    const total = active !== null && archived !== null ? active + archived : null;
+
+    return {
+        active,
+        archived,
+        total,
+        isLoading: isLoadingActive || isLoadingArchived,
+        isLoadingActive,
+        isLoadingArchived,
+    };
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/hooks/useApplicationTypeConfiguration.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/hooks/useApplicationTypeConfiguration.ts
@@ -1,0 +1,30 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useEnvironment } from '@gravitee/gamma-modules-sdk';
+import { useQuery } from '@tanstack/react-query';
+
+import { getApplicationTypeConfiguration } from '../services/applicationDetail';
+import { applicationDetailKeys } from '../utils/queryKeys';
+
+export function useApplicationTypeConfiguration(applicationId: string | undefined, enabled: boolean) {
+    const env = useEnvironment();
+    return useQuery({
+        queryKey: applicationDetailKeys.typeConfig(env?.id ?? '', applicationId ?? ''),
+        queryFn: () => getApplicationTypeConfiguration(env!.id, applicationId!),
+        enabled: Boolean(env && applicationId && enabled),
+        staleTime: 60_000,
+    });
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/hooks/useApplicationTypes.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/hooks/useApplicationTypes.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useEnvironment } from '@gravitee/gamma-modules-sdk';
+import { useQuery } from '@tanstack/react-query';
+
+import { listApplicationTypes } from '../services/applicationConfiguration';
+import type { ApplicationTypeConfig } from '../types/applicationCreate';
+import { normalizeApplicationTypes } from '../utils/applicationTypeLabels';
+import { applicationListKeys } from '../utils/queryKeys';
+
+export function useApplicationTypes() {
+    const env = useEnvironment();
+    return useQuery<ApplicationTypeConfig[]>({
+        queryKey: applicationListKeys.types(env?.id ?? ''),
+        queryFn: async () => {
+            const apiTypes = await listApplicationTypes(env!.id);
+            return normalizeApplicationTypes(apiTypes);
+        },
+        enabled: Boolean(env),
+        staleTime: 60_000,
+    });
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/hooks/useCreateApplication.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/hooks/useCreateApplication.ts
@@ -1,0 +1,43 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useEnvironment } from '@gravitee/gamma-modules-sdk';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { ApimApiError } from '../../../shared/api/apimClient';
+import { createApplication } from '../services/applicationCreate';
+import type { ApplicationTypeConfig, CreatedApplication, RegisterApplicationDraft } from '../types/applicationCreate';
+import { mapDraftToCreateRequest } from '../utils/applicationCreateMapper';
+import { applicationListKeys } from '../utils/queryKeys';
+
+interface CreateApplicationInput {
+    draft: RegisterApplicationDraft;
+    selectedType: ApplicationTypeConfig;
+}
+
+export function useCreateApplication() {
+    const env = useEnvironment();
+    const queryClient = useQueryClient();
+
+    return useMutation<CreatedApplication, ApimApiError, CreateApplicationInput>({
+        mutationFn: async ({ draft, selectedType }) => {
+            if (!env) throw new ApimApiError(0, 'Environment not ready');
+            return createApplication(env.id, mapDraftToCreateRequest(draft, selectedType));
+        },
+        onSuccess: async () => {
+            await queryClient.invalidateQueries({ queryKey: applicationListKeys.all });
+        },
+    });
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/hooks/useRestoreApplication.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/hooks/useRestoreApplication.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useEnvironment } from '@gravitee/gamma-modules-sdk';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { restoreApplication } from '../services/applicationList';
+import { applicationListKeys } from '../utils/queryKeys';
+
+export function useRestoreApplication() {
+    const env = useEnvironment();
+    const queryClient = useQueryClient();
+
+    return useMutation({
+        mutationFn: (applicationId: string) => restoreApplication(env!.id, applicationId),
+        onSuccess: () => {
+            void queryClient.invalidateQueries({ queryKey: applicationListKeys.all });
+        },
+    });
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/hooks/useUserGroupRequired.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/hooks/useUserGroupRequired.spec.tsx
@@ -1,0 +1,55 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { renderHook, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+
+import { useUserGroupRequired } from './useUserGroupRequired';
+import { ConsoleSettingsProvider } from '../../../shared/console-settings';
+import { fetchOrgConsoleSettings } from '../../../shared/services/orgConsoleSettings';
+
+jest.mock('../../../shared/services/orgConsoleSettings');
+
+const mockFetchOrgConsoleSettings = jest.mocked(fetchOrgConsoleSettings);
+
+function wrapper({ children }: { children: ReactNode }) {
+    return <ConsoleSettingsProvider>{children}</ConsoleSettingsProvider>;
+}
+
+describe('useUserGroupRequired', () => {
+    beforeEach(() => {
+        mockFetchOrgConsoleSettings.mockReset();
+    });
+
+    it('returns false when user groups are not required', async () => {
+        mockFetchOrgConsoleSettings.mockResolvedValue({});
+
+        const { result } = renderHook(() => useUserGroupRequired(), { wrapper });
+
+        await waitFor(() => {
+            expect(result.current.requireUserGroups).toBe(false);
+        });
+    });
+
+    it('reads requireUserGroups from loaded settings', async () => {
+        mockFetchOrgConsoleSettings.mockResolvedValue({ userGroup: { required: { enabled: true } } });
+
+        const { result } = renderHook(() => useUserGroupRequired(), { wrapper });
+
+        await waitFor(() => {
+            expect(result.current.requireUserGroups).toBe(true);
+        });
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/hooks/useUserGroupRequired.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/hooks/useUserGroupRequired.ts
@@ -13,5 +13,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { isUserGroupRequired, useConsoleSettings } from '../../../shared/console-settings';
 
-export * from '../../../../../../gamma-ui-shared/src/api/apimClient';
+/**
+ * Reads org console settings from {@link ConsoleSettingsProvider}.
+ * Only call under routes wrapped by that provider (settings are ready when children render).
+ */
+export function useUserGroupRequired(): { requireUserGroups: boolean } {
+    const settings = useConsoleSettings();
+
+    return {
+        requireUserGroups: isUserGroupRequired(settings),
+    };
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/services/applicationConfiguration.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/services/applicationConfiguration.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { apimFetchJsonV1Env } from '../../../shared/api/apimClient';
+import type { ApplicationGroup, ApplicationTypeConfig } from '../types/applicationCreate';
+
+/** GET /organizations/{orgId}/environments/{envId}/configuration/applications/types (console ApplicationTypesService). */
+export async function listApplicationTypes(environmentId: string): Promise<ApplicationTypeConfig[]> {
+    return apimFetchJsonV1Env<ApplicationTypeConfig[]>(environmentId, '/configuration/applications/types');
+}
+
+/** GET /organizations/{orgId}/environments/{envId}/configuration/groups (console GroupService). */
+export async function listApplicationGroups(environmentId: string): Promise<ApplicationGroup[]> {
+    return apimFetchJsonV1Env<ApplicationGroup[]>(environmentId, '/configuration/groups');
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/services/applicationCreate.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/services/applicationCreate.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { apimFetchJsonV1Env } from '../../../shared/api/apimClient';
+import type { CreateApplicationRequest, CreatedApplication } from '../types/applicationCreate';
+
+const JSON_HEADERS = { 'Content-Type': 'application/json' };
+
+/** POST /organizations/{orgId}/environments/{envId}/applications (console ApplicationService.create). */
+export async function createApplication(environmentId: string, request: CreateApplicationRequest): Promise<CreatedApplication> {
+    return apimFetchJsonV1Env<CreatedApplication>(environmentId, '/applications', {
+        method: 'POST',
+        headers: JSON_HEADERS,
+        body: JSON.stringify(request),
+    });
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/services/applicationDetail.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/services/applicationDetail.ts
@@ -1,0 +1,127 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { apimFetchJsonV1Env } from '../../../shared/api/apimClient';
+import type { ApplicationListItem } from '../types/application';
+import type {
+    ClientCertificate,
+    ClientCertificatePagedResult,
+    CreateClientCertificate,
+    UpdateClientCertificate,
+    ValidateCertificateResponse,
+} from '../types/applicationCertificate';
+import type { ApplicationTypeConfig } from '../types/applicationCreate';
+
+export async function getApplication(environmentId: string, applicationId: string): Promise<ApplicationListItem> {
+    return apimFetchJsonV1Env<ApplicationListItem>(environmentId, `/applications/${applicationId}`);
+}
+
+export async function getApplicationTypeConfiguration(environmentId: string, applicationId: string): Promise<ApplicationTypeConfig> {
+    return apimFetchJsonV1Env<ApplicationTypeConfig>(environmentId, `/applications/${applicationId}/configuration`);
+}
+
+export interface UpdateApplicationPayload {
+    name: string;
+    description: string;
+    domain?: string;
+    groups?: string[];
+    settings?: ApplicationListItem['settings'];
+    picture?: string | null;
+    background?: string | null;
+    disable_membership_notifications?: boolean;
+    api_key_mode?: ApplicationListItem['api_key_mode'];
+}
+
+export async function updateApplication(
+    environmentId: string,
+    application: ApplicationListItem,
+    payload: UpdateApplicationPayload,
+): Promise<ApplicationListItem> {
+    const body: UpdateApplicationPayload = {
+        name: payload.name,
+        description: payload.description,
+        domain: payload.domain,
+        groups: application.groups,
+        settings: payload.settings,
+        disable_membership_notifications: application.disable_membership_notifications,
+        api_key_mode: application.api_key_mode,
+    };
+    if (payload.picture !== undefined) {
+        body.picture = payload.picture;
+    }
+    if (payload.background !== undefined) {
+        body.background = payload.background;
+    }
+    return apimFetchJsonV1Env<ApplicationListItem>(environmentId, `/applications/${application.id}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+    });
+}
+
+export async function deleteApplication(environmentId: string, applicationId: string): Promise<ApplicationListItem> {
+    return apimFetchJsonV1Env<ApplicationListItem>(environmentId, `/applications/${applicationId}/`, {
+        method: 'DELETE',
+    });
+}
+
+export async function listApplicationCertificates(
+    environmentId: string,
+    applicationId: string,
+    page = 1,
+    size = 100,
+): Promise<ClientCertificatePagedResult> {
+    return apimFetchJsonV1Env<ClientCertificatePagedResult>(
+        environmentId,
+        `/applications/${applicationId}/certificates?page=${page}&size=${size}`,
+    );
+}
+
+export async function createApplicationCertificate(
+    environmentId: string,
+    applicationId: string,
+    certificate: CreateClientCertificate,
+): Promise<ClientCertificate> {
+    return apimFetchJsonV1Env<ClientCertificate>(environmentId, `/applications/${applicationId}/certificates`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(certificate),
+    });
+}
+
+export async function updateApplicationCertificate(
+    environmentId: string,
+    applicationId: string,
+    certificateId: string,
+    update: UpdateClientCertificate,
+): Promise<ClientCertificate> {
+    return apimFetchJsonV1Env<ClientCertificate>(environmentId, `/applications/${applicationId}/certificates/${certificateId}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(update),
+    });
+}
+
+export async function validateApplicationCertificate(
+    environmentId: string,
+    applicationId: string,
+    certificate: string,
+): Promise<ValidateCertificateResponse> {
+    return apimFetchJsonV1Env<ValidateCertificateResponse>(environmentId, `/applications/${applicationId}/certificates/_validate`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ certificate }),
+    });
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/services/applicationList.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/services/applicationList.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { apimFetchJsonV1Env } from '../../../shared/api/apimClient';
+import type { ApplicationListResponse, ApplicationStatus } from '../types/application';
+
+export async function listApplications(
+    environmentId: string,
+    {
+        query,
+        page,
+        size,
+        status = 'ACTIVE',
+    }: {
+        query?: string;
+        page: number;
+        size: number;
+        status?: ApplicationStatus;
+    },
+): Promise<ApplicationListResponse> {
+    const params = new URLSearchParams({
+        page: String(page),
+        size: String(size),
+        status,
+    });
+    if (query) {
+        params.set('query', query);
+    }
+    return apimFetchJsonV1Env<ApplicationListResponse>(environmentId, `/applications/_paged?${params}`);
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/services/applicationList.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/services/applicationList.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import { apimFetchJsonV1Env } from '../../../shared/api/apimClient';
-import type { ApplicationListResponse, ApplicationStatus } from '../types/application';
+import type { ApplicationListItem, ApplicationListResponse, ApplicationStatus } from '../types/application';
 
 export async function listApplications(
     environmentId: string,
@@ -39,4 +39,10 @@ export async function listApplications(
         params.set('query', query);
     }
     return apimFetchJsonV1Env<ApplicationListResponse>(environmentId, `/applications/_paged?${params}`);
+}
+
+export async function restoreApplication(environmentId: string, applicationId: string): Promise<ApplicationListItem> {
+    return apimFetchJsonV1Env<ApplicationListItem>(environmentId, `/applications/${applicationId}/_restore`, {
+        method: 'POST',
+    });
 }

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/services/applicationPermissions.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/services/applicationPermissions.ts
@@ -1,0 +1,30 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { normalizeCrudMapRecord } from '@gravitee/gamma-modules-sdk';
+
+import { apimFetchJsonV1Env } from '../../../shared/api/apimClient';
+
+/**
+ * Fetches the current user's permission set for a specific application and returns
+ * normalized flat strings ready for `permissionService.load('application', ...)`.
+ */
+export async function getApplicationPermissions(environmentId: string, applicationId: string): Promise<string[]> {
+    const raw = await apimFetchJsonV1Env<Record<string, string[]>>(
+        environmentId,
+        `/applications/${encodeURIComponent(applicationId)}/members/permissions`,
+    );
+    return normalizeCrudMapRecord('application', raw);
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/types/application.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/types/application.ts
@@ -1,0 +1,57 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export type ApplicationStatus = 'ACTIVE' | 'ARCHIVED';
+
+export interface ApplicationOwner {
+    id: string;
+    displayName: string;
+    type: string;
+}
+
+export interface ApplicationSettings {
+    app?: {
+        type?: string;
+        client_id?: string;
+    };
+}
+
+export interface ApplicationListItem {
+    id: string;
+    name: string;
+    description?: string;
+    status: ApplicationStatus;
+    type?: string;
+    created_at: number;
+    updated_at: number;
+    owner?: ApplicationOwner;
+    settings?: ApplicationSettings;
+    picture_url?: string;
+    origin?: string;
+}
+
+export interface ApplicationPagedMeta {
+    current: number;
+    size: number;
+    per_page: number;
+    total_pages: number;
+    total_elements: number;
+}
+
+export interface ApplicationListResponse {
+    data: ApplicationListItem[];
+    page: ApplicationPagedMeta;
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/types/application.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/types/application.ts
@@ -22,24 +22,42 @@ export interface ApplicationOwner {
     type: string;
 }
 
+export type ApiKeyMode = 'UNSPECIFIED' | 'SHARED' | 'EXCLUSIVE';
+
+export interface ApplicationOAuthSettings {
+    client_id?: string;
+    client_secret?: string;
+    grant_types?: string[];
+    redirect_uris?: string[];
+    application_type?: string;
+    additional_client_metadata?: Record<string, string>;
+}
+
 export interface ApplicationSettings {
     app?: {
         type?: string;
         client_id?: string;
     };
+    oauth?: ApplicationOAuthSettings;
 }
 
 export interface ApplicationListItem {
     id: string;
     name: string;
     description?: string;
+    domain?: string;
     status: ApplicationStatus;
     type?: string;
     created_at: number;
     updated_at: number;
     owner?: ApplicationOwner;
     settings?: ApplicationSettings;
+    picture?: string;
+    background?: string;
     picture_url?: string;
+    api_key_mode?: ApiKeyMode;
+    groups?: string[];
+    disable_membership_notifications?: boolean;
     origin?: string;
 }
 

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/types/applicationCertificate.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/types/applicationCertificate.ts
@@ -1,0 +1,60 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export type ClientCertificateStatus = 'ACTIVE' | 'ACTIVE_WITH_END' | 'SCHEDULED' | 'REVOKED';
+
+export interface ClientCertificate {
+    id: string;
+    name: string;
+    startsAt?: string;
+    endsAt?: string;
+    createdAt: string;
+    updatedAt?: string;
+    certificate?: string;
+    certificateExpiration?: string;
+    subject?: string;
+    issuer?: string;
+    fingerprint?: string;
+    status: ClientCertificateStatus;
+}
+
+export interface ClientCertificatePagedResult {
+    data: ClientCertificate[];
+    page?: {
+        current: number;
+        size: number;
+        total_elements: number;
+    };
+}
+
+export interface CreateClientCertificate {
+    name: string;
+    certificate: string;
+    startsAt?: string;
+    endsAt?: string;
+}
+
+export interface UpdateClientCertificate {
+    name: string;
+    startsAt?: string;
+    endsAt?: string;
+}
+
+export interface ValidateCertificateResponse {
+    certificateExpiration: string;
+    subject: string;
+    issuer: string;
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/types/applicationCreate.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/types/applicationCreate.ts
@@ -1,0 +1,91 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/** Matches Management API grant type objects (see applications/types.json). */
+export interface ApplicationGrantType {
+    type: string;
+    name: string;
+    response_types?: string[];
+}
+
+/** Enabled type from GET .../configuration/applications/types. */
+export interface ApplicationTypeConfig {
+    id: string;
+    name: string;
+    description?: string;
+    default_grant_types: ApplicationGrantType[];
+    requires_redirect_uris: boolean;
+    allowed_grant_types: ApplicationGrantType[];
+    mandatory_grant_types: ApplicationGrantType[];
+}
+
+export interface ApplicationTypesResponse {
+    data: ApplicationTypeConfig[];
+}
+
+export interface ApplicationGroup {
+    id: string;
+    name: string;
+}
+
+export interface ApplicationTlsSettings {
+    client_certificate?: string;
+}
+
+export interface ApplicationOAuthSettings {
+    application_type: string;
+    grant_types: string[];
+    redirect_uris: string[];
+    additional_client_metadata?: Record<string, string>;
+}
+
+export interface ApplicationSimpleSettings {
+    type?: string;
+    client_id?: string;
+}
+
+export interface ApplicationCreateSettings {
+    app?: ApplicationSimpleSettings;
+    oauth?: ApplicationOAuthSettings;
+    tls?: ApplicationTlsSettings;
+}
+
+export interface CreateApplicationRequest {
+    name: string;
+    description: string;
+    domain?: string;
+    groups?: string[];
+    settings?: ApplicationCreateSettings;
+}
+
+export interface CreatedApplication {
+    id: string;
+    name: string;
+}
+
+export interface RegisterApplicationDraft {
+    name: string;
+    description: string;
+    domain: string;
+    typeId: string;
+    groups: string[];
+    appType: string;
+    appClientId: string;
+    grantTypes: string[];
+    redirectUris: string;
+    clientCertificate: string;
+    additionalClientMetadata: Record<string, string> | null;
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/types/navigation.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/types/navigation.ts
@@ -14,4 +14,6 @@
  * limitations under the License.
  */
 
-export * from '../../../../../../gamma-ui-shared/src/api/apimClient';
+export interface ApplicationsListLocationState {
+    successMessage?: string;
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/utils/applicationCreateMapper.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/utils/applicationCreateMapper.spec.ts
@@ -1,0 +1,176 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+    defaultGrantTypesForType,
+    isMandatoryGrantType,
+    isRegisterApplicationFormValid,
+    mapDraftToCreateRequest,
+    rowsToAdditionalClientMetadata,
+} from './applicationCreateMapper';
+import { APPLICATION_TYPES_FIXTURE } from '../fixtures/applicationTypes.fixture';
+import type { RegisterApplicationDraft } from '../types/applicationCreate';
+
+const BASE_DRAFT: RegisterApplicationDraft = {
+    name: 'My App',
+    description: 'Description',
+    domain: '',
+    typeId: 'simple',
+    groups: [],
+    appType: '',
+    appClientId: '',
+    grantTypes: [],
+    redirectUris: '',
+    clientCertificate: '',
+    additionalClientMetadata: null,
+};
+
+describe('isMandatoryGrantType', () => {
+    it('returns false for default-only grant types (SPA)', () => {
+        const spaType = APPLICATION_TYPES_FIXTURE[1]!;
+
+        expect(defaultGrantTypesForType(spaType)).toContain('authorization_code');
+        expect(isMandatoryGrantType(spaType, 'authorization_code')).toBe(false);
+    });
+
+    it('returns true only for mandatory grant types', () => {
+        const webType = APPLICATION_TYPES_FIXTURE[2]!;
+
+        expect(isMandatoryGrantType(webType, 'authorization_code')).toBe(true);
+        expect(isMandatoryGrantType(webType, 'refresh_token')).toBe(false);
+    });
+});
+
+describe('isRegisterApplicationFormValid', () => {
+    it('requires name and description', () => {
+        expect(isRegisterApplicationFormValid({ ...BASE_DRAFT, name: '' }, APPLICATION_TYPES_FIXTURE[0])).toBe(false);
+        expect(isRegisterApplicationFormValid({ ...BASE_DRAFT, description: '  ' }, APPLICATION_TYPES_FIXTURE[0])).toBe(false);
+    });
+
+    it('is valid for simple type when general fields are filled', () => {
+        expect(isRegisterApplicationFormValid(BASE_DRAFT, APPLICATION_TYPES_FIXTURE[0])).toBe(true);
+    });
+
+    it('requires at least one group when userGroup.required.enabled is on', () => {
+        const simpleType = APPLICATION_TYPES_FIXTURE[0]!;
+
+        expect(isRegisterApplicationFormValid(BASE_DRAFT, simpleType, { requireUserGroups: true })).toBe(false);
+        expect(isRegisterApplicationFormValid({ ...BASE_DRAFT, groups: ['group-1'] }, simpleType, { requireUserGroups: true })).toBe(true);
+    });
+
+    it('does not require groups when userGroup.required.enabled is off', () => {
+        expect(isRegisterApplicationFormValid(BASE_DRAFT, APPLICATION_TYPES_FIXTURE[0], { requireUserGroups: false })).toBe(true);
+    });
+
+    it('requires grant types and redirect URIs for oauth types', () => {
+        const webType = APPLICATION_TYPES_FIXTURE[2]!;
+
+        expect(isRegisterApplicationFormValid({ ...BASE_DRAFT, typeId: 'web', grantTypes: [], redirectUris: '' }, webType)).toBe(false);
+
+        expect(
+            isRegisterApplicationFormValid(
+                {
+                    ...BASE_DRAFT,
+                    typeId: 'web',
+                    grantTypes: ['authorization_code'],
+                    redirectUris: 'https://app.example.com/callback',
+                },
+                webType,
+            ),
+        ).toBe(true);
+
+        expect(
+            isRegisterApplicationFormValid(
+                {
+                    ...BASE_DRAFT,
+                    typeId: 'web',
+                    grantTypes: ['authorization_code'],
+                    redirectUris: 'https://a.example.com/callback, https://b.example.com/callback',
+                },
+                webType,
+            ),
+        ).toBe(true);
+    });
+});
+
+describe('rowsToAdditionalClientMetadata', () => {
+    it('returns null when all rows are empty', () => {
+        expect(rowsToAdditionalClientMetadata([{ key: '', value: '' }])).toBeNull();
+    });
+
+    it('builds a record from non-empty rows', () => {
+        expect(
+            rowsToAdditionalClientMetadata([
+                { key: 'policy_uri', value: 'https://example.com/policy' },
+                { key: '', value: '' },
+            ]),
+        ).toEqual({ policy_uri: 'https://example.com/policy' });
+    });
+});
+
+describe('mapDraftToCreateRequest', () => {
+    it('parses comma-separated redirect URIs', () => {
+        const webType = APPLICATION_TYPES_FIXTURE[2]!;
+        const request = mapDraftToCreateRequest(
+            {
+                ...BASE_DRAFT,
+                typeId: 'web',
+                grantTypes: ['authorization_code'],
+                redirectUris: 'https://a.example.com/callback,https://b.example.com/callback',
+            },
+            webType,
+        );
+
+        expect(request.settings?.oauth?.redirect_uris).toEqual(['https://a.example.com/callback', 'https://b.example.com/callback']);
+    });
+
+    it('includes additional_client_metadata when provided', () => {
+        const webType = APPLICATION_TYPES_FIXTURE[2]!;
+        const request = mapDraftToCreateRequest(
+            {
+                ...BASE_DRAFT,
+                typeId: 'web',
+                grantTypes: ['authorization_code'],
+                redirectUris: 'https://app.example.com/callback',
+                additionalClientMetadata: {
+                    policy_uri: 'https://example.com/policy',
+                    tos_uri: 'https://example.com/tos',
+                },
+            },
+            webType,
+        );
+
+        expect(request.settings?.oauth?.additional_client_metadata).toEqual({
+            policy_uri: 'https://example.com/policy',
+            tos_uri: 'https://example.com/tos',
+        });
+    });
+
+    it('omits additional_client_metadata when empty', () => {
+        const webType = APPLICATION_TYPES_FIXTURE[2]!;
+        const request = mapDraftToCreateRequest(
+            {
+                ...BASE_DRAFT,
+                typeId: 'web',
+                grantTypes: ['authorization_code'],
+                redirectUris: 'https://app.example.com/callback',
+                additionalClientMetadata: null,
+            },
+            webType,
+        );
+
+        expect(request.settings?.oauth?.additional_client_metadata).toBeUndefined();
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/utils/applicationCreateMapper.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/utils/applicationCreateMapper.ts
@@ -1,0 +1,134 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { isSameApplicationType } from './applicationTypeLabels';
+import type {
+    ApplicationCreateSettings,
+    ApplicationTypeConfig,
+    CreateApplicationRequest,
+    RegisterApplicationDraft,
+} from '../types/applicationCreate';
+
+interface MetadataRow {
+    key: string;
+    value: string;
+}
+
+export function rowsToAdditionalClientMetadata(rows: MetadataRow[]): Record<string, string> | null {
+    const record: Record<string, string> = {};
+
+    rows.forEach(row => {
+        const key = row.key.trim();
+        if (key) {
+            record[key] = row.value.trim();
+        }
+    });
+
+    return Object.keys(record).length > 0 ? record : null;
+}
+
+function parseRedirectUris(value: string): string[] {
+    return value
+        .split(/[\n,]/)
+        .map(uri => uri.trim())
+        .filter(Boolean);
+}
+
+export function mapDraftToCreateRequest(draft: RegisterApplicationDraft, selectedType: ApplicationTypeConfig): CreateApplicationRequest {
+    const isSimple = isSameApplicationType(selectedType.id, 'simple');
+    const groups = draft.groups.length > 0 ? draft.groups : undefined;
+    const domain = draft.domain.trim() || undefined;
+
+    const settings: ApplicationCreateSettings = isSimple
+        ? {
+              app: {
+                  type: draft.appType.trim() || undefined,
+                  client_id: draft.appClientId.trim() || undefined,
+              },
+          }
+        : {
+              oauth: {
+                  application_type: selectedType.id,
+                  grant_types: draft.grantTypes,
+                  redirect_uris: parseRedirectUris(draft.redirectUris),
+                  ...(draft.additionalClientMetadata && { additional_client_metadata: draft.additionalClientMetadata }),
+              },
+          };
+
+    if (draft.clientCertificate.trim()) {
+        settings.tls = { client_certificate: draft.clientCertificate.trim() };
+    }
+
+    return {
+        name: draft.name.trim(),
+        description: draft.description.trim(),
+        domain,
+        groups,
+        settings,
+    };
+}
+
+export function defaultGrantTypesForType(type: ApplicationTypeConfig): string[] {
+    return type.default_grant_types.map(grantType => grantType.type);
+}
+
+export function isMandatoryGrantType(type: ApplicationTypeConfig, grantType: string): boolean {
+    return type.mandatory_grant_types.some(mandatory => mandatory.type === grantType);
+}
+
+export function isOAuthApplicationType(typeId: string): boolean {
+    return !isSameApplicationType(typeId, 'simple');
+}
+
+export interface RegisterApplicationFormValidationContext {
+    requireUserGroups: boolean;
+}
+
+export function isRegisterApplicationFormValid(
+    draft: RegisterApplicationDraft,
+    selectedType: ApplicationTypeConfig | undefined,
+    validation?: RegisterApplicationFormValidationContext,
+): boolean {
+    if (!selectedType) {
+        return false;
+    }
+
+    if (!draft.name.trim() || !draft.description.trim()) {
+        return false;
+    }
+
+    if (validation?.requireUserGroups && draft.groups.length === 0) {
+        return false;
+    }
+
+    if (!isOAuthApplicationType(selectedType.id)) {
+        return true;
+    }
+
+    if (draft.grantTypes.length === 0) {
+        return false;
+    }
+
+    const hasMandatoryGrantTypes = selectedType.mandatory_grant_types.every(mandatory => draft.grantTypes.includes(mandatory.type));
+    if (!hasMandatoryGrantTypes) {
+        return false;
+    }
+
+    if (selectedType.requires_redirect_uris && parseRedirectUris(draft.redirectUris).length === 0) {
+        return false;
+    }
+
+    return true;
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/utils/applicationFormatters.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/utils/applicationFormatters.spec.ts
@@ -13,12 +13,23 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { formatApplicationTypeLabel } from './applicationFormatters';
+import { formatApplicationOwnerLabel, formatApplicationSecurityTypeLabel, formatApplicationTypeLabel } from './applicationFormatters';
 
 describe('applicationFormatters', () => {
     it('maps known application types to display labels', () => {
         expect(formatApplicationTypeLabel({ type: 'SIMPLE' })).toBe('Service');
         expect(formatApplicationTypeLabel({ type: 'BROWSER' })).toBe('SPA');
         expect(formatApplicationTypeLabel({ type: 'BACKEND_TO_BACKEND' })).toBe('Backend');
+    });
+
+    it('maps security types for application detail header', () => {
+        expect(formatApplicationSecurityTypeLabel({ type: 'SIMPLE' })).toBe('Simple');
+        expect(formatApplicationSecurityTypeLabel({ type: 'BROWSER' })).toBe('SPA');
+        expect(formatApplicationSecurityTypeLabel({ type: 'BACKEND_TO_BACKEND' })).toBe('Backend to backend');
+    });
+
+    it('formats owner with role label', () => {
+        expect(formatApplicationOwnerLabel({ id: '1', displayName: 'Alice Chen', type: 'USER' })).toBe('Alice Chen (User)');
+        expect(formatApplicationOwnerLabel(undefined)).toBeNull();
     });
 });

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/utils/applicationFormatters.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/utils/applicationFormatters.spec.ts
@@ -13,5 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { formatApplicationTypeLabel } from './applicationFormatters';
 
-export * from '../../../../../../gamma-ui-shared/src/api/apimClient';
+describe('applicationFormatters', () => {
+    it('maps known application types to display labels', () => {
+        expect(formatApplicationTypeLabel({ type: 'SIMPLE' })).toBe('Service');
+        expect(formatApplicationTypeLabel({ type: 'BROWSER' })).toBe('SPA');
+        expect(formatApplicationTypeLabel({ type: 'BACKEND_TO_BACKEND' })).toBe('Backend');
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/utils/applicationFormatters.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/utils/applicationFormatters.ts
@@ -1,0 +1,44 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import type { ApplicationListItem } from '../types/application';
+
+const TYPE_LABELS: Record<string, string> = {
+    SIMPLE: 'Service',
+    BROWSER: 'SPA',
+    WEB: 'Web',
+    NATIVE: 'Mobile',
+    BACKEND_TO_BACKEND: 'Backend',
+    AI_AGENT: 'AI Agent',
+};
+
+export function formatApplicationTypeLabel(application: Pick<ApplicationListItem, 'type' | 'settings'>): string {
+    const settingsType = application.settings?.app?.type;
+    if (settingsType) {
+        return TYPE_LABELS[settingsType] ?? toTitleLabel(settingsType);
+    }
+    if (!application.type) {
+        return '—';
+    }
+    return TYPE_LABELS[application.type] ?? toTitleLabel(application.type);
+}
+
+function toTitleLabel(value: string): string {
+    return value
+        .toLowerCase()
+        .split('_')
+        .map(part => part.charAt(0).toUpperCase() + part.slice(1))
+        .join(' ');
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/utils/applicationFormatters.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/utils/applicationFormatters.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import type { ApplicationListItem } from '../types/application';
+import type { ApplicationListItem, ApplicationOwner } from '../types/application';
 
 const TYPE_LABELS: Record<string, string> = {
     SIMPLE: 'Service',
@@ -24,6 +24,42 @@ const TYPE_LABELS: Record<string, string> = {
     AI_AGENT: 'AI Agent',
 };
 
+/** Security type labels for application detail (matches applications/types.json names). */
+const SECURITY_TYPE_LABELS: Record<string, string> = {
+    SIMPLE: 'Simple',
+    BROWSER: 'SPA',
+    WEB: 'Web',
+    NATIVE: 'Native',
+    BACKEND_TO_BACKEND: 'Backend to backend',
+    AI_AGENT: 'AI Agent',
+};
+
+const OWNER_TYPE_LABELS: Record<string, string> = {
+    USER: 'User',
+    GROUP: 'Group',
+};
+
+export function formatApplicationSecurityTypeLabel(application: Pick<ApplicationListItem, 'type' | 'settings'>): string {
+    const settingsType = application.settings?.app?.type;
+    if (settingsType) {
+        const normalized = settingsType.toUpperCase();
+        return SECURITY_TYPE_LABELS[normalized] ?? toTitleLabel(settingsType);
+    }
+    if (!application.type) {
+        return '—';
+    }
+    const normalized = application.type.toUpperCase();
+    return SECURITY_TYPE_LABELS[normalized] ?? toTitleLabel(application.type);
+}
+
+export function formatApplicationOwnerLabel(owner: ApplicationOwner | undefined): string | null {
+    if (!owner?.displayName) {
+        return null;
+    }
+    const roleLabel = owner.type ? (OWNER_TYPE_LABELS[owner.type.toUpperCase()] ?? toTitleLabel(owner.type)) : null;
+    return roleLabel ? `${owner.displayName} (${roleLabel})` : owner.displayName;
+}
+
 export function formatApplicationTypeLabel(application: Pick<ApplicationListItem, 'type' | 'settings'>): string {
     const settingsType = application.settings?.app?.type;
     if (settingsType) {
@@ -33,6 +69,30 @@ export function formatApplicationTypeLabel(application: Pick<ApplicationListItem
         return '—';
     }
     return TYPE_LABELS[application.type] ?? toTitleLabel(application.type);
+}
+
+const API_KEY_MODE_LABELS: Record<string, string> = {
+    UNSPECIFIED: 'Unspecified',
+    SHARED: 'Shared',
+    EXCLUSIVE: 'Exclusive',
+};
+
+export function formatApplicationApiKeyMode(mode: string | undefined): string {
+    if (!mode) return '—';
+    return API_KEY_MODE_LABELS[mode] ?? mode;
+}
+
+export function formatApplicationDateTime(value: number | string | undefined): string {
+    if (value === undefined || value === '') return '—';
+    const date = typeof value === 'number' ? new Date(value) : new Date(value);
+    if (Number.isNaN(date.getTime())) return '—';
+    return date.toLocaleString('en-US', {
+        year: 'numeric',
+        month: 'short',
+        day: 'numeric',
+        hour: 'numeric',
+        minute: '2-digit',
+    });
 }
 
 function toTitleLabel(value: string): string {

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/utils/applicationGeneralMapper.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/utils/applicationGeneralMapper.spec.ts
@@ -1,0 +1,98 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+    buildUpdatePayload,
+    formFromApplication,
+    hasApplicationGeneralValidationErrors,
+    isApplicationGeneralFormDirty,
+    validateApplicationGeneralForm,
+} from './applicationGeneralMapper';
+import type { ApplicationListItem } from '../types/application';
+
+const baseApplication: ApplicationListItem = {
+    id: 'app-1',
+    name: 'My App',
+    description: 'Desc',
+    status: 'ACTIVE',
+    type: 'SIMPLE',
+    created_at: 1,
+    updated_at: 1,
+    settings: { app: { client_id: 'client-1' } },
+};
+
+describe('applicationGeneralMapper', () => {
+    it('maps application to form', () => {
+        const form = formFromApplication(baseApplication);
+        expect(form.name).toBe('My App');
+        expect(form.simpleClientId).toBe('client-1');
+    });
+
+    it('validates required fields', () => {
+        const errors = validateApplicationGeneralForm({
+            ...formFromApplication(baseApplication),
+            name: '',
+            description: '',
+        });
+        expect(hasApplicationGeneralValidationErrors(errors)).toBe(true);
+        expect(errors.name).toBeDefined();
+        expect(errors.description).toBeDefined();
+    });
+
+    it('detects dirty state with explicit field comparison', () => {
+        const saved = formFromApplication(baseApplication);
+        const unchanged = { ...saved };
+        const renamed = { ...saved, name: 'Other' };
+        const reorderedGrantTypes = { ...saved, grantTypes: [...saved.grantTypes].reverse() };
+
+        expect(isApplicationGeneralFormDirty(unchanged, saved)).toBe(false);
+        expect(isApplicationGeneralFormDirty(renamed, saved)).toBe(true);
+        expect(isApplicationGeneralFormDirty(reorderedGrantTypes, saved)).toBe(false);
+    });
+
+    it('builds simple application update payload', () => {
+        const form = { ...formFromApplication(baseApplication), name: 'Updated', simpleClientId: 'new-client' };
+        const payload = buildUpdatePayload(baseApplication, form, undefined);
+        expect(payload.name).toBe('Updated');
+        expect(payload.settings?.app?.client_id).toBe('new-client');
+    });
+
+    it('parses redirect URIs for oauth applications', () => {
+        const oauthApp: ApplicationListItem = {
+            ...baseApplication,
+            type: 'WEB',
+            settings: {
+                oauth: {
+                    client_id: 'oauth-id',
+                    grant_types: ['authorization_code'],
+                    redirect_uris: [],
+                },
+            },
+        };
+        const form = {
+            ...formFromApplication(oauthApp),
+            redirectUrisText: 'https://a.example\nhttps://b.example\n',
+        };
+        const payload = buildUpdatePayload(oauthApp, form, {
+            id: 'WEB',
+            name: 'Web',
+            allowed_grant_types: [],
+            mandatory_grant_types: [],
+            default_grant_types: [],
+            requires_redirect_uris: true,
+        });
+        expect(payload.settings?.oauth?.redirect_uris).toEqual(['https://a.example', 'https://b.example']);
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/utils/applicationGeneralMapper.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/utils/applicationGeneralMapper.ts
@@ -1,0 +1,160 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import type { UpdateApplicationPayload } from '../services/applicationDetail';
+import type { ApplicationListItem } from '../types/application';
+import type { ApplicationTypeConfig } from '../types/applicationCreate';
+
+export interface ApplicationGeneralForm {
+    name: string;
+    description: string;
+    domain: string;
+    picture: string | null;
+    background: string | null;
+    pictureRemoved: boolean;
+    backgroundRemoved: boolean;
+    simpleClientId: string;
+    oauthClientId: string;
+    oauthClientSecret: string;
+    grantTypes: string[];
+    redirectUrisText: string;
+}
+
+export interface ApplicationGeneralValidation {
+    name?: string;
+    description?: string;
+}
+
+export function formFromApplication(application: ApplicationListItem): ApplicationGeneralForm {
+    const isSimple = application.type === 'SIMPLE';
+    return {
+        name: application.name ?? '',
+        description: application.description ?? '',
+        domain: application.domain ?? '',
+        picture: application.picture ?? application.picture_url ?? null,
+        background: application.background ?? null,
+        pictureRemoved: false,
+        backgroundRemoved: false,
+        simpleClientId: isSimple ? (application.settings?.app?.client_id ?? '') : '',
+        oauthClientId: !isSimple ? (application.settings?.oauth?.client_id ?? '') : '',
+        oauthClientSecret: !isSimple ? (application.settings?.oauth?.client_secret ?? '') : '',
+        grantTypes: !isSimple ? [...(application.settings?.oauth?.grant_types ?? [])] : [],
+        redirectUrisText: !isSimple ? (application.settings?.oauth?.redirect_uris ?? []).join('\n') : '',
+    };
+}
+
+export function validateApplicationGeneralForm(form: ApplicationGeneralForm): ApplicationGeneralValidation {
+    const errors: ApplicationGeneralValidation = {};
+    if (!form.name.trim()) {
+        errors.name = 'Application name is required.';
+    } else if (form.name.length > 512) {
+        errors.name = 'Application name must be 512 characters or fewer.';
+    }
+    if (!form.description.trim()) {
+        errors.description = 'Application description is required.';
+    }
+    return errors;
+}
+
+export function hasApplicationGeneralValidationErrors(errors: ApplicationGeneralValidation): boolean {
+    return Boolean(errors.name || errors.description);
+}
+
+function grantTypesEqual(a: string[], b: string[]): boolean {
+    if (a.length !== b.length) {
+        return false;
+    }
+    const sortedA = [...a].sort();
+    const sortedB = [...b].sort();
+    return sortedA.every((value, index) => value === sortedB[index]);
+}
+
+/** Returns true when local draft differs from the last saved snapshot. */
+export function isApplicationGeneralFormDirty(current: ApplicationGeneralForm, saved: ApplicationGeneralForm): boolean {
+    return (
+        current.name !== saved.name ||
+        current.description !== saved.description ||
+        current.domain !== saved.domain ||
+        current.picture !== saved.picture ||
+        current.background !== saved.background ||
+        current.pictureRemoved !== saved.pictureRemoved ||
+        current.backgroundRemoved !== saved.backgroundRemoved ||
+        current.simpleClientId !== saved.simpleClientId ||
+        current.oauthClientId !== saved.oauthClientId ||
+        current.oauthClientSecret !== saved.oauthClientSecret ||
+        current.redirectUrisText !== saved.redirectUrisText ||
+        !grantTypesEqual(current.grantTypes, saved.grantTypes)
+    );
+}
+
+function parseRedirectUris(text: string): string[] {
+    return text
+        .split('\n')
+        .map(line => line.trim())
+        .filter(Boolean);
+}
+
+export function buildUpdatePayload(
+    application: ApplicationListItem,
+    form: ApplicationGeneralForm,
+    applicationTypeConfig: ApplicationTypeConfig | undefined,
+): UpdateApplicationPayload {
+    const isSimple = application.type === 'SIMPLE';
+
+    let picture: string | null | undefined;
+    if (form.pictureRemoved) {
+        picture = null;
+    } else if (form.picture && form.picture !== application.picture) {
+        picture = form.picture;
+    }
+
+    let background: string | null | undefined;
+    if (form.backgroundRemoved) {
+        background = null;
+    } else if (form.background && form.background !== application.background) {
+        background = form.background;
+    }
+
+    const settings = isSimple
+        ? {
+              app: {
+                  ...application.settings?.app,
+                  client_id: form.simpleClientId || undefined,
+              },
+          }
+        : {
+              oauth: {
+                  ...application.settings?.oauth,
+                  client_id: form.oauthClientId || application.settings?.oauth?.client_id,
+                  client_secret: form.oauthClientSecret || application.settings?.oauth?.client_secret,
+                  grant_types: form.grantTypes,
+                  redirect_uris: parseRedirectUris(form.redirectUrisText),
+                  application_type: applicationTypeConfig?.id ?? application.settings?.oauth?.application_type,
+              },
+          };
+
+    return {
+        name: form.name.trim(),
+        description: form.description.trim(),
+        domain: form.domain.trim() || undefined,
+        settings,
+        ...(picture !== undefined ? { picture } : {}),
+        ...(background !== undefined ? { background } : {}),
+    };
+}
+
+export function isApplicationGeneralReadOnly(application: ApplicationListItem): boolean {
+    return application.status === 'ARCHIVED' || application.origin === 'KUBERNETES';
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/utils/applicationTypeIcons.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/utils/applicationTypeIcons.ts
@@ -13,5 +13,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { AppWindowIcon, GlobeIcon, MonitorIcon, ServerIcon, ThumbsUpIcon } from '@gravitee/graphene-core/icons';
+import type { LucideIcon } from '@gravitee/graphene-core/icons';
 
-export * from '../../../../../../gamma-ui-shared/src/api/apimClient';
+const TYPE_ICONS: Record<string, LucideIcon> = {
+    simple: ThumbsUpIcon,
+    browser: MonitorIcon,
+    web: GlobeIcon,
+    native: AppWindowIcon,
+    backend_to_backend: ServerIcon,
+};
+
+export function applicationTypeIcon(typeId: string): LucideIcon {
+    return TYPE_ICONS[typeId.toLowerCase()] ?? AppWindowIcon;
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/utils/applicationTypeLabels.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/utils/applicationTypeLabels.spec.ts
@@ -1,0 +1,62 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { isSameApplicationType, normalizeApplicationTypes } from './applicationTypeLabels';
+import { APPLICATION_TYPES_FIXTURE } from '../fixtures/applicationTypes.fixture';
+
+describe('normalizeApplicationTypes', () => {
+    it('returns only API-enabled types with API ids, labels, and grant metadata', () => {
+        const normalized = normalizeApplicationTypes([
+            {
+                id: 'simple',
+                name: 'Simple',
+                description: 'A standalone client where you manage your own client_id. No DCR involved.',
+                requires_redirect_uris: false,
+                allowed_grant_types: [],
+                default_grant_types: [],
+                mandatory_grant_types: [],
+            },
+        ]);
+
+        expect(normalized).toHaveLength(1);
+        expect(normalized[0]?.id).toBe('simple');
+        expect(normalized[0]?.name).toBe('Simple');
+    });
+
+    it('preserves response_types on grant types (applications/types.json shape)', () => {
+        const normalized = normalizeApplicationTypes([APPLICATION_TYPES_FIXTURE[1]!]);
+
+        expect(normalized[0]?.id).toBe('browser');
+        expect(normalized[0]?.allowed_grant_types[0]?.response_types).toEqual(['code']);
+        expect(normalized[0]?.allowed_grant_types[1]?.response_types).toEqual(['token', 'id_token']);
+    });
+
+    it('sorts types in catalog order and supports partial API responses', () => {
+        const normalized = normalizeApplicationTypes([
+            APPLICATION_TYPES_FIXTURE[4]!,
+            APPLICATION_TYPES_FIXTURE[1]!,
+            APPLICATION_TYPES_FIXTURE[0]!,
+        ]);
+
+        expect(normalized.map(type => type.id)).toEqual(['simple', 'browser', 'backend_to_backend']);
+    });
+});
+
+describe('isSameApplicationType', () => {
+    it('compares ids case-insensitively', () => {
+        expect(isSameApplicationType('simple', 'SIMPLE')).toBe(true);
+        expect(isSameApplicationType('browser', 'web')).toBe(false);
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/utils/applicationTypeLabels.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/utils/applicationTypeLabels.ts
@@ -1,0 +1,55 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import type { ApplicationGrantType, ApplicationTypeConfig } from '../types/applicationCreate';
+
+const TYPE_ORDER = ['simple', 'browser', 'web', 'native', 'backend_to_backend'] as const;
+
+export function normalizeTypeId(typeId: string): string {
+    return typeId.toLowerCase();
+}
+
+function typeSortIndex(typeId: string): number {
+    const normalized = normalizeTypeId(typeId);
+    const index = TYPE_ORDER.indexOf(normalized as (typeof TYPE_ORDER)[number]);
+    return index === -1 ? TYPE_ORDER.length : index;
+}
+
+function normalizeGrantTypes(grantTypes: ApplicationGrantType[] | undefined): ApplicationGrantType[] {
+    return (grantTypes ?? []).map(grantType => ({
+        type: grantType.type,
+        name: grantType.name,
+        ...(grantType.response_types?.length ? { response_types: [...grantType.response_types] } : {}),
+    }));
+}
+
+/** Normalize enabled types from GET /configuration/applications/types (gravitee-apim-rest-api applications/types.json). */
+export function normalizeApplicationTypes(types: readonly ApplicationTypeConfig[]): ApplicationTypeConfig[] {
+    return [...types]
+        .map(type => ({
+            id: normalizeTypeId(type.id),
+            name: type.name,
+            description: type.description,
+            requires_redirect_uris: Boolean(type.requires_redirect_uris),
+            allowed_grant_types: normalizeGrantTypes(type.allowed_grant_types),
+            default_grant_types: normalizeGrantTypes(type.default_grant_types),
+            mandatory_grant_types: normalizeGrantTypes(type.mandatory_grant_types),
+        }))
+        .sort((left, right) => typeSortIndex(left.id) - typeSortIndex(right.id));
+}
+
+export function isSameApplicationType(left: string, right: string): boolean {
+    return normalizeTypeId(left) === normalizeTypeId(right);
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/utils/queryKeys.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/utils/queryKeys.ts
@@ -14,6 +14,18 @@
  * limitations under the License.
  */
 
+export const applicationDetailKeys = {
+    all: ['application-detail'] as const,
+    detail: (envId: string, applicationId: string) => [...applicationDetailKeys.all, envId, applicationId] as const,
+    typeConfig: (envId: string, applicationId: string) => [...applicationDetailKeys.all, 'type-config', envId, applicationId] as const,
+    certificates: (envId: string, applicationId: string) => [...applicationDetailKeys.all, 'certificates', envId, applicationId] as const,
+} as const;
+
+export const applicationPermissionKeys = {
+    all: ['application-permissions'] as const,
+    detail: (envId: string, applicationId: string) => [...applicationPermissionKeys.all, envId, applicationId] as const,
+} as const;
+
 export const applicationListKeys = {
     all: ['application-list'] as const,
     search: (envId: string, query: string, status: string, page: number, perPage: number) =>

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/utils/queryKeys.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/utils/queryKeys.ts
@@ -14,4 +14,11 @@
  * limitations under the License.
  */
 
-export * from '../../../../../../gamma-ui-shared/src/api/apimClient';
+export const applicationListKeys = {
+    all: ['application-list'] as const,
+    search: (envId: string, query: string, status: string, page: number, perPage: number) =>
+        [...applicationListKeys.all, 'search', envId, query, status, page, perPage] as const,
+    count: (envId: string, filter: object) => [...applicationListKeys.all, 'count', envId, filter] as const,
+    types: (envId: string) => [...applicationListKeys.all, 'types', envId] as const,
+    groups: (envId: string) => [...applicationListKeys.all, 'groups', envId] as const,
+} as const;

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/shared/components/FeatureTile.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/shared/components/FeatureTile.tsx
@@ -13,5 +13,24 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import type { LucideIcon } from '@gravitee/graphene-core/icons';
 
-export * from '../../../../../../gamma-ui-shared/src/api/apimClient';
+export function FeatureTile({
+    Icon,
+    title,
+    description,
+}: {
+    readonly Icon: LucideIcon;
+    readonly title: string;
+    readonly description: string;
+}) {
+    return (
+        <div className="space-y-2">
+            <div className="rounded-lg bg-muted p-2 w-fit">
+                <Icon className="size-4 text-muted-foreground" aria-hidden />
+            </div>
+            <p className="text-sm font-medium">{title}</p>
+            <p className="text-xs text-muted-foreground">{description}</p>
+        </div>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/shared/components/SuccessBanner.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/shared/components/SuccessBanner.tsx
@@ -14,4 +14,11 @@
  * limitations under the License.
  */
 
-export * from '../../../../../../gamma-ui-shared/src/api/apimClient';
+/** Inline success feedback (same pattern as ApiEntrypointsPage save confirmation in gamma-module-apim). */
+export function SuccessBanner({ message }: { readonly message: string }) {
+    return (
+        <div className="rounded-lg border border-success/30 bg-success/5 px-4 py-3" role="status">
+            <p className="text-sm text-success">{message}</p>
+        </div>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/shared/components/index.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/shared/components/index.ts
@@ -13,5 +13,5 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-export * from '../../../../../../gamma-ui-shared/src/api/apimClient';
+export { FeatureTile } from './FeatureTile';
+export { SuccessBanner } from './SuccessBanner';

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/shared/hooks/useDetailBasePath.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/shared/hooks/useDetailBasePath.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useLocation } from 'react-router-dom';
+
+/**
+ * Returns the base path up to and including `/<segment>/<id>`, slicing off
+ * any child route segments. Used by detail layout components to build sidebar
+ * navigation links that are stable regardless of the active child route.
+ */
+export function useDetailBasePath(segment: string, id: string | undefined): string {
+    const { pathname } = useLocation();
+    if (!id) return pathname;
+    const marker = `/${segment}/${id}`;
+    const idx = pathname.indexOf(marker);
+    return idx >= 0 ? pathname.slice(0, idx + marker.length) : pathname;
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/shared/hooks/usePermissionServiceSnapshot.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/shared/hooks/usePermissionServiceSnapshot.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { permissionService } from '@gravitee/gamma-modules-sdk';
+import { useSyncExternalStore } from 'react';
+
+/** Re-renders when {@link permissionService} loads or clears a scope. */
+export function usePermissionServiceSnapshot(): number {
+    return useSyncExternalStore(
+        listener => permissionService.subscribe(listener),
+        () => permissionService.getSnapshot(),
+        () => permissionService.getSnapshot(),
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/ApplicationDetailGeneralPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/ApplicationDetailGeneralPage.tsx
@@ -1,0 +1,78 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Alert, AlertDescription, Skeleton } from '@gravitee/graphene-core';
+import { CircleCheckIcon } from '@gravitee/graphene-core/icons';
+import { useEffect, useState } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+
+import { ApplicationGeneralContent } from '../features/applications/components/general/ApplicationGeneralContent';
+import { useApplicationDetailContext } from '../features/applications/context/ApplicationDetailContext';
+
+export interface ApplicationCreateLocationState {
+    created?: boolean;
+    applicationName?: string;
+}
+
+export function ApplicationDetailGeneralPage() {
+    const location = useLocation();
+    const navigate = useNavigate();
+    const { application, isLoading } = useApplicationDetailContext();
+    const [createdMessage] = useState<string | null>(() => {
+        const state = location.state as ApplicationCreateLocationState | null;
+        return state?.created && state.applicationName ? state.applicationName : null;
+    });
+
+    useEffect(() => {
+        if (location.state) {
+            navigate('.', { replace: true, state: null });
+        }
+    }, [location.state, navigate]);
+
+    if (isLoading) {
+        return (
+            <div className="space-y-6">
+                {createdMessage ? (
+                    <Alert className="border-success/30 bg-success/5">
+                        <CircleCheckIcon className="size-4 text-success" aria-hidden />
+                        <AlertDescription className="text-success">
+                            Application &quot;{createdMessage}&quot; has been created successfully.
+                        </AlertDescription>
+                    </Alert>
+                ) : null}
+                <Skeleton className="h-10 w-64" />
+                <Skeleton className="h-96 w-full" />
+            </div>
+        );
+    }
+
+    if (!application) {
+        return <p className="text-sm text-muted-foreground">Application not found or you may not have access.</p>;
+    }
+
+    return (
+        <div className="space-y-6">
+            {createdMessage ? (
+                <Alert className="border-success/30 bg-success/5">
+                    <CircleCheckIcon className="size-4 text-success" aria-hidden />
+                    <AlertDescription className="text-success">
+                        Application &quot;{createdMessage}&quot; has been created successfully.
+                    </AlertDescription>
+                </Alert>
+            ) : null}
+            <ApplicationGeneralContent application={application} />
+        </div>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/ApplicationsPage.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/ApplicationsPage.spec.tsx
@@ -1,0 +1,244 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useHasPermission } from '@gravitee/gamma-modules-sdk';
+import { TooltipProvider } from '@gravitee/graphene-core';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+
+import { ApplicationsPage } from './ApplicationsPage';
+import { useApplicationList } from '../features/applications/hooks/useApplicationList';
+import { useApplicationStats } from '../features/applications/hooks/useApplicationStats';
+
+jest.mock('@gravitee/gamma-modules-sdk', () => ({
+    useHasPermission: jest.fn(),
+}));
+jest.mock('../features/applications/hooks/useApplicationList');
+jest.mock('../features/applications/hooks/useApplicationStats');
+
+const mockUseHasPermission = jest.mocked(useHasPermission);
+const mockUseApplicationList = jest.mocked(useApplicationList);
+const mockUseApplicationStats = jest.mocked(useApplicationStats);
+
+const STUB_STATS = {
+    active: 0,
+    archived: 0,
+    total: 0,
+    isLoading: false,
+    isLoadingActive: false,
+    isLoadingArchived: false,
+};
+
+const EMPTY_PAGE = { current: 1, size: 0, per_page: 25, total_pages: 0, total_elements: 0 };
+
+const STUB_APPLICATION = {
+    id: 'app-1',
+    name: 'Billing App',
+    status: 'ACTIVE' as const,
+    created_at: 0,
+    updated_at: 0,
+};
+
+function statsResult(overrides: Partial<ReturnType<typeof useApplicationStats>> = {}): ReturnType<typeof useApplicationStats> {
+    return { ...STUB_STATS, ...overrides } as ReturnType<typeof useApplicationStats>;
+}
+
+function listHookResult(overrides: Partial<ReturnType<typeof useApplicationList>> = {}): ReturnType<typeof useApplicationList> {
+    return {
+        data: { data: [], page: EMPTY_PAGE },
+        isLoading: false,
+        isFetching: false,
+        isError: false,
+        ...overrides,
+    } as ReturnType<typeof useApplicationList>;
+}
+
+function renderPage() {
+    return render(
+        <MemoryRouter>
+            <TooltipProvider>
+                <ApplicationsPage />
+            </TooltipProvider>
+        </MemoryRouter>,
+    );
+}
+
+describe('ApplicationsPage', () => {
+    beforeEach(() => {
+        mockUseHasPermission.mockReturnValue(true);
+        mockUseApplicationStats.mockReturnValue(STUB_STATS);
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+        jest.useRealTimers();
+    });
+
+    it('shows the empty landing when there are no applications and no active search', () => {
+        mockUseApplicationList.mockReturnValue(listHookResult());
+        renderPage();
+
+        expect(screen.queryByText('Why register an application?')).not.toBeNull();
+        expect(screen.queryByPlaceholderText('Search applications...')).toBeNull();
+    });
+
+    it('hides the Register Application button on the empty landing when the user cannot create', () => {
+        mockUseHasPermission.mockReturnValue(false);
+        mockUseApplicationList.mockReturnValue(listHookResult());
+        renderPage();
+
+        expect(screen.queryByRole('button', { name: /Register Application/i })).toBeNull();
+    });
+
+    it('hides the Register Application button on the list view when the user cannot create', () => {
+        mockUseHasPermission.mockReturnValue(false);
+        mockUseApplicationList.mockReturnValue(
+            listHookResult({
+                data: { data: [STUB_APPLICATION], page: { ...EMPTY_PAGE, total_elements: 1, total_pages: 1 } },
+            }),
+        );
+        mockUseApplicationStats.mockReturnValue(statsResult({ active: 1, archived: 0, total: 1 }));
+        renderPage();
+
+        expect(screen.queryByRole('button', { name: /Register Application/i })).toBeNull();
+        expect(screen.queryByPlaceholderText('Search applications...')).not.toBeNull();
+    });
+
+    it('shows the list view when only archived applications exist', () => {
+        mockUseApplicationList.mockReturnValue(listHookResult());
+        mockUseApplicationStats.mockReturnValue(statsResult({ active: 0, archived: 3, total: 3 }));
+        renderPage();
+
+        expect(screen.queryByText('Why register an application?')).toBeNull();
+        expect(screen.queryByPlaceholderText('Search applications...')).not.toBeNull();
+    });
+
+    it('shows the list view while stats are loading — does not flash the empty landing', () => {
+        mockUseApplicationList.mockReturnValue(listHookResult());
+        mockUseApplicationStats.mockReturnValue(
+            statsResult({
+                active: null,
+                archived: null,
+                total: null,
+                isLoading: true,
+                isLoadingActive: true,
+                isLoadingArchived: true,
+            }),
+        );
+        renderPage();
+
+        expect(screen.queryByText('Why register an application?')).toBeNull();
+        expect(screen.queryByPlaceholderText('Search applications...')).not.toBeNull();
+    });
+
+    it('shows the list view when applications exist', () => {
+        mockUseApplicationList.mockReturnValue(
+            listHookResult({
+                data: { data: [STUB_APPLICATION], page: { ...EMPTY_PAGE, total_elements: 1, total_pages: 1 } },
+            }),
+        );
+        mockUseApplicationStats.mockReturnValue(statsResult({ active: 1, archived: 0, total: 1 }));
+        renderPage();
+
+        expect(screen.queryByText('Why register an application?')).toBeNull();
+        expect(screen.queryByPlaceholderText('Search applications...')).not.toBeNull();
+        expect(screen.queryByText('Billing App')).not.toBeNull();
+    });
+
+    it('shows a success banner when returning from application creation', () => {
+        mockUseApplicationList.mockReturnValue(
+            listHookResult({
+                data: { data: [STUB_APPLICATION], page: { ...EMPTY_PAGE, total_elements: 1, total_pages: 1 } },
+            }),
+        );
+        mockUseApplicationStats.mockReturnValue(statsResult({ active: 1, archived: 0, total: 1 }));
+        render(
+            <MemoryRouter initialEntries={[{ pathname: '/applications', state: { successMessage: 'Application "Billing App" created.' } }]}>
+                <TooltipProvider>
+                    <ApplicationsPage />
+                </TooltipProvider>
+            </MemoryRouter>,
+        );
+
+        expect(screen.getByRole('status').textContent).toBe('Application "Billing App" created.');
+    });
+
+    it('shows the list view while loading — does not flash the empty landing', () => {
+        mockUseApplicationList.mockReturnValue(listHookResult({ data: undefined, isLoading: true }));
+        renderPage();
+
+        expect(screen.queryByText('Why register an application?')).toBeNull();
+        expect(screen.queryByPlaceholderText('Search applications...')).not.toBeNull();
+    });
+
+    it('shows the list view while fetching — does not flash the empty landing', () => {
+        mockUseApplicationList.mockReturnValue(
+            listHookResult({
+                data: { data: [], page: EMPTY_PAGE },
+                isFetching: true,
+            }),
+        );
+        renderPage();
+
+        expect(screen.queryByText('Why register an application?')).toBeNull();
+        expect(screen.queryByPlaceholderText('Search applications...')).not.toBeNull();
+    });
+
+    it('shows the list view when the search term is active but there are no matches', () => {
+        mockUseApplicationList.mockReturnValue(
+            listHookResult({
+                data: { data: [STUB_APPLICATION], page: { ...EMPTY_PAGE, total_elements: 1, total_pages: 1 } },
+            }),
+        );
+        mockUseApplicationStats.mockReturnValue(statsResult({ active: 1, archived: 0, total: 1 }));
+        renderPage();
+
+        mockUseApplicationList.mockReturnValue(listHookResult());
+        fireEvent.change(screen.getByPlaceholderText('Search applications...'), { target: { value: 'billing' } });
+
+        expect(screen.queryByText('Why register an application?')).toBeNull();
+        expect(screen.queryByPlaceholderText('Search applications...')).not.toBeNull();
+    });
+
+    it('shows an error message when the list query fails', () => {
+        mockUseApplicationList.mockReturnValue(listHookResult({ data: undefined, isError: true }));
+        renderPage();
+
+        expect(screen.queryByText('Failed to load applications. Please refresh and try again.')).not.toBeNull();
+        expect(screen.queryByText('Why register an application?')).toBeNull();
+    });
+
+    it('resets page to 1 when the search term changes', async () => {
+        jest.useFakeTimers();
+        mockUseApplicationList.mockReturnValue(
+            listHookResult({
+                data: { data: [STUB_APPLICATION], page: { ...EMPTY_PAGE, total_elements: 1, total_pages: 1 } },
+            }),
+        );
+        mockUseApplicationStats.mockReturnValue(statsResult({ active: 1, archived: 0, total: 1 }));
+        renderPage();
+
+        fireEvent.change(screen.getByPlaceholderText('Search applications...'), { target: { value: 'billing' } });
+        act(() => {
+            jest.advanceTimersByTime(300);
+        });
+
+        await waitFor(() => {
+            const searchCall = mockUseApplicationList.mock.calls.find(([params]) => params.query === 'billing');
+            expect(searchCall).toBeDefined();
+            expect(searchCall![0].page).toBe(1);
+        });
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/ApplicationsPage.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/ApplicationsPage.spec.tsx
@@ -21,16 +21,19 @@ import { MemoryRouter } from 'react-router-dom';
 import { ApplicationsPage } from './ApplicationsPage';
 import { useApplicationList } from '../features/applications/hooks/useApplicationList';
 import { useApplicationStats } from '../features/applications/hooks/useApplicationStats';
+import { useRestoreApplication } from '../features/applications/hooks/useRestoreApplication';
 
 jest.mock('@gravitee/gamma-modules-sdk', () => ({
     useHasPermission: jest.fn(),
 }));
 jest.mock('../features/applications/hooks/useApplicationList');
 jest.mock('../features/applications/hooks/useApplicationStats');
+jest.mock('../features/applications/hooks/useRestoreApplication');
 
 const mockUseHasPermission = jest.mocked(useHasPermission);
 const mockUseApplicationList = jest.mocked(useApplicationList);
 const mockUseApplicationStats = jest.mocked(useApplicationStats);
+const mockUseRestoreApplication = jest.mocked(useRestoreApplication);
 
 const STUB_STATS = {
     active: 0,
@@ -79,6 +82,10 @@ describe('ApplicationsPage', () => {
     beforeEach(() => {
         mockUseHasPermission.mockReturnValue(true);
         mockUseApplicationStats.mockReturnValue(STUB_STATS);
+        mockUseRestoreApplication.mockReturnValue({
+            mutate: jest.fn(),
+            isPending: false,
+        } as ReturnType<typeof useRestoreApplication>);
     });
 
     afterEach(() => {

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/ApplicationsPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/ApplicationsPage.tsx
@@ -13,11 +13,119 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { useHasPermission } from '@gravitee/gamma-modules-sdk';
+import { useEffect, useState } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+
+import { ApplicationsEmptyLanding } from '../features/applications/components';
+import { ApplicationsListView } from '../features/applications/components/list';
+import { useApplicationList } from '../features/applications/hooks/useApplicationList';
+import { useApplicationStats } from '../features/applications/hooks/useApplicationStats';
+import type { ApplicationStatus } from '../features/applications/types/application';
+import type { ApplicationsListLocationState } from '../features/applications/types/navigation';
+import { SuccessBanner } from '../features/shared/components';
+
+const DEFAULT_PAGE = 1;
+const DEFAULT_PER_PAGE = 25;
+const DEFAULT_STATUS: ApplicationStatus = 'ACTIVE';
+const SEARCH_DEBOUNCE_MS = 300;
+
 export function ApplicationsPage() {
+    const navigate = useNavigate();
+    const location = useLocation();
+    const canCreate = useHasPermission({ anyOf: ['environment-application-c'] });
+
+    const [successMessage, setSuccessMessage] = useState<string | null>(null);
+    const [search, setSearch] = useState('');
+    const [debouncedSearch, setDebouncedSearch] = useState('');
+    const [status, setStatus] = useState<ApplicationStatus>(DEFAULT_STATUS);
+    const [page, setPage] = useState(DEFAULT_PAGE);
+    const [perPage, setPerPage] = useState(DEFAULT_PER_PAGE);
+
+    useEffect(() => {
+        const timer = setTimeout(() => setDebouncedSearch(search), SEARCH_DEBOUNCE_MS);
+        return () => clearTimeout(timer);
+    }, [search]);
+
+    useEffect(() => {
+        const state = location.state as ApplicationsListLocationState | null;
+        const message = state?.successMessage;
+        if (!message) return;
+
+        setSuccessMessage(message);
+        navigate(location.pathname, { replace: true, state: null });
+    }, [location.pathname, location.state, navigate]);
+
+    const { data, isLoading, isFetching, isError } = useApplicationList({
+        query: debouncedSearch,
+        status,
+        page,
+        perPage,
+    });
+
+    const applications = data?.data ?? [];
+    const totalCount = data?.page.total_elements ?? 0;
+
+    const knownCounts =
+        data?.page.total_elements !== undefined
+            ? status === 'ACTIVE'
+                ? { active: data.page.total_elements }
+                : { archived: data.page.total_elements }
+            : undefined;
+
+    const stats = useApplicationStats(debouncedSearch || undefined, { knownCounts });
+
+    const handleSearchChange = (value: string) => {
+        setSearch(value);
+        setPage(DEFAULT_PAGE);
+    };
+
+    const handlePerPageChange = (nextPerPage: number) => {
+        setPerPage(nextPerPage);
+        setPage(DEFAULT_PAGE);
+    };
+
+    const handleStatusChange = (nextStatus: ApplicationStatus) => {
+        setStatus(nextStatus);
+        setPage(DEFAULT_PAGE);
+    };
+
+    const handleRegisterApplication = () => {
+        navigate('new');
+    };
+
+    if (isError) {
+        return (
+            <div className="flex items-center justify-center p-8">
+                <p className="text-sm text-muted-foreground">Failed to load applications. Please refresh and try again.</p>
+            </div>
+        );
+    }
+
+    const hasNoApplications = !isLoading && !isFetching && !search && !debouncedSearch && !stats.isLoading && stats.total === 0;
+    if (hasNoApplications) {
+        return <ApplicationsEmptyLanding onRegisterApplication={handleRegisterApplication} canCreate={canCreate} />;
+    }
+
     return (
-        <div>
-            <h1>Applications</h1>
-            <p>Manage applications on the platform.</p>
+        <div className="space-y-4">
+            {successMessage && <SuccessBanner message={successMessage} />}
+            <ApplicationsListView
+                applications={applications}
+                totalCount={totalCount}
+                stats={stats}
+                isLoading={isLoading}
+                search={search}
+                status={status}
+                page={page}
+                perPage={perPage}
+                onSearchChange={handleSearchChange}
+                onStatusChange={handleStatusChange}
+                onPageChange={setPage}
+                onPerPageChange={handlePerPageChange}
+                onRegisterApplication={handleRegisterApplication}
+                canCreate={canCreate}
+            />
         </div>
     );
 }

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/RegisterApplicationPage.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/RegisterApplicationPage.spec.tsx
@@ -1,0 +1,40 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+
+import { RegisterApplicationPage } from './RegisterApplicationPage';
+
+jest.mock('../features/applications/components/create', () => ({
+    RegisterApplicationForm: () => <div data-testid="register-form" />,
+}));
+
+function renderPage() {
+    return render(
+        <MemoryRouter initialEntries={['/applications/new']}>
+            <RegisterApplicationPage />
+        </MemoryRouter>,
+    );
+}
+
+describe('RegisterApplicationPage', () => {
+    it('renders the page header and registration form', () => {
+        renderPage();
+
+        expect(screen.queryByText('Application creation')).not.toBeNull();
+        expect(screen.queryByTestId('register-form')).not.toBeNull();
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/RegisterApplicationPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/RegisterApplicationPage.tsx
@@ -1,0 +1,43 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Button } from '@gravitee/graphene-core';
+import { ArrowLeftIcon } from '@gravitee/graphene-core/icons';
+import { useNavigate } from 'react-router-dom';
+
+import { RegisterApplicationForm } from '../features/applications/components/create';
+
+export function RegisterApplicationPage() {
+    const navigate = useNavigate();
+
+    return (
+        <div className="space-y-6">
+            <div className="flex items-center gap-3">
+                <Button type="button" variant="ghost" size="icon" onClick={() => navigate('..')} aria-label="Back to applications">
+                    <ArrowLeftIcon className="size-4" aria-hidden />
+                </Button>
+                <div>
+                    <h1 className="text-2xl font-semibold tracking-tight">Application creation</h1>
+                    <p className="text-sm text-muted-foreground">
+                        An application is required to subscribe to API&apos;s plan. It is the intermediate link between a user (you) and an
+                        API managed by someone else.
+                    </p>
+                </div>
+            </div>
+
+            <RegisterApplicationForm />
+        </div>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/shared/api/apimClient.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/shared/api/apimClient.ts
@@ -13,11 +13,5 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export function ApplicationsPage() {
-    return (
-        <div>
-            <h1>Applications</h1>
-            <p>Manage applications for consumers of your APIs.</p>
-        </div>
-    );
-}
+
+export * from '../../../../../../gamma-ui-shared/src/api/apimClient';

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/shared/console-settings/ConsoleSettingsProvider.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/shared/console-settings/ConsoleSettingsProvider.spec.tsx
@@ -1,0 +1,82 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { render, screen, waitFor } from '@testing-library/react';
+
+import { fetchOrgConsoleSettings } from '../services/orgConsoleSettings';
+
+import { ConsoleSettingsProvider, useConsoleSettings, useConsoleSettingsReady } from './index';
+
+jest.mock('../services/orgConsoleSettings');
+
+const mockFetchOrgConsoleSettings = jest.mocked(fetchOrgConsoleSettings);
+
+function SettingsProbe() {
+    const settings = useConsoleSettings();
+    const isReady = useConsoleSettingsReady();
+    return (
+        <div>
+            <span data-testid="ready">{String(isReady)}</span>
+            <span data-testid="require-groups">{String(settings?.userGroup?.required?.enabled ?? false)}</span>
+        </div>
+    );
+}
+
+describe('ConsoleSettingsProvider', () => {
+    beforeEach(() => {
+        mockFetchOrgConsoleSettings.mockReset();
+    });
+
+    it('shows loading UI while console settings are fetched', () => {
+        mockFetchOrgConsoleSettings.mockReturnValue(new Promise(() => {}));
+
+        render(
+            <ConsoleSettingsProvider>
+                <SettingsProbe />
+            </ConsoleSettingsProvider>,
+        );
+
+        expect(screen.getByText('Loading organization settings…')).toBeTruthy();
+    });
+
+    it('loads settings and exposes them to children', async () => {
+        mockFetchOrgConsoleSettings.mockResolvedValue({ userGroup: { required: { enabled: true } } });
+
+        render(
+            <ConsoleSettingsProvider>
+                <SettingsProbe />
+            </ConsoleSettingsProvider>,
+        );
+
+        await waitFor(() => {
+            expect(screen.getByTestId('ready').textContent).toBe('true');
+        });
+        expect(screen.getByTestId('require-groups').textContent).toBe('true');
+    });
+
+    it('shows an error when the console settings fetch fails', async () => {
+        mockFetchOrgConsoleSettings.mockRejectedValue(new Error('Failed to fetch console config: 503'));
+
+        render(
+            <ConsoleSettingsProvider>
+                <SettingsProbe />
+            </ConsoleSettingsProvider>,
+        );
+
+        await waitFor(() => {
+            expect(screen.getByText('Management API unreachable or error occurs, please check logs')).toBeTruthy();
+        });
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/shared/console-settings/ConsoleSettingsProvider.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/shared/console-settings/ConsoleSettingsProvider.tsx
@@ -1,0 +1,104 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { createContext, useContext, useEffect, useMemo, useState, type ReactNode } from 'react';
+
+import type { ConsoleSettings } from './types';
+import { fetchOrgConsoleSettings } from '../services/orgConsoleSettings';
+
+const LOAD_ERROR_MESSAGE = 'Management API unreachable or error occurs, please check logs';
+
+interface ConsoleSettingsContextValue {
+    settings: ConsoleSettings | null;
+    isReady: boolean;
+}
+
+const ConsoleSettingsContext = createContext<ConsoleSettingsContextValue | null>(null);
+
+interface ConsoleSettingsProviderProps {
+    readonly children: ReactNode;
+}
+
+/**
+ * Platform bootstrap for GET /organizations/{orgId}/console.
+ * Blocks child routes until settings load (APIM console strictness); failures stay inside platform only.
+ */
+export function ConsoleSettingsProvider({ children }: ConsoleSettingsProviderProps) {
+    const [settings, setSettings] = useState<ConsoleSettings | null>(null);
+    const [isReady, setIsReady] = useState(false);
+    const [isLoading, setIsLoading] = useState(true);
+    const [error, setError] = useState<Error | null>(null);
+
+    useEffect(() => {
+        let cancelled = false;
+
+        (async () => {
+            try {
+                const loaded = await fetchOrgConsoleSettings();
+                if (cancelled) return;
+                setSettings(loaded);
+                setIsReady(true);
+                setError(null);
+            } catch (err) {
+                if (cancelled) return;
+                setError(err instanceof Error ? err : new Error(String(err)));
+            } finally {
+                if (!cancelled) {
+                    setIsLoading(false);
+                }
+            }
+        })();
+
+        return () => {
+            cancelled = true;
+        };
+    }, []);
+
+    const value = useMemo(() => ({ settings, isReady }), [settings, isReady]);
+
+    if (isLoading) {
+        return (
+            <div className="flex items-center justify-center p-8">
+                <p className="text-sm text-muted-foreground">Loading organization settings…</p>
+            </div>
+        );
+    }
+
+    if (error) {
+        return (
+            <div className="flex items-center justify-center p-8">
+                <p className="text-sm text-destructive">{LOAD_ERROR_MESSAGE}</p>
+            </div>
+        );
+    }
+
+    return <ConsoleSettingsContext.Provider value={value}>{children}</ConsoleSettingsContext.Provider>;
+}
+
+function useConsoleSettingsContext(): ConsoleSettingsContextValue {
+    const value = useContext(ConsoleSettingsContext);
+    if (!value) {
+        throw new Error('useConsoleSettings must be used within ConsoleSettingsProvider');
+    }
+    return value;
+}
+
+export function useConsoleSettings(): ConsoleSettings | null {
+    return useConsoleSettingsContext().settings;
+}
+
+export function useConsoleSettingsReady(): boolean {
+    return useConsoleSettingsContext().isReady;
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/shared/console-settings/index.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/shared/console-settings/index.ts
@@ -13,5 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-export * from '../../../../../../gamma-ui-shared/src/api/apimClient';
+export type { ConsoleSettings } from './types';
+export { ConsoleSettingsProvider, useConsoleSettings, useConsoleSettingsReady } from './ConsoleSettingsProvider';
+export { isUserGroupRequired } from './isUserGroupRequired';

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/shared/console-settings/isUserGroupRequired.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/shared/console-settings/isUserGroupRequired.spec.ts
@@ -1,0 +1,37 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { isUserGroupRequired } from './isUserGroupRequired';
+import type { ConsoleSettings } from './types';
+
+describe('isUserGroupRequired', () => {
+    it('returns false when config is undefined', () => {
+        expect(isUserGroupRequired(undefined)).toBe(false);
+    });
+
+    it('returns false when required is disabled', () => {
+        const config: ConsoleSettings = {
+            userGroup: { required: { enabled: false } },
+        };
+        expect(isUserGroupRequired(config)).toBe(false);
+    });
+
+    it('returns true when required is enabled', () => {
+        const config: ConsoleSettings = {
+            userGroup: { required: { enabled: true } },
+        };
+        expect(isUserGroupRequired(config)).toBe(true);
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/shared/console-settings/isUserGroupRequired.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/shared/console-settings/isUserGroupRequired.ts
@@ -13,5 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import type { ConsoleSettings } from './types';
 
-export * from '../../../../../../gamma-ui-shared/src/api/apimClient';
+export function isUserGroupRequired(config: ConsoleSettings | null | undefined): boolean {
+    return Boolean(config?.userGroup?.required?.enabled);
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/shared/console-settings/types.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/shared/console-settings/types.ts
@@ -14,4 +14,14 @@
  * limitations under the License.
  */
 
-export * from '../../../../../../gamma-ui-shared/src/api/apimClient';
+/**
+ * Subset of GET /organizations/{orgId}/console (ConsoleConfigEntity; Angular `entities/consoleSettings`).
+ * Extend here when platform features need more org settings fields.
+ */
+export interface ConsoleSettings {
+    userGroup?: {
+        required?: {
+            enabled?: boolean;
+        };
+    };
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/shared/gamma-modules-sdk.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/shared/gamma-modules-sdk.ts
@@ -34,8 +34,8 @@ export const permissionService = {
     clear: (_scope: string): void => {},
     reset: (): void => {},
     getAllPermissions: (): string[] => [],
-    hasAnyOf: (): boolean => true,
-    hasAllOf: (): boolean => true,
+    hasAnyOf: (_required?: string[]): boolean => true,
+    hasAllOf: (_required?: string[]): boolean => true,
     subscribe:
         (_listener: () => void): (() => void) =>
         () => {},
@@ -59,9 +59,12 @@ export function PermissionGate({
  * e.g. `normalizeCrudMapRecord('api', { DEFINITION: ['R','U'] })` → `['api-definition-r', 'api-definition-u']`
  */
 export function normalizeCrudMapRecord(scope: string, record: Record<string, string[] | string>): string[] {
-    return Object.entries(record).flatMap(([resource, ops]) => {
-        const operations = Array.isArray(ops) ? ops : [ops];
-        return operations.map(op => `${scope}-${resource.toLowerCase()}-${op.toLowerCase()}`);
+    return Object.entries(record).flatMap(([key, crudValues]) => {
+        const keyPart = key.toLowerCase();
+        if (Array.isArray(crudValues)) {
+            return crudValues.map(letter => `${scope}-${keyPart}-${letter.toLowerCase()}`);
+        }
+        return crudValues.split('').map(letter => `${scope}-${keyPart}-${letter.toLowerCase()}`);
     });
 }
 

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/shared/gamma-modules-sdk.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/shared/gamma-modules-sdk.ts
@@ -1,0 +1,70 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Test stub for `@gravitee/gamma-modules-sdk`.
+ * Replaced at runtime by the MF singleton from the host shell.
+ * Individual tests mock specific exports via jest.mock().
+ *
+ * Permission stubs default to granted so feature tests render normally.
+ * To test denied states, mock `useHasPermission` or `permissionService` per-test.
+ */
+import type { PermissionCheck } from '@gravitee/gamma-modules-sdk/types';
+import type { ReactNode } from 'react';
+
+// ─── Permissions ──────────────────────────────────────────────────────────────
+
+export const useHasPermission = (_options: PermissionCheck): boolean => true;
+
+export const permissionService = {
+    load: (_scope: string, _permissions: string[]): void => {},
+    clear: (_scope: string): void => {},
+    reset: (): void => {},
+    getAllPermissions: (): string[] => [],
+    hasAnyOf: (): boolean => true,
+    hasAllOf: (): boolean => true,
+    subscribe:
+        (_listener: () => void): (() => void) =>
+        () => {},
+    getSnapshot: (): number => 0,
+};
+
+export function PermissionGate({
+    children,
+    fallback = null,
+}: {
+    children: ReactNode;
+    fallback?: ReactNode;
+    anyOf?: string[];
+    allOf?: string[];
+}): ReactNode {
+    return children ?? fallback;
+}
+
+/**
+ * Normalizes a CRUD permission map from the backend into flat permission strings.
+ * e.g. `normalizeCrudMapRecord('api', { DEFINITION: ['R','U'] })` → `['api-definition-r', 'api-definition-u']`
+ */
+export function normalizeCrudMapRecord(scope: string, record: Record<string, string[] | string>): string[] {
+    return Object.entries(record).flatMap(([resource, ops]) => {
+        const operations = Array.isArray(ops) ? ops : [ops];
+        return operations.map(op => `${scope}-${resource.toLowerCase()}-${op.toLowerCase()}`);
+    });
+}
+
+// ─── Environment ──────────────────────────────────────────────────────────────
+
+export const useEnvironment = () => ({ id: 'DEFAULT' });

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/shared/hooks/useEnvironmentPermissions.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/shared/hooks/useEnvironmentPermissions.ts
@@ -1,0 +1,44 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { permissionService, useEnvironment } from '@gravitee/gamma-modules-sdk';
+import { useQuery } from '@tanstack/react-query';
+import { useEffect } from 'react';
+
+import { getEnvironmentPermissions } from '../services/environmentPermissions';
+import { environmentPermissionKeys } from '../utils/queryKeys';
+
+/**
+ * Fetches environment-scoped permissions and merges them into the shared
+ * `permissionService` while the module layout is mounted.
+ *
+ * When federated, the host permission-sync also loads this scope; duplicate
+ * loads are harmless. Does not clear on unmount — the host owns that scope.
+ */
+export function useEnvironmentPermissions(): void {
+    const env = useEnvironment();
+
+    const { data: permissions } = useQuery({
+        queryKey: environmentPermissionKeys.detail(env?.id ?? ''),
+        queryFn: () => getEnvironmentPermissions(env!.id),
+        enabled: Boolean(env?.id),
+        staleTime: 60_000,
+    });
+
+    useEffect(() => {
+        if (!permissions) return;
+        permissionService.load('environment', permissions);
+    }, [permissions]);
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/shared/services/environmentPermissions.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/shared/services/environmentPermissions.ts
@@ -13,5 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { normalizeCrudMapRecord } from '@gravitee/gamma-modules-sdk';
 
-export * from '../../../../../../gamma-ui-shared/src/api/apimClient';
+import { apimFetchJsonV1Env } from '../api/apimClient';
+
+/**
+ * Fetches the current user's environment-scoped permissions and returns
+ * normalized flat strings ready for `permissionService.load('environment', ...)`.
+ */
+export async function getEnvironmentPermissions(environmentId: string): Promise<string[]> {
+    const raw = await apimFetchJsonV1Env<Record<string, string[] | string>>(environmentId, '/permissions');
+    return normalizeCrudMapRecord('environment', raw);
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/shared/services/orgConsoleSettings.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/shared/services/orgConsoleSettings.ts
@@ -13,5 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { apimFetchJsonOrg } from '../api/apimClient';
+import type { ConsoleSettings } from '../console-settings';
 
-export * from '../../../../../../gamma-ui-shared/src/api/apimClient';
+/** GET /organizations/{orgId}/console (Angular `constants.org.settings`). */
+export async function fetchOrgConsoleSettings(): Promise<ConsoleSettings> {
+    return apimFetchJsonOrg<ConsoleSettings>('/console');
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/shared/utils/queryKeys.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/shared/utils/queryKeys.ts
@@ -14,4 +14,7 @@
  * limitations under the License.
  */
 
-export * from '../../../../../../gamma-ui-shared/src/api/apimClient';
+export const environmentPermissionKeys = {
+    all: ['environment-permissions'] as const,
+    detail: (envId: string) => [...environmentPermissionKeys.all, envId] as const,
+} as const;

--- a/gravitee-gamma/gravitee-gamma-module-platform/tsconfig.app.json
+++ b/gravitee-gamma/gravitee-gamma-module-platform/tsconfig.app.json
@@ -5,7 +5,10 @@
         "outDir": "../../dist/out-tsc",
         "moduleResolution": "bundler",
         "types": ["node", "@nx/react/typings/cssmodule.d.ts", "@nx/react/typings/image.d.ts"],
-        "paths": {}
+        "paths": {
+            "@gravitee/gamma-modules-sdk": ["./src/main/ui/shared/gamma-modules-sdk.ts"],
+            "@gravitee/gamma-ui-shared/api": ["../gamma-ui-shared/src/api/apimClient.ts"]
+        }
     },
     "exclude": [
         "src/**/*.spec.ts",

--- a/gravitee-gamma/gravitee-gamma-module-platform/tsconfig.json
+++ b/gravitee-gamma/gravitee-gamma-module-platform/tsconfig.json
@@ -10,6 +10,9 @@
     "references": [
         {
             "path": "./tsconfig.app.json"
+        },
+        {
+            "path": "./tsconfig.spec.json"
         }
     ]
 }

--- a/gravitee-gamma/gravitee-gamma-module-platform/tsconfig.spec.json
+++ b/gravitee-gamma/gravitee-gamma-module-platform/tsconfig.spec.json
@@ -1,0 +1,18 @@
+{
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "outDir": "../../dist/out-tsc",
+        "module": "commonjs",
+        "moduleResolution": "node10",
+        "jsx": "react-jsx",
+        "types": ["jest", "node", "@nx/react/typings/cssmodule.d.ts", "@nx/react/typings/image.d.ts"]
+    },
+    "include": [
+        "jest.config.ts",
+        "src/main/ui/**/*.test.ts",
+        "src/main/ui/**/*.spec.ts",
+        "src/main/ui/**/*.test.tsx",
+        "src/main/ui/**/*.spec.tsx",
+        "src/main/ui/**/*.d.ts"
+    ]
+}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-XXX

## Description

Summary
Adds Gamma platform UI support for archived applications on the list view and a first application detail experience focused on General configuration.

Applications list: Archived tab/filter, row actions for archived apps, and restore flow (ApplicationRestoreDialog + useRestoreApplication).
Application detail: Nested routes under /applications/:applicationId, layout with sidebar navigation, permission-gated outlet, and a General tab (details, OAuth, lifecycle, certificates, images, delete).
Supporting layer: Detail services/hooks, general mappers/formatters, certificate types/utils, and unit tests for navigation and mapping.
Other detail tabs render placeholders until implemented.

Test plan

 Open Applications → switch to Archived; verify list, actions, and restore

 Open an application → confirm General tab loads and edits persist (details, OAuth, lifecycle, certificates, image)

 Confirm unauthorized users see access denied on detail routes

 Run platform UI unit tests (applicationDetailNavigation, applicationGeneralMapper, applicationFormatters)

## Additional context



Uploading general-settings-app-gamma.mov…




<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

