### PR TITLE
perf(repository): single-$in defVersion query + ESR index (APIM-14088)

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/api/ApiMongoRepositoryImpl.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/api/ApiMongoRepositoryImpl.java
@@ -159,15 +159,12 @@ public class ApiMongoRepositoryImpl implements ApiMongoRepositoryCustom {
                         criteria.add(where("crossId").is(apiCriteria.getCrossId()));
                     }
                     if (apiCriteria.getDefinitionVersion() != null && !apiCriteria.getDefinitionVersion().isEmpty()) {
-                        var lookingForV2 = apiCriteria.getDefinitionVersion().stream().anyMatch(DefinitionVersion.V2::equals);
-
-                        var definitionVersionCriteria = new ArrayList<Criteria>();
-                        definitionVersionCriteria.add(where("definitionVersion").in(apiCriteria.getDefinitionVersion()));
-                        if (lookingForV2) {
-                            // V2 are stored with a null value for DefinitionVersion
-                            definitionVersionCriteria.add(where("definitionVersion").isNull());
+                        var values = new ArrayList<DefinitionVersion>(apiCriteria.getDefinitionVersion());
+                        if (values.contains(DefinitionVersion.V2)) {
+                            // V2 APIs are stored with definitionVersion=null (or missing); $in matches both.
+                            values.add(null);
                         }
-                        criteria.add(new Criteria().orOperator(definitionVersionCriteria));
+                        criteria.add(where("definitionVersion").in(values));
                     }
                     if (apiCriteria.getIntegrationId() != null && !apiCriteria.getIntegrationId().isEmpty()) {
                         criteria.add(where("integrationId").is(apiCriteria.getIntegrationId()));

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/index/apis/EnvironmentIdDefinitionVersionNameIndexUpgrader.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/index/apis/EnvironmentIdDefinitionVersionNameIndexUpgrader.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.mongodb.management.upgrade.upgrader.index.apis;
+
+import io.gravitee.repository.mongodb.management.upgrade.upgrader.index.Index;
+import io.gravitee.repository.mongodb.management.upgrade.upgrader.index.IndexUpgrader;
+import org.springframework.stereotype.Component;
+
+@Component("ApisEnvironmentIdDefinitionVersionNameIndexUpgrader")
+public class EnvironmentIdDefinitionVersionNameIndexUpgrader extends IndexUpgrader {
+
+    @Override
+    protected Index buildIndex() {
+        return Index.builder()
+            .collection("apis")
+            .name("ei1dv1n1")
+            .key("environmentId", ascending())
+            .key("definitionVersion", ascending())
+            .key("name", ascending())
+            .build();
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/test/java/io/gravitee/repository/mongodb/management/ApiMongoFieldAbsentDefVersionTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/test/java/io/gravitee/repository/mongodb/management/ApiMongoFieldAbsentDefVersionTest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.mongodb.management;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.definition.model.DefinitionVersion;
+import io.gravitee.repository.management.AbstractManagementRepositoryTest;
+import io.gravitee.repository.management.api.search.ApiCriteria;
+import io.gravitee.repository.management.api.search.ApiFieldFilter;
+import io.gravitee.repository.management.model.Api;
+import java.util.List;
+import org.bson.Document;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.mongodb.core.MongoTemplate;
+
+/**
+ * Closes the "field-absent vs BSON-null" coverage gap left by ApiRepositoryTest:
+ * fixture docs go through Spring Data's POJO writer, which materialises every
+ * absent JSON key as an explicit BSON null. The legacy-V2 production scenario —
+ * documents where the {@code definitionVersion} key is omitted entirely — is
+ * never represented in that corpus.
+ *
+ * This test inserts a document directly via {@link MongoTemplate}, bypassing the
+ * POJO writer, and asserts the {@code $in [..., null]} query matches it. A
+ * {@code $exists: false} sanity check confirms the field is truly absent.
+ */
+public class ApiMongoFieldAbsentDefVersionTest extends AbstractManagementRepositoryTest {
+
+    private static final String FIELD_ABSENT_API_ID = "field-absent-v2-api";
+    private static final String FIELD_ABSENT_ENV_ID = "ENV-FIELD-ABSENT";
+
+    @Autowired
+    private MongoTemplate mongoTemplate;
+
+    @Value("${management.mongodb.prefix:}")
+    private String collectionPrefix;
+
+    @Override
+    protected String getTestCasesPath() {
+        return null;
+    }
+
+    @Override
+    protected String getModelPackage() {
+        return "io.gravitee.repository.management.model.";
+    }
+
+    @Override
+    protected void createModel(Object object) {
+        // not used: fixture loading is disabled
+    }
+
+    private String apisCollectionName() {
+        return collectionPrefix + "apis";
+    }
+
+    @Before
+    public void insertFieldAbsentDoc() {
+        Document doc = new Document()
+            .append("_id", FIELD_ABSENT_API_ID)
+            .append("environmentId", FIELD_ABSENT_ENV_ID)
+            .append("name", "field-absent v2 api")
+            .append("definition", "{}")
+            .append("visibility", "PRIVATE");
+        // No definitionVersion key at all — this is the legacy-V2 storage shape.
+        mongoTemplate.getCollection(apisCollectionName()).insertOne(doc);
+    }
+
+    @After
+    public void deleteFieldAbsentDoc() {
+        mongoTemplate.getCollection(apisCollectionName()).deleteOne(new Document("_id", FIELD_ABSENT_API_ID));
+    }
+
+    @Test
+    public void v2QueryMatchesDocsWithDefinitionVersionFieldAbsent() {
+        long fieldAbsentCount = mongoTemplate
+            .getCollection(apisCollectionName())
+            .countDocuments(new Document("_id", FIELD_ABSENT_API_ID).append("definitionVersion", new Document("$exists", false)));
+        assertThat(fieldAbsentCount).as("seeded doc must have definitionVersion truly absent, not BSON-null").isEqualTo(1L);
+
+        List<Api> apis = apiRepository.search(
+            new ApiCriteria.Builder().definitionVersion(List.of(DefinitionVersion.V2)).environmentId(FIELD_ABSENT_ENV_ID).build(),
+            ApiFieldFilter.allFields()
+        );
+        assertThat(apis).extracting(Api::getId).containsExactly(FIELD_ABSENT_API_ID);
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/ApiRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/ApiRepositoryTest.java
@@ -286,7 +286,7 @@ public class ApiRepositoryTest extends AbstractManagementRepositoryTest {
             new ApiCriteria.Builder().definitionVersion(List.of(DefinitionVersion.V2)).build(),
             ApiFieldFilter.allFields()
         );
-        assertThat(v2Apis).hasSize(10);
+        assertThat(v2Apis).hasSize(11);
 
         List<Api> v4Apis = apiRepository.search(
             new ApiCriteria.Builder().definitionVersion(List.of(DefinitionVersion.V4)).build(),
@@ -462,6 +462,9 @@ public class ApiRepositoryTest extends AbstractManagementRepositoryTest {
         assertEquals(DefinitionVersion.V4, apis.get(0).getDefinitionVersion());
         assertEquals(ApiType.MESSAGE, apis.get(0).getType());
         assertEquals("async-searched-crossId", apis.get(0).getCrossId());
+        // Guard against a future regression that incorrectly broadens $in to always include null:
+        // V4-only must NOT pull legacy null/missing-defVersion docs.
+        assertThat(apis.stream().map(Api::getId).toList()).doesNotContain("legacy-explicit-null-defv-api");
     }
 
     @Test
@@ -475,6 +478,23 @@ public class ApiRepositoryTest extends AbstractManagementRepositoryTest {
         assertTrue(apis.stream().map(Api::getId).toList().containsAll(asList("api-to-delete", "big-name")));
         assertNull(apis.get(0).getDefinitionVersion());
         assertNull(apis.get(1).getDefinitionVersion());
+    }
+
+    @Test
+    public void shouldFindByDefinitionVersion_V2AndV4_includesLegacyNullDocs() {
+        final List<Api> apis = apiRepository.search(
+            new ApiCriteria.Builder().definitionVersion(List.of(DefinitionVersion.V2, DefinitionVersion.V4)).build(),
+            ApiFieldFilter.allFields()
+        );
+        assertNotNull(apis);
+        assertThat(apis).hasSize(12);
+        assertThat(apis.stream().map(Api::getId).toList()).contains(
+            "async-api",
+            "api-with-many-categories",
+            "legacy-explicit-null-defv-api",
+            "api-to-delete",
+            "big-name"
+        );
     }
 
     @Test
@@ -652,7 +672,7 @@ public class ApiRepositoryTest extends AbstractManagementRepositoryTest {
 
         assertNotNull(apis);
         assertFalse(apis.isEmpty());
-        assertEquals(12, apis.size());
+        assertEquals(13, apis.size());
     }
 
     @Test

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/resources/data/api-tests/apis.json
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/resources/data/api-tests/apis.json
@@ -207,5 +207,21 @@
         "apiLifecycleState": "CREATED",
         "disableMembershipNotifications": false,
         "integrationId": "integration-id"
+    },
+    {
+        "id": "legacy-explicit-null-defv-api",
+        "environmentId": "ENV-NULL-DEFV",
+        "origin": "management",
+        "mode": "fully_managed",
+        "name": "legacy explicit null defv api name",
+        "definitionVersion": null,
+        "version": "legacy-null",
+        "definition": "{\"id\":\"legacy-explicit-null\",\"name\":\"legacy\",\"version\":\"legacy-null\"}",
+        "visibility": "PRIVATE",
+        "createdAt": 1439022010883,
+        "updatedAt": 1439022010883,
+        "lifecycleState": "STARTED",
+        "apiLifecycleState": "CREATED",
+        "disableMembershipNotifications": true
     }
 ]


### PR DESCRIPTION
## Summary

- Collapse `definitionVersion` `$or [$in, isNull]` to a single `$in [..., null]` in `ApiMongoRepositoryImpl.fillQuery()`. MongoDB matches both BSON null and missing field for `null` inside `$in` — exact equivalence with the previous `$or`. Spring Data 4.4.4's `QueryMapper` preserves the `null` element through serialisation (verified by the new test).
- Add complementary index `ei1dv1n1` = `{environmentId:1, definitionVersion:1, name:1}` — ESR-ordered (equality envId, equality defVersion, sort name) for definitionVersion-filtered API listings. Does **not** replace `ei1n1dv1` or `dv1ei1n1`; both stay (see ticket for rationale — they serve distinct access patterns).
- Add cross-backend regression test `shouldFindByDefinitionVersion_V2AndV4_includesLegacyNullDocs` + one seed doc with explicit `"definitionVersion": null` to prove `$in [..., null]` matches BSON-undefined (missing field) and BSON-null equivalently.

Ticket: https://gravitee.atlassian.net/browse/APIM-14088

## Test plan

- [x] `ApiRepositoryTest` passes on Mongo backend (45/45) — characterisation test passes both before and after the query refactor, confirming equivalence.
- [x] `ApiRepositoryTest` passes on JDBC backend (45/45) — cross-backend equivalence (JDBC code path untouched, has its own V2-null bridging).
- [x] Real-mAPI smoke: started `apim-worktree APIM-14088 mapi` against MongoDB 6.0; `db.apis.getIndexes()` confirmed all three indexes present after upgrader run: `ei1n1dv1`, `dv1ei1n1`, and new `ei1dv1n1`.

## Future work (not in this PR)

Backfill `definitionVersion = "2.0.0"` on legacy docs and retire the null-as-V2 sentinel across `GenericApiMapper:77`, `EventServiceImpl:441`, `SearchIndexInitializer:219`, `ApiDocumentTransformer:130`, `IndexableApiDocumentTransformer:69`, and `JdbcApiRepository:532, 595`. Coordinated multi-PR refactor — deliberately out of scope here.