### PR TITLE
fix: openapi update use group ids in generic api schema

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-apis.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-apis.yaml
@@ -3208,10 +3208,10 @@ components:
                           additionalProperties: true
                       groups:
                           type: array
-                          description: API's groups. Used to add team in your API.
+                          description: List of group IDs associated with this API. Used to manage team access.
                           example:
-                              - MY_GROUP1
-                              - MY_GROUP2
+                              - 6c530064-0b2c-4004-9300-640b2ce0047b
+                              - 12559b64-0b2c-4004-9300-640b2ce0047b
                           items:
                               type: string
                       state:
@@ -3594,10 +3594,10 @@ components:
                     $ref: "#/components/schemas/DefinitionVersion"
                 groups:
                     type: array
-                    description: API's groups. Used to add team in your API.
+                    description: List of group IDs associated with this API. Used to manage team access.
                     example:
-                        - MY_GROUP1
-                        - MY_GROUP2
+                        - 6c530064-0b2c-4004-9300-640b2ce0047b
+                        - 12559b64-0b2c-4004-9300-640b2ce0047b
                     items:
                         type: string
             required: [name, apiVersion, definitionVersion]
@@ -3799,10 +3799,10 @@ components:
                     $ref: "#/components/schemas/DefinitionVersion"
                 groups:
                     type: array
-                    description: API's groups. Used to add team in your API.
+                    description: List of group IDs associated with this API. Used to manage team access.
                     example:
-                        - MY_GROUP1
-                        - MY_GROUP2
+                        - 6c530064-0b2c-4004-9300-640b2ce0047b
+                        - 12559b64-0b2c-4004-9300-640b2ce0047b
                     items:
                         type: string
                 tags:


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-13693

## Description

Align OpenAPI docs with actual API behaviour: groups accepts group identifiers, not group display names.

