### PR TITLE
feat(portal): APIM-14142 expose application invitation creation endpoint

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/mapper/ApplicationInvitationsCreateInputMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/mapper/ApplicationInvitationsCreateInputMapper.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.portal.rest.mapper;
+
+import io.gravitee.apim.core.invitation.model.CreateApplicationInvitations;
+import io.gravitee.rest.api.portal.rest.model.InvitationCreateInput;
+import io.gravitee.rest.api.portal.rest.model.InvitationRecipientInput;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+import org.mapstruct.Mapper;
+import org.mapstruct.factory.Mappers;
+
+@Mapper
+public interface ApplicationInvitationsCreateInputMapper {
+    ApplicationInvitationsCreateInputMapper INSTANCE = Mappers.getMapper(ApplicationInvitationsCreateInputMapper.class);
+
+    default CreateApplicationInvitations toCreateApplicationInvitations(InvitationCreateInput input) {
+        return new CreateApplicationInvitations(
+            toRecipientEmails(input.getRecipients()),
+            normalizeRoleName(input.getRole()),
+            input.getNotify() == null || input.getNotify()
+        );
+    }
+
+    private Set<String> toRecipientEmails(List<InvitationRecipientInput> recipients) {
+        if (recipients == null) {
+            return Set.of();
+        }
+
+        var emails = new LinkedHashSet<String>();
+        recipients.forEach(recipient -> emails.add(normalizeEmail(recipient == null ? null : recipient.getEmail())));
+        return emails;
+    }
+
+    private String normalizeEmail(String email) {
+        return email == null ? null : email.trim().toLowerCase(Locale.ROOT);
+    }
+
+    private String normalizeRoleName(String roleName) {
+        return roleName == null ? null : roleName.trim();
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/ApplicationInvitationsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/ApplicationInvitationsResource.java
@@ -15,14 +15,18 @@
  */
 package io.gravitee.rest.api.portal.rest.resource;
 
+import io.gravitee.apim.core.invitation.use_case.CreateApplicationInvitationsUseCase;
 import io.gravitee.apim.core.invitation.use_case.SearchApplicationInvitationsUseCase;
 import io.gravitee.common.http.MediaType;
 import io.gravitee.rest.api.model.common.PageableImpl;
 import io.gravitee.rest.api.model.permissions.RolePermission;
 import io.gravitee.rest.api.model.permissions.RolePermissionAction;
 import io.gravitee.rest.api.portal.rest.mapper.ApplicationInvitationMapper;
+import io.gravitee.rest.api.portal.rest.mapper.ApplicationInvitationsCreateInputMapper;
 import io.gravitee.rest.api.portal.rest.mapper.ApplicationInvitationsSearchCriteriaMapper;
 import io.gravitee.rest.api.portal.rest.model.ApplicationInvitationsSearchInput;
+import io.gravitee.rest.api.portal.rest.model.InvitationCreateInput;
+import io.gravitee.rest.api.portal.rest.model.InvitationsResponse;
 import io.gravitee.rest.api.portal.rest.resource.param.PaginationParam;
 import io.gravitee.rest.api.rest.annotation.Permission;
 import io.gravitee.rest.api.rest.annotation.Permissions;
@@ -48,6 +52,31 @@ public class ApplicationInvitationsResource extends AbstractResource {
 
     @Inject
     private SearchApplicationInvitationsUseCase searchApplicationInvitationsUseCase;
+
+    @Inject
+    private CreateApplicationInvitationsUseCase createApplicationInvitationsUseCase;
+
+    @POST
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    @Permissions({ @Permission(value = RolePermission.APPLICATION_MEMBER, acls = RolePermissionAction.CREATE) })
+    public Response createApplicationInvitations(
+        @PathParam("applicationId") String applicationId,
+        @Valid @NotNull(message = "Input must not be null.") InvitationCreateInput input
+    ) {
+        var executionContext = GraviteeContext.getExecutionContext();
+        var output = createApplicationInvitationsUseCase.execute(
+            new CreateApplicationInvitationsUseCase.Input(
+                executionContext,
+                applicationId,
+                ApplicationInvitationsCreateInputMapper.INSTANCE.toCreateApplicationInvitations(input)
+            )
+        );
+
+        return Response.status(Response.Status.CREATED)
+            .entity(new InvitationsResponse().data(INVITATION_MAPPER.toInvitation(output.invitations())))
+            .build();
+    }
 
     @POST
     @Path("/_search")

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/mapper/ApplicationInvitationsCreateInputMapperTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/mapper/ApplicationInvitationsCreateInputMapperTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.portal.rest.mapper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.rest.api.portal.rest.model.InvitationCreateInput;
+import io.gravitee.rest.api.portal.rest.model.InvitationRecipientInput;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class ApplicationInvitationsCreateInputMapperTest {
+
+    private final ApplicationInvitationsCreateInputMapper cut = ApplicationInvitationsCreateInputMapper.INSTANCE;
+
+    @Test
+    void should_map_input_with_default_notify_true() {
+        var input = new InvitationCreateInput()
+            .recipients(
+                List.of(
+                    new InvitationRecipientInput().email(" Alice@Example.com "),
+                    new InvitationRecipientInput().email("BOB@example.com")
+                )
+            )
+            .role(" USER ");
+        input.setNotify(null);
+
+        var result = cut.toCreateApplicationInvitations(input);
+
+        assertThat(result.recipientEmails()).containsExactly("alice@example.com", "bob@example.com");
+        assertThat(result.roleName()).isEqualTo("USER");
+        assertThat(result.notifyUsers()).isTrue();
+    }
+
+    @Test
+    void should_map_input_with_explicit_notify_false() {
+        var input = new InvitationCreateInput()
+            .recipients(List.of(new InvitationRecipientInput().email("alice@example.com")))
+            .role("USER")
+            .notify(false);
+
+        var result = cut.toCreateApplicationInvitations(input);
+
+        assertThat(result.recipientEmails()).containsExactly("alice@example.com");
+        assertThat(result.notifyUsers()).isFalse();
+    }
+
+    @Test
+    void should_deduplicate_recipients_after_email_normalization() {
+        var input = new InvitationCreateInput()
+            .recipients(
+                List.of(
+                    new InvitationRecipientInput().email("Alice@Example.com"),
+                    new InvitationRecipientInput().email(" alice@example.com ")
+                )
+            )
+            .role("USER")
+            .notify(false);
+
+        var result = cut.toCreateApplicationInvitations(input);
+
+        assertThat(result.recipientEmails()).containsExactly("alice@example.com");
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/ApplicationInvitationsResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/ApplicationInvitationsResourceTest.java
@@ -18,6 +18,7 @@ package io.gravitee.rest.api.portal.rest.resource;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.reset;
@@ -25,16 +26,21 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import inmemory.ApplicationCrudServiceInMemory;
+import inmemory.RoleQueryServiceInMemory;
+import io.gravitee.apim.core.invitation.crud_service.InvitationCrudService;
 import io.gravitee.apim.core.invitation.model.ApplicationInvitation;
 import io.gravitee.apim.core.invitation.model.ApplicationInvitationId;
 import io.gravitee.apim.core.invitation.model.SearchApplicationInvitationsCriteria;
 import io.gravitee.apim.core.invitation.query_service.InvitationQueryService;
+import io.gravitee.apim.core.membership.model.Role;
 import io.gravitee.common.data.domain.Page;
 import io.gravitee.common.http.HttpStatusCode;
 import io.gravitee.rest.api.model.BaseApplicationEntity;
 import io.gravitee.rest.api.model.common.PageableImpl;
 import io.gravitee.rest.api.portal.rest.model.ApplicationInvitationsSearchFilters;
 import io.gravitee.rest.api.portal.rest.model.ApplicationInvitationsSearchInput;
+import io.gravitee.rest.api.portal.rest.model.InvitationCreateInput;
+import io.gravitee.rest.api.portal.rest.model.InvitationRecipientInput;
 import io.gravitee.rest.api.portal.rest.model.InvitationsResponse;
 import jakarta.ws.rs.client.Entity;
 import jakarta.ws.rs.core.Response;
@@ -51,12 +57,19 @@ class ApplicationInvitationsResourceTest extends AbstractResourceTest {
     private static final String UNKNOWN_APPLICATION = "unknown-application";
     private static final String INVITATION_ID_1 = "00000000-0000-0000-0000-000000000001";
     private static final String INVITATION_ID_2 = "00000000-0000-0000-0000-000000000002";
+    private static final String ROLE_NAME = "USER";
 
     @Autowired
     private InvitationQueryService invitationQueryService;
 
     @Autowired
+    private InvitationCrudService invitationCrudService;
+
+    @Autowired
     private ApplicationCrudServiceInMemory applicationCrudService;
+
+    @Autowired
+    private RoleQueryServiceInMemory roleQueryService;
 
     @Override
     protected String contextPath() {
@@ -67,9 +80,95 @@ class ApplicationInvitationsResourceTest extends AbstractResourceTest {
     void init() {
         resetAllMocks();
         reset(invitationQueryService);
+        reset(invitationCrudService);
         applicationCrudService.reset();
+        roleQueryService.reset();
         applicationCrudService.initWith(List.of(BaseApplicationEntity.builder().id(APPLICATION).environmentId("DEFAULT").build()));
+        roleQueryService.initWith(List.of(applicationRole()));
         when(permissionService.hasPermission(any(), any(), any(), any())).thenReturn(true);
+    }
+
+    @Test
+    void should_create_invitations() {
+        when(invitationQueryService.findByReference(any())).thenReturn(List.of());
+        when(invitationCrudService.create(any(ApplicationInvitation.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        var response = target(APPLICATION)
+            .path("invitations")
+            .request()
+            .post(
+                Entity.json(
+                    new InvitationCreateInput()
+                        .recipients(
+                            List.of(
+                                new InvitationRecipientInput().email(" Alice@example.com "),
+                                new InvitationRecipientInput().email("BOB@example.com")
+                            )
+                        )
+                        .role(ROLE_NAME)
+                        .notify(false)
+                )
+            );
+
+        assertThat(response.getStatus()).isEqualTo(HttpStatusCode.CREATED_201);
+        var invitationsResponse = response.readEntity(InvitationsResponse.class);
+        assertThat(invitationsResponse.getData()).hasSize(2);
+        assertThat(invitationsResponse.getData())
+            .extracting(io.gravitee.rest.api.portal.rest.model.Invitation::getEmail)
+            .containsExactly("alice@example.com", "bob@example.com");
+        assertThat(invitationsResponse.getData())
+            .extracting(io.gravitee.rest.api.portal.rest.model.Invitation::getRole)
+            .containsOnly(ROLE_NAME);
+        verify(invitationCrudService).create(
+            argThat(invitation -> invitation.applicationId().equals(APPLICATION) && invitation.email().equals("alice@example.com"))
+        );
+        verify(invitationCrudService).create(
+            argThat(invitation -> invitation.applicationId().equals(APPLICATION) && invitation.email().equals("bob@example.com"))
+        );
+    }
+
+    @Test
+    void should_return_bad_request_when_create_input_is_invalid() {
+        var response = target(APPLICATION)
+            .path("invitations")
+            .request()
+            .post(
+                Entity.json(
+                    new InvitationCreateInput()
+                        .recipients(List.of(new InvitationRecipientInput().email("not-an-email")))
+                        .role(ROLE_NAME)
+                        .notify(false)
+                )
+            );
+
+        assertThat(response.getStatus()).isEqualTo(HttpStatusCode.BAD_REQUEST_400);
+        verify(invitationCrudService, never()).create(any());
+    }
+
+    @Test
+    void should_return_not_found_when_creating_invitation_for_unknown_application() {
+        var response = target(UNKNOWN_APPLICATION).path("invitations").request().post(Entity.json(createInput(false)));
+
+        assertThat(response.getStatus()).isEqualTo(HttpStatusCode.NOT_FOUND_404);
+        verify(invitationCrudService, never()).create(any());
+    }
+
+    @Test
+    void should_return_conflict_when_pending_invitation_already_exists() {
+        when(invitationQueryService.findByReference(any())).thenReturn(List.of(anInvitation(INVITATION_ID_1, "alice@example.com")));
+
+        var response = target(APPLICATION).path("invitations").request().post(Entity.json(createInput(false)));
+
+        assertThat(response.getStatus()).isEqualTo(HttpStatusCode.CONFLICT_409);
+        verify(invitationCrudService, never()).create(any());
+    }
+
+    @Test
+    void should_return_internal_server_error_when_notify_is_not_supported_yet() {
+        var response = target(APPLICATION).path("invitations").request().post(Entity.json(createInput(true)));
+
+        assertThat(response.getStatus()).isEqualTo(HttpStatusCode.INTERNAL_SERVER_ERROR_500);
+        verify(invitationCrudService, never()).create(any());
     }
 
     @Test
@@ -161,5 +260,22 @@ class ApplicationInvitationsResourceTest extends AbstractResourceTest {
             ZonedDateTime.parse("2026-04-23T09:30:00Z"),
             ZonedDateTime.parse("2026-04-23T09:45:00Z")
         );
+    }
+
+    private InvitationCreateInput createInput(boolean notify) {
+        return new InvitationCreateInput()
+            .recipients(List.of(new InvitationRecipientInput().email("alice@example.com")))
+            .role(ROLE_NAME)
+            .notify(notify);
+    }
+
+    private Role applicationRole() {
+        return Role.builder()
+            .id("application-user-role")
+            .name(ROLE_NAME)
+            .referenceId("DEFAULT")
+            .referenceType(Role.ReferenceType.ORGANIZATION)
+            .scope(Role.Scope.APPLICATION)
+            .build();
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/invitation/model/CreateApplicationInvitations.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/invitation/model/CreateApplicationInvitations.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.invitation.model;
+
+import java.util.Set;
+
+public record CreateApplicationInvitations(Set<String> recipientEmails, String roleName, boolean notifyUsers) {}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/invitation/use_case/CreateApplicationInvitationsUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/invitation/use_case/CreateApplicationInvitationsUseCase.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.invitation.use_case;
+
+import io.gravitee.apim.core.UseCase;
+import io.gravitee.apim.core.application.crud_service.ApplicationCrudService;
+import io.gravitee.apim.core.invitation.domain_service.CreateApplicationInvitationsDomainService;
+import io.gravitee.apim.core.invitation.model.ApplicationInvitation;
+import io.gravitee.apim.core.invitation.model.CreateApplicationInvitations;
+import io.gravitee.rest.api.service.common.ExecutionContext;
+import java.util.List;
+
+@UseCase
+public class CreateApplicationInvitationsUseCase {
+
+    private final ApplicationCrudService applicationCrudService;
+    private final CreateApplicationInvitationsDomainService createApplicationInvitationsDomainService;
+
+    public CreateApplicationInvitationsUseCase(
+        ApplicationCrudService applicationCrudService,
+        CreateApplicationInvitationsDomainService createApplicationInvitationsDomainService
+    ) {
+        this.applicationCrudService = applicationCrudService;
+        this.createApplicationInvitationsDomainService = createApplicationInvitationsDomainService;
+    }
+
+    public Output execute(Input input) {
+        applicationCrudService.findById(input.applicationId(), input.executionContext().getEnvironmentId());
+        var createApplicationInvitations = input.createApplicationInvitations();
+
+        return new Output(
+            createApplicationInvitationsDomainService.create(
+                input.executionContext().getOrganizationId(),
+                input.applicationId(),
+                createApplicationInvitations.recipientEmails(),
+                createApplicationInvitations.roleName(),
+                createApplicationInvitations.notifyUsers()
+            )
+        );
+    }
+
+    public record Input(
+        ExecutionContext executionContext,
+        String applicationId,
+        CreateApplicationInvitations createApplicationInvitations
+    ) {}
+
+    public record Output(List<ApplicationInvitation> invitations) {}
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/invitation/use_case/CreateApplicationInvitationsUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/invitation/use_case/CreateApplicationInvitationsUseCaseTest.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.invitation.use_case;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.apim.core.application.crud_service.ApplicationCrudService;
+import io.gravitee.apim.core.invitation.domain_service.CreateApplicationInvitationsDomainService;
+import io.gravitee.apim.core.invitation.model.ApplicationInvitation;
+import io.gravitee.apim.core.invitation.model.CreateApplicationInvitations;
+import io.gravitee.rest.api.model.BaseApplicationEntity;
+import io.gravitee.rest.api.service.common.ExecutionContext;
+import io.gravitee.rest.api.service.exceptions.ApplicationNotFoundException;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class CreateApplicationInvitationsUseCaseTest {
+
+    private static final String APPLICATION_ID = "application-id";
+    private static final String ENVIRONMENT_ID = "environment-id";
+    private static final String ORGANIZATION_ID = "organization-id";
+    private static final String ROLE_NAME = "USER";
+
+    @Mock
+    private ApplicationCrudService applicationCrudService;
+
+    @Mock
+    private CreateApplicationInvitationsDomainService createApplicationInvitationsDomainService;
+
+    private CreateApplicationInvitationsUseCase cut;
+
+    @BeforeEach
+    void setUp() {
+        cut = new CreateApplicationInvitationsUseCase(applicationCrudService, createApplicationInvitationsDomainService);
+    }
+
+    @Test
+    void should_validate_application_existence_before_creating_invitations() {
+        var executionContext = new ExecutionContext(ORGANIZATION_ID, ENVIRONMENT_ID);
+        when(applicationCrudService.findById(APPLICATION_ID, ENVIRONMENT_ID)).thenThrow(new ApplicationNotFoundException(APPLICATION_ID));
+
+        Throwable throwable = catchThrowable(() ->
+            cut.execute(
+                new CreateApplicationInvitationsUseCase.Input(
+                    executionContext,
+                    APPLICATION_ID,
+                    new CreateApplicationInvitations(Set.of("alice@example.com"), ROLE_NAME, false)
+                )
+            )
+        );
+
+        assertThat(throwable).isInstanceOf(ApplicationNotFoundException.class).hasMessageContaining(APPLICATION_ID);
+        verifyNoInteractions(createApplicationInvitationsDomainService);
+    }
+
+    @Test
+    void should_create_application_invitations() {
+        var executionContext = new ExecutionContext(ORGANIZATION_ID, ENVIRONMENT_ID);
+        var recipients = Set.of("alice@example.com", "bob@example.com");
+        var application = BaseApplicationEntity.builder().id(APPLICATION_ID).environmentId(ENVIRONMENT_ID).build();
+        var invitations = List.of(anInvitation("alice@example.com"), anInvitation("bob@example.com"));
+        when(applicationCrudService.findById(APPLICATION_ID, ENVIRONMENT_ID)).thenReturn(application);
+        when(createApplicationInvitationsDomainService.create(ORGANIZATION_ID, APPLICATION_ID, recipients, ROLE_NAME, false)).thenReturn(
+            invitations
+        );
+
+        var result = cut.execute(
+            new CreateApplicationInvitationsUseCase.Input(
+                executionContext,
+                APPLICATION_ID,
+                new CreateApplicationInvitations(recipients, ROLE_NAME, false)
+            )
+        );
+
+        assertThat(result.invitations()).isEqualTo(invitations);
+        verify(createApplicationInvitationsDomainService).create(ORGANIZATION_ID, APPLICATION_ID, recipients, ROLE_NAME, false);
+    }
+
+    @Test
+    void should_propagate_notify_not_implemented_exception() {
+        var executionContext = new ExecutionContext(ORGANIZATION_ID, ENVIRONMENT_ID);
+        var recipients = Set.of("alice@example.com");
+        var application = BaseApplicationEntity.builder().id(APPLICATION_ID).environmentId(ENVIRONMENT_ID).build();
+        when(applicationCrudService.findById(APPLICATION_ID, ENVIRONMENT_ID)).thenReturn(application);
+        when(createApplicationInvitationsDomainService.create(ORGANIZATION_ID, APPLICATION_ID, recipients, ROLE_NAME, true)).thenThrow(
+            new UnsupportedOperationException("Application invitation notifications are not implemented yet.")
+        );
+
+        Throwable throwable = catchThrowable(() ->
+            cut.execute(
+                new CreateApplicationInvitationsUseCase.Input(
+                    executionContext,
+                    APPLICATION_ID,
+                    new CreateApplicationInvitations(recipients, ROLE_NAME, true)
+                )
+            )
+        );
+
+        assertThat(throwable).isInstanceOf(UnsupportedOperationException.class).hasMessageContaining("not implemented yet");
+    }
+
+    private ApplicationInvitation anInvitation(String email) {
+        return ApplicationInvitation.create(APPLICATION_ID, email, ROLE_NAME);
+    }
+}


### PR DESCRIPTION


## Issue

https://gravitee.atlassian.net/browse/APIM-14142

## Description

Implements PR2 for application invitation creation.
- Adds CreateApplicationInvitationsUseCase
- Exposes POST /applications/{applicationId}/invitations
- Maps InvitationCreateInput into the use case input
- Returns created invitations using existing InvitationsResponse
- Supports notify=false creation flow
- Keeps notify=true / omitted notify on the temporary not-implemented notification path for PR3

