### PR TITLE
Enforce and configure cron schedule limits for various features

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/component/health-check-form/api-health-check-form.component.html
+++ b/gravitee-apim-console-webui/src/management/api/component/health-check-form/api-health-check-form.component.html
@@ -88,8 +88,13 @@
       <div class="health-check-card__trigger">
         <gio-form-cron class="health-check-card__trigger__field" formControlName="schedule">
           <gio-form-cron-label>Schedule *</gio-form-cron-label>
-          <gio-form-cron-hint>Cron expression to schedule the health check</gio-form-cron-hint>
+          <gio-form-cron-hint>
+            {{ (scheduleLimitHint$ | async) || 'Cron expression to schedule the health check' }}
+          </gio-form-cron-hint>
         </gio-form-cron>
+        <mat-error *ngIf="healthCheckForm.get('schedule').errors?.minimumInterval">
+          {{ healthCheckForm.get('schedule').errors.minimumInterval }}
+        </mat-error>
       </div>
       <!-- Request -->
       <h3>Request</h3>

--- a/gravitee-apim-console-webui/src/management/api/component/health-check-form/api-health-check-form.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/component/health-check-form/api-health-check-form.component.spec.ts
@@ -25,6 +25,7 @@ import { MatInputHarness } from '@angular/material/input/testing';
 import { GioFormCronHarness, GioFormHeadersHarness } from '@gravitee/ui-particles-angular';
 import { MatIconTestingModule } from '@angular/material/icon/testing';
 import { MatButtonHarness } from '@angular/material/button/testing';
+import { of } from 'rxjs';
 
 import { ApiHealthCheckFormComponent } from './api-health-check-form.component';
 import { ApiHealthCheckFormModule } from './api-health-check-form.module';
@@ -32,6 +33,7 @@ import { ApiHealthCheckFormModule } from './api-health-check-form.module';
 import { GioTestingModule } from '../../../../shared/testing';
 import { HealthCheck } from '../../../../entities/health-check';
 import { GioTestingPermissionProvider } from '../../../../shared/components/gio-permission/gio-permission.service';
+import { ScheduleLimitsService } from '../../../../services-ngx/schedule-limits.service';
 
 describe('ApiProxyHealthCheckFormComponent', () => {
   let fixture: ComponentFixture<ApiHealthCheckFormComponent>;
@@ -42,7 +44,13 @@ describe('ApiProxyHealthCheckFormComponent', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [NoopAnimationsModule, GioTestingModule, ApiHealthCheckFormModule, MatIconTestingModule],
-      providers: [{ provide: GioTestingPermissionProvider, useValue: ['api-definition-u'] }],
+      providers: [
+        { provide: GioTestingPermissionProvider, useValue: ['api-definition-u'] },
+        {
+          provide: ScheduleLimitsService,
+          useValue: { limits$: of({ autoFetch: 0, dynamicProperties: 0, dictionary: 0, healthcheck: 300_000 }) },
+        },
+      ],
     }).overrideProvider(InteractivityChecker, {
       useValue: {
         isFocusable: () => true, // This checks focus trap, set it to true to  avoid the warning
@@ -108,6 +116,12 @@ describe('ApiProxyHealthCheckFormComponent', () => {
       enabled: false,
       inherit: true,
     });
+  });
+
+  it('should display the configured minimum interval', () => {
+    initHealthCheckFormComponent();
+
+    expect(fixture.nativeElement.textContent).toContain('Minimum interval configured by your administrator: 5 minutes');
   });
 
   it('should add health check', async () => {

--- a/gravitee-apim-console-webui/src/management/api/component/health-check-form/api-health-check-form.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/component/health-check-form/api-health-check-form.component.ts
@@ -13,13 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Component, Input, OnChanges, OnDestroy, SimpleChanges } from '@angular/core';
+import { Component, inject, Input, OnChanges, OnDestroy, SimpleChanges } from '@angular/core';
 import { UntypedFormGroup, UntypedFormControl, Validators, UntypedFormArray } from '@angular/forms';
 import { combineLatest, Observable, Subject } from 'rxjs';
 import { map, shareReplay, startWith, takeUntil } from 'rxjs/operators';
 import { omit } from 'lodash';
 
 import { EndpointHealthCheckService } from '../../../../entities/management-api-v2';
+import { ScheduleLimitsService } from '../../../../services-ngx/schedule-limits.service';
+import { getMinimumIntervalHint } from '../../../../shared/utils/schedule-limits.util';
 
 @Component({
   selector: 'api-health-check-form',
@@ -28,7 +30,12 @@ import { EndpointHealthCheckService } from '../../../../entities/management-api-
   standalone: false,
 })
 export class ApiHealthCheckFormComponent implements OnChanges, OnDestroy {
+  private readonly scheduleLimitsService = inject(ScheduleLimitsService);
   private unsubscribe$: Subject<boolean> = new Subject<boolean>();
+
+  public readonly scheduleLimitHint$ = this.scheduleLimitsService.limits$.pipe(
+    map(({ healthcheck }) => getMinimumIntervalHint(healthcheck)),
+  );
 
   public static NewHealthCheckFormGroup = (healthCheck?: EndpointHealthCheckService, isReadOnly = true): UntypedFormGroup => {
     // If the health check is disabled and inherit is not false, we need to set inherit to false

--- a/gravitee-apim-console-webui/src/management/api/documentation-v4/components/documentation-edit-page/documentation-edit-page.component.html
+++ b/gravitee-apim-console-webui/src/management/api/documentation-v4/components/documentation-edit-page/documentation-edit-page.component.html
@@ -189,11 +189,17 @@
           @if (page.source?.type) {
             <mat-tab label="Configure External Source">
               @if (fetcherSchema$ | async; as jsonSchema) {
+                @if (scheduleLimitHint$ | async; as scheduleLimitHint) {
+                  <div>{{ scheduleLimitHint }}</div>
+                }
                 <gio-form-json-schema
                   (ready)="onGioSchemaFormReady($event)"
                   formControlName="sourceConfiguration"
                   [jsonSchema]="jsonSchema"
                 />
+                @if (form.controls.sourceConfiguration.errors?.minimumInterval) {
+                  <mat-error>{{ form.controls.sourceConfiguration.errors.minimumInterval }}</mat-error>
+                }
               }
             </mat-tab>
           }

--- a/gravitee-apim-console-webui/src/management/api/documentation-v4/components/documentation-edit-page/documentation-edit-page.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/documentation-v4/components/documentation-edit-page/documentation-edit-page.component.spec.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { of } from 'rxjs';
 import { HarnessLoader } from '@angular/cdk/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
@@ -48,6 +49,7 @@ import {
 import { ApiDocumentationV4ContentEditorHarness } from '../api-documentation-v4-content-editor/api-documentation-v4-content-editor.harness';
 import { ApiDocumentationV4BreadcrumbHarness } from '../api-documentation-v4-breadcrumb/api-documentation-v4-breadcrumb.harness';
 import { GioTestingPermissionProvider } from '../../../../../shared/components/gio-permission/gio-permission.service';
+import { ScheduleLimitsService } from '../../../../../services-ngx/schedule-limits.service';
 import { ApiDocumentationV4PageConfigurationHarness } from '../api-documentation-v4-page-configuration/api-documentation-v4-page-configuration.harness';
 import { FetcherListItem } from '../../../../../entities/fetcher';
 import { fakeFetcherList } from '../../../../../entities/fetcher/fetcher.fixture';
@@ -79,7 +81,13 @@ describe('DocumentationEditPageComponent', () => {
         CommonModule,
         DocumentationEditPageComponent,
       ],
-      providers: [{ provide: GioTestingPermissionProvider, useValue: apiPermissions }],
+      providers: [
+        { provide: GioTestingPermissionProvider, useValue: apiPermissions },
+        {
+          provide: ScheduleLimitsService,
+          useValue: { limits$: of({ autoFetch: 0, dynamicProperties: 0, dictionary: 0, healthcheck: 0 }) },
+        },
+      ],
     })
       .overrideProvider(InteractivityChecker, {
         useValue: {

--- a/gravitee-apim-console-webui/src/management/api/documentation-v4/components/documentation-edit-page/documentation-edit-page.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/documentation-v4/components/documentation-edit-page/documentation-edit-page.component.ts
@@ -157,9 +157,7 @@ export class DocumentationEditPageComponent implements OnInit {
     private readonly environmentSettingsService: EnvironmentSettingsService,
     scheduleLimitsService: ScheduleLimitsService,
   ) {
-    this.scheduleLimitHint$ = scheduleLimitsService.limits$.pipe(
-      map(({ autoFetch }) => getMinimumIntervalHint(autoFetch)),
-    );
+    this.scheduleLimitHint$ = scheduleLimitsService.limits$.pipe(map(({ autoFetch }) => getMinimumIntervalHint(autoFetch)));
   }
 
   ngOnInit(): void {

--- a/gravitee-apim-console-webui/src/management/api/documentation-v4/components/documentation-edit-page/documentation-edit-page.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/documentation-v4/components/documentation-edit-page/documentation-edit-page.component.ts
@@ -57,6 +57,8 @@ import {
 import { ApiDocumentationV4PageHeaderComponent } from '../api-documentation-v4-page-header/api-documentation-v4-page-header.component';
 import { FetcherService } from '../../../../../services-ngx/fetcher.service';
 import { EnvironmentSettingsService } from '../../../../../services-ngx/environment-settings.service';
+import { ScheduleLimitsService } from '../../../../../services-ngx/schedule-limits.service';
+import { applyMinimumIntervalError, getMinimumIntervalHint } from '../../../../../shared/utils/schedule-limits.util';
 
 interface OpenApiConfiguration {
   entrypointAsBasePath: FormControl<boolean>;
@@ -141,6 +143,7 @@ export class DocumentationEditPageComponent implements OnInit {
   private destroyRef = inject(DestroyRef);
   private initialFormValue: unknown;
   sourceConfigurationChanged$: Observable<boolean> = of(false);
+  readonly scheduleLimitHint$: Observable<string | null>;
 
   constructor(
     private readonly activatedRoute: ActivatedRoute,
@@ -152,7 +155,12 @@ export class DocumentationEditPageComponent implements OnInit {
     private readonly matDialog: MatDialog,
     private readonly fetcherService: FetcherService,
     private readonly environmentSettingsService: EnvironmentSettingsService,
-  ) {}
+    scheduleLimitsService: ScheduleLimitsService,
+  ) {
+    this.scheduleLimitHint$ = scheduleLimitsService.limits$.pipe(
+      map(({ autoFetch }) => getMinimumIntervalHint(autoFetch)),
+    );
+  }
 
   ngOnInit(): void {
     this.isHomepage = this.page.homepage === true;
@@ -320,6 +328,9 @@ export class DocumentationEditPageComponent implements OnInit {
         return this.apiDocumentationService.updateDocumentationPage(this.api.id, this.page.id, updateDocumentation);
       }),
       catchError((err: HttpErrorResponse) => {
+        if (applyMinimumIntervalError(err.error, this.form.controls.sourceConfiguration)) {
+          return EMPTY;
+        }
         if (err.status === 500 && err.error.message.includes('fetch') && !!this.page.source?.type) {
           this.snackBarService.error('External source configuration invalid.');
         } else {

--- a/gravitee-apim-console-webui/src/management/api/documentation-v4/components/documentation-new-page/documentation-new-page.component.html
+++ b/gravitee-apim-console-webui/src/management/api/documentation-v4/components/documentation-new-page/documentation-new-page.component.html
@@ -107,7 +107,13 @@
             }
             @case ('EXTERNAL') {
               @if (selectedFetcherSchema) {
+                @if (scheduleLimitHint$ | async; as scheduleLimitHint) {
+                  <div>{{ scheduleLimitHint }}</div>
+                }
                 <gio-form-json-schema [formControl]="sourceConfiguration" [jsonSchema]="selectedFetcherSchema"></gio-form-json-schema>
+                @if (sourceConfiguration.errors?.minimumInterval) {
+                  <mat-error>{{ sourceConfiguration.errors.minimumInterval }}</mat-error>
+                }
               }
             }
           }

--- a/gravitee-apim-console-webui/src/management/api/documentation-v4/components/documentation-new-page/documentation-new-page.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/documentation-v4/components/documentation-new-page/documentation-new-page.component.spec.ts
@@ -19,6 +19,7 @@ import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { MatStepperHarness } from '@angular/material/stepper/testing';
 import { FormsModule } from '@angular/forms';
+import { of } from 'rxjs';
 import { GioMonacoEditorHarness } from '@gravitee/ui-particles-angular';
 import { MatButtonHarness } from '@angular/material/button/testing';
 import { HttpTestingController } from '@angular/common/http/testing';
@@ -37,6 +38,7 @@ import { ApiDocumentationV4ContentEditorHarness } from '../api-documentation-v4-
 import { ApiDocumentationV4BreadcrumbHarness } from '../api-documentation-v4-breadcrumb/api-documentation-v4-breadcrumb.harness';
 import { ApiDocumentationV4FileUploadHarness } from '../api-documentation-v4-file-upload/api-documentation-v4-file-upload.harness';
 import { GioTestingPermissionProvider } from '../../../../../shared/components/gio-permission/gio-permission.service';
+import { ScheduleLimitsService } from '../../../../../services-ngx/schedule-limits.service';
 import { ApiDocumentationV4PageConfigurationHarness } from '../api-documentation-v4-page-configuration/api-documentation-v4-page-configuration.harness';
 import { FetcherListItem } from '../../../../../entities/fetcher';
 import { fakeFetcherList } from '../../../../../entities/fetcher/fetcher.fixture';
@@ -63,7 +65,13 @@ describe('DocumentationNewPageComponent', () => {
   ) => {
     await TestBed.configureTestingModule({
       imports: [NoopAnimationsModule, ApiDocumentationV4Module, FormsModule, GioTestingModule, CommonModule, DocumentationNewPageComponent],
-      providers: [{ provide: GioTestingPermissionProvider, useValue: apiPermissions }],
+      providers: [
+        { provide: GioTestingPermissionProvider, useValue: apiPermissions },
+        {
+          provide: ScheduleLimitsService,
+          useValue: { limits$: of({ autoFetch: 0, dynamicProperties: 0, dictionary: 0, healthcheck: 0 }) },
+        },
+      ],
     })
       .overrideProvider(InteractivityChecker, {
         useValue: {

--- a/gravitee-apim-console-webui/src/management/api/documentation-v4/components/documentation-new-page/documentation-new-page.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/documentation-v4/components/documentation-new-page/documentation-new-page.component.ts
@@ -27,9 +27,10 @@ import { MatStepperModule } from '@angular/material/stepper';
 import { FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
 import { combineLatest, EMPTY, Observable } from 'rxjs';
 import { MatDialog } from '@angular/material/dialog';
-import { catchError, debounceTime, distinctUntilChanged, switchMap, tap } from 'rxjs/operators';
+import { catchError, debounceTime, distinctUntilChanged, map, switchMap, tap } from 'rxjs/operators';
 import { ActivatedRoute, Router } from '@angular/router';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { AsyncPipe } from '@angular/common';
 import { HttpErrorResponse } from '@angular/common/http';
 
 import { ApiDocumentationV2Service } from '../../../../../services-ngx/api-documentation-v2.service';
@@ -57,6 +58,8 @@ import {
   PageConfigurationForm,
 } from '../api-documentation-v4-page-configuration/api-documentation-v4-page-configuration.component';
 import { ApiDocumentationV4PageHeaderComponent } from '../api-documentation-v4-page-header/api-documentation-v4-page-header.component';
+import { ScheduleLimitsService } from '../../../../../services-ngx/schedule-limits.service';
+import { applyMinimumIntervalError, getMinimumIntervalHint } from '../../../../../shared/utils/schedule-limits.util';
 
 interface CreatePageForm {
   stepOne: FormGroup<PageConfigurationForm>;
@@ -84,6 +87,7 @@ interface FetcherVM {
     MatError,
     MatStepperModule,
     ReactiveFormsModule,
+    AsyncPipe,
     ApiDocumentationV4ContentEditorComponent,
     ApiDocumentationV4FileUploadComponent,
     ApiDocumentationV4PageConfigurationComponent,
@@ -110,6 +114,7 @@ export class DocumentationNewPageComponent implements OnInit {
 
   form: FormGroup<CreatePageForm>;
   sourceConfiguration?: FormControl<undefined | unknown>;
+  readonly scheduleLimitHint$: Observable<string | null>;
 
   defaultSourceType: string = 'FILL';
   breadcrumbs: Breadcrumb[];
@@ -134,7 +139,12 @@ export class DocumentationNewPageComponent implements OnInit {
     private readonly snackBarService: SnackBarService,
     private readonly matDialog: MatDialog,
     private readonly fetcherService: FetcherService,
-  ) {}
+    scheduleLimitsService: ScheduleLimitsService,
+  ) {
+    this.scheduleLimitHint$ = scheduleLimitsService.limits$.pipe(
+      map(({ autoFetch }) => getMinimumIntervalHint(autoFetch)),
+    );
+  }
 
   ngOnInit(): void {
     if (this.createHomepage) {
@@ -286,6 +296,10 @@ export class DocumentationNewPageComponent implements OnInit {
     };
     return this.apiDocumentationService.createDocumentationPage(this.api.id, createPage).pipe(
       catchError((err: HttpErrorResponse) => {
+        const sourceConfiguration = this.sourceConfiguration;
+        if (sourceConfiguration && applyMinimumIntervalError(err.error, sourceConfiguration)) {
+          return EMPTY;
+        }
         if (err.status === 500 && err.error?.message?.includes('fetch') && formValue.sourceType === 'EXTERNAL') {
           this.snackBarService.error('External source configuration invalid.');
         } else {

--- a/gravitee-apim-console-webui/src/management/api/documentation-v4/components/documentation-new-page/documentation-new-page.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/documentation-v4/components/documentation-new-page/documentation-new-page.component.ts
@@ -141,9 +141,7 @@ export class DocumentationNewPageComponent implements OnInit {
     private readonly fetcherService: FetcherService,
     scheduleLimitsService: ScheduleLimitsService,
   ) {
-    this.scheduleLimitHint$ = scheduleLimitsService.limits$.pipe(
-      map(({ autoFetch }) => getMinimumIntervalHint(autoFetch)),
-    );
+    this.scheduleLimitHint$ = scheduleLimitsService.limits$.pipe(map(({ autoFetch }) => getMinimumIntervalHint(autoFetch)));
   }
 
   ngOnInit(): void {

--- a/gravitee-apim-console-webui/src/management/api/endpoints/groups/endpoint/edit/api-proxy-group-endpoint-edit.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/endpoints/groups/endpoint/edit/api-proxy-group-endpoint-edit.component.spec.ts
@@ -26,6 +26,7 @@ import { MatSelectHarness } from '@angular/material/select/testing';
 import { MatSlideToggleHarness } from '@angular/material/slide-toggle/testing';
 import { MatCheckboxHarness } from '@angular/material/checkbox/testing';
 import { ActivatedRoute } from '@angular/router';
+import { of } from 'rxjs';
 
 import { ApiProxyGroupEndpointEditComponent } from './api-proxy-group-endpoint-edit.component';
 
@@ -38,6 +39,7 @@ import { SnackBarService } from '../../../../../../services-ngx/snack-bar.servic
 import { ApiV2, fakeApiV2 } from '../../../../../../entities/management-api-v2';
 import { EndpointHttpConfigHarness } from '../../../components/endpoint-http-config/endpoint-http-config.harness';
 import { GioTestingPermissionProvider } from '../../../../../../shared/components/gio-permission/gio-permission.service';
+import { ScheduleLimitsService } from '../../../../../../services-ngx/schedule-limits.service';
 
 describe('ApiProxyGroupEndpointEditComponent', () => {
   const API_ID = 'apiId';
@@ -60,6 +62,10 @@ describe('ApiProxyGroupEndpointEditComponent', () => {
           useValue: { snapshot: { params: { apiId: API_ID, groupName: DEFAULT_GROUP_NAME, endpointName: DEFAULT_ENDPOINT_NAME } } },
         },
         { provide: GioTestingPermissionProvider, useValue: ['api-definition-u'] },
+        {
+          provide: ScheduleLimitsService,
+          useValue: { limits$: of({ autoFetch: 0, dynamicProperties: 0, dictionary: 0, healthcheck: 0 }) },
+        },
       ],
     });
 

--- a/gravitee-apim-console-webui/src/management/api/health-check/api-health-check.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/health-check/api-health-check.component.spec.ts
@@ -25,6 +25,7 @@ import { MatInputHarness } from '@angular/material/input/testing';
 import { GioFormCronHarness, GioSaveBarHarness } from '@gravitee/ui-particles-angular';
 import { MatIconTestingModule } from '@angular/material/icon/testing';
 import { ActivatedRoute } from '@angular/router';
+import { of } from 'rxjs';
 
 import { ApiHealthCheckComponent } from './api-health-check.component';
 import { ApiHealthCheckModule } from './api-health-check.module';
@@ -32,6 +33,7 @@ import { ApiHealthCheckModule } from './api-health-check.module';
 import { CONSTANTS_TESTING, GioTestingModule } from '../../../shared/testing';
 import { ApiV2, fakeApiV2 } from '../../../entities/management-api-v2';
 import { GioTestingPermissionProvider } from '../../../shared/components/gio-permission/gio-permission.service';
+import { ScheduleLimitsService } from '../../../services-ngx/schedule-limits.service';
 
 describe('ApiProxyHealthCheckComponent', () => {
   const API_ID = 'my-api';
@@ -46,6 +48,10 @@ describe('ApiProxyHealthCheckComponent', () => {
       providers: [
         { provide: ActivatedRoute, useValue: { snapshot: { params: { apiId: API_ID } } } },
         { provide: GioTestingPermissionProvider, useValue: ['api-health-c'] },
+        {
+          provide: ScheduleLimitsService,
+          useValue: { limits$: of({ autoFetch: 0, dynamicProperties: 0, dictionary: 0, healthcheck: 0 }) },
+        },
       ],
     }).overrideProvider(InteractivityChecker, {
       useValue: {

--- a/gravitee-apim-console-webui/src/management/api/health-check/api-health-check.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/health-check/api-health-check.component.ts
@@ -25,6 +25,8 @@ import { ApiHealthCheckFormComponent } from '../component/health-check-form/api-
 import { ApiV2Service } from '../../../services-ngx/api-v2.service';
 import { onlyApiV1V2Filter, onlyApiV2Filter } from '../../../util/apiFilter.operator';
 import { Proxy } from '../../../entities/management-api-v2';
+import { ScheduleLimitsService } from '../../../services-ngx/schedule-limits.service';
+import { applyMinimumIntervalError } from '../../../shared/utils/schedule-limits.util';
 
 @Component({
   selector: 'api-health-check',
@@ -86,6 +88,9 @@ export class ApiHealthCheckComponent implements OnInit, OnDestroy {
         }),
         tap(() => this.snackBarService.success('Configuration successfully saved!')),
         catchError(({ error }) => {
+          if (applyMinimumIntervalError(error, this.healthCheckForm.get('schedule'))) {
+            return EMPTY;
+          }
           this.snackBarService.error(error.message);
           return EMPTY;
         }),

--- a/gravitee-apim-console-webui/src/management/api/health-check/api-health-check.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/health-check/api-health-check.component.ts
@@ -25,7 +25,6 @@ import { ApiHealthCheckFormComponent } from '../component/health-check-form/api-
 import { ApiV2Service } from '../../../services-ngx/api-v2.service';
 import { onlyApiV1V2Filter, onlyApiV2Filter } from '../../../util/apiFilter.operator';
 import { Proxy } from '../../../entities/management-api-v2';
-import { ScheduleLimitsService } from '../../../services-ngx/schedule-limits.service';
 import { applyMinimumIntervalError } from '../../../shared/utils/schedule-limits.util';
 
 @Component({

--- a/gravitee-apim-console-webui/src/management/api/properties/components/dynamic-properties-v2/api-dynamic-properties.component.html
+++ b/gravitee-apim-console-webui/src/management/api/properties/components/dynamic-properties-v2/api-dynamic-properties.component.html
@@ -59,7 +59,9 @@
 
       <gio-form-cron class="apiDynamicProperties__scheduleField" formControlName="schedule">
         <gio-form-cron-label>Schedule *</gio-form-cron-label>
+        <gio-form-cron-hint *ngIf="scheduleLimitHint$ | async as scheduleLimitHint">{{ scheduleLimitHint }}</gio-form-cron-hint>
       </gio-form-cron>
+      <mat-error *ngIf="form.get('schedule').errors?.minimumInterval">{{ form.get('schedule').errors.minimumInterval }}</mat-error>
 
       <div class="apiDynamicProperties__methodUrl">
         <mat-form-field class="apiDynamicProperties__methodUrl__methodField">

--- a/gravitee-apim-console-webui/src/management/api/properties/components/dynamic-properties-v2/api-dynamic-properties.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/properties/components/dynamic-properties-v2/api-dynamic-properties.component.spec.ts
@@ -27,12 +27,15 @@ import { GioFormCronHarness, GioFormHeadersHarness, GioMonacoEditorHarness, GioS
 import { MatInputHarness } from '@angular/material/input/testing';
 import { ActivatedRoute, Router } from '@angular/router';
 import { MatButtonHarness } from '@angular/material/button/testing';
+import { of } from 'rxjs';
 
 import { ApiDynamicPropertiesComponent } from './api-dynamic-properties.component';
 import { ApiDynamicPropertiesV2Module } from './api-dynamic-properties-v2.module';
 
 import { CONSTANTS_TESTING, GioTestingModule } from '../../../../../shared/testing';
 import { Api, fakeApiV2 } from '../../../../../entities/management-api-v2';
+import { ScheduleLimitsService } from '../../../../../services-ngx/schedule-limits.service';
+import { SnackBarService } from '../../../../../services-ngx/snack-bar.service';
 
 describe('ApiDynamicPropertiesComponent', () => {
   const API_ID = 'apiId';
@@ -44,7 +47,13 @@ describe('ApiDynamicPropertiesComponent', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [NoopAnimationsModule, GioTestingModule, ApiDynamicPropertiesV2Module, MatIconTestingModule],
-      providers: [{ provide: ActivatedRoute, useValue: { snapshot: { params: { apiId: API_ID } } } }],
+      providers: [
+        { provide: ActivatedRoute, useValue: { snapshot: { params: { apiId: API_ID } } } },
+        {
+          provide: ScheduleLimitsService,
+          useValue: { limits$: of({ autoFetch: 0, dynamicProperties: 300_000, dictionary: 0, healthcheck: 0 }) },
+        },
+      ],
     }).overrideProvider(InteractivityChecker, {
       useValue: {
         isFocusable: () => true, // This traps focus checks and so avoid warnings when dealing with
@@ -204,6 +213,52 @@ describe('ApiDynamicPropertiesComponent', () => {
         specification: 'specification',
       },
     });
+  });
+
+  it('should preserve the form and display an inline schedule error when the limit is exceeded', () => {
+    const api = fakeApiV2({
+      id: API_ID,
+      services: {
+        dynamicProperty: {
+          enabled: true,
+          provider: 'HTTP',
+          schedule: '* * * * * *',
+          configuration: { method: 'GET', url: 'https://example.com' },
+        },
+      },
+    });
+    expectGetApi(api);
+
+    fixture.componentInstance.onSave();
+    expectGetApi(api);
+    httpTestingController.expectOne({ method: 'PUT', url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${API_ID}` }).flush(
+      {
+        technicalCode: 'schedule.minimumIntervalExceeded',
+        parameters: { field: 'services.dynamicProperty.schedule', schedule: '* * * * * *', minimumInterval: '300000' },
+      },
+      { status: 400, statusText: 'Bad Request' },
+    );
+    fixture.detectChanges();
+
+    expect(fixture.componentInstance.form.get('schedule').value).toEqual('* * * * * *');
+    expect(fixture.componentInstance.form.get('schedule').errors).toEqual({
+      minimumInterval: 'Schedule must not run more frequently than every 5 minutes',
+    });
+    expect(fixture.nativeElement.textContent).toContain('Schedule must not run more frequently than every 5 minutes');
+  });
+
+  it('should use the snackbar as fallback for an unmapped error', () => {
+    const api = fakeApiV2({ id: API_ID, services: { dynamicProperty: undefined } });
+    const snackBarError = jest.spyOn(TestBed.inject(SnackBarService), 'error');
+    expectGetApi(api);
+
+    fixture.componentInstance.onSave();
+    expectGetApi(api);
+    httpTestingController
+      .expectOne({ method: 'PUT', url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${API_ID}` })
+      .flush({ technicalCode: 'other', message: 'Update failed' }, { status: 400, statusText: 'Bad Request' });
+
+    expect(snackBarError).toHaveBeenCalledWith('Update failed');
   });
 
   it('should navigate to properties page', async () => {

--- a/gravitee-apim-console-webui/src/management/api/properties/components/dynamic-properties-v2/api-dynamic-properties.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/properties/components/dynamic-properties-v2/api-dynamic-properties.component.ts
@@ -68,9 +68,7 @@ export class ApiDynamicPropertiesComponent implements OnInit, OnDestroy {
     private readonly snackBarService: SnackBarService,
     scheduleLimitsService: ScheduleLimitsService,
   ) {
-    this.scheduleLimitHint$ = scheduleLimitsService.limits$.pipe(
-      map(({ dynamicProperties }) => getMinimumIntervalHint(dynamicProperties)),
-    );
+    this.scheduleLimitHint$ = scheduleLimitsService.limits$.pipe(map(({ dynamicProperties }) => getMinimumIntervalHint(dynamicProperties)));
   }
 
   ngOnInit(): void {

--- a/gravitee-apim-console-webui/src/management/api/properties/components/dynamic-properties-v2/api-dynamic-properties.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/properties/components/dynamic-properties-v2/api-dynamic-properties.component.ts
@@ -15,9 +15,9 @@
  */
 
 import { Component, OnDestroy, OnInit } from '@angular/core';
-import { combineLatest, Subject } from 'rxjs';
+import { combineLatest, Observable, Subject } from 'rxjs';
 import { UntypedFormControl, UntypedFormGroup, Validators } from '@angular/forms';
-import { startWith, switchMap, takeUntil, tap } from 'rxjs/operators';
+import { map, startWith, switchMap, takeUntil, tap } from 'rxjs/operators';
 import { MonacoEditorLanguageConfig } from '@gravitee/ui-particles-angular';
 import { ActivatedRoute } from '@angular/router';
 
@@ -26,6 +26,8 @@ import { CorsUtil } from '../../../../../shared/utils';
 import { ApiV2 } from '../../../../../entities/management-api-v2';
 import { SnackBarService } from '../../../../../services-ngx/snack-bar.service';
 import { onlyApiV2Filter } from '../../../../../util/apiFilter.operator';
+import { ScheduleLimitsService } from '../../../../../services-ngx/schedule-limits.service';
+import { getMinimumIntervalError, getMinimumIntervalHint } from '../../../../../shared/utils/schedule-limits.util';
 
 @Component({
   selector: 'api-dynamic-properties',
@@ -55,14 +57,21 @@ export class ApiDynamicPropertiesComponent implements OnInit, OnDestroy {
 
   public form: UntypedFormGroup;
   public initialFormValue: unknown;
+  private scheduleMinimumIntervalError: string | null = null;
 
   public httpMethods = CorsUtil.httpMethods;
+  public readonly scheduleLimitHint$: Observable<string | null>;
 
   constructor(
     private readonly activatedRoute: ActivatedRoute,
     private readonly apiService: ApiV2Service,
     private readonly snackBarService: SnackBarService,
-  ) {}
+    scheduleLimitsService: ScheduleLimitsService,
+  ) {
+    this.scheduleLimitHint$ = scheduleLimitsService.limits$.pipe(
+      map(({ dynamicProperties }) => getMinimumIntervalHint(dynamicProperties)),
+    );
+  }
 
   ngOnInit(): void {
     combineLatest([this.apiService.get(this.activatedRoute.snapshot.params.apiId)])
@@ -73,6 +82,7 @@ export class ApiDynamicPropertiesComponent implements OnInit, OnDestroy {
           }
           const isReadonly = api.definitionContext?.origin === 'KUBERNETES';
           const dynamicProperty = api.services?.dynamicProperty;
+          this.scheduleMinimumIntervalError = null;
 
           this.form = new UntypedFormGroup({
             enabled: new UntypedFormControl({
@@ -84,7 +94,10 @@ export class ApiDynamicPropertiesComponent implements OnInit, OnDestroy {
                 value: dynamicProperty?.schedule ?? '0 */5 * * * *',
                 disabled: isReadonly,
               },
-              [Validators.required],
+              [
+                Validators.required,
+                () => (this.scheduleMinimumIntervalError ? { minimumInterval: this.scheduleMinimumIntervalError } : null),
+              ],
             ),
             provider: new UntypedFormControl({
               value: dynamicProperty?.provider ?? 'HTTP', // Only http is supported for now.
@@ -119,6 +132,16 @@ export class ApiDynamicPropertiesComponent implements OnInit, OnDestroy {
             }),
           });
           this.initialFormValue = this.form.value;
+
+          this.form
+            .get('schedule')
+            .valueChanges.pipe(takeUntil(this.unsubscribe$))
+            .subscribe(() => {
+              if (this.scheduleMinimumIntervalError) {
+                this.scheduleMinimumIntervalError = null;
+                this.form.get('schedule').updateValueAndValidity({ emitEvent: false });
+              }
+            });
 
           this.form
             .get('enabled')
@@ -178,6 +201,12 @@ export class ApiDynamicPropertiesComponent implements OnInit, OnDestroy {
       )
       .subscribe({
         error: ({ error }) => {
+          const scheduleError = getMinimumIntervalError(error);
+          if (scheduleError) {
+            this.scheduleMinimumIntervalError = scheduleError;
+            this.form.get('schedule').updateValueAndValidity({ emitEvent: false });
+            return;
+          }
           this.snackBarService.error(error?.message ?? 'An error occurred while updating dynamic properties.');
         },
         next: () => {

--- a/gravitee-apim-console-webui/src/management/api/properties/components/dynamic-properties-v4/api-dynamic-properties-v4.component.html
+++ b/gravitee-apim-console-webui/src/management/api/properties/components/dynamic-properties-v4/api-dynamic-properties-v4.component.html
@@ -56,7 +56,11 @@
           name="enabled"
         ></mat-slide-toggle>
       </gio-form-slide-toggle>
+      <div *ngIf="scheduleLimitHint$ | async as scheduleLimitHint">{{ scheduleLimitHint }}</div>
       <gio-form-json-schema [jsonSchema]="schema" formControlName="configuration"></gio-form-json-schema>
+      <mat-error *ngIf="form.controls.configuration.errors?.minimumInterval">
+        {{ form.controls.configuration.errors.minimumInterval }}
+      </mat-error>
     </form>
   </mat-card-content>
 </mat-card>

--- a/gravitee-apim-console-webui/src/management/api/properties/components/dynamic-properties-v4/api-dynamic-properties-v4.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/properties/components/dynamic-properties-v4/api-dynamic-properties-v4.component.spec.ts
@@ -20,6 +20,7 @@ import { RouterTestingModule } from '@angular/router/testing';
 import { ActivatedRoute, Router } from '@angular/router';
 import { HttpTestingController } from '@angular/common/http/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { of } from 'rxjs';
 
 import { ApiDynamicPropertiesV4Component } from './api-dynamic-properties-v4.component';
 import { ApiDynamicPropertiesV4Harness } from './api-dynamic-properties-v4.harness';
@@ -27,6 +28,7 @@ import { ApiDynamicPropertiesV4Harness } from './api-dynamic-properties-v4.harne
 import { Api, ApiV4, fakeApiV4 } from '../../../../../entities/management-api-v2';
 import { ApiPropertiesModule } from '../../properties/api-properties.module';
 import { CONSTANTS_TESTING, GioTestingModule } from '../../../../../shared/testing';
+import { ScheduleLimitsService } from '../../../../../services-ngx/schedule-limits.service';
 
 describe('ApiDynamicPropertiesV4Component', () => {
   const API_ID = 'apiId';
@@ -53,7 +55,13 @@ describe('ApiDynamicPropertiesV4Component', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [NoopAnimationsModule, GioTestingModule, ApiPropertiesModule, MatIconTestingModule, RouterTestingModule],
-      providers: [{ provide: ActivatedRoute, useValue: { snapshot: { params: { apiId: API_ID } } } }],
+      providers: [
+        { provide: ActivatedRoute, useValue: { snapshot: { params: { apiId: API_ID } } } },
+        {
+          provide: ScheduleLimitsService,
+          useValue: { limits$: of({ autoFetch: 0, dynamicProperties: 0, dictionary: 0, healthcheck: 0 }) },
+        },
+      ],
     }).compileComponents();
 
     fixture = TestBed.createComponent(ApiDynamicPropertiesV4Component);

--- a/gravitee-apim-console-webui/src/management/api/properties/components/dynamic-properties-v4/api-dynamic-properties-v4.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/properties/components/dynamic-properties-v4/api-dynamic-properties-v4.component.ts
@@ -75,9 +75,7 @@ export class ApiDynamicPropertiesV4Component implements OnInit, OnDestroy {
     private readonly snackBarService: SnackBarService,
     scheduleLimitsService: ScheduleLimitsService,
   ) {
-    this.scheduleLimitHint$ = scheduleLimitsService.limits$.pipe(
-      map(({ dynamicProperties }) => getMinimumIntervalHint(dynamicProperties)),
-    );
+    this.scheduleLimitHint$ = scheduleLimitsService.limits$.pipe(map(({ dynamicProperties }) => getMinimumIntervalHint(dynamicProperties)));
   }
 
   ngOnInit(): void {

--- a/gravitee-apim-console-webui/src/management/api/properties/components/dynamic-properties-v4/api-dynamic-properties-v4.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/properties/components/dynamic-properties-v4/api-dynamic-properties-v4.component.ts
@@ -15,9 +15,9 @@
  */
 
 import { Component, OnDestroy, OnInit } from '@angular/core';
-import { combineLatest, Subject } from 'rxjs';
+import { combineLatest, Observable, Subject } from 'rxjs';
 import { FormControl, FormGroup } from '@angular/forms';
-import { distinctUntilChanged, switchMap, takeUntil, tap } from 'rxjs/operators';
+import { distinctUntilChanged, map, switchMap, takeUntil, tap } from 'rxjs/operators';
 import { GioJsonSchema } from '@gravitee/ui-particles-angular';
 import { ActivatedRoute } from '@angular/router';
 
@@ -27,6 +27,8 @@ import { SnackBarService } from '../../../../../services-ngx/snack-bar.service';
 import { onlyApiV4Filter } from '../../../../../util/apiFilter.operator';
 import { ApiV4 } from '../../../../../entities/management-api-v2';
 import { ApiServicePluginsV2Service } from '../../../../../services-ngx/apiservice-plugins-v2.service';
+import { ScheduleLimitsService } from '../../../../../services-ngx/schedule-limits.service';
+import { applyMinimumIntervalError, getMinimumIntervalHint } from '../../../../../shared/utils/schedule-limits.util';
 
 export type DynamicPropertiesType = {
   enabled: boolean;
@@ -64,13 +66,19 @@ export class ApiDynamicPropertiesV4Component implements OnInit, OnDestroy {
   public initialFormValue: DynamicPropertiesType;
   public httpMethods = CorsUtil.httpMethods;
   public schema: GioJsonSchema;
+  public readonly scheduleLimitHint$: Observable<string | null>;
 
   constructor(
     private readonly activatedRoute: ActivatedRoute,
     private readonly apiV2Service: ApiV2Service,
     private readonly apiServicePluginsV2Service: ApiServicePluginsV2Service,
     private readonly snackBarService: SnackBarService,
-  ) {}
+    scheduleLimitsService: ScheduleLimitsService,
+  ) {
+    this.scheduleLimitHint$ = scheduleLimitsService.limits$.pipe(
+      map(({ dynamicProperties }) => getMinimumIntervalHint(dynamicProperties)),
+    );
+  }
 
   ngOnInit(): void {
     combineLatest([
@@ -142,6 +150,9 @@ export class ApiDynamicPropertiesV4Component implements OnInit, OnDestroy {
       )
       .subscribe({
         error: ({ error }) => {
+          if (applyMinimumIntervalError(error, this.form.controls.configuration)) {
+            return;
+          }
           this.snackBarService.error(error?.message ?? 'An error occurred while updating dynamic properties.');
         },
         next: () => {

--- a/gravitee-apim-console-webui/src/services-ngx/schedule-limits.service.spec.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/schedule-limits.service.spec.ts
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { HttpTestingController } from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+
+import { ScheduleLimitsService } from './schedule-limits.service';
+
+import { CONSTANTS_TESTING, GioTestingModule } from '../shared/testing';
+
+describe('ScheduleLimitsService', () => {
+  let httpTestingController: HttpTestingController;
+  let service: ScheduleLimitsService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({ imports: [GioTestingModule] });
+    httpTestingController = TestBed.inject(HttpTestingController);
+    service = TestBed.inject(ScheduleLimitsService);
+  });
+
+  afterEach(() => httpTestingController.verify());
+
+  it('should fetch and cache schedule limits', () => {
+    const limits = { autoFetch: 300_000, dynamicProperties: 60_000, dictionary: 0, healthcheck: 1_000 };
+    const received: (typeof limits)[] = [];
+
+    service.limits$.subscribe(value => received.push(value));
+    service.limits$.subscribe(value => received.push(value));
+
+    const request = httpTestingController.expectOne(`${CONSTANTS_TESTING.env.baseURL}/configuration/schedule-limits`);
+    expect(request.request.method).toEqual('GET');
+    request.flush(limits);
+
+    expect(received).toEqual([limits, limits]);
+  });
+
+});

--- a/gravitee-apim-console-webui/src/services-ngx/schedule-limits.service.spec.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/schedule-limits.service.spec.ts
@@ -45,5 +45,4 @@ describe('ScheduleLimitsService', () => {
 
     expect(received).toEqual([limits, limits]);
   });
-
 });

--- a/gravitee-apim-console-webui/src/services-ngx/schedule-limits.service.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/schedule-limits.service.ts
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { HttpClient } from '@angular/common/http';
+import { inject, Injectable } from '@angular/core';
+import { shareReplay } from 'rxjs/operators';
+
+import { Constants } from '../entities/Constants';
+
+export interface ScheduleLimits {
+  autoFetch: number;
+  dynamicProperties: number;
+  dictionary: number;
+  healthcheck: number;
+}
+
+@Injectable({ providedIn: 'root' })
+export class ScheduleLimitsService {
+  private readonly http = inject(HttpClient);
+  private readonly constants = inject(Constants);
+
+  readonly limits$ = this.http
+    .get<ScheduleLimits>(`${this.constants.env.baseURL}/configuration/schedule-limits`)
+    .pipe(shareReplay({ bufferSize: 1, refCount: false }));
+}

--- a/gravitee-apim-console-webui/src/shared/utils/schedule-limits.util.spec.ts
+++ b/gravitee-apim-console-webui/src/shared/utils/schedule-limits.util.spec.ts
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { FormControl } from '@angular/forms';
+
+import { applyMinimumIntervalError, formatScheduleInterval, getMinimumIntervalError, getMinimumIntervalHint } from './schedule-limits.util';
+
+describe('Schedule limits utils', () => {
+  it.each([
+    [300_000, '5 minutes'],
+    [3_600_000, '1 hour'],
+    [1_500, '1500 milliseconds'],
+  ])('should format %s milliseconds as %s', (milliseconds, expected) => {
+    expect(formatScheduleInterval(milliseconds)).toEqual(expected);
+  });
+
+  it('should map the minimum interval technical code to an inline error', () => {
+    expect(
+      getMinimumIntervalError({
+        technicalCode: 'schedule.minimumIntervalExceeded',
+        parameters: { minimumInterval: '300000' },
+      }),
+    ).toEqual('Schedule must not run more frequently than every 5 minutes');
+  });
+
+  it('should ignore unrelated errors', () => {
+    expect(getMinimumIntervalError({ technicalCode: 'other' })).toBeNull();
+  });
+
+  it('should expose a formatted hint for an enabled limit', () => {
+    expect(getMinimumIntervalHint(300_000)).toEqual('Minimum interval configured by your administrator: 5 minutes');
+  });
+
+  it('should apply a minimum interval error without replacing existing control errors', () => {
+    const control = new FormControl();
+    control.setErrors({ required: true });
+
+    expect(
+      applyMinimumIntervalError(
+        { technicalCode: 'schedule.minimumIntervalExceeded', parameters: { minimumInterval: '300000' } },
+        control,
+      ),
+    ).toBe(true);
+    expect(control.errors).toEqual({ required: true, minimumInterval: 'Schedule must not run more frequently than every 5 minutes' });
+  });
+});

--- a/gravitee-apim-console-webui/src/shared/utils/schedule-limits.util.spec.ts
+++ b/gravitee-apim-console-webui/src/shared/utils/schedule-limits.util.spec.ts
@@ -48,10 +48,7 @@ describe('Schedule limits utils', () => {
     control.setErrors({ required: true });
 
     expect(
-      applyMinimumIntervalError(
-        { technicalCode: 'schedule.minimumIntervalExceeded', parameters: { minimumInterval: '300000' } },
-        control,
-      ),
+      applyMinimumIntervalError({ technicalCode: 'schedule.minimumIntervalExceeded', parameters: { minimumInterval: '300000' } }, control),
     ).toBe(true);
     expect(control.errors).toEqual({ required: true, minimumInterval: 'Schedule must not run more frequently than every 5 minutes' });
   });

--- a/gravitee-apim-console-webui/src/shared/utils/schedule-limits.util.ts
+++ b/gravitee-apim-console-webui/src/shared/utils/schedule-limits.util.ts
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { AbstractControl } from '@angular/forms';
+
+export interface ScheduleLimitError {
+  technicalCode?: string;
+  message?: string;
+  parameters?: {
+    field?: string;
+    schedule?: string;
+    minimumInterval?: string;
+  };
+}
+
+export const formatScheduleInterval = (milliseconds: number): string => {
+  const units = [
+    { milliseconds: 86_400_000, label: 'day' },
+    { milliseconds: 3_600_000, label: 'hour' },
+    { milliseconds: 60_000, label: 'minute' },
+    { milliseconds: 1_000, label: 'second' },
+  ];
+  const unit = units.find(candidate => milliseconds >= candidate.milliseconds && milliseconds % candidate.milliseconds === 0);
+  if (!unit) {
+    return `${milliseconds} milliseconds`;
+  }
+  const value = milliseconds / unit.milliseconds;
+  return `${value} ${unit.label}${value === 1 ? '' : 's'}`;
+};
+
+export const getMinimumIntervalError = (error: ScheduleLimitError): string | null => {
+  if (error.technicalCode !== 'schedule.minimumIntervalExceeded') {
+    return null;
+  }
+  const minimumInterval = Number(error.parameters?.minimumInterval);
+  return Number.isFinite(minimumInterval)
+    ? `Schedule must not run more frequently than every ${formatScheduleInterval(minimumInterval)}`
+    : (error.message ?? 'Schedule exceeds the minimum interval configured by your administrator.');
+};
+
+export const applyMinimumIntervalError = (error: ScheduleLimitError, control: AbstractControl): boolean => {
+  const message = getMinimumIntervalError(error);
+  if (!message) {
+    return false;
+  }
+  control.setErrors({ ...control.errors, minimumInterval: message });
+  return true;
+};
+
+export const getMinimumIntervalHint = (milliseconds: number): string | null =>
+  milliseconds > 0 ? `Minimum interval configured by your administrator: ${formatScheduleInterval(milliseconds)}` : null;

--- a/gravitee-apim-gateway/gravitee-apim-gateway-env/src/main/java/io/gravitee/gateway/env/GatewayConfiguration.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-env/src/main/java/io/gravitee/gateway/env/GatewayConfiguration.java
@@ -51,6 +51,7 @@ public class GatewayConfiguration implements InitializingBean {
     private static final String ALLOW_OVERLAPPING_API_CONTEXTS_PROPERTY = "api.allowOverlappingContext";
 
     static final String HEALTHCHECK_JITTER_PROPERTY = "services.healthcheck.jitterInMs";
+    static final String HEALTHCHECK_MINIMUM_INTERVAL_PROPERTY = "services.healthcheck.minimum_interval";
     static final int DEFAULT_HEALTHCHECK_JITTER_MS = 900;
     private static final int MAX_HEALTHCHECK_JITTER_MS = 5000;
 
@@ -60,6 +61,7 @@ public class GatewayConfiguration implements InitializingBean {
     private Optional<List<String>> environments;
     private Optional<List<String>> organizations;
     private int healthCheckJitterMs;
+    private long healthCheckMinimumInterval;
 
     @Autowired
     private Configuration configuration;
@@ -72,6 +74,7 @@ public class GatewayConfiguration implements InitializingBean {
         this.initEnvironments();
         this.initVertxWebsocket();
         this.initHealthCheckJitter();
+        this.initHealthCheckMinimumInterval();
     }
 
     private void initVertxWebsocket() {
@@ -190,6 +193,17 @@ public class GatewayConfiguration implements InitializingBean {
      */
     public int healthCheckJitterInMs() {
         return healthCheckJitterMs;
+    }
+
+    private void initHealthCheckMinimumInterval() {
+        healthCheckMinimumInterval = configuration.getProperty(HEALTHCHECK_MINIMUM_INTERVAL_PROPERTY, Long.class, 0L);
+        if (healthCheckMinimumInterval < 0) {
+            throw new IllegalArgumentException(HEALTHCHECK_MINIMUM_INTERVAL_PROPERTY + " must be greater than or equal to 0");
+        }
+    }
+
+    public long healthCheckMinimumInterval() {
+        return healthCheckMinimumInterval;
     }
 
     public boolean hasMatchingTags(Set<String> tags) {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-env/src/test/java/io/gravitee/gateway/env/GatewayConfigurationTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-env/src/test/java/io/gravitee/gateway/env/GatewayConfigurationTest.java
@@ -47,6 +47,7 @@ public class GatewayConfigurationTest {
         System.clearProperty("vertx.disableWebsockets");
         when(configuration.getProperty("http.websocket.enabled", Boolean.class, false)).thenReturn(false);
         when(configuration.getProperty("services.healthcheck.jitterInMs", Integer.class, 900)).thenReturn(900);
+        when(configuration.getProperty("services.healthcheck.minimum_interval", Long.class, 0L)).thenReturn(0L);
     }
 
     @Test
@@ -174,5 +175,30 @@ public class GatewayConfigurationTest {
         Assert.assertTrue(tenantOpt.isPresent());
 
         Assert.assertEquals("asia", tenantOpt.get());
+    }
+
+    @Test
+    public void shouldConfigureHealthCheckMinimumInterval() {
+        when(configuration.getProperty("services.healthcheck.minimum_interval", Long.class, 0L)).thenReturn(60_000L);
+
+        gatewayConfiguration.afterPropertiesSet();
+
+        Assert.assertEquals(60_000L, gatewayConfiguration.healthCheckMinimumInterval());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldRejectNegativeHealthCheckMinimumInterval() {
+        when(configuration.getProperty("services.healthcheck.minimum_interval", Long.class, 0L)).thenReturn(-1L);
+
+        gatewayConfiguration.afterPropertiesSet();
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldRejectNonNumericHealthCheckMinimumInterval() {
+        when(configuration.getProperty("services.healthcheck.minimum_interval", Long.class, 0L)).thenThrow(
+            new IllegalArgumentException("not a number")
+        );
+
+        gatewayConfiguration.afterPropertiesSet();
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/test/java/io/gravitee/gateway/reactive/debug/DebugReactorEventListenerTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/test/java/io/gravitee/gateway/reactive/debug/DebugReactorEventListenerTest.java
@@ -307,22 +307,26 @@ class DebugReactorEventListenerTest {
 
             debugReactorEventListener.onEvent(getAReactorEvent(ReactorEvent.DEBUG, reactableWrapper));
 
-            verify(reactorHandlerRegistry, times(1)).create(any(DebugApiV2.class));
-            verify(reactorHandlerRegistry, times(1)).contains(any(DebugApiV2.class));
-            verify(reactorHandlerRegistry, timeout(10000).times(1)).remove(any(DebugApiV2.class));
+            await()
+                .atMost(5, TimeUnit.SECONDS)
+                .untilAsserted(() -> {
+                    verify(reactorHandlerRegistry, times(1)).create(any(DebugApiV2.class));
+                    verify(reactorHandlerRegistry, times(1)).contains(any(DebugApiV2.class));
+                    verify(reactorHandlerRegistry, times(1)).remove(any(DebugApiV2.class));
 
-            verify(eventRepository, times(2)).update(eventCaptor.capture());
+                    verify(eventRepository, times(2)).update(eventCaptor.capture());
 
-            final List<io.gravitee.repository.management.model.Event> events = eventCaptor.getAllValues();
-            assertThat(events.get(1).getProperties()).containsEntry(API_DEBUG_STATUS.getValue(), ApiDebugStatus.ERROR.name());
+                    final List<io.gravitee.repository.management.model.Event> events = eventCaptor.getAllValues();
+                    assertThat(events.get(1).getProperties()).containsEntry(API_DEBUG_STATUS.getValue(), ApiDebugStatus.ERROR.name());
 
-            verify(eventManager, timeout(10000)).publishEvent(eq(SecretDiscoveryEventType.REVOKE), secretDiscoveryEventCaptor.capture());
+                    verify(eventManager).publishEvent(eq(SecretDiscoveryEventType.REVOKE), secretDiscoveryEventCaptor.capture());
 
-            final SecretDiscoveryEvent capturedRevokeEvent = secretDiscoveryEventCaptor.getValue();
-            assertThat(capturedRevokeEvent).isNotNull();
-            assertThat(capturedRevokeEvent.envId()).isEqualTo(reactableWrapper.getEnvironmentId());
-            assertThat(capturedRevokeEvent.definition()).isEqualTo(debugApiModel);
-            assertThat(capturedRevokeEvent.metadata()).isNotNull();
+                    final SecretDiscoveryEvent capturedRevokeEvent = secretDiscoveryEventCaptor.getValue();
+                    assertThat(capturedRevokeEvent).isNotNull();
+                    assertThat(capturedRevokeEvent.envId()).isEqualTo(reactableWrapper.getEnvironmentId());
+                    assertThat(capturedRevokeEvent.definition()).isEqualTo(debugApiModel);
+                    assertThat(capturedRevokeEvent.metadata()).isNotNull();
+                });
         }
 
         @Test

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-healthcheck/src/main/java/io/gravitee/gateway/services/healthcheck/rule/EndpointRuleCronHandler.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-healthcheck/src/main/java/io/gravitee/gateway/services/healthcheck/rule/EndpointRuleCronHandler.java
@@ -21,6 +21,7 @@ import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
 import java.io.Serializable;
 import java.util.Objects;
+import java.util.concurrent.TimeUnit;
 
 /**
  * @author Guillaume CUSNIEUX (guillaume.cusnieux at graviteesource.com)
@@ -33,11 +34,18 @@ public class EndpointRuleCronHandler<T extends Endpoint> implements Handler<Long
     private transient EndpointRuleHandler<T> handler;
     private long timerId;
     private final long spreadOffsetMs;
+    private final long minimumInterval;
+    private transient long lastExecutionNanos = Long.MIN_VALUE;
 
     public EndpointRuleCronHandler(Vertx vertx, EndpointRule<T> rule, long jitterMs) {
+        this(vertx, rule, jitterMs, 0);
+    }
+
+    public EndpointRuleCronHandler(Vertx vertx, EndpointRule<T> rule, long jitterMs, long minimumInterval) {
         this.vertx = vertx;
         this.endpoint = rule.endpoint();
         this.spreadOffsetMs = Math.floorMod(Objects.hash(rule.api().getId(), rule.endpoint().getName()), (int) (jitterMs + 1));
+        this.minimumInterval = minimumInterval;
     }
 
     public EndpointRuleCronHandler<T> schedule(EndpointRuleHandler<T> handler) {
@@ -45,13 +53,14 @@ public class EndpointRuleCronHandler<T extends Endpoint> implements Handler<Long
             throw new IllegalArgumentException("Handler is null.");
         }
         this.handler = handler;
-        handler.setRescheduleHandler(v -> this.timerId = vertx.setTimer(handler.getDelayMillis() + spreadOffsetMs, this));
-        timerId = vertx.setTimer(handler.getDelayMillis() + spreadOffsetMs, this);
+        handler.setRescheduleHandler(v -> this.timerId = vertx.setTimer(nextDelay(handler, true), this));
+        timerId = vertx.setTimer(nextDelay(handler, false), this);
         return this;
     }
 
     @Override
     public void handle(final Long timerId) {
+        lastExecutionNanos = System.nanoTime();
         handler.handle(this.timerId);
     }
 
@@ -66,5 +75,14 @@ public class EndpointRuleCronHandler<T extends Endpoint> implements Handler<Long
 
     public Endpoint getEndpoint() {
         return endpoint;
+    }
+
+    private long nextDelay(EndpointRuleHandler<T> handler, boolean enforceMinimumInterval) {
+        var cronDelay = handler.getDelayMillis() + spreadOffsetMs;
+        if (!enforceMinimumInterval || minimumInterval == 0 || lastExecutionNanos == Long.MIN_VALUE) {
+            return cronDelay;
+        }
+        var elapsed = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - lastExecutionNanos);
+        return Math.max(cronDelay, Math.max(0, minimumInterval - elapsed));
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-healthcheck/src/main/java/io/gravitee/gateway/services/healthcheck/verticle/EndpointHealthcheckVerticle.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-healthcheck/src/main/java/io/gravitee/gateway/services/healthcheck/verticle/EndpointHealthcheckVerticle.java
@@ -143,7 +143,12 @@ public class EndpointHealthcheckVerticle extends AbstractVerticle implements Eve
             runner.setStatusHandler(statusReporter);
             runner.setAlertEventProducer(alertEventProducer);
             runner.setNode(node);
-            EndpointRuleCronHandler cronHandler = new EndpointRuleCronHandler(vertx, rule, gatewayConfiguration.healthCheckJitterInMs());
+            EndpointRuleCronHandler cronHandler = new EndpointRuleCronHandler(
+                vertx,
+                rule,
+                gatewayConfiguration.healthCheckJitterInMs(),
+                gatewayConfiguration.healthCheckMinimumInterval()
+            );
             cronHandler.schedule(runner);
 
             apiHandlers.get(api).add(cronHandler);

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-healthcheck/src/test/java/io/gravitee/gateway/services/healthcheck/rule/EndpointRuleCronHandlerTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-healthcheck/src/test/java/io/gravitee/gateway/services/healthcheck/rule/EndpointRuleCronHandlerTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.services.healthcheck.rule;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.longThat;
+import static org.mockito.ArgumentMatchers.same;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.definition.model.Endpoint;
+import io.gravitee.gateway.handlers.api.definition.Api;
+import io.gravitee.gateway.services.healthcheck.EndpointRule;
+import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+class EndpointRuleCronHandlerTest {
+
+    @Test
+    void should_preserve_initial_cron_delay_and_enforce_minimum_interval_on_reschedule() {
+        var vertx = mock(Vertx.class);
+        var endpoint = mock(Endpoint.class);
+        var api = mock(Api.class);
+        @SuppressWarnings("unchecked")
+        EndpointRule<Endpoint> rule = mock(EndpointRule.class);
+        @SuppressWarnings("unchecked")
+        EndpointRuleHandler<Endpoint> handler = mock(EndpointRuleHandler.class);
+        when(rule.endpoint()).thenReturn(endpoint);
+        when(rule.api()).thenReturn(api);
+        when(endpoint.getName()).thenReturn("endpoint");
+        when(api.getId()).thenReturn("api");
+        when(handler.getDelayMillis()).thenReturn(500L);
+        var cut = new EndpointRuleCronHandler<>(vertx, rule, 0, 5_000L);
+
+        cut.schedule(handler);
+
+        verify(vertx).setTimer(eq(500L), same(cut));
+        @SuppressWarnings("unchecked")
+        var rescheduleCaptor = ArgumentCaptor.forClass(Handler.class);
+        verify(handler).setRescheduleHandler(rescheduleCaptor.capture());
+
+        cut.handle(1L);
+        rescheduleCaptor.getValue().handle(null);
+
+        verify(vertx).setTimer(longThat(delay -> delay >= 4_900L && delay <= 5_000L), same(cut));
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/src/main/resources/config/gravitee.yml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/src/main/resources/config/gravitee.yml
@@ -676,7 +676,9 @@ services:
 #      gc-pressure: 1 # Default is 15%
 
 
-#  healthcheck:
+  healthcheck:
+    # Minimum interval between user-configured health checks in milliseconds. 0 means no limit.
+    minimum_interval: 0
 #    jitterInMs: 900
 
   # Synchronization daemon used to keep the gateway state in sync with the configuration from the management repository

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/spring/ResourceContextConfiguration.java
@@ -198,6 +198,7 @@ import io.gravitee.rest.api.service.RoleService;
 import io.gravitee.rest.api.service.SubscriptionService;
 import io.gravitee.rest.api.service.UserService;
 import io.gravitee.rest.api.service.WorkflowService;
+import io.gravitee.rest.api.service.common.ScheduleMinimumIntervalValidator;
 import io.gravitee.rest.api.service.configuration.application.ApplicationTypeService;
 import io.gravitee.rest.api.service.impl.configuration.application.ApplicationTypeServiceImpl;
 import io.gravitee.rest.api.service.v4.ApiDuplicateService;
@@ -725,7 +726,7 @@ public class ResourceContextConfiguration {
 
     @Bean
     public ValidatePageSourceDomainService validatePageSourceDomainService() {
-        return new ValidatePageSourceDomainServiceImpl(new ObjectMapper(), Vertx.vertx());
+        return new ValidatePageSourceDomainServiceImpl(new ObjectMapper(), Vertx.vertx(), mock(ScheduleMinimumIntervalValidator.class));
     }
 
     @Bean

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/spring/ResourceContextConfiguration.java
@@ -245,6 +245,7 @@ import io.gravitee.rest.api.service.RoleService;
 import io.gravitee.rest.api.service.SubscriptionService;
 import io.gravitee.rest.api.service.UserService;
 import io.gravitee.rest.api.service.WorkflowService;
+import io.gravitee.rest.api.service.common.ScheduleMinimumIntervalValidator;
 import io.gravitee.rest.api.service.configuration.application.ApplicationTypeService;
 import io.gravitee.rest.api.service.impl.configuration.application.ApplicationTypeServiceImpl;
 import io.gravitee.rest.api.service.v4.ApiDuplicateService;
@@ -781,7 +782,7 @@ public class ResourceContextConfiguration {
 
     @Bean
     public ValidatePageSourceDomainService validatePageSourceDomainService() {
-        return new ValidatePageSourceDomainServiceImpl(new ObjectMapper(), Vertx.vertx());
+        return new ValidatePageSourceDomainServiceImpl(new ObjectMapper(), Vertx.vertx(), mock(ScheduleMinimumIntervalValidator.class));
     }
 
     @Bean

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/EnvironmentConfigurationResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/EnvironmentConfigurationResource.java
@@ -35,6 +35,7 @@ import io.gravitee.rest.api.service.configuration.flow.FlowService;
 import io.gravitee.rest.api.service.configuration.spel.SpelService;
 import io.gravitee.rest.api.service.notification.Hook;
 import io.gravitee.rest.api.service.notification.PortalHook;
+import io.gravitee.rest.api.service.spring.ScheduleLimitsConfiguration;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -73,6 +74,22 @@ public class EnvironmentConfigurationResource {
 
     @Inject
     private SpelService spelService;
+
+    @Inject
+    private ScheduleLimitsConfiguration scheduleLimitsConfiguration;
+
+    @GET
+    @Path("schedule-limits")
+    @Operation(summary = "Get the configured minimum intervals for scheduled services")
+    @Produces(MediaType.APPLICATION_JSON)
+    public ScheduleLimits getScheduleLimits() {
+        return new ScheduleLimits(
+            scheduleLimitsConfiguration.getAutoFetchMinimumInterval(),
+            scheduleLimitsConfiguration.getDynamicPropertiesMinimumInterval(),
+            scheduleLimitsConfiguration.getDictionaryMinimumInterval(),
+            scheduleLimitsConfiguration.getHealthcheckMinimumInterval()
+        );
+    }
 
     @GET
     @Path("/hooks")
@@ -209,4 +226,6 @@ public class EnvironmentConfigurationResource {
     public JsonNode getGrammar() {
         return spelService.getGrammar();
     }
+
+    public record ScheduleLimits(long autoFetch, long dynamicProperties, long dictionary, long healthcheck) {}
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/EnvironmentConfigurationResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/EnvironmentConfigurationResourceTest.java
@@ -20,6 +20,7 @@ import static org.mockito.Mockito.when;
 
 import io.gravitee.rest.api.model.notification.NotifierEntity;
 import io.gravitee.rest.api.service.NotifierService;
+import io.gravitee.rest.api.service.spring.ScheduleLimitsConfiguration;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -36,6 +37,9 @@ public class EnvironmentConfigurationResourceTest {
     @Mock
     private NotifierService notifierService;
 
+    @Mock
+    private ScheduleLimitsConfiguration scheduleLimitsConfiguration;
+
     @Test
     public void getApiNotifiers() {
         when(notifierService.list()).thenReturn(
@@ -45,5 +49,20 @@ public class EnvironmentConfigurationResourceTest {
         var notifiersIds = notifiers.stream().map(NotifierEntity::getId).toList();
         assertThat(notifiersIds.size()).isEqualTo(2);
         assertThat(notifiersIds).containsAll(List.of("n1", "n2"));
+    }
+
+    @Test
+    void should_return_schedule_limits() {
+        when(scheduleLimitsConfiguration.getAutoFetchMinimumInterval()).thenReturn(1_000L);
+        when(scheduleLimitsConfiguration.getDynamicPropertiesMinimumInterval()).thenReturn(2_000L);
+        when(scheduleLimitsConfiguration.getDictionaryMinimumInterval()).thenReturn(0L);
+        when(scheduleLimitsConfiguration.getHealthcheckMinimumInterval()).thenReturn(3_000L);
+
+        var limits = environmentConfigurationResource.getScheduleLimits();
+
+        assertThat(limits.autoFetch()).isEqualTo(1_000L);
+        assertThat(limits.dynamicProperties()).isEqualTo(2_000L);
+        assertThat(limits.dictionary()).isZero();
+        assertThat(limits.healthcheck()).isEqualTo(3_000L);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/spring/ResourceContextConfiguration.java
@@ -229,6 +229,7 @@ import io.gravitee.rest.api.service.TokenService;
 import io.gravitee.rest.api.service.TopApiService;
 import io.gravitee.rest.api.service.UserService;
 import io.gravitee.rest.api.service.WorkflowService;
+import io.gravitee.rest.api.service.common.ScheduleMinimumIntervalValidator;
 import io.gravitee.rest.api.service.configuration.application.ApplicationTypeService;
 import io.gravitee.rest.api.service.configuration.application.ClientRegistrationService;
 import io.gravitee.rest.api.service.configuration.dictionary.DictionaryService;
@@ -937,7 +938,7 @@ public class ResourceContextConfiguration {
 
     @Bean
     public ValidatePageSourceDomainService validatePageSourceDomainService() {
-        return new ValidatePageSourceDomainServiceImpl(new ObjectMapper(), Vertx.vertx());
+        return new ValidatePageSourceDomainServiceImpl(new ObjectMapper(), Vertx.vertx(), mock(ScheduleMinimumIntervalValidator.class));
     }
 
     @Bean

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/spring/ResourceContextConfiguration.java
@@ -242,6 +242,7 @@ import io.gravitee.rest.api.service.converter.CategoryMapper;
 import io.gravitee.rest.api.service.impl.swagger.policy.PolicyOperationVisitorManager;
 import io.gravitee.rest.api.service.promotion.PromotionService;
 import io.gravitee.rest.api.service.search.SearchEngineService;
+import io.gravitee.rest.api.service.spring.ScheduleLimitsConfiguration;
 import io.gravitee.rest.api.service.v4.ApiGroupService;
 import io.gravitee.rest.api.service.v4.PlanSearchService;
 import io.vertx.rxjava3.core.Vertx;
@@ -368,6 +369,11 @@ public class ResourceContextConfiguration {
     @Bean
     public NotifierService notifierService() {
         return mock(NotifierService.class);
+    }
+
+    @Bean
+    public ScheduleLimitsConfiguration scheduleLimitsConfiguration() {
+        return mock(ScheduleLimitsConfiguration.class);
     }
 
     @Bean

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/spring/ResourceContextConfiguration.java
@@ -235,6 +235,7 @@ import io.gravitee.rest.api.service.ThemeService;
 import io.gravitee.rest.api.service.TicketService;
 import io.gravitee.rest.api.service.TopApiService;
 import io.gravitee.rest.api.service.UserService;
+import io.gravitee.rest.api.service.common.ScheduleMinimumIntervalValidator;
 import io.gravitee.rest.api.service.configuration.application.ApplicationTypeService;
 import io.gravitee.rest.api.service.configuration.identity.IdentityProviderActivationService;
 import io.gravitee.rest.api.service.filtering.FilteringService;
@@ -860,7 +861,7 @@ public class ResourceContextConfiguration {
 
     @Bean
     public ValidatePageSourceDomainService validatePageSourceDomainService() {
-        return new ValidatePageSourceDomainServiceImpl(new ObjectMapper(), mock(Vertx.class));
+        return new ValidatePageSourceDomainServiceImpl(new ObjectMapper(), mock(Vertx.class), mock(ScheduleMinimumIntervalValidator.class));
     }
 
     @Bean

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/documentation/ValidatePageSourceDomainServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/documentation/ValidatePageSourceDomainServiceImpl.java
@@ -22,7 +22,7 @@ import io.gravitee.apim.core.documentation.exception.InvalidPageSourceException;
 import io.gravitee.apim.core.utils.CollectionUtils;
 import io.gravitee.apim.core.utils.StringUtils;
 import io.gravitee.apim.core.validation.Validator;
-import io.gravitee.rest.api.service.common.CronScheduleLimits;
+import io.gravitee.rest.api.service.common.ScheduleMinimumIntervalValidator;
 import io.reactivex.rxjava3.core.Single;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.RequestOptions;
@@ -35,7 +35,6 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import lombok.CustomLog;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.scheduling.support.CronExpression;
 import org.springframework.stereotype.Service;
 
@@ -81,13 +80,16 @@ public class ValidatePageSourceDomainServiceImpl implements ValidatePageSourceDo
 
     private final ObjectMapper objectMapper;
     private final Vertx vertx;
+    private final ScheduleMinimumIntervalValidator scheduleMinimumIntervalValidator;
 
-    @Value("${services.auto_fetch.cron_limit:}")
-    private String autoFetchCronLimit;
-
-    public ValidatePageSourceDomainServiceImpl(ObjectMapper objectMapper, Vertx vertx) {
+    public ValidatePageSourceDomainServiceImpl(
+        ObjectMapper objectMapper,
+        Vertx vertx,
+        ScheduleMinimumIntervalValidator scheduleMinimumIntervalValidator
+    ) {
         this.objectMapper = objectMapper;
         this.vertx = vertx;
+        this.scheduleMinimumIntervalValidator = scheduleMinimumIntervalValidator;
     }
 
     @Override
@@ -249,16 +251,8 @@ public class ValidatePageSourceDomainServiceImpl implements ValidatePageSourceDo
     }
 
     private Validator.Result<String> validateFetchCronLimit(String pageName, String sourceType, String cronExpression) {
-        return CronScheduleLimits.isMoreFrequentThanLimit(cronExpression, autoFetchCronLimit)
-            ? Result.withError(
-                Error.severe(
-                    "property [fetchCron] of source [%s] must not run more frequently than [%s] for page [%s]",
-                    sourceType,
-                    autoFetchCronLimit,
-                    pageName
-                )
-            )
-            : Result.ofValue(cronExpression);
+        scheduleMinimumIntervalValidator.validateAutoFetch("source.fetchCron", cronExpression);
+        return Result.ofValue(cronExpression);
     }
 
     private Validator.Result<Map<String, Object>> checkRequiredProperties(

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/documentation/ValidatePageSourceDomainServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/documentation/ValidatePageSourceDomainServiceImpl.java
@@ -22,6 +22,7 @@ import io.gravitee.apim.core.documentation.exception.InvalidPageSourceException;
 import io.gravitee.apim.core.utils.CollectionUtils;
 import io.gravitee.apim.core.utils.StringUtils;
 import io.gravitee.apim.core.validation.Validator;
+import io.gravitee.rest.api.service.common.CronScheduleLimits;
 import io.reactivex.rxjava3.core.Single;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.RequestOptions;
@@ -34,6 +35,7 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import lombok.CustomLog;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.scheduling.support.CronExpression;
 import org.springframework.stereotype.Service;
 
@@ -79,6 +81,9 @@ public class ValidatePageSourceDomainServiceImpl implements ValidatePageSourceDo
 
     private final ObjectMapper objectMapper;
     private final Vertx vertx;
+
+    @Value("${services.auto_fetch.cron_limit:}")
+    private String autoFetchCronLimit;
 
     public ValidatePageSourceDomainServiceImpl(ObjectMapper objectMapper, Vertx vertx) {
         this.objectMapper = objectMapper;
@@ -237,10 +242,23 @@ public class ValidatePageSourceDomainServiceImpl implements ValidatePageSourceDo
             return Result.empty();
         }
         return CronExpression.isValidExpression(cronExpression)
-            ? Result.ofValue(cronExpression)
+            ? validateFetchCronLimit(pageName, sourceType, cronExpression)
             : Result.withError(
                 Error.severe("property [fetchCron] of source [%s] must be a valid cron expression for page [%s]", sourceType, pageName)
             );
+    }
+
+    private Validator.Result<String> validateFetchCronLimit(String pageName, String sourceType, String cronExpression) {
+        return CronScheduleLimits.isMoreFrequentThanLimit(cronExpression, autoFetchCronLimit)
+            ? Result.withError(
+                Error.severe(
+                    "property [fetchCron] of source [%s] must not run more frequently than [%s] for page [%s]",
+                    sourceType,
+                    autoFetchCronLimit,
+                    pageName
+                )
+            )
+            : Result.ofValue(cronExpression);
     }
 
     private Validator.Result<Map<String, Object>> checkRequiredProperties(

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/common/CronScheduleLimits.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/common/CronScheduleLimits.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.common;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.scheduling.support.CronExpression;
+
+public final class CronScheduleLimits {
+
+    private static final LocalDateTime REFERENCE_TIME = LocalDateTime.of(2026, 1, 1, 0, 0);
+
+    private CronScheduleLimits() {}
+
+    public static String limitFrequency(String userCron, String cronLimit) {
+        if (StringUtils.isBlank(cronLimit)) {
+            return userCron;
+        }
+
+        return frequency(userCron).compareTo(frequency(cronLimit)) < 0 ? cronLimit : userCron;
+    }
+
+    public static long limitFrequency(long userDelayMillis, long delayLimitMillis) {
+        return delayLimitMillis > 0 ? Math.max(userDelayMillis, delayLimitMillis) : userDelayMillis;
+    }
+
+    private static Duration frequency(String cron) {
+        var cronExpression = CronExpression.parse(cron);
+        var firstExecution = cronExpression.next(REFERENCE_TIME);
+        if (firstExecution == null) {
+            throw new IllegalArgumentException("Cron expression has no future execution: " + cron);
+        }
+        var secondExecution = cronExpression.next(firstExecution);
+
+        if (secondExecution == null) {
+            throw new IllegalArgumentException("Cron expression has no future execution: " + cron);
+        }
+
+        return Duration.between(firstExecution, secondExecution);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/common/CronScheduleLimits.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/common/CronScheduleLimits.java
@@ -15,49 +15,92 @@
  */
 package io.gravitee.rest.api.service.common;
 
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.util.concurrent.UncheckedExecutionException;
 import java.time.Duration;
 import java.time.LocalDateTime;
-import org.apache.commons.lang3.StringUtils;
+import java.time.LocalTime;
+import java.util.concurrent.ExecutionException;
 import org.springframework.scheduling.support.CronExpression;
 
 public final class CronScheduleLimits {
 
-    private static final LocalDateTime REFERENCE_TIME = LocalDateTime.of(2026, 1, 1, 0, 0);
+    private static final LocalDateTime CYCLE_START = LocalDateTime.of(2000, 1, 1, 0, 0);
+    private static final LocalDateTime CYCLE_END = CYCLE_START.plusYears(400);
+    private static final Cache<String, Duration> MINIMUM_INTERVALS = CacheBuilder.newBuilder().maximumSize(1_000).build();
 
     private CronScheduleLimits() {}
 
-    public static String limitFrequency(String userCron, String cronLimit) {
-        if (StringUtils.isBlank(cronLimit)) {
-            return userCron;
+    public static boolean isMoreFrequentThanLimit(String userCron, long minimumIntervalMillis) {
+        return minimumIntervalMillis > 0 && minimumInterval(userCron).compareTo(Duration.ofMillis(minimumIntervalMillis)) < 0;
+    }
+
+    public static long limitFrequency(long userDelayMillis, long minimumIntervalMillis) {
+        return minimumIntervalMillis > 0 ? Math.max(userDelayMillis, minimumIntervalMillis) : userDelayMillis;
+    }
+
+    public static boolean isMoreFrequentThanLimit(long userDelayMillis, long minimumIntervalMillis) {
+        return minimumIntervalMillis > 0 && userDelayMillis < minimumIntervalMillis;
+    }
+
+    static Duration minimumInterval(String cron) {
+        var expression = CronExpression.parse(cron);
+        try {
+            return MINIMUM_INTERVALS.get(expression.toString(), () -> computeMinimumInterval(expression));
+        } catch (ExecutionException | UncheckedExecutionException e) {
+            if (e.getCause() instanceof IllegalArgumentException illegalArgumentException) {
+                throw illegalArgumentException;
+            }
+            throw new IllegalStateException("Unable to analyze cron expression: " + cron, e.getCause());
+        }
+    }
+
+    private static Duration computeMinimumInterval(CronExpression expression) {
+        var firstExecution = expression.next(CYCLE_START.minusNanos(1));
+        if (firstExecution == null || !firstExecution.isBefore(CYCLE_END)) {
+            throw new IllegalArgumentException("Cron expression has no execution in a complete Gregorian calendar cycle: " + expression);
         }
 
-        return isMoreFrequentThanLimit(userCron, cronLimit) ? cronLimit : userCron;
-    }
+        var firstTime = firstExecution.toLocalTime();
+        var lastTime = firstTime;
+        Duration minimumWithinDay = null;
+        var nextExecution = expression.next(firstExecution);
 
-    public static long limitFrequency(long userDelayMillis, long delayLimitMillis) {
-        return delayLimitMillis > 0 ? Math.max(userDelayMillis, delayLimitMillis) : userDelayMillis;
-    }
-
-    public static boolean isMoreFrequentThanLimit(String userCron, String cronLimit) {
-        return StringUtils.isNotBlank(cronLimit) && frequency(userCron).compareTo(frequency(cronLimit)) < 0;
-    }
-
-    public static boolean isMoreFrequentThanLimit(long userDelayMillis, long delayLimitMillis) {
-        return delayLimitMillis > 0 && userDelayMillis < delayLimitMillis;
-    }
-
-    private static Duration frequency(String cron) {
-        var cronExpression = CronExpression.parse(cron);
-        var firstExecution = cronExpression.next(REFERENCE_TIME);
-        if (firstExecution == null) {
-            throw new IllegalArgumentException("Cron expression has no future execution: " + cron);
-        }
-        var secondExecution = cronExpression.next(firstExecution);
-
-        if (secondExecution == null) {
-            throw new IllegalArgumentException("Cron expression has no future execution: " + cron);
+        while (nextExecution != null && nextExecution.toLocalDate().equals(firstExecution.toLocalDate())) {
+            var interval = Duration.between(lastTime, nextExecution.toLocalTime());
+            minimumWithinDay = shorter(minimumWithinDay, interval);
+            lastTime = nextExecution.toLocalTime();
+            nextExecution = expression.next(nextExecution);
         }
 
-        return Duration.between(firstExecution, secondExecution);
+        var shortestPossibleDayBoundary = Duration.between(
+            CYCLE_START.toLocalDate().atTime(lastTime),
+            CYCLE_START.toLocalDate().plusDays(1).atTime(firstTime)
+        );
+        if (minimumWithinDay != null && shortestPossibleDayBoundary.compareTo(minimumWithinDay) >= 0) {
+            return minimumWithinDay;
+        }
+
+        Duration minimum = minimumWithinDay;
+        var previousDate = firstExecution.toLocalDate();
+        var current = nextExecution;
+        while (current != null && current.isBefore(CYCLE_END)) {
+            var boundaryInterval = Duration.between(previousDate.atTime(lastTime), current.toLocalDate().atTime(firstTime));
+            minimum = shorter(minimum, boundaryInterval);
+            if (boundaryInterval.equals(shortestPossibleDayBoundary)) {
+                return minimum;
+            }
+            previousDate = current.toLocalDate();
+            current = expression.next(previousDate.atTime(LocalTime.MAX));
+        }
+
+        var wrappedFirstExecution = firstExecution.plusYears(400);
+        var wrappedBoundary = Duration.between(previousDate.atTime(lastTime), wrappedFirstExecution.toLocalDate().atTime(firstTime));
+        return shorter(minimum, wrappedBoundary);
+    }
+
+    private static Duration shorter(Duration current, Duration candidate) {
+        return current == null || candidate.compareTo(current) < 0 ? candidate : current;
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/common/CronScheduleLimits.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/common/CronScheduleLimits.java
@@ -31,11 +31,19 @@ public final class CronScheduleLimits {
             return userCron;
         }
 
-        return frequency(userCron).compareTo(frequency(cronLimit)) < 0 ? cronLimit : userCron;
+        return isMoreFrequentThanLimit(userCron, cronLimit) ? cronLimit : userCron;
     }
 
     public static long limitFrequency(long userDelayMillis, long delayLimitMillis) {
         return delayLimitMillis > 0 ? Math.max(userDelayMillis, delayLimitMillis) : userDelayMillis;
+    }
+
+    public static boolean isMoreFrequentThanLimit(String userCron, String cronLimit) {
+        return StringUtils.isNotBlank(cronLimit) && frequency(userCron).compareTo(frequency(cronLimit)) < 0;
+    }
+
+    public static boolean isMoreFrequentThanLimit(long userDelayMillis, long delayLimitMillis) {
+        return delayLimitMillis > 0 && userDelayMillis < delayLimitMillis;
     }
 
     private static Duration frequency(String cron) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/common/ScheduleMinimumIntervalValidator.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/common/ScheduleMinimumIntervalValidator.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.common;
+
+import io.gravitee.rest.api.service.exceptions.ScheduleMinimumIntervalExceededException;
+import io.gravitee.rest.api.service.spring.ScheduleLimitsConfiguration;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ScheduleMinimumIntervalValidator {
+
+    private final ScheduleLimitsConfiguration configuration;
+
+    public boolean isDynamicPropertiesLimitEnabled() {
+        return configuration.getDynamicPropertiesMinimumInterval() > 0;
+    }
+
+    public boolean isHealthcheckLimitEnabled() {
+        return configuration.getHealthcheckMinimumInterval() > 0;
+    }
+
+    public void validateAutoFetch(String field, String schedule) {
+        validate(field, schedule, configuration.getAutoFetchMinimumInterval());
+    }
+
+    public void validateDynamicProperties(String field, String schedule) {
+        validate(field, schedule, configuration.getDynamicPropertiesMinimumInterval());
+    }
+
+    public void validateHealthcheck(String field, String schedule) {
+        validate(field, schedule, configuration.getHealthcheckMinimumInterval());
+    }
+
+    public void validateDictionary(String field, long delay) {
+        var minimumInterval = configuration.getDictionaryMinimumInterval();
+        if (CronScheduleLimits.isMoreFrequentThanLimit(delay, minimumInterval)) {
+            throw new ScheduleMinimumIntervalExceededException(field, Long.toString(delay), minimumInterval);
+        }
+    }
+
+    private static void validate(String field, String schedule, long minimumInterval) {
+        if (CronScheduleLimits.isMoreFrequentThanLimit(schedule, minimumInterval)) {
+            throw new ScheduleMinimumIntervalExceededException(field, schedule, minimumInterval);
+        }
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/exceptions/InvalidFetchCronExpressionException.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/exceptions/InvalidFetchCronExpressionException.java
@@ -47,7 +47,7 @@ public class InvalidFetchCronExpressionException extends AbstractManagementExcep
 
     @Override
     public String getMessage() {
-        return "The fetch cron expression is invalid: " + fetchCron;
+        return fetchCron != null ? "The fetch cron expression is invalid: " + fetchCron : super.getMessage();
     }
 
     @Override

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/exceptions/ScheduleMinimumIntervalExceededException.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/exceptions/ScheduleMinimumIntervalExceededException.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.exceptions;
+
+import io.gravitee.common.http.HttpStatusCode;
+import java.util.Map;
+
+public class ScheduleMinimumIntervalExceededException extends AbstractManagementException {
+
+    private final String field;
+    private final String schedule;
+    private final long minimumInterval;
+
+    public ScheduleMinimumIntervalExceededException(String field, String schedule, long minimumInterval) {
+        super("Schedule must not run more frequently than every " + minimumInterval + " milliseconds");
+        this.field = field;
+        this.schedule = schedule;
+        this.minimumInterval = minimumInterval;
+    }
+
+    @Override
+    public int getHttpStatusCode() {
+        return HttpStatusCode.BAD_REQUEST_400;
+    }
+
+    @Override
+    public String getTechnicalCode() {
+        return "schedule.minimumIntervalExceeded";
+    }
+
+    @Override
+    public Map<String, String> getParameters() {
+        return Map.of("field", field, "schedule", schedule, "minimumInterval", Long.toString(minimumInterval));
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiDuplicatorServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiDuplicatorServiceImpl.java
@@ -67,6 +67,7 @@ import io.gravitee.rest.api.service.PermissionService;
 import io.gravitee.rest.api.service.PlanService;
 import io.gravitee.rest.api.service.RoleService;
 import io.gravitee.rest.api.service.UserService;
+import io.gravitee.rest.api.service.common.CronScheduleLimits;
 import io.gravitee.rest.api.service.common.ExecutionContext;
 import io.gravitee.rest.api.service.common.UuidString;
 import io.gravitee.rest.api.service.converter.ApiConverter;
@@ -103,6 +104,7 @@ import java.util.stream.Stream;
 import lombok.CustomLog;
 import net.minidev.json.JSONObject;
 import org.jetbrains.annotations.NotNull;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.scheduling.support.CronExpression;
 import org.springframework.stereotype.Component;
@@ -139,6 +141,9 @@ public class ApiDuplicatorServiceImpl extends AbstractService implements ApiDupl
     private final PermissionService permissionService;
     private final ApiIdsCalculatorService apiIdsCalculatorService;
     private final CategoryMapper categoryMapper;
+
+    @Value("${services.auto_fetch.cron_limit:}")
+    private String autoFetchCronLimit;
 
     public ApiDuplicatorServiceImpl(
         HttpClientService httpClientService,
@@ -1147,6 +1152,15 @@ public class ApiDuplicatorServiceImpl extends AbstractService implements ApiDupl
                         log.debug("Validating fetchCron '{}'", cron);
                         try {
                             CronExpression.parse(cron); // Validate cron
+                            if (CronScheduleLimits.isMoreFrequentThanLimit(cron, autoFetchCronLimit)) {
+                                String pageName = pageNode.path("name").asText("Unnamed Page");
+                                throw new ApiImportException(
+                                    "Invalid fetchCron expression in page '" +
+                                        pageName +
+                                        "': it must not run more frequently than the configured limit " +
+                                        autoFetchCronLimit
+                                );
+                            }
                         } catch (IllegalArgumentException e) {
                             String pageName = pageNode.path("name").asText("Unnamed Page");
                             throw new ApiImportException("Invalid fetchCron expression in page '" + pageName + "': " + e.getMessage());

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiDuplicatorServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiDuplicatorServiceImpl.java
@@ -67,8 +67,8 @@ import io.gravitee.rest.api.service.PermissionService;
 import io.gravitee.rest.api.service.PlanService;
 import io.gravitee.rest.api.service.RoleService;
 import io.gravitee.rest.api.service.UserService;
-import io.gravitee.rest.api.service.common.CronScheduleLimits;
 import io.gravitee.rest.api.service.common.ExecutionContext;
+import io.gravitee.rest.api.service.common.ScheduleMinimumIntervalValidator;
 import io.gravitee.rest.api.service.common.UuidString;
 import io.gravitee.rest.api.service.converter.ApiConverter;
 import io.gravitee.rest.api.service.converter.CategoryMapper;
@@ -142,8 +142,7 @@ public class ApiDuplicatorServiceImpl extends AbstractService implements ApiDupl
     private final ApiIdsCalculatorService apiIdsCalculatorService;
     private final CategoryMapper categoryMapper;
 
-    @Value("${services.auto_fetch.cron_limit:}")
-    private String autoFetchCronLimit;
+    private final ScheduleMinimumIntervalValidator scheduleMinimumIntervalValidator;
 
     public ApiDuplicatorServiceImpl(
         HttpClientService httpClientService,
@@ -164,7 +163,8 @@ public class ApiDuplicatorServiceImpl extends AbstractService implements ApiDupl
         PlanConverter planConverter,
         PermissionService permissionService,
         ApiIdsCalculatorService apiIdsCalculatorService,
-        CategoryMapper categoryMapper
+        CategoryMapper categoryMapper,
+        ScheduleMinimumIntervalValidator scheduleMinimumIntervalValidator
     ) {
         this.httpClientService = httpClientService;
         this.importConfiguration = importConfiguration;
@@ -185,6 +185,7 @@ public class ApiDuplicatorServiceImpl extends AbstractService implements ApiDupl
         this.permissionService = permissionService;
         this.apiIdsCalculatorService = apiIdsCalculatorService;
         this.categoryMapper = categoryMapper;
+        this.scheduleMinimumIntervalValidator = scheduleMinimumIntervalValidator;
     }
 
     @Override
@@ -1152,15 +1153,7 @@ public class ApiDuplicatorServiceImpl extends AbstractService implements ApiDupl
                         log.debug("Validating fetchCron '{}'", cron);
                         try {
                             CronExpression.parse(cron); // Validate cron
-                            if (CronScheduleLimits.isMoreFrequentThanLimit(cron, autoFetchCronLimit)) {
-                                String pageName = pageNode.path("name").asText("Unnamed Page");
-                                throw new ApiImportException(
-                                    "Invalid fetchCron expression in page '" +
-                                        pageName +
-                                        "': it must not run more frequently than the configured limit " +
-                                        autoFetchCronLimit
-                                );
-                            }
+                            scheduleMinimumIntervalValidator.validateAutoFetch("source.fetchCron", cron);
                         } catch (IllegalArgumentException e) {
                             String pageName = pageNode.path("name").asText("Unnamed Page");
                             throw new ApiImportException("Invalid fetchCron expression in page '" + pageName + "': " + e.getMessage());

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiServiceImpl.java
@@ -171,6 +171,7 @@ import io.gravitee.rest.api.service.UserService;
 import io.gravitee.rest.api.service.V4EmulationEngineService;
 import io.gravitee.rest.api.service.WorkflowService;
 import io.gravitee.rest.api.service.builder.EmailNotificationBuilder;
+import io.gravitee.rest.api.service.common.CronScheduleLimits;
 import io.gravitee.rest.api.service.common.ExecutionContext;
 import io.gravitee.rest.api.service.common.UuidString;
 import io.gravitee.rest.api.service.configuration.flow.FlowService;
@@ -399,6 +400,9 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
     @Value("${configuration.default-api-icon:}")
     private String defaultApiIcon;
 
+    @Value("${services.healthcheck.cron_limit:}")
+    private String healthcheckCronLimit;
+
     @Autowired
     private PrimaryOwnerService primaryOwnerService;
 
@@ -612,6 +616,9 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
 
             // check endpoints configuration
             checkEndpointsConfiguration(api);
+
+            // validate HC cron schedule
+            validateHealtcheckSchedule(api);
 
             // check CORS Allow-origin format
             corsValidationService.validateAndSanitize(api.getProxy().getCors());
@@ -850,7 +857,8 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
                 String schedule = healthCheckService.getSchedule();
                 if (schedule != null) {
                     try {
-                        new CronTrigger(schedule);
+                        healthCheckService.setSchedule(CronScheduleLimits.limitFrequency(schedule, healthcheckCronLimit));
+                        new CronTrigger(healthCheckService.getSchedule());
                     } catch (IllegalArgumentException e) {
                         throw new InvalidDataException(e);
                     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiServiceImpl.java
@@ -68,6 +68,7 @@ import io.gravitee.definition.model.flow.Flow;
 import io.gravitee.definition.model.flow.Step;
 import io.gravitee.definition.model.plugins.resources.Resource;
 import io.gravitee.definition.model.services.discovery.EndpointDiscoveryService;
+import io.gravitee.definition.model.services.dynamicproperty.DynamicPropertyService;
 import io.gravitee.definition.model.services.healthcheck.HealthCheckService;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.ApiQualityRuleRepository;
@@ -403,6 +404,9 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
     @Value("${services.healthcheck.cron_limit:}")
     private String healthcheckCronLimit;
 
+    @Value("${services.dynamic_properties.cron_limit:}")
+    private String dynamicPropertiesCronLimit;
+
     @Autowired
     private PrimaryOwnerService primaryOwnerService;
 
@@ -619,6 +623,7 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
 
             // validate HC cron schedule
             validateHealtcheckSchedule(api);
+            validateDynamicPropertiesSchedule(api);
 
             // check CORS Allow-origin format
             corsValidationService.validateAndSanitize(api.getProxy().getCors());
@@ -857,8 +862,34 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
                 String schedule = healthCheckService.getSchedule();
                 if (schedule != null) {
                     try {
-                        healthCheckService.setSchedule(CronScheduleLimits.limitFrequency(schedule, healthcheckCronLimit));
-                        new CronTrigger(healthCheckService.getSchedule());
+                        new CronTrigger(schedule);
+                        if (CronScheduleLimits.isMoreFrequentThanLimit(schedule, healthcheckCronLimit)) {
+                            throw new InvalidDataException(
+                                "Healthcheck schedule must not run more frequently than the configured limit: " + healthcheckCronLimit
+                            );
+                        }
+                    } catch (IllegalArgumentException e) {
+                        throw new InvalidDataException(e);
+                    }
+                }
+            }
+        }
+    }
+
+    private void validateDynamicPropertiesSchedule(UpdateApiEntity api) {
+        if (api.getServices() != null) {
+            DynamicPropertyService dynamicPropertyService = api.getServices().get(DynamicPropertyService.class);
+            if (dynamicPropertyService != null) {
+                String schedule = dynamicPropertyService.getSchedule();
+                if (schedule != null) {
+                    try {
+                        new CronTrigger(schedule);
+                        if (CronScheduleLimits.isMoreFrequentThanLimit(schedule, dynamicPropertiesCronLimit)) {
+                            throw new InvalidDataException(
+                                "Dynamic properties schedule must not run more frequently than the configured limit: " +
+                                    dynamicPropertiesCronLimit
+                            );
+                        }
                     } catch (IllegalArgumentException e) {
                         throw new InvalidDataException(e);
                     }
@@ -1223,6 +1254,7 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
 
             // validate HC cron schedule
             validateHealtcheckSchedule(updateApiEntity);
+            validateDynamicPropertiesSchedule(updateApiEntity);
 
             // check CORS Allow-origin format
             updateApiEntity.getProxy().setCors(corsValidationService.validateAndSanitize(updateApiEntity.getProxy().getCors()));

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiServiceImpl.java
@@ -67,6 +67,7 @@ import io.gravitee.definition.model.VirtualHost;
 import io.gravitee.definition.model.flow.Flow;
 import io.gravitee.definition.model.flow.Step;
 import io.gravitee.definition.model.plugins.resources.Resource;
+import io.gravitee.definition.model.services.Services;
 import io.gravitee.definition.model.services.discovery.EndpointDiscoveryService;
 import io.gravitee.definition.model.services.dynamicproperty.DynamicPropertyService;
 import io.gravitee.definition.model.services.healthcheck.HealthCheckService;
@@ -172,8 +173,8 @@ import io.gravitee.rest.api.service.UserService;
 import io.gravitee.rest.api.service.V4EmulationEngineService;
 import io.gravitee.rest.api.service.WorkflowService;
 import io.gravitee.rest.api.service.builder.EmailNotificationBuilder;
-import io.gravitee.rest.api.service.common.CronScheduleLimits;
 import io.gravitee.rest.api.service.common.ExecutionContext;
+import io.gravitee.rest.api.service.common.ScheduleMinimumIntervalValidator;
 import io.gravitee.rest.api.service.common.UuidString;
 import io.gravitee.rest.api.service.configuration.flow.FlowService;
 import io.gravitee.rest.api.service.converter.ApiConverter;
@@ -194,6 +195,7 @@ import io.gravitee.rest.api.service.exceptions.GroupsNotFoundException;
 import io.gravitee.rest.api.service.exceptions.InvalidDataException;
 import io.gravitee.rest.api.service.exceptions.LifecycleStateChangeNotAllowedException;
 import io.gravitee.rest.api.service.exceptions.PaginationInvalidException;
+import io.gravitee.rest.api.service.exceptions.ScheduleMinimumIntervalExceededException;
 import io.gravitee.rest.api.service.exceptions.TagNotAllowedException;
 import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
 import io.gravitee.rest.api.service.impl.search.SearchResult;
@@ -239,6 +241,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
+import java.util.function.BiConsumer;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.regex.Pattern;
@@ -401,11 +404,8 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
     @Value("${configuration.default-api-icon:}")
     private String defaultApiIcon;
 
-    @Value("${services.healthcheck.cron_limit:}")
-    private String healthcheckCronLimit;
-
-    @Value("${services.dynamic_properties.cron_limit:}")
-    private String dynamicPropertiesCronLimit;
+    @Autowired
+    private ScheduleMinimumIntervalValidator scheduleMinimumIntervalValidator;
 
     @Autowired
     private PrimaryOwnerService primaryOwnerService;
@@ -856,45 +856,50 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
     }
 
     private void validateHealtcheckSchedule(UpdateApiEntity api) {
-        if (api.getServices() != null) {
-            HealthCheckService healthCheckService = api.getServices().get(HealthCheckService.class);
-            if (healthCheckService != null) {
-                String schedule = healthCheckService.getSchedule();
-                if (schedule != null) {
-                    try {
-                        new CronTrigger(schedule);
-                        if (CronScheduleLimits.isMoreFrequentThanLimit(schedule, healthcheckCronLimit)) {
-                            throw new InvalidDataException(
-                                "Healthcheck schedule must not run more frequently than the configured limit: " + healthcheckCronLimit
-                            );
-                        }
-                    } catch (IllegalArgumentException e) {
-                        throw new InvalidDataException(e);
-                    }
-                }
-            }
+        validateHealtcheckSchedule(api.getServices());
+    }
+
+    private void validateHealtcheckSchedule(Services services) {
+        if (services == null) {
+            return;
+        }
+        HealthCheckService healthCheckService = services.get(HealthCheckService.class);
+        if (healthCheckService != null) {
+            validateSchedule(
+                "services.healthcheck.schedule",
+                healthCheckService.getSchedule(),
+                scheduleMinimumIntervalValidator::validateHealthcheck
+            );
         }
     }
 
     private void validateDynamicPropertiesSchedule(UpdateApiEntity api) {
-        if (api.getServices() != null) {
-            DynamicPropertyService dynamicPropertyService = api.getServices().get(DynamicPropertyService.class);
-            if (dynamicPropertyService != null) {
-                String schedule = dynamicPropertyService.getSchedule();
-                if (schedule != null) {
-                    try {
-                        new CronTrigger(schedule);
-                        if (CronScheduleLimits.isMoreFrequentThanLimit(schedule, dynamicPropertiesCronLimit)) {
-                            throw new InvalidDataException(
-                                "Dynamic properties schedule must not run more frequently than the configured limit: " +
-                                    dynamicPropertiesCronLimit
-                            );
-                        }
-                    } catch (IllegalArgumentException e) {
-                        throw new InvalidDataException(e);
-                    }
-                }
-            }
+        validateDynamicPropertiesSchedule(api.getServices());
+    }
+
+    private void validateDynamicPropertiesSchedule(Services services) {
+        if (services == null) {
+            return;
+        }
+        DynamicPropertyService dynamicPropertyService = services.get(DynamicPropertyService.class);
+        if (dynamicPropertyService != null) {
+            validateSchedule(
+                "services.dynamicProperty.schedule",
+                dynamicPropertyService.getSchedule(),
+                scheduleMinimumIntervalValidator::validateDynamicProperties
+            );
+        }
+    }
+
+    private void validateSchedule(String field, String schedule, BiConsumer<String, String> minimumIntervalValidator) {
+        if (schedule == null) {
+            return;
+        }
+        try {
+            new CronTrigger(schedule);
+            minimumIntervalValidator.accept(field, schedule);
+        } catch (IllegalArgumentException e) {
+            throw new InvalidDataException(e);
         }
     }
 
@@ -1961,6 +1966,8 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
             log.debug("Deploy API : {}", apiId);
 
             return deployCurrentAPI(executionContext, apiId, userId, eventType, apiDeploymentEntity);
+        } catch (ScheduleMinimumIntervalExceededException ex) {
+            throw ex;
         } catch (Exception ex) {
             throw new TechnicalManagementException("An error occurs while trying to deploy API: " + apiId, ex);
         }
@@ -2002,6 +2009,10 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
         ApiDeploymentEntity apiDeploymentEntity
     ) throws Exception {
         Api api = apiRepository.findById(apiId).orElseThrow(() -> new ApiNotFoundException(apiId));
+
+        var currentApi = convert(executionContext, singletonList(api)).iterator().next();
+        validateHealtcheckSchedule(currentApi.getServices());
+        validateDynamicPropertiesSchedule(currentApi.getServices());
 
         // add deployment date
         api.setUpdatedAt(new Date());

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiServiceImpl.java
@@ -621,7 +621,6 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
             // check endpoints configuration
             checkEndpointsConfiguration(api);
 
-            // validate HC cron schedule
             validateHealtcheckSchedule(api);
             validateDynamicPropertiesSchedule(api);
 
@@ -1257,7 +1256,6 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
             // check endpoints configuration
             checkEndpointsConfiguration(updateApiEntity);
 
-            // validate HC cron schedule
             validateHealtcheckSchedule(updateApiEntity);
             validateDynamicPropertiesSchedule(updateApiEntity);
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/PageServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/PageServiceImpl.java
@@ -72,6 +72,7 @@ import io.gravitee.rest.api.service.sanitizer.HtmlSanitizer;
 import io.gravitee.rest.api.service.sanitizer.UrlSanitizerUtils;
 import io.gravitee.rest.api.service.search.SearchEngineService;
 import io.gravitee.rest.api.service.spring.ImportConfiguration;
+import io.gravitee.rest.api.service.spring.ScheduleLimitsConfiguration;
 import io.gravitee.rest.api.service.swagger.OAIDescriptor;
 import io.gravitee.rest.api.service.swagger.SwaggerDescriptor;
 import io.gravitee.rest.api.service.v4.ApiEntrypointService;
@@ -82,6 +83,7 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.lang.reflect.Field;
+import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.*;
@@ -129,8 +131,8 @@ public class PageServiceImpl extends AbstractService implements PageService, App
     @Value("${documentation.audit.max-content-size:-1}")
     private int maxContentSize;
 
-    @Value("${services.auto_fetch.cron_limit:}")
-    private String autoFetchCronLimit;
+    @Autowired
+    private ScheduleLimitsConfiguration scheduleLimitsConfiguration;
 
     @Lazy
     @Autowired
@@ -344,10 +346,10 @@ public class PageServiceImpl extends AbstractService implements PageService, App
     }
 
     public static void validateFetchConfig(String jsonConfig) throws InvalidFetchCronExpressionException {
-        validateFetchConfig(jsonConfig, null);
+        validateFetchConfig(jsonConfig, 0);
     }
 
-    public static void validateFetchConfig(String jsonConfig, String fetchCronLimit) throws InvalidFetchCronExpressionException {
+    public static void validateFetchConfig(String jsonConfig, long minimumInterval) throws InvalidFetchCronExpressionException {
         ObjectMapper mapper = new ObjectMapper();
         JsonNode root;
         try {
@@ -365,10 +367,8 @@ public class PageServiceImpl extends AbstractService implements PageService, App
         if (!isInvalid) {
             try {
                 CronExpression.parse(fetchCron);
-                if (CronScheduleLimits.isMoreFrequentThanLimit(fetchCron, fetchCronLimit)) {
-                    throw new InvalidFetchCronExpressionException(
-                        "fetchCron must not run more frequently than the configured limit: " + fetchCronLimit
-                    );
+                if (CronScheduleLimits.isMoreFrequentThanLimit(fetchCron, minimumInterval)) {
+                    throw new ScheduleMinimumIntervalExceededException("source.fetchCron", fetchCron, minimumInterval);
                 }
             } catch (IllegalArgumentException e) {
                 throw new InvalidFetchCronExpressionException(fetchCron, e);
@@ -1442,7 +1442,7 @@ public class PageServiceImpl extends AbstractService implements PageService, App
     private void validatePageFetchConfig(FetchablePageEntity pageEntity) {
         if (pageEntity.getSource() != null && pageEntity.getSource().getConfiguration() != null) {
             log.debug("Validating fetch config for page");
-            validateFetchConfig(pageEntity.getSource().getConfiguration(), autoFetchCronLimit);
+            validateFetchConfig(pageEntity.getSource().getConfiguration(), scheduleLimitsConfiguration.getAutoFetchMinimumInterval());
         }
     }
 
@@ -1732,12 +1732,20 @@ public class PageServiceImpl extends AbstractService implements PageService, App
             if (configuration.isAutoFetch()) {
                 String cron = configuration.getFetchCron();
                 if (cron != null && !cron.isEmpty()) {
-                    CronExpression cronExpression = CronExpression.parse(CronScheduleLimits.limitFrequency(cron, autoFetchCronLimit));
+                    CronExpression cronExpression = CronExpression.parse(cron);
                     if (pageItem.getUpdatedAt() != null) {
                         LocalDateTime nextRun;
                         LocalDateTime updatedAt = LocalDateTime.ofInstant(pageItem.getUpdatedAt().toInstant(), ZoneId.systemDefault());
                         if ((nextRun = cronExpression.next(updatedAt)) != null) {
-                            fetchRequired = nextRun.isBefore(LocalDateTime.now());
+                            var now = Instant.now();
+                            fetchRequired =
+                                nextRun.isBefore(LocalDateTime.ofInstant(now, ZoneId.systemDefault())) &&
+                                (scheduleLimitsConfiguration.getAutoFetchMinimumInterval() == 0 ||
+                                    !pageItem
+                                        .getUpdatedAt()
+                                        .toInstant()
+                                        .plusMillis(scheduleLimitsConfiguration.getAutoFetchMinimumInterval())
+                                        .isAfter(now));
                         }
                     }
                 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/PageServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/PageServiceImpl.java
@@ -58,6 +58,7 @@ import io.gravitee.rest.api.model.v4.api.GenericApiEntity;
 import io.gravitee.rest.api.model.v4.api.GenericApiModel;
 import io.gravitee.rest.api.model.v4.plan.GenericPlanEntity;
 import io.gravitee.rest.api.service.*;
+import io.gravitee.rest.api.service.common.CronScheduleLimits;
 import io.gravitee.rest.api.service.common.ExecutionContext;
 import io.gravitee.rest.api.service.common.UuidString;
 import io.gravitee.rest.api.service.converter.PageConverter;
@@ -127,6 +128,9 @@ public class PageServiceImpl extends AbstractService implements PageService, App
 
     @Value("${documentation.audit.max-content-size:-1}")
     private int maxContentSize;
+
+    @Value("${services.auto_fetch.cron_limit:}")
+    private String autoFetchCronLimit;
 
     @Lazy
     @Autowired
@@ -1719,7 +1723,7 @@ public class PageServiceImpl extends AbstractService implements PageService, App
             if (configuration.isAutoFetch()) {
                 String cron = configuration.getFetchCron();
                 if (cron != null && !cron.isEmpty()) {
-                    CronExpression cronExpression = CronExpression.parse(cron);
+                    CronExpression cronExpression = CronExpression.parse(CronScheduleLimits.limitFrequency(cron, autoFetchCronLimit));
                     if (pageItem.getUpdatedAt() != null) {
                         LocalDateTime nextRun;
                         LocalDateTime updatedAt = LocalDateTime.ofInstant(pageItem.getUpdatedAt().toInstant(), ZoneId.systemDefault());

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/PageServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/PageServiceImpl.java
@@ -344,6 +344,10 @@ public class PageServiceImpl extends AbstractService implements PageService, App
     }
 
     public static void validateFetchConfig(String jsonConfig) throws InvalidFetchCronExpressionException {
+        validateFetchConfig(jsonConfig, null);
+    }
+
+    public static void validateFetchConfig(String jsonConfig, String fetchCronLimit) throws InvalidFetchCronExpressionException {
         ObjectMapper mapper = new ObjectMapper();
         JsonNode root;
         try {
@@ -361,6 +365,11 @@ public class PageServiceImpl extends AbstractService implements PageService, App
         if (!isInvalid) {
             try {
                 CronExpression.parse(fetchCron);
+                if (CronScheduleLimits.isMoreFrequentThanLimit(fetchCron, fetchCronLimit)) {
+                    throw new InvalidFetchCronExpressionException(
+                        "fetchCron must not run more frequently than the configured limit: " + fetchCronLimit
+                    );
+                }
             } catch (IllegalArgumentException e) {
                 throw new InvalidFetchCronExpressionException(fetchCron, e);
             }
@@ -1433,7 +1442,7 @@ public class PageServiceImpl extends AbstractService implements PageService, App
     private void validatePageFetchConfig(FetchablePageEntity pageEntity) {
         if (pageEntity.getSource() != null && pageEntity.getSource().getConfiguration() != null) {
             log.debug("Validating fetch config for page");
-            validateFetchConfig(pageEntity.getSource().getConfiguration());
+            validateFetchConfig(pageEntity.getSource().getConfiguration(), autoFetchCronLimit);
         }
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/PageServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/PageServiceImpl.java
@@ -1738,14 +1738,12 @@ public class PageServiceImpl extends AbstractService implements PageService, App
                         LocalDateTime updatedAt = LocalDateTime.ofInstant(pageItem.getUpdatedAt().toInstant(), ZoneId.systemDefault());
                         if ((nextRun = cronExpression.next(updatedAt)) != null) {
                             var now = Instant.now();
-                            fetchRequired =
-                                nextRun.isBefore(LocalDateTime.ofInstant(now, ZoneId.systemDefault())) &&
-                                (scheduleLimitsConfiguration.getAutoFetchMinimumInterval() == 0 ||
-                                    !pageItem
-                                        .getUpdatedAt()
-                                        .toInstant()
-                                        .plusMillis(scheduleLimitsConfiguration.getAutoFetchMinimumInterval())
-                                        .isAfter(now));
+                            var cronScheduleHasPassed = nextRun.isBefore(LocalDateTime.ofInstant(now, ZoneId.systemDefault()));
+                            var minimumInterval = scheduleLimitsConfiguration.getAutoFetchMinimumInterval();
+                            var minimumIntervalHasPassed =
+                                minimumInterval == 0 || !pageItem.getUpdatedAt().toInstant().plusMillis(minimumInterval).isAfter(now);
+
+                            fetchRequired = cronScheduleHasPassed && minimumIntervalHasPassed;
                         }
                     }
                 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/configuration/dictionary/DictionaryServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/configuration/dictionary/DictionaryServiceImpl.java
@@ -38,9 +38,11 @@ import io.gravitee.rest.api.model.configuration.dictionary.UpdateDictionaryEntit
 import io.gravitee.rest.api.service.AuditService;
 import io.gravitee.rest.api.service.EnvironmentService;
 import io.gravitee.rest.api.service.EventService;
+import io.gravitee.rest.api.service.common.CronScheduleLimits;
 import io.gravitee.rest.api.service.common.ExecutionContext;
 import io.gravitee.rest.api.service.common.UuidString;
 import io.gravitee.rest.api.service.configuration.dictionary.DictionaryService;
+import io.gravitee.rest.api.service.exceptions.InvalidDataException;
 import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
 import io.gravitee.rest.api.service.impl.AbstractService;
 import java.io.IOException;
@@ -52,6 +54,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.CustomLog;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Component;
 
@@ -78,6 +81,9 @@ public class DictionaryServiceImpl extends AbstractService implements Dictionary
 
     @Autowired
     private ObjectMapper mapper;
+
+    @Value("${services.dictionary.delay_limit:0}")
+    private long delayLimitMillis;
 
     @Override
     public Set<DictionaryEntity> findAll(ExecutionContext executionContext) {
@@ -249,6 +255,7 @@ public class DictionaryServiceImpl extends AbstractService implements Dictionary
 
             //if dictionary with this name exists, we generate a UUID, otherwise we use the name as ID to be backward compatible
             Dictionary dictionary = convert(newDictionaryEntity, dictionaryRepository.findById(key).isEmpty());
+            validateTriggerLimit(dictionary);
 
             dictionary.setEnvironmentId(executionContext.getEnvironmentId());
 
@@ -277,6 +284,7 @@ public class DictionaryServiceImpl extends AbstractService implements Dictionary
                 .orElseThrow(() -> new DictionaryNotFoundException(updateDictionaryEntity.getName()));
 
             Dictionary dictionary = convert(updateDictionaryEntity);
+            validateTriggerLimit(dictionary);
 
             dictionary.setId(id);
             dictionary.setKey(dictionaryToUpdate.getKey());
@@ -529,5 +537,18 @@ public class DictionaryServiceImpl extends AbstractService implements Dictionary
         }
 
         return entity;
+    }
+
+    private void validateTriggerLimit(Dictionary dictionary) {
+        if (
+            dictionary.getType() == DictionaryType.DYNAMIC && dictionary.getTrigger() != null && dictionary.getTrigger().getUnit() != null
+        ) {
+            long delayMillis = dictionary.getTrigger().getUnit().toMillis(dictionary.getTrigger().getRate());
+            if (CronScheduleLimits.isMoreFrequentThanLimit(delayMillis, delayLimitMillis)) {
+                throw new InvalidDataException(
+                    "Dictionary trigger must not run more frequently than the configured limit: " + delayLimitMillis + "ms"
+                );
+            }
+        }
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/configuration/dictionary/DictionaryServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/configuration/dictionary/DictionaryServiceImpl.java
@@ -38,11 +38,10 @@ import io.gravitee.rest.api.model.configuration.dictionary.UpdateDictionaryEntit
 import io.gravitee.rest.api.service.AuditService;
 import io.gravitee.rest.api.service.EnvironmentService;
 import io.gravitee.rest.api.service.EventService;
-import io.gravitee.rest.api.service.common.CronScheduleLimits;
 import io.gravitee.rest.api.service.common.ExecutionContext;
+import io.gravitee.rest.api.service.common.ScheduleMinimumIntervalValidator;
 import io.gravitee.rest.api.service.common.UuidString;
 import io.gravitee.rest.api.service.configuration.dictionary.DictionaryService;
-import io.gravitee.rest.api.service.exceptions.InvalidDataException;
 import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
 import io.gravitee.rest.api.service.impl.AbstractService;
 import java.io.IOException;
@@ -82,8 +81,8 @@ public class DictionaryServiceImpl extends AbstractService implements Dictionary
     @Autowired
     private ObjectMapper mapper;
 
-    @Value("${services.dictionary.delay_limit:0}")
-    private long delayLimitMillis;
+    @Autowired
+    private ScheduleMinimumIntervalValidator scheduleMinimumIntervalValidator;
 
     @Override
     public Set<DictionaryEntity> findAll(ExecutionContext executionContext) {
@@ -544,11 +543,7 @@ public class DictionaryServiceImpl extends AbstractService implements Dictionary
             dictionary.getType() == DictionaryType.DYNAMIC && dictionary.getTrigger() != null && dictionary.getTrigger().getUnit() != null
         ) {
             long delayMillis = dictionary.getTrigger().getUnit().toMillis(dictionary.getTrigger().getRate());
-            if (CronScheduleLimits.isMoreFrequentThanLimit(delayMillis, delayLimitMillis)) {
-                throw new InvalidDataException(
-                    "Dictionary trigger must not run more frequently than the configured limit: " + delayLimitMillis + "ms"
-                );
-            }
+            scheduleMinimumIntervalValidator.validateDictionary("trigger", delayMillis);
         }
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/spring/ScheduleLimitsConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/spring/ScheduleLimitsConfiguration.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.spring;
+
+import lombok.Getter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+
+@Getter
+@Configuration
+public class ScheduleLimitsConfiguration {
+
+    private final long autoFetchMinimumInterval;
+    private final long dynamicPropertiesMinimumInterval;
+    private final long dictionaryMinimumInterval;
+    private final long healthcheckMinimumInterval;
+
+    public ScheduleLimitsConfiguration(
+        @Value("${services.auto_fetch.minimum_interval:0}") long autoFetchMinimumInterval,
+        @Value("${services.dynamic_properties.minimum_interval:0}") long dynamicPropertiesMinimumInterval,
+        @Value("${services.dictionary.minimum_interval:0}") long dictionaryMinimumInterval,
+        @Value("${services.healthcheck.minimum_interval:0}") long healthcheckMinimumInterval
+    ) {
+        this.autoFetchMinimumInterval = validate("services.auto_fetch.minimum_interval", autoFetchMinimumInterval);
+        this.dynamicPropertiesMinimumInterval = validate("services.dynamic_properties.minimum_interval", dynamicPropertiesMinimumInterval);
+        this.dictionaryMinimumInterval = validate("services.dictionary.minimum_interval", dictionaryMinimumInterval);
+        this.healthcheckMinimumInterval = validate("services.healthcheck.minimum_interval", healthcheckMinimumInterval);
+    }
+
+    private static long validate(String property, long value) {
+        if (value < 0) {
+            throw new IllegalArgumentException(property + " must be greater than or equal to 0");
+        }
+        return value;
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/ApiStateServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/ApiStateServiceImpl.java
@@ -25,6 +25,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.gravitee.apim.core.utils.CollectionUtils;
 import io.gravitee.common.event.EventManager;
 import io.gravitee.definition.model.DefinitionVersion;
+import io.gravitee.definition.model.v4.ApiType;
 import io.gravitee.definition.model.v4.plan.PlanStatus;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.ApiRepository;
@@ -174,6 +175,11 @@ public class ApiStateServiceImpl implements ApiStateService {
         ApiDeploymentEntity apiDeploymentEntity
     ) {
         log.debug("Deploy API: {}", apiToDeploy.getId());
+
+        var apiEntity = apiMapper.toEntity(apiToDeploy, null);
+        if (ApiType.PROXY.equals(apiEntity.getType())) {
+            apiValidationService.validateSchedules(apiEntity);
+        }
 
         if (!apiValidationService.canDeploy(executionContext, apiToDeploy.getId())) {
             throw new ApiNotDeployableException(

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/validation/ApiValidationServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/validation/ApiValidationServiceImpl.java
@@ -19,6 +19,8 @@ import static io.gravitee.rest.api.model.api.ApiLifecycleState.ARCHIVED;
 import static io.gravitee.rest.api.model.api.ApiLifecycleState.CREATED;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.gravitee.apim.core.api_product.query_service.ApiProductQueryService;
 import io.gravitee.apim.core.flow.domain_service.FlowValidationDomainService;
 import io.gravitee.definition.model.DefinitionVersion;
@@ -36,6 +38,7 @@ import io.gravitee.rest.api.model.v4.api.NewApiEntity;
 import io.gravitee.rest.api.model.v4.api.UpdateApiEntity;
 import io.gravitee.rest.api.model.v4.plan.PlanEntity;
 import io.gravitee.rest.api.sanitizer.HtmlSanitizer;
+import io.gravitee.rest.api.service.common.CronScheduleLimits;
 import io.gravitee.rest.api.service.common.ExecutionContext;
 import io.gravitee.rest.api.service.exceptions.DefinitionVersionException;
 import io.gravitee.rest.api.service.exceptions.DynamicPropertiesInvalidException;
@@ -59,6 +62,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Stream;
 import lombok.CustomLog;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 /**
@@ -68,6 +72,9 @@ import org.springframework.stereotype.Component;
 @Component
 @CustomLog
 public class ApiValidationServiceImpl extends TransactionalService implements ApiValidationService {
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private static final String SCHEDULE_CONFIGURATION_FIELD = "schedule";
 
     private final TagsValidationService tagsValidationService;
     private final GroupValidationService groupValidationService;
@@ -81,6 +88,9 @@ public class ApiValidationServiceImpl extends TransactionalService implements Ap
     private final ApiServicePluginService apiServicePluginService;
     private final FlowValidationDomainService flowValidationDomainService;
     private final ApiProductQueryService apiProductQueryService;
+
+    @Value("${services.dynamic_properties.cron_limit:}")
+    private String dynamicPropertiesCronLimit;
 
     public ApiValidationServiceImpl(
         final TagsValidationService tagsValidationService,
@@ -320,6 +330,28 @@ public class ApiValidationServiceImpl extends TransactionalService implements Ap
         dynamicProperties.setConfiguration(
             this.apiServicePluginService.validateApiServiceConfiguration(dynamicProperties.getType(), dynamicProperties.getConfiguration())
         );
+        validateDynamicPropertiesSchedule(dynamicProperties);
+    }
+
+    private void validateDynamicPropertiesSchedule(Service dynamicProperties) {
+        var configuration = dynamicProperties.getConfiguration();
+        if (isBlank(dynamicPropertiesCronLimit) || isBlank(configuration)) {
+            return;
+        }
+
+        try {
+            var scheduleNode = OBJECT_MAPPER.readTree(configuration).get(SCHEDULE_CONFIGURATION_FIELD);
+            if (scheduleNode != null && !scheduleNode.isNull()) {
+                var schedule = scheduleNode.asText();
+                if (CronScheduleLimits.isMoreFrequentThanLimit(schedule, dynamicPropertiesCronLimit)) {
+                    throw new InvalidDataException(
+                        "Dynamic properties schedule must not run more frequently than the configured limit: " + dynamicPropertiesCronLimit
+                    );
+                }
+            }
+        } catch (JsonProcessingException | IllegalArgumentException e) {
+            throw new DynamicPropertiesInvalidException(dynamicProperties.getType());
+        }
     }
 
     public List<Resource> validateAndSanitize(List<Resource> resources) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/validation/ApiValidationServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/validation/ApiValidationServiceImpl.java
@@ -38,8 +38,8 @@ import io.gravitee.rest.api.model.v4.api.NewApiEntity;
 import io.gravitee.rest.api.model.v4.api.UpdateApiEntity;
 import io.gravitee.rest.api.model.v4.plan.PlanEntity;
 import io.gravitee.rest.api.sanitizer.HtmlSanitizer;
-import io.gravitee.rest.api.service.common.CronScheduleLimits;
 import io.gravitee.rest.api.service.common.ExecutionContext;
+import io.gravitee.rest.api.service.common.ScheduleMinimumIntervalValidator;
 import io.gravitee.rest.api.service.exceptions.DefinitionVersionException;
 import io.gravitee.rest.api.service.exceptions.DynamicPropertiesInvalidException;
 import io.gravitee.rest.api.service.exceptions.InvalidDataException;
@@ -62,7 +62,6 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Stream;
 import lombok.CustomLog;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 /**
@@ -88,9 +87,7 @@ public class ApiValidationServiceImpl extends TransactionalService implements Ap
     private final ApiServicePluginService apiServicePluginService;
     private final FlowValidationDomainService flowValidationDomainService;
     private final ApiProductQueryService apiProductQueryService;
-
-    @Value("${services.dynamic_properties.cron_limit:}")
-    private String dynamicPropertiesCronLimit;
+    private final ScheduleMinimumIntervalValidator scheduleMinimumIntervalValidator;
 
     public ApiValidationServiceImpl(
         final TagsValidationService tagsValidationService,
@@ -104,7 +101,8 @@ public class ApiValidationServiceImpl extends TransactionalService implements Ap
         final PlanValidationService planValidationService,
         ApiServicePluginService apiServicePluginService,
         FlowValidationDomainService flowValidationDomainService,
-        ApiProductQueryService apiProductQueryService
+        ApiProductQueryService apiProductQueryService,
+        ScheduleMinimumIntervalValidator scheduleMinimumIntervalValidator
     ) {
         this.tagsValidationService = tagsValidationService;
         this.groupValidationService = groupValidationService;
@@ -118,6 +116,7 @@ public class ApiValidationServiceImpl extends TransactionalService implements Ap
         this.apiServicePluginService = apiServicePluginService;
         this.flowValidationDomainService = flowValidationDomainService;
         this.apiProductQueryService = apiProductQueryService;
+        this.scheduleMinimumIntervalValidator = scheduleMinimumIntervalValidator;
     }
 
     @Override
@@ -335,7 +334,7 @@ public class ApiValidationServiceImpl extends TransactionalService implements Ap
 
     private void validateDynamicPropertiesSchedule(Service dynamicProperties) {
         var configuration = dynamicProperties.getConfiguration();
-        if (isBlank(dynamicPropertiesCronLimit) || isBlank(configuration)) {
+        if (!scheduleMinimumIntervalValidator.isDynamicPropertiesLimitEnabled() || isBlank(configuration)) {
             return;
         }
 
@@ -343,15 +342,19 @@ public class ApiValidationServiceImpl extends TransactionalService implements Ap
             var scheduleNode = OBJECT_MAPPER.readTree(configuration).get(SCHEDULE_CONFIGURATION_FIELD);
             if (scheduleNode != null && !scheduleNode.isNull()) {
                 var schedule = scheduleNode.asText();
-                if (CronScheduleLimits.isMoreFrequentThanLimit(schedule, dynamicPropertiesCronLimit)) {
-                    throw new InvalidDataException(
-                        "Dynamic properties schedule must not run more frequently than the configured limit: " + dynamicPropertiesCronLimit
-                    );
-                }
+                scheduleMinimumIntervalValidator.validateDynamicProperties("services.dynamicProperty.schedule", schedule);
             }
         } catch (JsonProcessingException | IllegalArgumentException e) {
             throw new DynamicPropertiesInvalidException(dynamicProperties.getType());
         }
+    }
+
+    @Override
+    public void validateSchedules(ApiEntity apiEntity) {
+        if (apiEntity.getServices() != null && apiEntity.getServices().getDynamicProperty() != null) {
+            validateDynamicPropertiesSchedule(apiEntity.getServices().getDynamicProperty());
+        }
+        endpointGroupsValidationService.validateHealthCheckSchedules(apiEntity.getEndpointGroups());
     }
 
     public List<Resource> validateAndSanitize(List<Resource> resources) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/validation/ApiValidationServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/validation/ApiValidationServiceImpl.java
@@ -88,6 +88,7 @@ public class ApiValidationServiceImpl extends TransactionalService implements Ap
     private final FlowValidationDomainService flowValidationDomainService;
     private final ApiProductQueryService apiProductQueryService;
     private final ScheduleMinimumIntervalValidator scheduleMinimumIntervalValidator;
+    private final EndpointHealthCheckScheduleValidator endpointHealthCheckScheduleValidator;
 
     public ApiValidationServiceImpl(
         final TagsValidationService tagsValidationService,
@@ -102,7 +103,8 @@ public class ApiValidationServiceImpl extends TransactionalService implements Ap
         ApiServicePluginService apiServicePluginService,
         FlowValidationDomainService flowValidationDomainService,
         ApiProductQueryService apiProductQueryService,
-        ScheduleMinimumIntervalValidator scheduleMinimumIntervalValidator
+        ScheduleMinimumIntervalValidator scheduleMinimumIntervalValidator,
+        EndpointHealthCheckScheduleValidator endpointHealthCheckScheduleValidator
     ) {
         this.tagsValidationService = tagsValidationService;
         this.groupValidationService = groupValidationService;
@@ -117,6 +119,7 @@ public class ApiValidationServiceImpl extends TransactionalService implements Ap
         this.flowValidationDomainService = flowValidationDomainService;
         this.apiProductQueryService = apiProductQueryService;
         this.scheduleMinimumIntervalValidator = scheduleMinimumIntervalValidator;
+        this.endpointHealthCheckScheduleValidator = endpointHealthCheckScheduleValidator;
     }
 
     @Override
@@ -354,7 +357,7 @@ public class ApiValidationServiceImpl extends TransactionalService implements Ap
         if (apiEntity.getServices() != null && apiEntity.getServices().getDynamicProperty() != null) {
             validateDynamicPropertiesSchedule(apiEntity.getServices().getDynamicProperty());
         }
-        endpointGroupsValidationService.validateHealthCheckSchedules(apiEntity.getEndpointGroups());
+        endpointHealthCheckScheduleValidator.validate(apiEntity.getEndpointGroups());
     }
 
     public List<Resource> validateAndSanitize(List<Resource> resources) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/validation/EndpointGroupsValidationServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/validation/EndpointGroupsValidationServiceImpl.java
@@ -33,6 +33,7 @@ import io.gravitee.definition.model.v4.endpointgroup.service.EndpointServices;
 import io.gravitee.definition.model.v4.nativeapi.NativeEndpointGroup;
 import io.gravitee.definition.model.v4.service.Service;
 import io.gravitee.rest.api.model.v4.connector.ConnectorPluginEntity;
+import io.gravitee.rest.api.service.common.CronScheduleLimits;
 import io.gravitee.rest.api.service.exceptions.EndpointConfigurationValidationException;
 import io.gravitee.rest.api.service.exceptions.EndpointGroupNameAlreadyExistsException;
 import io.gravitee.rest.api.service.exceptions.EndpointMissingException;
@@ -40,6 +41,7 @@ import io.gravitee.rest.api.service.exceptions.EndpointNameAlreadyExistsExceptio
 import io.gravitee.rest.api.service.exceptions.EndpointNameInvalidException;
 import io.gravitee.rest.api.service.exceptions.HealthcheckInheritanceException;
 import io.gravitee.rest.api.service.exceptions.HealthcheckInvalidException;
+import io.gravitee.rest.api.service.exceptions.InvalidDataException;
 import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
 import io.gravitee.rest.api.service.impl.TransactionalService;
 import io.gravitee.rest.api.service.v4.ApiServicePluginService;
@@ -57,6 +59,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import lombok.CustomLog;
 import org.apache.commons.lang3.StringUtils;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 /**
@@ -68,10 +71,14 @@ import org.springframework.stereotype.Component;
 public class EndpointGroupsValidationServiceImpl extends TransactionalService implements EndpointGroupsValidationService {
 
     private static final String LLM_PROXY_TYPE = "llm-proxy";
+    private static final String SCHEDULE_CONFIGURATION_FIELD = "schedule";
 
     private final EndpointConnectorPluginService endpointService;
     private final ApiServicePluginService apiServicePluginService;
     private final ObjectMapper objectMapper;
+
+    @Value("${services.healthcheck.cron_limit:}")
+    private String healthcheckCronLimit;
 
     public EndpointGroupsValidationServiceImpl(
         final EndpointConnectorPluginService endpointService,
@@ -258,6 +265,27 @@ public class EndpointGroupsValidationServiceImpl extends TransactionalService im
         healthCheck.setConfiguration(
             this.apiServicePluginService.validateApiServiceConfiguration(healthCheck.getType(), healthCheck.getConfiguration())
         );
+        validateHealthCheckSchedule(healthCheck);
+    }
+
+    private void validateHealthCheckSchedule(Service healthCheck) {
+        if (isBlank(healthcheckCronLimit) || isBlank(healthCheck.getConfiguration())) {
+            return;
+        }
+
+        try {
+            var scheduleNode = objectMapper.readTree(healthCheck.getConfiguration()).get(SCHEDULE_CONFIGURATION_FIELD);
+            if (scheduleNode != null && !scheduleNode.isNull()) {
+                var schedule = scheduleNode.asText();
+                if (CronScheduleLimits.isMoreFrequentThanLimit(schedule, healthcheckCronLimit)) {
+                    throw new InvalidDataException(
+                        "Healthcheck schedule must not run more frequently than the configured limit: " + healthcheckCronLimit
+                    );
+                }
+            }
+        } catch (JsonProcessingException | IllegalArgumentException e) {
+            throw new HealthcheckInvalidException(healthCheck.getType());
+        }
     }
 
     private void validateName(final String name) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/validation/EndpointGroupsValidationServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/validation/EndpointGroupsValidationServiceImpl.java
@@ -33,7 +33,7 @@ import io.gravitee.definition.model.v4.endpointgroup.service.EndpointServices;
 import io.gravitee.definition.model.v4.nativeapi.NativeEndpointGroup;
 import io.gravitee.definition.model.v4.service.Service;
 import io.gravitee.rest.api.model.v4.connector.ConnectorPluginEntity;
-import io.gravitee.rest.api.service.common.CronScheduleLimits;
+import io.gravitee.rest.api.service.common.ScheduleMinimumIntervalValidator;
 import io.gravitee.rest.api.service.exceptions.EndpointConfigurationValidationException;
 import io.gravitee.rest.api.service.exceptions.EndpointGroupNameAlreadyExistsException;
 import io.gravitee.rest.api.service.exceptions.EndpointMissingException;
@@ -59,7 +59,6 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import lombok.CustomLog;
 import org.apache.commons.lang3.StringUtils;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 /**
@@ -76,18 +75,18 @@ public class EndpointGroupsValidationServiceImpl extends TransactionalService im
     private final EndpointConnectorPluginService endpointService;
     private final ApiServicePluginService apiServicePluginService;
     private final ObjectMapper objectMapper;
-
-    @Value("${services.healthcheck.cron_limit:}")
-    private String healthcheckCronLimit;
+    private final ScheduleMinimumIntervalValidator scheduleMinimumIntervalValidator;
 
     public EndpointGroupsValidationServiceImpl(
         final EndpointConnectorPluginService endpointService,
         final ApiServicePluginService apiServicePluginService,
-        final ObjectMapper objectMapper
+        final ObjectMapper objectMapper,
+        final ScheduleMinimumIntervalValidator scheduleMinimumIntervalValidator
     ) {
         this.endpointService = endpointService;
         this.apiServicePluginService = apiServicePluginService;
         this.objectMapper = objectMapper;
+        this.scheduleMinimumIntervalValidator = scheduleMinimumIntervalValidator;
     }
 
     @Override
@@ -269,7 +268,7 @@ public class EndpointGroupsValidationServiceImpl extends TransactionalService im
     }
 
     private void validateHealthCheckSchedule(Service healthCheck) {
-        if (isBlank(healthcheckCronLimit) || isBlank(healthCheck.getConfiguration())) {
+        if (!scheduleMinimumIntervalValidator.isHealthcheckLimitEnabled() || isBlank(healthCheck.getConfiguration())) {
             return;
         }
 
@@ -277,15 +276,30 @@ public class EndpointGroupsValidationServiceImpl extends TransactionalService im
             var scheduleNode = objectMapper.readTree(healthCheck.getConfiguration()).get(SCHEDULE_CONFIGURATION_FIELD);
             if (scheduleNode != null && !scheduleNode.isNull()) {
                 var schedule = scheduleNode.asText();
-                if (CronScheduleLimits.isMoreFrequentThanLimit(schedule, healthcheckCronLimit)) {
-                    throw new InvalidDataException(
-                        "Healthcheck schedule must not run more frequently than the configured limit: " + healthcheckCronLimit
-                    );
-                }
+                scheduleMinimumIntervalValidator.validateHealthcheck("services.healthcheck.schedule", schedule);
             }
         } catch (JsonProcessingException | IllegalArgumentException e) {
             throw new HealthcheckInvalidException(healthCheck.getType());
         }
+    }
+
+    @Override
+    public void validateHealthCheckSchedules(List<EndpointGroup> endpointGroups) {
+        if (endpointGroups == null) {
+            return;
+        }
+        endpointGroups.forEach(group -> {
+            if (group.getServices() != null && group.getServices().getHealthCheck() != null) {
+                validateHealthCheckSchedule(group.getServices().getHealthCheck());
+            }
+            if (group.getEndpoints() != null) {
+                group
+                    .getEndpoints()
+                    .stream()
+                    .filter(endpoint -> endpoint.getServices() != null && endpoint.getServices().getHealthCheck() != null)
+                    .forEach(endpoint -> validateHealthCheckSchedule(endpoint.getServices().getHealthCheck()));
+            }
+        });
     }
 
     private void validateName(final String name) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/validation/EndpointGroupsValidationServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/validation/EndpointGroupsValidationServiceImpl.java
@@ -33,7 +33,6 @@ import io.gravitee.definition.model.v4.endpointgroup.service.EndpointServices;
 import io.gravitee.definition.model.v4.nativeapi.NativeEndpointGroup;
 import io.gravitee.definition.model.v4.service.Service;
 import io.gravitee.rest.api.model.v4.connector.ConnectorPluginEntity;
-import io.gravitee.rest.api.service.common.ScheduleMinimumIntervalValidator;
 import io.gravitee.rest.api.service.exceptions.EndpointConfigurationValidationException;
 import io.gravitee.rest.api.service.exceptions.EndpointGroupNameAlreadyExistsException;
 import io.gravitee.rest.api.service.exceptions.EndpointMissingException;
@@ -70,23 +69,22 @@ import org.springframework.stereotype.Component;
 public class EndpointGroupsValidationServiceImpl extends TransactionalService implements EndpointGroupsValidationService {
 
     private static final String LLM_PROXY_TYPE = "llm-proxy";
-    private static final String SCHEDULE_CONFIGURATION_FIELD = "schedule";
 
     private final EndpointConnectorPluginService endpointService;
     private final ApiServicePluginService apiServicePluginService;
     private final ObjectMapper objectMapper;
-    private final ScheduleMinimumIntervalValidator scheduleMinimumIntervalValidator;
+    private final EndpointHealthCheckScheduleValidator endpointHealthCheckScheduleValidator;
 
     public EndpointGroupsValidationServiceImpl(
         final EndpointConnectorPluginService endpointService,
         final ApiServicePluginService apiServicePluginService,
         final ObjectMapper objectMapper,
-        final ScheduleMinimumIntervalValidator scheduleMinimumIntervalValidator
+        final EndpointHealthCheckScheduleValidator endpointHealthCheckScheduleValidator
     ) {
         this.endpointService = endpointService;
         this.apiServicePluginService = apiServicePluginService;
         this.objectMapper = objectMapper;
-        this.scheduleMinimumIntervalValidator = scheduleMinimumIntervalValidator;
+        this.endpointHealthCheckScheduleValidator = endpointHealthCheckScheduleValidator;
     }
 
     @Override
@@ -264,42 +262,7 @@ public class EndpointGroupsValidationServiceImpl extends TransactionalService im
         healthCheck.setConfiguration(
             this.apiServicePluginService.validateApiServiceConfiguration(healthCheck.getType(), healthCheck.getConfiguration())
         );
-        validateHealthCheckSchedule(healthCheck);
-    }
-
-    private void validateHealthCheckSchedule(Service healthCheck) {
-        if (!scheduleMinimumIntervalValidator.isHealthcheckLimitEnabled() || isBlank(healthCheck.getConfiguration())) {
-            return;
-        }
-
-        try {
-            var scheduleNode = objectMapper.readTree(healthCheck.getConfiguration()).get(SCHEDULE_CONFIGURATION_FIELD);
-            if (scheduleNode != null && !scheduleNode.isNull()) {
-                var schedule = scheduleNode.asText();
-                scheduleMinimumIntervalValidator.validateHealthcheck("services.healthcheck.schedule", schedule);
-            }
-        } catch (JsonProcessingException | IllegalArgumentException e) {
-            throw new HealthcheckInvalidException(healthCheck.getType());
-        }
-    }
-
-    @Override
-    public void validateHealthCheckSchedules(List<EndpointGroup> endpointGroups) {
-        if (endpointGroups == null) {
-            return;
-        }
-        endpointGroups.forEach(group -> {
-            if (group.getServices() != null && group.getServices().getHealthCheck() != null) {
-                validateHealthCheckSchedule(group.getServices().getHealthCheck());
-            }
-            if (group.getEndpoints() != null) {
-                group
-                    .getEndpoints()
-                    .stream()
-                    .filter(endpoint -> endpoint.getServices() != null && endpoint.getServices().getHealthCheck() != null)
-                    .forEach(endpoint -> validateHealthCheckSchedule(endpoint.getServices().getHealthCheck()));
-            }
-        });
+        endpointHealthCheckScheduleValidator.validate(healthCheck);
     }
 
     private void validateName(final String name) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/validation/EndpointHealthCheckScheduleValidator.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/validation/EndpointHealthCheckScheduleValidator.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.v4.impl.validation;
+
+import static org.apache.commons.lang3.StringUtils.isBlank;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.gravitee.definition.model.v4.endpointgroup.EndpointGroup;
+import io.gravitee.definition.model.v4.service.Service;
+import io.gravitee.rest.api.service.common.ScheduleMinimumIntervalValidator;
+import io.gravitee.rest.api.service.exceptions.HealthcheckInvalidException;
+import java.util.List;
+import org.springframework.stereotype.Component;
+
+@Component
+public class EndpointHealthCheckScheduleValidator {
+
+    private static final String SCHEDULE_CONFIGURATION_FIELD = "schedule";
+
+    private final ObjectMapper objectMapper;
+    private final ScheduleMinimumIntervalValidator scheduleMinimumIntervalValidator;
+
+    public EndpointHealthCheckScheduleValidator(
+        final ObjectMapper objectMapper,
+        final ScheduleMinimumIntervalValidator scheduleMinimumIntervalValidator
+    ) {
+        this.objectMapper = objectMapper;
+        this.scheduleMinimumIntervalValidator = scheduleMinimumIntervalValidator;
+    }
+
+    public void validate(List<EndpointGroup> endpointGroups) {
+        if (endpointGroups == null) {
+            return;
+        }
+
+        endpointGroups.forEach(group -> {
+            if (group.getServices() != null) {
+                validate(group.getServices().getHealthCheck());
+            }
+            if (group.getEndpoints() != null) {
+                group
+                    .getEndpoints()
+                    .stream()
+                    .filter(endpoint -> endpoint.getServices() != null)
+                    .forEach(endpoint -> validate(endpoint.getServices().getHealthCheck()));
+            }
+        });
+    }
+
+    public void validate(Service healthCheck) {
+        if (
+            healthCheck == null || !scheduleMinimumIntervalValidator.isHealthcheckLimitEnabled() || isBlank(healthCheck.getConfiguration())
+        ) {
+            return;
+        }
+
+        try {
+            var scheduleNode = objectMapper.readTree(healthCheck.getConfiguration()).get(SCHEDULE_CONFIGURATION_FIELD);
+            if (scheduleNode != null && !scheduleNode.isNull()) {
+                var schedule = scheduleNode.asText();
+                scheduleMinimumIntervalValidator.validateHealthcheck("services.healthcheck.schedule", schedule);
+            }
+        } catch (JsonProcessingException | IllegalArgumentException e) {
+            throw new HealthcheckInvalidException(healthCheck.getType());
+        }
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/validation/ApiValidationService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/validation/ApiValidationService.java
@@ -52,5 +52,7 @@ public interface ApiValidationService {
 
     void validateDynamicProperties(Service dynamicProperties);
 
+    void validateSchedules(ApiEntity apiEntity);
+
     List<Resource> validateAndSanitize(List<Resource> resources);
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/validation/EndpointGroupsValidationService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/validation/EndpointGroupsValidationService.java
@@ -27,4 +27,5 @@ import java.util.List;
 public interface EndpointGroupsValidationService {
     List<EndpointGroup> validateAndSanitizeHttpV4(ApiType apiType, List<EndpointGroup> endpointGroups);
     List<NativeEndpointGroup> validateAndSanitizeNativeV4(List<NativeEndpointGroup> endpointGroups);
+    void validateHealthCheckSchedules(List<EndpointGroup> endpointGroups);
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/validation/EndpointGroupsValidationService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/validation/EndpointGroupsValidationService.java
@@ -27,5 +27,4 @@ import java.util.List;
 public interface EndpointGroupsValidationService {
     List<EndpointGroup> validateAndSanitizeHttpV4(ApiType apiType, List<EndpointGroup> endpointGroups);
     List<NativeEndpointGroup> validateAndSanitizeNativeV4(List<NativeEndpointGroup> endpointGroups);
-    void validateHealthCheckSchedules(List<EndpointGroup> endpointGroups);
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/ImportApiCRDUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/ImportApiCRDUseCaseTest.java
@@ -179,6 +179,7 @@ import io.gravitee.rest.api.model.notification.NotificationConfigType;
 import io.gravitee.rest.api.model.notification.PortalNotificationConfigEntity;
 import io.gravitee.rest.api.model.parameters.Key;
 import io.gravitee.rest.api.model.settings.ApiPrimaryOwnerMode;
+import io.gravitee.rest.api.service.common.ScheduleMinimumIntervalValidator;
 import io.gravitee.rest.api.service.common.UuidString;
 import io.vertx.rxjava3.core.Vertx;
 import java.time.Clock;
@@ -371,7 +372,11 @@ class ImportApiCRDUseCaseTest {
             indexer
         );
 
-        var pageSourceValidator = new ValidatePageSourceDomainServiceImpl(new ObjectMapper(), mock(Vertx.class));
+        var pageSourceValidator = new ValidatePageSourceDomainServiceImpl(
+            new ObjectMapper(),
+            mock(Vertx.class),
+            mock(ScheduleMinimumIntervalValidator.class)
+        );
         var accessControlValidator = new ValidatePageAccessControlsDomainService(groupQueryService);
 
         userDomainService.initWith(

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/documentation/ValidatePageSourceDomainServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/documentation/ValidatePageSourceDomainServiceImplTest.java
@@ -36,6 +36,7 @@ import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
 
 /**
  * @author Antoine CORDIER (antoine.cordier at graviteesource.com)
@@ -374,6 +375,29 @@ public class ValidatePageSourceDomainServiceImplTest {
                 .isNotEmpty()
                 .hasValue(
                     List.of(severe("property [fetchCron] of source [http-fetcher] must be a valid cron expression for page [test-page]"))
+                );
+        }
+
+        @Test
+        void should_return_error_when_cron_is_more_frequent_than_configured_limit() {
+            var cut = new ValidatePageSourceDomainServiceImpl(new ObjectMapper(), vertx);
+            ReflectionTestUtils.setField(cut, "autoFetchCronLimit", "0 */5 * * * *");
+            var source = PageSource.builder()
+                .type("http-fetcher")
+                .configurationMap(Map.of("url", "https://petstore.swagger.io/v2/swagger.json", "fetchCron", "* * * * * *"))
+                .build();
+
+            var result = cut.validateAndSanitize(new ValidatePageSourceDomainService.Input(PAGE_NAME, source));
+
+            assertThat(result.warning()).isEmpty();
+            assertThat(result.severe())
+                .isNotEmpty()
+                .hasValue(
+                    List.of(
+                        severe(
+                            "property [fetchCron] of source [http-fetcher] must not run more frequently than [0 */5 * * * *] for page [test-page]"
+                        )
+                    )
                 );
         }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/documentation/ValidatePageSourceDomainServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/documentation/ValidatePageSourceDomainServiceImplTest.java
@@ -24,6 +24,9 @@ import static org.mockito.Mockito.when;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.gravitee.apim.core.documentation.domain_service.ValidatePageSourceDomainService;
 import io.gravitee.apim.core.documentation.model.PageSource;
+import io.gravitee.rest.api.service.common.ScheduleMinimumIntervalValidator;
+import io.gravitee.rest.api.service.exceptions.ScheduleMinimumIntervalExceededException;
+import io.gravitee.rest.api.service.spring.ScheduleLimitsConfiguration;
 import io.reactivex.rxjava3.core.Single;
 import io.vertx.rxjava3.core.Vertx;
 import io.vertx.rxjava3.core.http.HttpClient;
@@ -48,7 +51,11 @@ public class ValidatePageSourceDomainServiceImplTest {
     private static final String PAGE_NAME = "test-page";
 
     Vertx vertx = mock(Vertx.class);
-    private final ValidatePageSourceDomainService cut = new ValidatePageSourceDomainServiceImpl(new ObjectMapper(), vertx);
+    private final ValidatePageSourceDomainService cut = new ValidatePageSourceDomainServiceImpl(
+        new ObjectMapper(),
+        vertx,
+        mock(ScheduleMinimumIntervalValidator.class)
+    );
 
     @Nested
     class Github {
@@ -379,26 +386,27 @@ public class ValidatePageSourceDomainServiceImplTest {
         }
 
         @Test
-        void should_return_error_when_cron_is_more_frequent_than_configured_limit() {
-            var cut = new ValidatePageSourceDomainServiceImpl(new ObjectMapper(), vertx);
-            ReflectionTestUtils.setField(cut, "autoFetchCronLimit", "0 */5 * * * *");
+        void should_throw_schedule_error_when_cron_is_more_frequent_than_configured_limit() {
+            var cut = new ValidatePageSourceDomainServiceImpl(
+                new ObjectMapper(),
+                vertx,
+                new ScheduleMinimumIntervalValidator(new ScheduleLimitsConfiguration(300_000L, 0, 0, 0))
+            );
             var source = PageSource.builder()
                 .type("http-fetcher")
                 .configurationMap(Map.of("url", "https://petstore.swagger.io/v2/swagger.json", "fetchCron", "* * * * * *"))
                 .build();
 
-            var result = cut.validateAndSanitize(new ValidatePageSourceDomainService.Input(PAGE_NAME, source));
-
-            assertThat(result.warning()).isEmpty();
-            assertThat(result.severe())
-                .isNotEmpty()
-                .hasValue(
-                    List.of(
-                        severe(
-                            "property [fetchCron] of source [http-fetcher] must not run more frequently than [0 */5 * * * *] for page [test-page]"
-                        )
-                    )
-                );
+            assertThatThrownBy(() -> cut.validateAndSanitize(new ValidatePageSourceDomainService.Input(PAGE_NAME, source)))
+                .isInstanceOf(ScheduleMinimumIntervalExceededException.class)
+                .satisfies(error -> {
+                    var scheduleError = (ScheduleMinimumIntervalExceededException) error;
+                    assertThat(scheduleError.getTechnicalCode()).isEqualTo("schedule.minimumIntervalExceeded");
+                    assertThat(scheduleError.getParameters())
+                        .containsEntry("field", "source.fetchCron")
+                        .containsEntry("schedule", "* * * * * *")
+                        .containsEntry("minimumInterval", "300000");
+                });
         }
 
         @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/common/CronScheduleLimitsTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/common/CronScheduleLimitsTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.common;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class CronScheduleLimitsTest {
+
+    @Test
+    void should_keep_user_cron_when_no_limit_is_configured() {
+        assertThat(CronScheduleLimits.limitFrequency("* * * * * *", "")).isEqualTo("* * * * * *");
+    }
+
+    @Test
+    void should_use_limit_when_user_cron_runs_more_frequently() {
+        assertThat(CronScheduleLimits.limitFrequency("* * * * * *", "0 */5 * * * *")).isEqualTo("0 */5 * * * *");
+    }
+
+    @Test
+    void should_keep_user_cron_when_user_cron_runs_less_frequently_than_limit() {
+        assertThat(CronScheduleLimits.limitFrequency("0 */10 * * * *", "0 */5 * * * *")).isEqualTo("0 */10 * * * *");
+    }
+
+    @Test
+    void should_limit_delay_when_user_delay_is_shorter() {
+        assertThat(CronScheduleLimits.limitFrequency(1_000, 60_000)).isEqualTo(60_000);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/common/CronScheduleLimitsTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/common/CronScheduleLimitsTest.java
@@ -43,4 +43,14 @@ class CronScheduleLimitsTest {
     void should_limit_delay_when_user_delay_is_shorter() {
         assertThat(CronScheduleLimits.limitFrequency(1_000, 60_000)).isEqualTo(60_000);
     }
+
+    @Test
+    void should_detect_cron_more_frequent_than_limit() {
+        assertThat(CronScheduleLimits.isMoreFrequentThanLimit("* * * * * *", "0 */5 * * * *")).isTrue();
+    }
+
+    @Test
+    void should_detect_delay_more_frequent_than_limit() {
+        assertThat(CronScheduleLimits.isMoreFrequentThanLimit(1_000, 60_000)).isTrue();
+    }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/common/CronScheduleLimitsTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/common/CronScheduleLimitsTest.java
@@ -16,7 +16,9 @@
 package io.gravitee.rest.api.service.common;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.time.Duration;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
@@ -25,28 +27,60 @@ import org.junit.jupiter.api.Test;
 class CronScheduleLimitsTest {
 
     @Test
-    void should_keep_user_cron_when_no_limit_is_configured() {
-        assertThat(CronScheduleLimits.limitFrequency("* * * * * *", "")).isEqualTo("* * * * * *");
+    void should_ignore_cron_limit_when_no_minimum_interval_is_configured() {
+        assertThat(CronScheduleLimits.isMoreFrequentThanLimit("* * * * * *", 0)).isFalse();
     }
 
     @Test
-    void should_use_limit_when_user_cron_runs_more_frequently() {
-        assertThat(CronScheduleLimits.limitFrequency("* * * * * *", "0 */5 * * * *")).isEqualTo("0 */5 * * * *");
+    void should_detect_regular_cron_more_frequent_than_limit() {
+        assertThat(CronScheduleLimits.isMoreFrequentThanLimit("* * * * * *", Duration.ofMinutes(5).toMillis())).isTrue();
     }
 
     @Test
-    void should_keep_user_cron_when_user_cron_runs_less_frequently_than_limit() {
-        assertThat(CronScheduleLimits.limitFrequency("0 */10 * * * *", "0 */5 * * * *")).isEqualTo("0 */10 * * * *");
+    void should_accept_cron_equal_to_limit() {
+        assertThat(CronScheduleLimits.isMoreFrequentThanLimit("0 */5 * * * *", Duration.ofMinutes(5).toMillis())).isFalse();
+    }
+
+    @Test
+    void should_detect_clustered_cron_more_frequent_across_day_boundary() {
+        assertThat(CronScheduleLimits.isMoreFrequentThanLimit("0 0 1,23 * * *", Duration.ofHours(3).toMillis())).isTrue();
+    }
+
+    @Test
+    void should_accept_clustered_cron_equal_to_limit_across_day_boundary() {
+        assertThat(CronScheduleLimits.isMoreFrequentThanLimit("0 0 1,23 * * *", Duration.ofHours(2).toMillis())).isFalse();
+    }
+
+    @Test
+    void should_compute_month_end_interval() {
+        assertThat(CronScheduleLimits.minimumInterval("0 0 0 L * *")).isEqualTo(Duration.ofDays(28));
+    }
+
+    @Test
+    void should_compute_leap_day_interval_over_complete_gregorian_cycle() {
+        assertThat(CronScheduleLimits.minimumInterval("0 0 0 29 2 *")).isEqualTo(Duration.ofDays(1_461));
+    }
+
+    @Test
+    void should_compute_nth_weekday_interval() {
+        assertThat(CronScheduleLimits.minimumInterval("0 0 0 ? * 2#5")).isEqualTo(Duration.ofDays(63));
+    }
+
+    @Test
+    void should_support_spring_cron_macros() {
+        assertThat(CronScheduleLimits.minimumInterval("@hourly")).isEqualTo(Duration.ofHours(1));
+    }
+
+    @Test
+    void should_reject_cron_without_execution() {
+        assertThatThrownBy(() -> CronScheduleLimits.minimumInterval("0 0 0 31 2 *"))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("no execution");
     }
 
     @Test
     void should_limit_delay_when_user_delay_is_shorter() {
         assertThat(CronScheduleLimits.limitFrequency(1_000, 60_000)).isEqualTo(60_000);
-    }
-
-    @Test
-    void should_detect_cron_more_frequent_than_limit() {
-        assertThat(CronScheduleLimits.isMoreFrequentThanLimit("* * * * * *", "0 */5 * * * *")).isTrue();
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/common/ScheduleMinimumIntervalValidatorTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/common/ScheduleMinimumIntervalValidatorTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.common;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.gravitee.rest.api.service.exceptions.ScheduleMinimumIntervalExceededException;
+import io.gravitee.rest.api.service.spring.ScheduleLimitsConfiguration;
+import org.junit.jupiter.api.Test;
+
+class ScheduleMinimumIntervalValidatorTest {
+
+    @Test
+    void should_validate_each_schedule_type_against_its_configured_limit() {
+        var validator = new ScheduleMinimumIntervalValidator(new ScheduleLimitsConfiguration(60_000, 120_000, 180_000, 300_000));
+
+        assertThat(validator.isDynamicPropertiesLimitEnabled()).isTrue();
+        assertThat(validator.isHealthcheckLimitEnabled()).isTrue();
+        assertThatCode(() -> validator.validateAutoFetch("autoFetch", "0 * * * * *")).doesNotThrowAnyException();
+        assertThatThrownBy(() -> validator.validateDynamicProperties("dynamicProperties", "0 * * * * *")).isInstanceOf(
+            ScheduleMinimumIntervalExceededException.class
+        );
+        assertThatThrownBy(() -> validator.validateDictionary("dictionary", 120_000)).isInstanceOf(
+            ScheduleMinimumIntervalExceededException.class
+        );
+        assertThatThrownBy(() -> validator.validateHealthcheck("healthcheck", "0 * * * * *")).isInstanceOf(
+            ScheduleMinimumIntervalExceededException.class
+        );
+    }
+
+    @Test
+    void should_preserve_existing_behavior_when_limits_are_disabled() {
+        var validator = new ScheduleMinimumIntervalValidator(new ScheduleLimitsConfiguration(0, 0, 0, 0));
+
+        assertThat(validator.isDynamicPropertiesLimitEnabled()).isFalse();
+        assertThat(validator.isHealthcheckLimitEnabled()).isFalse();
+        assertThatCode(() -> validator.validateAutoFetch("autoFetch", "* * * * * *")).doesNotThrowAnyException();
+        assertThatCode(() -> validator.validateDynamicProperties("dynamicProperties", "* * * * * *")).doesNotThrowAnyException();
+        assertThatCode(() -> validator.validateDictionary("dictionary", 1)).doesNotThrowAnyException();
+        assertThatCode(() -> validator.validateHealthcheck("healthcheck", "* * * * * *")).doesNotThrowAnyException();
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiDuplicatorServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiDuplicatorServiceImplTest.java
@@ -552,4 +552,34 @@ public class ApiDuplicatorServiceImplTest {
         assertTrue(exception.getMessage().startsWith("Invalid fetchCron expression in page"));
         assertTrue(exception.getMessage().contains("Cron expression must consist of 6 fields"));
     }
+
+    @Test
+    public void shouldThrowExceptionForFetchCronMoreFrequentThanConfiguredLimit() throws IOException {
+        ReflectionTestUtils.setField(apiDuplicatorService, "autoFetchCronLimit", "0 */5 * * * *");
+        ImportApiJsonNode node = new ImportApiJsonNode(
+            objectMapper.readTree(
+                """
+                {
+                  "pages": [
+                    {
+                      "name": "Test",
+                      "source": {
+                        "configuration": {
+                          "fetchCron": "* * * * * *"
+                        }
+                      }
+                    }
+                  ]
+                }
+                """
+            )
+        );
+
+        ApiImportException exception = assertThrows(ApiImportException.class, () ->
+            ReflectionTestUtils.invokeMethod(apiDuplicatorService, "checkPagesConsistency", node)
+        );
+
+        assertTrue(exception.getMessage().startsWith("Invalid fetchCron expression in page 'Test'"));
+        assertTrue(exception.getMessage().contains("must not run more frequently than the configured limit 0 */5 * * * *"));
+    }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiDuplicatorServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiDuplicatorServiceImplTest.java
@@ -58,8 +58,10 @@ import io.gravitee.rest.api.service.PlanService;
 import io.gravitee.rest.api.service.RoleService;
 import io.gravitee.rest.api.service.UserService;
 import io.gravitee.rest.api.service.common.GraviteeContext;
+import io.gravitee.rest.api.service.common.ScheduleMinimumIntervalValidator;
 import io.gravitee.rest.api.service.converter.CategoryMapper;
 import io.gravitee.rest.api.service.exceptions.ApiImportException;
+import io.gravitee.rest.api.service.exceptions.ScheduleMinimumIntervalExceededException;
 import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
 import io.gravitee.rest.api.service.imports.ImportApiJsonNode;
 import io.gravitee.rest.api.service.spring.ServiceConfiguration;
@@ -116,6 +118,9 @@ public class ApiDuplicatorServiceImplTest {
 
     @Mock
     private GroupService groupService;
+
+    @Mock
+    private ScheduleMinimumIntervalValidator scheduleMinimumIntervalValidator;
 
     @Spy
     private ObjectMapper objectMapper = (new ServiceConfiguration()).objectMapper();
@@ -555,7 +560,9 @@ public class ApiDuplicatorServiceImplTest {
 
     @Test
     public void shouldThrowExceptionForFetchCronMoreFrequentThanConfiguredLimit() throws IOException {
-        ReflectionTestUtils.setField(apiDuplicatorService, "autoFetchCronLimit", "0 */5 * * * *");
+        doThrow(new ScheduleMinimumIntervalExceededException("source.fetchCron", "* * * * * *", 300_000L))
+            .when(scheduleMinimumIntervalValidator)
+            .validateAutoFetch("source.fetchCron", "* * * * * *");
         ImportApiJsonNode node = new ImportApiJsonNode(
             objectMapper.readTree(
                 """
@@ -575,11 +582,13 @@ public class ApiDuplicatorServiceImplTest {
             )
         );
 
-        ApiImportException exception = assertThrows(ApiImportException.class, () ->
+        ScheduleMinimumIntervalExceededException exception = assertThrows(ScheduleMinimumIntervalExceededException.class, () ->
             ReflectionTestUtils.invokeMethod(apiDuplicatorService, "checkPagesConsistency", node)
         );
 
-        assertTrue(exception.getMessage().startsWith("Invalid fetchCron expression in page 'Test'"));
-        assertTrue(exception.getMessage().contains("must not run more frequently than the configured limit 0 */5 * * * *"));
+        assertEquals("schedule.minimumIntervalExceeded", exception.getTechnicalCode());
+        assertEquals("source.fetchCron", exception.getParameters().get("field"));
+        assertEquals("* * * * * *", exception.getParameters().get("schedule"));
+        assertEquals("300000", exception.getParameters().get("minimumInterval"));
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiService_UpdateTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiService_UpdateTest.java
@@ -169,6 +169,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.util.ReflectionTestUtils;
 
 /**
  * @author Azize ELAMRANI (azize.elamrani at graviteesource.com)
@@ -1064,6 +1065,21 @@ public class ApiService_UpdateTest {
         assertEquals(API_NAME, apiEntity.getName());
         verify(searchEngineService, times(1)).index(eq(GraviteeContext.getExecutionContext()), any(), eq(false));
         verify(apiNotificationService, times(1)).triggerUpdateNotification(eq(GraviteeContext.getExecutionContext()), eq(apiEntity));
+    }
+
+    @Test
+    public void shouldLimitHealthcheckScheduleWhenConfiguredCronIsSlower() throws TechnicalException {
+        ReflectionTestUtils.setField(apiService, "healthcheckCronLimit", "0 */5 * * * *");
+        prepareUpdate();
+        Services services = new Services();
+        HealthCheckService healthCheckService = new HealthCheckService();
+        healthCheckService.setSchedule("* * * * * *");
+        services.put(HealthCheckService.class, healthCheckService);
+        updateApiEntity.setServices(services);
+
+        apiService.update(GraviteeContext.getExecutionContext(), API_ID, updateApiEntity);
+
+        assertEquals("0 */5 * * * *", healthCheckService.getSchedule());
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiService_UpdateTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiService_UpdateTest.java
@@ -71,6 +71,7 @@ import io.gravitee.definition.model.VirtualHost;
 import io.gravitee.definition.model.flow.Flow;
 import io.gravitee.definition.model.plugins.resources.Resource;
 import io.gravitee.definition.model.services.Services;
+import io.gravitee.definition.model.services.dynamicproperty.DynamicPropertyService;
 import io.gravitee.definition.model.services.healthcheck.HealthCheckService;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.ApiRepository;
@@ -1068,7 +1069,7 @@ public class ApiService_UpdateTest {
     }
 
     @Test
-    public void shouldLimitHealthcheckScheduleWhenConfiguredCronIsSlower() throws TechnicalException {
+    public void shouldRejectHealthcheckScheduleWhenConfiguredCronIsSlower() throws TechnicalException {
         ReflectionTestUtils.setField(apiService, "healthcheckCronLimit", "0 */5 * * * *");
         prepareUpdate();
         Services services = new Services();
@@ -1077,9 +1078,24 @@ public class ApiService_UpdateTest {
         services.put(HealthCheckService.class, healthCheckService);
         updateApiEntity.setServices(services);
 
-        apiService.update(GraviteeContext.getExecutionContext(), API_ID, updateApiEntity);
+        assertThatThrownBy(() -> apiService.update(GraviteeContext.getExecutionContext(), API_ID, updateApiEntity)).isInstanceOf(
+            InvalidDataException.class
+        );
+    }
 
-        assertEquals("0 */5 * * * *", healthCheckService.getSchedule());
+    @Test
+    public void shouldRejectDynamicPropertiesScheduleWhenConfiguredCronIsSlower() throws TechnicalException {
+        ReflectionTestUtils.setField(apiService, "dynamicPropertiesCronLimit", "0 */5 * * * *");
+        prepareUpdate();
+        Services services = new Services();
+        DynamicPropertyService dynamicPropertyService = new DynamicPropertyService();
+        dynamicPropertyService.setSchedule("* * * * * *");
+        services.put(DynamicPropertyService.class, dynamicPropertyService);
+        updateApiEntity.setServices(services);
+
+        assertThatThrownBy(() -> apiService.update(GraviteeContext.getExecutionContext(), API_ID, updateApiEntity)).isInstanceOf(
+            InvalidDataException.class
+        );
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiService_UpdateTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiService_UpdateTest.java
@@ -123,6 +123,7 @@ import io.gravitee.rest.api.service.WorkflowService;
 import io.gravitee.rest.api.service.builder.EmailNotificationBuilder;
 import io.gravitee.rest.api.service.common.ExecutionContext;
 import io.gravitee.rest.api.service.common.GraviteeContext;
+import io.gravitee.rest.api.service.common.ScheduleMinimumIntervalValidator;
 import io.gravitee.rest.api.service.configuration.flow.FlowService;
 import io.gravitee.rest.api.service.converter.ApiConverter;
 import io.gravitee.rest.api.service.converter.CategoryMapper;
@@ -135,11 +136,13 @@ import io.gravitee.rest.api.service.exceptions.EndpointNameInvalidException;
 import io.gravitee.rest.api.service.exceptions.GroupsNotFoundException;
 import io.gravitee.rest.api.service.exceptions.InvalidDataException;
 import io.gravitee.rest.api.service.exceptions.LifecycleStateChangeNotAllowedException;
+import io.gravitee.rest.api.service.exceptions.ScheduleMinimumIntervalExceededException;
 import io.gravitee.rest.api.service.exceptions.TagNotAllowedException;
 import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
 import io.gravitee.rest.api.service.jackson.filter.ApiPermissionFilter;
 import io.gravitee.rest.api.service.notification.NotificationTemplateService;
 import io.gravitee.rest.api.service.search.SearchEngineService;
+import io.gravitee.rest.api.service.spring.ScheduleLimitsConfiguration;
 import io.gravitee.rest.api.service.v4.ApiCategoryService;
 import io.gravitee.rest.api.service.v4.ApiEntrypointService;
 import io.gravitee.rest.api.service.v4.ApiNotificationService;
@@ -247,6 +250,9 @@ public class ApiService_UpdateTest {
 
     @InjectMocks
     private ApiServiceImpl apiService = new ApiServiceImpl();
+
+    @Mock
+    private ScheduleMinimumIntervalValidator scheduleMinimumIntervalValidator;
 
     @Mock
     private ApiEntrypointService apiEntrypointService;
@@ -1070,7 +1076,11 @@ public class ApiService_UpdateTest {
 
     @Test
     public void shouldRejectHealthcheckScheduleWhenConfiguredCronIsSlower() throws TechnicalException {
-        ReflectionTestUtils.setField(apiService, "healthcheckCronLimit", "0 */5 * * * *");
+        ReflectionTestUtils.setField(
+            apiService,
+            "scheduleMinimumIntervalValidator",
+            new ScheduleMinimumIntervalValidator(new ScheduleLimitsConfiguration(0, 0, 0, 300_000L))
+        );
         prepareUpdate();
         Services services = new Services();
         HealthCheckService healthCheckService = new HealthCheckService();
@@ -1079,13 +1089,17 @@ public class ApiService_UpdateTest {
         updateApiEntity.setServices(services);
 
         assertThatThrownBy(() -> apiService.update(GraviteeContext.getExecutionContext(), API_ID, updateApiEntity)).isInstanceOf(
-            InvalidDataException.class
+            ScheduleMinimumIntervalExceededException.class
         );
     }
 
     @Test
     public void shouldRejectDynamicPropertiesScheduleWhenConfiguredCronIsSlower() throws TechnicalException {
-        ReflectionTestUtils.setField(apiService, "dynamicPropertiesCronLimit", "0 */5 * * * *");
+        ReflectionTestUtils.setField(
+            apiService,
+            "scheduleMinimumIntervalValidator",
+            new ScheduleMinimumIntervalValidator(new ScheduleLimitsConfiguration(0, 300_000L, 0, 0))
+        );
         prepareUpdate();
         Services services = new Services();
         DynamicPropertyService dynamicPropertyService = new DynamicPropertyService();
@@ -1094,7 +1108,7 @@ public class ApiService_UpdateTest {
         updateApiEntity.setServices(services);
 
         assertThatThrownBy(() -> apiService.update(GraviteeContext.getExecutionContext(), API_ID, updateApiEntity)).isInstanceOf(
-            InvalidDataException.class
+            ScheduleMinimumIntervalExceededException.class
         );
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/PageService_AutoFetchTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/PageService_AutoFetchTest.java
@@ -44,9 +44,10 @@ import io.gravitee.rest.api.model.UpdatePageEntity;
 import io.gravitee.rest.api.model.Visibility;
 import io.gravitee.rest.api.service.AuditService;
 import io.gravitee.rest.api.service.common.GraviteeContext;
-import io.gravitee.rest.api.service.exceptions.InvalidFetchCronExpressionException;
+import io.gravitee.rest.api.service.exceptions.ScheduleMinimumIntervalExceededException;
 import io.gravitee.rest.api.service.search.SearchEngineService;
 import io.gravitee.rest.api.service.spring.ImportConfiguration;
+import io.gravitee.rest.api.service.spring.ScheduleLimitsConfiguration;
 import io.gravitee.rest.api.service.v4.PlanSearchService;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
@@ -77,6 +78,9 @@ public class PageService_AutoFetchTest {
 
     @Mock
     private PageRepository pageRepository;
+
+    @Mock
+    private ScheduleLimitsConfiguration scheduleLimitsConfiguration;
 
     @Mock
     private AuditService auditService;
@@ -192,8 +196,8 @@ public class PageService_AutoFetchTest {
     }
 
     @Test
-    public void shouldNotFetch_SourcePage_AutoFetch_LimitedByConfiguredCron() throws Exception {
-        ReflectionTestUtils.setField(pageService, "autoFetchCronLimit", "0 0 0 1 1 *");
+    public void shouldNotFetch_SourcePage_AutoFetch_LimitedByConfiguredInterval() throws Exception {
+        ReflectionTestUtils.setField(pageService, "scheduleLimitsConfiguration", new ScheduleLimitsConfiguration(60_000L, 0, 0, 0));
 
         PageSource pageSource = new PageSource();
 
@@ -227,8 +231,8 @@ public class PageService_AutoFetchTest {
 
     @Test
     public void shouldRejectFetchCronMoreFrequentThanConfiguredLimit() {
-        assertThrows(InvalidFetchCronExpressionException.class, () ->
-            PageServiceImpl.validateFetchConfig("{\"autoFetch\": true, \"fetchCron\" : \"* * * * * *\"}", "0 */5 * * * *")
+        assertThrows(ScheduleMinimumIntervalExceededException.class, () ->
+            PageServiceImpl.validateFetchConfig("{\"autoFetch\": true, \"fetchCron\" : \"* * * * * *\"}", 300_000)
         );
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/PageService_AutoFetchTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/PageService_AutoFetchTest.java
@@ -16,6 +16,7 @@
 package io.gravitee.rest.api.service.impl;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.AdditionalAnswers.returnsFirstArg;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -43,6 +44,7 @@ import io.gravitee.rest.api.model.UpdatePageEntity;
 import io.gravitee.rest.api.model.Visibility;
 import io.gravitee.rest.api.service.AuditService;
 import io.gravitee.rest.api.service.common.GraviteeContext;
+import io.gravitee.rest.api.service.exceptions.InvalidFetchCronExpressionException;
 import io.gravitee.rest.api.service.search.SearchEngineService;
 import io.gravitee.rest.api.service.spring.ImportConfiguration;
 import io.gravitee.rest.api.service.v4.PlanSearchService;
@@ -191,7 +193,7 @@ public class PageService_AutoFetchTest {
 
     @Test
     public void shouldNotFetch_SourcePage_AutoFetch_LimitedByConfiguredCron() throws Exception {
-        ReflectionTestUtils.setField(pageService, "autoFetchCronLimit", "0 */5 * * * *");
+        ReflectionTestUtils.setField(pageService, "autoFetchCronLimit", "0 0 0 1 1 *");
 
         PageSource pageSource = new PageSource();
 
@@ -221,6 +223,13 @@ public class PageService_AutoFetchTest {
 
         verify(pageRepository, times(0)).update(any());
         verify(pageRepository, times(0)).create(any());
+    }
+
+    @Test
+    public void shouldRejectFetchCronMoreFrequentThanConfiguredLimit() {
+        assertThrows(InvalidFetchCronExpressionException.class, () ->
+            PageServiceImpl.validateFetchConfig("{\"autoFetch\": true, \"fetchCron\" : \"* * * * * *\"}", "0 */5 * * * *")
+        );
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/PageService_AutoFetchTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/PageService_AutoFetchTest.java
@@ -59,6 +59,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.config.AutowireCapableBeanFactory;
 import org.springframework.context.ApplicationContext;
+import org.springframework.test.util.ReflectionTestUtils;
 
 /**
  * @author Eric LELEU (eric.leleu at graviteesource.com)
@@ -185,6 +186,40 @@ public class PageService_AutoFetchTest {
         assertEquals(1, pages);
 
         verify(pageRepository, times(1)).update(any());
+        verify(pageRepository, times(0)).create(any());
+    }
+
+    @Test
+    public void shouldNotFetch_SourcePage_AutoFetch_LimitedByConfiguredCron() throws Exception {
+        ReflectionTestUtils.setField(pageService, "autoFetchCronLimit", "0 */5 * * * *");
+
+        PageSource pageSource = new PageSource();
+
+        pageSource.setType("type");
+        pageSource.setConfiguration("{\"autoFetch\": true, \"fetchCron\" : \"* * * * * *\"}");
+        when(mockPage.getSource()).thenReturn(pageSource);
+        when(mockPage.getUpdatedAt()).thenReturn(new Date(Instant.now().minus(2, ChronoUnit.SECONDS).toEpochMilli()));
+        when(pageRepository.search(any())).thenReturn(Arrays.asList(mockPage));
+
+        FetcherPlugin fetcherPlugin = mock(FetcherPlugin.class);
+        when(fetcherPlugin.clazz()).thenReturn("io.gravitee.rest.api.service.impl.PageService_ImportSimplePageMockFetcher");
+        when(fetcherPlugin.configuration()).thenReturn(PageService_MockSinglePageFetcherConfiguration.class);
+        when(fetcherPluginManager.get(any())).thenReturn(fetcherPlugin);
+        Class<PageService_ImportSimplePageMockFetcher> mockFetcherClass = PageService_ImportSimplePageMockFetcher.class;
+        when(fetcherPlugin.fetcher()).thenReturn(mockFetcherClass);
+        PageService_MockSinglePageFetcherConfiguration fetcherConfiguration = new PageService_MockSinglePageFetcherConfiguration();
+        when(fetcherConfigurationFactory.create(eq(PageService_MockSinglePageFetcherConfiguration.class), anyString())).thenReturn(
+            fetcherConfiguration
+        );
+        AutowireCapableBeanFactory mockAutowireCapableBeanFactory = mock(AutowireCapableBeanFactory.class);
+        when(applicationContext.getAutowireCapableBeanFactory()).thenReturn(mockAutowireCapableBeanFactory);
+        PageService_MockSinglePageFetcherConfiguration.forceCronValue("* * * * * *");
+        PageService_MockSinglePageFetcherConfiguration.forceAutoFetchValue(true);
+
+        long pages = pageService.execAutoFetch(GraviteeContext.getExecutionContext());
+        assertEquals(0, pages);
+
+        verify(pageRepository, times(0)).update(any());
         verify(pageRepository, times(0)).create(any());
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/PageService_ImportDescriptorTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/PageService_ImportDescriptorTest.java
@@ -46,6 +46,7 @@ import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.common.UuidString;
 import io.gravitee.rest.api.service.search.SearchEngineService;
 import io.gravitee.rest.api.service.spring.ImportConfiguration;
+import io.gravitee.rest.api.service.spring.ScheduleLimitsConfiguration;
 import io.gravitee.rest.api.service.swagger.OAIDescriptor;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
@@ -99,6 +100,9 @@ public class PageService_ImportDescriptorTest {
 
     @Mock
     private ImportConfiguration importConfiguration;
+
+    @Mock
+    private ScheduleLimitsConfiguration scheduleLimitsConfiguration;
 
     private ObjectMapper mapper = new ObjectMapper();
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/PageService_ImportDirectoryTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/PageService_ImportDirectoryTest.java
@@ -45,6 +45,7 @@ import io.gravitee.rest.api.service.common.ExecutionContext;
 import io.gravitee.rest.api.service.common.UuidString;
 import io.gravitee.rest.api.service.search.SearchEngineService;
 import io.gravitee.rest.api.service.spring.ImportConfiguration;
+import io.gravitee.rest.api.service.spring.ScheduleLimitsConfiguration;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -89,6 +90,9 @@ public class PageService_ImportDirectoryTest {
 
     @Mock
     private ImportConfiguration importConfiguration;
+
+    @Mock
+    private ScheduleLimitsConfiguration scheduleLimitsConfiguration;
 
     @Mock
     private PageRevisionService pageRevisionService;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/configuration/dictionary/DictionaryServiceImpl_UpdateTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/configuration/dictionary/DictionaryServiceImpl_UpdateTest.java
@@ -31,20 +31,24 @@ import io.gravitee.repository.management.model.Dictionary;
 import io.gravitee.repository.management.model.LifecycleState;
 import io.gravitee.rest.api.model.EventType;
 import io.gravitee.rest.api.model.configuration.dictionary.DictionaryEntity;
+import io.gravitee.rest.api.model.configuration.dictionary.DictionaryTriggerEntity;
 import io.gravitee.rest.api.model.configuration.dictionary.DictionaryType;
 import io.gravitee.rest.api.model.configuration.dictionary.UpdateDictionaryEntity;
 import io.gravitee.rest.api.service.AuditService;
 import io.gravitee.rest.api.service.EnvironmentService;
 import io.gravitee.rest.api.service.EventService;
 import io.gravitee.rest.api.service.common.GraviteeContext;
+import io.gravitee.rest.api.service.exceptions.InvalidDataException;
 import java.util.Collections;
 import java.util.Date;
 import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.test.util.ReflectionTestUtils;
 
 @RunWith(MockitoJUnitRunner.class)
 public class DictionaryServiceImpl_UpdateTest {
@@ -190,6 +194,29 @@ public class DictionaryServiceImpl_UpdateTest {
                     auditLogData.getCreatedAt().equals(updatedDictionary.getUpdatedAt())
             )
         );
+    }
+
+    @Test(expected = InvalidDataException.class)
+    public void shouldNotUpdateDynamicDictionaryWhenTriggerIsMoreFrequentThanConfiguredLimit() throws TechnicalException {
+        ReflectionTestUtils.setField(dictionaryService, "delayLimitMillis", 60_000L);
+
+        Dictionary dictionaryInDb = new Dictionary();
+        dictionaryInDb.setId(DICTIONARY_ID);
+        dictionaryInDb.setCreatedAt(new Date());
+        dictionaryInDb.setState(LifecycleState.STARTED);
+        dictionaryInDb.setEnvironmentId(ENVIRONMENT_ID);
+        when(dictionaryRepository.findById(dictionaryInDb.getId())).thenReturn(Optional.of(dictionaryInDb));
+
+        DictionaryTriggerEntity trigger = new DictionaryTriggerEntity();
+        trigger.setRate(1);
+        trigger.setUnit(TimeUnit.SECONDS);
+
+        UpdateDictionaryEntity updateDictionaryEntity = new UpdateDictionaryEntity();
+        updateDictionaryEntity.setName("UpdatedName");
+        updateDictionaryEntity.setType(DictionaryType.DYNAMIC);
+        updateDictionaryEntity.setTrigger(trigger);
+
+        dictionaryService.update(GraviteeContext.getExecutionContext(), dictionaryInDb.getId(), updateDictionaryEntity);
     }
 
     @Test(expected = DictionaryNotFoundException.class)

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/configuration/dictionary/DictionaryServiceImpl_UpdateTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/configuration/dictionary/DictionaryServiceImpl_UpdateTest.java
@@ -38,7 +38,9 @@ import io.gravitee.rest.api.service.AuditService;
 import io.gravitee.rest.api.service.EnvironmentService;
 import io.gravitee.rest.api.service.EventService;
 import io.gravitee.rest.api.service.common.GraviteeContext;
-import io.gravitee.rest.api.service.exceptions.InvalidDataException;
+import io.gravitee.rest.api.service.common.ScheduleMinimumIntervalValidator;
+import io.gravitee.rest.api.service.exceptions.ScheduleMinimumIntervalExceededException;
+import io.gravitee.rest.api.service.spring.ScheduleLimitsConfiguration;
 import java.util.Collections;
 import java.util.Date;
 import java.util.Optional;
@@ -71,6 +73,9 @@ public class DictionaryServiceImpl_UpdateTest {
 
     @Mock
     private AuditService auditService;
+
+    @Mock
+    private ScheduleMinimumIntervalValidator scheduleMinimumIntervalValidator;
 
     @Test
     public void shouldUpdateDictionary() throws TechnicalException {
@@ -196,9 +201,13 @@ public class DictionaryServiceImpl_UpdateTest {
         );
     }
 
-    @Test(expected = InvalidDataException.class)
+    @Test(expected = ScheduleMinimumIntervalExceededException.class)
     public void shouldNotUpdateDynamicDictionaryWhenTriggerIsMoreFrequentThanConfiguredLimit() throws TechnicalException {
-        ReflectionTestUtils.setField(dictionaryService, "delayLimitMillis", 60_000L);
+        ReflectionTestUtils.setField(
+            dictionaryService,
+            "scheduleMinimumIntervalValidator",
+            new ScheduleMinimumIntervalValidator(new ScheduleLimitsConfiguration(0, 0, 60_000L, 0))
+        );
 
         Dictionary dictionaryInDb = new Dictionary();
         dictionaryInDb.setId(DICTIONARY_ID);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/spring/ScheduleLimitsConfigurationTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/spring/ScheduleLimitsConfigurationTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.spring;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+
+class ScheduleLimitsConfigurationTest {
+
+    @Test
+    void should_accept_disabled_and_positive_limits() {
+        var configuration = new ScheduleLimitsConfiguration(0, 1_000, 2_000, 3_000);
+
+        assertThat(configuration.getAutoFetchMinimumInterval()).isZero();
+        assertThat(configuration.getDynamicPropertiesMinimumInterval()).isEqualTo(1_000);
+        assertThat(configuration.getDictionaryMinimumInterval()).isEqualTo(2_000);
+        assertThat(configuration.getHealthcheckMinimumInterval()).isEqualTo(3_000);
+    }
+
+    @Test
+    void should_reject_negative_limit() {
+        assertThatThrownBy(() -> new ScheduleLimitsConfiguration(0, -1, 0, 0))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("services.dynamic_properties.minimum_interval must be greater than or equal to 0");
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/ApiStateServiceImpl_DeployTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/ApiStateServiceImpl_DeployTest.java
@@ -41,6 +41,7 @@ import io.gravitee.rest.api.service.converter.ApiConverter;
 import io.gravitee.rest.api.service.converter.CategoryMapper;
 import io.gravitee.rest.api.service.exceptions.ApiNotDeployableException;
 import io.gravitee.rest.api.service.exceptions.ApiNotFoundException;
+import io.gravitee.rest.api.service.exceptions.ScheduleMinimumIntervalExceededException;
 import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
 import io.gravitee.rest.api.service.processor.SynchronizationService;
 import io.gravitee.rest.api.service.search.SearchEngineService;
@@ -250,6 +251,21 @@ public class ApiStateServiceImpl_DeployTest {
             )
         );
         verify(apiNotificationService).triggerDeployNotification(any(ExecutionContext.class), eq(result));
+        verify(apiValidationService).validateSchedules(any(io.gravitee.rest.api.model.v4.api.ApiEntity.class));
+    }
+
+    @Test(expected = ScheduleMinimumIntervalExceededException.class)
+    public void should_not_deploy_when_a_schedule_exceeds_the_minimum_interval() throws TechnicalException {
+        when(apiSearchService.findRepositoryApiById(any(), eq(API_ID))).thenReturn(api);
+        doThrow(new ScheduleMinimumIntervalExceededException("services.dynamicProperty.schedule", "* * * * * *", 300_000L))
+            .when(apiValidationService)
+            .validateSchedules(any());
+
+        try {
+            apiStateService.deploy(GraviteeContext.getExecutionContext(), API_ID, USER_NAME, new ApiDeploymentEntity());
+        } finally {
+            verify(apiRepository, never()).update(any());
+        }
     }
 
     @Test(expected = ApiNotDeployableException.class)

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/validation/ApiValidationServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/validation/ApiValidationServiceImplTest.java
@@ -46,6 +46,7 @@ import io.gravitee.definition.model.v4.flow.Flow;
 import io.gravitee.definition.model.v4.flow.selector.HttpSelector;
 import io.gravitee.definition.model.v4.flow.selector.Selector;
 import io.gravitee.definition.model.v4.plan.PlanStatus;
+import io.gravitee.definition.model.v4.service.Service;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.rest.api.model.PrimaryOwnerEntity;
 import io.gravitee.rest.api.model.api.ApiLifecycleState;
@@ -76,6 +77,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.test.util.ReflectionTestUtils;
 
 /**
  * @author Florent CHAMFROY (florent.chamfroy at graviteesource.com)
@@ -192,6 +194,32 @@ public class ApiValidationServiceImplTest {
         verify(resourcesValidationService, times(1)).validateAndSanitize(List.of());
         verify(planValidationService, times(1)).validateAndSanitize(apiEntity.getType(), Set.of());
         verify(flowValidationDomainService, times(1)).validatePathParameters(any(), any(), any());
+    }
+
+    @Test(expected = InvalidDataException.class)
+    public void shouldRejectDynamicPropertiesScheduleWhenConfiguredCronIsSlower() {
+        var validator = new ApiValidationServiceImpl(
+            tagsValidationService,
+            groupValidationService,
+            listenerValidationService,
+            endpointGroupsValidationService,
+            flowValidationService,
+            resourcesValidationService,
+            loggingValidationService,
+            planSearchService,
+            planValidationService,
+            apiServicePluginService,
+            flowValidationDomainService,
+            apiProductQueryService
+        );
+        ReflectionTestUtils.setField(validator, "dynamicPropertiesCronLimit", "0 */5 * * * *");
+
+        var dynamicProperties = Service.builder().type("http-dynamic-properties").configuration("{\"schedule\":\"* * * * * *\"}").build();
+        when(
+            apiServicePluginService.validateApiServiceConfiguration(dynamicProperties.getType(), dynamicProperties.getConfiguration())
+        ).thenReturn(dynamicProperties.getConfiguration());
+
+        validator.validateDynamicProperties(dynamicProperties);
     }
 
     @Test(expected = InvalidDataException.class)

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/validation/ApiValidationServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/validation/ApiValidationServiceImplTest.java
@@ -56,8 +56,11 @@ import io.gravitee.rest.api.model.v4.api.UpdateApiEntity;
 import io.gravitee.rest.api.model.v4.plan.PlanEntity;
 import io.gravitee.rest.api.service.common.ExecutionContext;
 import io.gravitee.rest.api.service.common.GraviteeContext;
+import io.gravitee.rest.api.service.common.ScheduleMinimumIntervalValidator;
 import io.gravitee.rest.api.service.exceptions.InvalidDataException;
 import io.gravitee.rest.api.service.exceptions.LifecycleStateChangeNotAllowedException;
+import io.gravitee.rest.api.service.exceptions.ScheduleMinimumIntervalExceededException;
+import io.gravitee.rest.api.service.spring.ScheduleLimitsConfiguration;
 import io.gravitee.rest.api.service.v4.ApiServicePluginService;
 import io.gravitee.rest.api.service.v4.PlanSearchService;
 import io.gravitee.rest.api.service.v4.exception.ApiTypeException;
@@ -77,7 +80,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
-import org.springframework.test.util.ReflectionTestUtils;
 
 /**
  * @author Florent CHAMFROY (florent.chamfroy at graviteesource.com)
@@ -124,6 +126,9 @@ public class ApiValidationServiceImplTest {
     @Mock
     private ApiProductQueryService apiProductQueryService;
 
+    @Mock
+    private ScheduleMinimumIntervalValidator scheduleMinimumIntervalValidator;
+
     @Before
     public void setUp() throws Exception {
         apiValidationService = new ApiValidationServiceImpl(
@@ -138,7 +143,8 @@ public class ApiValidationServiceImplTest {
             planValidationService,
             apiServicePluginService,
             flowValidationDomainService,
-            apiProductQueryService
+            apiProductQueryService,
+            scheduleMinimumIntervalValidator
         );
     }
 
@@ -196,7 +202,7 @@ public class ApiValidationServiceImplTest {
         verify(flowValidationDomainService, times(1)).validatePathParameters(any(), any(), any());
     }
 
-    @Test(expected = InvalidDataException.class)
+    @Test(expected = ScheduleMinimumIntervalExceededException.class)
     public void shouldRejectDynamicPropertiesScheduleWhenConfiguredCronIsSlower() {
         var validator = new ApiValidationServiceImpl(
             tagsValidationService,
@@ -210,9 +216,9 @@ public class ApiValidationServiceImplTest {
             planValidationService,
             apiServicePluginService,
             flowValidationDomainService,
-            apiProductQueryService
+            apiProductQueryService,
+            new ScheduleMinimumIntervalValidator(new ScheduleLimitsConfiguration(0, 300_000L, 0, 0))
         );
-        ReflectionTestUtils.setField(validator, "dynamicPropertiesCronLimit", "0 */5 * * * *");
 
         var dynamicProperties = Service.builder().type("http-dynamic-properties").configuration("{\"schedule\":\"* * * * * *\"}").build();
         when(
@@ -524,7 +530,8 @@ public class ApiValidationServiceImplTest {
             planValidationService,
             apiServicePluginService,
             new FlowValidationDomainService(mock(PolicyValidationDomainService.class), mock(EntrypointPluginQueryService.class)),
-            apiProductQueryService
+            apiProductQueryService,
+            scheduleMinimumIntervalValidator
         );
 
         HttpSelector httpSelector = new HttpSelector();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/validation/ApiValidationServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/validation/ApiValidationServiceImplTest.java
@@ -42,6 +42,7 @@ import io.gravitee.apim.core.plugin.query_service.EntrypointPluginQueryService;
 import io.gravitee.apim.core.policy.domain_service.PolicyValidationDomainService;
 import io.gravitee.definition.model.DefinitionVersion;
 import io.gravitee.definition.model.v4.ApiType;
+import io.gravitee.definition.model.v4.endpointgroup.EndpointGroup;
 import io.gravitee.definition.model.v4.flow.Flow;
 import io.gravitee.definition.model.v4.flow.selector.HttpSelector;
 import io.gravitee.definition.model.v4.flow.selector.Selector;
@@ -129,6 +130,9 @@ public class ApiValidationServiceImplTest {
     @Mock
     private ScheduleMinimumIntervalValidator scheduleMinimumIntervalValidator;
 
+    @Mock
+    private EndpointHealthCheckScheduleValidator endpointHealthCheckScheduleValidator;
+
     @Before
     public void setUp() throws Exception {
         apiValidationService = new ApiValidationServiceImpl(
@@ -144,7 +148,8 @@ public class ApiValidationServiceImplTest {
             apiServicePluginService,
             flowValidationDomainService,
             apiProductQueryService,
-            scheduleMinimumIntervalValidator
+            scheduleMinimumIntervalValidator,
+            endpointHealthCheckScheduleValidator
         );
     }
 
@@ -217,7 +222,8 @@ public class ApiValidationServiceImplTest {
             apiServicePluginService,
             flowValidationDomainService,
             apiProductQueryService,
-            new ScheduleMinimumIntervalValidator(new ScheduleLimitsConfiguration(0, 300_000L, 0, 0))
+            new ScheduleMinimumIntervalValidator(new ScheduleLimitsConfiguration(0, 300_000L, 0, 0)),
+            endpointHealthCheckScheduleValidator
         );
 
         var dynamicProperties = Service.builder().type("http-dynamic-properties").configuration("{\"schedule\":\"* * * * * *\"}").build();
@@ -226,6 +232,17 @@ public class ApiValidationServiceImplTest {
         ).thenReturn(dynamicProperties.getConfiguration());
 
         validator.validateDynamicProperties(dynamicProperties);
+    }
+
+    @Test
+    public void shouldValidateEndpointHealthCheckSchedulesWhenValidatingSchedules() {
+        var apiEntity = new ApiEntity();
+        var endpointGroups = List.of(new EndpointGroup());
+        apiEntity.setEndpointGroups(endpointGroups);
+
+        apiValidationService.validateSchedules(apiEntity);
+
+        verify(endpointHealthCheckScheduleValidator).validate(endpointGroups);
     }
 
     @Test(expected = InvalidDataException.class)
@@ -531,7 +548,8 @@ public class ApiValidationServiceImplTest {
             apiServicePluginService,
             new FlowValidationDomainService(mock(PolicyValidationDomainService.class), mock(EntrypointPluginQueryService.class)),
             apiProductQueryService,
-            scheduleMinimumIntervalValidator
+            scheduleMinimumIntervalValidator,
+            endpointHealthCheckScheduleValidator
         );
 
         HttpSelector httpSelector = new HttpSelector();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/validation/EndpointGroupsValidationServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/validation/EndpointGroupsValidationServiceImplTest.java
@@ -36,6 +36,7 @@ import io.gravitee.definition.model.v4.nativeapi.NativeEndpoint;
 import io.gravitee.definition.model.v4.nativeapi.NativeEndpointGroup;
 import io.gravitee.definition.model.v4.service.Service;
 import io.gravitee.rest.api.model.v4.connector.ConnectorPluginEntity;
+import io.gravitee.rest.api.service.common.ScheduleMinimumIntervalValidator;
 import io.gravitee.rest.api.service.exceptions.EndpointConfigurationValidationException;
 import io.gravitee.rest.api.service.exceptions.EndpointGroupNameAlreadyExistsException;
 import io.gravitee.rest.api.service.exceptions.EndpointMissingException;
@@ -44,7 +45,9 @@ import io.gravitee.rest.api.service.exceptions.EndpointNameInvalidException;
 import io.gravitee.rest.api.service.exceptions.HealthcheckInheritanceException;
 import io.gravitee.rest.api.service.exceptions.HealthcheckInvalidException;
 import io.gravitee.rest.api.service.exceptions.InvalidDataException;
+import io.gravitee.rest.api.service.exceptions.ScheduleMinimumIntervalExceededException;
 import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
+import io.gravitee.rest.api.service.spring.ScheduleLimitsConfiguration;
 import io.gravitee.rest.api.service.v4.ApiServicePluginService;
 import io.gravitee.rest.api.service.v4.EndpointConnectorPluginService;
 import io.gravitee.rest.api.service.v4.exception.*;
@@ -58,7 +61,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.test.util.ReflectionTestUtils;
 
 /**
  * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
@@ -107,7 +109,8 @@ public class EndpointGroupsValidationServiceImplTest {
         endpointGroupsValidationService = new EndpointGroupsValidationServiceImpl(
             endpointService,
             apiServicePluginService,
-            new ObjectMapper()
+            new ObjectMapper(),
+            new ScheduleMinimumIntervalValidator(new ScheduleLimitsConfiguration(0, 0, 0, 0))
         );
     }
 
@@ -242,7 +245,12 @@ public class EndpointGroupsValidationServiceImplTest {
 
     @Test
     public void shouldRejectEndpointGroupsWithHealthCheckMoreFrequentThanConfiguredLimit() {
-        ReflectionTestUtils.setField(endpointGroupsValidationService, "healthcheckCronLimit", "0 */5 * * * *");
+        endpointGroupsValidationService = new EndpointGroupsValidationServiceImpl(
+            endpointService,
+            apiServicePluginService,
+            new ObjectMapper(),
+            new ScheduleMinimumIntervalValidator(new ScheduleLimitsConfiguration(0, 0, 0, 300_000L))
+        );
         EndpointGroup endpointGroup = new EndpointGroup();
         endpointGroup.setName("my name");
         endpointGroup.setType("http");
@@ -265,7 +273,7 @@ public class EndpointGroupsValidationServiceImplTest {
 
         assertThatThrownBy(() ->
             endpointGroupsValidationService.validateAndSanitizeHttpV4(ApiType.PROXY, List.of(endpointGroup))
-        ).isInstanceOf(InvalidDataException.class);
+        ).isInstanceOf(ScheduleMinimumIntervalExceededException.class);
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/validation/EndpointGroupsValidationServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/validation/EndpointGroupsValidationServiceImplTest.java
@@ -43,6 +43,7 @@ import io.gravitee.rest.api.service.exceptions.EndpointNameAlreadyExistsExceptio
 import io.gravitee.rest.api.service.exceptions.EndpointNameInvalidException;
 import io.gravitee.rest.api.service.exceptions.HealthcheckInheritanceException;
 import io.gravitee.rest.api.service.exceptions.HealthcheckInvalidException;
+import io.gravitee.rest.api.service.exceptions.InvalidDataException;
 import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
 import io.gravitee.rest.api.service.v4.ApiServicePluginService;
 import io.gravitee.rest.api.service.v4.EndpointConnectorPluginService;
@@ -57,6 +58,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 
 /**
  * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
@@ -236,6 +238,34 @@ public class EndpointGroupsValidationServiceImplTest {
         assertThat(validatedEndpointGroup.getSharedConfiguration()).isNotNull();
         assertThat(validatedEndpointGroup.getLoadBalancer()).isNotNull();
         assertThat(validatedEndpointGroup.getLoadBalancer().getType()).isEqualTo(LoadBalancerType.ROUND_ROBIN);
+    }
+
+    @Test
+    public void shouldRejectEndpointGroupsWithHealthCheckMoreFrequentThanConfiguredLimit() {
+        ReflectionTestUtils.setField(endpointGroupsValidationService, "healthcheckCronLimit", "0 */5 * * * *");
+        EndpointGroup endpointGroup = new EndpointGroup();
+        endpointGroup.setName("my name");
+        endpointGroup.setType("http");
+        endpointGroup.setSharedConfiguration("sharedConfiguration");
+        Endpoint endpoint = new Endpoint();
+        endpoint.setName("endpoint");
+        endpoint.setType("http");
+        endpoint.setInheritConfiguration(true);
+        endpointGroup.setEndpoints(List.of(endpoint));
+
+        Service healthCheck = new Service();
+        healthCheck.setType(HEALTH_CHECK_TYPE);
+        healthCheck.setEnabled(true);
+        healthCheck.setConfiguration("{\"schedule\":\"* * * * * *\"}");
+        endpointGroup.getServices().setHealthCheck(healthCheck);
+
+        when(apiServicePluginService.validateApiServiceConfiguration(eq(HEALTH_CHECK_TYPE), any())).thenReturn(
+            healthCheck.getConfiguration()
+        );
+
+        assertThatThrownBy(() ->
+            endpointGroupsValidationService.validateAndSanitizeHttpV4(ApiType.PROXY, List.of(endpointGroup))
+        ).isInstanceOf(InvalidDataException.class);
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/validation/EndpointGroupsValidationServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/validation/EndpointGroupsValidationServiceImplTest.java
@@ -110,7 +110,7 @@ public class EndpointGroupsValidationServiceImplTest {
             endpointService,
             apiServicePluginService,
             new ObjectMapper(),
-            new ScheduleMinimumIntervalValidator(new ScheduleLimitsConfiguration(0, 0, 0, 0))
+            endpointHealthCheckScheduleValidator(new ScheduleLimitsConfiguration(0, 0, 0, 0))
         );
     }
 
@@ -249,7 +249,7 @@ public class EndpointGroupsValidationServiceImplTest {
             endpointService,
             apiServicePluginService,
             new ObjectMapper(),
-            new ScheduleMinimumIntervalValidator(new ScheduleLimitsConfiguration(0, 0, 0, 300_000L))
+            endpointHealthCheckScheduleValidator(new ScheduleLimitsConfiguration(0, 0, 0, 300_000L))
         );
         EndpointGroup endpointGroup = new EndpointGroup();
         endpointGroup.setName("my name");
@@ -1147,5 +1147,14 @@ public class EndpointGroupsValidationServiceImplTest {
                 .withMessageContaining("aliases")
                 .withMessageContaining("llm-group-name");
         }
+    }
+
+    private EndpointHealthCheckScheduleValidator endpointHealthCheckScheduleValidator(
+        ScheduleLimitsConfiguration scheduleLimitsConfiguration
+    ) {
+        return new EndpointHealthCheckScheduleValidator(
+            new ObjectMapper(),
+            new ScheduleMinimumIntervalValidator(scheduleLimitsConfiguration)
+        );
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-dictionary/src/main/java/io/gravitee/rest/api/services/dictionary/DictionaryService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-dictionary/src/main/java/io/gravitee/rest/api/services/dictionary/DictionaryService.java
@@ -64,8 +64,8 @@ public class DictionaryService extends AbstractService implements EventListener<
     @Autowired
     private Node node;
 
-    @Value("${services.dictionary.delay_limit:0}")
-    private long delayLimitMillis;
+    @Value("${services.dictionary.minimum_interval:0}")
+    private long minimumInterval;
 
     private final Map<String, Long> timers = new HashMap<>();
 
@@ -133,7 +133,7 @@ public class DictionaryService extends AbstractService implements EventListener<
                     refresher.handle(null);
 
                     long periodicTimer = vertx.setPeriodic(
-                        CronScheduleLimits.limitFrequency(getDelayMillis(dictionary.getTrigger()), delayLimitMillis),
+                        CronScheduleLimits.limitFrequency(getDelayMillis(dictionary.getTrigger()), minimumInterval),
                         refresher
                     );
                     timers.put(dictionary.getId(), periodicTimer);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-dictionary/src/main/java/io/gravitee/rest/api/services/dictionary/DictionaryService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-dictionary/src/main/java/io/gravitee/rest/api/services/dictionary/DictionaryService.java
@@ -26,6 +26,7 @@ import io.gravitee.rest.api.model.configuration.dictionary.DictionaryEntity;
 import io.gravitee.rest.api.model.configuration.dictionary.DictionaryProviderEntity;
 import io.gravitee.rest.api.model.configuration.dictionary.DictionaryTriggerEntity;
 import io.gravitee.rest.api.service.HttpClientService;
+import io.gravitee.rest.api.service.common.CronScheduleLimits;
 import io.gravitee.rest.api.service.event.DictionaryEvent;
 import io.gravitee.rest.api.services.dictionary.provider.http.HttpProvider;
 import io.gravitee.rest.api.services.dictionary.provider.http.configuration.HttpProviderConfiguration;
@@ -34,6 +35,7 @@ import java.util.HashMap;
 import java.util.Map;
 import lombok.CustomLog;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
@@ -61,6 +63,9 @@ public class DictionaryService extends AbstractService implements EventListener<
 
     @Autowired
     private Node node;
+
+    @Value("${services.dictionary.delay_limit:0}")
+    private long delayLimitMillis;
 
     private final Map<String, Long> timers = new HashMap<>();
 
@@ -127,7 +132,10 @@ public class DictionaryService extends AbstractService implements EventListener<
                     // Force the first refresh, and then run it periodically
                     refresher.handle(null);
 
-                    long periodicTimer = vertx.setPeriodic(getDelayMillis(dictionary.getTrigger()), refresher);
+                    long periodicTimer = vertx.setPeriodic(
+                        CronScheduleLimits.limitFrequency(getDelayMillis(dictionary.getTrigger()), delayLimitMillis),
+                        refresher
+                    );
                     timers.put(dictionary.getId(), periodicTimer);
                 } catch (JsonProcessingException jpe) {
                     log.error("Dictionary provider configuration for dictionary [{}] is invalid", dictionary.getId(), jpe);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-dictionary/src/test/java/io/gravitee/rest/api/services/dictionary/DictionaryServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-dictionary/src/test/java/io/gravitee/rest/api/services/dictionary/DictionaryServiceTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.services.dictionary;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.gravitee.common.event.impl.SimpleEvent;
+import io.gravitee.node.api.Node;
+import io.gravitee.rest.api.model.configuration.dictionary.DictionaryEntity;
+import io.gravitee.rest.api.model.configuration.dictionary.DictionaryProviderEntity;
+import io.gravitee.rest.api.model.configuration.dictionary.DictionaryTriggerEntity;
+import io.gravitee.rest.api.service.HttpClientService;
+import io.gravitee.rest.api.service.event.DictionaryEvent;
+import io.vertx.core.Vertx;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@ExtendWith(MockitoExtension.class)
+class DictionaryServiceTest {
+
+    @Mock
+    private Vertx vertx;
+
+    @Mock
+    private HttpClientService httpClientService;
+
+    @Mock
+    private io.gravitee.rest.api.service.configuration.dictionary.DictionaryService dictionaryManagementService;
+
+    @Mock
+    private Node node;
+
+    @InjectMocks
+    private DictionaryService dictionaryService;
+
+    @Test
+    void should_limit_dictionary_polling_delay_when_configured_delay_is_slower() {
+        ReflectionTestUtils.setField(dictionaryService, "objectMapper", new ObjectMapper());
+        ReflectionTestUtils.setField(dictionaryService, "delayLimitMillis", 60_000L);
+        ReflectionTestUtils.setField(dictionaryService, "dictionaryService", dictionaryManagementService);
+
+        dictionaryService.onEvent(new SimpleEvent<>(DictionaryEvent.START, dictionary()));
+
+        verify(vertx).setPeriodic(eq(60_000L), any(DictionaryRefresher.class));
+    }
+
+    private DictionaryEntity dictionary() {
+        var provider = new DictionaryProviderEntity();
+        provider.setType("HTTP");
+        provider.setConfiguration(
+            new ObjectMapper()
+                .createObjectNode()
+                .put("url", "not-a-url")
+                .put(
+                    "specification",
+                    "[{\"operation\":\"shift\",\"spec\":{\"content\":{\"*\":{\"$\":\"[#2].key\",\"@\":\"[#2].value\"}}}}]"
+                )
+        );
+
+        var trigger = new DictionaryTriggerEntity();
+        trigger.setRate(1);
+        trigger.setUnit(TimeUnit.SECONDS);
+
+        return DictionaryEntity.builder().id("dictionary-id").name("dictionary").provider(provider).trigger(trigger).build();
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-dictionary/src/test/java/io/gravitee/rest/api/services/dictionary/DictionaryServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-dictionary/src/test/java/io/gravitee/rest/api/services/dictionary/DictionaryServiceTest.java
@@ -60,7 +60,7 @@ class DictionaryServiceTest {
     @Test
     void should_limit_dictionary_polling_delay_when_configured_delay_is_slower() {
         ReflectionTestUtils.setField(dictionaryService, "objectMapper", new ObjectMapper());
-        ReflectionTestUtils.setField(dictionaryService, "delayLimitMillis", 60_000L);
+        ReflectionTestUtils.setField(dictionaryService, "minimumInterval", 60_000L);
         ReflectionTestUtils.setField(dictionaryService, "dictionaryService", dictionaryManagementService);
 
         dictionaryService.onEvent(new SimpleEvent<>(DictionaryEvent.START, dictionary()));

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-dynamic-properties/src/main/java/io/gravitee/rest/api/services/dynamicproperties/DynamicPropertiesService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-dynamic-properties/src/main/java/io/gravitee/rest/api/services/dynamicproperties/DynamicPropertiesService.java
@@ -31,6 +31,7 @@ import io.gravitee.rest.api.model.api.ApiEntity;
 import io.gravitee.rest.api.service.ApiService;
 import io.gravitee.rest.api.service.EnvironmentService;
 import io.gravitee.rest.api.service.HttpClientService;
+import io.gravitee.rest.api.service.common.CronScheduleLimits;
 import io.gravitee.rest.api.service.common.ExecutionContext;
 import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.converter.ApiConverter;
@@ -41,6 +42,7 @@ import java.util.Map;
 import java.util.Objects;
 import lombok.CustomLog;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 
 @CustomLog
 public class DynamicPropertiesService extends AbstractService implements EventListener<ApiEvent, Api> {
@@ -67,6 +69,9 @@ public class DynamicPropertiesService extends AbstractService implements EventLi
 
     @Autowired
     private Node node;
+
+    @Value("${services.dynamic_properties.cron_limit:}")
+    private String cronLimit;
 
     @Override
     protected String name() {
@@ -148,9 +153,10 @@ public class DynamicPropertiesService extends AbstractService implements EventLi
 
         EnvironmentEntity environment = environmentService.findById(api.getEnvironmentId());
         ExecutionContext executionContext = new ExecutionContext(environment.getOrganizationId(), environment.getId());
+        String schedule = CronScheduleLimits.limitFrequency(dynamicPropertyService.getSchedule(), cronLimit);
         DynamicPropertyScheduler scheduler = DynamicPropertyScheduler.builder()
             .clusterManager(clusterManager)
-            .schedule(dynamicPropertyService.getSchedule())
+            .schedule(schedule)
             .api(api)
             .apiConverter(apiConverter)
             .apiService(apiService)
@@ -158,7 +164,7 @@ public class DynamicPropertiesService extends AbstractService implements EventLi
             .build();
         if (DynamicPropertyProvider.HTTP == dynamicPropertyService.getProvider()) {
             HttpProvider provider = new HttpProvider(dynamicPropertyService.getConfiguration(), httpClientService, node);
-            log.info("{} Add a scheduled task to poll dynamic properties each {}", api.getId(), dynamicPropertyService.getSchedule());
+            log.info("{} Add a scheduled task to poll dynamic properties each {}", api.getId(), schedule);
 
             // Force the first refresh, and then run it periodically
             scheduler.schedule(provider);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-dynamic-properties/src/main/java/io/gravitee/rest/api/services/dynamicproperties/DynamicPropertiesService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-dynamic-properties/src/main/java/io/gravitee/rest/api/services/dynamicproperties/DynamicPropertiesService.java
@@ -31,7 +31,6 @@ import io.gravitee.rest.api.model.api.ApiEntity;
 import io.gravitee.rest.api.service.ApiService;
 import io.gravitee.rest.api.service.EnvironmentService;
 import io.gravitee.rest.api.service.HttpClientService;
-import io.gravitee.rest.api.service.common.CronScheduleLimits;
 import io.gravitee.rest.api.service.common.ExecutionContext;
 import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.converter.ApiConverter;
@@ -70,8 +69,8 @@ public class DynamicPropertiesService extends AbstractService implements EventLi
     @Autowired
     private Node node;
 
-    @Value("${services.dynamic_properties.cron_limit:}")
-    private String cronLimit;
+    @Value("${services.dynamic_properties.minimum_interval:0}")
+    private long minimumInterval;
 
     @Override
     protected String name() {
@@ -153,10 +152,11 @@ public class DynamicPropertiesService extends AbstractService implements EventLi
 
         EnvironmentEntity environment = environmentService.findById(api.getEnvironmentId());
         ExecutionContext executionContext = new ExecutionContext(environment.getOrganizationId(), environment.getId());
-        String schedule = CronScheduleLimits.limitFrequency(dynamicPropertyService.getSchedule(), cronLimit);
+        String schedule = dynamicPropertyService.getSchedule();
         DynamicPropertyScheduler scheduler = DynamicPropertyScheduler.builder()
             .clusterManager(clusterManager)
             .schedule(schedule)
+            .minimumInterval(minimumInterval)
             .api(api)
             .apiConverter(apiConverter)
             .apiService(apiService)

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-dynamic-properties/src/main/java/io/gravitee/rest/api/services/dynamicproperties/DynamicPropertyScheduler.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-dynamic-properties/src/main/java/io/gravitee/rest/api/services/dynamicproperties/DynamicPropertyScheduler.java
@@ -59,9 +59,11 @@ public class DynamicPropertyScheduler {
     private final ApiService apiService;
     private final ApiConverter apiConverter;
     private final String schedule;
+    private final long minimumInterval;
     private final ApiEntity api;
     private final ExecutionContext executionContext;
     private Disposable disposable;
+    private volatile long lastExecutionNanos = Long.MIN_VALUE;
 
     @Builder
     public DynamicPropertyScheduler(
@@ -69,6 +71,7 @@ public class DynamicPropertyScheduler {
         final ApiService apiService,
         final ApiConverter apiConverter,
         final String schedule,
+        final long minimumInterval,
         final ApiEntity api,
         final ExecutionContext executionContext
     ) {
@@ -76,6 +79,7 @@ public class DynamicPropertyScheduler {
         this.apiService = apiService;
         this.apiConverter = apiConverter;
         this.schedule = schedule;
+        this.minimumInterval = minimumInterval;
         this.api = api;
         this.executionContext = executionContext;
     }
@@ -84,9 +88,10 @@ public class DynamicPropertyScheduler {
         CronTrigger cronTrigger = new CronTrigger(schedule);
         log.debug("[{}] Running dynamic properties scheduler", api.getId());
 
-        disposable = Observable.defer(() -> Observable.timer(cronTrigger.nextExecutionIn(), TimeUnit.MILLISECONDS))
+        disposable = Observable.defer(() -> Observable.timer(nextExecutionIn(cronTrigger), TimeUnit.MILLISECONDS))
             .observeOn(Schedulers.computation())
             .filter(aLong -> clusterManager.self().primary())
+            .doOnNext(aLong -> lastExecutionNanos = System.nanoTime())
             .switchMapCompletable(aLong ->
                 provider
                     .get()
@@ -116,6 +121,16 @@ public class DynamicPropertyScheduler {
         if (disposable != null && !disposable.isDisposed()) {
             disposable.dispose();
         }
+    }
+
+    long nextExecutionIn(CronTrigger cronTrigger) {
+        var cronDelay = cronTrigger.nextExecutionIn();
+        if (minimumInterval == 0 || lastExecutionNanos == Long.MIN_VALUE) {
+            return cronDelay;
+        }
+
+        var elapsed = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - lastExecutionNanos);
+        return Math.max(cronDelay, Math.max(0, minimumInterval - elapsed));
     }
 
     private void authenticateAsAdmin() {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-dynamic-properties/src/test/java/io/gravitee/rest/api/services/dynamicproperties/DynamicPropertiesServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-dynamic-properties/src/test/java/io/gravitee/rest/api/services/dynamicproperties/DynamicPropertiesServiceTest.java
@@ -65,6 +65,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 
 /**
  * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)
@@ -134,6 +135,21 @@ public class DynamicPropertiesServiceTest {
         cut.onEvent(new SimpleEvent<>(ApiEvent.DEPLOY, api));
 
         assertThat(cut.schedulers).isNotEmpty();
+    }
+
+    @Test
+    public void should_start_scheduler_with_configured_cron_limit_when_user_cron_is_faster() throws Exception {
+        ReflectionTestUtils.setField(cut, "cronLimit", "0 */5 * * * *");
+        HttpDynamicPropertyProviderConfiguration providerConfiguration = new HttpDynamicPropertyProviderConfiguration();
+        providerConfiguration.setUrl("http://localhost:8080/success");
+        providerConfiguration.setSpecification(IOUtils.toString(read("/jolt/specification-value-as-key.json"), Charset.defaultCharset()));
+        final Api api = createApi(providerConfiguration);
+
+        cut.onEvent(new SimpleEvent<>(ApiEvent.DEPLOY, api));
+
+        assertThat(cut.schedulers.values())
+            .singleElement()
+            .satisfies(scheduler -> assertThat(ReflectionTestUtils.getField(scheduler, "schedule")).isEqualTo("0 */5 * * * *"));
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-dynamic-properties/src/test/java/io/gravitee/rest/api/services/dynamicproperties/DynamicPropertiesServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-dynamic-properties/src/test/java/io/gravitee/rest/api/services/dynamicproperties/DynamicPropertiesServiceTest.java
@@ -138,8 +138,8 @@ public class DynamicPropertiesServiceTest {
     }
 
     @Test
-    public void should_start_scheduler_with_configured_cron_limit_when_user_cron_is_faster() throws Exception {
-        ReflectionTestUtils.setField(cut, "cronLimit", "0 */5 * * * *");
+    public void should_start_scheduler_with_original_cron_and_minimum_interval() throws Exception {
+        ReflectionTestUtils.setField(cut, "minimumInterval", 300_000L);
         HttpDynamicPropertyProviderConfiguration providerConfiguration = new HttpDynamicPropertyProviderConfiguration();
         providerConfiguration.setUrl("http://localhost:8080/success");
         providerConfiguration.setSpecification(IOUtils.toString(read("/jolt/specification-value-as-key.json"), Charset.defaultCharset()));
@@ -149,7 +149,10 @@ public class DynamicPropertiesServiceTest {
 
         assertThat(cut.schedulers.values())
             .singleElement()
-            .satisfies(scheduler -> assertThat(ReflectionTestUtils.getField(scheduler, "schedule")).isEqualTo("0 */5 * * * *"));
+            .satisfies(scheduler -> {
+                assertThat(ReflectionTestUtils.getField(scheduler, "schedule")).isEqualTo("*/60 * * * * *");
+                assertThat(ReflectionTestUtils.getField(scheduler, "minimumInterval")).isEqualTo(300_000L);
+            });
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-dynamic-properties/src/test/java/io/gravitee/rest/api/services/dynamicproperties/DynamicPropertySchedulerTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-dynamic-properties/src/test/java/io/gravitee/rest/api/services/dynamicproperties/DynamicPropertySchedulerTest.java
@@ -26,6 +26,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
+import io.gravitee.common.cron.CronTrigger;
 import io.gravitee.definition.model.Properties;
 import io.gravitee.definition.model.Property;
 import io.gravitee.node.api.cluster.ClusterManager;
@@ -53,6 +54,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
@@ -87,7 +89,7 @@ public class DynamicPropertySchedulerTest {
 
     @BeforeEach
     public void beforeEach() {
-        when(clusterManager.self()).thenReturn(new StandaloneMember());
+        lenient().when(clusterManager.self()).thenReturn(new StandaloneMember());
         properties.setProperties(propertiesList);
 
         existingApi = new ApiEntity();
@@ -186,5 +188,23 @@ public class DynamicPropertySchedulerTest {
 
         verify(apiService, never()).update(any(), any(), any(), eq(false), eq(false), eq(true));
         verify(apiService, never()).deploy(any(), any(), any(), any(), any());
+    }
+
+    @Test
+    void should_defer_next_execution_until_minimum_interval_has_elapsed() {
+        var cronTrigger = org.mockito.Mockito.mock(CronTrigger.class);
+        when(cronTrigger.nextExecutionIn()).thenReturn(500L);
+        dynamicPropertyScheduler = DynamicPropertyScheduler.builder()
+            .schedule("* * * * * *")
+            .minimumInterval(5_000L)
+            .clusterManager(clusterManager)
+            .apiService(apiService)
+            .api(existingApi)
+            .executionContext(executionContext)
+            .apiConverter(apiConverter)
+            .build();
+        ReflectionTestUtils.setField(dynamicPropertyScheduler, "lastExecutionNanos", System.nanoTime() - TimeUnit.SECONDS.toNanos(1));
+
+        assertThat(dynamicPropertyScheduler.nextExecutionIn(cronTrigger)).isBetween(501L, 4_000L);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/src/main/resources/config/gravitee.yml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/src/main/resources/config/gravitee.yml
@@ -286,23 +286,23 @@ services:
   auto_fetch:
     enabled: true
     cron: "0 */5 * * * *"
-    # Limit user-configured documentation fetch cron frequency. Empty means no limit.
-    # cron_limit: "0 */5 * * * *"
+    # Minimum interval between user-configured documentation fetches in milliseconds. 0 means no limit.
+    minimum_interval: 0
 
   # Dynamic properties service.
   dynamic_properties:
-    # Limit user-configured dynamic properties cron frequency. Empty means no limit.
-    # cron_limit: "0 */5 * * * *"
+    # Minimum interval between dynamic properties updates in milliseconds. 0 means no limit.
+    minimum_interval: 0
 
   # Dynamic dictionaries service.
   dictionary:
-    # Limit user-configured dynamic dictionary polling delay in milliseconds. 0 means no limit.
-    delay_limit: 0
+    # Minimum interval between dynamic dictionary updates in milliseconds. 0 means no limit.
+    minimum_interval: 0
 
   # Health-check service.
   healthcheck:
-    # Limit user-configured health-check cron frequency. Empty means no limit.
-    # cron_limit: "0 */5 * * * *"
+    # Minimum interval between user-configured health checks in milliseconds. 0 means no limit.
+    minimum_interval: 0
 
   # Subscription service
   subscription:

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/src/main/resources/config/gravitee.yml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/src/main/resources/config/gravitee.yml
@@ -286,6 +286,23 @@ services:
   auto_fetch:
     enabled: true
     cron: "0 */5 * * * *"
+    # Limit user-configured documentation fetch cron frequency. Empty means no limit.
+    # cron_limit: "0 */5 * * * *"
+
+  # Dynamic properties service.
+  dynamic_properties:
+    # Limit user-configured dynamic properties cron frequency. Empty means no limit.
+    # cron_limit: "0 */5 * * * *"
+
+  # Dynamic dictionaries service.
+  dictionary:
+    # Limit user-configured dynamic dictionary polling delay in milliseconds. 0 means no limit.
+    delay_limit: 0
+
+  # Health-check service.
+  healthcheck:
+    # Limit user-configured health-check cron frequency. Empty means no limit.
+    # cron_limit: "0 */5 * * * *"
 
   # Subscription service
   subscription:

--- a/package.json
+++ b/package.json
@@ -204,7 +204,7 @@
         "console:build": "NODE_OPTIONS=--max_old_space_size=7168 nx build console",
         "console:build:prod": "NODE_OPTIONS=--max_old_space_size=7168 nx build console --configuration=production",
         "console:test": "nx test console",
-        "console:test:ci": "node --max-old-space-size=10240 --expose-gc ./node_modules/.bin/jest --config gravitee-apim-console-webui/jest.config.js --ci --maxWorkers=7 --collectCoverage=true --logHeapUsage",
+        "console:test:ci": "node --max-old-space-size=10240 --expose-gc ./node_modules/.bin/jest --config gravitee-apim-console-webui/jest.config.js --ci --maxWorkers=7 --collectCoverage=true --logHeapUsage && node scripts/rewrite-lcov-for-sonar.js gravitee-apim-console-webui",
         "console:storybook": "nx storybook console",
         "portal-next:serve": "NODE_OPTIONS=--max_old_space_size=7168 nx serve portal-next",
         "portal-next:serve:apim-master": "BACKEND_ENV=apim-master-api.team-apim.gravitee.dev NODE_OPTIONS=--max_old_space_size=7168 nx serve portal-next",


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-14126

## Description

Adds configurable minimum schedule limits for cron-based management API jobs and rejects user configurations that run more frequently than those limits.

This covers dynamic properties, dynamic dictionaries, documentation auto-fetch, and health checks. Runtime scheduling also keeps the slower schedule as a fallback safeguard.

## Additional context

Tested with targeted Maven tests in a Java 21 container for the updated validation paths and scheduler runtime behavior.