### PR TITLE
Optimize subscription expiration schedulers (APIM-14086)

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/SubscriptionRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/SubscriptionRepository.java
@@ -41,6 +41,13 @@ public interface SubscriptionRepository extends CrudRepository<Subscription, Str
 
     List<Subscription> search(SubscriptionCriteria criteria) throws TechnicalException;
 
+    /**
+     * Same filters as {@link #search(SubscriptionCriteria)} but skips the implicit {@code createdAt desc}
+     * default sort. Use this for index-friendly queries where order is irrelevant — notably range scans on
+     * {@code endingAt} that would otherwise be blocked by the sort stage (ESR violation).
+     */
+    List<Subscription> searchUnordered(SubscriptionCriteria criteria) throws TechnicalException;
+
     List<Subscription> findByIdIn(Collection<String> ids) throws TechnicalException;
 
     Set<String> findReferenceIdsOrderByNumberOfSubscriptions(SubscriptionCriteria criteria, Order order) throws TechnicalException;

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcSubscriptionRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcSubscriptionRepository.java
@@ -165,6 +165,11 @@ public class JdbcSubscriptionRepository extends JdbcAbstractCrudRepository<Subsc
     }
 
     @Override
+    public List<Subscription> searchUnordered(final SubscriptionCriteria criteria) throws TechnicalException {
+        return searchPage(criteria, null, null, false).getContent();
+    }
+
+    @Override
     public List<String> deleteByEnvironmentId(String environmentId) throws TechnicalException {
         log.debug("JdbcSubscriptionRepository.deleteByEnvironment({})", environmentId);
         try {
@@ -191,13 +196,13 @@ public class JdbcSubscriptionRepository extends JdbcAbstractCrudRepository<Subsc
 
     @Override
     public List<Subscription> search(final SubscriptionCriteria criteria, final Sortable sortable) throws TechnicalException {
-        return searchPage(criteria, sortable, null).getContent();
+        return searchPage(criteria, sortable, null, true).getContent();
     }
 
     @Override
     public Page<Subscription> search(final SubscriptionCriteria criteria, final Sortable sortable, final Pageable pageable)
         throws TechnicalException {
-        return searchPage(criteria, sortable, pageable);
+        return searchPage(criteria, sortable, pageable, true);
     }
 
     @Override
@@ -259,7 +264,12 @@ public class JdbcSubscriptionRepository extends JdbcAbstractCrudRepository<Subsc
         };
     }
 
-    private Page<Subscription> searchPage(final SubscriptionCriteria criteria, final Sortable sortable, final Pageable pageable) {
+    private Page<Subscription> searchPage(
+        final SubscriptionCriteria criteria,
+        final Sortable sortable,
+        final Pageable pageable,
+        final boolean applyDefaultSort
+    ) {
         final List<Object> argsList = new ArrayList<>();
         JdbcHelper.CollatingRowMapper<Subscription> rowMapper = new JdbcHelper.CollatingRowMapper<>(
             getOrm().getRowMapper(),
@@ -364,7 +374,7 @@ public class JdbcSubscriptionRepository extends JdbcAbstractCrudRepository<Subsc
             builder.append(" order by s.");
             builder.append(toSnakeCase(sortable.field()));
             builder.append(sortable.order() == null || sortable.order().equals(Order.ASC) ? " asc " : " desc ");
-        } else {
+        } else if (applyDefaultSort) {
             builder.append(" order by s.created_at desc ");
         }
 

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoSubscriptionRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoSubscriptionRepository.java
@@ -69,6 +69,11 @@ public class MongoSubscriptionRepository implements SubscriptionRepository {
     }
 
     @Override
+    public List<Subscription> searchUnordered(final SubscriptionCriteria criteria) throws TechnicalException {
+        return mapper.mapSubscriptions(internalSubscriptionRepository.searchUnordered(criteria));
+    }
+
+    @Override
     public Set<String> findReferenceIdsOrderByNumberOfSubscriptions(SubscriptionCriteria criteria, Order order) {
         return internalSubscriptionRepository.findReferenceIdsOrderByNumberOfSubscriptions(criteria, order);
     }

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/plan/SubscriptionMongoRepositoryCustom.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/plan/SubscriptionMongoRepositoryCustom.java
@@ -21,6 +21,7 @@ import io.gravitee.repository.management.api.search.Pageable;
 import io.gravitee.repository.management.api.search.Sortable;
 import io.gravitee.repository.management.api.search.SubscriptionCriteria;
 import io.gravitee.repository.mongodb.management.internal.model.SubscriptionMongo;
+import java.util.List;
 import java.util.Set;
 import org.springframework.stereotype.Repository;
 
@@ -31,6 +32,8 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface SubscriptionMongoRepositoryCustom {
     Page<SubscriptionMongo> search(SubscriptionCriteria criteria, Sortable sortable, Pageable pageable);
+
+    List<SubscriptionMongo> searchUnordered(SubscriptionCriteria criteria);
 
     Set<String> findReferenceIdsOrderByNumberOfSubscriptions(SubscriptionCriteria criteria, Order order);
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/plan/SubscriptionMongoRepositoryImpl.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/plan/SubscriptionMongoRepositoryImpl.java
@@ -60,6 +60,64 @@ public class SubscriptionMongoRepositoryImpl implements SubscriptionMongoReposit
 
     @Override
     public Page<SubscriptionMongo> search(SubscriptionCriteria criteria, final Sortable sortable, final Pageable pageable) {
+        List<Bson> filterPipeline = buildFilterPipeline(criteria);
+
+        Integer totalCount = null;
+        // if pageable, count total subscriptions matching criteria — counting only needs the $match stages,
+        // not the sort or projection that follows, so build the count pipeline before adding those.
+        if (pageable != null) {
+            List<Bson> countPipeline = new ArrayList<>(filterPipeline);
+            countPipeline.add(count("totalCount"));
+            AggregateIterable<Document> countAggregate = mongoTemplate
+                .getCollection(mongoTemplate.getCollectionName(SubscriptionMongo.class))
+                .aggregate(countPipeline);
+            if (countAggregate.first() != null) {
+                totalCount = countAggregate.first().getInteger("totalCount", 0);
+            }
+        }
+
+        List<Bson> dataPipeline = new ArrayList<>(filterPipeline);
+        // set sortable
+        if (sortable != null) {
+            if (sortable.order().equals(Order.ASC)) {
+                dataPipeline.add(sort(Sorts.ascending(FieldUtils.toCamelCase(sortable.field()))));
+            } else {
+                dataPipeline.add(sort(Sorts.descending(FieldUtils.toCamelCase(sortable.field()))));
+            }
+        } else {
+            dataPipeline.add(sort(Sorts.descending("createdAt")));
+        }
+        dataPipeline.add(Aggregates.project(Projections.exclude("_class")));
+
+        if (pageable != null) {
+            dataPipeline.add(skip(pageable.pageNumber() * pageable.pageSize()));
+            dataPipeline.add(limit(pageable.pageSize()));
+        }
+
+        AggregateIterable<Document> dataAggregate = mongoTemplate
+            .getCollection(mongoTemplate.getCollectionName(SubscriptionMongo.class))
+            .aggregate(dataPipeline);
+        return buildSubscriptionsPage(pageable, dataAggregate, totalCount);
+    }
+
+    @Override
+    public List<SubscriptionMongo> searchUnordered(SubscriptionCriteria criteria) {
+        List<Bson> dataPipeline = buildFilterPipeline(criteria);
+        dataPipeline.add(Aggregates.project(Projections.exclude("_class")));
+
+        AggregateIterable<Document> dataAggregate = mongoTemplate
+            .getCollection(mongoTemplate.getCollectionName(SubscriptionMongo.class))
+            .aggregate(dataPipeline);
+
+        List<SubscriptionMongo> subscriptions = new ArrayList<>();
+        MongoConverter converter = mongoTemplate.getConverter();
+        for (Document doc : dataAggregate) {
+            subscriptions.add(converter.read(SubscriptionMongo.class, doc));
+        }
+        return subscriptions;
+    }
+
+    private List<Bson> buildFilterPipeline(SubscriptionCriteria criteria) {
         List<Bson> dataPipeline = new ArrayList<>();
 
         if (criteria.getClientId() != null) {
@@ -169,38 +227,7 @@ public class SubscriptionMongoRepositoryImpl implements SubscriptionMongoReposit
             dataPipeline.add(match(nin("referenceId", criteria.getExcludedApis())));
         }
 
-        // set sortable
-        if (sortable != null) {
-            if (sortable.order().equals(Order.ASC)) {
-                dataPipeline.add(sort(Sorts.ascending(FieldUtils.toCamelCase(sortable.field()))));
-            } else {
-                dataPipeline.add(sort(Sorts.descending(FieldUtils.toCamelCase(sortable.field()))));
-            }
-        } else {
-            dataPipeline.add(sort(Sorts.descending("createdAt")));
-        }
-
-        dataPipeline.add(Aggregates.project(Projections.exclude("_class")));
-
-        Integer totalCount = null;
-        // if pageable, count total subscriptions matching criterias
-        if (pageable != null) {
-            List<Bson> countPipeline = new ArrayList<>(dataPipeline);
-            countPipeline.add(count("totalCount"));
-            AggregateIterable<Document> countAggregate = mongoTemplate
-                .getCollection(mongoTemplate.getCollectionName(SubscriptionMongo.class))
-                .aggregate(countPipeline);
-            if (countAggregate.first() != null) {
-                totalCount = countAggregate.first().getInteger("totalCount", 0);
-            }
-            dataPipeline.add(skip(pageable.pageNumber() * pageable.pageSize()));
-            dataPipeline.add(limit(pageable.pageSize()));
-        }
-
-        AggregateIterable<Document> dataAggregate = mongoTemplate
-            .getCollection(mongoTemplate.getCollectionName(SubscriptionMongo.class))
-            .aggregate(dataPipeline);
-        return buildSubscriptionsPage(pageable, dataAggregate, totalCount);
+        return dataPipeline;
     }
 
     @Override

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/index/subscriptions/StatusEndingAtIndexUpgrader.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/index/subscriptions/StatusEndingAtIndexUpgrader.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.mongodb.management.upgrade.upgrader.index.subscriptions;
+
+import io.gravitee.repository.mongodb.management.upgrade.upgrader.index.Index;
+import io.gravitee.repository.mongodb.management.upgrade.upgrader.index.IndexUpgrader;
+import org.springframework.stereotype.Component;
+
+/**
+ * Compound index {@code {status:1, endingAt:1}} on the {@code subscriptions} collection.
+ *
+ * <p>Serves the cron-driven pre-expiration and close-expired scheduler queries, both of which match
+ * subscriptions by status (equality / {@code $in}) and constrain {@code endingAt} to a range
+ * (typically a 1-hour cron-tick window).</p>
+ *
+ * <p>The field ordering follows MongoDB's Equality-Sort-Range (ESR) rule. Status (equality) MUST
+ * come first; endingAt (range) second. Reordering — for example inserting another field between
+ * status and endingAt — will silently regress to a collection-style scan since the planner can no
+ * longer use the index for the range predicate. Name {@code s1ea1} encodes the index shape:
+ * status asc, endingAt asc.</p>
+ *
+ * <p>See APIM-14086 for the original ESR violation this index resolves.</p>
+ */
+@Component("StatusEndingAtIndexUpgrader")
+public class StatusEndingAtIndexUpgrader extends IndexUpgrader {
+
+    @Override
+    protected Index buildIndex() {
+        return Index.builder()
+            .collection("subscriptions")
+            .name("s1ea1")
+            .key("status", ascending())
+            .key("endingAt", ascending())
+            .build();
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-noop/src/main/java/io/gravitee/repository/noop/management/NoOpSubscriptionRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-noop/src/main/java/io/gravitee/repository/noop/management/NoOpSubscriptionRepository.java
@@ -53,6 +53,11 @@ public class NoOpSubscriptionRepository extends AbstractNoOpManagementRepository
     }
 
     @Override
+    public List<Subscription> searchUnordered(SubscriptionCriteria criteria) throws TechnicalException {
+        return List.of();
+    }
+
+    @Override
     public List<Subscription> findByIdIn(Collection<String> ids) throws TechnicalException {
         return List.of();
     }

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/SubscriptionRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/SubscriptionRepositoryTest.java
@@ -695,4 +695,18 @@ public class SubscriptionRepositoryTest extends AbstractManagementRepositoryTest
         assertNotNull(subscription);
         assertFalse(subscription.isPresent());
     }
+
+    @Test
+    public void searchUnorderedShouldReturnSameSetAsSearch() throws TechnicalException {
+        SubscriptionCriteria criteria = SubscriptionCriteria.builder().applications(singleton("app1")).build();
+
+        List<Subscription> sorted = subscriptionRepository.search(criteria);
+        List<Subscription> unordered = subscriptionRepository.searchUnordered(criteria);
+
+        assertNotNull(unordered);
+        assertEquals("Subscriptions size", sorted.size(), unordered.size());
+        Set<String> sortedIds = sorted.stream().map(Subscription::getId).collect(Collectors.toSet());
+        Set<String> unorderedIds = unordered.stream().map(Subscription::getId).collect(Collectors.toSet());
+        assertEquals("Subscription id set", sortedIds, unorderedIds);
+    }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/subscription/model/ExpiringSubscription.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/subscription/model/ExpiringSubscription.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.subscription.model;
+
+import java.time.ZonedDateTime;
+
+/**
+ * Minimal projection of a subscription used by the pre-expiration notification scheduler.
+ * Carries only the fields needed for window bucketing, idempotency and notification dispatch.
+ */
+public record ExpiringSubscription(
+    String id,
+    String apiId,
+    String planId,
+    String applicationId,
+    String subscribedBy,
+    ZonedDateTime endingAt,
+    Integer daysToExpirationOnLastNotification
+) {}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/subscription/query_service/SubscriptionQueryService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/subscription/query_service/SubscriptionQueryService.java
@@ -15,8 +15,11 @@
  */
 package io.gravitee.apim.core.subscription.query_service;
 
+import io.gravitee.apim.core.subscription.model.ExpiringSubscription;
 import io.gravitee.apim.core.subscription.model.SubscriptionEntity;
 import io.gravitee.apim.core.subscription.model.SubscriptionReferenceType;
+import io.gravitee.rest.api.model.SubscriptionStatus;
+import java.time.Instant;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
@@ -24,6 +27,19 @@ import java.util.Set;
 
 public interface SubscriptionQueryService {
     List<SubscriptionEntity> findExpiredSubscriptions();
+
+    /**
+     * Returns subscriptions whose {@code endingAt} falls inside any of the per-bucket windows
+     * {@code [now + d*24h, now + d*24h + windowMs)} for each {@code d} in {@code daysBuckets}, restricted
+     * to the given statuses. Runs as a single repository query over the outer-union range; callers
+     * perform bucket-inference in memory.
+     */
+    List<ExpiringSubscription> findExpiringSubscriptions(
+        Instant now,
+        List<Integer> daysBuckets,
+        long windowMs,
+        List<SubscriptionStatus> statuses
+    );
 
     List<SubscriptionEntity> findSubscriptionsByPlan(String planId);
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/query_service/subscription/SubscriptionQueryServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/query_service/subscription/SubscriptionQueryServiceImpl.java
@@ -16,6 +16,7 @@
 package io.gravitee.apim.infra.query_service.subscription;
 
 import io.gravitee.apim.core.exception.TechnicalDomainException;
+import io.gravitee.apim.core.subscription.model.ExpiringSubscription;
 import io.gravitee.apim.core.subscription.model.SubscriptionEntity;
 import io.gravitee.apim.core.subscription.model.SubscriptionReferenceType;
 import io.gravitee.apim.core.subscription.query_service.SubscriptionQueryService;
@@ -23,9 +24,15 @@ import io.gravitee.apim.infra.adapter.SubscriptionAdapter;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.SubscriptionRepository;
 import io.gravitee.repository.management.api.search.SubscriptionCriteria;
+import io.gravitee.repository.management.model.Subscription;
 import io.gravitee.rest.api.model.SubscriptionStatus;
 import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.Date;
 import java.util.List;
 import java.util.Optional;
@@ -52,10 +59,53 @@ public class SubscriptionQueryServiceImpl implements SubscriptionQueryService {
             .build();
 
         try {
-            return subscriptionRepository.search(criteria).stream().map(subscriptionAdapter::toEntity).toList();
+            return subscriptionRepository.searchUnordered(criteria).stream().map(subscriptionAdapter::toEntity).toList();
         } catch (TechnicalException e) {
             throw new TechnicalManagementException("An error occurs while trying to find expired subscription", e);
         }
+    }
+
+    @Override
+    public List<ExpiringSubscription> findExpiringSubscriptions(
+        Instant now,
+        List<Integer> daysBuckets,
+        long windowMs,
+        List<SubscriptionStatus> statuses
+    ) {
+        if (daysBuckets == null || daysBuckets.isEmpty()) {
+            return List.of();
+        }
+        long oneDayMs = Duration.ofDays(1).toMillis();
+        long min = daysBuckets.stream().min(Comparator.naturalOrder()).get();
+        long max = daysBuckets.stream().max(Comparator.naturalOrder()).get();
+        long nowMs = now.toEpochMilli();
+        long endingAfter = nowMs + min * oneDayMs;
+        long endingBefore = nowMs + max * oneDayMs + windowMs;
+
+        SubscriptionCriteria criteria = SubscriptionCriteria.builder()
+            .statuses(statuses.stream().map(SubscriptionStatus::name).toList())
+            .endingAtAfter(endingAfter)
+            .endingAtBefore(endingBefore)
+            .build();
+
+        try {
+            return subscriptionRepository.searchUnordered(criteria).stream().map(SubscriptionQueryServiceImpl::toExpiring).toList();
+        } catch (TechnicalException e) {
+            throw new TechnicalManagementException("An error occurs while trying to find expiring subscriptions", e);
+        }
+    }
+
+    private static ExpiringSubscription toExpiring(Subscription s) {
+        ZonedDateTime ending = s.getEndingAt() == null ? null : s.getEndingAt().toInstant().atZone(ZoneOffset.UTC);
+        return new ExpiringSubscription(
+            s.getId(),
+            s.getApi(),
+            s.getPlan(),
+            s.getApplication(),
+            s.getSubscribedBy(),
+            ending,
+            s.getDaysToExpirationOnLastNotification()
+        );
     }
 
     @Override

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/SubscriptionQueryServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/SubscriptionQueryServiceInMemory.java
@@ -17,9 +17,12 @@ package inmemory;
 
 import io.gravitee.apim.core.plan.crud_service.PlanCrudService;
 import io.gravitee.apim.core.plan.model.Plan;
+import io.gravitee.apim.core.subscription.model.ExpiringSubscription;
 import io.gravitee.apim.core.subscription.model.SubscriptionEntity;
 import io.gravitee.apim.core.subscription.model.SubscriptionReferenceType;
 import io.gravitee.apim.core.subscription.query_service.SubscriptionQueryService;
+import io.gravitee.rest.api.model.SubscriptionStatus;
+import java.time.Instant;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -51,6 +54,16 @@ public class SubscriptionQueryServiceInMemory implements SubscriptionQueryServic
 
     public void setPlanCrudService(PlanCrudService planCrudService) {
         this.planCrudService = planCrudService;
+    }
+
+    @Override
+    public List<ExpiringSubscription> findExpiringSubscriptions(
+        Instant now,
+        List<Integer> daysBuckets,
+        long windowMs,
+        List<SubscriptionStatus> statuses
+    ) {
+        return List.of();
     }
 
     @Override

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/query_service/subscription/SubscriptionQueryServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/query_service/subscription/SubscriptionQueryServiceImplTest.java
@@ -33,6 +33,7 @@ import io.gravitee.repository.management.api.SubscriptionRepository;
 import io.gravitee.repository.management.api.search.SubscriptionCriteria;
 import io.gravitee.repository.management.model.Subscription;
 import io.gravitee.repository.management.model.SubscriptionReferenceType;
+import io.gravitee.rest.api.model.SubscriptionStatus;
 import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
 import java.time.Instant;
 import java.time.ZoneId;
@@ -69,14 +70,14 @@ public class SubscriptionQueryServiceImplTest {
         void should_query_for_expired_subscriptions() throws TechnicalException {
             // Given
             var now = new Date().getTime();
-            when(subscriptionRepository.search(any())).thenAnswer(invocation -> List.of());
+            when(subscriptionRepository.searchUnordered(any())).thenAnswer(invocation -> List.of());
 
             // When
             service.findExpiredSubscriptions();
 
             // Then
             var captor = ArgumentCaptor.forClass(SubscriptionCriteria.class);
-            verify(subscriptionRepository).search(captor.capture());
+            verify(subscriptionRepository).searchUnordered(captor.capture());
             assertThat(captor.getValue()).satisfies(criteria -> {
                 assertThat(criteria.getStatuses()).containsExactly(Subscription.Status.ACCEPTED.name());
                 assertThat(criteria.getEndingAtBefore()).isBetween(now, new Date().getTime());
@@ -97,7 +98,7 @@ public class SubscriptionQueryServiceImplTest {
         @Test
         void should_return_subscriptions_and_adapt_them() throws TechnicalException {
             // Given
-            when(subscriptionRepository.search(any())).thenAnswer(invocation ->
+            when(subscriptionRepository.searchUnordered(any())).thenAnswer(invocation ->
                 List.of(aSubscription("s1").status(Subscription.Status.ACCEPTED).build())
             );
 
@@ -124,7 +125,7 @@ public class SubscriptionQueryServiceImplTest {
         @Test
         void should_return_empty_stream_when_no_subscriptions_found() throws TechnicalException {
             // Given
-            when(subscriptionRepository.search(any())).thenReturn(List.of());
+            when(subscriptionRepository.searchUnordered(any())).thenReturn(List.of());
 
             // When
             var result = service.findExpiredSubscriptions();
@@ -136,7 +137,7 @@ public class SubscriptionQueryServiceImplTest {
         @Test
         void should_throw_when_technical_exception_occurs() throws TechnicalException {
             // Given
-            when(subscriptionRepository.search(any())).thenThrow(TechnicalException.class);
+            when(subscriptionRepository.searchUnordered(any())).thenThrow(TechnicalException.class);
 
             // When
             Throwable throwable = catchThrowable(() -> service.findExpiredSubscriptions());
@@ -145,6 +146,47 @@ public class SubscriptionQueryServiceImplTest {
             assertThat(throwable)
                 .isInstanceOf(TechnicalManagementException.class)
                 .hasMessage("An error occurs while trying to find expired subscription");
+        }
+    }
+
+    @Nested
+    class FindExpiringSubscriptions {
+
+        private static final long ONE_DAY_MS = 24L * 60L * 60L * 1000L;
+        private static final long ONE_HOUR_MS = 60L * 60L * 1000L;
+
+        @Test
+        void should_query_outer_range_covering_all_buckets_and_pin_exact_bounds() throws TechnicalException {
+            // Given a fixed instant so we can assert exact epoch millis (catches seconds-vs-millis flips
+            // and min/max swaps that previous shouldFindSubscriptionExpirationsToNotify caught).
+            Instant now = Instant.ofEpochMilli(1_700_000_000_000L);
+            when(subscriptionRepository.searchUnordered(any())).thenReturn(List.of());
+
+            // When
+            service.findExpiringSubscriptions(
+                now,
+                List.of(90, 45, 30),
+                ONE_HOUR_MS,
+                List.of(SubscriptionStatus.ACCEPTED, SubscriptionStatus.PAUSED)
+            );
+
+            // Then
+            var captor = ArgumentCaptor.forClass(SubscriptionCriteria.class);
+            verify(subscriptionRepository).searchUnordered(captor.capture());
+            assertThat(captor.getValue()).satisfies(criteria -> {
+                assertThat(criteria.getStatuses()).containsExactly(SubscriptionStatus.ACCEPTED.name(), SubscriptionStatus.PAUSED.name());
+                // endingAtAfter = now + min(daysBuckets) days
+                assertThat(criteria.getEndingAtAfter()).isEqualTo(1_700_000_000_000L + 30L * ONE_DAY_MS);
+                // endingAtBefore = now + max(daysBuckets) days + windowMs
+                assertThat(criteria.getEndingAtBefore()).isEqualTo(1_700_000_000_000L + 90L * ONE_DAY_MS + ONE_HOUR_MS);
+            });
+        }
+
+        @Test
+        void should_return_empty_when_no_buckets_given() throws TechnicalException {
+            var result = service.findExpiringSubscriptions(Instant.now(), List.of(), ONE_HOUR_MS, List.of(SubscriptionStatus.ACCEPTED));
+            assertThat(result).isEmpty();
+            verify(subscriptionRepository, org.mockito.Mockito.never()).searchUnordered(any());
         }
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-subscription-pre-expiration-notif/src/main/java/io/gravitee/rest/api/services/subscriptionpreexpirationnotif/ScheduledSubscriptionPreExpirationNotificationService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-subscription-pre-expiration-notif/src/main/java/io/gravitee/rest/api/services/subscriptionpreexpirationnotif/ScheduledSubscriptionPreExpirationNotificationService.java
@@ -16,13 +16,13 @@
 package io.gravitee.rest.api.services.subscriptionpreexpirationnotif;
 
 import com.google.common.annotations.VisibleForTesting;
+import io.gravitee.apim.core.subscription.model.ExpiringSubscription;
+import io.gravitee.apim.core.subscription.query_service.SubscriptionQueryService;
 import io.gravitee.common.service.AbstractService;
 import io.gravitee.rest.api.model.ApiKeyEntity;
 import io.gravitee.rest.api.model.ApplicationEntity;
-import io.gravitee.rest.api.model.SubscriptionEntity;
 import io.gravitee.rest.api.model.SubscriptionStatus;
 import io.gravitee.rest.api.model.key.ApiKeyQuery;
-import io.gravitee.rest.api.model.subscription.SubscriptionQuery;
 import io.gravitee.rest.api.model.v4.api.GenericApiEntity;
 import io.gravitee.rest.api.model.v4.plan.GenericPlanEntity;
 import io.gravitee.rest.api.service.ApiKeyService;
@@ -33,17 +33,18 @@ import io.gravitee.rest.api.service.SubscriptionService;
 import io.gravitee.rest.api.service.UserService;
 import io.gravitee.rest.api.service.builder.EmailNotificationBuilder;
 import io.gravitee.rest.api.service.common.GraviteeContext;
-import io.gravitee.rest.api.service.common.ReferenceContext;
 import io.gravitee.rest.api.service.notification.NotificationParamsBuilder;
 import io.gravitee.rest.api.service.v4.ApiSearchService;
 import io.gravitee.rest.api.service.v4.PlanSearchService;
 import java.time.Duration;
 import java.time.Instant;
-import java.util.Arrays;
+import java.time.ZonedDateTime;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicLong;
@@ -83,6 +84,9 @@ public class ScheduledSubscriptionPreExpirationNotificationService extends Abstr
     private SubscriptionService subscriptionService;
 
     @Autowired
+    private SubscriptionQueryService subscriptionQueryService;
+
+    @Autowired
     private UserService userService;
 
     @Autowired
@@ -119,13 +123,47 @@ public class ScheduledSubscriptionPreExpirationNotificationService extends Abstr
         log.debug("Subscription Pre Expiration Notification #{} started at {}", counter.incrementAndGet(), Instant.now().toString());
 
         Instant now = Instant.now();
+        Map<Integer, List<ExpiringSubscription>> subscriptionsByBucket = bucketExpiringSubscriptions(now);
 
-        notificationDays.forEach(daysToExpiration -> {
-            Set<String> notifiedSubscriptionIds = notifySubscriptionsExpirations(now, daysToExpiration);
+        // Iterate buckets in descending day order. Within a single tick this only affects ordering of side-effects,
+        // since windows are disjoint (1h cron slot vs day-granularity offsets). Across ticks it keeps the
+        // daysToExpirationOnLastNotification idempotency filter monotonic: a later tick covering a smaller D
+        // will not overwrite a previous notification with a smaller-than-current value.
+        subscriptionsByBucket.forEach((daysToExpiration, subs) -> {
+            Set<String> notifiedSubscriptionIds = notifySubscriptionsExpirations(daysToExpiration, subs);
             notifyApiKeysExpirations(now, daysToExpiration, notifiedSubscriptionIds);
         });
 
         log.debug("Subscription Pre Expiration Notification #{} ended at {}", counter.get(), Instant.now().toString());
+    }
+
+    @VisibleForTesting
+    Map<Integer, List<ExpiringSubscription>> bucketExpiringSubscriptions(Instant now) {
+        List<ExpiringSubscription> expiring = subscriptionQueryService.findExpiringSubscriptions(
+            now,
+            notificationDays,
+            cronPeriodInMs,
+            List.of(SubscriptionStatus.ACCEPTED, SubscriptionStatus.PAUSED)
+        );
+        Map<Integer, List<ExpiringSubscription>> buckets = new LinkedHashMap<>();
+        long oneDayMs = Duration.ofDays(1).toMillis();
+        for (Integer d : notificationDays) {
+            long lo = now.toEpochMilli() + d * oneDayMs;
+            long hi = lo + cronPeriodInMs;
+            List<ExpiringSubscription> inBucket = expiring
+                .stream()
+                .filter(s -> {
+                    ZonedDateTime ending = s.endingAt();
+                    if (ending == null) {
+                        return false;
+                    }
+                    long endingMs = ending.toInstant().toEpochMilli();
+                    return endingMs >= lo && endingMs < hi;
+                })
+                .toList();
+            buckets.put(d, inBucket);
+        }
+        return buckets;
     }
 
     private void notifyApiKeysExpirations(Instant now, Integer daysToExpiration, Set<String> notifiedSubscriptionIds) {
@@ -158,7 +196,7 @@ public class ScheduledSubscriptionPreExpirationNotificationService extends Abstr
                 );
                 GenericPlanEntity plan = planSearchService.findById(GraviteeContext.getExecutionContext(), subscription.getPlan());
 
-                findEmailsToNotify(subscription, application).forEach(email ->
+                findEmailsToNotify(subscription.getSubscribedBy(), application).forEach(email ->
                     this.sendEmail(email, daysToExpiration, api, plan, application, apiKey)
                 );
             });
@@ -166,32 +204,31 @@ public class ScheduledSubscriptionPreExpirationNotificationService extends Abstr
         apiKeyService.updateDaysToExpirationOnLastNotification(GraviteeContext.getExecutionContext(), apiKey, daysToExpiration);
     }
 
-    private Set<String> notifySubscriptionsExpirations(Instant now, Integer daysToExpiration) {
-        Collection<SubscriptionEntity> subscriptionExpirationsToNotify = findSubscriptionExpirationsToNotify(now, daysToExpiration);
-
-        findSubscriptionExpirationsToNotify(now, daysToExpiration)
+    private Set<String> notifySubscriptionsExpirations(Integer daysToExpiration, List<ExpiringSubscription> subscriptions) {
+        subscriptions
             .stream()
             .filter(
-                subscription -> // Remove the ones for which an email has already been sent (could happen in case of restart or concurrent processing with multiple instance of APIM)
-                    subscription.getDaysToExpirationOnLastNotification() == null ||
-                    subscription.getDaysToExpirationOnLastNotification() > daysToExpiration
+                // Remove the ones for which an email has already been sent (could happen in case of restart or concurrent processing with multiple instance of APIM)
+                subscription ->
+                    subscription.daysToExpirationOnLastNotification() == null ||
+                    subscription.daysToExpirationOnLastNotification() > daysToExpiration
             )
             .forEach(subscription -> notifySubscriptionExpiration(daysToExpiration, subscription));
 
-        return subscriptionExpirationsToNotify.stream().map(SubscriptionEntity::getId).collect(Collectors.toSet());
+        return subscriptions.stream().map(ExpiringSubscription::id).collect(Collectors.toSet());
     }
 
-    private void notifySubscriptionExpiration(Integer daysToExpiration, SubscriptionEntity subscription) {
-        GenericApiEntity api = apiSearchService.findById(GraviteeContext.getExecutionContext(), subscription.getApi());
-        GenericPlanEntity plan = planSearchService.findById(GraviteeContext.getExecutionContext(), subscription.getPlan());
+    private void notifySubscriptionExpiration(Integer daysToExpiration, ExpiringSubscription subscription) {
+        GenericApiEntity api = apiSearchService.findById(GraviteeContext.getExecutionContext(), subscription.apiId());
+        GenericPlanEntity plan = planSearchService.findById(GraviteeContext.getExecutionContext(), subscription.planId());
 
-        ApplicationEntity application = applicationService.findById(GraviteeContext.getExecutionContext(), subscription.getApplication());
+        ApplicationEntity application = applicationService.findById(GraviteeContext.getExecutionContext(), subscription.applicationId());
 
-        findEmailsToNotify(subscription, application).forEach(email ->
+        findEmailsToNotify(subscription.subscribedBy(), application).forEach(email ->
             this.sendEmail(email, daysToExpiration, api, plan, application, null)
         );
 
-        subscriptionService.updateDaysToExpirationOnLastNotification(subscription.getId(), daysToExpiration);
+        subscriptionService.updateDaysToExpirationOnLastNotification(subscription.id(), daysToExpiration);
     }
 
     @VisibleForTesting
@@ -219,18 +256,6 @@ public class ScheduledSubscriptionPreExpirationNotificationService extends Abstr
     }
 
     @VisibleForTesting
-    Collection<SubscriptionEntity> findSubscriptionExpirationsToNotify(Instant now, Integer daysToExpiration) {
-        long expirationStartingTime = now.plus(Duration.ofDays((long) daysToExpiration)).getEpochSecond() * 1000;
-
-        SubscriptionQuery query = new SubscriptionQuery();
-        query.setStatuses(Arrays.asList(SubscriptionStatus.ACCEPTED, SubscriptionStatus.PAUSED));
-        query.setEndingAtAfter(expirationStartingTime);
-        query.setEndingAtBefore(expirationStartingTime + cronPeriodInMs);
-
-        return subscriptionService.search(GraviteeContext.getExecutionContext(), query);
-    }
-
-    @VisibleForTesting
     Collection<ApiKeyEntity> findApiKeyExpirationsToNotify(Instant now, Integer daysToExpiration) {
         long expirationStartingTime = now.plus(Duration.ofDays((long) daysToExpiration)).getEpochSecond() * 1000;
 
@@ -244,9 +269,9 @@ public class ScheduledSubscriptionPreExpirationNotificationService extends Abstr
     }
 
     @VisibleForTesting
-    Set<String> findEmailsToNotify(SubscriptionEntity subscription, ApplicationEntity application) {
+    Set<String> findEmailsToNotify(String subscribedBy, ApplicationEntity application) {
         Set<String> emails = new HashSet<>();
-        emails.add(userService.findById(GraviteeContext.getExecutionContext(), subscription.getSubscribedBy()).getEmail());
+        emails.add(userService.findById(GraviteeContext.getExecutionContext(), subscribedBy).getEmail());
         emails.add(application.getPrimaryOwner().getEmail());
 
         // Email can be null, in that case we can't send a notification so just remove it

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-subscription-pre-expiration-notif/src/test/java/io/gravitee/rest/api/services/subscriptionpreexpirationnotif/ScheduledSubscriptionPreExpirationNotificationServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-subscription-pre-expiration-notif/src/test/java/io/gravitee/rest/api/services/subscriptionpreexpirationnotif/ScheduledSubscriptionPreExpirationNotificationServiceTest.java
@@ -16,16 +16,26 @@
 package io.gravitee.rest.api.services.subscriptionpreexpirationnotif;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.*;
 
+import io.gravitee.apim.core.subscription.model.ExpiringSubscription;
+import io.gravitee.apim.core.subscription.query_service.SubscriptionQueryService;
 import io.gravitee.rest.api.model.*;
 import io.gravitee.rest.api.model.api.ApiEntity;
 import io.gravitee.rest.api.model.key.ApiKeyQuery;
-import io.gravitee.rest.api.model.subscription.SubscriptionQuery;
 import io.gravitee.rest.api.service.*;
 import io.gravitee.rest.api.service.builder.EmailNotificationBuilder;
 import io.gravitee.rest.api.service.common.GraviteeContext;
+import io.gravitee.rest.api.service.v4.ApiSearchService;
+import io.gravitee.rest.api.service.v4.PlanSearchService;
+import java.lang.reflect.Field;
 import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 import java.util.*;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -46,10 +56,22 @@ class ScheduledSubscriptionPreExpirationNotificationServiceTest {
     SubscriptionService subscriptionService;
 
     @Mock
+    SubscriptionQueryService subscriptionQueryService;
+
+    @Mock
     ApiKeyService apiKeyService;
 
     @Mock
     EmailService emailService;
+
+    @Mock
+    ApiSearchService apiSearchService;
+
+    @Mock
+    PlanSearchService planSearchService;
+
+    @Mock
+    ApplicationService applicationService;
 
     @Test
     void shouldCleanNotificationDays() {
@@ -60,33 +82,80 @@ class ScheduledSubscriptionPreExpirationNotificationServiceTest {
     }
 
     @Test
-    void shouldFindSubscriptionExpirationsToNotify() {
-        Instant now = Instant.ofEpochMilli(1469022010000L);
-        Integer daysBeforeNotification = 10;
+    void shouldQueryExpiringSubscriptionsOnceRegardlessOfScheduleLength() throws Exception {
+        setNotificationDays(List.of(90, 45, 30));
+        when(subscriptionQueryService.findExpiringSubscriptions(any(Instant.class), anyList(), anyLong(), anyList())).thenReturn(List.of());
 
-        SubscriptionEntity subscription = mock(SubscriptionEntity.class);
+        service.run();
 
-        when(subscriptionService.search(eq(GraviteeContext.getExecutionContext()), any(SubscriptionQuery.class))).thenReturn(
-            Collections.singletonList(subscription)
+        verify(subscriptionQueryService, times(1)).findExpiringSubscriptions(
+            any(Instant.class),
+            eq(List.of(90, 45, 30)),
+            anyLong(),
+            eq(List.of(SubscriptionStatus.ACCEPTED, SubscriptionStatus.PAUSED))
+        );
+    }
+
+    @Test
+    void shouldBucketSubscriptionsByLargestMatchingDay() throws Exception {
+        setNotificationDays(List.of(90, 45, 30));
+
+        // run() uses Instant.now() internally — build endingAts relative to wall clock so they land in the cron-hour window.
+        ZonedDateTime ending30 = ZonedDateTime.now().plusDays(30).plusMinutes(5);
+        ZonedDateTime ending45 = ZonedDateTime.now().plusDays(45).plusMinutes(5);
+        ZonedDateTime ending90 = ZonedDateTime.now().plusDays(90).plusMinutes(5);
+
+        ExpiringSubscription sub30 = new ExpiringSubscription("s30", "api1", "plan1", "app1", "user1", ending30, null);
+        ExpiringSubscription sub45 = new ExpiringSubscription("s45", "api1", "plan1", "app1", "user1", ending45, null);
+        ExpiringSubscription sub90 = new ExpiringSubscription("s90", "api1", "plan1", "app1", "user1", ending90, null);
+
+        when(subscriptionQueryService.findExpiringSubscriptions(any(Instant.class), anyList(), anyLong(), anyList())).thenReturn(
+            List.of(sub30, sub45, sub90)
         );
 
-        Collection<SubscriptionEntity> subscriptionsToNotify = service.findSubscriptionExpirationsToNotify(now, daysBeforeNotification);
+        when(userService.findById(eq(GraviteeContext.getExecutionContext()), eq("user1"))).thenReturn(mock(UserEntity.class));
+        ApplicationEntity app = mock(ApplicationEntity.class);
+        when(app.getPrimaryOwner()).thenReturn(mock(PrimaryOwnerEntity.class));
+        when(applicationService.findById(any(), eq("app1"))).thenReturn(app);
 
-        assertThat(subscriptionsToNotify).isEqualTo(Collections.singletonList(subscription));
+        service.run();
 
-        verify(subscriptionService, times(1)).search(
-            eq(GraviteeContext.getExecutionContext()),
-            argThat(
-                subscriptionQuery ->
-                    Arrays.asList(SubscriptionStatus.ACCEPTED, SubscriptionStatus.PAUSED).equals(subscriptionQuery.getStatuses()) &&
-                    // 1469886010000 -> now + 10 days
-                    subscriptionQuery.getEndingAtAfter() ==
-                    1469886010000L &&
-                    // 1469889610000 -> now + 10 days + 1h (cron period)
-                    subscriptionQuery.getEndingAtBefore() ==
-                    1469889610000L
-            )
+        verify(subscriptionService, times(1)).updateDaysToExpirationOnLastNotification("s30", 30);
+        verify(subscriptionService, times(1)).updateDaysToExpirationOnLastNotification("s45", 45);
+        verify(subscriptionService, times(1)).updateDaysToExpirationOnLastNotification("s90", 90);
+        verify(subscriptionService, times(3)).updateDaysToExpirationOnLastNotification(anyString(), anyInt());
+    }
+
+    @Test
+    void bucketingIsInclusiveAtLowerBoundExclusiveAtUpperBound() throws Exception {
+        setNotificationDays(List.of(30));
+
+        Instant now = Instant.ofEpochMilli(1_700_000_000_000L);
+        long oneDay = 24L * 60L * 60L * 1000L;
+        long oneHour = 60L * 60L * 1000L;
+        ZonedDateTime atLo = Instant.ofEpochMilli(now.toEpochMilli() + 30 * oneDay).atZone(ZoneOffset.UTC);
+        ZonedDateTime justInsideHi = Instant.ofEpochMilli(now.toEpochMilli() + 30 * oneDay + oneHour - 1).atZone(ZoneOffset.UTC);
+        ZonedDateTime atHi = Instant.ofEpochMilli(now.toEpochMilli() + 30 * oneDay + oneHour).atZone(ZoneOffset.UTC);
+        ZonedDateTime justBeforeLo = Instant.ofEpochMilli(now.toEpochMilli() + 30 * oneDay - 1).atZone(ZoneOffset.UTC);
+
+        ExpiringSubscription subAtLo = new ExpiringSubscription("at-lo", "a", "p", "ap", "u", atLo, null);
+        ExpiringSubscription subJustInsideHi = new ExpiringSubscription("just-inside-hi", "a", "p", "ap", "u", justInsideHi, null);
+        ExpiringSubscription subAtHi = new ExpiringSubscription("at-hi", "a", "p", "ap", "u", atHi, null);
+        ExpiringSubscription subJustBeforeLo = new ExpiringSubscription("just-before-lo", "a", "p", "ap", "u", justBeforeLo, null);
+
+        when(subscriptionQueryService.findExpiringSubscriptions(eq(now), anyList(), anyLong(), anyList())).thenReturn(
+            List.of(subAtLo, subJustInsideHi, subAtHi, subJustBeforeLo)
         );
+
+        var buckets = service.bucketExpiringSubscriptions(now);
+
+        assertThat(buckets.get(30)).extracting(ExpiringSubscription::id).containsExactly("at-lo", "just-inside-hi");
+    }
+
+    private void setNotificationDays(List<Integer> days) throws Exception {
+        Field f = ScheduledSubscriptionPreExpirationNotificationService.class.getDeclaredField("notificationDays");
+        f.setAccessible(true);
+        f.set(service, days);
     }
 
     @Test
@@ -94,9 +163,6 @@ class ScheduledSubscriptionPreExpirationNotificationServiceTest {
         String subscriberId = UUID.randomUUID().toString();
         UserEntity subscriber = mock(UserEntity.class);
         when(subscriber.getEmail()).thenReturn("subscriber@gravitee.io");
-
-        SubscriptionEntity subscription = mock(SubscriptionEntity.class);
-        when(subscription.getSubscribedBy()).thenReturn(subscriberId);
 
         when(userService.findById(GraviteeContext.getExecutionContext(), subscriberId)).thenReturn(subscriber);
 
@@ -106,7 +172,7 @@ class ScheduledSubscriptionPreExpirationNotificationServiceTest {
         ApplicationEntity application = mock(ApplicationEntity.class);
         when(application.getPrimaryOwner()).thenReturn(primaryOwner);
 
-        Collection<String> usersToNotify = service.findEmailsToNotify(subscription, application);
+        Collection<String> usersToNotify = service.findEmailsToNotify(subscriberId, application);
 
         Set<String> expected = new HashSet<>();
         expected.add("subscriber@gravitee.io");
@@ -120,9 +186,6 @@ class ScheduledSubscriptionPreExpirationNotificationServiceTest {
         UserEntity subscriber = mock(UserEntity.class);
         when(subscriber.getEmail()).thenReturn("primary_owner@gravitee.io");
 
-        SubscriptionEntity subscription = mock(SubscriptionEntity.class);
-        when(subscription.getSubscribedBy()).thenReturn(subscriberId);
-
         when(userService.findById(GraviteeContext.getExecutionContext(), subscriberId)).thenReturn(subscriber);
 
         PrimaryOwnerEntity primaryOwner = mock(PrimaryOwnerEntity.class);
@@ -131,7 +194,7 @@ class ScheduledSubscriptionPreExpirationNotificationServiceTest {
         ApplicationEntity application = mock(ApplicationEntity.class);
         when(application.getPrimaryOwner()).thenReturn(primaryOwner);
 
-        Collection<String> usersToNotify = service.findEmailsToNotify(subscription, application);
+        Collection<String> usersToNotify = service.findEmailsToNotify(subscriberId, application);
 
         Set<String> expected = new HashSet<>();
         expected.add("primary_owner@gravitee.io");


### PR DESCRIPTION
## Summary

- Adds ESR-correct `{status:1, endingAt:1}` index on `subscriptions` so the cron-driven `endingAt` range queries can use an index-range scan instead of walking all `status:ACCEPTED` rows in `createdAt` order.
- Collapses the pre-expiration scheduler's per-`notification-schedule` queries (default `90,45,30` → 3 calls/hr) into one outer-range query per cron tick, with bucket-inference in the scheduler.
- Adds `SubscriptionRepository.searchUnordered(criteria)` so scheduler queries can opt out of the implicit `createdAt desc` default sort (the ESR violator). Migrates `findExpiredSubscriptions` to it as well.
- Fixes a doubled-call bug in `notifySubscriptionsExpirations` (the search was invoked twice per `notificationDays` iteration).

## Test plan

- [x] Unit tests: scheduler single-call invariant + bucket-by-largest-matching-day + doubled-call regression (`times(3)` strict count). 7/7.
- [x] Repo integration tests: `searchUnordered` set-equivalence against real Mongo and JDBC (H2). 45/45 + 45/45.
- [x] `SubscriptionQueryServiceImpl` tests updated for `searchUnordered` migration. 16/16.
- [x] Smoke: real mAPI — `s1ea1` index visible at startup via `db.subscriptions.getIndexes()`, scheduler bean wired, no startup errors.
- [ ] CI: full repo suite (mongo + jdbc-* matrix).

## Risk

Existing callers that implicitly relied on `createdAt desc` ordering without passing a `Sortable` — survey indicates none, but flagging.

## Follow-up

- APIM-14132 — same fix for the ApiKey side of the cron tick.

Refs APIM-14086.