### PR TITLE
fix(audit): chunk retention deletes to avoid Mongo timeout

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/audit/AuditMongoRepositoryImpl.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/audit/AuditMongoRepositoryImpl.java
@@ -17,6 +17,7 @@ package io.gravitee.repository.mongodb.management.internal.audit;
 
 import static org.springframework.data.mongodb.core.query.Criteria.where;
 
+import com.mongodb.client.result.DeleteResult;
 import io.gravitee.common.data.domain.Page;
 import io.gravitee.repository.management.api.search.AuditCriteria;
 import io.gravitee.repository.management.api.search.Pageable;
@@ -24,7 +25,9 @@ import io.gravitee.repository.mongodb.management.internal.model.AuditMongo;
 import java.time.Instant;
 import java.util.Date;
 import java.util.List;
+import lombok.CustomLog;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.mongodb.core.MongoTemplate;
@@ -35,10 +38,14 @@ import org.springframework.data.mongodb.core.query.Query;
  * @author Nicolas GERAUD (nicolas.geraud at graviteesource.com)
  * @author GraviteeSource Team
  */
+@CustomLog
 public class AuditMongoRepositoryImpl implements AuditMongoRepositoryCustom {
 
     @Autowired
     private MongoTemplate mongoTemplate;
+
+    @Value("${services.audit.cleanup.batchSize:1000}")
+    private int batchSize;
 
     @Override
     public Page<AuditMongo> search(AuditCriteria filter, Pageable pageable) {
@@ -89,6 +96,28 @@ public class AuditMongoRepositoryImpl implements AuditMongoRepositoryCustom {
 
     public void deleteByEnvironmentIdAndAge(String environmentId, Instant limit) {
         var criteria = where("environmentId").is(environmentId).andOperator(where("createdAt").lt(Date.from(limit)));
-        mongoTemplate.remove(new Query(criteria), AuditMongo.class);
+        Query chunkQuery = new Query(criteria).limit(batchSize);
+        chunkQuery.fields().include("_id");
+
+        long totalDeleted = 0;
+        List<AuditMongo> chunk = mongoTemplate.find(chunkQuery, AuditMongo.class);
+        while (!chunk.isEmpty()) {
+            List<String> ids = chunk.stream().map(AuditMongo::getId).toList();
+            DeleteResult result = mongoTemplate.remove(new Query(where("_id").in(ids)), AuditMongo.class);
+            long deleted = result.getDeletedCount();
+            if (deleted == 0) {
+                log.warn(
+                    "Audit cleanup made no progress for environment {} after fetching {} candidates; aborting tick",
+                    environmentId,
+                    ids.size()
+                );
+                break;
+            }
+            totalDeleted += deleted;
+            chunk = mongoTemplate.find(chunkQuery, AuditMongo.class);
+        }
+        if (totalDeleted > 0) {
+            log.info("Cleaned {} audit docs for environment {}", totalDeleted, environmentId);
+        }
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/audits/AuditsEnvironmentIdCreatedAtIndexUpgrader.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/audits/AuditsEnvironmentIdCreatedAtIndexUpgrader.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.mongodb.management.upgrade.upgrader.audits;
+
+import io.gravitee.repository.mongodb.management.upgrade.upgrader.index.Index;
+import io.gravitee.repository.mongodb.management.upgrade.upgrader.index.IndexUpgrader;
+import org.springframework.stereotype.Component;
+
+@Component("AuditsEnvironmentIdCreatedAtIndexUpgrader")
+public class AuditsEnvironmentIdCreatedAtIndexUpgrader extends IndexUpgrader {
+
+    @Override
+    protected Index buildIndex() {
+        return Index.builder().collection("audits").name("e1c1").key("environmentId", ascending()).key("createdAt", ascending()).build();
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/test/java/io/gravitee/repository/mongodb/management/internal/audit/AuditMongoRepositoryImplTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/test/java/io/gravitee/repository/mongodb/management/internal/audit/AuditMongoRepositoryImplTest.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.mongodb.management.internal.audit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import com.mongodb.client.result.DeleteResult;
+import io.gravitee.repository.mongodb.management.internal.model.AuditMongo;
+import java.time.Instant;
+import java.util.Collections;
+import java.util.List;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Query;
+
+public class AuditMongoRepositoryImplTest {
+
+    private MongoTemplate mongoTemplate;
+    private AuditMongoRepositoryImpl repository;
+
+    @Before
+    public void setUp() throws Exception {
+        mongoTemplate = mock(MongoTemplate.class);
+        repository = new AuditMongoRepositoryImpl();
+
+        var mongoTemplateField = AuditMongoRepositoryImpl.class.getDeclaredField("mongoTemplate");
+        mongoTemplateField.setAccessible(true);
+        mongoTemplateField.set(repository, mongoTemplate);
+
+        var batchSizeField = AuditMongoRepositoryImpl.class.getDeclaredField("batchSize");
+        batchSizeField.setAccessible(true);
+        batchSizeField.setInt(repository, 2);
+
+        when(mongoTemplate.remove(any(Query.class), eq(AuditMongo.class))).thenReturn(DeleteResult.acknowledged(Long.MAX_VALUE));
+    }
+
+    @Test
+    public void deleteByEnvironmentIdAndAge_pages_through_results_until_exhausted() {
+        AuditMongo a = auditWithId("a");
+        AuditMongo b = auditWithId("b");
+        AuditMongo c = auditWithId("c");
+
+        when(mongoTemplate.find(any(Query.class), eq(AuditMongo.class)))
+            .thenReturn(List.of(a, b))
+            .thenReturn(List.of(c))
+            .thenReturn(Collections.emptyList());
+        when(mongoTemplate.remove(any(Query.class), eq(AuditMongo.class))).thenReturn(
+            DeleteResult.acknowledged(2),
+            DeleteResult.acknowledged(1)
+        );
+
+        repository.deleteByEnvironmentIdAndAge("env-1", Instant.parse("2026-01-01T00:00:00Z"));
+
+        verify(mongoTemplate, times(3)).find(any(Query.class), eq(AuditMongo.class));
+        verify(mongoTemplate, times(2)).remove(any(Query.class), eq(AuditMongo.class));
+    }
+
+    @Test
+    public void deleteByEnvironmentIdAndAge_issues_no_delete_when_nothing_matches() {
+        when(mongoTemplate.find(any(Query.class), eq(AuditMongo.class))).thenReturn(Collections.emptyList());
+
+        repository.deleteByEnvironmentIdAndAge("env-1", Instant.parse("2026-01-01T00:00:00Z"));
+
+        verify(mongoTemplate, times(1)).find(any(Query.class), eq(AuditMongo.class));
+        verifyNoMoreInteractions(mongoTemplate);
+    }
+
+    @Test
+    public void deleteByEnvironmentIdAndAge_deletes_each_chunk_by_id() {
+        AuditMongo a = auditWithId("a");
+        AuditMongo b = auditWithId("b");
+
+        when(mongoTemplate.find(any(Query.class), eq(AuditMongo.class))).thenReturn(List.of(a, b)).thenReturn(Collections.emptyList());
+        when(mongoTemplate.remove(any(Query.class), eq(AuditMongo.class))).thenReturn(DeleteResult.acknowledged(2));
+
+        repository.deleteByEnvironmentIdAndAge("env-1", Instant.parse("2026-01-01T00:00:00Z"));
+
+        ArgumentCaptor<Query> deleteQueryCaptor = ArgumentCaptor.forClass(Query.class);
+        verify(mongoTemplate).remove(deleteQueryCaptor.capture(), eq(AuditMongo.class));
+        assertThat(deleteQueryCaptor.getValue().getQueryObject().toJson()).contains("\"a\"").contains("\"b\"");
+    }
+
+    @Test
+    public void deleteByEnvironmentIdAndAge_aborts_when_remove_makes_no_progress() {
+        AuditMongo a = auditWithId("a");
+        AuditMongo b = auditWithId("b");
+
+        when(mongoTemplate.find(any(Query.class), eq(AuditMongo.class))).thenReturn(List.of(a, b));
+        when(mongoTemplate.remove(any(Query.class), eq(AuditMongo.class))).thenReturn(DeleteResult.acknowledged(0));
+
+        repository.deleteByEnvironmentIdAndAge("env-1", Instant.parse("2026-01-01T00:00:00Z"));
+
+        verify(mongoTemplate, times(1)).find(any(Query.class), eq(AuditMongo.class));
+        verify(mongoTemplate, times(1)).remove(any(Query.class), eq(AuditMongo.class));
+    }
+
+    private static AuditMongo auditWithId(String id) {
+        AuditMongo audit = new AuditMongo();
+        audit.setId(id);
+        return audit;
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-audit/src/main/java/io/gravitee/rest/api/services/audit/ScheduledAuditCleanerService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-audit/src/main/java/io/gravitee/rest/api/services/audit/ScheduledAuditCleanerService.java
@@ -94,7 +94,11 @@ public class ScheduledAuditCleanerService extends AbstractService implements Run
                 environment.getId(),
                 environment.getOrganizationId()
             );
-            removeOldAuditDataUseCase.execute(new RemoveOldAuditDataUseCase.Input(environment.getId(), maxAge));
+            try {
+                removeOldAuditDataUseCase.execute(new RemoveOldAuditDataUseCase.Input(environment.getId(), maxAge));
+            } catch (Exception e) {
+                log.error("Audit cleanup failed for environment {} ({})", environment.getName(), environment.getId(), e);
+            }
         }
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-audit/src/test/java/io/gravitee/rest/api/services/audit/ScheduledAuditCleanerServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-audit/src/test/java/io/gravitee/rest/api/services/audit/ScheduledAuditCleanerServiceTest.java
@@ -17,7 +17,9 @@ package io.gravitee.rest.api.services.audit;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -125,6 +127,29 @@ class ScheduledAuditCleanerServiceTest {
 
         // Then - scheduler is registered regardless; primary check happens in run()
         verify(scheduler).schedule(eq(service), any(CronTrigger.class));
+    }
+
+    @Test
+    void run_continues_to_next_environment_when_one_environment_fails() {
+        Member mockMember = mock(Member.class);
+        when(mockMember.primary()).thenReturn(true);
+        when(clusterManager.self()).thenReturn(mockMember);
+        OrganizationEntity org = new OrganizationEntity();
+        org.setId("oId");
+        when(organizationService.findAll()).thenReturn(List.of(org));
+        EnvironmentEntity env1 = new EnvironmentEntity();
+        env1.setId("env1");
+        EnvironmentEntity env2 = new EnvironmentEntity();
+        env2.setId("env2");
+        when(environmentService.findByOrganization(any())).thenReturn(List.of(env1, env2));
+        doThrow(new RuntimeException("boom"))
+            .when(removeOldAuditDataUseCase)
+            .execute(argThat(input -> "env1".equals(input.environmentId())));
+
+        sut.run();
+
+        verify(removeOldAuditDataUseCase, times(2)).execute(inputArgumentCaptor.capture());
+        assertThat(inputArgumentCaptor.getAllValues()).map(RemoveOldAuditDataUseCase.Input::environmentId).containsExactly("env1", "env2");
     }
 
     @Test

--- a/helm/CHANGELOG.md
+++ b/helm/CHANGELOG.md
@@ -3,6 +3,9 @@
 
 This file documents all notable changes to [Gravitee.io API Management 3.x](https://github.com/gravitee-io/helm-charts/tree/master/apim/3.x) Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
 
+### 4.11.8
+- Expose `api.services.audit.cleanup.batchSize` to tune the page size used by the audit retention cleaner (defaults to `1000`).
+
 ### 4.11.5
 - Support Hazelcast as a distributed rate-limit backend (`ratelimit.type=hazelcast`). Renders `config/hazelcast-ratelimit.xml` with Kubernetes discovery, exposes a ClusterIP `-hz` Service for peer discovery, allows configuring the rate-limit Hazelcast port with `gateway.ratelimit.hazelcast.port`, and creates a ClusterRole/Binding granting the gateway ServiceAccount `get`/`list` on `endpoints`/`pods`/`nodes`/`services`.
 

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -29,4 +29,6 @@ annotations:
   ###########
   # "changes" must be the last section in this file, because a CI job clean it after each release
   ###########
-  artifacthub.io/changes: 
+  artifacthub.io/changes: |
+    - kind: added
+      description: "Expose `api.services.audit.cleanup.batchSize` to tune the audit retention cleaner page size"

--- a/helm/tests/api/configmap_services_test.yaml
+++ b/helm/tests/api/configmap_services_test.yaml
@@ -70,6 +70,24 @@ tests:
             \s   retention:
             \s     days: 90
 
+  - it: Enable audit cleaner service with custom cleanup batchSize
+    template: api/api-configmap.yaml
+    set:
+      api:
+        services:
+          audit:
+            enabled: true
+            cleanup:
+              batchSize: 500
+    asserts:
+      - matchRegex:
+          path: data["gravitee.yml"]
+          pattern: |
+            \s audit:
+            \s   cleanup:
+            \s     batchSize: 500
+            \s   enabled: true
+
   - it: Does not render audit section when disabled
     template: api/api-configmap.yaml
     set:

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -821,6 +821,8 @@ api:
 #      cron: "0 1 * * * *"
 #      retention:
 #        days: 365
+#      cleanup:
+#        batchSize: 1000
   http:
     services:
       core:


### PR DESCRIPTION
Fixes [APIM-14089](https://gravitee.atlassian.net/browse/APIM-14089).

## Problem

`AuditMongoRepositoryImpl.deleteByEnvironmentIdAndAge` runs a single `mongoTemplate.remove(query)` matching `environmentId == X AND createdAt < limit`. On populated `audits` collections, this op exceeds the Mongo driver socket read timeout and surfaces as:

```
DataAccessResourceFailureException: Timeout while receiving message
Caused by: java.net.SocketTimeoutException: Read timed out
```

Retention is then silently not enforced. Every hourly tick fails the same way, the working set grows, the next tick fails on an even bigger one.

## Fix

1. **New index** `e1c1` = `{environmentId:1, createdAt:1}` on `audits` via a new `AuditsEnvironmentIdCreatedAtIndexUpgrader`. The cleaner query is now bounded by both predicates directly instead of scanning the date or environment partition. Additive — does not touch existing indexes.
2. **Chunked deletes** — `AuditMongoRepositoryImpl.deleteByEnvironmentIdAndAge` now pages through results with `find().projection(_id).limit(batchSize)` then `deleteMany({_id: $in})` per chunk. Each round-trip is bounded below the socket read timeout regardless of backlog. Configurable via `services.audit.cleanup.batchSize` (default `1000`).
3. **Per-env failure isolation** — `ScheduledAuditCleanerService.run()` wraps the per-environment call in try/catch so one environment's failure no longer skips every subsequent environment in the same tick (a defect masked by the original timeout).

## Out of scope

- **JDBC backend** has a similar unchunked `deleteByEnvironmentIdAndAge` path (`JdbcAuditRepository:336-348`). No customer report on JDBC yet; left as a separate concern.
- **TTL index** on `createdAt` (would retire the cron entirely) deferred — not opening a follow-up.
- `create-index.js` bootstrap script intentionally not updated; bootstrap/upgrader drift accepted.

## Operator notice

First startup after deploy on backlogged clusters will block while the new `e1c1` index is built — duration scales with the existing `audits` collection size. Index build runs in background mode server-side (writes proceed during build) but the upgrader caller blocks until completion, same as every other Gravitee index upgrader. Look for `Starting creation of index e1c1 on audits` in mAPI logs.

## Tests

- New `AuditMongoRepositoryImplTest` — 3 tests covering the chunking loop (pages through results, terminates on empty, deletes by `_id`).
- New test in `ScheduledAuditCleanerServiceTest` — verifies env2 still runs when env1 throws.
- Cross-backend regression tests `shouldRemoveTooOldData` / `shouldNotRemoveYoungData` continue to pass.

## Manual smoke

Verified locally with apim-worktree:

1. Seeded `gravitee_apim_14089.audits` with 2500 docs (createdAt = 2 days ago) + 5 young docs in env `DEFAULT`.
2. Configured `services.audit.cron: */15 * * * * *`, `services.audit.retention.days: 1`, `services.audit.cleanup.batchSize: 100`.
3. Started mAPI; observed cleaner ticking every 15s with no `SocketTimeoutException`.
4. Confirmed: `e1c1` index present, 2500 old docs deleted (25 chunks), 5 young docs preserved, 0 audit-related errors in `mapi.log`.

## Test plan
- [ ] CI green
- [ ] Index `e1c1` visible on `audits` collection post-deploy on a populated cluster
- [ ] `audit-cleaner-1` thread no longer emits `SocketTimeoutException`
- [ ] Existing retention behavior unchanged on small collections

[APIM-14089]: https://gravitee.atlassian.net/browse/APIM-14089?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ