### PR TITLE
feat(repository): drop unique constraint on portal navigation item ti…

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_11_8/00_drop_portal_navigation_items_title_unique_constraint.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_11_8/00_drop_portal_navigation_items_title_unique_constraint.yml
@@ -1,0 +1,13 @@
+databaseChangeLog:
+  - changeSet:
+      id: 4.11.8_00_drop_portal_navigation_items_title_unique_constraint
+      author: GraviteeSource Team
+      preConditions:
+        - onFail: MARK_RAN
+        - uniqueConstraintExists:
+            constraintName: uk_${gravitee_prefix}portal_navigation_items_org_env_title
+            tableName: ${gravitee_prefix}portal_navigation_items
+      changes:
+        - dropUniqueConstraint:
+            constraintName: uk_${gravitee_prefix}portal_navigation_items_org_env_title
+            tableName: ${gravitee_prefix}portal_navigation_items

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/master.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/master.yml
@@ -328,3 +328,5 @@ databaseChangeLog:
         - file: liquibase/changelogs/v4_11_1/00_add_validation_constraints_to_subscription_forms.yml
     - include:
         - file: liquibase/changelogs/v4_11_1/01_add_apis_environment_id_updated_at_index.yml
+    - include:
+        - file: liquibase/changelogs/v4_11_8/00_drop_portal_navigation_items_title_unique_constraint.yml

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/PortalNavigationItemRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/PortalNavigationItemRepositoryTest.java
@@ -601,4 +601,106 @@ public class PortalNavigationItemRepositoryTest extends AbstractManagementReposi
 
         assertThat(items).isEmpty();
     }
+
+    @Test
+    public void should_allow_duplicate_page_titles_for_same_organization_and_environment() throws Exception {
+        String sharedTitle = "Shared Page Title";
+
+        PortalNavigationItem firstPage = PortalNavigationItem.builder()
+            .id("duplicate-title-page-1")
+            .organizationId("org-1")
+            .environmentId("env-duplicate-title")
+            .title(sharedTitle)
+            .type(PortalNavigationItem.Type.PAGE)
+            .area(PortalNavigationItem.Area.TOP_NAVBAR)
+            .order(1)
+            .published(true)
+            .configuration("{ \"portalPageContentId\": \"880e8400-e29b-41d4-a716-446655440003\" }")
+            .visibility(PortalNavigationItem.Visibility.PUBLIC)
+            .rootId("duplicate-title-page-1")
+            .build();
+
+        PortalNavigationItem secondPage = PortalNavigationItem.builder()
+            .id("duplicate-title-page-2")
+            .organizationId("org-1")
+            .environmentId("env-duplicate-title")
+            .title(sharedTitle)
+            .type(PortalNavigationItem.Type.PAGE)
+            .area(PortalNavigationItem.Area.TOP_NAVBAR)
+            .order(2)
+            .published(true)
+            .configuration("{ \"portalPageContentId\": \"990e8400-e29b-41d4-a716-446655440004\" }")
+            .visibility(PortalNavigationItem.Visibility.PUBLIC)
+            .rootId("duplicate-title-page-2")
+            .build();
+
+        try {
+            portalNavigationItemRepository.create(firstPage);
+            portalNavigationItemRepository.create(secondPage);
+
+            var firstFound = portalNavigationItemRepository.findById("duplicate-title-page-1");
+            var secondFound = portalNavigationItemRepository.findById("duplicate-title-page-2");
+
+            assertThat(firstFound).isPresent();
+            assertThat(secondFound).isPresent();
+            assertThat(firstFound.get().getTitle()).isEqualTo(sharedTitle);
+            assertThat(secondFound.get().getTitle()).isEqualTo(sharedTitle);
+        } finally {
+            portalNavigationItemRepository.delete("duplicate-title-page-1");
+            portalNavigationItemRepository.delete("duplicate-title-page-2");
+        }
+    }
+
+    @Test
+    public void should_allow_duplicate_api_titles_for_same_organization_and_environment() throws Exception {
+        String sharedTitle = "Shared API Name";
+
+        PortalNavigationItem firstApi = PortalNavigationItem.builder()
+            .id("duplicate-title-api-1")
+            .organizationId("org-1")
+            .environmentId("env-duplicate-api-title")
+            .title(sharedTitle)
+            .type(PortalNavigationItem.Type.API)
+            .apiId("api-duplicate-title-1")
+            .area(PortalNavigationItem.Area.TOP_NAVBAR)
+            .order(1)
+            .published(true)
+            .configuration("{}")
+            .visibility(PortalNavigationItem.Visibility.PUBLIC)
+            .rootId("duplicate-title-api-1")
+            .build();
+
+        PortalNavigationItem secondApi = PortalNavigationItem.builder()
+            .id("duplicate-title-api-2")
+            .organizationId("org-1")
+            .environmentId("env-duplicate-api-title")
+            .title(sharedTitle)
+            .type(PortalNavigationItem.Type.API)
+            .apiId("api-duplicate-title-2")
+            .area(PortalNavigationItem.Area.TOP_NAVBAR)
+            .order(2)
+            .published(true)
+            .configuration("{}")
+            .visibility(PortalNavigationItem.Visibility.PUBLIC)
+            .rootId("duplicate-title-api-2")
+            .build();
+
+        try {
+            portalNavigationItemRepository.create(firstApi);
+            portalNavigationItemRepository.create(secondApi);
+
+            var firstFound = portalNavigationItemRepository.findById("duplicate-title-api-1");
+            var secondFound = portalNavigationItemRepository.findById("duplicate-title-api-2");
+
+            assertThat(firstFound).isPresent();
+            assertThat(secondFound).isPresent();
+            assertThat(firstFound.get().getTitle()).isEqualTo(sharedTitle);
+            assertThat(secondFound.get().getTitle()).isEqualTo(sharedTitle);
+            assertThat(firstFound.get().getApiId()).isEqualTo("api-duplicate-title-1");
+            assertThat(secondFound.get().getApiId()).isEqualTo("api-duplicate-title-2");
+        } finally {
+            portalNavigationItemRepository.delete("duplicate-title-api-1");
+            portalNavigationItemRepository.delete("duplicate-title-api-2");
+        }
+    }
 }


### PR DESCRIPTION
…tles

Remove the unique constraint on portal navigation item titles to allow duplicate titles within the same organization and environment. Includes migration script and test updates.

## Issue

https://gravitee.atlassian.net/browse/APIM-14018

JDBC no longer enforces unique portal navigation titles per org/env, aligned with MongoDB and the existing domain-level validation. Multiple pages or APIs with the same display name can now coexist in the same organization/environment as long as they have distinct ids (and, for APIs, distinct `apiId` values).
### Liquibase migration
- Added `liquibase/changelogs/v4_11_8/00_drop_portal_navigation_items_title_unique_constraint.yml` (change set id `4.11.8_00_drop_portal_navigation_items_title_unique_constraint`).
- The change set drops `uk_${gravitee_prefix}portal_navigation_items_org_env_title` on `${gravitee_prefix}portal_navigation_items`.
- Guarded by a `uniqueConstraintExists` precondition with `onFail: MARK_RAN`, so environments that don’t have the constraint (e.g. fresh installs running master.yml end-to-end after this change, or anyone who already dropped it manually) skip it cleanly.
- Registered in `liquibase/master.yml` after the existing `v4_11_1` entries (next free slot on the 4.11.x line; current snapshot is `4.11.8-SNAPSHOT`).
- The original `v4_10_0/02_add_portal_navigation_items_table.yml` is intentionally left unchanged so existing checksums stay stable on upgraded environments.
### Repository tests
Extended `PortalNavigationItemRepositoryTest` in `gravitee-apim-repository-test` (so all repository implementations exercise it) with:
- `should_allow_duplicate_page_titles_for_same_organization_and_environment` — two PAGE items, same org/env/title, different ids.
- `should_allow_duplicate_api_titles_for_same_organization_and_environment` — two API items, same org/env/title, different ids and different `apiId` values.
## Target version
This PR targets the `4.11.x` branch. `pom.xml` is currently at `4.11.8-SNAPSHOT` (latest released tag on this line is `4.11.7`), which is why the change set lives under `v4_11_8/` and the change set id is prefixed `4.11.8_`. A separate forward-port to master (`v4_12_0/`) will follow if needed.

https://github.com/user-attachments/assets/2fa39bb5-403b-4860-a931-93dfd16678cd

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

