### PR TITLE
Apim 14018 multiple pages and ap is with same name cannot be added to new portal

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_11_2/00_drop_portal_navigation_items_title_unique_constraint.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_11_2/00_drop_portal_navigation_items_title_unique_constraint.yml
@@ -1,0 +1,13 @@
+databaseChangeLog:
+  - changeSet:
+      id: 4.11.2_00_drop_portal_navigation_items_title_unique_constraint
+      author: GraviteeSource Team
+      preConditions:
+        - onFail: MARK_RAN
+        - uniqueConstraintExists:
+            constraintName: uk_${gravitee_prefix}portal_navigation_items_org_env_title
+            tableName: ${gravitee_prefix}portal_navigation_items
+      changes:
+        - dropUniqueConstraint:
+            constraintName: uk_${gravitee_prefix}portal_navigation_items_org_env_title
+            tableName: ${gravitee_prefix}portal_navigation_items

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/master.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/master.yml
@@ -328,3 +328,5 @@ databaseChangeLog:
         - file: liquibase/changelogs/v4_11_1/00_add_validation_constraints_to_subscription_forms.yml
     - include:
         - file: liquibase/changelogs/v4_11_1/01_add_apis_environment_id_updated_at_index.yml
+    - include:
+        - file: liquibase/changelogs/v4_11_2/00_drop_portal_navigation_items_title_unique_constraint.yml

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/PortalNavigationItemRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/PortalNavigationItemRepositoryTest.java
@@ -601,4 +601,106 @@ public class PortalNavigationItemRepositoryTest extends AbstractManagementReposi
 
         assertThat(items).isEmpty();
     }
+
+    @Test
+    public void should_allow_duplicate_page_titles_for_same_organization_and_environment() throws Exception {
+        String sharedTitle = "Shared Page Title";
+
+        PortalNavigationItem firstPage = PortalNavigationItem.builder()
+            .id("duplicate-title-page-1")
+            .organizationId("org-1")
+            .environmentId("env-duplicate-title")
+            .title(sharedTitle)
+            .type(PortalNavigationItem.Type.PAGE)
+            .area(PortalNavigationItem.Area.TOP_NAVBAR)
+            .order(1)
+            .published(true)
+            .configuration("{ \"portalPageContentId\": \"880e8400-e29b-41d4-a716-446655440003\" }")
+            .visibility(PortalNavigationItem.Visibility.PUBLIC)
+            .rootId("duplicate-title-page-1")
+            .build();
+
+        PortalNavigationItem secondPage = PortalNavigationItem.builder()
+            .id("duplicate-title-page-2")
+            .organizationId("org-1")
+            .environmentId("env-duplicate-title")
+            .title(sharedTitle)
+            .type(PortalNavigationItem.Type.PAGE)
+            .area(PortalNavigationItem.Area.TOP_NAVBAR)
+            .order(2)
+            .published(true)
+            .configuration("{ \"portalPageContentId\": \"990e8400-e29b-41d4-a716-446655440004\" }")
+            .visibility(PortalNavigationItem.Visibility.PUBLIC)
+            .rootId("duplicate-title-page-2")
+            .build();
+
+        try {
+            portalNavigationItemRepository.create(firstPage);
+            portalNavigationItemRepository.create(secondPage);
+
+            var firstFound = portalNavigationItemRepository.findById("duplicate-title-page-1");
+            var secondFound = portalNavigationItemRepository.findById("duplicate-title-page-2");
+
+            assertThat(firstFound).isPresent();
+            assertThat(secondFound).isPresent();
+            assertThat(firstFound.get().getTitle()).isEqualTo(sharedTitle);
+            assertThat(secondFound.get().getTitle()).isEqualTo(sharedTitle);
+        } finally {
+            portalNavigationItemRepository.delete("duplicate-title-page-1");
+            portalNavigationItemRepository.delete("duplicate-title-page-2");
+        }
+    }
+
+    @Test
+    public void should_allow_duplicate_api_titles_for_same_organization_and_environment() throws Exception {
+        String sharedTitle = "Shared API Name";
+
+        PortalNavigationItem firstApi = PortalNavigationItem.builder()
+            .id("duplicate-title-api-1")
+            .organizationId("org-1")
+            .environmentId("env-duplicate-api-title")
+            .title(sharedTitle)
+            .type(PortalNavigationItem.Type.API)
+            .apiId("api-duplicate-title-1")
+            .area(PortalNavigationItem.Area.TOP_NAVBAR)
+            .order(1)
+            .published(true)
+            .configuration("{}")
+            .visibility(PortalNavigationItem.Visibility.PUBLIC)
+            .rootId("duplicate-title-api-1")
+            .build();
+
+        PortalNavigationItem secondApi = PortalNavigationItem.builder()
+            .id("duplicate-title-api-2")
+            .organizationId("org-1")
+            .environmentId("env-duplicate-api-title")
+            .title(sharedTitle)
+            .type(PortalNavigationItem.Type.API)
+            .apiId("api-duplicate-title-2")
+            .area(PortalNavigationItem.Area.TOP_NAVBAR)
+            .order(2)
+            .published(true)
+            .configuration("{}")
+            .visibility(PortalNavigationItem.Visibility.PUBLIC)
+            .rootId("duplicate-title-api-2")
+            .build();
+
+        try {
+            portalNavigationItemRepository.create(firstApi);
+            portalNavigationItemRepository.create(secondApi);
+
+            var firstFound = portalNavigationItemRepository.findById("duplicate-title-api-1");
+            var secondFound = portalNavigationItemRepository.findById("duplicate-title-api-2");
+
+            assertThat(firstFound).isPresent();
+            assertThat(secondFound).isPresent();
+            assertThat(firstFound.get().getTitle()).isEqualTo(sharedTitle);
+            assertThat(secondFound.get().getTitle()).isEqualTo(sharedTitle);
+            assertThat(firstFound.get().getApiId()).isEqualTo("api-duplicate-title-1");
+            assertThat(secondFound.get().getApiId()).isEqualTo("api-duplicate-title-2");
+        } finally {
+            portalNavigationItemRepository.delete("duplicate-title-api-1");
+            portalNavigationItemRepository.delete("duplicate-title-api-2");
+        }
+    }
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-14018

## Description

JDBC no longer enforces unique portal navigation titles per org/env, aligned with MongoDB and existing domain validation.

Liquibase migration

- Added v4_12_0/09_drop_portal_navigation_items_title_unique_constraint.yml to drop uk_${gravitee_prefix}portal_navigation_items_org_env_title, with a uniqueConstraintExists precondition and onFail: MARK_RAN so environments without the constraint skip safely.
- Registered in liquibase/master.yml after the other v4_12_0 changes.
- The original v4_10_0/02_add_portal_navigation_items_table.yml is unchanged (stable checksums for upgrades).

Repository tests

- Extended PortalNavigationItemRepositoryTest with:
        - should_allow_duplicate_page_titles_for_same_organization_and_environment — two PAGE items, same org/env/title, different ids
        - should_allow_duplicate_api_titles_for_same_organization_and_environment — two API items, same title, different apiId values

https://github.com/user-attachments/assets/2fa39bb5-403b-4860-a931-93dfd16678cd

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

