### PR TITLE
feat(service): implement AcceptUserInvitationUseCase in onion arch…

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/mapper/ApplicationInvitationMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/mapper/ApplicationInvitationMapper.java
@@ -16,7 +16,7 @@
 package io.gravitee.rest.api.portal.rest.mapper;
 
 import io.gravitee.apim.core.invitation.model.ApplicationInvitation;
-import io.gravitee.apim.core.invitation.model.ApplicationInvitationId;
+import io.gravitee.apim.core.invitation.model.InvitationId;
 import io.gravitee.rest.api.portal.rest.model.Invitation;
 import java.time.OffsetDateTime;
 import java.time.ZonedDateTime;
@@ -34,7 +34,7 @@ public interface ApplicationInvitationMapper {
 
     List<Invitation> toInvitation(List<ApplicationInvitation> invitations);
 
-    default String map(ApplicationInvitationId id) {
+    default String map(InvitationId id) {
         return id.toString();
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/mapper/ApplicationInvitationMapperTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/mapper/ApplicationInvitationMapperTest.java
@@ -18,7 +18,7 @@ package io.gravitee.rest.api.portal.rest.mapper;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.gravitee.apim.core.invitation.model.ApplicationInvitation;
-import io.gravitee.apim.core.invitation.model.ApplicationInvitationId;
+import io.gravitee.apim.core.invitation.model.InvitationId;
 import java.time.OffsetDateTime;
 import java.time.ZonedDateTime;
 import org.junit.jupiter.api.Test;
@@ -31,7 +31,7 @@ class ApplicationInvitationMapperTest {
     void should_map_application_invitation_item() {
         var invitationId = "00000000-0000-0000-0000-000000000001";
         var invitationItem = new ApplicationInvitation(
-            ApplicationInvitationId.of(invitationId),
+            InvitationId.of(invitationId),
             "application-id",
             "alice@example.com",
             "USER",

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/ApplicationInvitationsResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/ApplicationInvitationsResourceTest.java
@@ -29,7 +29,7 @@ import inmemory.ApplicationCrudServiceInMemory;
 import inmemory.RoleQueryServiceInMemory;
 import io.gravitee.apim.core.invitation.crud_service.InvitationCrudService;
 import io.gravitee.apim.core.invitation.model.ApplicationInvitation;
-import io.gravitee.apim.core.invitation.model.ApplicationInvitationId;
+import io.gravitee.apim.core.invitation.model.InvitationId;
 import io.gravitee.apim.core.invitation.model.SearchApplicationInvitationsCriteria;
 import io.gravitee.apim.core.invitation.query_service.InvitationQueryService;
 import io.gravitee.apim.core.membership.model.Role;
@@ -253,7 +253,7 @@ class ApplicationInvitationsResourceTest extends AbstractResourceTest {
 
     private ApplicationInvitation anInvitation(String id, String email) {
         return new ApplicationInvitation(
-            ApplicationInvitationId.of(id),
+            InvitationId.of(id),
             APPLICATION,
             email,
             "USER",

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/audit/domain_service/AuditDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/audit/domain_service/AuditDomainService.java
@@ -25,6 +25,7 @@ import io.gravitee.apim.core.audit.model.AuditEntity;
 import io.gravitee.apim.core.audit.model.AuditProperties;
 import io.gravitee.apim.core.audit.model.DashboardAuditLogEntity;
 import io.gravitee.apim.core.audit.model.EnvironmentAuditLogEntity;
+import io.gravitee.apim.core.audit.model.OrganizationAuditLogEntity;
 import io.gravitee.apim.core.json.JsonDiffProcessor;
 import io.gravitee.apim.core.user.crud_service.UserCrudService;
 import io.gravitee.rest.api.service.common.UuidString;
@@ -128,6 +129,26 @@ public class AuditDomainService {
             auditCrudService.create(entity);
         } catch (TechnicalManagementException e) {
             log.error("Error occurs during the creation of an API Product Audit Log.", e);
+        }
+    }
+
+    public void createOrganizationAuditLog(OrganizationAuditLogEntity audit) {
+        try {
+            var entity = AuditEntity.builder()
+                .id(UuidString.generateRandom())
+                .organizationId(audit.organizationId())
+                .createdAt(audit.createdAt())
+                .user(createActor(audit.actor()))
+                .properties(adaptAuditLogProperties(audit.properties()))
+                .referenceType(AuditEntity.AuditReferenceType.ORGANIZATION)
+                .referenceId(audit.organizationId())
+                .event(audit.event().name())
+                .patch(jsonDiffProcessor.diff(audit.oldValue(), audit.newValue()))
+                .build();
+
+            auditCrudService.create(entity);
+        } catch (TechnicalManagementException e) {
+            log.error("Error occurs during the creation of an Organization Audit Log.", e);
         }
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/audit/model/OrganizationAuditLogEntity.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/audit/model/OrganizationAuditLogEntity.java
@@ -13,21 +13,20 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.apim.core.invitation.model;
+package io.gravitee.apim.core.audit.model;
 
-import io.gravitee.common.utils.TimeProvider;
+import io.gravitee.apim.core.audit.model.event.AuditEvent;
 import java.time.ZonedDateTime;
+import java.util.Map;
+import lombok.Builder;
 
-public record ApplicationInvitation(
-    InvitationId id,
-    String applicationId,
-    String email,
-    String roleName,
+@Builder
+public record OrganizationAuditLogEntity(
+    String organizationId,
+    AuditActor actor,
+    Map<AuditProperties, String> properties,
+    AuditEvent event,
     ZonedDateTime createdAt,
-    ZonedDateTime updatedAt
-) implements Invitation {
-    public static ApplicationInvitation create(String applicationId, String email, String roleName) {
-        var now = TimeProvider.now();
-        return new ApplicationInvitation(InvitationId.random(), applicationId, email, roleName, now, now);
-    }
-}
+    Object oldValue,
+    Object newValue
+) {}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/audit/model/event/UserAuditEvent.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/audit/model/event/UserAuditEvent.java
@@ -13,21 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.apim.core.invitation.model;
+package io.gravitee.apim.core.audit.model.event;
 
-import io.gravitee.common.utils.TimeProvider;
-import java.time.ZonedDateTime;
-
-public record ApplicationInvitation(
-    InvitationId id,
-    String applicationId,
-    String email,
-    String roleName,
-    ZonedDateTime createdAt,
-    ZonedDateTime updatedAt
-) implements Invitation {
-    public static ApplicationInvitation create(String applicationId, String email, String roleName) {
-        var now = TimeProvider.now();
-        return new ApplicationInvitation(InvitationId.random(), applicationId, email, roleName, now, now);
-    }
+public enum UserAuditEvent implements AuditEvent {
+    USER_CREATED,
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/invitation/domain_service/AcceptInvitationDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/invitation/domain_service/AcceptInvitationDomainService.java
@@ -13,21 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.apim.core.invitation.crud_service;
+package io.gravitee.apim.core.invitation.domain_service;
 
-import io.gravitee.apim.core.invitation.model.ApplicationInvitation;
 import io.gravitee.apim.core.invitation.model.Invitation;
-import io.gravitee.apim.core.invitation.model.InvitationId;
-import java.util.List;
+import io.gravitee.rest.api.service.common.ExecutionContext;
 
-public interface InvitationCrudService {
-    ApplicationInvitation create(ApplicationInvitation invitation);
-
-    default List<Invitation> findByEmail(String email) {
-        throw new UnsupportedOperationException("findByEmail not implemented");
-    }
-
-    default void delete(InvitationId invitationId) {
-        throw new UnsupportedOperationException("delete not implemented");
-    }
+public interface AcceptInvitationDomainService {
+    /**
+     * Adds {@code userId} as a member of the resource referenced by {@code invitation}.
+     * Dispatches on invitation type (GROUP, APPLICATION, …).
+     */
+    void addMember(ExecutionContext executionContext, Invitation invitation, String userId);
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/invitation/exception/InvitationCanceledException.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/invitation/exception/InvitationCanceledException.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.invitation.exception;
+
+import io.gravitee.apim.core.exception.ValidationDomainException;
+
+public class InvitationCanceledException extends ValidationDomainException {
+
+    public InvitationCanceledException(String email) {
+        super("No active invitation found for email [" + email + "]");
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/invitation/model/GroupInvitation.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/invitation/model/GroupInvitation.java
@@ -15,19 +15,11 @@
  */
 package io.gravitee.apim.core.invitation.model;
 
-import io.gravitee.common.utils.TimeProvider;
-import java.time.ZonedDateTime;
-
-public record ApplicationInvitation(
+public record GroupInvitation(
     InvitationId id,
-    String applicationId,
+    String referenceId,
+    String referenceType,
     String email,
-    String roleName,
-    ZonedDateTime createdAt,
-    ZonedDateTime updatedAt
-) implements Invitation {
-    public static ApplicationInvitation create(String applicationId, String email, String roleName) {
-        var now = TimeProvider.now();
-        return new ApplicationInvitation(InvitationId.random(), applicationId, email, roleName, now, now);
-    }
-}
+    String apiRole,
+    String applicationRole
+) implements Invitation {}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/invitation/model/Invitation.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/invitation/model/Invitation.java
@@ -15,19 +15,8 @@
  */
 package io.gravitee.apim.core.invitation.model;
 
-import io.gravitee.common.utils.TimeProvider;
-import java.time.ZonedDateTime;
+public sealed interface Invitation permits ApplicationInvitation, GroupInvitation {
+    InvitationId id();
 
-public record ApplicationInvitation(
-    InvitationId id,
-    String applicationId,
-    String email,
-    String roleName,
-    ZonedDateTime createdAt,
-    ZonedDateTime updatedAt
-) implements Invitation {
-    public static ApplicationInvitation create(String applicationId, String email, String roleName) {
-        var now = TimeProvider.now();
-        return new ApplicationInvitation(InvitationId.random(), applicationId, email, roleName, now, now);
-    }
+    String email();
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/invitation/model/InvitationId.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/invitation/model/InvitationId.java
@@ -17,20 +17,15 @@ package io.gravitee.apim.core.invitation.model;
 
 import com.fasterxml.jackson.annotation.JsonValue;
 import jakarta.annotation.Nonnull;
-import java.util.Objects;
 import java.util.UUID;
 
-public record ApplicationInvitationId(@Nonnull UUID id) {
-    public ApplicationInvitationId {
-        Objects.requireNonNull(id, "id");
+public record InvitationId(@Nonnull UUID id) {
+    public static InvitationId random() {
+        return new InvitationId(UUID.randomUUID());
     }
 
-    public static ApplicationInvitationId random() {
-        return new ApplicationInvitationId(UUID.randomUUID());
-    }
-
-    public static ApplicationInvitationId of(String value) {
-        return new ApplicationInvitationId(UUID.fromString(value));
+    public static InvitationId of(String value) {
+        return new InvitationId(UUID.fromString(value));
     }
 
     @JsonValue

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/invitation/use_case/AcceptUserInvitationUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/invitation/use_case/AcceptUserInvitationUseCase.java
@@ -22,6 +22,7 @@ import io.gravitee.apim.core.audit.model.OrganizationAuditLogEntity;
 import io.gravitee.apim.core.audit.model.event.UserAuditEvent;
 import io.gravitee.apim.core.invitation.crud_service.InvitationCrudService;
 import io.gravitee.apim.core.invitation.domain_service.AcceptInvitationDomainService;
+import io.gravitee.apim.core.invitation.exception.InvitationCanceledException;
 import io.gravitee.apim.core.invitation.model.Invitation;
 import io.gravitee.apim.core.user.crud_service.UserCrudService;
 import io.gravitee.apim.core.user.domain_service.CreateUserDomainService;
@@ -53,7 +54,7 @@ public class AcceptUserInvitationUseCase {
     private final AuditDomainService auditDomainService;
 
     public Output execute(Input input) {
-        input.password().ifPresent(pwd -> userPasswordService.validate(pwd));
+        input.password().ifPresent(userPasswordService::validate);
 
         var pendingInvitations = switch (input.action()) {
             case UserRegistrationAction ignored -> {
@@ -63,7 +64,7 @@ public class AcceptUserInvitationUseCase {
             case GroupInvitationAction a -> {
                 var invitations = invitationCrudService.findByEmail(a.email());
                 if (invitations.isEmpty()) {
-                    throw new IllegalStateException("Invitation has been canceled");
+                    throw new InvitationCanceledException(a.email());
                 }
                 yield invitations;
             }
@@ -72,13 +73,7 @@ public class AcceptUserInvitationUseCase {
         var user = input
             .action()
             .existingUserId()
-            .map(userId -> {
-                var found = userCrudService.findBaseUserById(userId).orElseThrow(() -> new UserNotFoundException(userId));
-                if (userCrudService.isPasswordSet(userId)) {
-                    throw new UserAlreadyFinalizedException(input.executionContext().getOrganizationId());
-                }
-                return found;
-            })
+            .map(userId -> findAndValidateExistingUser(userId, input.executionContext()))
             .orElseGet(() ->
                 createUserDomainService.createExternalUser(
                     input.executionContext(),
@@ -90,10 +85,9 @@ public class AcceptUserInvitationUseCase {
 
         switch (input.action()) {
             case UserRegistrationAction ignored -> {}
-            case GroupInvitationAction ignored -> pendingInvitations.forEach(invitation -> {
-                acceptInvitationDomainService.addMember(input.executionContext(), invitation, user.getId());
-                invitationCrudService.delete(invitation.id());
-            });
+            case GroupInvitationAction ignored -> pendingInvitations.forEach(invitation ->
+                processInvitation(input.executionContext(), invitation, user.getId())
+            );
         }
 
         user.setUpdatedAt(Date.from(TimeProvider.now().toInstant()));
@@ -118,6 +112,19 @@ public class AcceptUserInvitationUseCase {
         userPortalNotificationService.triggerUserRegistered(input.executionContext(), updated);
 
         return new Output(updated);
+    }
+
+    private BaseUserEntity findAndValidateExistingUser(String userId, ExecutionContext executionContext) {
+        var user = userCrudService.findBaseUserById(userId).orElseThrow(() -> new UserNotFoundException(userId));
+        if (userCrudService.isPasswordSet(userId)) {
+            throw new UserAlreadyFinalizedException(executionContext.getOrganizationId());
+        }
+        return user;
+    }
+
+    private void processInvitation(ExecutionContext executionContext, Invitation invitation, String userId) {
+        acceptInvitationDomainService.addMember(executionContext, invitation, userId);
+        invitationCrudService.delete(invitation.id());
     }
 
     public sealed interface Action permits UserRegistrationAction, GroupInvitationAction {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/invitation/use_case/AcceptUserInvitationUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/invitation/use_case/AcceptUserInvitationUseCase.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.invitation.use_case;
+
+import io.gravitee.apim.core.audit.domain_service.AuditDomainService;
+import io.gravitee.apim.core.audit.model.AuditActor;
+import io.gravitee.apim.core.audit.model.AuditProperties;
+import io.gravitee.apim.core.audit.model.OrganizationAuditLogEntity;
+import io.gravitee.apim.core.audit.model.event.UserAuditEvent;
+import io.gravitee.apim.core.invitation.crud_service.InvitationCrudService;
+import io.gravitee.apim.core.invitation.domain_service.AcceptInvitationDomainService;
+import io.gravitee.apim.core.invitation.model.Invitation;
+import io.gravitee.apim.core.user.crud_service.UserCrudService;
+import io.gravitee.apim.core.user.domain_service.CreateUserDomainService;
+import io.gravitee.apim.core.user.model.BaseUserEntity;
+import io.gravitee.apim.core.user.model.RawPassword;
+import io.gravitee.apim.core.user.service_provider.UserPasswordService;
+import io.gravitee.apim.core.user.service_provider.UserPortalNotificationService;
+import io.gravitee.apim.core.user.service_provider.UserRegistrationEnabledService;
+import io.gravitee.common.utils.TimeProvider;
+import io.gravitee.rest.api.service.common.ExecutionContext;
+import io.gravitee.rest.api.service.exceptions.UserAlreadyFinalizedException;
+import io.gravitee.rest.api.service.exceptions.UserNotFoundException;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class AcceptUserInvitationUseCase {
+
+    private final UserCrudService userCrudService;
+    private final CreateUserDomainService createUserDomainService;
+    private final InvitationCrudService invitationCrudService;
+    private final AcceptInvitationDomainService acceptInvitationDomainService;
+    private final UserRegistrationEnabledService userRegistrationEnabledService;
+    private final UserPasswordService userPasswordService;
+    private final UserPortalNotificationService userPortalNotificationService;
+    private final AuditDomainService auditDomainService;
+
+    public Output execute(Input input) {
+        input.password().ifPresent(pwd -> userPasswordService.validate(pwd));
+
+        var pendingInvitations = switch (input.action()) {
+            case UserRegistrationAction ignored -> {
+                userRegistrationEnabledService.checkEnabled(input.executionContext());
+                yield List.<Invitation>of();
+            }
+            case GroupInvitationAction a -> {
+                var invitations = invitationCrudService.findByEmail(a.email());
+                if (invitations.isEmpty()) {
+                    throw new IllegalStateException("Invitation has been canceled");
+                }
+                yield invitations;
+            }
+        };
+
+        var user = input
+            .action()
+            .existingUserId()
+            .map(userId -> {
+                var found = userCrudService.findBaseUserById(userId).orElseThrow(() -> new UserNotFoundException(userId));
+                if (userCrudService.isPasswordSet(userId)) {
+                    throw new UserAlreadyFinalizedException(input.executionContext().getOrganizationId());
+                }
+                return found;
+            })
+            .orElseGet(() ->
+                createUserDomainService.createExternalUser(
+                    input.executionContext(),
+                    input.action().email(),
+                    input.firstname(),
+                    input.lastname()
+                )
+            );
+
+        switch (input.action()) {
+            case UserRegistrationAction ignored -> {}
+            case GroupInvitationAction ignored -> pendingInvitations.forEach(invitation -> {
+                acceptInvitationDomainService.addMember(input.executionContext(), invitation, user.getId());
+                invitationCrudService.delete(invitation.id());
+            });
+        }
+
+        user.setUpdatedAt(Date.from(TimeProvider.now().toInstant()));
+
+        var updated = input
+            .password()
+            .map(pwd -> userCrudService.updateAndSetPassword(user, userPasswordService.encode(pwd)))
+            .orElseGet(() -> userCrudService.update(user));
+
+        auditDomainService.createOrganizationAuditLog(
+            OrganizationAuditLogEntity.builder()
+                .organizationId(input.executionContext().getOrganizationId())
+                .actor(AuditActor.builder().userId(updated.getId()).build())
+                .properties(Map.of(AuditProperties.USER, updated.getId()))
+                .event(UserAuditEvent.USER_CREATED)
+                .createdAt(TimeProvider.now())
+                .oldValue(null)
+                .newValue(updated)
+                .build()
+        );
+
+        userPortalNotificationService.triggerUserRegistered(input.executionContext(), updated);
+
+        return new Output(updated);
+    }
+
+    public sealed interface Action permits UserRegistrationAction, GroupInvitationAction {
+        String email();
+
+        Optional<String> existingUserId();
+    }
+
+    public record UserRegistrationAction(String email, Optional<String> existingUserId) implements Action {}
+
+    public record GroupInvitationAction(String email, Optional<String> existingUserId) implements Action {}
+
+    public record Input(
+        ExecutionContext executionContext,
+        Action action,
+        Optional<RawPassword> password,
+        Optional<String> firstname,
+        Optional<String> lastname
+    ) {}
+
+    public record Output(BaseUserEntity user) {}
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/user/crud_service/UserCrudService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/user/crud_service/UserCrudService.java
@@ -16,6 +16,7 @@
 package io.gravitee.apim.core.user.crud_service;
 
 import io.gravitee.apim.core.user.model.BaseUserEntity;
+import io.gravitee.apim.core.user.model.EncodedPassword;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -24,4 +25,20 @@ public interface UserCrudService {
     Optional<BaseUserEntity> findBaseUserById(String id);
     Set<BaseUserEntity> findBaseUsersByIds(List<String> userIds);
     BaseUserEntity getBaseUser(String id);
+
+    default BaseUserEntity create(BaseUserEntity user) {
+        throw new UnsupportedOperationException("create not implemented");
+    }
+
+    default BaseUserEntity update(BaseUserEntity user) {
+        throw new UnsupportedOperationException("update not implemented");
+    }
+
+    default BaseUserEntity updateAndSetPassword(BaseUserEntity user, EncodedPassword encodedPassword) {
+        throw new UnsupportedOperationException("updateAndSetPassword not implemented");
+    }
+
+    default boolean isPasswordSet(String userId) {
+        throw new UnsupportedOperationException("isPasswordSet not implemented");
+    }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/user/domain_service/CreateUserDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/user/domain_service/CreateUserDomainService.java
@@ -13,21 +13,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.apim.core.invitation.model;
+package io.gravitee.apim.core.user.domain_service;
 
-import io.gravitee.common.utils.TimeProvider;
-import java.time.ZonedDateTime;
+import io.gravitee.apim.core.user.model.BaseUserEntity;
+import io.gravitee.rest.api.service.common.ExecutionContext;
+import java.util.Optional;
 
-public record ApplicationInvitation(
-    InvitationId id,
-    String applicationId,
-    String email,
-    String roleName,
-    ZonedDateTime createdAt,
-    ZonedDateTime updatedAt
-) implements Invitation {
-    public static ApplicationInvitation create(String applicationId, String email, String roleName) {
-        var now = TimeProvider.now();
-        return new ApplicationInvitation(InvitationId.random(), applicationId, email, roleName, now, now);
-    }
+public interface CreateUserDomainService {
+    BaseUserEntity createExternalUser(
+        ExecutionContext executionContext,
+        String email,
+        Optional<String> firstname,
+        Optional<String> lastname
+    );
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/user/model/BaseUserEntity.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/user/model/BaseUserEntity.java
@@ -38,6 +38,7 @@ public class BaseUserEntity {
     private String source;
     /** The user reference in the external source */
     private String sourceId;
+    private String status;
 
     public String displayName() {
         if (isNotBlank(firstname)) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/user/model/EncodedPassword.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/user/model/EncodedPassword.java
@@ -13,21 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.apim.core.invitation.model;
+package io.gravitee.apim.core.user.model;
 
-import io.gravitee.common.utils.TimeProvider;
-import java.time.ZonedDateTime;
-
-public record ApplicationInvitation(
-    InvitationId id,
-    String applicationId,
-    String email,
-    String roleName,
-    ZonedDateTime createdAt,
-    ZonedDateTime updatedAt
-) implements Invitation {
-    public static ApplicationInvitation create(String applicationId, String email, String roleName) {
-        var now = TimeProvider.now();
-        return new ApplicationInvitation(InvitationId.random(), applicationId, email, roleName, now, now);
-    }
-}
+public record EncodedPassword(String value) {}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/user/model/RawPassword.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/user/model/RawPassword.java
@@ -13,21 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.apim.core.invitation.model;
+package io.gravitee.apim.core.user.model;
 
-import io.gravitee.common.utils.TimeProvider;
-import java.time.ZonedDateTime;
-
-public record ApplicationInvitation(
-    InvitationId id,
-    String applicationId,
-    String email,
-    String roleName,
-    ZonedDateTime createdAt,
-    ZonedDateTime updatedAt
-) implements Invitation {
-    public static ApplicationInvitation create(String applicationId, String email, String roleName) {
-        var now = TimeProvider.now();
-        return new ApplicationInvitation(InvitationId.random(), applicationId, email, roleName, now, now);
-    }
-}
+public record RawPassword(String value) {}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/user/service_provider/UserPasswordService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/user/service_provider/UserPasswordService.java
@@ -13,21 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.apim.core.invitation.model;
+package io.gravitee.apim.core.user.service_provider;
 
-import io.gravitee.common.utils.TimeProvider;
-import java.time.ZonedDateTime;
+import io.gravitee.apim.core.user.model.EncodedPassword;
+import io.gravitee.apim.core.user.model.RawPassword;
 
-public record ApplicationInvitation(
-    InvitationId id,
-    String applicationId,
-    String email,
-    String roleName,
-    ZonedDateTime createdAt,
-    ZonedDateTime updatedAt
-) implements Invitation {
-    public static ApplicationInvitation create(String applicationId, String email, String roleName) {
-        var now = TimeProvider.now();
-        return new ApplicationInvitation(InvitationId.random(), applicationId, email, roleName, now, now);
-    }
+public interface UserPasswordService {
+    /** Throws {@link io.gravitee.rest.api.service.exceptions.PasswordFormatInvalidException} if the password does not meet format requirements. */
+    void validate(RawPassword password);
+
+    EncodedPassword encode(RawPassword password);
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/user/service_provider/UserPortalNotificationService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/user/service_provider/UserPortalNotificationService.java
@@ -13,21 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.apim.core.invitation.model;
+package io.gravitee.apim.core.user.service_provider;
 
-import io.gravitee.common.utils.TimeProvider;
-import java.time.ZonedDateTime;
+import io.gravitee.apim.core.user.model.BaseUserEntity;
+import io.gravitee.rest.api.service.common.ExecutionContext;
 
-public record ApplicationInvitation(
-    InvitationId id,
-    String applicationId,
-    String email,
-    String roleName,
-    ZonedDateTime createdAt,
-    ZonedDateTime updatedAt
-) implements Invitation {
-    public static ApplicationInvitation create(String applicationId, String email, String roleName) {
-        var now = TimeProvider.now();
-        return new ApplicationInvitation(InvitationId.random(), applicationId, email, roleName, now, now);
-    }
+public interface UserPortalNotificationService {
+    void triggerUserRegistered(ExecutionContext executionContext, BaseUserEntity user);
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/user/service_provider/UserRegistrationEnabledService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/user/service_provider/UserRegistrationEnabledService.java
@@ -13,21 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.apim.core.invitation.model;
+package io.gravitee.apim.core.user.service_provider;
 
-import io.gravitee.common.utils.TimeProvider;
-import java.time.ZonedDateTime;
+import io.gravitee.rest.api.service.common.ExecutionContext;
 
-public record ApplicationInvitation(
-    InvitationId id,
-    String applicationId,
-    String email,
-    String roleName,
-    ZonedDateTime createdAt,
-    ZonedDateTime updatedAt
-) implements Invitation {
-    public static ApplicationInvitation create(String applicationId, String email, String roleName) {
-        var now = TimeProvider.now();
-        return new ApplicationInvitation(InvitationId.random(), applicationId, email, roleName, now, now);
-    }
+public interface UserRegistrationEnabledService {
+    void checkEnabled(ExecutionContext executionContext);
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/ApplicationInvitationAdapter.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/ApplicationInvitationAdapter.java
@@ -16,7 +16,7 @@
 package io.gravitee.apim.infra.adapter;
 
 import io.gravitee.apim.core.invitation.model.ApplicationInvitation;
-import io.gravitee.apim.core.invitation.model.ApplicationInvitationId;
+import io.gravitee.apim.core.invitation.model.InvitationId;
 import io.gravitee.common.utils.TimeProvider;
 import io.gravitee.repository.management.model.Invitation;
 import java.time.ZonedDateTime;
@@ -39,11 +39,11 @@ public interface ApplicationInvitationAdapter {
     @Mapping(target = "apiRole", ignore = true)
     Invitation toRepository(ApplicationInvitation invitation);
 
-    default ApplicationInvitationId map(String id) {
-        return ApplicationInvitationId.of(id);
+    default InvitationId map(String id) {
+        return InvitationId.of(id);
     }
 
-    default String map(ApplicationInvitationId id) {
+    default String map(InvitationId id) {
         return id.toString();
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/fixtures/core/model/ApplicationInvitationFixtures.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/fixtures/core/model/ApplicationInvitationFixtures.java
@@ -16,7 +16,7 @@
 package fixtures.core.model;
 
 import io.gravitee.apim.core.invitation.model.ApplicationInvitation;
-import io.gravitee.apim.core.invitation.model.ApplicationInvitationId;
+import io.gravitee.apim.core.invitation.model.InvitationId;
 import java.time.Instant;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
@@ -37,7 +37,7 @@ public class ApplicationInvitationFixtures {
     }
 
     public static ApplicationInvitation anApplicationInvitation(String id, String applicationId, String email, String role) {
-        return new ApplicationInvitation(ApplicationInvitationId.of(id), applicationId, email, role, date(), date());
+        return new ApplicationInvitation(InvitationId.of(id), applicationId, email, role, date(), date());
     }
 
     private static ZonedDateTime date() {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/InvitationCrudServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/InvitationCrudServiceInMemory.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package inmemory;
+
+import io.gravitee.apim.core.invitation.crud_service.InvitationCrudService;
+import io.gravitee.apim.core.invitation.model.ApplicationInvitation;
+import io.gravitee.apim.core.invitation.model.Invitation;
+import io.gravitee.apim.core.invitation.model.InvitationId;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class InvitationCrudServiceInMemory implements InvitationCrudService, InMemoryAlternative<Invitation> {
+
+    private final List<Invitation> storage = new ArrayList<>();
+
+    @Override
+    public ApplicationInvitation create(ApplicationInvitation invitation) {
+        storage.add(invitation);
+        return invitation;
+    }
+
+    @Override
+    public List<Invitation> findByEmail(String email) {
+        return storage
+            .stream()
+            .filter(i -> i.email().equals(email))
+            .toList();
+    }
+
+    @Override
+    public void delete(InvitationId invitationId) {
+        storage.removeIf(i -> i.id().equals(invitationId));
+    }
+
+    @Override
+    public void initWith(List<Invitation> items) {
+        storage.clear();
+        storage.addAll(items);
+    }
+
+    @Override
+    public void reset() {
+        storage.clear();
+    }
+
+    @Override
+    public List<Invitation> storage() {
+        return Collections.unmodifiableList(storage);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/UserCrudServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/UserCrudServiceInMemory.java
@@ -17,10 +17,13 @@ package inmemory;
 
 import io.gravitee.apim.core.user.crud_service.UserCrudService;
 import io.gravitee.apim.core.user.model.BaseUserEntity;
+import io.gravitee.apim.core.user.model.EncodedPassword;
 import io.gravitee.rest.api.service.exceptions.UserNotFoundException;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -28,6 +31,7 @@ import java.util.stream.Collectors;
 public class UserCrudServiceInMemory implements UserCrudService, InMemoryAlternative<BaseUserEntity> {
 
     final List<BaseUserEntity> storage = new ArrayList<>();
+    private final Map<String, EncodedPassword> passwords = new HashMap<>();
 
     @Override
     public Optional<BaseUserEntity> findBaseUserById(String userId) {
@@ -55,6 +59,38 @@ public class UserCrudServiceInMemory implements UserCrudService, InMemoryAlterna
     }
 
     @Override
+    public BaseUserEntity create(BaseUserEntity user) {
+        storage.add(user);
+        return user;
+    }
+
+    @Override
+    public BaseUserEntity update(BaseUserEntity user) {
+        var index = findIndex(storage, u -> u.getId().equals(user.getId()));
+        if (index.isPresent()) {
+            storage.set(index.getAsInt(), user);
+        } else {
+            storage.add(user);
+        }
+        return user;
+    }
+
+    @Override
+    public BaseUserEntity updateAndSetPassword(BaseUserEntity user, EncodedPassword encodedPassword) {
+        passwords.put(user.getId(), encodedPassword);
+        return update(user);
+    }
+
+    @Override
+    public boolean isPasswordSet(String userId) {
+        return passwords.containsKey(userId);
+    }
+
+    public Optional<EncodedPassword> getStoredPassword(String userId) {
+        return Optional.ofNullable(passwords.get(userId));
+    }
+
+    @Override
     public void initWith(List<BaseUserEntity> items) {
         storage.addAll(items);
     }
@@ -62,6 +98,7 @@ public class UserCrudServiceInMemory implements UserCrudService, InMemoryAlterna
     @Override
     public void reset() {
         storage.clear();
+        passwords.clear();
     }
 
     @Override

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/application/ImportApplicationCRDUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/application/ImportApplicationCRDUseCaseTest.java
@@ -353,7 +353,8 @@ class ImportApplicationCRDUseCaseTest {
                 new Date(),
                 new Date(),
                 MEMBER_SOURCE,
-                MEMBER_SOURCE_ID_1
+                MEMBER_SOURCE_ID_1,
+                null
             ),
             new BaseUserEntity(
                 USER_ID,
@@ -364,7 +365,8 @@ class ImportApplicationCRDUseCaseTest {
                 new Date(),
                 new Date(),
                 MEMBER_SOURCE,
-                MEMBER_SOURCE_ID_2
+                MEMBER_SOURCE_ID_2,
+                null
             )
         );
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/invitation/use_case/AcceptUserInvitationUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/invitation/use_case/AcceptUserInvitationUseCaseTest.java
@@ -1,0 +1,442 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.invitation.use_case;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import inmemory.AbstractUseCaseTest;
+import inmemory.InvitationCrudServiceInMemory;
+import io.gravitee.apim.core.audit.domain_service.AuditDomainService;
+import io.gravitee.apim.core.audit.model.AuditEntity;
+import io.gravitee.apim.core.audit.model.AuditProperties;
+import io.gravitee.apim.core.invitation.domain_service.AcceptInvitationDomainService;
+import io.gravitee.apim.core.invitation.model.GroupInvitation;
+import io.gravitee.apim.core.invitation.model.InvitationId;
+import io.gravitee.apim.core.invitation.use_case.AcceptUserInvitationUseCase.GroupInvitationAction;
+import io.gravitee.apim.core.invitation.use_case.AcceptUserInvitationUseCase.UserRegistrationAction;
+import io.gravitee.apim.core.user.domain_service.CreateUserDomainService;
+import io.gravitee.apim.core.user.model.BaseUserEntity;
+import io.gravitee.apim.core.user.model.EncodedPassword;
+import io.gravitee.apim.core.user.model.RawPassword;
+import io.gravitee.apim.core.user.service_provider.UserPasswordService;
+import io.gravitee.apim.core.user.service_provider.UserPortalNotificationService;
+import io.gravitee.apim.core.user.service_provider.UserRegistrationEnabledService;
+import io.gravitee.apim.infra.json.jackson.JacksonJsonDiffProcessor;
+import io.gravitee.rest.api.service.common.ExecutionContext;
+import io.gravitee.rest.api.service.exceptions.UserAlreadyFinalizedException;
+import io.gravitee.rest.api.service.exceptions.UserNotFoundException;
+import io.gravitee.rest.api.service.exceptions.UserRegistrationUnavailableException;
+import java.time.ZoneId;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@ExtendWith(MockitoExtension.class)
+class AcceptUserInvitationUseCaseTest extends AbstractUseCaseTest {
+
+    private static final String USER_EMAIL = "user@example.com";
+    private static final String EXISTING_USER_ID = "existing-user-id";
+    private static final RawPassword RAW_PASSWORD = new RawPassword("Password123!");
+    private static final EncodedPassword ENCODED_PASSWORD = new EncodedPassword("$2a$encoded");
+
+    private final InvitationCrudServiceInMemory invitationCrudService = new InvitationCrudServiceInMemory();
+
+    @Mock
+    private AcceptInvitationDomainService acceptInvitationDomainService;
+
+    @Mock
+    private UserRegistrationEnabledService userRegistrationEnabledService;
+
+    @Mock
+    private UserPasswordService userPasswordService;
+
+    @Mock
+    private UserPortalNotificationService userPortalNotificationService;
+
+    @Mock
+    private CreateUserDomainService createUserDomainService;
+
+    private AuditDomainService auditDomainService;
+    private AcceptUserInvitationUseCase cut;
+    private ExecutionContext executionContext;
+
+    @BeforeEach
+    void setUp() {
+        auditDomainService = new AuditDomainService(auditCrudService, userCrudService, new JacksonJsonDiffProcessor());
+        cut = new AcceptUserInvitationUseCase(
+            userCrudService,
+            createUserDomainService,
+            invitationCrudService,
+            acceptInvitationDomainService,
+            userRegistrationEnabledService,
+            userPasswordService,
+            userPortalNotificationService,
+            auditDomainService
+        );
+        executionContext = new ExecutionContext(ORG_ID, ENV_ID);
+        invitationCrudService.reset();
+        userCrudService.reset();
+        auditCrudService.reset();
+    }
+
+    @Nested
+    class UserRegistrationAction_Tests {
+
+        @Test
+        void should_create_new_user_and_set_password() {
+            var createdUser = aUser(GENERATED_UUID, USER_EMAIL);
+            when(createUserDomainService.createExternalUser(eq(executionContext), eq(USER_EMAIL), any(), any())).thenReturn(createdUser);
+            when(userPasswordService.encode(RAW_PASSWORD)).thenReturn(ENCODED_PASSWORD);
+
+            var output = cut.execute(
+                new AcceptUserInvitationUseCase.Input(
+                    executionContext,
+                    new UserRegistrationAction(USER_EMAIL, Optional.empty()),
+                    Optional.of(RAW_PASSWORD),
+                    Optional.of("John"),
+                    Optional.of("Doe")
+                )
+            );
+
+            assertThat(output.user().getId()).isEqualTo(GENERATED_UUID);
+            assertThat(output.user().getUpdatedAt()).isEqualTo(Date.from(INSTANT_NOW));
+            assertThat(userCrudService.getStoredPassword(GENERATED_UUID)).contains(ENCODED_PASSWORD);
+            verify(userRegistrationEnabledService).checkEnabled(executionContext);
+            verify(userPasswordService).validate(RAW_PASSWORD);
+            verify(userPortalNotificationService).triggerUserRegistered(executionContext, output.user());
+        }
+
+        @Test
+        void should_create_new_user_without_password() {
+            var createdUser = aUser(GENERATED_UUID, USER_EMAIL);
+            when(createUserDomainService.createExternalUser(eq(executionContext), eq(USER_EMAIL), any(), any())).thenReturn(createdUser);
+
+            var output = cut.execute(
+                new AcceptUserInvitationUseCase.Input(
+                    executionContext,
+                    new UserRegistrationAction(USER_EMAIL, Optional.empty()),
+                    Optional.empty(),
+                    Optional.empty(),
+                    Optional.empty()
+                )
+            );
+
+            assertThat(output.user().getId()).isEqualTo(GENERATED_UUID);
+            assertThat(userCrudService.getStoredPassword(GENERATED_UUID)).isEmpty();
+            verify(userPasswordService, never()).validate(any());
+            verify(userPortalNotificationService).triggerUserRegistered(executionContext, output.user());
+        }
+
+        @Test
+        void should_finalize_existing_user() {
+            var existingUser = aUser(EXISTING_USER_ID, USER_EMAIL);
+            userCrudService.initWith(List.of(existingUser));
+            when(userPasswordService.encode(RAW_PASSWORD)).thenReturn(ENCODED_PASSWORD);
+
+            var output = cut.execute(
+                new AcceptUserInvitationUseCase.Input(
+                    executionContext,
+                    new UserRegistrationAction(USER_EMAIL, Optional.of(EXISTING_USER_ID)),
+                    Optional.of(RAW_PASSWORD),
+                    Optional.empty(),
+                    Optional.empty()
+                )
+            );
+
+            assertThat(output.user().getId()).isEqualTo(EXISTING_USER_ID);
+            assertThat(userCrudService.getStoredPassword(EXISTING_USER_ID)).contains(ENCODED_PASSWORD);
+            verify(createUserDomainService, never()).createExternalUser(any(), any(), any(), any());
+        }
+
+        @Test
+        void should_throw_when_registration_is_disabled() {
+            doThrow(new UserRegistrationUnavailableException()).when(userRegistrationEnabledService).checkEnabled(executionContext);
+
+            assertThatThrownBy(() ->
+                cut.execute(
+                    new AcceptUserInvitationUseCase.Input(
+                        executionContext,
+                        new UserRegistrationAction(USER_EMAIL, Optional.empty()),
+                        Optional.empty(),
+                        Optional.empty(),
+                        Optional.empty()
+                    )
+                )
+            ).isInstanceOf(UserRegistrationUnavailableException.class);
+
+            verify(createUserDomainService, never()).createExternalUser(any(), any(), any(), any());
+            verify(userPortalNotificationService, never()).triggerUserRegistered(any(), any());
+        }
+
+        @Test
+        void should_throw_when_existing_user_not_found() {
+            assertThatThrownBy(() ->
+                cut.execute(
+                    new AcceptUserInvitationUseCase.Input(
+                        executionContext,
+                        new UserRegistrationAction(USER_EMAIL, Optional.of("nonexistent-id")),
+                        Optional.of(RAW_PASSWORD),
+                        Optional.empty(),
+                        Optional.empty()
+                    )
+                )
+            ).isInstanceOf(UserNotFoundException.class);
+        }
+
+        @Test
+        void should_throw_when_user_already_finalized() {
+            var existingUser = aUser(EXISTING_USER_ID, USER_EMAIL);
+            userCrudService.initWith(List.of(existingUser));
+            userCrudService.updateAndSetPassword(existingUser, ENCODED_PASSWORD);
+
+            assertThatThrownBy(() ->
+                cut.execute(
+                    new AcceptUserInvitationUseCase.Input(
+                        executionContext,
+                        new UserRegistrationAction(USER_EMAIL, Optional.of(EXISTING_USER_ID)),
+                        Optional.of(RAW_PASSWORD),
+                        Optional.empty(),
+                        Optional.empty()
+                    )
+                )
+            ).isInstanceOf(UserAlreadyFinalizedException.class);
+        }
+
+        @Test
+        void should_throw_when_password_is_invalid() {
+            doThrow(new IllegalArgumentException("Password too weak")).when(userPasswordService).validate(RAW_PASSWORD);
+
+            assertThatThrownBy(() ->
+                cut.execute(
+                    new AcceptUserInvitationUseCase.Input(
+                        executionContext,
+                        new UserRegistrationAction(USER_EMAIL, Optional.empty()),
+                        Optional.of(RAW_PASSWORD),
+                        Optional.empty(),
+                        Optional.empty()
+                    )
+                )
+            )
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Password too weak");
+
+            verify(userRegistrationEnabledService, never()).checkEnabled(any());
+            verify(createUserDomainService, never()).createExternalUser(any(), any(), any(), any());
+        }
+
+        @Test
+        void should_create_organization_audit_log() {
+            var createdUser = aUser(GENERATED_UUID, USER_EMAIL);
+            when(createUserDomainService.createExternalUser(any(), any(), any(), any())).thenReturn(createdUser);
+
+            cut.execute(
+                new AcceptUserInvitationUseCase.Input(
+                    executionContext,
+                    new UserRegistrationAction(USER_EMAIL, Optional.empty()),
+                    Optional.empty(),
+                    Optional.empty(),
+                    Optional.empty()
+                )
+            );
+
+            assertThat(auditCrudService.storage())
+                .usingRecursiveFieldByFieldElementComparatorIgnoringFields("patch")
+                .containsExactly(
+                    AuditEntity.builder()
+                        .id(GENERATED_UUID)
+                        .organizationId(ORG_ID)
+                        .referenceType(AuditEntity.AuditReferenceType.ORGANIZATION)
+                        .referenceId(ORG_ID)
+                        .user(GENERATED_UUID)
+                        .properties(Map.of(AuditProperties.USER.name(), GENERATED_UUID))
+                        .event("USER_CREATED")
+                        .createdAt(INSTANT_NOW.atZone(ZoneId.systemDefault()))
+                        .build()
+                );
+        }
+    }
+
+    @Nested
+    class GroupInvitationAction_Tests {
+
+        @Test
+        void should_create_new_user_and_accept_invitations() {
+            var invitation = new GroupInvitation(
+                InvitationId.of("00000000-0000-0000-0000-000000000001"),
+                "group-1",
+                "GROUP",
+                USER_EMAIL,
+                "USER",
+                null
+            );
+            invitationCrudService.initWith(List.of(invitation));
+            var createdUser = aUser(GENERATED_UUID, USER_EMAIL);
+            when(createUserDomainService.createExternalUser(eq(executionContext), eq(USER_EMAIL), any(), any())).thenReturn(createdUser);
+
+            var output = cut.execute(
+                new AcceptUserInvitationUseCase.Input(
+                    executionContext,
+                    new GroupInvitationAction(USER_EMAIL, Optional.empty()),
+                    Optional.empty(),
+                    Optional.empty(),
+                    Optional.empty()
+                )
+            );
+
+            assertThat(output.user().getId()).isEqualTo(GENERATED_UUID);
+            assertThat(invitationCrudService.storage()).isEmpty();
+            verify(acceptInvitationDomainService).addMember(executionContext, invitation, GENERATED_UUID);
+            verify(userPortalNotificationService).triggerUserRegistered(executionContext, output.user());
+        }
+
+        @Test
+        void should_accept_multiple_invitations() {
+            var inv1 = new GroupInvitation(
+                InvitationId.of("00000000-0000-0000-0000-000000000001"),
+                "group-1",
+                "GROUP",
+                USER_EMAIL,
+                "USER",
+                null
+            );
+            var inv2 = new GroupInvitation(
+                InvitationId.of("00000000-0000-0000-0000-000000000002"),
+                "group-2",
+                "GROUP",
+                USER_EMAIL,
+                "ADMIN",
+                null
+            );
+            invitationCrudService.initWith(List.of(inv1, inv2));
+            var createdUser = aUser(GENERATED_UUID, USER_EMAIL);
+            when(createUserDomainService.createExternalUser(any(), any(), any(), any())).thenReturn(createdUser);
+
+            cut.execute(
+                new AcceptUserInvitationUseCase.Input(
+                    executionContext,
+                    new GroupInvitationAction(USER_EMAIL, Optional.empty()),
+                    Optional.empty(),
+                    Optional.empty(),
+                    Optional.empty()
+                )
+            );
+
+            assertThat(invitationCrudService.storage()).isEmpty();
+            verify(acceptInvitationDomainService).addMember(executionContext, inv1, GENERATED_UUID);
+            verify(acceptInvitationDomainService).addMember(executionContext, inv2, GENERATED_UUID);
+        }
+
+        @Test
+        void should_finalize_existing_user_and_accept_invitations() {
+            var invitation = new GroupInvitation(
+                InvitationId.of("00000000-0000-0000-0000-000000000001"),
+                "group-1",
+                "GROUP",
+                USER_EMAIL,
+                "USER",
+                null
+            );
+            invitationCrudService.initWith(List.of(invitation));
+            var existingUser = aUser(EXISTING_USER_ID, USER_EMAIL);
+            userCrudService.initWith(List.of(existingUser));
+            when(userPasswordService.encode(RAW_PASSWORD)).thenReturn(ENCODED_PASSWORD);
+
+            var output = cut.execute(
+                new AcceptUserInvitationUseCase.Input(
+                    executionContext,
+                    new GroupInvitationAction(USER_EMAIL, Optional.of(EXISTING_USER_ID)),
+                    Optional.of(RAW_PASSWORD),
+                    Optional.empty(),
+                    Optional.empty()
+                )
+            );
+
+            assertThat(output.user().getId()).isEqualTo(EXISTING_USER_ID);
+            assertThat(invitationCrudService.storage()).isEmpty();
+            assertThat(userCrudService.getStoredPassword(EXISTING_USER_ID)).contains(ENCODED_PASSWORD);
+            verify(acceptInvitationDomainService).addMember(executionContext, invitation, EXISTING_USER_ID);
+            verify(createUserDomainService, never()).createExternalUser(any(), any(), any(), any());
+        }
+
+        @Test
+        void should_throw_when_no_pending_invitations() {
+            assertThatThrownBy(() ->
+                cut.execute(
+                    new AcceptUserInvitationUseCase.Input(
+                        executionContext,
+                        new GroupInvitationAction(USER_EMAIL, Optional.empty()),
+                        Optional.empty(),
+                        Optional.empty(),
+                        Optional.empty()
+                    )
+                )
+            )
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("Invitation has been canceled");
+
+            verify(createUserDomainService, never()).createExternalUser(any(), any(), any(), any());
+            verify(userPortalNotificationService, never()).triggerUserRegistered(any(), any());
+        }
+
+        @Test
+        void should_not_process_invitations_for_different_email() {
+            var invitation = new GroupInvitation(
+                InvitationId.of("00000000-0000-0000-0000-000000000001"),
+                "group-1",
+                "GROUP",
+                "other@example.com",
+                "USER",
+                null
+            );
+            invitationCrudService.initWith(List.of(invitation));
+
+            assertThatThrownBy(() ->
+                cut.execute(
+                    new AcceptUserInvitationUseCase.Input(
+                        executionContext,
+                        new GroupInvitationAction(USER_EMAIL, Optional.empty()),
+                        Optional.empty(),
+                        Optional.empty(),
+                        Optional.empty()
+                    )
+                )
+            )
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("Invitation has been canceled");
+        }
+    }
+
+    private static BaseUserEntity aUser(String id, String email) {
+        return BaseUserEntity.builder().id(id).email(email).source("gravitee").sourceId(email).build();
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/invitation/use_case/AcceptUserInvitationUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/invitation/use_case/AcceptUserInvitationUseCaseTest.java
@@ -30,6 +30,7 @@ import io.gravitee.apim.core.audit.domain_service.AuditDomainService;
 import io.gravitee.apim.core.audit.model.AuditEntity;
 import io.gravitee.apim.core.audit.model.AuditProperties;
 import io.gravitee.apim.core.invitation.domain_service.AcceptInvitationDomainService;
+import io.gravitee.apim.core.invitation.exception.InvitationCanceledException;
 import io.gravitee.apim.core.invitation.model.GroupInvitation;
 import io.gravitee.apim.core.invitation.model.InvitationId;
 import io.gravitee.apim.core.invitation.use_case.AcceptUserInvitationUseCase.GroupInvitationAction;
@@ -401,8 +402,8 @@ class AcceptUserInvitationUseCaseTest extends AbstractUseCaseTest {
                     )
                 )
             )
-                .isInstanceOf(IllegalStateException.class)
-                .hasMessage("Invitation has been canceled");
+                .isInstanceOf(InvitationCanceledException.class)
+                .hasMessageContaining("user@example.com");
 
             verify(createUserDomainService, never()).createExternalUser(any(), any(), any(), any());
             verify(userPortalNotificationService, never()).triggerUserRegistered(any(), any());
@@ -431,8 +432,8 @@ class AcceptUserInvitationUseCaseTest extends AbstractUseCaseTest {
                     )
                 )
             )
-                .isInstanceOf(IllegalStateException.class)
-                .hasMessage("Invitation has been canceled");
+                .isInstanceOf(InvitationCanceledException.class)
+                .hasMessageContaining("user@example.com");
         }
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/query_service/invitation/InvitationQueryServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/query_service/invitation/InvitationQueryServiceImplTest.java
@@ -21,7 +21,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.gravitee.apim.core.exception.TechnicalDomainException;
-import io.gravitee.apim.core.invitation.model.ApplicationInvitationId;
+import io.gravitee.apim.core.invitation.model.InvitationId;
 import io.gravitee.apim.core.invitation.model.InvitationReference;
 import io.gravitee.apim.core.invitation.model.SearchApplicationInvitationsCriteria;
 import io.gravitee.common.data.domain.Page;
@@ -86,12 +86,12 @@ class InvitationQueryServiceImplTest {
         assertThat(result.getPageElements()).isEqualTo(2);
         assertThat(result.getTotalElements()).isEqualTo(3);
         assertThat(result.getContent()).hasSize(2);
-        assertThat(result.getContent().get(0).id()).isEqualTo(ApplicationInvitationId.of(INVITATION_ID_2));
+        assertThat(result.getContent().get(0).id()).isEqualTo(InvitationId.of(INVITATION_ID_2));
         assertThat(result.getContent().get(0).applicationId()).isEqualTo(APPLICATION_ID);
         assertThat(result.getContent().get(0).roleName()).isNull();
         assertThat(result.getContent().get(0).createdAt()).isEqualTo(expectedCreatedAt);
         assertThat(result.getContent().get(0).updatedAt()).isEqualTo(expectedUpdatedAt);
-        assertThat(result.getContent().get(1).id()).isEqualTo(ApplicationInvitationId.of(INVITATION_ID_1));
+        assertThat(result.getContent().get(1).id()).isEqualTo(InvitationId.of(INVITATION_ID_1));
         assertThat(result.getContent().get(1).applicationId()).isEqualTo(APPLICATION_ID);
         assertThat(result.getContent().get(1).roleName()).isEqualTo("USER");
         assertThat(result.getContent().get(1).createdAt()).isEqualTo(expectedCreatedAt);
@@ -110,7 +110,7 @@ class InvitationQueryServiceImplTest {
         var result = cut.findByReference(InvitationReference.application(APPLICATION_ID));
 
         assertThat(result).hasSize(1);
-        assertThat(result.getFirst().id()).isEqualTo(ApplicationInvitationId.of(INVITATION_ID_1));
+        assertThat(result.getFirst().id()).isEqualTo(InvitationId.of(INVITATION_ID_1));
         assertThat(result.getFirst().applicationId()).isEqualTo(APPLICATION_ID);
         assertThat(result.getFirst().email()).isEqualTo("john@example.com");
         assertThat(result.getFirst().roleName()).isEqualTo("USER");


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-14130

## Description

- Added `AcceptUserInvitationUseCase` in `io.gravitee.apim.core.invitation.use_case` supporting `USER_REGISTRATION` and `GROUP_INVITATION` JWT actions; sealed `Action` interface leaves `APPLICATION_INVITATION` as a compile-enforced extension point for the next task
- Introduced `Invitation` sealed interface + `GroupInvitation` record and `InvitationCrudService` / `AcceptInvitationDomainService` ports; `addMember` separated from CRUD into a dedicated domain service
- Added `RawPassword` / `EncodedPassword` value objects and `UserPasswordService`, `UserRegistrationEnabledService`, `UserPortalNotificationService`, `CreateUserDomainService` service-provider / domain-service interfaces
- Extended `UserCrudService` with `create`, `update`, `updateAndSetPassword`, `isPasswordSet` (password kept off `BaseUserEntity` to avoid Lucene index exposure); added `OrganizationAuditLogEntity`, `UserAuditEvent`, and `createOrganizationAuditLog` to `AuditDomainService`
- 13 unit tests covering both action paths, error cases, audit log, and portal notification; `@UseCase` intentionally omitted — Spring wiring comes in the follow-up resource-layer task

## Additional context

- Password is not stored on `BaseUserEntity` because the entity is indexed in Lucene; `isPasswordSet(userId)` on `UserCrudService` lets the use case check finalization status via the DB layer only.


