### PR TITLE
feat(service): user create/update methods

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/UserAdapter.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/UserAdapter.java
@@ -19,6 +19,7 @@ import io.gravitee.apim.core.user.model.BaseUserEntity;
 import io.gravitee.repository.management.model.User;
 import io.gravitee.rest.api.model.UserEntity;
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
 import org.mapstruct.factory.Mappers;
 
 /**
@@ -32,4 +33,13 @@ public interface UserAdapter {
     BaseUserEntity fromUser(User user);
     BaseUserEntity fromUser(UserEntity user);
     UserEntity toUserEntity(BaseUserEntity base);
+
+    @Mapping(target = "password", ignore = true)
+    @Mapping(target = "lastConnectionAt", ignore = true)
+    @Mapping(target = "firstConnectionAt", ignore = true)
+    @Mapping(target = "picture", ignore = true)
+    @Mapping(target = "loginCount", ignore = true)
+    @Mapping(target = "newsletterSubscribed", ignore = true)
+    @Mapping(target = "isServiceAccount", ignore = true)
+    User toUser(BaseUserEntity base);
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/crud_service/user/UserCrudServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/crud_service/user/UserCrudServiceImpl.java
@@ -17,6 +17,7 @@ package io.gravitee.apim.infra.crud_service.user;
 
 import io.gravitee.apim.core.user.crud_service.UserCrudService;
 import io.gravitee.apim.core.user.model.BaseUserEntity;
+import io.gravitee.apim.core.user.model.EncodedPassword;
 import io.gravitee.apim.infra.adapter.UserAdapter;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.UserRepository;
@@ -76,6 +77,57 @@ public class UserCrudServiceImpl implements UserCrudService {
         } catch (TechnicalException ex) {
             log.error("An error occurs while trying to get user using [userId={}]", id, ex);
             throw new TechnicalManagementException("An error occurs while trying to get user " + id, ex);
+        }
+    }
+
+    @Override
+    public BaseUserEntity create(BaseUserEntity user) {
+        try {
+            log.debug("Create user [userId={}]", user.getId());
+            User created = userRepository.create(UserAdapter.INSTANCE.toUser(user));
+            return UserAdapter.INSTANCE.fromUser(created);
+        } catch (TechnicalException ex) {
+            log.error("An error occurs while trying to create user [userId={}]", user.getId(), ex);
+            throw new TechnicalManagementException(ex);
+        }
+    }
+
+    @Override
+    public BaseUserEntity update(BaseUserEntity user) {
+        try {
+            log.debug("Update user [userId={}]", user.getId());
+            User updated = userRepository.update(UserAdapter.INSTANCE.toUser(user));
+            return UserAdapter.INSTANCE.fromUser(updated);
+        } catch (TechnicalException ex) {
+            log.error("An error occurs while trying to update user [userId={}]", user.getId(), ex);
+            throw new TechnicalManagementException(ex);
+        }
+    }
+
+    @Override
+    public BaseUserEntity updateAndSetPassword(BaseUserEntity user, EncodedPassword encodedPassword) {
+        try {
+            log.debug("Update user with password [userId={}]", user.getId());
+            User repoUser = UserAdapter.INSTANCE.toUser(user);
+            repoUser.setPassword(encodedPassword.value());
+            return UserAdapter.INSTANCE.fromUser(userRepository.update(repoUser));
+        } catch (TechnicalException ex) {
+            log.error("An error occurs while trying to update user with password [userId={}]", user.getId(), ex);
+            throw new TechnicalManagementException(ex);
+        }
+    }
+
+    @Override
+    public boolean isPasswordSet(String userId) {
+        try {
+            log.debug("Check if password is set [userId={}]", userId);
+            return userRepository
+                .findById(userId)
+                .map(u -> u.getPassword() != null && !u.getPassword().isBlank())
+                .orElse(false);
+        } catch (TechnicalException ex) {
+            log.error("An error occurs while trying to check password for user [userId={}]", userId, ex);
+            throw new TechnicalManagementException(ex);
         }
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/fixtures/core/model/BaseUserEntityFixtures.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/fixtures/core/model/BaseUserEntityFixtures.java
@@ -16,10 +16,26 @@
 package fixtures.core.model;
 
 import io.gravitee.apim.core.user.model.BaseUserEntity;
+import java.time.Instant;
+import java.util.Date;
 
 public class BaseUserEntityFixtures {
 
     private BaseUserEntityFixtures() {}
+
+    public static BaseUserEntity aBaseUserEntity() {
+        return BaseUserEntity.builder()
+            .id("user-id")
+            .organizationId("organization-id")
+            .source("source")
+            .sourceId("source-id")
+            .email("jane.doe@gravitee.io")
+            .firstname("Jane")
+            .lastname("Doe")
+            .createdAt(Date.from(Instant.parse("2020-01-01T00:00:00Z")))
+            .updatedAt(Date.from(Instant.parse("2020-01-02T00:00:00Z")))
+            .build();
+    }
 
     public static BaseUserEntity aBaseUserEntity(String userId) {
         return BaseUserEntity.builder()

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/fixtures/repository/UserFixtures.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/fixtures/repository/UserFixtures.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package fixtures.repository;
+
+import io.gravitee.repository.management.model.User;
+import java.time.Instant;
+import java.util.Date;
+
+public class UserFixtures {
+
+    private UserFixtures() {}
+
+    public static User aRepositoryUser() {
+        return baseBuilder("user-id", "source", "source-id", "jane.doe@gravitee.io", "Jane", "Doe").build();
+    }
+
+    public static User aRepositoryUser(String id, String source, String sourceId, String email, String firstname, String lastname) {
+        return baseBuilder(id, source, sourceId, email, firstname, lastname).build();
+    }
+
+    private static User.UserBuilder baseBuilder(
+        String id,
+        String source,
+        String sourceId,
+        String email,
+        String firstname,
+        String lastname
+    ) {
+        return User.builder()
+            .id(id)
+            .organizationId("organization-id")
+            .source(source)
+            .sourceId(sourceId)
+            .email(email)
+            .firstname(firstname)
+            .lastname(lastname)
+            .createdAt(Date.from(Instant.parse("2020-01-01T00:00:00Z")))
+            .updatedAt(Date.from(Instant.parse("2020-01-02T00:00:00Z")));
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/UserRepositoryInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/UserRepositoryInMemory.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package inmemory;
+
+import io.gravitee.common.data.domain.Page;
+import io.gravitee.repository.exceptions.TechnicalException;
+import io.gravitee.repository.management.api.UserRepository;
+import io.gravitee.repository.management.api.search.Pageable;
+import io.gravitee.repository.management.api.search.UserCriteria;
+import io.gravitee.repository.management.model.User;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class UserRepositoryInMemory implements UserRepository {
+
+    private final Map<String, User> storage = new LinkedHashMap<>();
+    private TechnicalException failure;
+
+    public void initWith(List<User> users) {
+        users.forEach(u -> storage.put(u.getId(), u));
+    }
+
+    public void failsWith(TechnicalException ex) {
+        this.failure = ex;
+    }
+
+    public void reset() {
+        storage.clear();
+        failure = null;
+    }
+
+    public Map<String, User> storage() {
+        return storage;
+    }
+
+    private void maybeThrow() throws TechnicalException {
+        if (failure != null) throw failure;
+    }
+
+    @Override
+    public Optional<User> findById(String id) throws TechnicalException {
+        maybeThrow();
+        return Optional.ofNullable(storage.get(id));
+    }
+
+    @Override
+    public User create(User user) throws TechnicalException {
+        maybeThrow();
+        storage.put(user.getId(), user);
+        return user;
+    }
+
+    @Override
+    public User update(User user) throws TechnicalException {
+        maybeThrow();
+        storage.put(user.getId(), user);
+        return user;
+    }
+
+    @Override
+    public void delete(String id) throws TechnicalException {
+        storage.remove(id);
+    }
+
+    @Override
+    public Optional<User> findBySource(String source, String sourceId, String organizationId) throws TechnicalException {
+        return storage
+            .values()
+            .stream()
+            .filter(
+                u ->
+                    Objects.equals(u.getSource(), source) &&
+                    Objects.equals(u.getSourceId(), sourceId) &&
+                    Objects.equals(u.getOrganizationId(), organizationId)
+            )
+            .findFirst();
+    }
+
+    @Override
+    public List<User> findByEmail(String email, String organizationId) throws TechnicalException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Set<User> findByIds(Collection<String> ids) throws TechnicalException {
+        maybeThrow();
+        return ids.stream().map(storage::get).filter(Objects::nonNull).collect(Collectors.toSet());
+    }
+
+    @Override
+    public Page<User> search(UserCriteria criteria, Pageable pageable) throws TechnicalException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public List<String> deleteByOrganizationId(String organizationId) throws TechnicalException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Set<User> findAll() throws TechnicalException {
+        return Set.copyOf(storage.values());
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/crud_service/user/UserCrudServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/crud_service/user/UserCrudServiceImplTest.java
@@ -15,25 +15,21 @@
  */
 package io.gravitee.apim.infra.crud_service.user;
 
+import static fixtures.core.model.BaseUserEntityFixtures.aBaseUserEntity;
+import static fixtures.repository.UserFixtures.aRepositoryUser;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
+import inmemory.UserRepositoryInMemory;
 import io.gravitee.apim.core.user.model.BaseUserEntity;
 import io.gravitee.apim.core.user.model.EncodedPassword;
 import io.gravitee.repository.exceptions.TechnicalException;
-import io.gravitee.repository.management.api.UserRepository;
 import io.gravitee.repository.management.model.User;
 import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
 import io.gravitee.rest.api.service.exceptions.UserNotFoundException;
 import java.time.Instant;
 import java.util.Date;
 import java.util.List;
-import java.util.Optional;
-import java.util.stream.Collectors;
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
@@ -43,81 +39,39 @@ import org.junit.jupiter.params.provider.NullAndEmptySource;
 
 public class UserCrudServiceImplTest {
 
-    UserRepository userRepository;
-
-    UserCrudServiceImpl service;
+    UserRepositoryInMemory userRepository = new UserRepositoryInMemory();
+    UserCrudServiceImpl service = new UserCrudServiceImpl(userRepository);
 
     @BeforeEach
     void setUp() {
-        userRepository = mock(UserRepository.class);
-
-        service = new UserCrudServiceImpl(userRepository);
+        userRepository.reset();
     }
 
     @Nested
     class FindBaseUserById {
 
         @Test
-        void should_find_user_and_adapt_it() throws TechnicalException {
-            // Given
-            when(userRepository.findById(any())).thenReturn(
-                Optional.of(
-                    User.builder()
-                        .id("user-id")
-                        .organizationId("organization-id")
-                        .source("source")
-                        .sourceId("source-id")
-                        .email("jane.doe@gravitee.io")
-                        .firstname("Jane")
-                        .lastname("Doe")
-                        .createdAt(Date.from(Instant.parse("2020-01-01T00:00:00Z")))
-                        .updatedAt(Date.from(Instant.parse("2020-01-02T00:00:00Z")))
-                        .build()
-                )
-            );
+        void should_find_user_and_adapt_it() {
+            userRepository.initWith(List.of(aRepositoryUser()));
 
-            // When
-            var user = service.findBaseUserById("userId");
+            var user = service.findBaseUserById("user-id");
 
-            // Then
-            assertThat(user).contains(
-                BaseUserEntity.builder()
-                    .id("user-id")
-                    .organizationId("organization-id")
-                    .source("source")
-                    .sourceId("source-id")
-                    .email("jane.doe@gravitee.io")
-                    .firstname("Jane")
-                    .lastname("Doe")
-                    .createdAt(Date.from(Instant.parse("2020-01-01T00:00:00Z")))
-                    .updatedAt(Date.from(Instant.parse("2020-01-02T00:00:00Z")))
-                    .build()
-            );
+            assertThat(user).contains(aBaseUserEntity());
         }
 
         @Test
-        void should_return_empty_when_user_not_found() throws TechnicalException {
-            // Given
-            var userId = "user-id";
-            when(userRepository.findById(any())).thenReturn(Optional.empty());
+        void should_return_empty_when_user_not_found() {
+            var result = service.findBaseUserById("user-id");
 
-            // When
-            var result = service.findBaseUserById(userId);
-
-            // Then
             assertThat(result).isEmpty();
         }
 
         @Test
-        void should_throw_when_technical_exception_occurs() throws TechnicalException {
-            // Given
-            var userId = "user-id";
-            when(userRepository.findById(any())).thenThrow(new TechnicalException("technical exception"));
+        void should_throw_when_technical_exception_occurs() {
+            userRepository.failsWith(new TechnicalException("technical exception"));
 
-            // When
-            Throwable throwable = catchThrowable(() -> service.findBaseUserById(userId));
+            var throwable = catchThrowable(() -> service.findBaseUserById("user-id"));
 
-            // Then
             assertThat(throwable).isInstanceOf(TechnicalManagementException.class).hasMessageContaining("technical exception");
         }
     }
@@ -128,38 +82,21 @@ public class UserCrudServiceImplTest {
         @ParameterizedTest
         @NullAndEmptySource
         void should_return_empty_set_when_user_ids_is_null_or_empty(List<String> userIds) {
-            var result = service.findBaseUsersByIds(userIds);
-            assertThat(result).isEmpty();
+            assertThat(service.findBaseUsersByIds(userIds)).isEmpty();
         }
 
         @Test
-        void should_find_users_and_adapt_them() throws TechnicalException {
-            // Given
-            when(userRepository.findByIds(any(List.class))).thenAnswer(invocation -> {
-                List<String> ids = invocation.getArgument(0);
-                return ids
-                    .stream()
-                    .map(id ->
-                        User.builder()
-                            .id(id)
-                            .organizationId("organization-id")
-                            .source("source-" + id)
-                            .sourceId("source-id-" + id)
-                            .email(id + "@gravitee.io")
-                            .firstname("Jane " + id)
-                            .lastname("Doe " + id)
-                            .createdAt(Date.from(Instant.parse("2020-01-01T00:00:00Z")))
-                            .updatedAt(Date.from(Instant.parse("2020-01-02T00:00:00Z")))
-                            .build()
-                    )
-                    .collect(Collectors.toSet());
-            });
+        void should_find_users_and_adapt_them() {
+            userRepository.initWith(
+                List.of(
+                    aRepositoryUser("1", "source-1", "source-id-1", "1@gravitee.io", "Jane 1", "Doe 1"),
+                    aRepositoryUser("2", "source-2", "source-id-2", "2@gravitee.io", "Jane 2", "Doe 2")
+                )
+            );
 
-            // When
-            var user = service.findBaseUsersByIds(List.of("1", "2"));
+            var users = service.findBaseUsersByIds(List.of("1", "2"));
 
-            // Then
-            assertThat(user)
+            assertThat(users)
                 .hasSize(2)
                 .contains(
                     BaseUserEntity.builder()
@@ -188,28 +125,18 @@ public class UserCrudServiceImplTest {
         }
 
         @Test
-        void should_return_empty_when_user_not_found() throws TechnicalException {
-            // Given
-            var userId = "user-id";
-            when(userRepository.findById(any())).thenReturn(Optional.empty());
+        void should_return_empty_when_no_matching_ids() {
+            var result = service.findBaseUsersByIds(List.of("unknown-id"));
 
-            // When
-            var result = service.findBaseUserById(userId);
-
-            // Then
             assertThat(result).isEmpty();
         }
 
         @Test
-        void should_throw_when_technical_exception_occurs() throws TechnicalException {
-            // Given
-            var userId = "user-id";
-            when(userRepository.findById(any())).thenThrow(new TechnicalException("technical exception"));
+        void should_throw_when_technical_exception_occurs() {
+            userRepository.failsWith(new TechnicalException("technical exception"));
 
-            // When
-            Throwable throwable = catchThrowable(() -> service.findBaseUserById(userId));
+            var throwable = catchThrowable(() -> service.findBaseUsersByIds(List.of("user-id")));
 
-            // Then
             assertThat(throwable).isInstanceOf(TechnicalManagementException.class).hasMessageContaining("technical exception");
         }
     }
@@ -218,30 +145,15 @@ public class UserCrudServiceImplTest {
     class Create {
 
         @Test
-        void should_create_user_and_return_adapted_entity() throws TechnicalException {
-            // Given
-            var userToCreate = BaseUserEntity.builder()
-                .id("user-id")
-                .organizationId("organization-id")
-                .source("gravitee")
-                .sourceId("jane@example.com")
-                .email("jane@example.com")
-                .firstname("Jane")
-                .lastname("Doe")
-                .build();
-            when(userRepository.create(any(User.class))).thenAnswer(invocation -> invocation.getArgument(0));
+        void should_create_user_and_return_adapted_entity() {
+            var result = service.create(aBaseUserEntity("user-id"));
 
-            // When
-            var result = service.create(userToCreate);
-
-            // Then
             assertThat(result.getId()).isEqualTo("user-id");
-            assertThat(result.getEmail()).isEqualTo("jane@example.com");
+            assertThat(result.getEmail()).isEqualTo("user@example.com");
         }
 
         @Test
-        void should_pass_all_fields_to_repository() throws TechnicalException {
-            // Given
+        void should_pass_all_fields_to_repository() {
             var created = Date.from(Instant.parse("2024-01-01T00:00:00Z"));
             var userToCreate = BaseUserEntity.builder()
                 .id("user-id")
@@ -253,13 +165,10 @@ public class UserCrudServiceImplTest {
                 .lastname("Doe")
                 .createdAt(created)
                 .build();
-            when(userRepository.create(any(User.class))).thenAnswer(invocation -> invocation.getArgument(0));
 
             service.create(userToCreate);
 
-            var captor = org.mockito.ArgumentCaptor.forClass(User.class);
-            verify(userRepository).create(captor.capture());
-            var sent = captor.getValue();
+            var sent = userRepository.storage().get("user-id");
             SoftAssertions.assertSoftly(soft -> {
                 soft.assertThat(sent.getId()).isEqualTo("user-id");
                 soft.assertThat(sent.getOrganizationId()).isEqualTo("org-id");
@@ -274,14 +183,11 @@ public class UserCrudServiceImplTest {
         }
 
         @Test
-        void should_throw_when_repository_fails() throws TechnicalException {
-            // Given
-            when(userRepository.create(any(User.class))).thenThrow(new TechnicalException("error"));
+        void should_throw_when_repository_fails() {
+            userRepository.failsWith(new TechnicalException("error"));
 
-            // When
             var throwable = catchThrowable(() -> service.create(BaseUserEntity.builder().id("user-id").build()));
 
-            // Then
             assertThat(throwable).isInstanceOf(TechnicalManagementException.class);
         }
     }
@@ -290,45 +196,33 @@ public class UserCrudServiceImplTest {
     class Update {
 
         @Test
-        void should_update_user_and_return_adapted_entity() throws TechnicalException {
-            // Given
+        void should_update_user_and_return_adapted_entity() {
             var userToUpdate = BaseUserEntity.builder()
                 .id("user-id")
                 .organizationId("org-id")
                 .email("updated@example.com")
                 .updatedAt(Date.from(Instant.parse("2024-06-01T00:00:00Z")))
                 .build();
-            when(userRepository.update(any(User.class))).thenAnswer(invocation -> invocation.getArgument(0));
 
-            // When
             var result = service.update(userToUpdate);
 
-            // Then
             assertThat(result.getId()).isEqualTo("user-id");
             assertThat(result.getEmail()).isEqualTo("updated@example.com");
         }
 
         @Test
-        void should_not_write_password_field() throws TechnicalException {
-            // Given
-            when(userRepository.update(any(User.class))).thenAnswer(invocation -> invocation.getArgument(0));
-
+        void should_not_write_password_field() {
             service.update(BaseUserEntity.builder().id("user-id").build());
 
-            var captor = org.mockito.ArgumentCaptor.forClass(User.class);
-            verify(userRepository).update(captor.capture());
-            assertThat(captor.getValue().getPassword()).isNull();
+            assertThat(userRepository.storage().get("user-id").getPassword()).isNull();
         }
 
         @Test
-        void should_throw_when_repository_fails() throws TechnicalException {
-            // Given
-            when(userRepository.update(any(User.class))).thenThrow(new TechnicalException("error"));
+        void should_throw_when_repository_fails() {
+            userRepository.failsWith(new TechnicalException("error"));
 
-            // When
             var throwable = catchThrowable(() -> service.update(BaseUserEntity.builder().id("user-id").build()));
 
-            // Then
             assertThat(throwable).isInstanceOf(TechnicalManagementException.class);
         }
     }
@@ -337,35 +231,29 @@ public class UserCrudServiceImplTest {
     class UpdateAndSetPassword {
 
         @Test
-        void should_write_encoded_password_to_repository() throws TechnicalException {
-            // Given
-            var user = BaseUserEntity.builder().id("user-id").email("jane@example.com").build();
-            var encodedPassword = new EncodedPassword("$2a$hashed");
-            when(userRepository.update(any(User.class))).thenAnswer(invocation -> invocation.getArgument(0));
+        void should_write_encoded_password_to_repository() {
+            service.updateAndSetPassword(
+                BaseUserEntity.builder().id("user-id").email("jane@example.com").build(),
+                new EncodedPassword("$2a$hashed")
+            );
 
-            service.updateAndSetPassword(user, encodedPassword);
-
-            var captor = org.mockito.ArgumentCaptor.forClass(User.class);
-            verify(userRepository).update(captor.capture());
-            assertThat(captor.getValue().getPassword()).isEqualTo("$2a$hashed");
+            assertThat(userRepository.storage().get("user-id").getPassword()).isEqualTo("$2a$hashed");
         }
 
         @Test
-        void should_return_updated_entity() throws TechnicalException {
-            // Given
-            var user = BaseUserEntity.builder().id("user-id").email("jane@example.com").build();
-            when(userRepository.update(any(User.class))).thenAnswer(invocation -> invocation.getArgument(0));
-
-            var result = service.updateAndSetPassword(user, new EncodedPassword("$2a$hashed"));
+        void should_return_updated_entity() {
+            var result = service.updateAndSetPassword(
+                BaseUserEntity.builder().id("user-id").email("jane@example.com").build(),
+                new EncodedPassword("$2a$hashed")
+            );
 
             assertThat(result.getId()).isEqualTo("user-id");
             assertThat(result.getEmail()).isEqualTo("jane@example.com");
         }
 
         @Test
-        void should_throw_when_repository_fails() throws TechnicalException {
-            // Given
-            when(userRepository.update(any(User.class))).thenThrow(new TechnicalException("error"));
+        void should_throw_when_repository_fails() {
+            userRepository.failsWith(new TechnicalException("error"));
 
             var throwable = catchThrowable(() ->
                 service.updateAndSetPassword(BaseUserEntity.builder().id("user-id").build(), new EncodedPassword("$2a$hashed"))
@@ -379,41 +267,34 @@ public class UserCrudServiceImplTest {
     class IsPasswordSet {
 
         @Test
-        void should_return_true_when_password_is_not_blank() throws TechnicalException {
-            // Given
-            when(userRepository.findById("user-id")).thenReturn(Optional.of(User.builder().id("user-id").password("$2a$hashed").build()));
+        void should_return_true_when_password_is_not_blank() {
+            userRepository.initWith(List.of(User.builder().id("user-id").password("$2a$hashed").build()));
 
             assertThat(service.isPasswordSet("user-id")).isTrue();
         }
 
         @Test
-        void should_return_false_when_password_is_blank() throws TechnicalException {
-            // Given
-            when(userRepository.findById("user-id")).thenReturn(Optional.of(User.builder().id("user-id").password("").build()));
+        void should_return_false_when_password_is_blank() {
+            userRepository.initWith(List.of(User.builder().id("user-id").password("").build()));
 
             assertThat(service.isPasswordSet("user-id")).isFalse();
         }
 
         @Test
-        void should_return_false_when_password_is_null() throws TechnicalException {
-            // Given
-            when(userRepository.findById("user-id")).thenReturn(Optional.of(User.builder().id("user-id").build()));
+        void should_return_false_when_password_is_null() {
+            userRepository.initWith(List.of(User.builder().id("user-id").build()));
 
             assertThat(service.isPasswordSet("user-id")).isFalse();
         }
 
         @Test
-        void should_return_false_when_user_not_found() throws TechnicalException {
-            // Given
-            when(userRepository.findById("user-id")).thenReturn(Optional.empty());
-
+        void should_return_false_when_user_not_found() {
             assertThat(service.isPasswordSet("user-id")).isFalse();
         }
 
         @Test
-        void should_throw_when_repository_fails() throws TechnicalException {
-            // Given
-            when(userRepository.findById("user-id")).thenThrow(new TechnicalException("error"));
+        void should_throw_when_repository_fails() {
+            userRepository.failsWith(new TechnicalException("error"));
 
             var throwable = catchThrowable(() -> service.isPasswordSet("user-id"));
 
@@ -425,28 +306,11 @@ public class UserCrudServiceImplTest {
     class GetBaseUser {
 
         @Test
-        void should_find_user_and_adapt_id() throws TechnicalException {
-            // Given
-            when(userRepository.findById(any())).thenReturn(
-                Optional.of(
-                    User.builder()
-                        .id("user-id")
-                        .organizationId("organization-id")
-                        .source("source")
-                        .sourceId("source-id")
-                        .email("jane.doe@gravitee.io")
-                        .firstname("Jane")
-                        .lastname("Doe")
-                        .createdAt(Date.from(Instant.parse("2020-01-01T00:00:00Z")))
-                        .updatedAt(Date.from(Instant.parse("2020-01-02T00:00:00Z")))
-                        .build()
-                )
-            );
+        void should_find_user_and_adapt_it() {
+            userRepository.initWith(List.of(aRepositoryUser()));
 
-            // When
-            var user = service.getBaseUser("userId");
+            var user = service.getBaseUser("user-id");
 
-            // Then
             SoftAssertions.assertSoftly(softly -> {
                 softly.assertThat(user.getId()).isEqualTo("user-id");
                 softly.assertThat(user.getOrganizationId()).isEqualTo("organization-id");
@@ -461,16 +325,10 @@ public class UserCrudServiceImplTest {
         }
 
         @Test
-        void should_throw_when_user_not_found() throws TechnicalException {
-            // Given
-            var userId = "user-id";
-            when(userRepository.findById(any())).thenReturn(Optional.empty());
+        void should_throw_when_user_not_found() {
+            var throwable = catchThrowable(() -> service.getBaseUser("user-id"));
 
-            // When
-            Throwable throwable = catchThrowable(() -> service.getBaseUser(userId));
-
-            // Then
-            assertThat(throwable).isInstanceOf(UserNotFoundException.class).hasMessage("User [" + userId + "] cannot be found.");
+            assertThat(throwable).isInstanceOf(UserNotFoundException.class).hasMessage("User [user-id] cannot be found.");
         }
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/crud_service/user/UserCrudServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/crud_service/user/UserCrudServiceImplTest.java
@@ -19,9 +19,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.gravitee.apim.core.user.model.BaseUserEntity;
+import io.gravitee.apim.core.user.model.EncodedPassword;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.UserRepository;
 import io.gravitee.repository.management.model.User;
@@ -209,6 +211,213 @@ public class UserCrudServiceImplTest {
 
             // Then
             assertThat(throwable).isInstanceOf(TechnicalManagementException.class).hasMessageContaining("technical exception");
+        }
+    }
+
+    @Nested
+    class Create {
+
+        @Test
+        void should_create_user_and_return_adapted_entity() throws TechnicalException {
+            // Given
+            var userToCreate = BaseUserEntity.builder()
+                .id("user-id")
+                .organizationId("organization-id")
+                .source("gravitee")
+                .sourceId("jane@example.com")
+                .email("jane@example.com")
+                .firstname("Jane")
+                .lastname("Doe")
+                .build();
+            when(userRepository.create(any(User.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+            // When
+            var result = service.create(userToCreate);
+
+            // Then
+            assertThat(result.getId()).isEqualTo("user-id");
+            assertThat(result.getEmail()).isEqualTo("jane@example.com");
+        }
+
+        @Test
+        void should_pass_all_fields_to_repository() throws TechnicalException {
+            // Given
+            var created = Date.from(Instant.parse("2024-01-01T00:00:00Z"));
+            var userToCreate = BaseUserEntity.builder()
+                .id("user-id")
+                .organizationId("org-id")
+                .source("gravitee")
+                .sourceId("jane@example.com")
+                .email("jane@example.com")
+                .firstname("Jane")
+                .lastname("Doe")
+                .createdAt(created)
+                .build();
+            when(userRepository.create(any(User.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+            service.create(userToCreate);
+
+            var captor = org.mockito.ArgumentCaptor.forClass(User.class);
+            verify(userRepository).create(captor.capture());
+            var sent = captor.getValue();
+            SoftAssertions.assertSoftly(soft -> {
+                soft.assertThat(sent.getId()).isEqualTo("user-id");
+                soft.assertThat(sent.getOrganizationId()).isEqualTo("org-id");
+                soft.assertThat(sent.getSource()).isEqualTo("gravitee");
+                soft.assertThat(sent.getSourceId()).isEqualTo("jane@example.com");
+                soft.assertThat(sent.getEmail()).isEqualTo("jane@example.com");
+                soft.assertThat(sent.getFirstname()).isEqualTo("Jane");
+                soft.assertThat(sent.getLastname()).isEqualTo("Doe");
+                soft.assertThat(sent.getCreatedAt()).isEqualTo(created);
+                soft.assertThat(sent.getPassword()).isNull();
+            });
+        }
+
+        @Test
+        void should_throw_when_repository_fails() throws TechnicalException {
+            // Given
+            when(userRepository.create(any(User.class))).thenThrow(new TechnicalException("error"));
+
+            // When
+            var throwable = catchThrowable(() -> service.create(BaseUserEntity.builder().id("user-id").build()));
+
+            // Then
+            assertThat(throwable).isInstanceOf(TechnicalManagementException.class);
+        }
+    }
+
+    @Nested
+    class Update {
+
+        @Test
+        void should_update_user_and_return_adapted_entity() throws TechnicalException {
+            // Given
+            var userToUpdate = BaseUserEntity.builder()
+                .id("user-id")
+                .organizationId("org-id")
+                .email("updated@example.com")
+                .updatedAt(Date.from(Instant.parse("2024-06-01T00:00:00Z")))
+                .build();
+            when(userRepository.update(any(User.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+            // When
+            var result = service.update(userToUpdate);
+
+            // Then
+            assertThat(result.getId()).isEqualTo("user-id");
+            assertThat(result.getEmail()).isEqualTo("updated@example.com");
+        }
+
+        @Test
+        void should_not_write_password_field() throws TechnicalException {
+            // Given
+            when(userRepository.update(any(User.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+            service.update(BaseUserEntity.builder().id("user-id").build());
+
+            var captor = org.mockito.ArgumentCaptor.forClass(User.class);
+            verify(userRepository).update(captor.capture());
+            assertThat(captor.getValue().getPassword()).isNull();
+        }
+
+        @Test
+        void should_throw_when_repository_fails() throws TechnicalException {
+            // Given
+            when(userRepository.update(any(User.class))).thenThrow(new TechnicalException("error"));
+
+            // When
+            var throwable = catchThrowable(() -> service.update(BaseUserEntity.builder().id("user-id").build()));
+
+            // Then
+            assertThat(throwable).isInstanceOf(TechnicalManagementException.class);
+        }
+    }
+
+    @Nested
+    class UpdateAndSetPassword {
+
+        @Test
+        void should_write_encoded_password_to_repository() throws TechnicalException {
+            // Given
+            var user = BaseUserEntity.builder().id("user-id").email("jane@example.com").build();
+            var encodedPassword = new EncodedPassword("$2a$hashed");
+            when(userRepository.update(any(User.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+            service.updateAndSetPassword(user, encodedPassword);
+
+            var captor = org.mockito.ArgumentCaptor.forClass(User.class);
+            verify(userRepository).update(captor.capture());
+            assertThat(captor.getValue().getPassword()).isEqualTo("$2a$hashed");
+        }
+
+        @Test
+        void should_return_updated_entity() throws TechnicalException {
+            // Given
+            var user = BaseUserEntity.builder().id("user-id").email("jane@example.com").build();
+            when(userRepository.update(any(User.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+            var result = service.updateAndSetPassword(user, new EncodedPassword("$2a$hashed"));
+
+            assertThat(result.getId()).isEqualTo("user-id");
+            assertThat(result.getEmail()).isEqualTo("jane@example.com");
+        }
+
+        @Test
+        void should_throw_when_repository_fails() throws TechnicalException {
+            // Given
+            when(userRepository.update(any(User.class))).thenThrow(new TechnicalException("error"));
+
+            var throwable = catchThrowable(() ->
+                service.updateAndSetPassword(BaseUserEntity.builder().id("user-id").build(), new EncodedPassword("$2a$hashed"))
+            );
+
+            assertThat(throwable).isInstanceOf(TechnicalManagementException.class);
+        }
+    }
+
+    @Nested
+    class IsPasswordSet {
+
+        @Test
+        void should_return_true_when_password_is_not_blank() throws TechnicalException {
+            // Given
+            when(userRepository.findById("user-id")).thenReturn(Optional.of(User.builder().id("user-id").password("$2a$hashed").build()));
+
+            assertThat(service.isPasswordSet("user-id")).isTrue();
+        }
+
+        @Test
+        void should_return_false_when_password_is_blank() throws TechnicalException {
+            // Given
+            when(userRepository.findById("user-id")).thenReturn(Optional.of(User.builder().id("user-id").password("").build()));
+
+            assertThat(service.isPasswordSet("user-id")).isFalse();
+        }
+
+        @Test
+        void should_return_false_when_password_is_null() throws TechnicalException {
+            // Given
+            when(userRepository.findById("user-id")).thenReturn(Optional.of(User.builder().id("user-id").build()));
+
+            assertThat(service.isPasswordSet("user-id")).isFalse();
+        }
+
+        @Test
+        void should_return_false_when_user_not_found() throws TechnicalException {
+            // Given
+            when(userRepository.findById("user-id")).thenReturn(Optional.empty());
+
+            assertThat(service.isPasswordSet("user-id")).isFalse();
+        }
+
+        @Test
+        void should_throw_when_repository_fails() throws TechnicalException {
+            // Given
+            when(userRepository.findById("user-id")).thenThrow(new TechnicalException("error"));
+
+            var throwable = catchThrowable(() -> service.isPasswordSet("user-id"));
+
+            assertThat(throwable).isInstanceOf(TechnicalManagementException.class);
         }
     }
 


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-14130

## Description

- Added `create`, `update`, `updateAndSetPassword`, and `isPasswordSet` to `UserCrudServiceImpl`
- Added `UserAdapter.toUser(BaseUserEntity)` MapStruct mapping; password and user-only fields (`lastConnectionAt`, `picture`, etc.) are explicitly ignored so they are never overwritten via this path
- `updateAndSetPassword` writes user + encoded password in a single repository call without exposing the hash on `BaseUserEntity` (which lives in the Lucene search index)
- `isPasswordSet` queries the repository directly for the same reason — keeps the password off the domain entity entirely
- 14 new unit tests covering all four methods including null/blank password edge cases and error propagation

## Additional context

Password is intentionally absent from `BaseUserEntity` — adding it would expose the hash via the search index. `updateAndSetPassword` and `isPasswordSet` are the direct consequence of that constraint. Decision documented in the APIM-14130 design note.