### PR TITLE
fix: correct log status and body for failed requests

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/analytics/logging/response/LogEndpointResponse.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/analytics/logging/response/LogEndpointResponse.java
@@ -17,6 +17,8 @@ package io.gravitee.gateway.reactive.handlers.api.v4.analytics.logging.response;
 
 import io.gravitee.gateway.api.buffer.Buffer;
 import io.gravitee.gateway.api.http.HttpHeaderNames;
+import io.gravitee.gateway.reactive.api.ExecutionFailure;
+import io.gravitee.gateway.reactive.api.context.InternalContextAttributes;
 import io.gravitee.gateway.reactive.api.context.http.HttpPlainExecutionContext;
 import io.gravitee.gateway.reactive.core.context.HttpExecutionContextInternal;
 import io.gravitee.gateway.reactive.core.context.HttpResponseInternal;
@@ -49,7 +51,9 @@ public class LogEndpointResponse extends LogResponse {
                 if (loggingContext.isBodyLoggable()) {
                     chunks = chunks
                         .doOnNext(chunk -> BufferUtils.appendBuffer(buffer, chunk, loggingContext.getMaxSizeLogMessage()))
-                        .doFinally(() -> this.setBody(buffer.toString()));
+                        .doFinally(() -> {
+                            if (buffer.length() > 0) this.setBody(buffer.toString());
+                        });
                 } else {
                     this.setBody("BODY NOT CAPTURED");
                 }
@@ -70,7 +74,17 @@ public class LogEndpointResponse extends LogResponse {
             this.setHeaders(response.headers());
             response.setHeaders(((LogHeadersCaptor) response.headers()).getDelegate());
         }
-        this.setStatus(response.status());
+        int status = response.status();
+        if (status != 0) {
+            final ExecutionFailure executionFailure = ctx.getInternalAttribute(InternalContextAttributes.ATTR_INTERNAL_EXECUTION_FAILURE);
+            if (executionFailure != null) {
+                status = executionFailure.statusCode();
+                if (isLogPayload() && loggingContext.isBodyLoggable() && executionFailure.message() != null && this.getBody() == null) {
+                    this.setBody(executionFailure.message());
+                }
+            }
+        }
+        this.setStatus(status);
     }
 
     protected boolean isLogPayload() {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/analytics/logging/response/LogEntrypointResponse.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/analytics/logging/response/LogEntrypointResponse.java
@@ -17,6 +17,8 @@ package io.gravitee.gateway.reactive.handlers.api.v4.analytics.logging.response;
 
 import io.gravitee.gateway.api.buffer.Buffer;
 import io.gravitee.gateway.api.http.HttpHeaderNames;
+import io.gravitee.gateway.reactive.api.ExecutionFailure;
+import io.gravitee.gateway.reactive.api.context.InternalContextAttributes;
 import io.gravitee.gateway.reactive.core.context.HttpExecutionContextInternal;
 import io.gravitee.gateway.reactive.core.context.HttpResponseInternal;
 import io.gravitee.gateway.reactive.core.v4.analytics.BufferUtils;
@@ -48,7 +50,9 @@ public class LogEntrypointResponse extends LogResponse {
                     response
                         .chunks()
                         .doOnNext(chunk -> BufferUtils.appendBuffer(buffer, chunk, loggingContext.getMaxSizeLogMessage()))
-                        .doOnComplete(() -> this.setBody(buffer.toString()))
+                        .doOnComplete(() -> {
+                            if (buffer.length() > 0) this.setBody(buffer.toString());
+                        })
                 );
             } else {
                 this.setBody("BODY NOT CAPTURED");
@@ -59,7 +63,17 @@ public class LogEntrypointResponse extends LogResponse {
             this.setHeaders(response.headers());
         }
 
-        this.setStatus(response.status());
+        final ExecutionFailure executionFailure = ctx.getInternalAttribute(InternalContextAttributes.ATTR_INTERNAL_EXECUTION_FAILURE);
+        this.setStatus(executionFailure != null ? executionFailure.statusCode() : response.status());
+        if (
+            isLogPayload() &&
+            loggingContext.isBodyLoggable() &&
+            executionFailure != null &&
+            executionFailure.message() != null &&
+            this.getBody() == null
+        ) {
+            this.setBody(executionFailure.message());
+        }
     }
 
     protected boolean isLogPayload() {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/processor/logging/LogResponseProcessor.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/processor/logging/LogResponseProcessor.java
@@ -15,12 +15,15 @@
  */
 package io.gravitee.gateway.reactive.handlers.api.v4.processor.logging;
 
+import io.gravitee.definition.model.v4.ApiType;
+import io.gravitee.gateway.reactive.api.ExecutionFailure;
 import io.gravitee.gateway.reactive.api.context.InternalContextAttributes;
 import io.gravitee.gateway.reactive.core.context.HttpExecutionContextInternal;
 import io.gravitee.gateway.reactive.core.processor.Processor;
 import io.gravitee.gateway.reactive.core.v4.analytics.AnalyticsContext;
 import io.gravitee.gateway.reactive.core.v4.analytics.LoggingContext;
 import io.gravitee.gateway.reactive.handlers.api.v4.analytics.logging.response.LogEntrypointResponse;
+import io.gravitee.reporter.api.common.Response;
 import io.gravitee.reporter.api.v4.log.Log;
 import io.reactivex.rxjava3.core.Completable;
 
@@ -53,6 +56,26 @@ public class LogResponseProcessor implements Processor {
             if (log != null && loggingContext.entrypointResponse()) {
                 LogEntrypointResponse entrypointResponse = (LogEntrypointResponse) log.getEntrypointResponse();
                 entrypointResponse.capture(ctx);
+            }
+
+            if (log != null && loggingContext.endpointResponse() && ApiType.MESSAGE == ApiType.fromLabel(ctx.metrics().getApiType())) {
+                final Response endpointResponse = log.getEndpointResponse();
+                if (endpointResponse != null && endpointResponse.getStatus() != 0) {
+                    final ExecutionFailure executionFailure = ctx.getInternalAttribute(
+                        InternalContextAttributes.ATTR_INTERNAL_EXECUTION_FAILURE
+                    );
+                    if (executionFailure != null) {
+                        endpointResponse.setStatus(executionFailure.statusCode());
+                        if (
+                            loggingContext.endpointResponsePayload() &&
+                            loggingContext.isBodyLoggable() &&
+                            executionFailure.message() != null &&
+                            endpointResponse.getBody() == null
+                        ) {
+                            endpointResponse.setBody(executionFailure.message());
+                        }
+                    }
+                }
             }
         });
     }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/v4/analytics/logging/response/LogEndpointResponseTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/v4/analytics/logging/response/LogEndpointResponseTest.java
@@ -25,12 +25,16 @@ import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.gravitee.gateway.api.buffer.Buffer;
 import io.gravitee.gateway.api.http.HttpHeaderNames;
 import io.gravitee.gateway.api.http.HttpHeaders;
 import io.gravitee.gateway.http.vertx.VertxHttpHeaders;
+import io.gravitee.gateway.reactive.api.ExecutionFailure;
+import io.gravitee.gateway.reactive.api.context.InternalContextAttributes;
 import io.gravitee.gateway.reactive.api.tracing.Tracer;
 import io.gravitee.gateway.reactive.core.context.HttpExecutionContextInternal;
 import io.gravitee.gateway.reactive.core.context.HttpResponseInternal;
@@ -79,7 +83,7 @@ class LogEndpointResponseTest {
 
     @BeforeEach
     void init() {
-        doNothing().when(response).registerBuffersInterceptor(buffersInterceptorCaptor.capture());
+        lenient().doNothing().when(response).registerBuffersInterceptor(buffersInterceptorCaptor.capture());
         cut = new LogEndpointResponse(loggingContext, response);
     }
 
@@ -305,6 +309,51 @@ class LogEndpointResponseTest {
 
         assertNull(cut.getHeaders());
         assertThat(cut.getBody()).isEqualTo("BODY NOT CAPTURED");
+    }
+
+    @Test
+    void should_use_failure_status_when_execution_failure_is_present() {
+        initializeHeaders(HttpHeaders.create());
+        when(loggingContext.endpointResponseHeaders()).thenReturn(false);
+        when(loggingContext.endpointResponsePayload()).thenReturn(false);
+        when(response.status()).thenReturn(OK_200);
+        when(ctx.getInternalAttribute(InternalContextAttributes.ATTR_INTERNAL_EXECUTION_FAILURE)).thenReturn(new ExecutionFailure(400));
+
+        cut.setupCapture(ctx);
+        triggerResponseFromBackend(null);
+
+        assertThat(cut.getStatus()).isEqualTo(400);
+        assertNull(cut.getBody());
+    }
+
+    @Test
+    void should_set_failure_message_as_body_when_payload_logging_enabled_and_no_body_captured() {
+        final String errorMessage = "{\"message\":\"validation failed\"}";
+        initializeHeaders(HttpHeaders.create());
+        when(loggingContext.endpointResponseHeaders()).thenReturn(false);
+        when(loggingContext.endpointResponsePayload()).thenReturn(true);
+        when(loggingContext.isBodyLoggable()).thenReturn(true);
+        when(loggingContext.isContentTypeLoggable(any(), any())).thenReturn(false);
+        when(response.status()).thenReturn(OK_200);
+        when(ctx.getInternalAttribute(InternalContextAttributes.ATTR_INTERNAL_EXECUTION_FAILURE)).thenReturn(
+            new ExecutionFailure(400).message(errorMessage)
+        );
+
+        cut.setupCapture(ctx);
+        triggerResponseFromBackend(null);
+
+        assertThat(cut.getStatus()).isEqualTo(400);
+        assertThat(cut.getBody()).isEqualTo(errorMessage);
+    }
+
+    @Test
+    void should_keep_status_zero_when_backend_did_not_respond_despite_failure() {
+        when(response.status()).thenReturn(0);
+
+        cut.finalizeCapture(ctx);
+
+        assertThat(cut.getStatus()).isEqualTo(0);
+        verify(ctx, never()).getInternalAttribute(InternalContextAttributes.ATTR_INTERNAL_EXECUTION_FAILURE);
     }
 
     private void triggerResponseFromBackend(HttpHeaders backendHeaders) {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/v4/analytics/logging/response/LogEntrypointResponseTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/v4/analytics/logging/response/LogEntrypointResponseTest.java
@@ -31,6 +31,8 @@ import io.gravitee.gateway.api.buffer.Buffer;
 import io.gravitee.gateway.api.http.HttpHeaderNames;
 import io.gravitee.gateway.api.http.HttpHeaders;
 import io.gravitee.gateway.http.vertx.VertxHttpHeaders;
+import io.gravitee.gateway.reactive.api.ExecutionFailure;
+import io.gravitee.gateway.reactive.api.context.InternalContextAttributes;
 import io.gravitee.gateway.reactive.api.tracing.Tracer;
 import io.gravitee.gateway.reactive.core.context.HttpExecutionContextInternal;
 import io.gravitee.gateway.reactive.core.context.HttpResponseInternal;
@@ -164,6 +166,38 @@ class LogEntrypointResponseTest {
 
         assertNull(logResponse.getHeaders());
         assertThat(logResponse.getBody()).isEqualTo(BODY_CONTENT.substring(0, maxPayloadSize));
+    }
+
+    @Test
+    void should_use_failure_status_when_execution_failure_is_present() {
+        when(loggingContext.entrypointResponseHeaders()).thenReturn(false);
+        when(loggingContext.entrypointResponsePayload()).thenReturn(false);
+        when(ctx.getInternalAttribute(InternalContextAttributes.ATTR_INTERNAL_EXECUTION_FAILURE)).thenReturn(new ExecutionFailure(400));
+
+        final var logResponse = new LogEntrypointResponse(loggingContext, response);
+        logResponse.capture(ctx);
+
+        assertThat(logResponse.getStatus()).isEqualTo(400);
+        assertNull(logResponse.getBody());
+    }
+
+    @Test
+    void should_set_failure_message_as_body_when_payload_logging_enabled_and_no_body_captured() {
+        final String errorMessage = "{\"message\":\"validation failed\"}";
+        when(response.headers()).thenReturn(HttpHeaders.create());
+        when(loggingContext.entrypointResponseHeaders()).thenReturn(false);
+        when(loggingContext.entrypointResponsePayload()).thenReturn(true);
+        when(loggingContext.isBodyLoggable()).thenReturn(true);
+        when(loggingContext.isContentTypeLoggable(any(), any())).thenReturn(false);
+        when(ctx.getInternalAttribute(InternalContextAttributes.ATTR_INTERNAL_EXECUTION_FAILURE)).thenReturn(
+            new ExecutionFailure(400).message(errorMessage)
+        );
+
+        final var logResponse = new LogEntrypointResponse(loggingContext, response);
+        logResponse.capture(ctx);
+
+        assertThat(logResponse.getStatus()).isEqualTo(400);
+        assertThat(logResponse.getBody()).isEqualTo(errorMessage);
     }
 
     @Test

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/v4/processor/logging/LogResponseProcessorTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/v4/processor/logging/LogResponseProcessorTest.java
@@ -24,10 +24,13 @@ import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import io.gravitee.definition.model.v4.ApiType;
+import io.gravitee.gateway.reactive.api.ExecutionFailure;
 import io.gravitee.gateway.reactive.api.context.InternalContextAttributes;
 import io.gravitee.gateway.reactive.api.tracing.Tracer;
 import io.gravitee.gateway.reactive.core.v4.analytics.AnalyticsContext;
 import io.gravitee.gateway.reactive.core.v4.analytics.LoggingContext;
+import io.gravitee.gateway.reactive.handlers.api.v4.analytics.logging.response.LogEndpointResponse;
 import io.gravitee.gateway.reactive.handlers.api.v4.analytics.logging.response.LogEntrypointResponse;
 import io.gravitee.gateway.reactive.handlers.api.v4.processor.AbstractV4ProcessorTest;
 import io.gravitee.reporter.api.v4.log.Log;
@@ -93,6 +96,91 @@ class LogResponseProcessorTest extends AbstractV4ProcessorTest {
         obs.assertComplete();
 
         assertNotNull(log.getEntrypointResponse());
+    }
+
+    @Test
+    void shouldNotOverwriteEndpointStatusWithEntrypointResponseWhenNoFailure() {
+        Log log = Log.builder().timestamp(System.currentTimeMillis()).build();
+        log.setEndpointResponse(new LogEndpointResponse(loggingContext, mockResponse));
+        log.getEndpointResponse().setStatus(201);
+        when(mockMetrics.getLog()).thenReturn(log);
+        when(loggingContext.entrypointResponse()).thenReturn(false);
+        when(loggingContext.endpointResponse()).thenReturn(true);
+
+        cut.execute(ctx).test().assertComplete();
+
+        assertThat(log.getEndpointResponse().getStatus()).isEqualTo(201);
+    }
+
+    @Test
+    void shouldKeepEndpointStatusZeroWhenBackendDidNotRespondDespiteFailure() {
+        Log log = Log.builder().timestamp(System.currentTimeMillis()).build();
+        log.setEndpointResponse(new LogEndpointResponse(loggingContext, mockResponse));
+        log.getEndpointResponse().setStatus(0);
+        when(mockMetrics.getLog()).thenReturn(log);
+        when(loggingContext.entrypointResponse()).thenReturn(false);
+        when(loggingContext.endpointResponse()).thenReturn(true);
+        ctx.setInternalAttribute(InternalContextAttributes.ATTR_INTERNAL_EXECUTION_FAILURE, new ExecutionFailure(504));
+
+        cut.execute(ctx).test().assertComplete();
+
+        assertThat(log.getEndpointResponse().getStatus()).isEqualTo(0);
+    }
+
+    @Test
+    void shouldUpdateEndpointResponseStatusWhenFailureIsPresentForMessageApi() {
+        Log log = Log.builder().timestamp(System.currentTimeMillis()).build();
+        log.setEndpointResponse(new LogEndpointResponse(loggingContext, mockResponse));
+        log.getEndpointResponse().setStatus(200);
+        when(mockMetrics.getLog()).thenReturn(log);
+        when(mockMetrics.getApiType()).thenReturn(ApiType.MESSAGE.getLabel());
+        when(loggingContext.entrypointResponse()).thenReturn(false);
+        when(loggingContext.endpointResponse()).thenReturn(true);
+        when(loggingContext.endpointResponsePayload()).thenReturn(false);
+        ctx.setInternalAttribute(InternalContextAttributes.ATTR_INTERNAL_EXECUTION_FAILURE, new ExecutionFailure(400));
+
+        cut.execute(ctx).test().assertComplete();
+
+        assertThat(log.getEndpointResponse().getStatus()).isEqualTo(400);
+    }
+
+    @Test
+    void shouldNotOverwriteEndpointStatusForProxyApiEvenWhenFailureIsPresent() {
+        Log log = Log.builder().timestamp(System.currentTimeMillis()).build();
+        log.setEndpointResponse(new LogEndpointResponse(loggingContext, mockResponse));
+        log.getEndpointResponse().setStatus(200);
+        when(mockMetrics.getLog()).thenReturn(log);
+        when(mockMetrics.getApiType()).thenReturn(ApiType.PROXY.getLabel());
+        when(loggingContext.entrypointResponse()).thenReturn(false);
+        when(loggingContext.endpointResponse()).thenReturn(true);
+        ctx.setInternalAttribute(InternalContextAttributes.ATTR_INTERNAL_EXECUTION_FAILURE, new ExecutionFailure(400));
+
+        cut.execute(ctx).test().assertComplete();
+
+        assertThat(log.getEndpointResponse().getStatus()).isEqualTo(200);
+    }
+
+    @Test
+    void shouldUpdateEndpointResponseBodyWhenFailureHasMessageAndPayloadLoggingEnabledForMessageApi() {
+        final String errorMessage = "{\"message\":\"orderId is required\"}";
+        Log log = Log.builder().timestamp(System.currentTimeMillis()).build();
+        log.setEndpointResponse(new LogEndpointResponse(loggingContext, mockResponse));
+        log.getEndpointResponse().setStatus(200);
+        when(mockMetrics.getLog()).thenReturn(log);
+        when(mockMetrics.getApiType()).thenReturn(ApiType.MESSAGE.getLabel());
+        when(loggingContext.entrypointResponse()).thenReturn(false);
+        when(loggingContext.endpointResponse()).thenReturn(true);
+        when(loggingContext.endpointResponsePayload()).thenReturn(true);
+        when(loggingContext.isBodyLoggable()).thenReturn(true);
+        ctx.setInternalAttribute(
+            InternalContextAttributes.ATTR_INTERNAL_EXECUTION_FAILURE,
+            new ExecutionFailure(400).message(errorMessage)
+        );
+
+        cut.execute(ctx).test().assertComplete();
+
+        assertThat(log.getEndpointResponse().getStatus()).isEqualTo(400);
+        assertThat(log.getEndpointResponse().getBody()).isEqualTo(errorMessage);
     }
 
     @Test


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-13864

## Problem

When a policy (e.g. JSON Validation) rejects a request, the runtime log detail (`GET /logs/{requestId}`) shows incorrect data:

- `entrypointResponse.status`: 200 instead of 400
- `endpointResponse.status`: 200 instead of 400
- No error detail in the response body

This makes the logs unreliable for debugging policy failures.

## Root Cause

**Capture timing:** `LogEntrypointResponse.capture()` and `LogEndpointResponse.finalizeCapture()` read `response.status()` directly at the moment they are called. At that point the error processors that set the correct HTTP status have not yet run, so they always record 200.

**MESSAGE API timing gap:** For MESSAGE APIs (e.g. Mock endpoint + JSON Validation on the PUBLISH flow), the backend invoker's `connect()` Completable completes successfully — it only sets up a lazy connection. `LoggingHook.post()` fires at that point with `ATTR_INTERNAL_EXECUTION_FAILURE` not yet set and `response.status() = 200`. The actual failure surfaces later inside `handleEntrypointResponse()`, long after the endpoint response has already been captured.

## Changes
### `LogEntrypointResponse.capture()` _(fix)_

Instead of reading `response.status()` directly, the method now reads `ATTR_INTERNAL_EXECUTION_FAILURE` from the context. If a failure is present, its status code is used. If payload logging is enabled and no body has been captured yet, the failure message is written into the log body.

---

### `LogEndpointResponse.finalizeCapture()` _(fix)_

Same fix as above, with an additional guard: if `response.status()` is `0` (meaning the backend never responded — e.g. a timeout), the status is kept as `0` and the failure status code is never applied. This prevents a gateway-generated 504 from overwriting a "no response" entry.

---
### `LogResponseProcessor.execute()` _(fix — MESSAGE API)_

Added a correction step that runs **after** all error processors have finished. For each non-zero endpoint response status, if an `ExecutionFailure` is present on the context, the status and body are corrected at that point. This closes the timing gap for MESSAGE APIs where the failure is only known after the endpoint response was originally captured.

---

## Tests

- `LogResponseProcessorTest` — 3 new tests: endpoint status corrected to `400` on failure; endpoint status `0` preserved despite a `504` failure; failure message written as body when payload logging is enabled
- `LogEndpointResponseTest` — 2 new tests covering the same scenarios in `finalizeCapture()`
- `LogEntrypointResponseTest` — 2 new tests covering the same scenarios in `capture()`

---

### before Fix & after fix
https://github.com/user-attachments/assets/e5517052-7209-4274-b3ec-47d81afa8c3b


