### PR TITLE
perf(repository): compound {plan, updatedAt} index for subscription search (APIM-14091)

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/index/subscriptions/PlanUpdatedAtAscIndexUpgrader.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/index/subscriptions/PlanUpdatedAtAscIndexUpgrader.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.mongodb.management.upgrade.upgrader.index.subscriptions;
+
+import io.gravitee.repository.mongodb.management.upgrade.upgrader.index.Index;
+import io.gravitee.repository.mongodb.management.upgrade.upgrader.index.IndexUpgrader;
+import org.springframework.stereotype.Component;
+
+@Component("SubscriptionsPlanUpdatedAtAscIndexUpgrader")
+public class PlanUpdatedAtAscIndexUpgrader extends IndexUpgrader {
+
+    @Override
+    protected Index buildIndex() {
+        return Index.builder()
+            .collection("subscriptions")
+            .name("p1ua1")
+            .key("plan", ascending())
+            .key("updatedAt", ascending())
+            .build();
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/test/java/io/gravitee/repository/mongodb/management/MongoSubscriptionPlanIndexTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/test/java/io/gravitee/repository/mongodb/management/MongoSubscriptionPlanIndexTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.mongodb.management;
+
+import static com.mongodb.client.model.Aggregates.match;
+import static com.mongodb.client.model.Aggregates.sort;
+import static com.mongodb.client.model.Filters.in;
+import static com.mongodb.client.model.Sorts.ascending;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.repository.management.AbstractManagementRepositoryTest;
+import jakarta.inject.Inject;
+import java.util.List;
+import java.util.Optional;
+import org.bson.Document;
+import org.bson.conversions.Bson;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.mongodb.core.MongoTemplate;
+
+public class MongoSubscriptionPlanIndexTest extends AbstractManagementRepositoryTest {
+
+    private static final String EXPECTED_INDEX_NAME = "p1ua1";
+
+    @Inject
+    private MongoTemplate mongoTemplate;
+
+    @Value("${management.mongodb.prefix:}")
+    private String tablePrefix;
+
+    @Override
+    protected String getTestCasesPath() {
+        return "/data/subscription-tests/";
+    }
+
+    /**
+     * Mirrors the production query in
+     * {@link io.gravitee.repository.mongodb.management.internal.plan.SubscriptionMongoRepositoryImpl#search}
+     * for callers that pass a multi-value {@code plans} criterion and sort ascending on {@code updatedAt}
+     * (e.g. {@code ApiProductSubscriptionRefresher.loadSubscriptionModels}, {@code SubscriptionFetcher.fetchLatest}).
+     */
+    @Test
+    public void searchByPlanListSortedByUpdatedAtAsc_shouldUseCompoundIndex() {
+        List<Bson> pipeline = List.of(match(in("plan", List.of("plan3", "plan4"))), sort(ascending("updatedAt")));
+
+        Document explain = mongoTemplate.getCollection(tablePrefix + "subscriptions").aggregate(pipeline).explain();
+
+        Optional<Document> winningPlan = findFirst(explain, "winningPlan");
+        Optional<String> indexName = winningPlan.flatMap(plan -> findFirst(plan, "indexName")).map(Object::toString);
+
+        assertThat(indexName)
+            .as("winning plan should use the %s compound index. Explain: %s", EXPECTED_INDEX_NAME, explain.toJson())
+            .contains(EXPECTED_INDEX_NAME);
+    }
+
+    /** Depth-first search for the first occurrence of {@code key} in {@code root} (a BSON document tree). */
+    @SuppressWarnings("unchecked")
+    private static <T> Optional<T> findFirst(Object root, String key) {
+        if (root instanceof Document doc) {
+            Object direct = doc.get(key);
+            if (direct != null) {
+                return Optional.of((T) direct);
+            }
+            for (Object child : doc.values()) {
+                Optional<T> nested = findFirst(child, key);
+                if (nested.isPresent()) {
+                    return nested;
+                }
+            }
+        } else if (root instanceof Iterable<?> iterable) {
+            for (Object child : iterable) {
+                Optional<T> nested = findFirst(child, key);
+                if (nested.isPresent()) {
+                    return nested;
+                }
+            }
+        }
+        return Optional.empty();
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a new MongoDB compound index `{plan: 1, updatedAt: 1}` (named `p1ua1`) on the `subscriptions` collection via a new `IndexUpgrader`.
- Targets the hot path in `ApiProductSubscriptionRefresher.loadSubscriptionModels` and `SubscriptionFetcher.fetchLatest`, which filter on a multi-value `plans` predicate and sort `updatedAt` ASC. The existing single-key indexes (`p1`, `ua1`) force the planner into either a blocking SORT or a residual filter — both degrade under realistic plan cardinality.
- Equality prefix on `plan` + matching sort suffix on `updatedAt` lets the planner seek per-plan and walk `updatedAt` in order, no in-memory sort.

## Test plan

- [x] New repository test `MongoSubscriptionPlanIndexTest` runs the exact aggregation shape (`$match: plan IN […]`, `$sort: updatedAt: 1`) against a real MongoDB Testcontainer and asserts via `explain()` that the **winning plan** uses the new `p1ua1` index.
- [x] Cross-DB `SubscriptionRepositoryTest` and `MongoSubscriptionRepositoryTest` still green (49/49 with the new test included).
- [x] Confirmed `notablescan=true` in the test container — any non-indexed query would have failed setup.

Refs: [APIM-14091](https://gravitee.atlassian.net/browse/APIM-14091)

[APIM-14091]: https://gravitee.atlassian.net/browse/APIM-14091?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ