### PR TITLE
feat(repository-mongodb): add compound index for catalog category filtering

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/index/apis/EnvironmentIdCategoriesNameIndexUpgrader.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/index/apis/EnvironmentIdCategoriesNameIndexUpgrader.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.mongodb.management.upgrade.upgrader.index.apis;
+
+import io.gravitee.repository.mongodb.management.upgrade.upgrader.index.Index;
+import io.gravitee.repository.mongodb.management.upgrade.upgrader.index.IndexUpgrader;
+import org.springframework.stereotype.Component;
+
+@Component("ApisEnvironmentIdCategoriesNameIndexUpgrader")
+public class EnvironmentIdCategoriesNameIndexUpgrader extends IndexUpgrader {
+
+    @Override
+    protected Index buildIndex() {
+        return Index.builder()
+            .collection("apis")
+            .name("ei1c1n1")
+            .key("environmentId", ascending())
+            .key("categories", ascending())
+            .key("name", ascending())
+            .build();
+    }
+}


### PR DESCRIPTION
## Summary
- Adds a new MongoDB compound index `ei1c1n1` on the `apis` collection: `{environmentId:1, categories:1, name:1}` (equality, equality (multikey), then sort).
- Targets the portal catalog query shape: filter by `environmentId` + `categories $in [...]`, sorted by `name`. Today the planner picks one of `c1` or `ei1n1dv1` and pays residuals.
- New upgrader: `EnvironmentIdCategoriesNameIndexUpgrader` (Spring bean `ApisEnvironmentIdCategoriesNameIndexUpgrader`), following the existing naming convention used for sibling apis-collection upgraders.
- The existing single-field `c1` index is **intentionally kept** — the ticket flags dropping it as optional and gated on production metrics, so this PR is purely additive.

Jira: [APIM-14092](https://gravitee.atlassian.net/browse/APIM-14092)

## Test plan
- [x] `mvn clean compile` on `gravitee-apim-repository-mongodb` passes
- [ ] Manual smoke: portal catalog page loads identically (per ticket acceptance)
- [ ] On a Mongo instance, after upgrade, `db.apis.getIndexes()` lists `ei1c1n1`
- [ ] `db.apis.find({environmentId:"X", categories:{$in:["Y"]}}).sort({name:1}).explain()` reports `IXSCAN` on `ei1c1n1`

## Notes
- No repository test was added: the module has no existing precedent for `explain()`-based index-usage assertions, and the ticket's stated acceptance is manual smoke. Happy to bootstrap one (Testcontainers + custom harness) if reviewers prefer.
- Risk: multikey index slightly larger on disk than `c1` — accepted per ticket.

[APIM-14092]: https://gravitee.atlassian.net/browse/APIM-14092?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ