### PR TITLE
feat(service): implement CreateUserDomainService

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/group/GroupsResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/group/GroupsResourceTest.java
@@ -30,6 +30,7 @@ import static org.mockito.Mockito.when;
 import io.gravitee.apim.core.group.model.crd.GroupCRDStatus;
 import io.gravitee.apim.core.membership.model.Role;
 import io.gravitee.apim.core.user.model.BaseUserEntity;
+import io.gravitee.apim.core.user.model.IdpSource;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.rest.api.management.v2.rest.mapper.GroupMapper;
 import io.gravitee.rest.api.management.v2.rest.mapper.MemberMapper;
@@ -335,7 +336,7 @@ public class GroupsResourceTest extends AbstractResourceTest {
                     BaseUserEntity.builder()
                         .organizationId(ORGANIZATION)
                         .sourceId("api1")
-                        .source("memory")
+                        .source(IdpSource.MEMORY)
                         .id("46f5c533-f083-4885-bbac-7bd9907d9aec")
                         .build()
                 )

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/invitation/use_case/AcceptUserInvitationUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/invitation/use_case/AcceptUserInvitationUseCase.java
@@ -75,7 +75,7 @@ public class AcceptUserInvitationUseCase {
             .existingUserId()
             .map(userId -> findAndValidateExistingUser(userId, input.executionContext()))
             .orElseGet(() ->
-                createUserDomainService.createExternalUser(
+                createUserDomainService.createGraviteeUser(
                     input.executionContext(),
                     input.action().email(),
                     input.firstname(),

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/promotion/use_case/CreatePromotionUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/promotion/use_case/CreatePromotionUseCase.java
@@ -142,7 +142,7 @@ public class CreatePromotionUseCase {
                         .userId(authenticatedUser.getId())
                         .displayName(authenticatedUser.displayName())
                         .email(authenticatedUser.getEmail())
-                        .source(authenticatedUser.getSource())
+                        .source(authenticatedUser.getSource() != null ? authenticatedUser.getSource().value() : null)
                         .sourceId(authenticatedUser.getSourceId())
                         .build()
                 )

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/user/domain_service/CreateUserDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/user/domain_service/CreateUserDomainService.java
@@ -20,7 +20,7 @@ import io.gravitee.rest.api.service.common.ExecutionContext;
 import java.util.Optional;
 
 public interface CreateUserDomainService {
-    BaseUserEntity createExternalUser(
+    BaseUserEntity createGraviteeUser(
         ExecutionContext executionContext,
         String email,
         Optional<String> firstname,

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/user/model/BaseUserEntity.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/user/model/BaseUserEntity.java
@@ -35,7 +35,7 @@ public class BaseUserEntity {
     private Date createdAt;
     private Date updatedAt;
     /** The source when user is coming from an external system (LDAP, ...) */
-    private String source;
+    private IdpSource source;
     /** The user reference in the external source */
     private String sourceId;
     private String status;
@@ -48,7 +48,7 @@ public class BaseUserEntity {
             return firstname;
         } else if (isNotBlank(lastname)) {
             return lastname;
-        } else if (isNotBlank(email) && !"memory".equals(source)) {
+        } else if (isNotBlank(email) && !IdpSource.MEMORY.equals(source)) {
             return email;
         }
         return sourceId;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/user/model/BaseUserEntity.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/user/model/BaseUserEntity.java
@@ -16,6 +16,8 @@
 package io.gravitee.apim.core.user.model;
 
 import java.util.Date;
+import java.util.Optional;
+import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -39,6 +41,27 @@ public class BaseUserEntity {
     /** The user reference in the external source */
     private String sourceId;
     private String status;
+
+    public static BaseUserEntity createGraviteeUser(
+        String organizationId,
+        String email,
+        Optional<String> firstname,
+        Optional<String> lastname,
+        Date now
+    ) {
+        return BaseUserEntity.builder()
+            .id(UUID.randomUUID().toString())
+            .organizationId(organizationId)
+            .source(IdpSource.GRAVITEE)
+            .sourceId(email)
+            .email(email)
+            .firstname(firstname.orElse(null))
+            .lastname(lastname.orElse(null))
+            .status("ACTIVE")
+            .createdAt(now)
+            .updatedAt(now)
+            .build();
+    }
 
     public String displayName() {
         if (isNotBlank(firstname)) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/user/model/IdpSource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/user/model/IdpSource.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.user.model;
+
+public record IdpSource(String value) {
+    public static final IdpSource GRAVITEE = new IdpSource("gravitee");
+    public static final IdpSource MEMORY = new IdpSource("memory");
+
+    private static final java.util.Map<String, IdpSource> CACHE = java.util.Map.of("gravitee", GRAVITEE, "memory", MEMORY);
+
+    public static IdpSource of(String value) {
+        if (value == null) {
+            return null;
+        }
+        return CACHE.getOrDefault(value, new IdpSource(value));
+    }
+
+    public static IdpSource gravitee() {
+        return GRAVITEE;
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/UserAdapter.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/UserAdapter.java
@@ -16,10 +16,12 @@
 package io.gravitee.apim.infra.adapter;
 
 import io.gravitee.apim.core.user.model.BaseUserEntity;
+import io.gravitee.apim.core.user.model.IdpSource;
 import io.gravitee.repository.management.model.User;
 import io.gravitee.rest.api.model.UserEntity;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
+import org.mapstruct.Named;
 import org.mapstruct.factory.Mappers;
 
 /**
@@ -30,8 +32,28 @@ import org.mapstruct.factory.Mappers;
 public interface UserAdapter {
     UserAdapter INSTANCE = Mappers.getMapper(UserAdapter.class);
 
+    @Mapping(target = "source", source = "source", qualifiedByName = "stringToIdpSource")
     BaseUserEntity fromUser(User user);
+
+    @Mapping(target = "source", source = "source", qualifiedByName = "stringToIdpSource")
     BaseUserEntity fromUser(UserEntity user);
+
+    @Mapping(target = "source", source = "source", qualifiedByName = "idpSourceToString")
+    @Mapping(target = "password", ignore = true)
+    @Mapping(target = "roles", ignore = true)
+    @Mapping(target = "envRoles", ignore = true)
+    @Mapping(target = "picture", ignore = true)
+    @Mapping(target = "lastConnectionAt", ignore = true)
+    @Mapping(target = "firstConnectionAt", ignore = true)
+    @Mapping(target = "primaryOwner", ignore = true)
+    @Mapping(target = "loginCount", ignore = true)
+    @Mapping(target = "nbActiveTokens", ignore = true)
+    @Mapping(target = "newsletterSubscribed", ignore = true)
+    @Mapping(target = "isServiceAccount", ignore = true)
+    @Mapping(target = "customFields", ignore = true)
+    @Mapping(target = "hasPassword", ignore = true)
+    @Mapping(target = "referenceType", ignore = true)
+    @Mapping(target = "referenceId", ignore = true)
     UserEntity toUserEntity(BaseUserEntity base);
 
     @Mapping(target = "password", ignore = true)
@@ -41,5 +63,16 @@ public interface UserAdapter {
     @Mapping(target = "loginCount", ignore = true)
     @Mapping(target = "newsletterSubscribed", ignore = true)
     @Mapping(target = "isServiceAccount", ignore = true)
+    @Mapping(target = "source", source = "source", qualifiedByName = "idpSourceToString")
     User toUser(BaseUserEntity base);
+
+    @Named("stringToIdpSource")
+    default IdpSource stringToIdpSource(String source) {
+        return IdpSource.of(source);
+    }
+
+    @Named("idpSourceToString")
+    default String idpSourceToString(IdpSource source) {
+        return source != null ? source.value() : null;
+    }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/api/ApiCRDExportDomainServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/api/ApiCRDExportDomainServiceImpl.java
@@ -121,7 +121,7 @@ public class ApiCRDExportDomainServiceImpl implements ApiCRDExportDomainService 
             var user = usersById.get(id);
             if (user != null) {
                 member.setSourceId(user.getSourceId());
-                member.setSource(user.getSource());
+                member.setSource(user.getSource() != null ? user.getSource().value() : null);
             }
             member.setId(null);
         });

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/user/CreateUserDomainServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/user/CreateUserDomainServiceImpl.java
@@ -18,6 +18,7 @@ package io.gravitee.apim.infra.domain_service.user;
 import io.gravitee.apim.core.user.crud_service.UserCrudService;
 import io.gravitee.apim.core.user.domain_service.CreateUserDomainService;
 import io.gravitee.apim.core.user.model.BaseUserEntity;
+import io.gravitee.apim.core.user.model.IdpSource;
 import io.gravitee.common.utils.TimeProvider;
 import io.gravitee.rest.api.service.common.ExecutionContext;
 import io.gravitee.rest.api.service.common.UuidString;
@@ -43,7 +44,7 @@ public class CreateUserDomainServiceImpl implements CreateUserDomainService {
         var user = BaseUserEntity.builder()
             .id(UuidString.generateRandom())
             .organizationId(executionContext.getOrganizationId())
-            .source("gravitee")
+            .source(IdpSource.gravitee())
             .sourceId(email)
             .email(email)
             .firstname(firstname.orElse(null))

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/user/CreateUserDomainServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/user/CreateUserDomainServiceImpl.java
@@ -18,10 +18,8 @@ package io.gravitee.apim.infra.domain_service.user;
 import io.gravitee.apim.core.user.crud_service.UserCrudService;
 import io.gravitee.apim.core.user.domain_service.CreateUserDomainService;
 import io.gravitee.apim.core.user.model.BaseUserEntity;
-import io.gravitee.apim.core.user.model.IdpSource;
 import io.gravitee.common.utils.TimeProvider;
 import io.gravitee.rest.api.service.common.ExecutionContext;
-import io.gravitee.rest.api.service.common.UuidString;
 import java.util.Date;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
@@ -34,25 +32,15 @@ public class CreateUserDomainServiceImpl implements CreateUserDomainService {
     private final UserCrudService userCrudService;
 
     @Override
-    public BaseUserEntity createExternalUser(
+    public BaseUserEntity createGraviteeUser(
         ExecutionContext executionContext,
         String email,
         Optional<String> firstname,
         Optional<String> lastname
     ) {
         var now = Date.from(TimeProvider.now().toInstant());
-        var user = BaseUserEntity.builder()
-            .id(UuidString.generateRandom())
-            .organizationId(executionContext.getOrganizationId())
-            .source(IdpSource.gravitee())
-            .sourceId(email)
-            .email(email)
-            .firstname(firstname.orElse(null))
-            .lastname(lastname.orElse(null))
-            .status("ACTIVE")
-            .createdAt(now)
-            .updatedAt(now)
-            .build();
-        return userCrudService.create(user);
+        return userCrudService.create(
+            BaseUserEntity.createGraviteeUser(executionContext.getOrganizationId(), email, firstname, lastname, now)
+        );
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/user/CreateUserDomainServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/user/CreateUserDomainServiceImpl.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.infra.domain_service.user;
+
+import io.gravitee.apim.core.user.crud_service.UserCrudService;
+import io.gravitee.apim.core.user.domain_service.CreateUserDomainService;
+import io.gravitee.apim.core.user.model.BaseUserEntity;
+import io.gravitee.common.utils.TimeProvider;
+import io.gravitee.rest.api.service.common.ExecutionContext;
+import io.gravitee.rest.api.service.common.UuidString;
+import java.util.Date;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CreateUserDomainServiceImpl implements CreateUserDomainService {
+
+    private final UserCrudService userCrudService;
+
+    @Override
+    public BaseUserEntity createExternalUser(
+        ExecutionContext executionContext,
+        String email,
+        Optional<String> firstname,
+        Optional<String> lastname
+    ) {
+        var now = Date.from(TimeProvider.now().toInstant());
+        var user = BaseUserEntity.builder()
+            .id(UuidString.generateRandom())
+            .organizationId(executionContext.getOrganizationId())
+            .source("gravitee")
+            .sourceId(email)
+            .email(email)
+            .firstname(firstname.orElse(null))
+            .lastname(lastname.orElse(null))
+            .status("ACTIVE")
+            .createdAt(now)
+            .updatedAt(now)
+            .build();
+        return userCrudService.create(user);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/fixtures/core/model/BaseUserEntityFixtures.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/fixtures/core/model/BaseUserEntityFixtures.java
@@ -16,6 +16,7 @@
 package fixtures.core.model;
 
 import io.gravitee.apim.core.user.model.BaseUserEntity;
+import io.gravitee.apim.core.user.model.IdpSource;
 import java.time.Instant;
 import java.util.Date;
 
@@ -27,7 +28,7 @@ public class BaseUserEntityFixtures {
         return BaseUserEntity.builder()
             .id("user-id")
             .organizationId("organization-id")
-            .source("source")
+            .source(IdpSource.of("source"))
             .sourceId("source-id")
             .email("jane.doe@gravitee.io")
             .firstname("Jane")
@@ -40,11 +41,15 @@ public class BaseUserEntityFixtures {
     public static BaseUserEntity aBaseUserEntity(String userId) {
         return BaseUserEntity.builder()
             .id(userId)
-            .source("test")
+            .source(IdpSource.of("test"))
             .sourceId("test-source-id")
             .email("user@example.com")
             .firstname("John")
             .lastname("Smith")
             .build();
+    }
+
+    public static BaseUserEntity aBaseUserEntity(String id, String email) {
+        return BaseUserEntity.builder().id(id).email(email).source(IdpSource.GRAVITEE).sourceId(email).build();
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/fixtures/core/model/BaseUserEntityFixtures.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/fixtures/core/model/BaseUserEntityFixtures.java
@@ -52,4 +52,14 @@ public class BaseUserEntityFixtures {
     public static BaseUserEntity aBaseUserEntity(String id, String email) {
         return BaseUserEntity.builder().id(id).email(email).source(IdpSource.GRAVITEE).sourceId(email).build();
     }
+
+    public static BaseUserEntity aBaseUserEntity(String id, String organizationId, String email) {
+        return BaseUserEntity.builder()
+            .id(id)
+            .organizationId(organizationId)
+            .source(IdpSource.GRAVITEE)
+            .sourceId(email)
+            .email(email)
+            .build();
+    }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/UserDomainServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/UserDomainServiceInMemory.java
@@ -33,7 +33,8 @@ public class UserDomainServiceInMemory implements UserDomainService, InMemoryAlt
             .filter(
                 userEntity ->
                     userEntity.getOrganizationId().equals(organizationId) &&
-                    userEntity.getSource().equals(source) &&
+                    userEntity.getSource() != null &&
+                    userEntity.getSource().value().equals(source) &&
                     userEntity.getSourceId().equals(sourceId)
             )
             .findFirst();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/domain_service/ValidateCRDMembersDomainServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/domain_service/ValidateCRDMembersDomainServiceTest.java
@@ -26,6 +26,7 @@ import io.gravitee.apim.core.member.model.MembershipReferenceType;
 import io.gravitee.apim.core.member.model.crd.MemberCRD;
 import io.gravitee.apim.core.membership.model.Role;
 import io.gravitee.apim.core.user.model.BaseUserEntity;
+import io.gravitee.apim.core.user.model.IdpSource;
 import io.gravitee.apim.core.validation.Validator;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -60,8 +61,13 @@ class ValidateCRDMembersDomainServiceTest {
     void setUp() {
         userDomainService.initWith(
             List.of(
-                BaseUserEntity.builder().organizationId(ORG_ID).id(USER_ID).source(USER_SOURCE).sourceId(USER_ID).build(),
-                BaseUserEntity.builder().organizationId(ORG_ID).id(ACTOR_USER_ID).source(USER_SOURCE).sourceId(ACTOR_USER_ID).build()
+                BaseUserEntity.builder().organizationId(ORG_ID).id(USER_ID).source(IdpSource.of(USER_SOURCE)).sourceId(USER_ID).build(),
+                BaseUserEntity.builder()
+                    .organizationId(ORG_ID)
+                    .id(ACTOR_USER_ID)
+                    .source(IdpSource.of(USER_SOURCE))
+                    .sourceId(ACTOR_USER_ID)
+                    .build()
             )
         );
         roleQueryService.initWith(
@@ -175,7 +181,7 @@ class ValidateCRDMembersDomainServiceTest {
     @EnumSource(value = MembershipReferenceType.class, names = { "APPLICATION", "API" })
     void should_return_error_changing_primary_owner_role(MembershipReferenceType referenceType) {
         userDomainService.initWith(
-            List.of(BaseUserEntity.builder().organizationId(ORG_ID).id(USER_ID).source(USER_SOURCE).sourceId(USER_ID).build())
+            List.of(BaseUserEntity.builder().organizationId(ORG_ID).id(USER_ID).source(IdpSource.of(USER_SOURCE)).sourceId(USER_ID).build())
         );
         var members = new LinkedHashSet<>(Set.of(MemberCRD.builder().source(USER_SOURCE).sourceId(ACTOR_USER_ID).role("USER").build()));
         var expectedMembers = Set.of();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/ImportApiCRDUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/ImportApiCRDUseCaseTest.java
@@ -18,6 +18,7 @@ package io.gravitee.apim.core.api.use_case;
 import static fixtures.ApplicationModelFixtures.anApplicationEntity;
 import static fixtures.core.model.ApiFixtures.aNativeApi;
 import static fixtures.core.model.ApiFixtures.aProxyApiV4;
+import static fixtures.core.model.BaseUserEntityFixtures.aBaseUserEntity;
 import static fixtures.core.model.MembershipFixtures.anApplicationPrimaryOwnerUserMembership;
 import static fixtures.core.model.SubscriptionFixtures.aSubscription;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -142,7 +143,6 @@ import io.gravitee.apim.core.subscription.domain_service.CloseSubscriptionDomain
 import io.gravitee.apim.core.subscription.domain_service.RejectSubscriptionDomainService;
 import io.gravitee.apim.core.subscription.model.SubscriptionEntity;
 import io.gravitee.apim.core.user.model.BaseUserEntity;
-import io.gravitee.apim.core.user.model.IdpSource;
 import io.gravitee.apim.core.validation.Validator;
 import io.gravitee.apim.infra.adapter.PlanAdapter;
 import io.gravitee.apim.infra.domain_service.documentation.ValidatePageSourceDomainServiceImpl;
@@ -388,18 +388,8 @@ class ImportApiCRDUseCaseTest {
 
         userDomainService.initWith(
             List.of(
-                BaseUserEntity.builder()
-                    .source(IdpSource.of(USER_ENTITY_SOURCE))
-                    .sourceId(USER_ENTITY_SOURCE_ID)
-                    .id(USER_ID)
-                    .organizationId(ORGANIZATION_ID)
-                    .build(),
-                BaseUserEntity.builder()
-                    .source(IdpSource.of(USER_ENTITY_SOURCE))
-                    .sourceId(ACTOR_USER_ID)
-                    .id(ACTOR_USER_ID)
-                    .organizationId(ORGANIZATION_ID)
-                    .build()
+                aBaseUserEntity(USER_ID, ORGANIZATION_ID, USER_ENTITY_SOURCE_ID),
+                aBaseUserEntity(ACTOR_USER_ID, ORGANIZATION_ID, ACTOR_USER_ID)
             )
         );
 
@@ -439,7 +429,7 @@ class ImportApiCRDUseCaseTest {
                     .build()
             )
         );
-        userCrudService.initWith(List.of(BaseUserEntity.builder().id(MY_MEMBER_ID).email(MEMBER_EMAIL).build()));
+        userCrudService.initWith(List.of(aBaseUserEntity(MY_MEMBER_ID, MEMBER_EMAIL)));
 
         var apiPrimaryOwnerService = new ApiPrimaryOwnerDomainService(
             auditDomainService,
@@ -524,22 +514,8 @@ class ImportApiCRDUseCaseTest {
         roleQueryService.resetSystemRoles(ORGANIZATION_ID);
         givenExistingUsers(
             List.of(
-                BaseUserEntity.builder()
-                    .organizationId(ORGANIZATION_ID)
-                    .id(ACTOR_USER_ID)
-                    .source(IdpSource.of(USER_ENTITY_SOURCE))
-                    .sourceId(ACTOR_USER_ID)
-                    .email("devops@gravitee.io")
-                    .build(),
-                BaseUserEntity.builder()
-                    .organizationId(ORGANIZATION_ID)
-                    .id(USER_ID)
-                    .source(IdpSource.of(USER_ENTITY_SOURCE))
-                    .sourceId(USER_ENTITY_SOURCE_ID)
-                    .firstname("Jane")
-                    .lastname("Doe")
-                    .email("jane.doe@gravitee.io")
-                    .build()
+                aBaseUserEntity(ACTOR_USER_ID, ORGANIZATION_ID, "devops@gravitee.io"),
+                aBaseUserEntity(USER_ID, ORGANIZATION_ID, USER_ENTITY_SOURCE_ID)
             )
         );
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/ImportApiCRDUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/ImportApiCRDUseCaseTest.java
@@ -142,6 +142,7 @@ import io.gravitee.apim.core.subscription.domain_service.CloseSubscriptionDomain
 import io.gravitee.apim.core.subscription.domain_service.RejectSubscriptionDomainService;
 import io.gravitee.apim.core.subscription.model.SubscriptionEntity;
 import io.gravitee.apim.core.user.model.BaseUserEntity;
+import io.gravitee.apim.core.user.model.IdpSource;
 import io.gravitee.apim.core.validation.Validator;
 import io.gravitee.apim.infra.adapter.PlanAdapter;
 import io.gravitee.apim.infra.domain_service.documentation.ValidatePageSourceDomainServiceImpl;
@@ -388,13 +389,13 @@ class ImportApiCRDUseCaseTest {
         userDomainService.initWith(
             List.of(
                 BaseUserEntity.builder()
-                    .source(USER_ENTITY_SOURCE)
+                    .source(IdpSource.of(USER_ENTITY_SOURCE))
                     .sourceId(USER_ENTITY_SOURCE_ID)
                     .id(USER_ID)
                     .organizationId(ORGANIZATION_ID)
                     .build(),
                 BaseUserEntity.builder()
-                    .source(USER_ENTITY_SOURCE)
+                    .source(IdpSource.of(USER_ENTITY_SOURCE))
                     .sourceId(ACTOR_USER_ID)
                     .id(ACTOR_USER_ID)
                     .organizationId(ORGANIZATION_ID)
@@ -526,14 +527,14 @@ class ImportApiCRDUseCaseTest {
                 BaseUserEntity.builder()
                     .organizationId(ORGANIZATION_ID)
                     .id(ACTOR_USER_ID)
-                    .source(USER_ENTITY_SOURCE)
+                    .source(IdpSource.of(USER_ENTITY_SOURCE))
                     .sourceId(ACTOR_USER_ID)
                     .email("devops@gravitee.io")
                     .build(),
                 BaseUserEntity.builder()
                     .organizationId(ORGANIZATION_ID)
                     .id(USER_ID)
-                    .source(USER_ENTITY_SOURCE)
+                    .source(IdpSource.of(USER_ENTITY_SOURCE))
                     .sourceId(USER_ENTITY_SOURCE_ID)
                     .firstname("Jane")
                     .lastname("Doe")

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/application/ImportApplicationCRDUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/application/ImportApplicationCRDUseCaseTest.java
@@ -39,6 +39,7 @@ import io.gravitee.apim.core.member.domain_service.ValidateCRDMembersDomainServi
 import io.gravitee.apim.core.member.model.crd.MemberCRD;
 import io.gravitee.apim.core.membership.model.Role;
 import io.gravitee.apim.core.user.model.BaseUserEntity;
+import io.gravitee.apim.core.user.model.IdpSource;
 import io.gravitee.apim.infra.domain_service.application.ValidateApplicationSettingsDomainServiceImpl;
 import io.gravitee.common.utils.TimeProvider;
 import io.gravitee.definition.model.Origin;
@@ -352,7 +353,7 @@ class ImportApplicationCRDUseCaseTest {
                 MEMBER_SOURCE_ID_1,
                 new Date(),
                 new Date(),
-                MEMBER_SOURCE,
+                IdpSource.of(MEMBER_SOURCE),
                 MEMBER_SOURCE_ID_1,
                 null
             ),
@@ -364,7 +365,7 @@ class ImportApplicationCRDUseCaseTest {
                 MEMBER_SOURCE_ID_2,
                 new Date(),
                 new Date(),
-                MEMBER_SOURCE,
+                IdpSource.of(MEMBER_SOURCE),
                 MEMBER_SOURCE_ID_2,
                 null
             )

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/invitation/use_case/AcceptUserInvitationUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/invitation/use_case/AcceptUserInvitationUseCaseTest.java
@@ -116,7 +116,7 @@ class AcceptUserInvitationUseCaseTest extends AbstractUseCaseTest {
         @Test
         void should_create_new_user_and_set_password() {
             var createdUser = aBaseUserEntity(GENERATED_UUID, USER_EMAIL);
-            when(createUserDomainService.createExternalUser(eq(executionContext), eq(USER_EMAIL), any(), any())).thenReturn(createdUser);
+            when(createUserDomainService.createGraviteeUser(eq(executionContext), eq(USER_EMAIL), any(), any())).thenReturn(createdUser);
             when(userPasswordService.encode(RAW_PASSWORD)).thenReturn(ENCODED_PASSWORD);
 
             var output = cut.execute(
@@ -140,7 +140,7 @@ class AcceptUserInvitationUseCaseTest extends AbstractUseCaseTest {
         @Test
         void should_create_new_user_without_password() {
             var createdUser = aBaseUserEntity(GENERATED_UUID, USER_EMAIL);
-            when(createUserDomainService.createExternalUser(eq(executionContext), eq(USER_EMAIL), any(), any())).thenReturn(createdUser);
+            when(createUserDomainService.createGraviteeUser(eq(executionContext), eq(USER_EMAIL), any(), any())).thenReturn(createdUser);
 
             var output = cut.execute(
                 new AcceptUserInvitationUseCase.Input(
@@ -176,7 +176,7 @@ class AcceptUserInvitationUseCaseTest extends AbstractUseCaseTest {
 
             assertThat(output.user().getId()).isEqualTo(EXISTING_USER_ID);
             assertThat(userCrudService.getStoredPassword(EXISTING_USER_ID)).contains(ENCODED_PASSWORD);
-            verify(createUserDomainService, never()).createExternalUser(any(), any(), any(), any());
+            verify(createUserDomainService, never()).createGraviteeUser(any(), any(), any(), any());
         }
 
         @Test
@@ -195,7 +195,7 @@ class AcceptUserInvitationUseCaseTest extends AbstractUseCaseTest {
                 )
             ).isInstanceOf(UserRegistrationUnavailableException.class);
 
-            verify(createUserDomainService, never()).createExternalUser(any(), any(), any(), any());
+            verify(createUserDomainService, never()).createGraviteeUser(any(), any(), any(), any());
             verify(userPortalNotificationService, never()).triggerUserRegistered(any(), any());
         }
 
@@ -252,13 +252,13 @@ class AcceptUserInvitationUseCaseTest extends AbstractUseCaseTest {
                 .hasMessage("Password too weak");
 
             verify(userRegistrationEnabledService, never()).checkEnabled(any());
-            verify(createUserDomainService, never()).createExternalUser(any(), any(), any(), any());
+            verify(createUserDomainService, never()).createGraviteeUser(any(), any(), any(), any());
         }
 
         @Test
         void should_create_organization_audit_log() {
             var createdUser = aBaseUserEntity(GENERATED_UUID, USER_EMAIL);
-            when(createUserDomainService.createExternalUser(any(), any(), any(), any())).thenReturn(createdUser);
+            when(createUserDomainService.createGraviteeUser(any(), any(), any(), any())).thenReturn(createdUser);
 
             cut.execute(
                 new AcceptUserInvitationUseCase.Input(
@@ -302,7 +302,7 @@ class AcceptUserInvitationUseCaseTest extends AbstractUseCaseTest {
             );
             invitationCrudService.initWith(List.of(invitation));
             var createdUser = aBaseUserEntity(GENERATED_UUID, USER_EMAIL);
-            when(createUserDomainService.createExternalUser(eq(executionContext), eq(USER_EMAIL), any(), any())).thenReturn(createdUser);
+            when(createUserDomainService.createGraviteeUser(eq(executionContext), eq(USER_EMAIL), any(), any())).thenReturn(createdUser);
 
             var output = cut.execute(
                 new AcceptUserInvitationUseCase.Input(
@@ -340,7 +340,7 @@ class AcceptUserInvitationUseCaseTest extends AbstractUseCaseTest {
             );
             invitationCrudService.initWith(List.of(inv1, inv2));
             var createdUser = aBaseUserEntity(GENERATED_UUID, USER_EMAIL);
-            when(createUserDomainService.createExternalUser(any(), any(), any(), any())).thenReturn(createdUser);
+            when(createUserDomainService.createGraviteeUser(any(), any(), any(), any())).thenReturn(createdUser);
 
             cut.execute(
                 new AcceptUserInvitationUseCase.Input(
@@ -386,7 +386,7 @@ class AcceptUserInvitationUseCaseTest extends AbstractUseCaseTest {
             assertThat(invitationCrudService.storage()).isEmpty();
             assertThat(userCrudService.getStoredPassword(EXISTING_USER_ID)).contains(ENCODED_PASSWORD);
             verify(acceptInvitationDomainService).addMember(executionContext, invitation, EXISTING_USER_ID);
-            verify(createUserDomainService, never()).createExternalUser(any(), any(), any(), any());
+            verify(createUserDomainService, never()).createGraviteeUser(any(), any(), any(), any());
         }
 
         @Test
@@ -405,7 +405,7 @@ class AcceptUserInvitationUseCaseTest extends AbstractUseCaseTest {
                 .isInstanceOf(InvitationCanceledException.class)
                 .hasMessageContaining("user@example.com");
 
-            verify(createUserDomainService, never()).createExternalUser(any(), any(), any(), any());
+            verify(createUserDomainService, never()).createGraviteeUser(any(), any(), any(), any());
             verify(userPortalNotificationService, never()).triggerUserRegistered(any(), any());
         }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/invitation/use_case/AcceptUserInvitationUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/invitation/use_case/AcceptUserInvitationUseCaseTest.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.apim.core.invitation.use_case;
 
+import static fixtures.core.model.BaseUserEntityFixtures.aBaseUserEntity;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
@@ -36,7 +37,6 @@ import io.gravitee.apim.core.invitation.model.InvitationId;
 import io.gravitee.apim.core.invitation.use_case.AcceptUserInvitationUseCase.GroupInvitationAction;
 import io.gravitee.apim.core.invitation.use_case.AcceptUserInvitationUseCase.UserRegistrationAction;
 import io.gravitee.apim.core.user.domain_service.CreateUserDomainService;
-import io.gravitee.apim.core.user.model.BaseUserEntity;
 import io.gravitee.apim.core.user.model.EncodedPassword;
 import io.gravitee.apim.core.user.model.RawPassword;
 import io.gravitee.apim.core.user.service_provider.UserPasswordService;
@@ -115,7 +115,7 @@ class AcceptUserInvitationUseCaseTest extends AbstractUseCaseTest {
 
         @Test
         void should_create_new_user_and_set_password() {
-            var createdUser = aUser(GENERATED_UUID, USER_EMAIL);
+            var createdUser = aBaseUserEntity(GENERATED_UUID, USER_EMAIL);
             when(createUserDomainService.createExternalUser(eq(executionContext), eq(USER_EMAIL), any(), any())).thenReturn(createdUser);
             when(userPasswordService.encode(RAW_PASSWORD)).thenReturn(ENCODED_PASSWORD);
 
@@ -139,7 +139,7 @@ class AcceptUserInvitationUseCaseTest extends AbstractUseCaseTest {
 
         @Test
         void should_create_new_user_without_password() {
-            var createdUser = aUser(GENERATED_UUID, USER_EMAIL);
+            var createdUser = aBaseUserEntity(GENERATED_UUID, USER_EMAIL);
             when(createUserDomainService.createExternalUser(eq(executionContext), eq(USER_EMAIL), any(), any())).thenReturn(createdUser);
 
             var output = cut.execute(
@@ -160,7 +160,7 @@ class AcceptUserInvitationUseCaseTest extends AbstractUseCaseTest {
 
         @Test
         void should_finalize_existing_user() {
-            var existingUser = aUser(EXISTING_USER_ID, USER_EMAIL);
+            var existingUser = aBaseUserEntity(EXISTING_USER_ID, USER_EMAIL);
             userCrudService.initWith(List.of(existingUser));
             when(userPasswordService.encode(RAW_PASSWORD)).thenReturn(ENCODED_PASSWORD);
 
@@ -216,7 +216,7 @@ class AcceptUserInvitationUseCaseTest extends AbstractUseCaseTest {
 
         @Test
         void should_throw_when_user_already_finalized() {
-            var existingUser = aUser(EXISTING_USER_ID, USER_EMAIL);
+            var existingUser = aBaseUserEntity(EXISTING_USER_ID, USER_EMAIL);
             userCrudService.initWith(List.of(existingUser));
             userCrudService.updateAndSetPassword(existingUser, ENCODED_PASSWORD);
 
@@ -257,7 +257,7 @@ class AcceptUserInvitationUseCaseTest extends AbstractUseCaseTest {
 
         @Test
         void should_create_organization_audit_log() {
-            var createdUser = aUser(GENERATED_UUID, USER_EMAIL);
+            var createdUser = aBaseUserEntity(GENERATED_UUID, USER_EMAIL);
             when(createUserDomainService.createExternalUser(any(), any(), any(), any())).thenReturn(createdUser);
 
             cut.execute(
@@ -301,7 +301,7 @@ class AcceptUserInvitationUseCaseTest extends AbstractUseCaseTest {
                 null
             );
             invitationCrudService.initWith(List.of(invitation));
-            var createdUser = aUser(GENERATED_UUID, USER_EMAIL);
+            var createdUser = aBaseUserEntity(GENERATED_UUID, USER_EMAIL);
             when(createUserDomainService.createExternalUser(eq(executionContext), eq(USER_EMAIL), any(), any())).thenReturn(createdUser);
 
             var output = cut.execute(
@@ -339,7 +339,7 @@ class AcceptUserInvitationUseCaseTest extends AbstractUseCaseTest {
                 null
             );
             invitationCrudService.initWith(List.of(inv1, inv2));
-            var createdUser = aUser(GENERATED_UUID, USER_EMAIL);
+            var createdUser = aBaseUserEntity(GENERATED_UUID, USER_EMAIL);
             when(createUserDomainService.createExternalUser(any(), any(), any(), any())).thenReturn(createdUser);
 
             cut.execute(
@@ -368,7 +368,7 @@ class AcceptUserInvitationUseCaseTest extends AbstractUseCaseTest {
                 null
             );
             invitationCrudService.initWith(List.of(invitation));
-            var existingUser = aUser(EXISTING_USER_ID, USER_EMAIL);
+            var existingUser = aBaseUserEntity(EXISTING_USER_ID, USER_EMAIL);
             userCrudService.initWith(List.of(existingUser));
             when(userPasswordService.encode(RAW_PASSWORD)).thenReturn(ENCODED_PASSWORD);
 
@@ -435,9 +435,5 @@ class AcceptUserInvitationUseCaseTest extends AbstractUseCaseTest {
                 .isInstanceOf(InvitationCanceledException.class)
                 .hasMessageContaining("user@example.com");
         }
-    }
-
-    private static BaseUserEntity aUser(String id, String email) {
-        return BaseUserEntity.builder().id(id).email(email).source("gravitee").sourceId(email).build();
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/user/domain_service/CreateUserDomainServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/user/domain_service/CreateUserDomainServiceImplTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.user.domain_service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import inmemory.UserCrudServiceInMemory;
+import io.gravitee.apim.core.user.model.BaseUserEntity;
+import io.gravitee.common.utils.TimeProvider;
+import io.gravitee.rest.api.service.common.ExecutionContext;
+import io.gravitee.rest.api.service.common.UuidString;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.Date;
+import java.util.Optional;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class CreateUserDomainServiceImplTest {
+
+    private static final Instant INSTANT_NOW = Instant.parse("2024-06-01T12:00:00Z");
+    private static final ExecutionContext EXECUTION_CONTEXT = new ExecutionContext("org-id", "env-id");
+
+    UserCrudServiceInMemory userCrudService = new UserCrudServiceInMemory();
+    CreateUserDomainServiceImpl service;
+
+    @BeforeAll
+    static void beforeAll() {
+        TimeProvider.overrideClock(Clock.fixed(INSTANT_NOW, ZoneId.systemDefault()));
+        UuidString.overrideGenerator(() -> "generated-uuid");
+    }
+
+    @AfterAll
+    static void afterAll() {
+        TimeProvider.overrideClock(Clock.systemDefaultZone());
+        UuidString.reset();
+    }
+
+    @BeforeEach
+    void setUp() {
+        service = new CreateUserDomainServiceImpl(userCrudService);
+    }
+
+    @AfterEach
+    void tearDown() {
+        userCrudService.reset();
+    }
+
+    @Test
+    void should_create_external_user_with_all_fields() {
+        var result = service.createExternalUser(EXECUTION_CONTEXT, "jane@example.com", Optional.of("Jane"), Optional.of("Doe"));
+
+        SoftAssertions.assertSoftly(soft -> {
+            soft.assertThat(result.getId()).isEqualTo("generated-uuid");
+            soft.assertThat(result.getOrganizationId()).isEqualTo("org-id");
+            soft.assertThat(result.getSource()).isEqualTo("gravitee");
+            soft.assertThat(result.getSourceId()).isEqualTo("jane@example.com");
+            soft.assertThat(result.getEmail()).isEqualTo("jane@example.com");
+            soft.assertThat(result.getFirstname()).isEqualTo("Jane");
+            soft.assertThat(result.getLastname()).isEqualTo("Doe");
+            soft.assertThat(result.getStatus()).isEqualTo("ACTIVE");
+            soft.assertThat(result.getCreatedAt()).isEqualTo(Date.from(INSTANT_NOW));
+            soft.assertThat(result.getUpdatedAt()).isEqualTo(Date.from(INSTANT_NOW));
+        });
+    }
+
+    @Test
+    void should_use_null_for_absent_firstname_and_lastname() {
+        var result = service.createExternalUser(EXECUTION_CONTEXT, "nofirstlast@example.com", Optional.empty(), Optional.empty());
+
+        assertThat(result.getFirstname()).isNull();
+        assertThat(result.getLastname()).isNull();
+    }
+
+    @Test
+    void should_store_user_in_crud_service() {
+        service.createExternalUser(EXECUTION_CONTEXT, "stored@example.com", Optional.empty(), Optional.empty());
+
+        assertThat(userCrudService.storage()).hasSize(1).extracting(BaseUserEntity::getEmail).containsExactly("stored@example.com");
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/user/model/BaseUserEntityTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/user/model/BaseUserEntityTest.java
@@ -45,19 +45,19 @@ public class BaseUserEntityTest {
 
         @Test
         void should_return_email_when_user_coming_from_idp() {
-            var user = BaseUserEntity.builder().email("jane.doe@gravitee.io").source("google").build();
+            var user = BaseUserEntity.builder().email("jane.doe@gravitee.io").source(IdpSource.of("google")).build();
             assertThat(user.displayName()).isEqualTo("jane.doe@gravitee.io");
         }
 
         @Test
         void should_return_sourceId_when_user_coming_from_idp_without_email() {
-            var user = BaseUserEntity.builder().sourceId("google-user-id").source("google").build();
+            var user = BaseUserEntity.builder().sourceId("google-user-id").source(IdpSource.of("google")).build();
             assertThat(user.displayName()).isEqualTo("google-user-id");
         }
 
         @Test
         void should_return_sourceId_when_user_is_in_memory_user() {
-            var user = BaseUserEntity.builder().sourceId("source-id").source("memory").build();
+            var user = BaseUserEntity.builder().sourceId("source-id").source(IdpSource.MEMORY).build();
             assertThat(user.displayName()).isEqualTo("source-id");
         }
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/crud_service/user/UserCrudServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/crud_service/user/UserCrudServiceImplTest.java
@@ -23,6 +23,7 @@ import static org.assertj.core.api.Assertions.catchThrowable;
 import inmemory.UserRepositoryInMemory;
 import io.gravitee.apim.core.user.model.BaseUserEntity;
 import io.gravitee.apim.core.user.model.EncodedPassword;
+import io.gravitee.apim.core.user.model.IdpSource;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.model.User;
 import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
@@ -102,7 +103,7 @@ public class UserCrudServiceImplTest {
                     BaseUserEntity.builder()
                         .id("1")
                         .organizationId("organization-id")
-                        .source("source-1")
+                        .source(IdpSource.of("source-1"))
                         .sourceId("source-id-1")
                         .email("1@gravitee.io")
                         .firstname("Jane 1")
@@ -113,7 +114,7 @@ public class UserCrudServiceImplTest {
                     BaseUserEntity.builder()
                         .id("2")
                         .organizationId("organization-id")
-                        .source("source-2")
+                        .source(IdpSource.of("source-2"))
                         .sourceId("source-id-2")
                         .email("2@gravitee.io")
                         .firstname("Jane 2")
@@ -158,7 +159,7 @@ public class UserCrudServiceImplTest {
             var userToCreate = BaseUserEntity.builder()
                 .id("user-id")
                 .organizationId("org-id")
-                .source("gravitee")
+                .source(IdpSource.GRAVITEE)
                 .sourceId("jane@example.com")
                 .email("jane@example.com")
                 .firstname("Jane")
@@ -314,7 +315,7 @@ public class UserCrudServiceImplTest {
             SoftAssertions.assertSoftly(softly -> {
                 softly.assertThat(user.getId()).isEqualTo("user-id");
                 softly.assertThat(user.getOrganizationId()).isEqualTo("organization-id");
-                softly.assertThat(user.getSource()).isEqualTo("source");
+                softly.assertThat(user.getSource()).isEqualTo(IdpSource.of("source"));
                 softly.assertThat(user.getSourceId()).isEqualTo("source-id");
                 softly.assertThat(user.getEmail()).isEqualTo("jane.doe@gravitee.io");
                 softly.assertThat(user.getFirstname()).isEqualTo("Jane");

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/api/ApiCRDExportDomainServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/api/ApiCRDExportDomainServiceImplTest.java
@@ -37,6 +37,7 @@ import io.gravitee.apim.core.audit.model.AuditActor;
 import io.gravitee.apim.core.audit.model.AuditInfo;
 import io.gravitee.apim.core.group.model.Group;
 import io.gravitee.apim.core.user.model.BaseUserEntity;
+import io.gravitee.apim.core.user.model.IdpSource;
 import io.gravitee.definition.model.v4.endpointgroup.Endpoint;
 import io.gravitee.definition.model.v4.endpointgroup.EndpointGroup;
 import io.gravitee.definition.model.v4.listener.http.HttpListener;
@@ -96,8 +97,8 @@ class ApiCRDExportDomainServiceImplTest {
     void setUp() {
         userCrudService.initWith(
             List.of(
-                BaseUserEntity.builder().id(USER_ID).source("gravitee").sourceId("user").build(),
-                BaseUserEntity.builder().id(PO_ID).source("gravitee").sourceId("user").build()
+                BaseUserEntity.builder().id(USER_ID).source(IdpSource.GRAVITEE).sourceId("user").build(),
+                BaseUserEntity.builder().id(PO_ID).source(IdpSource.GRAVITEE).sourceId("user").build()
             )
         );
         groupQueryServiceInMemory.initWith(List.of(Group.builder().id(GROUP_ID).name(GROUP_NAME).build()));

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/user/CreateUserDomainServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/user/CreateUserDomainServiceImplTest.java
@@ -22,7 +22,6 @@ import io.gravitee.apim.core.user.model.BaseUserEntity;
 import io.gravitee.apim.core.user.model.IdpSource;
 import io.gravitee.common.utils.TimeProvider;
 import io.gravitee.rest.api.service.common.ExecutionContext;
-import io.gravitee.rest.api.service.common.UuidString;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneId;
@@ -46,13 +45,11 @@ class CreateUserDomainServiceImplTest {
     @BeforeAll
     static void beforeAll() {
         TimeProvider.overrideClock(Clock.fixed(INSTANT_NOW, ZoneId.systemDefault()));
-        UuidString.overrideGenerator(() -> "generated-uuid");
     }
 
     @AfterAll
     static void afterAll() {
         TimeProvider.overrideClock(Clock.systemDefaultZone());
-        UuidString.reset();
     }
 
     @BeforeEach
@@ -67,10 +64,10 @@ class CreateUserDomainServiceImplTest {
 
     @Test
     void should_create_external_user_with_all_fields() {
-        var result = service.createExternalUser(EXECUTION_CONTEXT, "jane@example.com", Optional.of("Jane"), Optional.of("Doe"));
+        var result = service.createGraviteeUser(EXECUTION_CONTEXT, "jane@example.com", Optional.of("Jane"), Optional.of("Doe"));
 
         SoftAssertions.assertSoftly(soft -> {
-            soft.assertThat(result.getId()).isEqualTo("generated-uuid");
+            soft.assertThat(result.getId()).matches("[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}");
             soft.assertThat(result.getOrganizationId()).isEqualTo("org-id");
             soft.assertThat(result.getSource()).isEqualTo(IdpSource.GRAVITEE);
             soft.assertThat(result.getSourceId()).isEqualTo("jane@example.com");
@@ -85,7 +82,7 @@ class CreateUserDomainServiceImplTest {
 
     @Test
     void should_use_null_for_absent_firstname_and_lastname() {
-        var result = service.createExternalUser(EXECUTION_CONTEXT, "nofirstlast@example.com", Optional.empty(), Optional.empty());
+        var result = service.createGraviteeUser(EXECUTION_CONTEXT, "nofirstlast@example.com", Optional.empty(), Optional.empty());
 
         assertThat(result.getFirstname()).isNull();
         assertThat(result.getLastname()).isNull();
@@ -93,7 +90,7 @@ class CreateUserDomainServiceImplTest {
 
     @Test
     void should_store_user_in_crud_service() {
-        service.createExternalUser(EXECUTION_CONTEXT, "stored@example.com", Optional.empty(), Optional.empty());
+        service.createGraviteeUser(EXECUTION_CONTEXT, "stored@example.com", Optional.empty(), Optional.empty());
 
         assertThat(userCrudService.storage()).hasSize(1).extracting(BaseUserEntity::getEmail).containsExactly("stored@example.com");
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/user/CreateUserDomainServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/user/CreateUserDomainServiceImplTest.java
@@ -19,6 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import inmemory.UserCrudServiceInMemory;
 import io.gravitee.apim.core.user.model.BaseUserEntity;
+import io.gravitee.apim.core.user.model.IdpSource;
 import io.gravitee.common.utils.TimeProvider;
 import io.gravitee.rest.api.service.common.ExecutionContext;
 import io.gravitee.rest.api.service.common.UuidString;
@@ -71,7 +72,7 @@ class CreateUserDomainServiceImplTest {
         SoftAssertions.assertSoftly(soft -> {
             soft.assertThat(result.getId()).isEqualTo("generated-uuid");
             soft.assertThat(result.getOrganizationId()).isEqualTo("org-id");
-            soft.assertThat(result.getSource()).isEqualTo("gravitee");
+            soft.assertThat(result.getSource()).isEqualTo(IdpSource.GRAVITEE);
             soft.assertThat(result.getSourceId()).isEqualTo("jane@example.com");
             soft.assertThat(result.getEmail()).isEqualTo("jane@example.com");
             soft.assertThat(result.getFirstname()).isEqualTo("Jane");

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/user/CreateUserDomainServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/user/CreateUserDomainServiceImplTest.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.apim.core.user.domain_service;
+package io.gravitee.apim.infra.domain_service.user;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiValidationServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiValidationServiceImplTest.java
@@ -46,6 +46,7 @@ import io.gravitee.apim.core.member.domain_service.ValidateCRDMembersDomainServi
 import io.gravitee.apim.core.membership.model.Role;
 import io.gravitee.apim.core.notification.domain_service.ValidatePortalNotificationDomainService;
 import io.gravitee.apim.core.user.model.BaseUserEntity;
+import io.gravitee.apim.core.user.model.IdpSource;
 import io.gravitee.apim.core.validation.Validator;
 import io.gravitee.definition.model.DefinitionContext;
 import io.gravitee.definition.model.DefinitionVersion;
@@ -139,13 +140,13 @@ public class ApiValidationServiceImplTest {
             List.of(
                 BaseUserEntity.builder()
                     .id(USER_NAME)
-                    .source(USER_SOURCE)
+                    .source(IdpSource.of(USER_SOURCE))
                     .sourceId(USER_NAME)
                     .organizationId(DEFAULT_ORGANIZATION_ID)
                     .build(),
                 BaseUserEntity.builder()
                     .id(ACTOR_USER_NAME)
-                    .source(USER_SOURCE)
+                    .source(IdpSource.of(USER_SOURCE))
                     .sourceId(ACTOR_USER_NAME)
                     .organizationId(DEFAULT_ORGANIZATION_ID)
                     .build()


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-14130

## Description

- Added `CreateUserDomainServiceImpl` in `infra/domain_service/user/` implementing `CreateUserDomainService`
- Sets `source="gravitee"`, `sourceId=email`, `status="ACTIVE"`, generates a UUID, and stamps `createdAt`/`updatedAt` via `TimeProvider` — matching the external-user creation sub-flow extracted from `UserServiceImpl.finalizeRegistration()`
- Delegates persistence to `UserCrudService.create()` (the domain port implemented in the previous branch)
- 3 unit tests covering full-field creation, absent `firstname`/`lastname` Optionals, and storage verification

## Additional context

Implementation lives in `infra` (Spring `@Service`), not `core`, because domain service _implementations_ belong to the infrastructure layer even when they only depend on domain ports.
