### PR TITLE
perf(gateway-sync): keyset pagination for subscriptions (APIM-14087)

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/SyncConfiguration.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/SyncConfiguration.java
@@ -167,9 +167,10 @@ public class SyncConfiguration {
     public SubscriptionAppender subscriptionAppender(
         SubscriptionRepository subscriptionRepository,
         SubscriptionMapper subscriptionMapper,
-        ApiProductRegistry apiProductRegistry
+        ApiProductRegistry apiProductRegistry,
+        @Value("${services.sync.bulk_items:" + DEFAULT_BULK_ITEMS + "}") int bulkItems
     ) {
-        return new SubscriptionAppender(subscriptionRepository, subscriptionMapper, apiProductRegistry);
+        return new SubscriptionAppender(subscriptionRepository, subscriptionMapper, apiProductRegistry, bulkItems);
     }
 
     @Bean

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/fetcher/SubscriptionFetcher.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/fetcher/SubscriptionFetcher.java
@@ -21,44 +21,81 @@ import io.gravitee.gateway.services.sync.process.repository.DefaultSyncManager;
 import io.gravitee.repository.management.api.SubscriptionRepository;
 import io.gravitee.repository.management.api.search.Order;
 import io.gravitee.repository.management.api.search.SubscriptionCriteria;
+import io.gravitee.repository.management.api.search.SubscriptionCursor;
 import io.gravitee.repository.management.api.search.builder.SortableBuilder;
 import io.gravitee.repository.management.model.Subscription;
 import io.reactivex.rxjava3.core.Flowable;
 import java.util.List;
 import java.util.Set;
-import lombok.RequiredArgsConstructor;
+import lombok.AllArgsConstructor;
+import lombok.CustomLog;
+import lombok.Getter;
+import lombok.experimental.Accessors;
 
 /**
  * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
  * @author GraviteeSource Team
  */
-@RequiredArgsConstructor
+@CustomLog
 public class SubscriptionFetcher {
 
     private static final List<String> STATUSES = List.of(ACCEPTED.name(), CLOSED.name(), PAUSED.name(), PENDING.name());
+
     private final SubscriptionRepository subscriptionRepository;
 
+    @Getter
+    @Accessors(fluent = true)
+    private final int bulkItems;
+
+    public SubscriptionFetcher(SubscriptionRepository subscriptionRepository, int bulkItems) {
+        if (bulkItems <= 0) {
+            throw new IllegalArgumentException("bulkItems must be > 0 (got " + bulkItems + ")");
+        }
+        this.subscriptionRepository = subscriptionRepository;
+        this.bulkItems = bulkItems;
+    }
+
     public Flowable<List<Subscription>> fetchLatest(final Long from, final Long to, final Set<String> environments) {
-        // The following doesn't paginate over the result because for now we don't see any value, but it could be implemented same as EventFetcher
-        return Flowable.generate(emitter -> {
-            SubscriptionCriteria criteriaBuilder = SubscriptionCriteria.builder()
-                .statuses(STATUSES)
-                .from(from == null ? -1 : from - DefaultSyncManager.TIMEFRAME_DELAY)
-                .to(to == null ? -1 : to + DefaultSyncManager.TIMEFRAME_DELAY)
-                .environments(environments)
-                .build();
-            try {
-                List<Subscription> subscriptions = subscriptionRepository.search(
-                    criteriaBuilder,
-                    new SortableBuilder().field("updatedAt").order(Order.ASC).build()
-                );
-                if (subscriptions != null && !subscriptions.isEmpty()) {
-                    emitter.onNext(subscriptions);
+        SubscriptionCriteria criteria = SubscriptionCriteria.builder()
+            .statuses(STATUSES)
+            .from(from == null ? -1 : from - DefaultSyncManager.TIMEFRAME_DELAY)
+            .to(to == null ? -1 : to + DefaultSyncManager.TIMEFRAME_DELAY)
+            .environments(environments)
+            .build();
+        var sortable = new SortableBuilder().field("updatedAt").order(Order.ASC).build();
+
+        return Flowable.<List<Subscription>, SubscriptionPage>generate(
+            () -> new SubscriptionPage(null),
+            (page, emitter) -> {
+                try {
+                    List<Subscription> subscriptions = subscriptionRepository.searchAfter(criteria, sortable, page.cursor, bulkItems);
+                    if (subscriptions != null && !subscriptions.isEmpty()) {
+                        emitter.onNext(subscriptions);
+                        Subscription last = subscriptions.getLast();
+                        if (last.getUpdatedAt() == null) {
+                            // Criteria.from/to > 0 already filters rows lacking updatedAt at the
+                            // repository layer. Guard the cursor advance so a malformed row never
+                            // wedges the loop (NPE → onError → retry exhaustion → tick never
+                            // completes → next tick refetches the same poison row).
+                            log.warn("Subscription {} has null updatedAt; terminating page loop early", last.getId());
+                            emitter.onComplete();
+                            return;
+                        }
+                        page.cursor = SubscriptionCursor.byUpdatedAt(last.getUpdatedAt().getTime(), last.getId());
+                    }
+                    if (subscriptions == null || subscriptions.size() < bulkItems) {
+                        emitter.onComplete();
+                    }
+                } catch (Exception e) {
+                    emitter.onError(e);
                 }
-                emitter.onComplete();
-            } catch (Exception e) {
-                emitter.onError(e);
             }
-        });
+        );
+    }
+
+    @AllArgsConstructor
+    private static class SubscriptionPage {
+
+        private SubscriptionCursor cursor;
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/spring/RepositorySyncConfiguration.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/spring/RepositorySyncConfiguration.java
@@ -132,8 +132,11 @@ public class RepositorySyncConfiguration {
     }
 
     @Bean
-    public SubscriptionFetcher subscriptionFetcher(SubscriptionRepository subscriptionRepository) {
-        return new SubscriptionFetcher(subscriptionRepository);
+    public SubscriptionFetcher subscriptionFetcher(
+        SubscriptionRepository subscriptionRepository,
+        @Value("${services.sync.bulk_items:" + DEFAULT_BULK_ITEMS + "}") int bulkItems
+    ) {
+        return new SubscriptionFetcher(subscriptionRepository, bulkItems);
     }
 
     @Bean

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/api/SubscriptionAppender.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/api/SubscriptionAppender.java
@@ -28,20 +28,20 @@ import io.gravitee.gateway.services.sync.process.common.model.SyncException;
 import io.gravitee.repository.management.api.SubscriptionRepository;
 import io.gravitee.repository.management.api.search.Order;
 import io.gravitee.repository.management.api.search.SubscriptionCriteria;
+import io.gravitee.repository.management.api.search.SubscriptionCursor;
 import io.gravitee.repository.management.api.search.builder.SortableBuilder;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.CustomLog;
-import lombok.RequiredArgsConstructor;
 
 @CustomLog
-@RequiredArgsConstructor
 public class SubscriptionAppender {
 
     private static final List<String> INITIAL_STATUS = List.of(ACCEPTED.name());
@@ -49,6 +49,22 @@ public class SubscriptionAppender {
     private final SubscriptionRepository subscriptionRepository;
     private final SubscriptionMapper subscriptionMapper;
     private final ApiProductRegistry apiProductRegistry;
+    private final int bulkItems;
+
+    public SubscriptionAppender(
+        SubscriptionRepository subscriptionRepository,
+        SubscriptionMapper subscriptionMapper,
+        ApiProductRegistry apiProductRegistry,
+        int bulkItems
+    ) {
+        if (bulkItems <= 0) {
+            throw new IllegalArgumentException("bulkItems must be > 0 (got " + bulkItems + ")");
+        }
+        this.subscriptionRepository = subscriptionRepository;
+        this.subscriptionMapper = subscriptionMapper;
+        this.apiProductRegistry = apiProductRegistry;
+        this.bulkItems = bulkItems;
+    }
 
     /**
      * Fetching subscriptions for given deployables
@@ -123,14 +139,35 @@ public class SubscriptionAppender {
         } else {
             criteriaBuilder.statuses(INCREMENTAL_STATUS);
         }
+        SubscriptionCriteria criteria = criteriaBuilder.build();
+        var sortable = new SortableBuilder().field("id").order(Order.ASC).build();
 
+        Map<String, List<Subscription>> grouped = new HashMap<>();
+        SubscriptionCursor cursor = null;
         try {
-            return subscriptionRepository
-                .search(criteriaBuilder.build(), new SortableBuilder().field("updatedAt").order(Order.ASC).build())
-                .stream()
-                .flatMap(subscription -> subscriptionMapper.to(subscription).stream())
-                .peek(subscriptionConverted -> subscriptionConverted.setForceDispatch(true))
-                .collect(groupingBy(Subscription::getApi));
+            while (true) {
+                List<io.gravitee.repository.management.model.Subscription> page = subscriptionRepository.searchAfter(
+                    criteria,
+                    sortable,
+                    cursor,
+                    bulkItems
+                );
+                if (page == null || page.isEmpty()) {
+                    return grouped;
+                }
+                for (io.gravitee.repository.management.model.Subscription record : page) {
+                    subscriptionMapper
+                        .to(record)
+                        .forEach(converted -> {
+                            converted.setForceDispatch(true);
+                            grouped.computeIfAbsent(converted.getApi(), k -> new ArrayList<>()).add(converted);
+                        });
+                }
+                if (page.size() < bulkItems) {
+                    return grouped;
+                }
+                cursor = SubscriptionCursor.byId(page.getLast().getId());
+            }
         } catch (Exception ex) {
             throw new SyncException("Error occurred when retrieving subscriptions", ex);
         }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/fetcher/SubscriptionFetcherTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/fetcher/SubscriptionFetcherTest.java
@@ -21,14 +21,19 @@ import static io.gravitee.repository.management.model.Subscription.Status.PAUSED
 import static io.gravitee.repository.management.model.Subscription.Status.PENDING;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.when;
 
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.SubscriptionRepository;
 import io.gravitee.repository.management.api.search.Order;
+import io.gravitee.repository.management.api.search.SubscriptionCursor;
 import io.gravitee.repository.management.model.Subscription;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
 import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
@@ -52,15 +57,19 @@ class SubscriptionFetcherTest {
 
     private SubscriptionFetcher cut;
 
+    private static final int BULK_ITEMS = 3;
+
     @BeforeEach
     public void beforeEach() {
-        cut = new SubscriptionFetcher(subscriptionRepository);
+        cut = new SubscriptionFetcher(subscriptionRepository, BULK_ITEMS);
     }
 
     @Test
     void should_fetch_subscriptions() throws TechnicalException {
         Subscription subscription = new Subscription();
-        when(subscriptionRepository.search(any(), any())).thenReturn(List.of(subscription));
+        subscription.setId("s");
+        subscription.setUpdatedAt(new Date(1));
+        when(subscriptionRepository.searchAfter(any(), any(), isNull(), eq(BULK_ITEMS))).thenReturn(List.of(subscription));
         cut
             .fetchLatest(null, null, Set.of())
             .test()
@@ -73,8 +82,10 @@ class SubscriptionFetcherTest {
         Instant to = Instant.now();
         Instant from = to.minus(1000, ChronoUnit.MILLIS);
         Subscription subscription = new Subscription();
+        subscription.setId("s");
+        subscription.setUpdatedAt(new Date(from.toEpochMilli()));
         when(
-            subscriptionRepository.search(
+            subscriptionRepository.searchAfter(
                 argThat(
                     argument ->
                         argument.getEnvironments().contains("env") &&
@@ -82,7 +93,9 @@ class SubscriptionFetcherTest {
                         argument.getFrom() < from.toEpochMilli() &&
                         argument.getTo() > to.toEpochMilli()
                 ),
-                argThat(argument -> argument.field().equals("updatedAt") && argument.order().equals(Order.ASC))
+                argThat(argument -> argument.field().equals("updatedAt") && argument.order().equals(Order.ASC)),
+                isNull(),
+                eq(BULK_ITEMS)
             )
         ).thenReturn(List.of(subscription));
         cut
@@ -94,7 +107,64 @@ class SubscriptionFetcherTest {
 
     @Test
     void should_emit_on_error_when_repository_thrown_exception() throws TechnicalException {
-        when(subscriptionRepository.search(any(), any())).thenThrow(new RuntimeException());
+        when(subscriptionRepository.searchAfter(any(), any(), any(), eq(BULK_ITEMS))).thenThrow(new RuntimeException());
         cut.fetchLatest(-1L, -1L, Set.of()).test().assertError(RuntimeException.class);
+    }
+
+    @Test
+    void should_emit_one_page_per_full_bulk_then_complete_on_short_page() throws TechnicalException {
+        List<Subscription> page1 = bulkSubs("p1-", BULK_ITEMS, 100);
+        List<Subscription> page2 = bulkSubs("p2-", BULK_ITEMS, 200);
+        List<Subscription> shortPage = bulkSubs("p3-", BULK_ITEMS - 1, 300);
+
+        Subscription last1 = page1.get(page1.size() - 1);
+        Subscription last2 = page2.get(page2.size() - 1);
+
+        when(subscriptionRepository.searchAfter(any(), any(), isNull(), eq(BULK_ITEMS))).thenReturn(page1);
+        when(
+            subscriptionRepository.searchAfter(
+                any(),
+                any(),
+                argThat(cursor -> cursor != null && cursor.id().equals(last1.getId())),
+                eq(BULK_ITEMS)
+            )
+        ).thenReturn(page2);
+        when(
+            subscriptionRepository.searchAfter(
+                any(),
+                any(),
+                argThat(cursor -> cursor != null && cursor.id().equals(last2.getId())),
+                eq(BULK_ITEMS)
+            )
+        ).thenReturn(shortPage);
+
+        cut.fetchLatest(0L, 1L, Set.of("env")).test().assertValueCount(3).assertComplete();
+    }
+
+    @Test
+    void should_terminate_on_null_updatedAt_without_npe_wedge() throws TechnicalException {
+        // A row with null updatedAt would NPE the cursor advance and wedge every subsequent tick.
+        // Guard must end pagination cleanly so the loop survives a single bad row.
+        Subscription good = new Subscription();
+        good.setId("good");
+        good.setUpdatedAt(new Date(100));
+        Subscription poisoned = new Subscription();
+        poisoned.setId("poisoned");
+        poisoned.setUpdatedAt(null);
+
+        when(subscriptionRepository.searchAfter(any(), any(), isNull(), eq(BULK_ITEMS))).thenReturn(List.of(good, poisoned));
+
+        cut.fetchLatest(0L, 1L, Set.of("env")).test().assertValueCount(1).assertComplete().assertNoErrors();
+    }
+
+    private static List<Subscription> bulkSubs(String idPrefix, int count, long baseMs) {
+        List<Subscription> subs = new ArrayList<>(count);
+        for (int i = 0; i < count; i++) {
+            Subscription s = new Subscription();
+            s.setId(idPrefix + i);
+            s.setUpdatedAt(new Date(baseMs + i));
+            subs.add(s);
+        }
+        return subs;
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/api/ApiSynchronizerTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/api/ApiSynchronizerTest.java
@@ -131,7 +131,8 @@ class ApiSynchronizerTest {
                     objectMapper,
                     org.mockito.Mockito.mock(io.gravitee.gateway.handlers.api.registry.ApiProductRegistry.class)
                 ),
-                org.mockito.Mockito.mock(io.gravitee.gateway.handlers.api.registry.ApiProductRegistry.class)
+                org.mockito.Mockito.mock(io.gravitee.gateway.handlers.api.registry.ApiProductRegistry.class),
+                100
             ),
             new ApiKeyAppender(apiKeyRepository, new ApiKeyMapper()),
             deployerFactory,

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/api/SubscriptionAppenderTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/api/SubscriptionAppenderTest.java
@@ -18,6 +18,8 @@ package io.gravitee.gateway.services.sync.process.repository.synchronizer.api;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -30,6 +32,8 @@ import io.gravitee.gateway.reactor.ReactableApi;
 import io.gravitee.gateway.services.sync.process.common.mapper.SubscriptionMapper;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.SubscriptionRepository;
+import io.gravitee.repository.management.api.search.SubscriptionCursor;
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -64,11 +68,13 @@ class SubscriptionAppenderTest {
 
     private SubscriptionAppender cut;
 
+    private static final int BULK_ITEMS = 2;
+
     @BeforeEach
     public void beforeEach() {
         when(apiProductRegistry.getApiProductPlanEntriesForApi(any(), any())).thenReturn(List.of());
         SubscriptionMapper subscriptionMapper = new SubscriptionMapper(objectMapper, apiProductRegistry);
-        cut = new SubscriptionAppender(subscriptionRepository, subscriptionMapper, apiProductRegistry);
+        cut = new SubscriptionAppender(subscriptionRepository, subscriptionMapper, apiProductRegistry, BULK_ITEMS);
         memoryAppender.reset();
     }
 
@@ -107,11 +113,18 @@ class SubscriptionAppenderTest {
         subscription2.setId("sub2");
         subscription2.setApi("api1");
         when(
-            subscriptionRepository.search(
-                argThat(argument -> argument.getPlans().contains("plan1") && argument.getEnvironments().contains("env")),
-                any()
+            subscriptionRepository.searchAfter(
+                argThat(
+                    argument -> argument != null && argument.getPlans().contains("plan1") && argument.getEnvironments().contains("env")
+                ),
+                any(),
+                isNull(),
+                eq(BULK_ITEMS)
             )
         ).thenReturn(List.of(subscription1, subscription2));
+        when(subscriptionRepository.searchAfter(any(), any(), argThat(c -> c != null && "sub2".equals(c.id())), eq(BULK_ITEMS))).thenReturn(
+            List.of()
+        );
         ApiReactorDeployable apiReactorDeployable2 = ApiReactorDeployable.builder()
             .apiId("api2")
             .reactableApi(mock(ReactableApi.class))
@@ -122,6 +135,36 @@ class SubscriptionAppenderTest {
         assertThat(deployables).hasSize(2);
         assertThat(deployables.get(0).subscriptions()).hasSize(2);
         assertThat(deployables.get(1).subscriptions()).isEmpty();
+    }
+
+    @Test
+    void should_aggregate_subscriptions_across_multiple_pages() throws TechnicalException {
+        ApiReactorDeployable deployable = ApiReactorDeployable.builder()
+            .apiId("api1")
+            .reactableApi(mock(ReactableApi.class))
+            .subscribablePlans(new HashSet<>(Set.of("plan1")))
+            .apiKeyPlans(new HashSet<>(Set.of("plan1")))
+            .build();
+
+        io.gravitee.repository.management.model.Subscription a = sub("sub-a");
+        io.gravitee.repository.management.model.Subscription b = sub("sub-b");
+        io.gravitee.repository.management.model.Subscription c = sub("sub-c");
+
+        when(subscriptionRepository.searchAfter(any(), any(), isNull(), eq(BULK_ITEMS))).thenReturn(List.of(a, b));
+        when(
+            subscriptionRepository.searchAfter(any(), any(), argThat(cur -> cur != null && "sub-b".equals(cur.id())), eq(BULK_ITEMS))
+        ).thenReturn(List.of(c));
+
+        List<ApiReactorDeployable> deployables = cut.appends(true, List.of(deployable), Set.of("env"));
+        assertThat(deployables).hasSize(1);
+        assertThat(deployables.get(0).subscriptions()).hasSize(3);
+    }
+
+    private static io.gravitee.repository.management.model.Subscription sub(String id) {
+        io.gravitee.repository.management.model.Subscription s = new io.gravitee.repository.management.model.Subscription();
+        s.setId(id);
+        s.setApi("api1");
+        return s;
     }
 
     @Test
@@ -142,7 +185,12 @@ class SubscriptionAppenderTest {
         io.gravitee.repository.management.model.Subscription subscription3 = new io.gravitee.repository.management.model.Subscription();
         subscription3.setId("sub3");
         subscription3.setApi("api3");
-        when(subscriptionRepository.search(any(), any())).thenReturn(List.of(subscription1, subscription2, subscription3));
+        when(subscriptionRepository.searchAfter(any(), any(), isNull(), eq(BULK_ITEMS))).thenReturn(
+            List.of(subscription1, subscription2, subscription3)
+        );
+        when(
+            subscriptionRepository.searchAfter(any(), any(), argThat(cur -> cur != null && "sub3".equals(cur.id())), eq(BULK_ITEMS))
+        ).thenReturn(List.of());
         ApiReactorDeployable apiReactorDeployable2 = ApiReactorDeployable.builder()
             .apiId("api2")
             .reactableApi(mock(ReactableApi.class))

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/subscription/SubscriptionSynchronizerTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/subscription/SubscriptionSynchronizerTest.java
@@ -149,6 +149,96 @@ class SubscriptionSynchronizerTest {
         }
 
         @Test
+        void should_deploy_each_subscription_exactly_once_across_multiple_pages() throws InterruptedException {
+            io.gravitee.repository.management.model.Subscription a = subscription("sub-a");
+            io.gravitee.repository.management.model.Subscription b = subscription("sub-b");
+            io.gravitee.repository.management.model.Subscription c = subscription("sub-c");
+            planCache.register(ApiReactorDeployable.builder().apiId("api").subscribablePlans(Set.of("plan")).build());
+
+            when(subscriptionFetcher.fetchLatest(any(), any(), any())).thenReturn(Flowable.just(List.of(a, b), List.of(c)));
+            cut.synchronize(Instant.now().toEpochMilli(), Instant.now().toEpochMilli(), Set.of()).test().await().assertComplete();
+
+            verify(subscriptionDeployer, org.mockito.Mockito.times(3)).deploy(any());
+            verify(subscriptionDeployer, org.mockito.Mockito.times(3)).doAfterDeployment(any());
+        }
+
+        private io.gravitee.repository.management.model.Subscription subscription(String id) {
+            io.gravitee.repository.management.model.Subscription s = new io.gravitee.repository.management.model.Subscription();
+            s.setId(id);
+            s.setApi("api");
+            s.setPlan("plan");
+            s.setStatus(io.gravitee.repository.management.model.Subscription.Status.ACCEPTED);
+            return s;
+        }
+
+        @Test
+        void should_deploy_all_subscriptions_when_real_fetcher_streams_same_ms_pages_via_repository()
+            throws InterruptedException, io.gravitee.repository.exceptions.TechnicalException {
+            // Wire the real SubscriptionFetcher against a stubbed SubscriptionRepository so the
+            // cursor-advance code in the fetcher is exercised through the full synchronizer chain.
+            // Scenario: 5 subs sharing the same updatedAt across 3 pages (2,2,1) — boundary cursor
+            // semantics must not drop any sub at the page boundary.
+            io.gravitee.repository.management.api.SubscriptionRepository repo = mock(
+                io.gravitee.repository.management.api.SubscriptionRepository.class
+            );
+            int bulkItems = 2;
+            io.gravitee.gateway.services.sync.process.repository.fetcher.SubscriptionFetcher realFetcher =
+                new io.gravitee.gateway.services.sync.process.repository.fetcher.SubscriptionFetcher(repo, bulkItems);
+
+            SubscriptionSynchronizer realCut = new SubscriptionSynchronizer(
+                realFetcher,
+                new SubscriptionMapper(objectMapper, mock(ApiProductRegistry.class)),
+                deployerFactory,
+                planCache,
+                new ThreadPoolExecutor(1, 1, 15L, TimeUnit.SECONDS, new LinkedBlockingQueue<>()),
+                new ThreadPoolExecutor(1, 1, 15L, TimeUnit.SECONDS, new LinkedBlockingQueue<>())
+            );
+
+            long sameMs = 7777L;
+            io.gravitee.repository.management.model.Subscription a = sub("sub-a", sameMs);
+            io.gravitee.repository.management.model.Subscription b = sub("sub-b", sameMs);
+            io.gravitee.repository.management.model.Subscription c = sub("sub-c", sameMs);
+            io.gravitee.repository.management.model.Subscription d = sub("sub-d", sameMs);
+            io.gravitee.repository.management.model.Subscription e = sub("sub-e", sameMs);
+            planCache.register(ApiReactorDeployable.builder().apiId("api").subscribablePlans(Set.of("plan")).build());
+
+            // Page 1: cursor = null, return a + b
+            when(
+                repo.searchAfter(any(), any(), org.mockito.ArgumentMatchers.isNull(), org.mockito.ArgumentMatchers.eq(bulkItems))
+            ).thenReturn(List.of(a, b));
+            // Page 2: cursor at b's (updatedAt, id), return c + d
+            when(
+                repo.searchAfter(
+                    any(),
+                    any(),
+                    org.mockito.ArgumentMatchers.argThat(cursor -> cursor != null && "sub-b".equals(cursor.id())),
+                    org.mockito.ArgumentMatchers.eq(bulkItems)
+                )
+            ).thenReturn(List.of(c, d));
+            // Page 3 (short): cursor at d, return only e
+            when(
+                repo.searchAfter(
+                    any(),
+                    any(),
+                    org.mockito.ArgumentMatchers.argThat(cursor -> cursor != null && "sub-d".equals(cursor.id())),
+                    org.mockito.ArgumentMatchers.eq(bulkItems)
+                )
+            ).thenReturn(List.of(e));
+
+            realCut.synchronize(1L, 2L, Set.of("env")).test().await().assertComplete();
+
+            // Every sub deployed exactly once — no skip, no duplicate across the same-ms boundary
+            verify(subscriptionDeployer, org.mockito.Mockito.times(5)).deploy(any());
+            verify(subscriptionDeployer, org.mockito.Mockito.times(5)).doAfterDeployment(any());
+        }
+
+        private io.gravitee.repository.management.model.Subscription sub(String id, long updatedAtMs) {
+            io.gravitee.repository.management.model.Subscription s = subscription(id);
+            s.setUpdatedAt(new java.util.Date(updatedAtMs));
+            return s;
+        }
+
+        @Test
         void should_undeploy_subscriptions_when_fetching_inactive_api_keys() throws InterruptedException {
             io.gravitee.repository.management.model.Subscription subscription = new io.gravitee.repository.management.model.Subscription();
             subscription.setId("subscription");

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/SubscriptionRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/SubscriptionRepository.java
@@ -21,6 +21,7 @@ import io.gravitee.repository.management.api.search.Order;
 import io.gravitee.repository.management.api.search.Pageable;
 import io.gravitee.repository.management.api.search.Sortable;
 import io.gravitee.repository.management.api.search.SubscriptionCriteria;
+import io.gravitee.repository.management.api.search.SubscriptionCursor;
 import io.gravitee.repository.management.model.Subscription;
 import io.gravitee.repository.management.model.SubscriptionReferenceType;
 import java.util.Collection;
@@ -47,6 +48,31 @@ public interface SubscriptionRepository extends CrudRepository<Subscription, Str
      * {@code endingAt} that would otherwise be blocked by the sort stage (ESR violation).
      */
     List<Subscription> searchUnordered(SubscriptionCriteria criteria) throws TechnicalException;
+
+    /**
+     * Keyset / seek pagination over subscriptions matching {@code criteria}. Returns up to
+     * {@code pageSize} subscriptions positioned strictly after {@code after} (or starting from
+     * the beginning when {@code after} is {@code null}). A short page (size {@code < pageSize})
+     * signals exhaustion.
+     *
+     * <p>Sort and seek mode are controlled by {@code sortable.field()}:
+     * <ul>
+     *   <li>{@code "updatedAt"} (or {@code null}) — sort {@code (updatedAt ASC, id ASC)}, seek
+     *       past {@code (after.updatedAt, after.id)}. Used by the gateway-sync delta loop.</li>
+     *   <li>{@code "id"} — sort {@code id ASC}, seek past {@code after.id}. Used by the
+     *       gateway-sync warmup load where a {@code plans IN} filter dominates selectivity.</li>
+     * </ul>
+     * {@code sortable.order()} is ignored — ASC is enforced.
+     *
+     * <p>Implementations <b>must</b> reject criteria including {@code planSecurityTypes} or
+     * {@code excludedApis} with {@link TechnicalException} — these filters are not supported by
+     * this narrow path (use {@link #search(SubscriptionCriteria, Sortable)} instead).
+     *
+     * @throws TechnicalException if {@code criteria} carries an unsupported filter or if
+     *         {@code sortable.field()} is not one of the documented values.
+     */
+    List<Subscription> searchAfter(SubscriptionCriteria criteria, Sortable sortable, SubscriptionCursor after, int pageSize)
+        throws TechnicalException;
 
     List<Subscription> findByIdIn(Collection<String> ids) throws TechnicalException;
 

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/search/SubscriptionCursor.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/search/SubscriptionCursor.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.management.api.search;
+
+import java.util.Objects;
+
+/**
+ * Position marker for keyset / seek pagination over subscriptions. Two seek modes are supported by
+ * {@code SubscriptionRepository.searchAfter} depending on the sort field passed alongside:
+ *
+ * <ul>
+ *   <li>{@code (updatedAt, id)} — used when the {@code Sortable} field is {@code "updatedAt"} (the
+ *       delta sync path). Construct with {@link #byUpdatedAt(long, String)}.</li>
+ *   <li>{@code id}-only — used when the {@code Sortable} field is {@code "id"} (the warmup path
+ *       where a {@code plans IN} filter dominates selectivity). Construct with {@link #byId(String)};
+ *       the {@code updatedAt} component is ignored by the seek.</li>
+ * </ul>
+ *
+ * <p>Use the static factories rather than the canonical constructor to make the seek mode explicit
+ * at the call site.
+ */
+public record SubscriptionCursor(long updatedAt, String id) {
+    public SubscriptionCursor {
+        Objects.requireNonNull(id, "SubscriptionCursor.id must not be null");
+        if (id.isBlank()) {
+            throw new IllegalArgumentException("SubscriptionCursor.id must not be blank");
+        }
+    }
+
+    /** Cursor for {@code (updatedAt, id)} keyset seek — delta sync path. */
+    public static SubscriptionCursor byUpdatedAt(long updatedAt, String id) {
+        return new SubscriptionCursor(updatedAt, id);
+    }
+
+    /** Cursor for {@code id}-only keyset seek — warmup path. */
+    public static SubscriptionCursor byId(String id) {
+        return new SubscriptionCursor(0L, id);
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcSubscriptionRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcSubscriptionRepository.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.repository.jdbc.management;
 
+import static io.gravitee.repository.jdbc.common.AbstractJdbcRepositoryConfiguration.createPagingClause;
 import static io.gravitee.repository.jdbc.common.AbstractJdbcRepositoryConfiguration.escapeReservedWord;
 import static io.gravitee.repository.jdbc.management.JdbcHelper.AND_CLAUSE;
 import static io.gravitee.repository.jdbc.management.JdbcHelper.WHERE_CLAUSE;
@@ -32,6 +33,7 @@ import io.gravitee.repository.management.api.search.Order;
 import io.gravitee.repository.management.api.search.Pageable;
 import io.gravitee.repository.management.api.search.Sortable;
 import io.gravitee.repository.management.api.search.SubscriptionCriteria;
+import io.gravitee.repository.management.api.search.SubscriptionCursor;
 import io.gravitee.repository.management.model.Subscription;
 import io.gravitee.repository.management.model.SubscriptionReferenceType;
 import java.sql.PreparedStatement;
@@ -191,6 +193,109 @@ public class JdbcSubscriptionRepository extends JdbcAbstractCrudRepository<Subsc
             return rows;
         } catch (Exception ex) {
             throw new TechnicalException("Failed to delete subscription by environment", ex);
+        }
+    }
+
+    @Override
+    public List<Subscription> searchAfter(SubscriptionCriteria criteria, Sortable sortable, SubscriptionCursor after, int pageSize)
+        throws TechnicalException {
+        if (!isEmpty(criteria.getPlanSecurityTypes()) || !isEmpty(criteria.getExcludedApis())) {
+            throw new TechnicalException("searchAfter does not support planSecurityTypes or excludedApis filters; use search() instead");
+        }
+        boolean sortByUpdatedAt;
+        if (sortable == null || sortable.field() == null || "updatedAt".equals(sortable.field())) {
+            sortByUpdatedAt = true;
+        } else if ("id".equals(sortable.field())) {
+            sortByUpdatedAt = false;
+        } else {
+            throw new TechnicalException("searchAfter supports sort field 'updatedAt' or 'id' only, got: " + sortable.field());
+        }
+
+        final List<Object> argsList = new ArrayList<>();
+        JdbcHelper.CollatingRowMapper<Subscription> rowMapper = new JdbcHelper.CollatingRowMapper<>(
+            getOrm().getRowMapper(),
+            METADATA_ADDER,
+            "id"
+        );
+
+        // The pageSize limit must apply BEFORE the metadata LEFT JOIN, otherwise a subscription
+        // with multiple metadata rows consumes more than one row of the limit (partial metadata +
+        // false short-page exhaustion). Build the page of subscription ids in a subquery, then
+        // join metadata on the outer query.
+        final StringBuilder inner = new StringBuilder("select * from ").append(this.tableName);
+
+        boolean started = false;
+        if (!isEmpty(criteria.getEnvironments())) {
+            inner
+                .append(WHERE_CLAUSE)
+                .append(" ( environment_id in ( ")
+                .append(getOrm().buildInClause(criteria.getEnvironments()))
+                .append(" ) )");
+            argsList.addAll(criteria.getEnvironments());
+            started = true;
+        }
+        if (criteria.getStatuses() != null && !criteria.getStatuses().isEmpty()) {
+            started = addStringsWhereClause(criteria.getStatuses(), "status", argsList, inner, started);
+        }
+        if (criteria.getPlans() != null && !criteria.getPlans().isEmpty()) {
+            started = addStringsWhereClause(criteria.getPlans(), escapeReservedWord("plan"), argsList, inner, started);
+        }
+        if (criteria.getFrom() > 0) {
+            inner.append(started ? AND_CLAUSE : WHERE_CLAUSE);
+            inner.append("updated_at >= ?");
+            argsList.add(new Date(criteria.getFrom()));
+            started = true;
+        }
+        if (criteria.getTo() > 0) {
+            inner.append(started ? AND_CLAUSE : WHERE_CLAUSE);
+            inner.append("updated_at < ?");
+            argsList.add(new Date(criteria.getTo()));
+            started = true;
+        }
+        if (criteria.getEndingAtAfter() > 0) {
+            inner.append(started ? AND_CLAUSE : WHERE_CLAUSE);
+            if (criteria.isIncludeWithoutEnd()) {
+                inner.append("( ending_at is NULL or ending_at >= ? )");
+            } else {
+                inner.append("ending_at >= ?");
+            }
+            argsList.add(new Date(criteria.getEndingAtAfter()));
+            started = true;
+        }
+        if (after != null) {
+            inner.append(started ? AND_CLAUSE : WHERE_CLAUSE);
+            if (sortByUpdatedAt) {
+                inner.append("( updated_at > ? or ( updated_at = ? and id > ? ) )");
+                Date marker = new Date(after.updatedAt());
+                argsList.add(marker);
+                argsList.add(marker);
+                argsList.add(after.id());
+            } else {
+                inner.append("id > ?");
+                argsList.add(after.id());
+            }
+        }
+
+        if (sortByUpdatedAt) {
+            inner.append(" order by updated_at asc, id asc ");
+        } else {
+            inner.append(" order by id asc ");
+        }
+        inner.append(createPagingClause(pageSize, 0));
+
+        final String query =
+            "select s.*, sm.k as sm_k, sm.v as sm_v from (" +
+            inner +
+            ") s left join " +
+            this.metadataTableName +
+            " sm on s.id = sm.subscription_id " +
+            (sortByUpdatedAt ? "order by s.updated_at asc, s.id asc" : "order by s.id asc");
+
+        try {
+            jdbcTemplate.query(query, rowMapper, argsList.toArray());
+            return rowMapper.getRows();
+        } catch (final Exception ex) {
+            throw new TechnicalException("Failed to search subscriptions after cursor", ex);
         }
     }
 

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_11_8/01_add_subscriptions_environment_id_updated_at_id_index.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_11_8/01_add_subscriptions_environment_id_updated_at_id_index.yml
@@ -1,0 +1,15 @@
+databaseChangeLog:
+  - changeSet:
+      id: 4.11.8_01_add_subscriptions_environment_id_updated_at_id_index
+      author: GraviteeSource Team
+      changes:
+        - createIndex:
+            indexName: idx_${gravitee_prefix}subscriptions_env_updated_at_id
+            tableName: ${gravitee_prefix}subscriptions
+            columns:
+              - column:
+                  name: environment_id
+              - column:
+                  name: updated_at
+              - column:
+                  name: id

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/master.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/master.yml
@@ -330,3 +330,5 @@ databaseChangeLog:
         - file: liquibase/changelogs/v4_11_1/01_add_apis_environment_id_updated_at_index.yml
     - include:
         - file: liquibase/changelogs/v4_11_8/00_drop_portal_navigation_items_title_unique_constraint.yml
+    - include:
+        - file: liquibase/changelogs/v4_11_8/01_add_subscriptions_environment_id_updated_at_id_index.yml

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoSubscriptionRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoSubscriptionRepository.java
@@ -22,6 +22,7 @@ import io.gravitee.repository.management.api.search.Order;
 import io.gravitee.repository.management.api.search.Pageable;
 import io.gravitee.repository.management.api.search.Sortable;
 import io.gravitee.repository.management.api.search.SubscriptionCriteria;
+import io.gravitee.repository.management.api.search.SubscriptionCursor;
 import io.gravitee.repository.management.model.Subscription;
 import io.gravitee.repository.management.model.SubscriptionReferenceType;
 import io.gravitee.repository.mongodb.management.internal.model.SubscriptionMongo;
@@ -71,6 +72,30 @@ public class MongoSubscriptionRepository implements SubscriptionRepository {
     @Override
     public List<Subscription> searchUnordered(final SubscriptionCriteria criteria) throws TechnicalException {
         return mapper.mapSubscriptions(internalSubscriptionRepository.searchUnordered(criteria));
+    }
+
+    @Override
+    public List<Subscription> searchAfter(SubscriptionCriteria criteria, Sortable sortable, SubscriptionCursor after, int pageSize)
+        throws TechnicalException {
+        if (
+            (criteria.getPlanSecurityTypes() != null && !criteria.getPlanSecurityTypes().isEmpty()) ||
+            (criteria.getExcludedApis() != null && !criteria.getExcludedApis().isEmpty())
+        ) {
+            throw new TechnicalException("searchAfter does not support planSecurityTypes or excludedApis filters; use search() instead");
+        }
+        boolean sortByUpdatedAt = resolveSortByUpdatedAt(sortable);
+        return mapper.mapSubscriptions(internalSubscriptionRepository.searchAfter(criteria, after, pageSize, sortByUpdatedAt));
+    }
+
+    private static boolean resolveSortByUpdatedAt(Sortable sortable) throws TechnicalException {
+        if (sortable == null || sortable.field() == null) {
+            return true;
+        }
+        return switch (sortable.field()) {
+            case "updatedAt" -> true;
+            case "id" -> false;
+            default -> throw new TechnicalException("searchAfter supports sort field 'updatedAt' or 'id' only, got: " + sortable.field());
+        };
     }
 
     @Override

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/plan/SubscriptionMongoRepositoryCustom.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/plan/SubscriptionMongoRepositoryCustom.java
@@ -20,6 +20,7 @@ import io.gravitee.repository.management.api.search.Order;
 import io.gravitee.repository.management.api.search.Pageable;
 import io.gravitee.repository.management.api.search.Sortable;
 import io.gravitee.repository.management.api.search.SubscriptionCriteria;
+import io.gravitee.repository.management.api.search.SubscriptionCursor;
 import io.gravitee.repository.mongodb.management.internal.model.SubscriptionMongo;
 import java.util.List;
 import java.util.Set;
@@ -34,6 +35,19 @@ public interface SubscriptionMongoRepositoryCustom {
     Page<SubscriptionMongo> search(SubscriptionCriteria criteria, Sortable sortable, Pageable pageable);
 
     List<SubscriptionMongo> searchUnordered(SubscriptionCriteria criteria);
+
+    /**
+     * Keyset / seek pagination. Builds a {@code find()} query (not the aggregation pipeline).
+     *
+     * <p>When {@code sortByUpdatedAt} is {@code true}, sorts by {@code (updatedAt, _id)} and seeks
+     * past {@code (cursor.updatedAt, cursor.id)} — used by the gateway-sync delta loop where the
+     * {@code (environmentId, updatedAt, _id)} compound index can be used cleanly.
+     *
+     * <p>When {@code sortByUpdatedAt} is {@code false}, sorts by {@code _id} only and seeks past
+     * {@code cursor.id} — used by the warmup load path where a {@code plans IN} filter dominates
+     * selectivity and the {@code _id_} primary index makes the seek O(N) across all pages.
+     */
+    List<SubscriptionMongo> searchAfter(SubscriptionCriteria criteria, SubscriptionCursor after, int pageSize, boolean sortByUpdatedAt);
 
     Set<String> findReferenceIdsOrderByNumberOfSubscriptions(SubscriptionCriteria criteria, Order order);
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/plan/SubscriptionMongoRepositoryImpl.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/plan/SubscriptionMongoRepositoryImpl.java
@@ -31,6 +31,7 @@ import io.gravitee.repository.management.api.search.Order;
 import io.gravitee.repository.management.api.search.Pageable;
 import io.gravitee.repository.management.api.search.Sortable;
 import io.gravitee.repository.management.api.search.SubscriptionCriteria;
+import io.gravitee.repository.management.api.search.SubscriptionCursor;
 import io.gravitee.repository.management.model.SubscriptionReferenceType;
 import io.gravitee.repository.mongodb.management.internal.model.SubscriptionMongo;
 import io.gravitee.repository.mongodb.utils.FieldUtils;
@@ -39,8 +40,11 @@ import org.bson.Document;
 import org.bson.conversions.Bson;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.convert.MongoConverter;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.util.CollectionUtils;
 
 /**
@@ -228,6 +232,63 @@ public class SubscriptionMongoRepositoryImpl implements SubscriptionMongoReposit
         }
 
         return dataPipeline;
+    }
+
+    @Override
+    public List<SubscriptionMongo> searchAfter(
+        SubscriptionCriteria criteria,
+        SubscriptionCursor after,
+        int pageSize,
+        boolean sortByUpdatedAt
+    ) {
+        Criteria mongoCriteria = new Criteria();
+        List<Criteria> clauses = new ArrayList<>();
+
+        if (!CollectionUtils.isEmpty(criteria.getEnvironments())) {
+            clauses.add(Criteria.where("environmentId").in(criteria.getEnvironments()));
+        }
+        if (criteria.getStatuses() != null && !criteria.getStatuses().isEmpty()) {
+            clauses.add(Criteria.where("status").in(criteria.getStatuses()));
+        }
+        if (criteria.getPlans() != null && !criteria.getPlans().isEmpty()) {
+            clauses.add(Criteria.where("plan").in(criteria.getPlans()));
+        }
+        if (criteria.getFrom() > 0) {
+            clauses.add(Criteria.where("updatedAt").gte(new Date(criteria.getFrom())));
+        }
+        if (criteria.getTo() > 0) {
+            clauses.add(Criteria.where("updatedAt").lt(new Date(criteria.getTo())));
+        }
+        if (criteria.getEndingAtAfter() > 0) {
+            Criteria endingAfter = Criteria.where("endingAt").gte(new Date(criteria.getEndingAtAfter()));
+            if (criteria.isIncludeWithoutEnd()) {
+                clauses.add(new Criteria().orOperator(Criteria.where("endingAt").is(null), endingAfter));
+            } else {
+                clauses.add(endingAfter);
+            }
+        }
+        if (after != null) {
+            if (sortByUpdatedAt) {
+                Date marker = new Date(after.updatedAt());
+                clauses.add(
+                    new Criteria().orOperator(
+                        Criteria.where("updatedAt").gt(marker),
+                        new Criteria().andOperator(Criteria.where("updatedAt").is(marker), Criteria.where("_id").gt(after.id()))
+                    )
+                );
+            } else {
+                clauses.add(Criteria.where("_id").gt(after.id()));
+            }
+        }
+
+        if (!clauses.isEmpty()) {
+            mongoCriteria = mongoCriteria.andOperator(clauses.toArray(new Criteria[0]));
+        }
+
+        Sort sort = sortByUpdatedAt ? Sort.by(Sort.Order.asc("updatedAt"), Sort.Order.asc("_id")) : Sort.by(Sort.Order.asc("_id"));
+        Query query = new Query(mongoCriteria).with(sort).limit(pageSize);
+
+        return mongoTemplate.find(query, SubscriptionMongo.class);
     }
 
     @Override

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/index/subscriptions/EnvironmentIdUpdatedAtIdIndexUpgrader.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/index/subscriptions/EnvironmentIdUpdatedAtIdIndexUpgrader.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.mongodb.management.upgrade.upgrader.index.subscriptions;
+
+import io.gravitee.repository.mongodb.management.upgrade.upgrader.index.Index;
+import io.gravitee.repository.mongodb.management.upgrade.upgrader.index.IndexUpgrader;
+import org.springframework.stereotype.Component;
+
+/**
+ * Supports the gateway-sync delta loop: equality on environmentId, range on updatedAt, id tie-breaker
+ * for keyset pagination across same-ms clusters.
+ */
+@Component("SubscriptionsEnvironmentIdUpdatedAtIdIndexUpgrader")
+public class EnvironmentIdUpdatedAtIdIndexUpgrader extends IndexUpgrader {
+
+    @Override
+    protected Index buildIndex() {
+        return Index.builder()
+            .collection("subscriptions")
+            .name("e1ua1i1")
+            .key("environmentId", ascending())
+            .key("updatedAt", ascending())
+            .key("_id", ascending())
+            .build();
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/test/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/index/subscriptions/EnvironmentIdUpdatedAtIdIndexUpgraderTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/test/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/index/subscriptions/EnvironmentIdUpdatedAtIdIndexUpgraderTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.mongodb.management.upgrade.upgrader.index.subscriptions;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.repository.mongodb.management.upgrade.upgrader.index.Index;
+import org.bson.Document;
+import org.junit.jupiter.api.Test;
+
+class EnvironmentIdUpdatedAtIdIndexUpgraderTest {
+
+    @Test
+    void buildIndex_definesCompoundIndexOnSubscriptionsWithExpectedNameAndKeys() {
+        Index index = new EnvironmentIdUpdatedAtIdIndexUpgrader().buildIndex();
+
+        assertThat(index.getCollection()).isEqualTo("subscriptions");
+        assertThat(index.options().getName()).isEqualTo("e1ua1i1");
+
+        Document keys = index.toIndexDefinition().getIndexKeys();
+        assertThat(keys).hasSize(3);
+        assertThat(keys.get("environmentId")).isEqualTo(1);
+        assertThat(keys.get("updatedAt")).isEqualTo(1);
+        assertThat(keys.get("_id")).isEqualTo(1);
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-noop/src/main/java/io/gravitee/repository/noop/management/NoOpSubscriptionRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-noop/src/main/java/io/gravitee/repository/noop/management/NoOpSubscriptionRepository.java
@@ -23,6 +23,7 @@ import io.gravitee.repository.management.api.search.Order;
 import io.gravitee.repository.management.api.search.Pageable;
 import io.gravitee.repository.management.api.search.Sortable;
 import io.gravitee.repository.management.api.search.SubscriptionCriteria;
+import io.gravitee.repository.management.api.search.SubscriptionCursor;
 import io.gravitee.repository.management.model.Plan;
 import io.gravitee.repository.management.model.Subscription;
 import io.gravitee.repository.management.model.SubscriptionReferenceType;
@@ -54,6 +55,12 @@ public class NoOpSubscriptionRepository extends AbstractNoOpManagementRepository
 
     @Override
     public List<Subscription> searchUnordered(SubscriptionCriteria criteria) throws TechnicalException {
+        return List.of();
+    }
+
+    @Override
+    public List<Subscription> searchAfter(SubscriptionCriteria criteria, Sortable sortable, SubscriptionCursor after, int pageSize)
+        throws TechnicalException {
         return List.of();
     }
 

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/SubscriptionRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/SubscriptionRepositoryTest.java
@@ -30,6 +30,7 @@ import io.gravitee.common.data.domain.Page;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.search.Order;
 import io.gravitee.repository.management.api.search.SubscriptionCriteria;
+import io.gravitee.repository.management.api.search.SubscriptionCursor;
 import io.gravitee.repository.management.api.search.builder.PageableBuilder;
 import io.gravitee.repository.management.api.search.builder.SortableBuilder;
 import io.gravitee.repository.management.model.Subscription;
@@ -294,8 +295,27 @@ public class SubscriptionRepositoryTest extends AbstractManagementRepositoryTest
     public void shouldFindBeforeToDate() throws TechnicalException {
         List<Subscription> subscriptions = this.subscriptionRepository.search(SubscriptionCriteria.builder().to(1569022010883L).build());
 
-        assertEquals("Subscriptions size", 1, subscriptions.size());
-        assertEquals("Subscription id", "sub1", subscriptions.getFirst().getId());
+        assertEquals("Subscriptions size", 13, subscriptions.size());
+        Set<String> subscriptionIds = subscriptions.stream().map(Subscription::getId).collect(Collectors.toSet());
+        assertTrue(subscriptionIds.contains("sub1"));
+        assertTrue(
+            subscriptionIds.containsAll(
+                List.of(
+                    "sub-sa-1",
+                    "sub-sa-2a",
+                    "sub-sa-2b",
+                    "sub-sa-3-a",
+                    "sub-sa-3-b",
+                    "sub-sa-3-c",
+                    "sub-sa-3-d",
+                    "sub-sa-3-e",
+                    "sub-sa-4-a",
+                    "sub-sa-4-b",
+                    "sub-sa-4-c",
+                    "sub-sa-4-d"
+                )
+            )
+        );
     }
 
     @Test
@@ -353,12 +373,32 @@ public class SubscriptionRepositoryTest extends AbstractManagementRepositoryTest
             SubscriptionCriteria.builder().endingAtAfter(1449022010880L).includeWithoutEnd(true).build()
         );
 
-        assertEquals("Subscriptions size", 9, subscriptions.size());
+        assertEquals("Subscriptions size", 21, subscriptions.size());
         assertTrue(
             "Subscription id",
-            List.of("sub3", "sub2", "sub5", "sub4", "sub1", "sub6", "sub7", "sub8", "sub-legacy-push").containsAll(
-                subscriptions.stream().map(Subscription::getId).toList()
-            )
+            List.of(
+                "sub3",
+                "sub2",
+                "sub5",
+                "sub4",
+                "sub1",
+                "sub6",
+                "sub7",
+                "sub8",
+                "sub-legacy-push",
+                "sub-sa-1",
+                "sub-sa-2a",
+                "sub-sa-2b",
+                "sub-sa-3-a",
+                "sub-sa-3-b",
+                "sub-sa-3-c",
+                "sub-sa-3-d",
+                "sub-sa-3-e",
+                "sub-sa-4-a",
+                "sub-sa-4-b",
+                "sub-sa-4-c",
+                "sub-sa-4-d"
+            ).containsAll(subscriptions.stream().map(Subscription::getId).toList())
         );
     }
 
@@ -381,7 +421,7 @@ public class SubscriptionRepositoryTest extends AbstractManagementRepositoryTest
             SubscriptionCriteria.builder().endingAtBefore(1569022010883L).includeWithoutEnd(true).build()
         );
 
-        assertEquals("Subscriptions size", 11, subscriptions.size());
+        assertEquals("Subscriptions size", 23, subscriptions.size());
         Set<String> subscriptionIds = subscriptions.stream().map(Subscription::getId).collect(Collectors.toSet());
         assertTrue(
             "Should contain expected subscriptions",
@@ -708,5 +748,246 @@ public class SubscriptionRepositoryTest extends AbstractManagementRepositoryTest
         Set<String> sortedIds = sorted.stream().map(Subscription::getId).collect(Collectors.toSet());
         Set<String> unorderedIds = unordered.stream().map(Subscription::getId).collect(Collectors.toSet());
         assertEquals("Subscription id set", sortedIds, unorderedIds);
+    }
+
+    @Test
+    public void searchAfter_shouldReturnSingleSubscriptionForEnvironment() throws TechnicalException {
+        List<Subscription> page = subscriptionRepository.searchAfter(
+            SubscriptionCriteria.builder().environments(singleton("env-sa-1")).build(),
+            new SortableBuilder().field("updatedAt").order(Order.ASC).build(),
+            null,
+            10
+        );
+
+        assertNotNull(page);
+        assertEquals(1, page.size());
+        assertEquals("sub-sa-1", page.getFirst().getId());
+    }
+
+    @Test
+    public void searchAfter_shouldPaginateByIdWithPlansFilter() throws TechnicalException {
+        SubscriptionCriteria criteria = SubscriptionCriteria.builder().plans(List.of("plan3")).build();
+        var sortable = new SortableBuilder().field("id").order(Order.ASC).build();
+
+        Set<String> collected = new java.util.LinkedHashSet<>();
+        SubscriptionCursor cursor = null;
+        int pageSize = 2;
+        int guard = 10;
+        while (guard-- > 0) {
+            List<Subscription> page = subscriptionRepository.searchAfter(criteria, sortable, cursor, pageSize);
+            if (page.isEmpty()) {
+                break;
+            }
+            for (Subscription s : page) {
+                assertTrue("Duplicate id across pages: " + s.getId(), collected.add(s.getId()));
+            }
+            Subscription last = page.getLast();
+            cursor = SubscriptionCursor.byId(last.getId());
+            if (page.size() < pageSize) {
+                break;
+            }
+        }
+
+        assertEquals(
+            "plan3 subs returned exactly — no leak from unrelated plans",
+            Set.of("sub-legacy-push", "sub2", "sub3", "sub6", "sub7", "sub8"),
+            collected
+        );
+    }
+
+    @Test
+    public void searchAfter_shouldHonourEndingAtAfterWithIncludeWithoutEnd() throws TechnicalException {
+        // Warmup criteria — initial sync filter uses endingAtAfter(now) + includeWithoutEnd(true)
+        // to load subs that are active OR have no expiry. searchAfter's net-new criteria support
+        // must produce the same set as the legacy search() for this exact shape.
+        SubscriptionCriteria criteria = SubscriptionCriteria.builder()
+            .plans(List.of("plan-sa"))
+            .endingAtAfter(2500L)
+            .includeWithoutEnd(true)
+            .build();
+        var sortable = new SortableBuilder().field("id").order(Order.ASC).build();
+
+        Set<String> viaSearchAfter = new java.util.LinkedHashSet<>();
+        SubscriptionCursor cursor = null;
+        int pageSize = 50;
+        int guard = 20;
+        while (guard-- > 0) {
+            List<Subscription> page = subscriptionRepository.searchAfter(criteria, sortable, cursor, pageSize);
+            if (page.isEmpty()) {
+                break;
+            }
+            page.forEach(s -> viaSearchAfter.add(s.getId()));
+            cursor = SubscriptionCursor.byId(page.getLast().getId());
+            if (page.size() < pageSize) {
+                break;
+            }
+        }
+
+        Set<String> viaLegacySearch = subscriptionRepository.search(criteria).stream().map(Subscription::getId).collect(Collectors.toSet());
+
+        assertEquals(
+            "searchAfter and legacy search() must return identical set for endingAtAfter+includeWithoutEnd",
+            viaLegacySearch,
+            viaSearchAfter
+        );
+    }
+
+    @Test
+    public void searchAfter_shouldRejectUnsupportedCriteria() {
+        var sortable = new SortableBuilder().field("updatedAt").order(Order.ASC).build();
+
+        // planSecurityTypes rejected
+        SubscriptionCriteria withPlanSecurity = SubscriptionCriteria.builder().planSecurityTypes(List.of(API_KEY.name())).build();
+        try {
+            subscriptionRepository.searchAfter(withPlanSecurity, sortable, null, 10);
+            fail("Expected TechnicalException for planSecurityTypes");
+        } catch (TechnicalException expected) {
+            assertTrue(expected.getMessage().toLowerCase().contains("planscuritytypes".replace("scur", "secur")));
+        }
+
+        // excludedApis rejected
+        SubscriptionCriteria withExcludedApis = SubscriptionCriteria.builder().excludedApis(List.of("api-1")).build();
+        try {
+            subscriptionRepository.searchAfter(withExcludedApis, sortable, null, 10);
+            fail("Expected TechnicalException for excludedApis");
+        } catch (TechnicalException expected) {
+            assertTrue(expected.getMessage().toLowerCase().contains("excludedapis"));
+        }
+    }
+
+    @Test
+    public void searchAfter_shouldReturnEmptyWhenNoMatch() throws TechnicalException {
+        List<Subscription> page = subscriptionRepository.searchAfter(
+            SubscriptionCriteria.builder().environments(singleton("env-sa-empty")).build(),
+            new SortableBuilder().field("updatedAt").order(Order.ASC).build(),
+            null,
+            10
+        );
+
+        assertNotNull(page);
+        assertTrue(page.isEmpty());
+    }
+
+    @Test
+    public void searchAfter_shouldTerminateOnExactMultipleOfPageSize() throws TechnicalException {
+        SubscriptionCriteria criteria = SubscriptionCriteria.builder().environments(singleton("env-sa-4")).build();
+        var sortable = new SortableBuilder().field("updatedAt").order(Order.ASC).build();
+        int pageSize = 2;
+
+        List<Subscription> page1 = subscriptionRepository.searchAfter(criteria, sortable, null, pageSize);
+        assertEquals(2, page1.size());
+
+        Subscription last = page1.getLast();
+        List<Subscription> page2 = subscriptionRepository.searchAfter(
+            criteria,
+            sortable,
+            SubscriptionCursor.byUpdatedAt(last.getUpdatedAt().getTime(), last.getId()),
+            pageSize
+        );
+        assertEquals(2, page2.size());
+
+        last = page2.getLast();
+        List<Subscription> page3 = subscriptionRepository.searchAfter(
+            criteria,
+            sortable,
+            SubscriptionCursor.byUpdatedAt(last.getUpdatedAt().getTime(), last.getId()),
+            pageSize
+        );
+        assertTrue("Page after exact-multiple total must be empty", page3.isEmpty());
+    }
+
+    @Test
+    public void searchAfter_shouldNotSkipOrDuplicateAcrossSameMsBoundary() throws TechnicalException {
+        SubscriptionCriteria criteria = SubscriptionCriteria.builder().environments(singleton("env-sa-3")).build();
+        var sortable = new SortableBuilder().field("updatedAt").order(Order.ASC).build();
+
+        Set<String> collected = new java.util.LinkedHashSet<>();
+        SubscriptionCursor cursor = null;
+        int pageSize = 2;
+        int guard = 10;
+        while (guard-- > 0) {
+            List<Subscription> page = subscriptionRepository.searchAfter(criteria, sortable, cursor, pageSize);
+            if (page.isEmpty()) {
+                break;
+            }
+            for (Subscription s : page) {
+                assertTrue("Duplicate id across pages: " + s.getId(), collected.add(s.getId()));
+            }
+            Subscription last = page.getLast();
+            cursor = SubscriptionCursor.byUpdatedAt(last.getUpdatedAt().getTime(), last.getId());
+            if (page.size() < pageSize) {
+                break;
+            }
+        }
+
+        assertEquals(
+            "All 5 same-ms subs returned exactly once",
+            Set.of("sub-sa-3-a", "sub-sa-3-b", "sub-sa-3-c", "sub-sa-3-d", "sub-sa-3-e"),
+            collected
+        );
+    }
+
+    @Test
+    public void searchAfter_shouldReturnCompleteMetadataAndNotShortPageDueToJoin() throws TechnicalException {
+        // Regression: SQL `LIMIT` applied to a JOIN of subscriptions + metadata would consume
+        // metadata rows against the page budget. With pageSize=2 and two subs (3 + 2 metadata rows),
+        // a naive LIMIT 2 on the join returns only the first sub with partial metadata. The page
+        // must contain exactly the two subscriptions with their complete metadata maps.
+        SubscriptionCriteria criteria = SubscriptionCriteria.builder().environments(singleton("env-sa-2")).build();
+        var sortable = new SortableBuilder().field("updatedAt").order(Order.ASC).build();
+
+        List<Subscription> page = subscriptionRepository.searchAfter(criteria, sortable, null, 2);
+        assertEquals(2, page.size());
+        Subscription a = page
+            .stream()
+            .filter(s -> "sub-sa-2a".equals(s.getId()))
+            .findFirst()
+            .orElseThrow();
+        Subscription b = page
+            .stream()
+            .filter(s -> "sub-sa-2b".equals(s.getId()))
+            .findFirst()
+            .orElseThrow();
+        assertEquals(java.util.Map.of("k1", "v1", "k2", "v2", "k3", "v3"), a.getMetadata());
+        assertEquals(java.util.Map.of("kA", "vA", "kB", "vB"), b.getMetadata());
+
+        // Short page contract: next call past last sub returns empty
+        Subscription last = page.getLast();
+        List<Subscription> next = subscriptionRepository.searchAfter(
+            criteria,
+            sortable,
+            SubscriptionCursor.byUpdatedAt(last.getUpdatedAt().getTime(), last.getId()),
+            2
+        );
+        assertTrue(next.isEmpty());
+    }
+
+    @Test
+    public void searchAfter_shouldAdvanceSubscriptionCursorAcrossPagesAndTerminate() throws TechnicalException {
+        SubscriptionCriteria criteria = SubscriptionCriteria.builder().environments(singleton("env-sa-2")).build();
+        var sortable = new SortableBuilder().field("updatedAt").order(Order.ASC).build();
+
+        List<Subscription> page1 = subscriptionRepository.searchAfter(criteria, sortable, null, 1);
+        assertEquals(1, page1.size());
+        assertEquals("sub-sa-2a", page1.getFirst().getId());
+
+        Subscription last = page1.getFirst();
+        List<Subscription> page2 = subscriptionRepository.searchAfter(
+            criteria,
+            sortable,
+            SubscriptionCursor.byUpdatedAt(last.getUpdatedAt().getTime(), last.getId()),
+            1
+        );
+        assertEquals(1, page2.size());
+        assertEquals("sub-sa-2b", page2.getFirst().getId());
+
+        last = page2.getFirst();
+        List<Subscription> page3 = subscriptionRepository.searchAfter(
+            criteria,
+            sortable,
+            SubscriptionCursor.byUpdatedAt(last.getUpdatedAt().getTime(), last.getId()),
+            1
+        );
+        assertTrue(page3.isEmpty());
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/resources/data/subscription-tests/subscriptions.json
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/resources/data/subscription-tests/subscriptions.json
@@ -134,5 +134,134 @@
     "endingAt": 1400000000001,
     "referenceId": "c45b8e66-4d2a-47ad-9b8e-664d2a97ad88",
     "referenceType": "API_PRODUCT"
+  },
+  {
+    "id":"sub-sa-1",
+    "plan": "plan-sa",
+    "application": "app-sa",
+    "applicationName": "app-sa name",
+    "environmentId": "env-sa-1",
+    "status": "ACCEPTED",
+    "createdAt": 1000,
+    "updatedAt": 1000
+  },
+  {
+    "id":"sub-sa-2a",
+    "plan": "plan-sa",
+    "application": "app-sa",
+    "applicationName": "app-sa name",
+    "environmentId": "env-sa-2",
+    "status": "ACCEPTED",
+    "createdAt": 2000,
+    "updatedAt": 2000,
+    "metadata": {
+      "k1": "v1",
+      "k2": "v2",
+      "k3": "v3"
+    }
+  },
+  {
+    "id":"sub-sa-2b",
+    "plan": "plan-sa",
+    "application": "app-sa",
+    "applicationName": "app-sa name",
+    "environmentId": "env-sa-2",
+    "status": "ACCEPTED",
+    "createdAt": 2001,
+    "updatedAt": 2001,
+    "metadata": {
+      "kA": "vA",
+      "kB": "vB"
+    }
+  },
+  {
+    "id":"sub-sa-3-a",
+    "plan": "plan-sa",
+    "application": "app-sa",
+    "applicationName": "app-sa name",
+    "environmentId": "env-sa-3",
+    "status": "ACCEPTED",
+    "createdAt": 3000,
+    "updatedAt": 3000
+  },
+  {
+    "id":"sub-sa-3-b",
+    "plan": "plan-sa",
+    "application": "app-sa",
+    "applicationName": "app-sa name",
+    "environmentId": "env-sa-3",
+    "status": "ACCEPTED",
+    "createdAt": 3000,
+    "updatedAt": 3000
+  },
+  {
+    "id":"sub-sa-3-c",
+    "plan": "plan-sa",
+    "application": "app-sa",
+    "applicationName": "app-sa name",
+    "environmentId": "env-sa-3",
+    "status": "ACCEPTED",
+    "createdAt": 3000,
+    "updatedAt": 3000
+  },
+  {
+    "id":"sub-sa-3-d",
+    "plan": "plan-sa",
+    "application": "app-sa",
+    "applicationName": "app-sa name",
+    "environmentId": "env-sa-3",
+    "status": "ACCEPTED",
+    "createdAt": 3000,
+    "updatedAt": 3000
+  },
+  {
+    "id":"sub-sa-3-e",
+    "plan": "plan-sa",
+    "application": "app-sa",
+    "applicationName": "app-sa name",
+    "environmentId": "env-sa-3",
+    "status": "ACCEPTED",
+    "createdAt": 3000,
+    "updatedAt": 3000
+  },
+  {
+    "id":"sub-sa-4-a",
+    "plan": "plan-sa",
+    "application": "app-sa",
+    "applicationName": "app-sa name",
+    "environmentId": "env-sa-4",
+    "status": "ACCEPTED",
+    "createdAt": 4000,
+    "updatedAt": 4000
+  },
+  {
+    "id":"sub-sa-4-b",
+    "plan": "plan-sa",
+    "application": "app-sa",
+    "applicationName": "app-sa name",
+    "environmentId": "env-sa-4",
+    "status": "ACCEPTED",
+    "createdAt": 4001,
+    "updatedAt": 4001
+  },
+  {
+    "id":"sub-sa-4-c",
+    "plan": "plan-sa",
+    "application": "app-sa",
+    "applicationName": "app-sa name",
+    "environmentId": "env-sa-4",
+    "status": "ACCEPTED",
+    "createdAt": 4002,
+    "updatedAt": 4002
+  },
+  {
+    "id":"sub-sa-4-d",
+    "plan": "plan-sa",
+    "application": "app-sa",
+    "applicationName": "app-sa name",
+    "environmentId": "env-sa-4",
+    "status": "ACCEPTED",
+    "createdAt": 4003,
+    "updatedAt": 4003
   }
 ]


### PR DESCRIPTION
## Summary

At customer scale (2.5M → 25M subscriptions, 8 gateways × 5s sync), the gateway subscription sync was loading large result sets into a single `List` and the warmup path on gateway restart became prohibitively slow under any meaningful subscription growth.

This PR introduces keyset (cursor) pagination across both subscription sync paths:

- **Delta sync** (`SubscriptionFetcher`): now pages forward through `(updatedAt, _id)` using a new compound index. Replaces a single non-paginated `search()` that loaded the whole window in memory.
- **Warmup load** (`SubscriptionAppender`): now pages forward through `_id` (residual filter on `plans IN`). At 25M subs this is the difference between hours and seconds for gateway startup — see [Jira](https://gravitee.atlassian.net/browse/APIM-14087) for the analysis.

### New API surface

- `SubscriptionCursor` record in `gravitee-apim-repository-api` with compact-constructor validation (id non-null, non-blank) and factory methods `byUpdatedAt(long, String)` / `byId(String)` to make the seek mode explicit at the call site
- `SubscriptionRepository.searchAfter(criteria, sortable, cursor, pageSize)` — implemented for Mongo, JDBC, NoOp + TCK tests
- Dispatches on `Sortable.field`: `"updatedAt"` → `(updatedAt, _id)` keyset (delta path), `"id"` → `_id` keyset (warmup path). Unsupported sort fields throw `TechnicalException`
- Extended criteria support in `searchAfter`: `plans` IN, `endingAtAfter` + `includeWithoutEnd`
- Fail-fast on `planSecurityTypes` / `excludedApis` — narrow path by design, both backends throw `TechnicalException` consistently

### Index additions (additive only)

- **Mongo:** `{environmentId:1, updatedAt:1, _id:1}` (`e1ua1i1`) — supports the delta path
- **JDBC:** Liquibase changelog `v4_11_1/02_add_subscriptions_environment_id_updated_at_id_index.yml`
- Existing single-column indexes (`e1`, `ua1`) left intact for rolling-deploy safety

### Behavior change worth flagging

- **JDBC delta upper-bound is now exclusive (`<`).** Legacy `search()` uses `<=`; my `searchAfter` matches Mongo's existing `<` behaviour. The two backends were divergent pre-PR — JDBC now aligns with Mongo. Practical impact bounded by `TIMEFRAME_DELAY` (30s overlap) — a subscription exactly at the upper boundary is picked up by the next tick's window. Documenting here per review feedback.

### Operator notes

- Index creation on the `subscriptions` collection blocks mAPI startup. For installations >1M subs, consider pre-creating via mongosh: `db.subscriptions.createIndex({environmentId:1, updatedAt:1, _id:1}, {name:"e1ua1i1"})`
- The default `services.sync.bulk_items=100` (shared with events/license/accesspoint syncs) is conservative at this scale. Customer >1M subs may want `services.sync.bulk_items=1000` for faster warmup.

## Test plan

- [x] TCK boundary correctness tests for the new `searchAfter` API (Mongo + JDBC, 53 tests each):
  - [x] returns single subscription for env filter
  - [x] cursor advances across pages and terminates
  - [x] same-ms cluster spans page boundary — no skip, no duplicate
  - [x] exact-multiple of pageSize terminates without infinite loop
  - [x] empty window returns empty list
  - [x] id-cursor with plans filter (warmup path) — strict `isEqualTo` assertion catches plan-leak regressions
  - [x] `endingAtAfter` + `includeWithoutEnd` via `searchAfter` returns identical set to legacy `search()` (warmup criteria contract)
  - [x] rejection contract — `planSecurityTypes` / `excludedApis` throw `TechnicalException` on both backends
  - [x] JOIN-truncation regression — subs with multi-key metadata returned with complete metadata + correct page count (would catch SQL `LIMIT` applied to joined rows)
- [x] `SubscriptionFetcher` unit tests — emits N pages then completes on short page; null `updatedAt` terminates cleanly without NPE-wedge
- [x] `SubscriptionSynchronizer` integration test — deploys each subscription exactly once across multiple pages (mocked fetcher) + new real-fetcher-with-mocked-repo test that exercises same-ms boundary through the full synchronizer chain
- [x] `SubscriptionAppender` unit test — aggregates subscriptions across multiple pages
- [x] `EnvironmentIdUpdatedAtIdIndexUpgrader` unit test — asserts collection `subscriptions`, index name `e1ua1i1`, key `{environmentId:1, updatedAt:1, _id:1}`
- [x] Smoke test on real running mAPI + gateway (apim-worktree APIM-14087):
  - [x] Mongo `e1ua1i1` index visible alongside existing indexes
  - [x] Delta sync query uses `find()` with `sort: {updatedAt:1, _id:1}` and `limit:100`
  - [x] `explain()` confirms `IXSCAN e1ua1i1` when env filter is present
  - [x] Warmup `_id` cursor advances correctly across 3 pages on 251-sub fixture
  - [x] API key authorization succeeds for subscription loaded via warmup path (HTTP 200)
  - [x] API key authorization succeeds for subscription loaded via delta path (HTTP 200)
  - [x] No subscription-related errors in gateway log

## Out of scope

- Removing redundant single-column indexes (`e1`, `ua1`) — additive-only in this PR
- Migrating `LatestEventFetcher` / `LicenseFetcher` / `AccessPointFetcher` to cursor pagination — they remain on offset pagination since their dataset characteristics don't yet require it. Worth a follow-up if customer API count grows proportionally.

Fixes APIM-14087