### PR TITLE
feat(gamma-platform-ui): Archived apps table options & general config…

### DIFF
--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/app/AppRoutes.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/app/AppRoutes.tsx
@@ -19,8 +19,11 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { useMemo } from 'react';
 import { Outlet, Route, Routes, useNavigate } from 'react-router-dom';
 
+import { APPLICATION_NAV_GROUPS, flattenApplicationDetailNavItems } from '../config/applicationDetailNavigation';
+import { applicationDetailTabElement } from '../config/applicationDetailPages';
 import { NAV_GROUPS } from '../config/navigation';
 import { PLATFORM_ROUTE_CONFIG } from '../config/routes';
+import { ApplicationDetailIndexRedirect, ApplicationDetailLayout } from '../features/applications/components/detail';
 import { ApplicationsPage } from '../pages/ApplicationsPage';
 import { DashboardPage } from '../pages/DashboardPage';
 import { RegisterApplicationPage } from '../pages/RegisterApplicationPage';
@@ -28,6 +31,8 @@ import { ConsoleSettingsProvider } from '../shared/console-settings';
 import { useEnvironmentPermissions } from '../shared/hooks/useEnvironmentPermissions';
 
 const queryClient = new QueryClient();
+
+const APPLICATION_DETAIL_TABS = flattenApplicationDetailNavItems(APPLICATION_NAV_GROUPS);
 
 function ModuleLayout() {
     useEnvironmentPermissions();
@@ -67,6 +72,13 @@ export function AppRoutes() {
                         <Route path="applications">
                             <Route index element={<ApplicationsPage />} />
                             <Route path="new" element={<RegisterApplicationPage />} />
+                            <Route path=":applicationId" element={<ApplicationDetailLayout />}>
+                                <Route index element={<ApplicationDetailIndexRedirect />} />
+                                {APPLICATION_DETAIL_TABS.map(tab => (
+                                    <Route key={tab.path} path={tab.path} element={applicationDetailTabElement(tab.path, tab.label)} />
+                                ))}
+                                <Route path="*" element={<ApplicationDetailIndexRedirect />} />
+                            </Route>
                         </Route>
                     </Route>
                 </Routes>

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/config/applicationDetailNavigation.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/config/applicationDetailNavigation.spec.ts
@@ -1,0 +1,79 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+    APPLICATION_IMPLEMENTED_DETAIL_PATHS,
+    APPLICATION_NAV_GROUPS,
+    filterApplicationDetailNavGroups,
+    getApplicationDetailTabPermissions,
+    getFirstAccessibleApplicationDetailPath,
+    getFirstAccessibleImplementedApplicationDetailPath,
+    resolveApplicationDetailLandingPath,
+} from './applicationDetailNavigation';
+
+describe('normalizeCrudMapRecord (application permissions)', () => {
+    it('expands CRUD strings into per-letter tokens', async () => {
+        const { normalizeCrudMapRecord } = await import('../shared/gamma-modules-sdk');
+        expect(normalizeCrudMapRecord('application', { DEFINITION: 'CRUD' })).toEqual([
+            'application-definition-c',
+            'application-definition-r',
+            'application-definition-u',
+            'application-definition-d',
+        ]);
+    });
+});
+
+describe('applicationDetailNavigation permissions', () => {
+    const hasDefinitionRead = (permissions: string[]) => permissions.includes('application-definition-r');
+    const hasMemberRead = (permissions: string[]) => permissions.includes('application-member-r');
+
+    it('maps general tab to application-definition-r', () => {
+        expect(getApplicationDetailTabPermissions('general')).toEqual(['application-definition-r']);
+    });
+
+    it('filters nav groups by permission', () => {
+        const filtered = filterApplicationDetailNavGroups(APPLICATION_NAV_GROUPS, hasDefinitionRead);
+        expect(filtered.map(g => g.label)).toEqual(['General']);
+        expect(filtered[0].items.map(i => i.path)).toEqual(['overview', 'general']);
+    });
+
+    it('returns first accessible path for the user', () => {
+        expect(getFirstAccessibleApplicationDetailPath(APPLICATION_NAV_GROUPS, hasMemberRead)).toBe('user-permissions');
+        expect(getFirstAccessibleApplicationDetailPath(APPLICATION_NAV_GROUPS, hasDefinitionRead)).toBe('overview');
+    });
+
+    it('returns first accessible implemented path (skips overview placeholder)', () => {
+        expect(
+            getFirstAccessibleImplementedApplicationDetailPath(
+                APPLICATION_NAV_GROUPS,
+                APPLICATION_IMPLEMENTED_DETAIL_PATHS,
+                hasDefinitionRead,
+            ),
+        ).toBe('general');
+        expect(
+            getFirstAccessibleImplementedApplicationDetailPath(APPLICATION_NAV_GROUPS, APPLICATION_IMPLEMENTED_DETAIL_PATHS, hasMemberRead),
+        ).toBeNull();
+    });
+
+    it('returns null when user has no tab permissions', () => {
+        expect(getFirstAccessibleApplicationDetailPath(APPLICATION_NAV_GROUPS, () => false)).toBeNull();
+    });
+
+    it('resolveApplicationDetailLandingPath prefers implemented tabs then any permitted tab', () => {
+        expect(resolveApplicationDetailLandingPath(hasDefinitionRead)).toBe('general');
+        expect(resolveApplicationDetailLandingPath(hasMemberRead)).toBe('user-permissions');
+        expect(resolveApplicationDetailLandingPath(() => false)).toBeNull();
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/config/applicationDetailNavigation.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/config/applicationDetailNavigation.ts
@@ -1,0 +1,116 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { LayoutDashboardIcon, PlugIcon, ShieldCheckIcon, SlidersHorizontalIcon } from '@gravitee/graphene-core/icons';
+import type { ComponentType } from 'react';
+
+import { APPLICATION_IMPLEMENTED_DETAIL_PATHS } from './applicationDetailPages';
+
+export interface ApplicationDetailNavItem {
+    path: string;
+    label: string;
+    icon: ComponentType<{ className?: string }>;
+    /** When set, the tab is shown only if the user has any of these permissions (application scope). */
+    permissions?: string[];
+}
+
+export interface ApplicationDetailNavGroup {
+    label: string;
+    items: ApplicationDetailNavItem[];
+}
+
+/** Single source of truth for application detail sidebar labels, paths, and nested routes. */
+export const APPLICATION_NAV_GROUPS: ApplicationDetailNavGroup[] = [
+    {
+        label: 'General',
+        items: [
+            { path: 'overview', label: 'Overview', icon: LayoutDashboardIcon, permissions: ['application-definition-r'] },
+            { path: 'general', label: 'General', icon: SlidersHorizontalIcon, permissions: ['application-definition-r'] },
+        ],
+    },
+    {
+        label: 'Security',
+        items: [{ path: 'user-permissions', label: 'User Permissions', icon: ShieldCheckIcon, permissions: ['application-member-r'] }],
+    },
+    {
+        label: 'Subscriptions',
+        items: [{ path: 'subscriptions', label: 'Subscriptions', icon: PlugIcon, permissions: ['application-subscription-r'] }],
+    },
+];
+
+export function flattenApplicationDetailNavItems(groups: ApplicationDetailNavGroup[]): ApplicationDetailNavItem[] {
+    return groups.flatMap(group => group.items);
+}
+
+/** Console-aligned default landing tab (Global settings). */
+export const APPLICATION_CONSOLE_DEFAULT_DETAIL_PATH = 'general';
+
+export function filterApplicationDetailNavGroups(
+    groups: ApplicationDetailNavGroup[],
+    hasAnyPermission: (permissions: string[]) => boolean,
+): ApplicationDetailNavGroup[] {
+    return groups
+        .map(group => ({
+            ...group,
+            items: group.items.filter(item => !item.permissions || hasAnyPermission(item.permissions)),
+        }))
+        .filter(group => group.items.length > 0);
+}
+
+export function getFirstAccessibleApplicationDetailPath(
+    groups: ApplicationDetailNavGroup[],
+    hasAnyPermission: (permissions: string[]) => boolean,
+): string | null {
+    for (const item of flattenApplicationDetailNavItems(groups)) {
+        if (!item.permissions || hasAnyPermission(item.permissions)) {
+            return item.path;
+        }
+    }
+    return null;
+}
+
+/** First permission-visible tab that has a real page (skips placeholder-only routes such as overview). */
+export function getFirstAccessibleImplementedApplicationDetailPath(
+    groups: ApplicationDetailNavGroup[],
+    implementedPaths: Set<string>,
+    hasAnyPermission: (permissions: string[]) => boolean,
+): string | null {
+    for (const item of flattenApplicationDetailNavItems(groups)) {
+        if (!implementedPaths.has(item.path)) {
+            continue;
+        }
+        if (!item.permissions || hasAnyPermission(item.permissions)) {
+            return item.path;
+        }
+    }
+    return null;
+}
+
+export function getApplicationDetailTabPermissions(tabPath: string): string[] | undefined {
+    return flattenApplicationDetailNavItems(APPLICATION_NAV_GROUPS).find(item => item.path === tabPath)?.permissions;
+}
+
+/** First tab the user may open (implemented pages preferred); null when no nav item is permitted. */
+export function resolveApplicationDetailLandingPath(hasAnyPermission: (permissions: string[]) => boolean): string | null {
+    return (
+        getFirstAccessibleImplementedApplicationDetailPath(
+            APPLICATION_NAV_GROUPS,
+            APPLICATION_IMPLEMENTED_DETAIL_PATHS,
+            hasAnyPermission,
+        ) ?? getFirstAccessibleApplicationDetailPath(APPLICATION_NAV_GROUPS, hasAnyPermission)
+    );
+}
+
+export { APPLICATION_IMPLEMENTED_DETAIL_PATHS } from './applicationDetailPages';

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/config/applicationDetailPages.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/config/applicationDetailPages.tsx
@@ -1,0 +1,36 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import type { ComponentType } from 'react';
+
+import { ApplicationDetailPlaceholderPage } from '../features/applications/components/detail';
+import { ApplicationDetailGeneralPage } from '../pages/ApplicationDetailGeneralPage';
+
+/** Tab paths with a dedicated page implementation (keys drive routing and landing redirect). */
+export const APPLICATION_DETAIL_PAGES = {
+    general: ApplicationDetailGeneralPage,
+} as const satisfies Record<string, ComponentType>;
+
+export type ApplicationDetailImplementedPath = keyof typeof APPLICATION_DETAIL_PAGES;
+
+export const APPLICATION_IMPLEMENTED_DETAIL_PATHS = new Set<string>(Object.keys(APPLICATION_DETAIL_PAGES));
+
+export function applicationDetailTabElement(path: string, label: string) {
+    const Page = APPLICATION_DETAIL_PAGES[path as ApplicationDetailImplementedPath];
+    if (Page) {
+        return <Page />;
+    }
+    return <ApplicationDetailPlaceholderPage title={label} />;
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/create/OAuthSecurityFields.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/create/OAuthSecurityFields.tsx
@@ -76,7 +76,7 @@ export function OAuthSecurityFields({
                                 {isActive && <CircleCheckIcon className="size-3.5" aria-hidden />}
                                 {grantType.name}
                                 {isMandatory && (
-                                    <Badge variant="secondary" className="ml-1 text-[10px]">
+                                    <Badge variant="secondary" className="ml-1 text-xs">
                                         Mandatory
                                     </Badge>
                                 )}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/create/RegisterApplicationForm.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/create/RegisterApplicationForm.tsx
@@ -116,9 +116,9 @@ export function RegisterApplicationForm() {
         createApplication.mutate(
             { draft, selectedType },
             {
-                onSuccess: application =>
-                    navigate('..', {
-                        state: { successMessage: `Application "${application.name}" created.` },
+                onSuccess: created =>
+                    navigate(`../${created.id}/general`, {
+                        state: { created: true, applicationName: created.name },
                     }),
             },
         );

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/detail/ApplicationDetailAccessDenied.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/detail/ApplicationDetailAccessDenied.tsx
@@ -1,0 +1,32 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ShieldIcon } from '@gravitee/graphene-core/icons';
+
+export function ApplicationDetailAccessDenied() {
+    return (
+        <div className="flex flex-col items-center justify-center gap-3 rounded-lg border border-dashed bg-muted/20 px-6 py-16 text-center">
+            <div className="flex size-10 items-center justify-center rounded-full bg-muted">
+                <ShieldIcon className="size-5 text-muted-foreground" aria-hidden />
+            </div>
+            <div className="space-y-1">
+                <h2 className="text-base font-semibold">Access denied</h2>
+                <p className="max-w-md text-sm text-muted-foreground">
+                    You do not have permission to view this section of the application. Contact your administrator if you need access.
+                </p>
+            </div>
+        </div>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/detail/ApplicationDetailLayout.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/detail/ApplicationDetailLayout.tsx
@@ -1,0 +1,184 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { permissionService } from '@gravitee/gamma-modules-sdk';
+import { Badge, Skeleton } from '@gravitee/graphene-core';
+import { AppWindowIcon } from '@gravitee/graphene-core/icons';
+import { useMemo } from 'react';
+import { Navigate, useNavigate, useParams } from 'react-router-dom';
+
+import { ApplicationDetailNoSectionsAvailable } from './ApplicationDetailNoSectionsAvailable';
+import { ApplicationDetailPermissionsError } from './ApplicationDetailPermissionsError';
+import { ApplicationDetailProtectedOutlet } from './ApplicationDetailProtectedOutlet';
+import { ApplicationDetailSidebarNav } from './ApplicationDetailSidebarNav';
+import { APPLICATION_NAV_GROUPS, resolveApplicationDetailLandingPath } from '../../../../config/applicationDetailNavigation';
+import { useDetailBasePath } from '../../../shared/hooks/useDetailBasePath';
+import { usePermissionServiceSnapshot } from '../../../shared/hooks/usePermissionServiceSnapshot';
+import { ApplicationDetailContext, useApplicationDetailContext } from '../../context/ApplicationDetailContext';
+import { useApplicationDetail } from '../../hooks/useApplicationDetail';
+import { useApplicationPermissions } from '../../hooks/useApplicationPermissions';
+import type { ApplicationListItem, ApplicationStatus } from '../../types/application';
+import { formatApplicationOwnerLabel, formatApplicationSecurityTypeLabel } from '../../utils/applicationFormatters';
+
+function StatusBadge({ status }: { status: ApplicationStatus }) {
+    if (status === 'ACTIVE') {
+        return (
+            <Badge className="h-6 w-fit rounded-md border-0 bg-primary px-2.5 text-xs font-medium lowercase text-primary-foreground">
+                active
+            </Badge>
+        );
+    }
+    return (
+        <Badge className="h-6 w-fit rounded-md border-0 bg-muted px-2.5 text-xs font-medium lowercase text-muted-foreground">
+            archived
+        </Badge>
+    );
+}
+
+function ApplicationInfoHeader({ application, isLoading }: { application: ApplicationListItem | null; isLoading: boolean }) {
+    if (isLoading) {
+        return (
+            <div className="space-y-2 border-b px-3 pb-4 pt-4">
+                <div className="flex items-start gap-2.5">
+                    <Skeleton className="size-8 shrink-0 rounded-lg" />
+                    <div className="min-w-0 flex-1 space-y-1.5">
+                        <Skeleton className="h-3.5 w-32 rounded" />
+                        <Skeleton className="h-6 w-14 rounded-md" />
+                    </div>
+                </div>
+                <Skeleton className="h-3 w-full rounded" />
+                <div className="flex gap-1.5">
+                    <Skeleton className="h-5 w-14 rounded-md" />
+                    <Skeleton className="h-5 w-24 rounded-md" />
+                </div>
+            </div>
+        );
+    }
+
+    if (!application) return null;
+
+    const ownerLabel = formatApplicationOwnerLabel(application.owner);
+
+    return (
+        <div className="space-y-2 border-b px-3 pb-4 pt-4">
+            <div className="flex items-start gap-2.5">
+                <div className="flex size-8 shrink-0 items-center justify-center rounded-lg border border-primary/30 bg-primary/5">
+                    <AppWindowIcon className="size-4 text-primary" aria-hidden />
+                </div>
+                <div className="min-w-0 flex-1 space-y-1.5">
+                    <p className="truncate text-sm font-semibold leading-snug text-foreground" title={application.name}>
+                        {application.name}
+                    </p>
+                    <StatusBadge status={application.status} />
+                </div>
+            </div>
+            {application.description ? (
+                <p className="line-clamp-2 break-all text-xs leading-relaxed text-muted-foreground" title={application.description}>
+                    {application.description}
+                </p>
+            ) : null}
+            <div className="flex flex-wrap items-center gap-1.5">
+                <span className="inline-flex h-5 items-center border border-border bg-background px-1.5 text-xs font-normal text-foreground">
+                    {formatApplicationSecurityTypeLabel(application)}
+                </span>
+                {ownerLabel ? (
+                    <span className="inline-flex h-5 items-center bg-muted px-1.5 text-xs font-normal text-foreground">{ownerLabel}</span>
+                ) : null}
+            </div>
+        </div>
+    );
+}
+
+export function ApplicationDetailLayout() {
+    const navigate = useNavigate();
+    const { applicationId } = useParams<{ applicationId: string }>();
+    const basePath = useDetailBasePath('applications', applicationId);
+    const { data: application, isLoading, isError } = useApplicationDetail(applicationId);
+    const { permissionsReady, isError: permissionsError, refetch: refetchPermissions } = useApplicationPermissions(applicationId);
+
+    if (isError) {
+        return (
+            <div className="flex items-center justify-center p-8">
+                <p className="text-sm text-muted-foreground">
+                    Failed to load application. It may have been deleted or you may not have access.
+                </p>
+            </div>
+        );
+    }
+
+    if (permissionsError) {
+        const applicationsListPath = applicationId
+            ? basePath.endsWith(`/${applicationId}`)
+                ? basePath.slice(0, -applicationId.length - 1)
+                : '..'
+            : '..';
+        return <ApplicationDetailPermissionsError onRetry={refetchPermissions} onBack={() => navigate(applicationsListPath)} />;
+    }
+
+    return (
+        <ApplicationDetailContext.Provider
+            value={{
+                application: application ?? null,
+                isLoading,
+                permissionsReady,
+                permissionsError: false,
+                refetchPermissions,
+            }}
+        >
+            <div className="flex gap-6">
+                <aside className="sticky top-0 max-h-[100dvh] w-56 min-w-0 max-w-56 shrink-0 self-start overflow-x-hidden overflow-y-auto pb-4">
+                    <ApplicationInfoHeader application={application ?? null} isLoading={isLoading} />
+                    <ApplicationDetailSidebarNav
+                        groups={APPLICATION_NAV_GROUPS}
+                        basePath={basePath}
+                        permissionsReady={permissionsReady && !isLoading}
+                    />
+                </aside>
+                <main className="min-w-0 flex-1">
+                    <ApplicationDetailProtectedOutlet />
+                </main>
+            </div>
+        </ApplicationDetailContext.Provider>
+    );
+}
+
+export function ApplicationDetailIndexRedirect() {
+    const { permissionsReady, permissionsError } = useApplicationDetailContext();
+    const permissionVersion = usePermissionServiceSnapshot();
+
+    const landingPath = useMemo(
+        () => resolveApplicationDetailLandingPath(permissions => permissionService.hasAnyOf(permissions)),
+        [permissionVersion],
+    );
+
+    if (permissionsError) {
+        return null;
+    }
+
+    if (!permissionsReady) {
+        return (
+            <div className="space-y-6">
+                <Skeleton className="h-10 w-64" />
+                <Skeleton className="h-96 w-full" />
+            </div>
+        );
+    }
+
+    if (!landingPath) {
+        return <ApplicationDetailNoSectionsAvailable />;
+    }
+
+    return <Navigate to={landingPath} replace />;
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/detail/ApplicationDetailNoSectionsAvailable.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/detail/ApplicationDetailNoSectionsAvailable.tsx
@@ -1,0 +1,33 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { AppWindowIcon } from '@gravitee/graphene-core/icons';
+
+export function ApplicationDetailNoSectionsAvailable() {
+    return (
+        <div className="flex flex-col items-center justify-center gap-3 rounded-lg border border-dashed bg-muted/20 px-6 py-16 text-center">
+            <div className="flex size-10 items-center justify-center rounded-full bg-muted">
+                <AppWindowIcon className="size-5 text-muted-foreground" aria-hidden />
+            </div>
+            <div className="space-y-1">
+                <h2 className="text-base font-semibold">No sections available</h2>
+                <p className="max-w-md text-sm text-muted-foreground">
+                    No sections are available with your current permissions for this application. Contact your administrator if you need
+                    access.
+                </p>
+            </div>
+        </div>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/detail/ApplicationDetailPermissionsError.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/detail/ApplicationDetailPermissionsError.tsx
@@ -1,0 +1,47 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Button } from '@gravitee/graphene-core';
+import { AlertCircleIcon } from '@gravitee/graphene-core/icons';
+
+interface ApplicationDetailPermissionsErrorProps {
+    readonly onRetry: () => void;
+    readonly onBack?: () => void;
+}
+
+export function ApplicationDetailPermissionsError({ onRetry, onBack }: ApplicationDetailPermissionsErrorProps) {
+    return (
+        <div className="flex flex-col items-center justify-center gap-4 p-8 text-center">
+            <AlertCircleIcon className="size-8 text-muted-foreground" aria-hidden />
+            <div className="space-y-1">
+                <p className="text-sm font-medium text-foreground">Failed to load permissions</p>
+                <p className="max-w-md text-sm text-muted-foreground">
+                    Application permissions could not be loaded. You may not have access to this application, or the service may be
+                    temporarily unavailable.
+                </p>
+            </div>
+            <div className="flex flex-wrap items-center justify-center gap-2">
+                <Button type="button" variant="outline" size="sm" onClick={onRetry}>
+                    Retry
+                </Button>
+                {onBack ? (
+                    <Button type="button" variant="ghost" size="sm" onClick={onBack}>
+                        Back to applications
+                    </Button>
+                ) : null}
+            </div>
+        </div>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/detail/ApplicationDetailPlaceholderPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/detail/ApplicationDetailPlaceholderPage.tsx
@@ -1,0 +1,24 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export function ApplicationDetailPlaceholderPage({ title }: { readonly title: string }) {
+    return (
+        <div className="space-y-2">
+            <h1 className="text-2xl font-semibold tracking-tight">{title}</h1>
+            <p className="text-sm text-muted-foreground">Coming soon.</p>
+        </div>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/detail/ApplicationDetailProtectedOutlet.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/detail/ApplicationDetailProtectedOutlet.tsx
@@ -1,0 +1,59 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useHasPermission } from '@gravitee/gamma-modules-sdk';
+import { Skeleton } from '@gravitee/graphene-core';
+import { Outlet, useLocation, useParams } from 'react-router-dom';
+
+import { ApplicationDetailAccessDenied } from './ApplicationDetailAccessDenied';
+import { getApplicationDetailTabPermissions } from '../../../../config/applicationDetailNavigation';
+import { useDetailBasePath } from '../../../shared/hooks/useDetailBasePath';
+import { useApplicationDetailContext } from '../../context/ApplicationDetailContext';
+
+function useApplicationDetailTabPath(): string {
+    const { applicationId } = useParams<{ applicationId: string }>();
+    const location = useLocation();
+    const basePath = useDetailBasePath('applications', applicationId);
+
+    if (!basePath || !location.pathname.startsWith(basePath)) {
+        return '';
+    }
+
+    const remainder = location.pathname.slice(basePath.length).replace(/^\//, '');
+    return remainder.split('/')[0] ?? '';
+}
+
+export function ApplicationDetailProtectedOutlet() {
+    const { permissionsReady, permissionsError } = useApplicationDetailContext();
+    const tabPath = useApplicationDetailTabPath();
+    const requiredPermissions = getApplicationDetailTabPermissions(tabPath);
+    const canAccessTab = useHasPermission({ anyOf: requiredPermissions ?? [] });
+    const isAccessDenied = Boolean(requiredPermissions?.length) && !canAccessTab;
+
+    if (permissionsError || !permissionsReady) {
+        return (
+            <div className="space-y-6">
+                <Skeleton className="h-10 w-64" />
+                <Skeleton className="h-96 w-full" />
+            </div>
+        );
+    }
+
+    if (isAccessDenied) {
+        return <ApplicationDetailAccessDenied />;
+    }
+
+    return <Outlet />;
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/detail/ApplicationDetailSidebarNav.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/detail/ApplicationDetailSidebarNav.tsx
@@ -1,0 +1,95 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { permissionService } from '@gravitee/gamma-modules-sdk';
+import { cn, Skeleton } from '@gravitee/graphene-core';
+import { useMemo } from 'react';
+import { NavLink } from 'react-router-dom';
+
+import type { ApplicationDetailNavGroup } from '../../../../config/applicationDetailNavigation';
+import { filterApplicationDetailNavGroups } from '../../../../config/applicationDetailNavigation';
+import { usePermissionServiceSnapshot } from '../../../shared/hooks/usePermissionServiceSnapshot';
+
+export type { ApplicationDetailNavGroup, ApplicationDetailNavItem } from '../../../../config/applicationDetailNavigation';
+export { APPLICATION_NAV_GROUPS } from '../../../../config/applicationDetailNavigation';
+
+interface ApplicationDetailSidebarNavProps {
+    readonly groups: ApplicationDetailNavGroup[];
+    readonly basePath: string;
+    /** When false, renders a loading skeleton in place of nav items. */
+    readonly permissionsReady?: boolean;
+}
+
+export function ApplicationDetailSidebarNav({ groups, basePath, permissionsReady = true }: ApplicationDetailSidebarNavProps) {
+    const permissionVersion = usePermissionServiceSnapshot();
+
+    const visibleGroups = useMemo(() => {
+        if (!permissionsReady) {
+            return [];
+        }
+        return filterApplicationDetailNavGroups(groups, permissions => permissionService.hasAnyOf(permissions));
+    }, [groups, permissionsReady, permissionVersion]);
+
+    if (!permissionsReady) {
+        return (
+            <div className="space-y-0.5 px-2 py-4">
+                {Array.from({ length: 5 }).map((_, index) => (
+                    <div key={index} className="px-3 py-2">
+                        <Skeleton className="h-4 rounded" />
+                    </div>
+                ))}
+            </div>
+        );
+    }
+
+    if (visibleGroups.length === 0) {
+        return (
+            <p className="px-3 py-4 text-xs text-muted-foreground">
+                No sections are available with your current permissions for this application.
+            </p>
+        );
+    }
+
+    return (
+        <div className="space-y-0.5 px-2 py-2">
+            {visibleGroups.map(group => (
+                <div key={group.label} className="pt-4 first:pt-0">
+                    <p className="mb-1 px-3 text-xs font-semibold uppercase tracking-wider text-muted-foreground">{group.label}</p>
+                    {group.items.map(item => {
+                        const Icon = item.icon;
+                        return (
+                            <NavLink
+                                end
+                                key={item.path}
+                                to={`${basePath}/${item.path}`}
+                                className={({ isActive }) =>
+                                    cn(
+                                        'flex items-center gap-2.5 rounded-lg px-3 py-2 text-sm transition-colors',
+                                        isActive
+                                            ? 'bg-accent text-foreground font-medium'
+                                            : 'text-muted-foreground hover:bg-muted hover:text-foreground',
+                                    )
+                                }
+                            >
+                                <Icon className="size-4 shrink-0" aria-hidden />
+                                {item.label}
+                            </NavLink>
+                        );
+                    })}
+                </div>
+            ))}
+        </div>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/detail/index.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/detail/index.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+export { ApplicationDetailIndexRedirect, ApplicationDetailLayout } from './ApplicationDetailLayout';
+export { ApplicationDetailPlaceholderPage } from './ApplicationDetailPlaceholderPage';

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/general/ApplicationAddCertificateDialog.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/general/ApplicationAddCertificateDialog.tsx
@@ -1,0 +1,191 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useEnvironment } from '@gravitee/gamma-modules-sdk';
+import {
+    Button,
+    Dialog,
+    DialogClose,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+    Input,
+    Label,
+    cn,
+} from '@gravitee/graphene-core';
+import { FileUpIcon, XIcon } from '@gravitee/graphene-core/icons';
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+import { findActiveCertificate, readFileAsText } from './certificateUtils';
+import { validateApplicationCertificate } from '../../services/applicationDetail';
+import type { ClientCertificate } from '../../types/applicationCertificate';
+
+export interface AddCertificateSubmit {
+    name: string;
+    certificate: string;
+    endsAt?: string;
+    gracePeriodEnd?: string;
+    activeCertificateId?: string;
+}
+
+export function ApplicationAddCertificateDialog({
+    open,
+    onOpenChange,
+    applicationId,
+    certificates,
+    onSubmit,
+    isSubmitting,
+    error,
+}: Readonly<{
+    open: boolean;
+    onOpenChange: (open: boolean) => void;
+    applicationId: string;
+    certificates: ClientCertificate[];
+    onSubmit: (payload: AddCertificateSubmit) => void;
+    isSubmitting: boolean;
+    error?: string | null;
+}>) {
+    const env = useEnvironment();
+    const fileRef = useRef<HTMLInputElement>(null);
+    const [name, setName] = useState('');
+    const [certificate, setCertificate] = useState('');
+    const [endsAt, setEndsAt] = useState('');
+    const [gracePeriodEnd, setGracePeriodEnd] = useState('');
+    const [fileError, setFileError] = useState<string | null>(null);
+    const [validating, setValidating] = useState(false);
+
+    const activeCert = findActiveCertificate(certificates);
+    const hasActive = Boolean(activeCert);
+
+    useEffect(() => {
+        if (!open) {
+            setName('');
+            setCertificate('');
+            setEndsAt('');
+            setGracePeriodEnd('');
+            setFileError(null);
+        }
+    }, [open]);
+
+    const handleFile = useCallback(
+        async (file: File | undefined) => {
+            if (!file || !env) return;
+            setFileError(null);
+            try {
+                const content = await readFileAsText(file);
+                setValidating(true);
+                await validateApplicationCertificate(env.id, applicationId, content);
+                setCertificate(content);
+            } catch (e) {
+                setCertificate('');
+                setFileError(e instanceof Error ? e.message : 'Invalid certificate.');
+            } finally {
+                setValidating(false);
+            }
+        },
+        [applicationId, env],
+    );
+
+    const handleAdd = () => {
+        if (!name.trim() || !certificate) return;
+        const endsAtIso = endsAt ? new Date(endsAt).toISOString() : undefined;
+        const graceIso = gracePeriodEnd ? new Date(gracePeriodEnd).toISOString() : undefined;
+        onSubmit({
+            name: name.trim(),
+            certificate,
+            endsAt: endsAtIso,
+            ...(hasActive && graceIso && activeCert ? { gracePeriodEnd: graceIso, activeCertificateId: activeCert.id } : {}),
+        });
+    };
+
+    const canSubmit =
+        Boolean(name.trim()) && Boolean(certificate) && !isSubmitting && !validating && (!hasActive || Boolean(gracePeriodEnd));
+
+    return (
+        <Dialog open={open} onOpenChange={onOpenChange}>
+            <DialogContent className="w-[clamp(20rem,33vw,36rem)] max-w-[clamp(20rem,33vw,36rem)]" showCloseButton={false}>
+                <DialogHeader className="flex-row items-start justify-between gap-3 space-y-0">
+                    <div className="space-y-1.5 text-left">
+                        <DialogTitle>Add certificate</DialogTitle>
+                        <DialogDescription>Upload a PEM client certificate for mutual TLS authentication.</DialogDescription>
+                    </div>
+                    <DialogClose asChild>
+                        <Button type="button" variant="ghost" size="icon" className="size-8 shrink-0" aria-label="Close">
+                            <XIcon className="size-4" aria-hidden />
+                        </Button>
+                    </DialogClose>
+                </DialogHeader>
+
+                <div className="space-y-4 py-2">
+                    <div className="space-y-2">
+                        <Label htmlFor="cert-name">Certificate name</Label>
+                        <Input id="cert-name" value={name} onChange={e => setName(e.target.value)} placeholder="e.g. my-app-mtls-2026" />
+                    </div>
+                    <div className="space-y-2">
+                        <Label htmlFor="cert-expiry">Expiry date (optional)</Label>
+                        <Input id="cert-expiry" type="date" value={endsAt} onChange={e => setEndsAt(e.target.value)} />
+                    </div>
+                    {hasActive ? (
+                        <div className="space-y-2">
+                            <Label htmlFor="cert-grace">Grace period end (required)</Label>
+                            <Input id="cert-grace" type="date" value={gracePeriodEnd} onChange={e => setGracePeriodEnd(e.target.value)} />
+                            <p className="text-xs text-muted-foreground">
+                                Sets when the current active certificate ({activeCert?.name}) stops being used.
+                            </p>
+                        </div>
+                    ) : null}
+                    <button
+                        type="button"
+                        onClick={() => fileRef.current?.click()}
+                        disabled={validating}
+                        className={cn(
+                            'flex min-h-36 w-full flex-col items-center justify-center rounded-lg border-2 border-dashed border-border bg-muted/30 p-6 transition-colors',
+                            validating ? 'opacity-60' : 'cursor-pointer hover:border-primary',
+                        )}
+                    >
+                        <FileUpIcon className="size-7 text-muted-foreground/50" aria-hidden />
+                        <p className="mt-2 text-sm font-medium">{validating ? 'Validating…' : 'Drop PEM file or click to browse'}</p>
+                        {certificate ? <p className="mt-1 text-xs text-success">Certificate loaded</p> : null}
+                        {fileError ? <p className="mt-1 text-xs text-destructive">{fileError}</p> : null}
+                    </button>
+                    <input
+                        ref={fileRef}
+                        type="file"
+                        accept=".pem,.crt,.cer,text/plain"
+                        className="sr-only"
+                        onChange={e => {
+                            void handleFile(e.target.files?.[0]);
+                            e.target.value = '';
+                        }}
+                    />
+                    {error ? <p className="text-sm text-destructive">{error}</p> : null}
+                </div>
+
+                <DialogFooter className="sm:justify-end">
+                    <DialogClose asChild>
+                        <Button type="button" variant="outline">
+                            Cancel
+                        </Button>
+                    </DialogClose>
+                    <Button type="button" onClick={handleAdd} disabled={!canSubmit}>
+                        {isSubmitting ? 'Adding…' : 'Add certificate'}
+                    </Button>
+                </DialogFooter>
+            </DialogContent>
+        </Dialog>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/general/ApplicationCertificateDetailDialog.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/general/ApplicationCertificateDetailDialog.tsx
@@ -1,0 +1,82 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+    Badge,
+    Button,
+    Dialog,
+    DialogClose,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+} from '@gravitee/graphene-core';
+import { XIcon } from '@gravitee/graphene-core/icons';
+
+import { certificateStatusLabel, certificateStatusVariant } from './certificateUtils';
+import type { ClientCertificate } from '../../types/applicationCertificate';
+import { formatApplicationDateTime } from '../../utils/applicationFormatters';
+
+export function ApplicationCertificateDetailDialog({
+    certificate,
+    onClose,
+}: Readonly<{
+    certificate: ClientCertificate | null;
+    onClose: () => void;
+}>) {
+    return (
+        <Dialog open={certificate !== null} onOpenChange={open => !open && onClose()}>
+            <DialogContent className="w-full max-w-sm sm:max-w-md" showCloseButton={false}>
+                <DialogHeader className="flex-row items-start justify-between gap-3 space-y-0">
+                    <div className="space-y-1.5 text-left">
+                        <DialogTitle>{certificate?.name}</DialogTitle>
+                        <DialogDescription>Certificate details</DialogDescription>
+                    </div>
+                    <DialogClose asChild>
+                        <Button type="button" variant="ghost" size="icon" className="size-8 shrink-0" aria-label="Close">
+                            <XIcon className="size-4" aria-hidden />
+                        </Button>
+                    </DialogClose>
+                </DialogHeader>
+                {certificate ? (
+                    <dl className="space-y-2 py-2 text-sm">
+                        <div className="flex justify-between gap-4">
+                            <dt className="text-muted-foreground">Uploaded</dt>
+                            <dd>{formatApplicationDateTime(certificate.createdAt)}</dd>
+                        </div>
+                        <div className="flex justify-between gap-4">
+                            <dt className="text-muted-foreground">Expiry</dt>
+                            <dd>{certificate.endsAt ? formatApplicationDateTime(certificate.endsAt) : '—'}</dd>
+                        </div>
+                        <div className="flex justify-between gap-4">
+                            <dt className="text-muted-foreground">Status</dt>
+                            <dd>
+                                <Badge variant={certificateStatusVariant(certificate.status)} className="text-xs">
+                                    {certificateStatusLabel(certificate.status)}
+                                </Badge>
+                            </dd>
+                        </div>
+                    </dl>
+                ) : null}
+                <DialogFooter className="sm:justify-end">
+                    <Button type="button" variant="outline" onClick={onClose}>
+                        Close
+                    </Button>
+                </DialogFooter>
+            </DialogContent>
+        </Dialog>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/general/ApplicationCertificatesSection.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/general/ApplicationCertificatesSection.tsx
@@ -1,0 +1,316 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+    Alert,
+    AlertDescription,
+    Badge,
+    Button,
+    Card,
+    CardContent,
+    CardDescription,
+    CardHeader,
+    CardTitle,
+    Skeleton,
+    Table,
+    TableBody,
+    TableCell,
+    TableHead,
+    TableHeader,
+    TableRow,
+} from '@gravitee/graphene-core';
+import { FileUpIcon, PlusIcon } from '@gravitee/graphene-core/icons';
+import type { UseMutationResult } from '@tanstack/react-query';
+import { useState } from 'react';
+
+import { ApplicationAddCertificateDialog, type AddCertificateSubmit } from './ApplicationAddCertificateDialog';
+import { ApplicationCertificateDetailDialog } from './ApplicationCertificateDetailDialog';
+import { ApplicationRevokeCertificateDialog } from './ApplicationRevokeCertificateDialog';
+import { certificateStatusLabel, certificateStatusVariant } from './certificateUtils';
+import { useApplicationCertificates } from '../../hooks/useApplicationCertificates';
+import {
+    toGracePeriodUpdateFailure,
+    type AddCertificateWithGraceInput,
+    type GracePeriodUpdateFailure,
+} from '../../hooks/useApplicationGeneralMutations';
+import type { ClientCertificate, UpdateClientCertificate } from '../../types/applicationCertificate';
+import { formatApplicationDateTime } from '../../utils/applicationFormatters';
+
+export interface ApplicationCertificatesSectionProps {
+    readonly applicationId: string;
+    readonly canManageCertificates: boolean;
+    readonly isMutating: boolean;
+    readonly addCertificateWithGraceMutation: UseMutationResult<ClientCertificate, Error, AddCertificateWithGraceInput, unknown>;
+    readonly updateCertificateMutation: UseMutationResult<
+        ClientCertificate,
+        Error,
+        { certificateId: string; update: UpdateClientCertificate },
+        unknown
+    >;
+}
+
+export function ApplicationCertificatesSection({
+    applicationId,
+    canManageCertificates,
+    isMutating,
+    addCertificateWithGraceMutation,
+    updateCertificateMutation,
+}: ApplicationCertificatesSectionProps) {
+    const { data: certificates = [], isLoading: certificatesLoading } = useApplicationCertificates(applicationId);
+
+    const [certDialogOpen, setCertDialogOpen] = useState(false);
+    const [viewCert, setViewCert] = useState<ClientCertificate | null>(null);
+    const [revokeCert, setRevokeCert] = useState<ClientCertificate | null>(null);
+    const [certError, setCertError] = useState<string | null>(null);
+    const [revokeError, setRevokeError] = useState<string | null>(null);
+    const [gracePeriodWarning, setGracePeriodWarning] = useState<GracePeriodUpdateFailure | null>(null);
+
+    const actionsDisabled = isMutating || !canManageCertificates;
+
+    const openAddDialog = () => {
+        setCertError(null);
+        setCertDialogOpen(true);
+    };
+
+    const handleAddCertificate = (submit: AddCertificateSubmit) => {
+        setCertError(null);
+        const activeCert = submit.activeCertificateId ? certificates.find(c => c.id === submit.activeCertificateId) : undefined;
+        addCertificateWithGraceMutation.mutate(
+            {
+                create: {
+                    name: submit.name,
+                    certificate: submit.certificate,
+                    endsAt: submit.endsAt,
+                },
+                gracePeriod:
+                    submit.gracePeriodEnd && submit.activeCertificateId && activeCert
+                        ? {
+                              certificateId: submit.activeCertificateId,
+                              name: activeCert.name,
+                              endsAt: submit.gracePeriodEnd,
+                          }
+                        : undefined,
+            },
+            {
+                onSuccess: () => {
+                    setCertDialogOpen(false);
+                    setGracePeriodWarning(null);
+                },
+                onError: (e: unknown) => {
+                    const graceFailure = toGracePeriodUpdateFailure(e);
+                    if (graceFailure) {
+                        setGracePeriodWarning(graceFailure);
+                        setCertDialogOpen(false);
+                        return;
+                    }
+                    setCertError(e instanceof Error ? e.message : 'Failed to add certificate.');
+                },
+            },
+        );
+    };
+
+    const handleRetryGracePeriod = () => {
+        if (!gracePeriodWarning) return;
+        updateCertificateMutation.mutate(
+            {
+                certificateId: gracePeriodWarning.certificateId,
+                update: { name: gracePeriodWarning.name, endsAt: gracePeriodWarning.endsAt },
+            },
+            {
+                onSuccess: () => setGracePeriodWarning(null),
+                onError: (e: unknown) =>
+                    setGracePeriodWarning(prev =>
+                        prev
+                            ? {
+                                  ...prev,
+                                  message: e instanceof Error ? e.message : 'Failed to update grace period.',
+                              }
+                            : prev,
+                    ),
+            },
+        );
+    };
+
+    const handleRevokeCertificate = () => {
+        if (!revokeCert) return;
+        setRevokeError(null);
+        const endsAt = new Date(Date.now() - 1000).toISOString();
+        updateCertificateMutation.mutate(
+            {
+                certificateId: revokeCert.id,
+                update: { name: revokeCert.name, endsAt },
+            },
+            {
+                onSuccess: () => {
+                    setRevokeCert(null);
+                    setRevokeError(null);
+                },
+                onError: (e: unknown) => setRevokeError(e instanceof Error ? e.message : 'Failed to revoke certificate.'),
+            },
+        );
+    };
+
+    return (
+        <>
+            {gracePeriodWarning ? (
+                <Alert variant="default" className="border-warning/40 bg-warning/10">
+                    <AlertDescription className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                        <span className="text-sm text-foreground">{gracePeriodWarning.message}</span>
+                        <Button
+                            type="button"
+                            size="sm"
+                            variant="outline"
+                            className="shrink-0"
+                            disabled={updateCertificateMutation.isPending}
+                            onClick={handleRetryGracePeriod}
+                        >
+                            {updateCertificateMutation.isPending ? 'Retrying…' : 'Retry grace period update'}
+                        </Button>
+                    </AlertDescription>
+                </Alert>
+            ) : null}
+
+            <Card>
+                <CardHeader className="pb-3">
+                    <div className="flex items-center justify-between gap-4">
+                        <div className="space-y-1">
+                            <CardTitle className="text-sm">Certificates</CardTitle>
+                            <CardDescription className="text-xs">
+                                mTLS client certificates for authenticating this application to the gateway.
+                            </CardDescription>
+                        </div>
+                        {canManageCertificates ? (
+                            <Button
+                                type="button"
+                                size="sm"
+                                variant="outline"
+                                className="shrink-0"
+                                disabled={actionsDisabled}
+                                onClick={openAddDialog}
+                            >
+                                <PlusIcon className="size-3.5" aria-hidden />
+                                Add certificate
+                            </Button>
+                        ) : null}
+                    </div>
+                </CardHeader>
+                <CardContent>
+                    {certificatesLoading ? (
+                        <Skeleton className="h-24 w-full" />
+                    ) : certificates.length === 0 ? (
+                        <div className="flex flex-col items-center justify-center rounded-lg border border-dashed bg-muted/20 px-4 py-10 text-center">
+                            <FileUpIcon className="mb-2 size-8 text-muted-foreground/40" aria-hidden />
+                            <p className="text-sm font-medium">No certificates</p>
+                            <p className="mt-1 max-w-sm text-xs text-muted-foreground">
+                                Upload a client certificate to enable mutual TLS for this application.
+                            </p>
+                            {canManageCertificates ? (
+                                <Button
+                                    type="button"
+                                    size="sm"
+                                    variant="outline"
+                                    className="mt-4"
+                                    disabled={actionsDisabled}
+                                    onClick={openAddDialog}
+                                >
+                                    <PlusIcon className="size-3.5" aria-hidden />
+                                    Add certificate
+                                </Button>
+                            ) : null}
+                        </div>
+                    ) : (
+                        <Table>
+                            <TableHeader>
+                                <TableRow>
+                                    <TableHead>Name</TableHead>
+                                    <TableHead>Uploaded</TableHead>
+                                    <TableHead>Expiry</TableHead>
+                                    <TableHead>Status</TableHead>
+                                    <TableHead className="text-right">Actions</TableHead>
+                                </TableRow>
+                            </TableHeader>
+                            <TableBody>
+                                {certificates.map(cert => (
+                                    <TableRow key={cert.id}>
+                                        <TableCell className="font-medium">{cert.name}</TableCell>
+                                        <TableCell className="text-sm text-muted-foreground">
+                                            {formatApplicationDateTime(cert.createdAt)}
+                                        </TableCell>
+                                        <TableCell className="text-sm text-muted-foreground">
+                                            {cert.endsAt ? formatApplicationDateTime(cert.endsAt) : '—'}
+                                        </TableCell>
+                                        <TableCell>
+                                            <Badge variant={certificateStatusVariant(cert.status)} className="text-xs">
+                                                {certificateStatusLabel(cert.status)}
+                                            </Badge>
+                                        </TableCell>
+                                        <TableCell className="text-right">
+                                            <div className="flex justify-end gap-1">
+                                                <Button type="button" variant="ghost" size="sm" onClick={() => setViewCert(cert)}>
+                                                    View
+                                                </Button>
+                                                {canManageCertificates && cert.status !== 'REVOKED' ? (
+                                                    <Button
+                                                        type="button"
+                                                        variant="ghost"
+                                                        size="sm"
+                                                        className="text-destructive hover:text-destructive"
+                                                        disabled={actionsDisabled}
+                                                        onClick={() => {
+                                                            setRevokeError(null);
+                                                            setRevokeCert(cert);
+                                                        }}
+                                                    >
+                                                        Revoke
+                                                    </Button>
+                                                ) : null}
+                                            </div>
+                                        </TableCell>
+                                    </TableRow>
+                                ))}
+                            </TableBody>
+                        </Table>
+                    )}
+                </CardContent>
+            </Card>
+
+            <ApplicationAddCertificateDialog
+                open={certDialogOpen}
+                onOpenChange={open => {
+                    setCertDialogOpen(open);
+                    if (!open) setCertError(null);
+                }}
+                applicationId={applicationId}
+                certificates={certificates}
+                onSubmit={handleAddCertificate}
+                isSubmitting={addCertificateWithGraceMutation.isPending}
+                error={certError}
+            />
+
+            <ApplicationCertificateDetailDialog certificate={viewCert} onClose={() => setViewCert(null)} />
+
+            <ApplicationRevokeCertificateDialog
+                certificate={revokeCert}
+                onClose={() => {
+                    setRevokeCert(null);
+                    setRevokeError(null);
+                }}
+                onConfirm={handleRevokeCertificate}
+                isLoading={updateCertificateMutation.isPending}
+                error={revokeError}
+            />
+        </>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/general/ApplicationDeleteDialog.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/general/ApplicationDeleteDialog.tsx
@@ -1,0 +1,88 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+    Button,
+    Dialog,
+    DialogClose,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+    Input,
+    Label,
+} from '@gravitee/graphene-core';
+import { Trash2Icon } from '@gravitee/graphene-core/icons';
+import { useEffect, useState } from 'react';
+
+export function ApplicationDeleteDialog({
+    open,
+    onOpenChange,
+    applicationName,
+    onDelete,
+    isLoading,
+    error,
+}: Readonly<{
+    open: boolean;
+    onOpenChange: (open: boolean) => void;
+    applicationName: string;
+    onDelete: () => void;
+    isLoading: boolean;
+    error?: string | null;
+}>) {
+    const [confirm, setConfirm] = useState('');
+
+    useEffect(() => {
+        if (!open) setConfirm('');
+    }, [open]);
+
+    return (
+        <Dialog open={open} onOpenChange={onOpenChange}>
+            <DialogContent className="w-full max-w-md sm:max-w-md" showCloseButton={false}>
+                <DialogHeader>
+                    <DialogTitle>Archive this application?</DialogTitle>
+                    <DialogDescription>
+                        The application <strong>{applicationName}</strong> will be archived. Active subscriptions will be closed.
+                    </DialogDescription>
+                </DialogHeader>
+                <div className="space-y-2 py-2">
+                    <Label htmlFor="application-delete-confirm" className="text-sm">
+                        Type <span className="font-mono font-semibold">{applicationName}</span> to confirm
+                    </Label>
+                    <Input
+                        id="application-delete-confirm"
+                        value={confirm}
+                        onChange={e => setConfirm(e.target.value)}
+                        placeholder={applicationName}
+                        autoComplete="off"
+                    />
+                    {error ? <p className="text-sm text-destructive">{error}</p> : null}
+                </div>
+                <DialogFooter className="sm:justify-end">
+                    <DialogClose asChild>
+                        <Button type="button" variant="outline" onClick={() => setConfirm('')}>
+                            Cancel
+                        </Button>
+                    </DialogClose>
+                    <Button type="button" variant="destructive" disabled={confirm !== applicationName || isLoading} onClick={onDelete}>
+                        <Trash2Icon className="size-4" aria-hidden />
+                        {isLoading ? 'Archiving…' : 'Archive application'}
+                    </Button>
+                </DialogFooter>
+            </DialogContent>
+        </Dialog>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/general/ApplicationDetailsSection.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/general/ApplicationDetailsSection.tsx
@@ -1,0 +1,201 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+    Button,
+    Card,
+    CardContent,
+    Input,
+    Label,
+    Separator,
+    Textarea,
+    Tooltip,
+    TooltipContent,
+    TooltipProvider,
+    TooltipTrigger,
+} from '@gravitee/graphene-core';
+import { ClockIcon, GlobeIcon, InfoIcon, KeyRoundIcon, SettingsIcon, UserIcon } from '@gravitee/graphene-core/icons';
+import type { CSSProperties } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+import { ApplicationImagePickers } from './ApplicationImagePickers';
+import { DetailRow } from './DetailRow';
+import type { ApplicationListItem } from '../../types/application';
+import {
+    formatApplicationApiKeyMode,
+    formatApplicationDateTime,
+    formatApplicationOwnerLabel,
+    formatApplicationSecurityTypeLabel,
+} from '../../utils/applicationFormatters';
+import type { ApplicationGeneralForm, ApplicationGeneralValidation } from '../../utils/applicationGeneralMapper';
+
+export interface ApplicationDetailsSectionProps {
+    readonly application: ApplicationListItem;
+    readonly form: ApplicationGeneralForm;
+    readonly validation: ApplicationGeneralValidation;
+    readonly isFormDisabled: boolean;
+    readonly showSubscribeToApis: boolean;
+    readonly subscriptionsPath: string;
+    readonly onFieldChange: <K extends keyof ApplicationGeneralForm>(key: K, value: ApplicationGeneralForm[K]) => void;
+    readonly onPictureChange: (value: string | null) => void;
+    readonly onBackgroundChange: (value: string | null) => void;
+}
+
+export function ApplicationDetailsSection({
+    application,
+    form,
+    validation,
+    isFormDisabled,
+    showSubscribeToApis,
+    subscriptionsPath,
+    onFieldChange,
+    onPictureChange,
+    onBackgroundChange,
+}: ApplicationDetailsSectionProps) {
+    const navigate = useNavigate();
+
+    return (
+        <Card>
+            <CardContent className="pt-6">
+                <div className="flex flex-row gap-8">
+                    <div className="min-w-0 flex-1 space-y-4">
+                        <div className="space-y-2">
+                            <Label htmlFor="app-name">
+                                Name <span className="text-destructive">*</span>
+                            </Label>
+                            <Input
+                                id="app-name"
+                                value={form.name}
+                                maxLength={512}
+                                onChange={e => onFieldChange('name', e.target.value)}
+                                disabled={isFormDisabled}
+                                placeholder="Application name"
+                            />
+                            {validation.name ? <p className="text-xs text-destructive">{validation.name}</p> : null}
+                        </div>
+                        <div className="space-y-2">
+                            <Label htmlFor="app-desc">
+                                Description <span className="text-destructive">*</span>
+                            </Label>
+                            <Textarea
+                                id="app-desc"
+                                rows={3}
+                                style={{ fieldSizing: 'fixed' } as CSSProperties}
+                                value={form.description}
+                                onChange={e => onFieldChange('description', e.target.value)}
+                                disabled={isFormDisabled}
+                                placeholder="Describe this application"
+                            />
+                            <p className="text-xs text-muted-foreground">
+                                A brief description of your application shown to API publishers.
+                            </p>
+                            {validation.description ? <p className="text-xs text-destructive">{validation.description}</p> : null}
+                        </div>
+                        <div className="space-y-2">
+                            <div className="flex items-center gap-1">
+                                <Label htmlFor="app-domain">Domain</Label>
+                                <TooltipProvider delayDuration={200}>
+                                    <Tooltip>
+                                        <TooltipTrigger asChild>
+                                            <button
+                                                type="button"
+                                                className="text-muted-foreground/60 transition-colors hover:text-muted-foreground"
+                                                aria-label="Domain field information"
+                                            >
+                                                <InfoIcon className="size-3.5" aria-hidden />
+                                            </button>
+                                        </TooltipTrigger>
+                                        <TooltipContent side="right" className="max-w-xs text-xs">
+                                            Optional domain used to group applications in the developer portal.
+                                        </TooltipContent>
+                                    </Tooltip>
+                                </TooltipProvider>
+                            </div>
+                            <Input
+                                id="app-domain"
+                                value={form.domain}
+                                onChange={e => onFieldChange('domain', e.target.value)}
+                                disabled={isFormDisabled}
+                                placeholder="e.g. operations.example.com"
+                            />
+                        </div>
+                    </div>
+
+                    <div className="w-[280px] shrink-0 space-y-5 border-l pl-8">
+                        <ApplicationImagePickers
+                            picture={form.picture}
+                            background={form.background}
+                            disabled={isFormDisabled}
+                            onPictureChange={onPictureChange}
+                            onBackgroundChange={onBackgroundChange}
+                        />
+                        <Separator />
+                        <div className="space-y-3">
+                            <p className="text-xs font-medium uppercase tracking-wider text-muted-foreground">DETAILS</p>
+                            <dl className="space-y-2.5">
+                                <DetailRow
+                                    label={
+                                        <>
+                                            <UserIcon className="size-3" aria-hidden />
+                                            Owner
+                                        </>
+                                    }
+                                    value={formatApplicationOwnerLabel(application.owner) ?? '—'}
+                                />
+                                <DetailRow
+                                    label={
+                                        <>
+                                            <ClockIcon className="size-3" aria-hidden />
+                                            Created
+                                        </>
+                                    }
+                                    value={formatApplicationDateTime(application.created_at)}
+                                />
+                                <DetailRow
+                                    label={
+                                        <>
+                                            <SettingsIcon className="size-3" aria-hidden />
+                                            Type
+                                        </>
+                                    }
+                                    value={formatApplicationSecurityTypeLabel(application)}
+                                />
+                                <DetailRow
+                                    label={
+                                        <>
+                                            <KeyRoundIcon className="size-3" aria-hidden />
+                                            API key mode
+                                        </>
+                                    }
+                                    value={formatApplicationApiKeyMode(application.api_key_mode)}
+                                />
+                            </dl>
+                        </div>
+                    </div>
+                </div>
+
+                {showSubscribeToApis ? (
+                    <>
+                        <Separator className="my-5" />
+                        <Button type="button" variant="outline" size="sm" onClick={() => navigate(subscriptionsPath)}>
+                            <GlobeIcon className="size-3.5" aria-hidden />
+                            Subscribe to APIs
+                        </Button>
+                    </>
+                ) : null}
+            </CardContent>
+        </Card>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/general/ApplicationGeneralContent.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/general/ApplicationGeneralContent.tsx
@@ -1,0 +1,194 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useHasPermission } from '@gravitee/gamma-modules-sdk';
+import { Button, Card, Skeleton } from '@gravitee/graphene-core';
+import { CheckIcon } from '@gravitee/graphene-core/icons';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+
+import { ApplicationCertificatesSection } from './ApplicationCertificatesSection';
+import { ApplicationDetailsSection } from './ApplicationDetailsSection';
+import { ApplicationLifecycleSection } from './ApplicationLifecycleSection';
+import { ApplicationOAuthSection } from './ApplicationOAuthSection';
+import { useDetailBasePath } from '../../../shared/hooks/useDetailBasePath';
+import { useApplicationDetailContext } from '../../context/ApplicationDetailContext';
+import { useApplicationGeneralMutations } from '../../hooks/useApplicationGeneralMutations';
+import { useApplicationTypeConfiguration } from '../../hooks/useApplicationTypeConfiguration';
+import type { ApplicationListItem } from '../../types/application';
+import {
+    buildUpdatePayload,
+    formFromApplication,
+    hasApplicationGeneralValidationErrors,
+    isApplicationGeneralFormDirty,
+    isApplicationGeneralReadOnly,
+    validateApplicationGeneralForm,
+    type ApplicationGeneralForm,
+} from '../../utils/applicationGeneralMapper';
+
+export function ApplicationGeneralContent({ application }: Readonly<{ application: ApplicationListItem }>) {
+    const { applicationId } = useParams<{ applicationId: string }>();
+    const navigate = useNavigate();
+    const basePath = useDetailBasePath('applications', applicationId);
+    const { permissionsReady } = useApplicationDetailContext();
+
+    const canUpdate = useHasPermission({ anyOf: ['application-definition-u'] });
+    const canDelete = useHasPermission({ anyOf: ['application-definition-d'] });
+
+    const isSimple = application.type === 'SIMPLE';
+    const isArchivedOrKubernetes = isApplicationGeneralReadOnly(application);
+    const isFormDisabled = !permissionsReady || isArchivedOrKubernetes || !canUpdate;
+    const showSubscribeToApis = permissionsReady && !isArchivedOrKubernetes && canUpdate;
+    const canManageCertificates = permissionsReady && !isArchivedOrKubernetes && canUpdate;
+
+    const { data: typeConfig } = useApplicationTypeConfiguration(applicationId, !isSimple);
+    const { saveMutation, deleteMutation, addCertificateWithGraceMutation, updateCertificateMutation, isMutating } =
+        useApplicationGeneralMutations(application, applicationId, {
+            onDeleteSuccess: () => navigate('../..', { relative: 'route' }),
+        });
+
+    const [form, setForm] = useState<ApplicationGeneralForm | null>(null);
+    const [savedForm, setSavedForm] = useState<ApplicationGeneralForm | null>(null);
+    const [saveError, setSaveError] = useState<string | null>(null);
+
+    useEffect(() => {
+        const seed = formFromApplication(application);
+        setForm(seed);
+        setSavedForm(seed);
+        setSaveError(null);
+    }, [application]);
+
+    const validation = useMemo(() => (form ? validateApplicationGeneralForm(form) : {}), [form]);
+    const isDirty = useMemo(() => form !== null && savedForm !== null && isApplicationGeneralFormDirty(form, savedForm), [form, savedForm]);
+    const hasValidationErrors = hasApplicationGeneralValidationErrors(validation);
+    const canSave = isDirty && !hasValidationErrors && !isMutating;
+
+    const setField = useCallback(<K extends keyof ApplicationGeneralForm>(key: K, value: ApplicationGeneralForm[K]) => {
+        setForm(prev => (prev ? { ...prev, [key]: value } : prev));
+        setSaveError(null);
+    }, []);
+
+    const handlePictureChange = useCallback((value: string | null) => {
+        setForm(prev =>
+            prev
+                ? {
+                      ...prev,
+                      picture: value,
+                      pictureRemoved: value === null,
+                  }
+                : prev,
+        );
+        setSaveError(null);
+    }, []);
+
+    const handleBackgroundChange = useCallback((value: string | null) => {
+        setForm(prev =>
+            prev
+                ? {
+                      ...prev,
+                      background: value,
+                      backgroundRemoved: value === null,
+                  }
+                : prev,
+        );
+        setSaveError(null);
+    }, []);
+
+    const copyToClipboard = (value: string) => {
+        void navigator.clipboard.writeText(value);
+    };
+
+    const handleSave = () => {
+        if (!form || isFormDisabled || !canSave) return;
+        const payload = buildUpdatePayload(application, form, typeConfig);
+        saveMutation.mutate(payload, {
+            onSuccess: () => {
+                setSavedForm(form);
+                setSaveError(null);
+            },
+            onError: (e: unknown) => setSaveError(e instanceof Error ? e.message : 'Failed to save changes.'),
+        });
+    };
+
+    if (!form || !applicationId) {
+        return (
+            <div className="space-y-5">
+                <Skeleton className="h-10 w-64" />
+                <Skeleton className="h-64 w-full" />
+            </div>
+        );
+    }
+
+    return (
+        <div className="space-y-5">
+            <div className="flex items-start justify-between gap-4">
+                <div className="space-y-1">
+                    <h1 className="text-2xl font-semibold tracking-tight">General</h1>
+                    <p className="text-sm text-muted-foreground">
+                        Application details, OAuth client configuration, certificates, and lifecycle.
+                    </p>
+                </div>
+                {!isFormDisabled ? (
+                    <Button type="button" size="sm" className="shrink-0" onClick={handleSave} disabled={!canSave}>
+                        <CheckIcon className="size-4" aria-hidden />
+                        {saveMutation.isPending ? 'Saving…' : 'Save changes'}
+                    </Button>
+                ) : null}
+            </div>
+
+            {saveError ? (
+                <Card className="border-destructive/30 bg-destructive/5 p-4">
+                    <p className="text-sm text-destructive">{saveError}</p>
+                </Card>
+            ) : null}
+
+            <ApplicationDetailsSection
+                application={application}
+                form={form}
+                validation={validation}
+                isFormDisabled={isFormDisabled || isMutating}
+                showSubscribeToApis={showSubscribeToApis}
+                subscriptionsPath={`${basePath}/subscriptions`}
+                onFieldChange={setField}
+                onPictureChange={handlePictureChange}
+                onBackgroundChange={handleBackgroundChange}
+            />
+
+            <ApplicationOAuthSection
+                isSimple={isSimple}
+                form={form}
+                typeConfig={typeConfig}
+                isFormDisabled={isFormDisabled || isMutating}
+                onFieldChange={setField}
+                onCopy={copyToClipboard}
+            />
+
+            <ApplicationCertificatesSection
+                applicationId={applicationId}
+                canManageCertificates={canManageCertificates}
+                isMutating={isMutating}
+                addCertificateWithGraceMutation={addCertificateWithGraceMutation}
+                updateCertificateMutation={updateCertificateMutation}
+            />
+
+            <ApplicationLifecycleSection
+                application={application}
+                canDelete={permissionsReady && canDelete && !isArchivedOrKubernetes}
+                isMutating={isMutating}
+                deleteMutation={deleteMutation}
+            />
+        </div>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/general/ApplicationImagePickers.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/general/ApplicationImagePickers.tsx
@@ -1,0 +1,147 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { cn } from '@gravitee/graphene-core';
+import { UploadIcon } from '@gravitee/graphene-core/icons';
+import { useCallback, useRef, useState } from 'react';
+
+const MAX_SIZE_BYTES = 500 * 1024;
+
+function fileToDataUrl(file: File): Promise<string> {
+    return new Promise((resolve, reject) => {
+        const reader = new FileReader();
+        reader.onload = () => resolve(reader.result as string);
+        reader.onerror = reject;
+        reader.readAsDataURL(file);
+    });
+}
+
+function ImageSlot({
+    label,
+    preview,
+    width,
+    height,
+    disabled,
+    onSelect,
+    onClear,
+}: Readonly<{
+    label: string;
+    preview: string | null;
+    width: number;
+    height: number;
+    disabled?: boolean;
+    onSelect: (dataUrl: string) => void;
+    onClear: () => void;
+}>) {
+    const inputRef = useRef<HTMLInputElement>(null);
+    const [sizeError, setSizeError] = useState<string | null>(null);
+
+    const handleFile = useCallback(
+        async (file: File) => {
+            if (file.size > MAX_SIZE_BYTES) {
+                setSizeError('File exceeds 500 KB limit.');
+                return;
+            }
+            setSizeError(null);
+            onSelect(await fileToDataUrl(file));
+        },
+        [onSelect],
+    );
+
+    return (
+        <div className="space-y-1.5 text-center">
+            <button
+                type="button"
+                disabled={disabled}
+                onClick={() => !disabled && inputRef.current?.click()}
+                onContextMenu={e => {
+                    if (!disabled && preview) {
+                        e.preventDefault();
+                        onClear();
+                    }
+                }}
+                className={cn(
+                    'flex items-center justify-center overflow-hidden rounded-xl border-2 border-dashed border-border bg-muted/30 transition-colors',
+                    disabled ? 'cursor-not-allowed opacity-50 pointer-events-none' : 'cursor-pointer hover:border-primary',
+                )}
+                style={{ width, height }}
+                aria-label={`Upload ${label}`}
+                aria-disabled={disabled}
+            >
+                {preview ? (
+                    <img src={preview} alt="" className="size-full object-cover" />
+                ) : (
+                    <UploadIcon className="size-6 text-muted-foreground/40" aria-hidden />
+                )}
+            </button>
+            <p className="text-xs text-muted-foreground">{label}</p>
+            {sizeError ? <p className="text-xs text-destructive">{sizeError}</p> : null}
+            <input
+                ref={inputRef}
+                type="file"
+                accept="image/png,image/jpeg,image/svg+xml"
+                className="sr-only"
+                disabled={disabled}
+                tabIndex={-1}
+                onChange={e => {
+                    const file = e.target.files?.[0];
+                    e.target.value = '';
+                    if (file) void handleFile(file);
+                }}
+            />
+        </div>
+    );
+}
+
+export function ApplicationImagePickers({
+    picture,
+    background,
+    disabled,
+    onPictureChange,
+    onBackgroundChange,
+}: Readonly<{
+    picture: string | null;
+    background: string | null;
+    disabled?: boolean;
+    onPictureChange: (value: string | null) => void;
+    onBackgroundChange: (value: string | null) => void;
+}>) {
+    return (
+        <div className="space-y-3">
+            <p className="text-xs font-medium uppercase tracking-wider text-muted-foreground">IMAGES</p>
+            <div className="flex items-start gap-3">
+                <ImageSlot
+                    label="Picture"
+                    preview={picture}
+                    width={72}
+                    height={72}
+                    disabled={disabled}
+                    onSelect={onPictureChange}
+                    onClear={() => onPictureChange(null)}
+                />
+                <ImageSlot
+                    label="Background"
+                    preview={background}
+                    width={112}
+                    height={72}
+                    disabled={disabled}
+                    onSelect={onBackgroundChange}
+                    onClear={() => onBackgroundChange(null)}
+                />
+            </div>
+            <p className="text-xs leading-snug text-muted-foreground">Click to upload. PNG, JPG, SVG. Max 500 KB.</p>
+        </div>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/general/ApplicationLifecycleSection.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/general/ApplicationLifecycleSection.tsx
@@ -1,0 +1,82 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Button, Card, CardContent } from '@gravitee/graphene-core';
+import { AlertCircleIcon, Trash2Icon } from '@gravitee/graphene-core/icons';
+import type { UseMutationResult } from '@tanstack/react-query';
+import { useState } from 'react';
+
+import { ApplicationDeleteDialog } from './ApplicationDeleteDialog';
+import type { ApplicationListItem } from '../../types/application';
+
+export interface ApplicationLifecycleSectionProps {
+    readonly application: ApplicationListItem;
+    readonly canDelete: boolean;
+    readonly isMutating: boolean;
+    readonly deleteMutation: UseMutationResult<ApplicationListItem, Error, void, unknown>;
+}
+
+export function ApplicationLifecycleSection({ application, canDelete, isMutating, deleteMutation }: ApplicationLifecycleSectionProps) {
+    const [deleteOpen, setDeleteOpen] = useState(false);
+
+    if (!canDelete) {
+        return null;
+    }
+
+    const deleteError = deleteMutation.isError
+        ? deleteMutation.error instanceof Error
+            ? deleteMutation.error.message
+            : 'Failed to delete application.'
+        : null;
+
+    return (
+        <>
+            <Card className="border-primary">
+                <CardContent className="py-4">
+                    <div className="flex items-center justify-between gap-4">
+                        <div className="flex items-center gap-3">
+                            <AlertCircleIcon className="size-4 shrink-0 text-destructive" aria-hidden />
+                            <div>
+                                <p className="text-sm font-medium text-destructive">Delete this Application</p>
+                                <p className="text-xs text-muted-foreground">
+                                    Archiving closes active subscriptions and moves this application to the archived list.
+                                </p>
+                            </div>
+                        </div>
+                        <Button
+                            type="button"
+                            size="sm"
+                            className="shrink-0 bg-primary text-primary-foreground hover:bg-primary/90"
+                            disabled={isMutating}
+                            onClick={() => setDeleteOpen(true)}
+                        >
+                            <Trash2Icon className="size-3.5 text-primary-foreground" aria-hidden />
+                            Delete
+                        </Button>
+                    </div>
+                </CardContent>
+            </Card>
+
+            <ApplicationDeleteDialog
+                open={deleteOpen}
+                onOpenChange={setDeleteOpen}
+                applicationName={application.name}
+                onDelete={() => deleteMutation.mutate()}
+                isLoading={deleteMutation.isPending}
+                error={deleteError}
+            />
+        </>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/general/ApplicationOAuthSection.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/general/ApplicationOAuthSection.tsx
@@ -1,0 +1,139 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Button, Card, CardContent, CardDescription, CardHeader, CardTitle, Input, Label, Textarea } from '@gravitee/graphene-core';
+import { CopyIcon } from '@gravitee/graphene-core/icons';
+
+import { GrantTypeChips } from './GrantTypeChips';
+import type { ApplicationTypeConfig } from '../../types/applicationCreate';
+import type { ApplicationGeneralForm } from '../../utils/applicationGeneralMapper';
+
+export interface ApplicationOAuthSectionProps {
+    readonly isSimple: boolean;
+    readonly form: ApplicationGeneralForm;
+    readonly typeConfig: ApplicationTypeConfig | undefined;
+    readonly isFormDisabled: boolean;
+    readonly onFieldChange: <K extends keyof ApplicationGeneralForm>(key: K, value: ApplicationGeneralForm[K]) => void;
+    readonly onCopy: (value: string) => void;
+}
+
+export function ApplicationOAuthSection({
+    isSimple,
+    form,
+    typeConfig,
+    isFormDisabled,
+    onFieldChange,
+    onCopy,
+}: ApplicationOAuthSectionProps) {
+    if (isSimple) {
+        return (
+            <Card>
+                <CardHeader className="pb-3">
+                    <CardTitle className="text-sm">OAuth2 Integration</CardTitle>
+                    <CardDescription className="text-xs">Client ID used when subscribing to OAuth2 or JWT plans.</CardDescription>
+                </CardHeader>
+                <CardContent className="max-w-xl space-y-2">
+                    <Label htmlFor="simple-client-id">Client ID</Label>
+                    <div className="flex gap-2">
+                        <Input
+                            id="simple-client-id"
+                            value={form.simpleClientId}
+                            maxLength={300}
+                            onChange={e => onFieldChange('simpleClientId', e.target.value)}
+                            disabled={isFormDisabled}
+                        />
+                        <Button
+                            type="button"
+                            variant="outline"
+                            size="icon"
+                            onClick={() => onCopy(form.simpleClientId)}
+                            disabled={!form.simpleClientId}
+                            aria-label="Copy client ID"
+                        >
+                            <CopyIcon className="size-4" aria-hidden />
+                        </Button>
+                    </div>
+                </CardContent>
+            </Card>
+        );
+    }
+
+    return (
+        <div className="space-y-3">
+            <h2 className="text-lg font-semibold">OpenID Connect Integration</h2>
+            <Card>
+                <CardContent className="max-w-2xl space-y-4 pt-6">
+                    <div className="space-y-2">
+                        <Label>Client ID</Label>
+                        <div className="flex gap-2">
+                            <Input value={form.oauthClientId} readOnly className="bg-muted/40" />
+                            <Button
+                                type="button"
+                                variant="outline"
+                                size="icon"
+                                onClick={() => onCopy(form.oauthClientId)}
+                                disabled={!form.oauthClientId}
+                                aria-label="Copy client ID"
+                            >
+                                <CopyIcon className="size-4" aria-hidden />
+                            </Button>
+                        </div>
+                    </div>
+                    <div className="space-y-2">
+                        <Label>Client secret</Label>
+                        <div className="flex gap-2">
+                            <Input value={form.oauthClientSecret} readOnly type="password" className="bg-muted/40" />
+                            <Button
+                                type="button"
+                                variant="outline"
+                                size="icon"
+                                onClick={() => onCopy(form.oauthClientSecret)}
+                                disabled={!form.oauthClientSecret}
+                                aria-label="Copy client secret"
+                            >
+                                <CopyIcon className="size-4" aria-hidden />
+                            </Button>
+                        </div>
+                    </div>
+                    {typeConfig ? (
+                        <div className="space-y-2">
+                            <Label>Authorized grant types</Label>
+                            <GrantTypeChips
+                                typeConfig={typeConfig}
+                                options={typeConfig.allowed_grant_types}
+                                values={form.grantTypes}
+                                onChange={next => onFieldChange('grantTypes', next)}
+                                disabled={isFormDisabled}
+                            />
+                        </div>
+                    ) : null}
+                    {typeConfig?.requires_redirect_uris ? (
+                        <div className="space-y-2">
+                            <Label htmlFor="redirect-uris">Redirect URIs</Label>
+                            <Textarea
+                                id="redirect-uris"
+                                value={form.redirectUrisText}
+                                onChange={e => onFieldChange('redirectUrisText', e.target.value)}
+                                disabled={isFormDisabled}
+                                placeholder="One URI per line"
+                                rows={3}
+                            />
+                        </div>
+                    ) : null}
+                </CardContent>
+            </Card>
+        </div>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/general/ApplicationRevokeCertificateDialog.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/general/ApplicationRevokeCertificateDialog.tsx
@@ -1,0 +1,66 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+    Button,
+    Dialog,
+    DialogClose,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+} from '@gravitee/graphene-core';
+
+import type { ClientCertificate } from '../../types/applicationCertificate';
+
+export function ApplicationRevokeCertificateDialog({
+    certificate,
+    onClose,
+    onConfirm,
+    isLoading,
+    error,
+}: Readonly<{
+    certificate: ClientCertificate | null;
+    onClose: () => void;
+    onConfirm: () => void;
+    isLoading: boolean;
+    error?: string | null;
+}>) {
+    return (
+        <Dialog open={certificate !== null} onOpenChange={open => !open && onClose()}>
+            <DialogContent className="w-full max-w-sm sm:max-w-md" showCloseButton={false}>
+                <DialogHeader>
+                    <DialogTitle>Revoke certificate?</DialogTitle>
+                    <DialogDescription>
+                        Revoking <strong>{certificate?.name}</strong> cannot be undone. Active mTLS connections using this certificate will
+                        fail.
+                    </DialogDescription>
+                </DialogHeader>
+                {error ? <p className="text-sm text-destructive">{error}</p> : null}
+                <DialogFooter className="sm:justify-end">
+                    <DialogClose asChild>
+                        <Button type="button" variant="outline">
+                            Cancel
+                        </Button>
+                    </DialogClose>
+                    <Button type="button" disabled={isLoading} onClick={onConfirm}>
+                        {isLoading ? 'Revoking…' : 'Revoke'}
+                    </Button>
+                </DialogFooter>
+            </DialogContent>
+        </Dialog>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/general/DetailRow.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/general/DetailRow.tsx
@@ -1,0 +1,25 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import type { ReactNode } from 'react';
+
+export function DetailRow({ label, value }: Readonly<{ label: ReactNode; value: string }>) {
+    return (
+        <div className="flex items-start justify-between gap-2">
+            <dt className="flex shrink-0 items-center gap-1.5 text-xs text-muted-foreground">{label}</dt>
+            <dd className="truncate text-right text-xs font-medium">{value}</dd>
+        </div>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/general/GrantTypeChips.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/general/GrantTypeChips.tsx
@@ -1,0 +1,70 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Badge, cn } from '@gravitee/graphene-core';
+
+import type { ApplicationGrantType, ApplicationTypeConfig } from '../../types/applicationCreate';
+import { isMandatoryGrantType } from '../../utils/applicationCreateMapper';
+
+export function GrantTypeChips({
+    typeConfig,
+    options,
+    values,
+    onChange,
+    disabled,
+}: Readonly<{
+    typeConfig: ApplicationTypeConfig;
+    options: ApplicationGrantType[];
+    values: string[];
+    onChange: (next: string[]) => void;
+    disabled?: boolean;
+}>) {
+    const toggle = (grantType: string) => {
+        if (disabled || isMandatoryGrantType(typeConfig, grantType)) return;
+        onChange(values.includes(grantType) ? values.filter(v => v !== grantType) : [...values, grantType]);
+    };
+
+    return (
+        <div className="flex flex-wrap gap-1.5">
+            {options.map(gt => {
+                const isMandatory = isMandatoryGrantType(typeConfig, gt.type);
+                const isChipDisabled = disabled || isMandatory;
+
+                return (
+                    <button
+                        key={gt.type}
+                        type="button"
+                        disabled={isChipDisabled}
+                        onClick={() => toggle(gt.type)}
+                        className={cn(
+                            'inline-flex h-6 items-center gap-1 border px-2 text-xs transition-colors disabled:opacity-50',
+                            values.includes(gt.type)
+                                ? 'border-primary bg-primary text-primary-foreground'
+                                : 'border-border bg-background text-foreground hover:border-primary/40',
+                            isMandatory && !disabled && 'cursor-not-allowed',
+                        )}
+                    >
+                        {gt.name}
+                        {isMandatory ? (
+                            <Badge variant="secondary" className="ml-1 px-1 py-0 text-xs leading-none">
+                                Mandatory
+                            </Badge>
+                        ) : null}
+                    </button>
+                );
+            })}
+        </div>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/general/certificateUtils.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/general/certificateUtils.ts
@@ -1,0 +1,50 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import type { ClientCertificate, ClientCertificateStatus } from '../../types/applicationCertificate';
+
+export function certificateStatusLabel(status: ClientCertificateStatus): string {
+    switch (status) {
+        case 'ACTIVE':
+        case 'ACTIVE_WITH_END':
+            return 'Active';
+        case 'SCHEDULED':
+            return 'Scheduled';
+        case 'REVOKED':
+            return 'Revoked';
+        default:
+            return status;
+    }
+}
+
+export function certificateStatusVariant(status: ClientCertificateStatus): 'default' | 'secondary' | 'destructive' | 'outline' {
+    if (status === 'REVOKED') return 'destructive';
+    if (status === 'SCHEDULED') return 'outline';
+    return 'secondary';
+}
+
+export function findActiveCertificate(certificates: ClientCertificate[]): ClientCertificate | undefined {
+    const sorted = [...certificates].sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
+    return sorted.find(c => c.status === 'ACTIVE') ?? sorted.find(c => c.status === 'ACTIVE_WITH_END');
+}
+
+export function readFileAsText(file: File): Promise<string> {
+    return new Promise((resolve, reject) => {
+        const reader = new FileReader();
+        reader.onload = () => resolve(reader.result as string);
+        reader.onerror = reject;
+        reader.readAsText(file);
+    });
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/list/ApplicationListTable.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/list/ApplicationListTable.tsx
@@ -13,13 +13,31 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Badge, Skeleton, Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@gravitee/graphene-core';
-import { AppWindowIcon } from '@gravitee/graphene-core/icons';
+import {
+    Badge,
+    Button,
+    DropdownMenu,
+    DropdownMenuContent,
+    DropdownMenuItem,
+    DropdownMenuTrigger,
+    Skeleton,
+    Table,
+    TableBody,
+    TableCell,
+    TableHead,
+    TableHeader,
+    TableRow,
+    Tooltip,
+    TooltipContent,
+    TooltipTrigger,
+} from '@gravitee/graphene-core';
+import { AppWindowIcon, ExternalLinkIcon, MoreHorizontalIcon, PlugIcon, Wand2Icon } from '@gravitee/graphene-core/icons';
+import { useNavigate } from 'react-router-dom';
 
-import type { ApplicationListItem } from '../../types/application';
-import { formatApplicationTypeLabel } from '../../utils/applicationFormatters';
+import type { ApplicationListItem, ApplicationStatus } from '../../types/application';
+import { formatApplicationDateTime, formatApplicationTypeLabel } from '../../utils/applicationFormatters';
 
-function SkeletonRow() {
+function ActiveSkeletonRow() {
     return (
         <TableRow>
             <TableCell>
@@ -31,42 +49,146 @@ function SkeletonRow() {
             <TableCell>
                 <Skeleton className="h-4 w-24 rounded" />
             </TableCell>
+            <TableCell />
         </TableRow>
+    );
+}
+
+function ArchivedSkeletonRow() {
+    return (
+        <TableRow>
+            <TableCell>
+                <Skeleton className="h-4 w-40 rounded" />
+            </TableCell>
+            <TableCell>
+                <Skeleton className="h-4 w-32 rounded" />
+            </TableCell>
+            <TableCell />
+        </TableRow>
+    );
+}
+
+function ApplicationActionsMenu({ applicationId, onNavigate }: { applicationId: string; onNavigate: (path: string) => void }) {
+    const navigateTo = (path: string) => (event: Event) => {
+        event.preventDefault();
+        onNavigate(path);
+    };
+
+    return (
+        <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+                <Button variant="ghost" size="icon" aria-label="Application actions" onClick={event => event.stopPropagation()}>
+                    <MoreHorizontalIcon className="size-4" aria-hidden />
+                </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end" className="w-auto min-w-[12rem]" onClick={event => event.stopPropagation()}>
+                <DropdownMenuItem className="gap-2" onSelect={navigateTo(`${applicationId}/general`)}>
+                    <ExternalLinkIcon className="size-4" aria-hidden />
+                    View Details
+                </DropdownMenuItem>
+                <DropdownMenuItem className="gap-2" onSelect={navigateTo(`${applicationId}/subscriptions`)}>
+                    <PlugIcon className="size-4" aria-hidden />
+                    Manage Subscriptions
+                </DropdownMenuItem>
+            </DropdownMenuContent>
+        </DropdownMenu>
     );
 }
 
 interface ApplicationListTableProps {
     readonly applications: ApplicationListItem[];
     readonly isLoading: boolean;
+    readonly status: ApplicationStatus;
     readonly skeletonRowCount?: number;
+    readonly canRestore?: boolean;
+    readonly onRestore?: (application: ApplicationListItem) => void;
 }
 
-export function ApplicationListTable({ applications, isLoading, skeletonRowCount = 5 }: ApplicationListTableProps) {
+export function ApplicationListTable({
+    applications,
+    isLoading,
+    status,
+    skeletonRowCount = 5,
+    canRestore = false,
+    onRestore,
+}: ApplicationListTableProps) {
+    const navigate = useNavigate();
+    const isArchived = status === 'ARCHIVED';
+
     return (
         <div className="rounded-lg border">
             <Table>
                 <TableHeader>
                     <TableRow>
                         <TableHead>Name</TableHead>
-                        <TableHead>Type</TableHead>
-                        <TableHead>Owner</TableHead>
+                        {isArchived ? (
+                            <>
+                                <TableHead>Archived at</TableHead>
+                                <TableHead className="w-12" />
+                            </>
+                        ) : (
+                            <>
+                                <TableHead>Type</TableHead>
+                                <TableHead>Owner</TableHead>
+                                <TableHead className="w-12" />
+                            </>
+                        )}
                     </TableRow>
                 </TableHeader>
                 <TableBody>
                     {isLoading ? (
-                        Array.from({ length: skeletonRowCount }).map((_, i) => <SkeletonRow key={i} />)
+                        Array.from({ length: skeletonRowCount }).map((_, index) =>
+                            isArchived ? <ArchivedSkeletonRow key={index} /> : <ActiveSkeletonRow key={index} />,
+                        )
                     ) : applications.length === 0 ? (
                         <TableRow>
-                            <TableCell colSpan={3} className="py-10 text-center text-sm text-muted-foreground">
+                            <TableCell colSpan={isArchived ? 3 : 4} className="py-10 text-center text-sm text-muted-foreground">
                                 No applications found.
                             </TableCell>
                         </TableRow>
-                    ) : (
+                    ) : isArchived ? (
                         applications.map(application => (
-                            <TableRow key={application.id} className="hover:bg-accent">
+                            <TableRow key={application.id}>
                                 <TableCell>
                                     <div className="flex items-center gap-2 font-medium">
-                                        <AppWindowIcon className="size-4 text-muted-foreground shrink-0" aria-hidden />
+                                        <AppWindowIcon className="size-4 shrink-0 text-muted-foreground" aria-hidden />
+                                        {application.name}
+                                    </div>
+                                </TableCell>
+                                <TableCell className="text-sm text-muted-foreground">
+                                    {formatApplicationDateTime(application.updated_at)}
+                                </TableCell>
+                                <TableCell className="text-right">
+                                    {canRestore && onRestore ? (
+                                        <Tooltip>
+                                            <TooltipTrigger asChild>
+                                                <Button
+                                                    type="button"
+                                                    variant="ghost"
+                                                    size="icon"
+                                                    className="size-8"
+                                                    aria-label={`Restore ${application.name}`}
+                                                    onClick={() => onRestore(application)}
+                                                >
+                                                    <Wand2Icon className="size-4" aria-hidden />
+                                                </Button>
+                                            </TooltipTrigger>
+                                            <TooltipContent>Restore application</TooltipContent>
+                                        </Tooltip>
+                                    ) : null}
+                                </TableCell>
+                            </TableRow>
+                        ))
+                    ) : (
+                        applications.map(application => (
+                            <TableRow
+                                key={application.id}
+                                className="cursor-pointer hover:bg-accent"
+                                onClick={() => navigate(`${application.id}/general`)}
+                            >
+                                <TableCell>
+                                    <div className="flex items-center gap-2 font-medium">
+                                        <AppWindowIcon className="size-4 shrink-0 text-muted-foreground" aria-hidden />
                                         {application.name}
                                     </div>
                                 </TableCell>
@@ -76,6 +198,9 @@ export function ApplicationListTable({ applications, isLoading, skeletonRowCount
                                     </Badge>
                                 </TableCell>
                                 <TableCell className="text-sm text-muted-foreground">{application.owner?.displayName ?? '—'}</TableCell>
+                                <TableCell className="text-right" onClick={event => event.stopPropagation()}>
+                                    <ApplicationActionsMenu applicationId={application.id} onNavigate={navigate} />
+                                </TableCell>
                             </TableRow>
                         ))
                     )}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/list/ApplicationRestoreDialog.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/list/ApplicationRestoreDialog.tsx
@@ -1,0 +1,73 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+    Button,
+    Dialog,
+    DialogClose,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+} from '@gravitee/graphene-core';
+
+import type { ApplicationListItem } from '../../types/application';
+
+export function ApplicationRestoreDialog({
+    application,
+    onClose,
+    onConfirm,
+    isLoading,
+    error,
+}: Readonly<{
+    application: ApplicationListItem | null;
+    onClose: () => void;
+    onConfirm: () => void;
+    isLoading: boolean;
+    error?: string | null;
+}>) {
+    return (
+        <Dialog open={application !== null} onOpenChange={open => !open && onClose()}>
+            <DialogContent className="w-full max-w-md sm:max-w-md" showCloseButton={false}>
+                <DialogHeader>
+                    <DialogTitle className="text-lg font-semibold leading-snug">
+                        Would you like to restore the application &ldquo;{application?.name}&rdquo;?
+                    </DialogTitle>
+                    <DialogDescription>
+                        Every subscription belonging to this application will be restored in PENDING status. Subscriptions can be
+                        reactivated as per requirements.
+                    </DialogDescription>
+                </DialogHeader>
+                {error ? <p className="text-sm text-destructive">{error}</p> : null}
+                <DialogFooter className="sm:justify-end">
+                    <DialogClose asChild>
+                        <Button type="button" variant="outline">
+                            Cancel
+                        </Button>
+                    </DialogClose>
+                    <Button
+                        type="button"
+                        className="bg-primary text-primary-foreground hover:bg-primary/90"
+                        disabled={isLoading}
+                        onClick={onConfirm}
+                    >
+                        {isLoading ? 'Restoring…' : 'Restore'}
+                    </Button>
+                </DialogFooter>
+            </DialogContent>
+        </Dialog>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/list/ApplicationsListView.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/list/ApplicationsListView.tsx
@@ -15,12 +15,14 @@
  */
 import { DataTablePagination, Input, Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@gravitee/graphene-core';
 import { SearchIcon } from '@gravitee/graphene-core/icons';
-import { useId } from 'react';
+import { useId, useState } from 'react';
 
 import { ApplicationsPageHeader } from '../ApplicationsPageHeader';
 import { ApplicationListTable } from './ApplicationListTable';
+import { ApplicationRestoreDialog } from './ApplicationRestoreDialog';
 import { ApplicationStatsCards } from './ApplicationStatsCards';
 import type { ApplicationStats } from '../../hooks/useApplicationStats';
+import { useRestoreApplication } from '../../hooks/useRestoreApplication';
 import type { ApplicationListItem, ApplicationStatus } from '../../types/application';
 
 const STATUS_OPTIONS: { value: ApplicationStatus; label: string }[] = [
@@ -44,6 +46,8 @@ interface ApplicationsListViewProps {
     readonly onPerPageChange: (perPage: number) => void;
     readonly onRegisterApplication: () => void;
     readonly canCreate: boolean;
+    readonly canManageArchived: boolean;
+    readonly canRestore: boolean;
 }
 
 export function ApplicationsListView({
@@ -61,12 +65,30 @@ export function ApplicationsListView({
     onPerPageChange,
     onRegisterApplication,
     canCreate,
+    canManageArchived,
+    canRestore,
 }: ApplicationsListViewProps) {
     const searchInputId = useId();
+    const [restoreTarget, setRestoreTarget] = useState<ApplicationListItem | null>(null);
+    const [restoreError, setRestoreError] = useState<string | null>(null);
+    const restoreMutation = useRestoreApplication();
+
+    const handleRestore = () => {
+        if (!restoreTarget) return;
+        setRestoreError(null);
+        restoreMutation.mutate(restoreTarget.id, {
+            onSuccess: () => setRestoreTarget(null),
+            onError: (e: unknown) => setRestoreError(e instanceof Error ? e.message : 'Failed to restore application.'),
+        });
+    };
 
     return (
         <div className="space-y-6">
-            <ApplicationsPageHeader canCreate={canCreate} onRegisterApplication={onRegisterApplication} showInfoTooltip />
+            <ApplicationsPageHeader
+                canCreate={canCreate && status === 'ACTIVE'}
+                onRegisterApplication={onRegisterApplication}
+                showInfoTooltip
+            />
 
             <ApplicationStatsCards stats={stats} />
 
@@ -89,18 +111,20 @@ export function ApplicationsListView({
                         />
                     </div>
 
-                    <Select value={status} onValueChange={value => onStatusChange(value as ApplicationStatus)}>
-                        <SelectTrigger className="h-9 w-36 shrink-0" aria-label="Filter by status">
-                            <SelectValue />
-                        </SelectTrigger>
-                        <SelectContent>
-                            {STATUS_OPTIONS.map(option => (
-                                <SelectItem key={option.value} value={option.value}>
-                                    {option.label}
-                                </SelectItem>
-                            ))}
-                        </SelectContent>
-                    </Select>
+                    {canManageArchived ? (
+                        <Select value={status} onValueChange={value => onStatusChange(value as ApplicationStatus)}>
+                            <SelectTrigger className="h-9 w-36 shrink-0" aria-label="Filter by status">
+                                <SelectValue />
+                            </SelectTrigger>
+                            <SelectContent>
+                                {STATUS_OPTIONS.map(option => (
+                                    <SelectItem key={option.value} value={option.value}>
+                                        {option.label}
+                                    </SelectItem>
+                                ))}
+                            </SelectContent>
+                        </Select>
+                    ) : null}
                 </div>
 
                 <DataTablePagination
@@ -113,7 +137,32 @@ export function ApplicationsListView({
                 />
             </div>
 
-            <ApplicationListTable applications={applications} isLoading={isLoading} skeletonRowCount={perPage} />
+            <ApplicationListTable
+                applications={applications}
+                isLoading={isLoading}
+                status={status}
+                skeletonRowCount={perPage}
+                canRestore={canRestore}
+                onRestore={
+                    canRestore
+                        ? application => {
+                              setRestoreError(null);
+                              setRestoreTarget(application);
+                          }
+                        : undefined
+                }
+            />
+
+            <ApplicationRestoreDialog
+                application={restoreTarget}
+                onClose={() => {
+                    setRestoreTarget(null);
+                    setRestoreError(null);
+                }}
+                onConfirm={handleRestore}
+                isLoading={restoreMutation.isPending}
+                error={restoreError}
+            />
 
             <div className="flex justify-end">
                 <DataTablePagination

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/context/ApplicationDetailContext.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/context/ApplicationDetailContext.tsx
@@ -1,0 +1,36 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { createContext, useContext } from 'react';
+
+import type { ApplicationListItem } from '../types/application';
+
+export interface ApplicationDetailContextValue {
+    application: ApplicationListItem | null;
+    isLoading: boolean;
+    permissionsReady: boolean;
+    permissionsError: boolean;
+    refetchPermissions: () => void;
+}
+
+export const ApplicationDetailContext = createContext<ApplicationDetailContextValue | null>(null);
+
+export function useApplicationDetailContext(): ApplicationDetailContextValue {
+    const context = useContext(ApplicationDetailContext);
+    if (!context) {
+        throw new Error('useApplicationDetailContext must be used within ApplicationDetailLayout');
+    }
+    return context;
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/hooks/useApplicationCertificates.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/hooks/useApplicationCertificates.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useEnvironment } from '@gravitee/gamma-modules-sdk';
+import { useQuery } from '@tanstack/react-query';
+
+import { listApplicationCertificates } from '../services/applicationDetail';
+import { applicationDetailKeys } from '../utils/queryKeys';
+
+export function useApplicationCertificates(applicationId: string | undefined) {
+    const env = useEnvironment();
+    return useQuery({
+        queryKey: applicationDetailKeys.certificates(env?.id ?? '', applicationId ?? ''),
+        queryFn: async () => {
+            const result = await listApplicationCertificates(env!.id, applicationId!);
+            return result.data ?? [];
+        },
+        enabled: Boolean(env && applicationId),
+        staleTime: 30_000,
+    });
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/hooks/useApplicationDetail.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/hooks/useApplicationDetail.ts
@@ -1,0 +1,30 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useEnvironment } from '@gravitee/gamma-modules-sdk';
+import { useQuery } from '@tanstack/react-query';
+
+import { getApplication } from '../services/applicationDetail';
+import { applicationDetailKeys } from '../utils/queryKeys';
+
+export function useApplicationDetail(applicationId: string | undefined) {
+    const env = useEnvironment();
+    return useQuery({
+        queryKey: applicationDetailKeys.detail(env?.id ?? '', applicationId ?? ''),
+        queryFn: () => getApplication(env!.id, applicationId!),
+        enabled: Boolean(env && applicationId),
+        staleTime: 60_000,
+    });
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/hooks/useApplicationGeneralMutations.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/hooks/useApplicationGeneralMutations.ts
@@ -1,0 +1,153 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useEnvironment } from '@gravitee/gamma-modules-sdk';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useRef } from 'react';
+
+import {
+    createApplicationCertificate,
+    deleteApplication,
+    updateApplication,
+    updateApplicationCertificate,
+    type UpdateApplicationPayload,
+} from '../services/applicationDetail';
+import type { ApplicationListItem } from '../types/application';
+import type { ClientCertificate, CreateClientCertificate, UpdateClientCertificate } from '../types/applicationCertificate';
+import { applicationDetailKeys, applicationListKeys } from '../utils/queryKeys';
+
+export const GRACE_PERIOD_UPDATE_ERROR = 'GracePeriodUpdateError';
+
+export interface AddCertificateWithGraceInput {
+    readonly create: CreateClientCertificate;
+    readonly gracePeriod?: {
+        readonly certificateId: string;
+        readonly name: string;
+        readonly endsAt: string;
+    };
+}
+
+export interface GracePeriodUpdateFailure {
+    readonly message: string;
+    readonly certificateId: string;
+    readonly name: string;
+    readonly endsAt: string;
+}
+
+function isGracePeriodUpdateError(error: unknown): error is Error {
+    return error instanceof Error && error.name === GRACE_PERIOD_UPDATE_ERROR;
+}
+
+export function toGracePeriodUpdateFailure(error: unknown): GracePeriodUpdateFailure | null {
+    if (!isGracePeriodUpdateError(error)) {
+        return null;
+    }
+    const failure = (error as Error & { gracePeriod?: GracePeriodUpdateFailure }).gracePeriod;
+    return failure ?? null;
+}
+
+interface ApplicationGeneralSideEffects {
+    onDeleteSuccess?: () => void;
+}
+
+export function useApplicationGeneralMutations(
+    application: ApplicationListItem | null,
+    applicationId: string | undefined,
+    sideEffects: ApplicationGeneralSideEffects = {},
+) {
+    const env = useEnvironment();
+    const queryClient = useQueryClient();
+    const sideEffectsRef = useRef(sideEffects);
+    sideEffectsRef.current = sideEffects;
+
+    const invalidateApplicationList = () => {
+        void queryClient.invalidateQueries({ queryKey: applicationListKeys.all });
+    };
+
+    const invalidateDetail = () => {
+        void queryClient.invalidateQueries({
+            queryKey: applicationDetailKeys.detail(env?.id ?? '', applicationId ?? ''),
+        });
+        invalidateApplicationList();
+    };
+
+    const invalidateCertificates = () => {
+        void queryClient.invalidateQueries({
+            queryKey: applicationDetailKeys.certificates(env?.id ?? '', applicationId ?? ''),
+        });
+        invalidateDetail();
+    };
+
+    const saveMutation = useMutation({
+        mutationFn: (payload: UpdateApplicationPayload) => updateApplication(env!.id, application!, payload),
+        onSuccess: invalidateDetail,
+    });
+
+    const deleteMutation = useMutation({
+        mutationFn: () => deleteApplication(env!.id, applicationId!),
+        onSuccess: async () => {
+            await queryClient.invalidateQueries({ queryKey: applicationListKeys.all });
+            sideEffectsRef.current.onDeleteSuccess?.();
+        },
+    });
+
+    const addCertificateWithGraceMutation = useMutation({
+        mutationFn: async ({ create, gracePeriod }: AddCertificateWithGraceInput): Promise<ClientCertificate> => {
+            const created = await createApplicationCertificate(env!.id, applicationId!, create);
+            if (!gracePeriod) {
+                return created;
+            }
+            try {
+                await updateApplicationCertificate(env!.id, applicationId!, gracePeriod.certificateId, {
+                    name: gracePeriod.name,
+                    endsAt: gracePeriod.endsAt,
+                });
+            } catch (cause) {
+                const detail = cause instanceof Error ? cause.message : 'Grace period update failed.';
+                const error = new Error(`Certificate added but grace period update failed: ${detail}`);
+                error.name = GRACE_PERIOD_UPDATE_ERROR;
+                (error as Error & { gracePeriod: GracePeriodUpdateFailure }).gracePeriod = {
+                    message: error.message,
+                    certificateId: gracePeriod.certificateId,
+                    name: gracePeriod.name,
+                    endsAt: gracePeriod.endsAt,
+                };
+                throw error;
+            }
+            return created;
+        },
+        onSuccess: invalidateCertificates,
+    });
+
+    const updateCertificateMutation = useMutation({
+        mutationFn: ({ certificateId, update }: { certificateId: string; update: UpdateClientCertificate }) =>
+            updateApplicationCertificate(env!.id, applicationId!, certificateId, update),
+        onSuccess: invalidateCertificates,
+    });
+
+    const isMutating =
+        saveMutation.isPending ||
+        deleteMutation.isPending ||
+        addCertificateWithGraceMutation.isPending ||
+        updateCertificateMutation.isPending;
+
+    return {
+        saveMutation,
+        deleteMutation,
+        addCertificateWithGraceMutation,
+        updateCertificateMutation,
+        isMutating,
+    };
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/hooks/useApplicationPermissions.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/hooks/useApplicationPermissions.spec.tsx
@@ -1,0 +1,70 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { permissionService, useEnvironment } from '@gravitee/gamma-modules-sdk';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+
+import { useApplicationPermissions } from './useApplicationPermissions';
+import { getApplicationPermissions } from '../services/applicationPermissions';
+
+jest.mock('@gravitee/gamma-modules-sdk', () => ({
+    useEnvironment: jest.fn(),
+    permissionService: {
+        load: jest.fn(),
+        clear: jest.fn(),
+    },
+}));
+
+jest.mock('../services/applicationPermissions');
+
+const mockUseEnvironment = jest.mocked(useEnvironment);
+const mockGetApplicationPermissions = jest.mocked(getApplicationPermissions);
+const mockPermissionService = permissionService as jest.Mocked<typeof permissionService>;
+
+function wrapper({ children }: { children: ReactNode }) {
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+}
+
+describe('useApplicationPermissions', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockUseEnvironment.mockReturnValue({ id: 'DEFAULT' });
+    });
+
+    it('sets permissionsReady on success and loads application scope', async () => {
+        mockGetApplicationPermissions.mockResolvedValue(['application-definition-r']);
+
+        const { result } = renderHook(() => useApplicationPermissions('app-1'), { wrapper });
+
+        await waitFor(() => expect(result.current.permissionsReady).toBe(true));
+
+        expect(mockPermissionService.load).toHaveBeenCalledWith('application', ['application-definition-r']);
+        expect(result.current.isError).toBe(false);
+    });
+
+    it('exposes isError when the permissions request fails', async () => {
+        mockGetApplicationPermissions.mockRejectedValue(new Error('network'));
+
+        const { result } = renderHook(() => useApplicationPermissions('app-1'), { wrapper });
+
+        await waitFor(() => expect(result.current.isError).toBe(true));
+
+        expect(result.current.permissionsReady).toBe(false);
+        expect(mockPermissionService.load).not.toHaveBeenCalled();
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/hooks/useApplicationPermissions.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/hooks/useApplicationPermissions.ts
@@ -1,0 +1,66 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { permissionService, useEnvironment } from '@gravitee/gamma-modules-sdk';
+import { useQuery } from '@tanstack/react-query';
+import { useEffect } from 'react';
+
+import { getApplicationPermissions } from '../services/applicationPermissions';
+import { applicationPermissionKeys } from '../utils/queryKeys';
+
+export interface UseApplicationPermissionsResult {
+    readonly permissionsReady: boolean;
+    readonly isError: boolean;
+    readonly isLoading: boolean;
+    readonly refetch: () => void;
+}
+
+/**
+ * Loads application-scoped permissions into `permissionService` for the detail view.
+ * Mirrors `useApiPermissions`: load on enter, clear on leave.
+ */
+export function useApplicationPermissions(applicationId: string | undefined): UseApplicationPermissionsResult {
+    const env = useEnvironment();
+
+    const {
+        data: permissions,
+        isSuccess,
+        isError,
+        isLoading,
+        refetch,
+    } = useQuery({
+        queryKey: applicationPermissionKeys.detail(env?.id ?? '', applicationId ?? ''),
+        queryFn: () => getApplicationPermissions(env!.id, applicationId!),
+        enabled: Boolean(env && applicationId),
+        staleTime: 60_000,
+    });
+
+    useEffect(() => {
+        if (!permissions) {
+            return;
+        }
+        permissionService.load('application', permissions);
+        return () => permissionService.clear('application');
+    }, [permissions]);
+
+    return {
+        permissionsReady: isSuccess,
+        isError,
+        isLoading,
+        refetch: () => {
+            void refetch();
+        },
+    };
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/hooks/useApplicationTypeConfiguration.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/hooks/useApplicationTypeConfiguration.ts
@@ -1,0 +1,30 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useEnvironment } from '@gravitee/gamma-modules-sdk';
+import { useQuery } from '@tanstack/react-query';
+
+import { getApplicationTypeConfiguration } from '../services/applicationDetail';
+import { applicationDetailKeys } from '../utils/queryKeys';
+
+export function useApplicationTypeConfiguration(applicationId: string | undefined, enabled: boolean) {
+    const env = useEnvironment();
+    return useQuery({
+        queryKey: applicationDetailKeys.typeConfig(env?.id ?? '', applicationId ?? ''),
+        queryFn: () => getApplicationTypeConfiguration(env!.id, applicationId!),
+        enabled: Boolean(env && applicationId && enabled),
+        staleTime: 60_000,
+    });
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/hooks/useOrganizationAdmin.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/hooks/useOrganizationAdmin.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useQuery } from '@tanstack/react-query';
+
+import { fetchCurrentUser, hasOrganizationAdminRole } from '../services/currentUser';
+import { currentUserKeys } from '../utils/queryKeys';
+
+/**
+ * Whether the current user has the organization ADMIN role (required to list archived apps and restore).
+ * Aligns with console `gioRole` / `ApplicationResource.restoreApplication` admin check.
+ */
+export function useOrganizationAdmin(): { isAdmin: boolean; isLoading: boolean } {
+    const { data, isLoading } = useQuery({
+        queryKey: currentUserKeys.detail(),
+        queryFn: fetchCurrentUser,
+        staleTime: 300_000,
+    });
+
+    return {
+        isAdmin: hasOrganizationAdminRole(data?.roles),
+        isLoading,
+    };
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/hooks/useRestoreApplication.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/hooks/useRestoreApplication.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useEnvironment } from '@gravitee/gamma-modules-sdk';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { restoreApplication } from '../services/applicationList';
+import { applicationListKeys } from '../utils/queryKeys';
+
+export function useRestoreApplication() {
+    const env = useEnvironment();
+    const queryClient = useQueryClient();
+
+    return useMutation({
+        mutationFn: (applicationId: string) => restoreApplication(env!.id, applicationId),
+        onSuccess: () => {
+            void queryClient.invalidateQueries({ queryKey: applicationListKeys.all });
+        },
+    });
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/services/applicationDetail.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/services/applicationDetail.ts
@@ -1,0 +1,128 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { apimFetchJsonV1Env } from '../../../shared/api/apimClient';
+import type { ApplicationListItem } from '../types/application';
+import type {
+    ClientCertificate,
+    ClientCertificatePagedResult,
+    CreateClientCertificate,
+    UpdateClientCertificate,
+    ValidateCertificateResponse,
+} from '../types/applicationCertificate';
+import type { ApplicationTypeConfig } from '../types/applicationCreate';
+
+export async function getApplication(environmentId: string, applicationId: string): Promise<ApplicationListItem> {
+    return apimFetchJsonV1Env<ApplicationListItem>(environmentId, `/applications/${applicationId}`);
+}
+
+export async function getApplicationTypeConfiguration(environmentId: string, applicationId: string): Promise<ApplicationTypeConfig> {
+    return apimFetchJsonV1Env<ApplicationTypeConfig>(environmentId, `/applications/${applicationId}/configuration`);
+}
+
+export interface UpdateApplicationPayload {
+    name: string;
+    description: string;
+    domain?: string;
+    groups?: string[];
+    settings?: ApplicationListItem['settings'];
+    picture?: string | null;
+    background?: string | null;
+    disable_membership_notifications?: boolean;
+    api_key_mode?: ApplicationListItem['api_key_mode'];
+}
+
+export async function updateApplication(
+    environmentId: string,
+    application: ApplicationListItem,
+    payload: UpdateApplicationPayload,
+): Promise<ApplicationListItem> {
+    const body: UpdateApplicationPayload = {
+        name: payload.name,
+        description: payload.description,
+        domain: payload.domain,
+        groups: application.groups,
+        settings: payload.settings,
+        disable_membership_notifications: application.disable_membership_notifications,
+        api_key_mode: application.api_key_mode,
+    };
+    if (payload.picture !== undefined) {
+        body.picture = payload.picture;
+    }
+    if (payload.background !== undefined) {
+        body.background = payload.background;
+    }
+    return apimFetchJsonV1Env<ApplicationListItem>(environmentId, `/applications/${application.id}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+    });
+}
+
+/** Trailing slash matches console `ApplicationService.delete` and management API usage. */
+export async function deleteApplication(environmentId: string, applicationId: string): Promise<ApplicationListItem> {
+    return apimFetchJsonV1Env<ApplicationListItem>(environmentId, `/applications/${applicationId}/`, {
+        method: 'DELETE',
+    });
+}
+
+export async function listApplicationCertificates(
+    environmentId: string,
+    applicationId: string,
+    page = 1,
+    size = 100,
+): Promise<ClientCertificatePagedResult> {
+    return apimFetchJsonV1Env<ClientCertificatePagedResult>(
+        environmentId,
+        `/applications/${applicationId}/certificates?page=${page}&size=${size}`,
+    );
+}
+
+export async function createApplicationCertificate(
+    environmentId: string,
+    applicationId: string,
+    certificate: CreateClientCertificate,
+): Promise<ClientCertificate> {
+    return apimFetchJsonV1Env<ClientCertificate>(environmentId, `/applications/${applicationId}/certificates`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(certificate),
+    });
+}
+
+export async function updateApplicationCertificate(
+    environmentId: string,
+    applicationId: string,
+    certificateId: string,
+    update: UpdateClientCertificate,
+): Promise<ClientCertificate> {
+    return apimFetchJsonV1Env<ClientCertificate>(environmentId, `/applications/${applicationId}/certificates/${certificateId}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(update),
+    });
+}
+
+export async function validateApplicationCertificate(
+    environmentId: string,
+    applicationId: string,
+    certificate: string,
+): Promise<ValidateCertificateResponse> {
+    return apimFetchJsonV1Env<ValidateCertificateResponse>(environmentId, `/applications/${applicationId}/certificates/_validate`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ certificate }),
+    });
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/services/applicationList.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/services/applicationList.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import { apimFetchJsonV1Env } from '../../../shared/api/apimClient';
-import type { ApplicationListResponse, ApplicationStatus } from '../types/application';
+import type { ApplicationListItem, ApplicationListResponse, ApplicationStatus } from '../types/application';
 
 export async function listApplications(
     environmentId: string,
@@ -39,4 +39,10 @@ export async function listApplications(
         params.set('query', query);
     }
     return apimFetchJsonV1Env<ApplicationListResponse>(environmentId, `/applications/_paged?${params}`);
+}
+
+export async function restoreApplication(environmentId: string, applicationId: string): Promise<ApplicationListItem> {
+    return apimFetchJsonV1Env<ApplicationListItem>(environmentId, `/applications/${applicationId}/_restore`, {
+        method: 'POST',
+    });
 }

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/services/applicationPermissions.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/services/applicationPermissions.ts
@@ -1,0 +1,30 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { normalizeCrudMapRecord } from '@gravitee/gamma-modules-sdk';
+
+import { apimFetchJsonV1Env } from '../../../shared/api/apimClient';
+
+/**
+ * Fetches the current user's permission set for a specific application and returns
+ * normalized flat strings ready for `permissionService.load('application', ...)`.
+ */
+export async function getApplicationPermissions(environmentId: string, applicationId: string): Promise<string[]> {
+    const raw = await apimFetchJsonV1Env<Record<string, string[]>>(
+        environmentId,
+        `/applications/${encodeURIComponent(applicationId)}/members/permissions`,
+    );
+    return normalizeCrudMapRecord('application', raw);
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/services/currentUser.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/services/currentUser.spec.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { hasOrganizationAdminRole } from './currentUser';
+
+describe('hasOrganizationAdminRole', () => {
+    it('returns true when user has ORGANIZATION ADMIN role', () => {
+        expect(hasOrganizationAdminRole([{ scope: 'ORGANIZATION', name: 'ADMIN', permissions: {} }])).toBe(true);
+    });
+
+    it('returns false for other roles or missing roles', () => {
+        expect(hasOrganizationAdminRole([{ scope: 'ENVIRONMENT', name: 'ADMIN', permissions: {} }])).toBe(false);
+        expect(hasOrganizationAdminRole(undefined)).toBe(false);
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/services/currentUser.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/services/currentUser.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import type { UserRole } from '@gravitee/gamma-modules-sdk/types';
+
+import { apimFetchJsonOrg } from '../../../shared/api/apimClient';
+
+export interface CurrentUser {
+    displayName?: string;
+    roles?: UserRole[];
+}
+
+/** GET /organizations/{orgId}/user — same resource as the control-plane auth store. */
+export async function fetchCurrentUser(): Promise<CurrentUser> {
+    return apimFetchJsonOrg<CurrentUser>('/user');
+}
+
+export function hasOrganizationAdminRole(roles: UserRole[] | undefined): boolean {
+    return roles?.some(role => role.scope === 'ORGANIZATION' && role.name === 'ADMIN') ?? false;
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/types/application.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/types/application.ts
@@ -22,24 +22,42 @@ export interface ApplicationOwner {
     type: string;
 }
 
+export type ApiKeyMode = 'UNSPECIFIED' | 'SHARED' | 'EXCLUSIVE';
+
+export interface ApplicationOAuthSettings {
+    client_id?: string;
+    client_secret?: string;
+    grant_types?: string[];
+    redirect_uris?: string[];
+    application_type?: string;
+    additional_client_metadata?: Record<string, string>;
+}
+
 export interface ApplicationSettings {
     app?: {
         type?: string;
         client_id?: string;
     };
+    oauth?: ApplicationOAuthSettings;
 }
 
 export interface ApplicationListItem {
     id: string;
     name: string;
     description?: string;
+    domain?: string;
     status: ApplicationStatus;
     type?: string;
     created_at: number;
     updated_at: number;
     owner?: ApplicationOwner;
     settings?: ApplicationSettings;
+    picture?: string;
+    background?: string;
     picture_url?: string;
+    api_key_mode?: ApiKeyMode;
+    groups?: string[];
+    disable_membership_notifications?: boolean;
     origin?: string;
 }
 

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/types/applicationCertificate.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/types/applicationCertificate.ts
@@ -1,0 +1,60 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export type ClientCertificateStatus = 'ACTIVE' | 'ACTIVE_WITH_END' | 'SCHEDULED' | 'REVOKED';
+
+export interface ClientCertificate {
+    id: string;
+    name: string;
+    startsAt?: string;
+    endsAt?: string;
+    createdAt: string;
+    updatedAt?: string;
+    certificate?: string;
+    certificateExpiration?: string;
+    subject?: string;
+    issuer?: string;
+    fingerprint?: string;
+    status: ClientCertificateStatus;
+}
+
+export interface ClientCertificatePagedResult {
+    data: ClientCertificate[];
+    page?: {
+        current: number;
+        size: number;
+        total_elements: number;
+    };
+}
+
+export interface CreateClientCertificate {
+    name: string;
+    certificate: string;
+    startsAt?: string;
+    endsAt?: string;
+}
+
+export interface UpdateClientCertificate {
+    name: string;
+    startsAt?: string;
+    endsAt?: string;
+}
+
+export interface ValidateCertificateResponse {
+    certificateExpiration: string;
+    subject: string;
+    issuer: string;
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/utils/applicationFormatters.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/utils/applicationFormatters.spec.ts
@@ -13,12 +13,23 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { formatApplicationTypeLabel } from './applicationFormatters';
+import { formatApplicationOwnerLabel, formatApplicationSecurityTypeLabel, formatApplicationTypeLabel } from './applicationFormatters';
 
 describe('applicationFormatters', () => {
     it('maps known application types to display labels', () => {
         expect(formatApplicationTypeLabel({ type: 'SIMPLE' })).toBe('Service');
         expect(formatApplicationTypeLabel({ type: 'BROWSER' })).toBe('SPA');
         expect(formatApplicationTypeLabel({ type: 'BACKEND_TO_BACKEND' })).toBe('Backend');
+    });
+
+    it('maps security types for application detail header', () => {
+        expect(formatApplicationSecurityTypeLabel({ type: 'SIMPLE' })).toBe('Simple');
+        expect(formatApplicationSecurityTypeLabel({ type: 'BROWSER' })).toBe('SPA');
+        expect(formatApplicationSecurityTypeLabel({ type: 'BACKEND_TO_BACKEND' })).toBe('Backend to backend');
+    });
+
+    it('formats owner with role label', () => {
+        expect(formatApplicationOwnerLabel({ id: '1', displayName: 'Alice Chen', type: 'USER' })).toBe('Alice Chen (User)');
+        expect(formatApplicationOwnerLabel(undefined)).toBeNull();
     });
 });

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/utils/applicationFormatters.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/utils/applicationFormatters.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import type { ApplicationListItem } from '../types/application';
+import type { ApplicationListItem, ApplicationOwner } from '../types/application';
 
 const TYPE_LABELS: Record<string, string> = {
     SIMPLE: 'Service',
@@ -24,6 +24,42 @@ const TYPE_LABELS: Record<string, string> = {
     AI_AGENT: 'AI Agent',
 };
 
+/** Security type labels for application detail (matches applications/types.json names). */
+const SECURITY_TYPE_LABELS: Record<string, string> = {
+    SIMPLE: 'Simple',
+    BROWSER: 'SPA',
+    WEB: 'Web',
+    NATIVE: 'Native',
+    BACKEND_TO_BACKEND: 'Backend to backend',
+    AI_AGENT: 'AI Agent',
+};
+
+const OWNER_TYPE_LABELS: Record<string, string> = {
+    USER: 'User',
+    GROUP: 'Group',
+};
+
+export function formatApplicationSecurityTypeLabel(application: Pick<ApplicationListItem, 'type' | 'settings'>): string {
+    const settingsType = application.settings?.app?.type;
+    if (settingsType) {
+        const normalized = settingsType.toUpperCase();
+        return SECURITY_TYPE_LABELS[normalized] ?? toTitleLabel(settingsType);
+    }
+    if (!application.type) {
+        return '—';
+    }
+    const normalized = application.type.toUpperCase();
+    return SECURITY_TYPE_LABELS[normalized] ?? toTitleLabel(application.type);
+}
+
+export function formatApplicationOwnerLabel(owner: ApplicationOwner | undefined): string | null {
+    if (!owner?.displayName) {
+        return null;
+    }
+    const roleLabel = owner.type ? (OWNER_TYPE_LABELS[owner.type.toUpperCase()] ?? toTitleLabel(owner.type)) : null;
+    return roleLabel ? `${owner.displayName} (${roleLabel})` : owner.displayName;
+}
+
 export function formatApplicationTypeLabel(application: Pick<ApplicationListItem, 'type' | 'settings'>): string {
     const settingsType = application.settings?.app?.type;
     if (settingsType) {
@@ -33,6 +69,30 @@ export function formatApplicationTypeLabel(application: Pick<ApplicationListItem
         return '—';
     }
     return TYPE_LABELS[application.type] ?? toTitleLabel(application.type);
+}
+
+const API_KEY_MODE_LABELS: Record<string, string> = {
+    UNSPECIFIED: 'Unspecified',
+    SHARED: 'Shared',
+    EXCLUSIVE: 'Exclusive',
+};
+
+export function formatApplicationApiKeyMode(mode: string | undefined): string {
+    if (!mode) return '—';
+    return API_KEY_MODE_LABELS[mode] ?? mode;
+}
+
+export function formatApplicationDateTime(value: number | string | undefined): string {
+    if (value === undefined || value === '') return '—';
+    const date = typeof value === 'number' ? new Date(value) : new Date(value);
+    if (Number.isNaN(date.getTime())) return '—';
+    return date.toLocaleString('en-US', {
+        year: 'numeric',
+        month: 'short',
+        day: 'numeric',
+        hour: 'numeric',
+        minute: '2-digit',
+    });
 }
 
 function toTitleLabel(value: string): string {

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/utils/applicationGeneralMapper.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/utils/applicationGeneralMapper.spec.ts
@@ -1,0 +1,98 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+    buildUpdatePayload,
+    formFromApplication,
+    hasApplicationGeneralValidationErrors,
+    isApplicationGeneralFormDirty,
+    validateApplicationGeneralForm,
+} from './applicationGeneralMapper';
+import type { ApplicationListItem } from '../types/application';
+
+const baseApplication: ApplicationListItem = {
+    id: 'app-1',
+    name: 'My App',
+    description: 'Desc',
+    status: 'ACTIVE',
+    type: 'SIMPLE',
+    created_at: 1,
+    updated_at: 1,
+    settings: { app: { client_id: 'client-1' } },
+};
+
+describe('applicationGeneralMapper', () => {
+    it('maps application to form', () => {
+        const form = formFromApplication(baseApplication);
+        expect(form.name).toBe('My App');
+        expect(form.simpleClientId).toBe('client-1');
+    });
+
+    it('validates required fields', () => {
+        const errors = validateApplicationGeneralForm({
+            ...formFromApplication(baseApplication),
+            name: '',
+            description: '',
+        });
+        expect(hasApplicationGeneralValidationErrors(errors)).toBe(true);
+        expect(errors.name).toBeDefined();
+        expect(errors.description).toBeDefined();
+    });
+
+    it('detects dirty state with explicit field comparison', () => {
+        const saved = formFromApplication(baseApplication);
+        const unchanged = { ...saved };
+        const renamed = { ...saved, name: 'Other' };
+        const reorderedGrantTypes = { ...saved, grantTypes: [...saved.grantTypes].reverse() };
+
+        expect(isApplicationGeneralFormDirty(unchanged, saved)).toBe(false);
+        expect(isApplicationGeneralFormDirty(renamed, saved)).toBe(true);
+        expect(isApplicationGeneralFormDirty(reorderedGrantTypes, saved)).toBe(false);
+    });
+
+    it('builds simple application update payload', () => {
+        const form = { ...formFromApplication(baseApplication), name: 'Updated', simpleClientId: 'new-client' };
+        const payload = buildUpdatePayload(baseApplication, form, undefined);
+        expect(payload.name).toBe('Updated');
+        expect(payload.settings?.app?.client_id).toBe('new-client');
+    });
+
+    it('parses redirect URIs for oauth applications', () => {
+        const oauthApp: ApplicationListItem = {
+            ...baseApplication,
+            type: 'WEB',
+            settings: {
+                oauth: {
+                    client_id: 'oauth-id',
+                    grant_types: ['authorization_code'],
+                    redirect_uris: [],
+                },
+            },
+        };
+        const form = {
+            ...formFromApplication(oauthApp),
+            redirectUrisText: 'https://a.example\nhttps://b.example\n',
+        };
+        const payload = buildUpdatePayload(oauthApp, form, {
+            id: 'WEB',
+            name: 'Web',
+            allowed_grant_types: [],
+            mandatory_grant_types: [],
+            default_grant_types: [],
+            requires_redirect_uris: true,
+        });
+        expect(payload.settings?.oauth?.redirect_uris).toEqual(['https://a.example', 'https://b.example']);
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/utils/applicationGeneralMapper.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/utils/applicationGeneralMapper.ts
@@ -1,0 +1,160 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import type { UpdateApplicationPayload } from '../services/applicationDetail';
+import type { ApplicationListItem } from '../types/application';
+import type { ApplicationTypeConfig } from '../types/applicationCreate';
+
+export interface ApplicationGeneralForm {
+    name: string;
+    description: string;
+    domain: string;
+    picture: string | null;
+    background: string | null;
+    pictureRemoved: boolean;
+    backgroundRemoved: boolean;
+    simpleClientId: string;
+    oauthClientId: string;
+    oauthClientSecret: string;
+    grantTypes: string[];
+    redirectUrisText: string;
+}
+
+export interface ApplicationGeneralValidation {
+    name?: string;
+    description?: string;
+}
+
+export function formFromApplication(application: ApplicationListItem): ApplicationGeneralForm {
+    const isSimple = application.type === 'SIMPLE';
+    return {
+        name: application.name ?? '',
+        description: application.description ?? '',
+        domain: application.domain ?? '',
+        picture: application.picture ?? application.picture_url ?? null,
+        background: application.background ?? null,
+        pictureRemoved: false,
+        backgroundRemoved: false,
+        simpleClientId: isSimple ? (application.settings?.app?.client_id ?? '') : '',
+        oauthClientId: !isSimple ? (application.settings?.oauth?.client_id ?? '') : '',
+        oauthClientSecret: !isSimple ? (application.settings?.oauth?.client_secret ?? '') : '',
+        grantTypes: !isSimple ? [...(application.settings?.oauth?.grant_types ?? [])] : [],
+        redirectUrisText: !isSimple ? (application.settings?.oauth?.redirect_uris ?? []).join('\n') : '',
+    };
+}
+
+export function validateApplicationGeneralForm(form: ApplicationGeneralForm): ApplicationGeneralValidation {
+    const errors: ApplicationGeneralValidation = {};
+    if (!form.name.trim()) {
+        errors.name = 'Application name is required.';
+    } else if (form.name.length > 512) {
+        errors.name = 'Application name must be 512 characters or fewer.';
+    }
+    if (!form.description.trim()) {
+        errors.description = 'Application description is required.';
+    }
+    return errors;
+}
+
+export function hasApplicationGeneralValidationErrors(errors: ApplicationGeneralValidation): boolean {
+    return Boolean(errors.name || errors.description);
+}
+
+function grantTypesEqual(a: string[], b: string[]): boolean {
+    if (a.length !== b.length) {
+        return false;
+    }
+    const sortedA = [...a].sort();
+    const sortedB = [...b].sort();
+    return sortedA.every((value, index) => value === sortedB[index]);
+}
+
+/** Returns true when local draft differs from the last saved snapshot. */
+export function isApplicationGeneralFormDirty(current: ApplicationGeneralForm, saved: ApplicationGeneralForm): boolean {
+    return (
+        current.name !== saved.name ||
+        current.description !== saved.description ||
+        current.domain !== saved.domain ||
+        current.picture !== saved.picture ||
+        current.background !== saved.background ||
+        current.pictureRemoved !== saved.pictureRemoved ||
+        current.backgroundRemoved !== saved.backgroundRemoved ||
+        current.simpleClientId !== saved.simpleClientId ||
+        current.oauthClientId !== saved.oauthClientId ||
+        current.oauthClientSecret !== saved.oauthClientSecret ||
+        current.redirectUrisText !== saved.redirectUrisText ||
+        !grantTypesEqual(current.grantTypes, saved.grantTypes)
+    );
+}
+
+function parseRedirectUris(text: string): string[] {
+    return text
+        .split('\n')
+        .map(line => line.trim())
+        .filter(Boolean);
+}
+
+export function buildUpdatePayload(
+    application: ApplicationListItem,
+    form: ApplicationGeneralForm,
+    applicationTypeConfig: ApplicationTypeConfig | undefined,
+): UpdateApplicationPayload {
+    const isSimple = application.type === 'SIMPLE';
+
+    let picture: string | null | undefined;
+    if (form.pictureRemoved) {
+        picture = null;
+    } else if (form.picture && form.picture !== application.picture) {
+        picture = form.picture;
+    }
+
+    let background: string | null | undefined;
+    if (form.backgroundRemoved) {
+        background = null;
+    } else if (form.background && form.background !== application.background) {
+        background = form.background;
+    }
+
+    const settings = isSimple
+        ? {
+              app: {
+                  ...application.settings?.app,
+                  client_id: form.simpleClientId || undefined,
+              },
+          }
+        : {
+              oauth: {
+                  ...application.settings?.oauth,
+                  client_id: form.oauthClientId || application.settings?.oauth?.client_id,
+                  client_secret: form.oauthClientSecret || application.settings?.oauth?.client_secret,
+                  grant_types: form.grantTypes,
+                  redirect_uris: parseRedirectUris(form.redirectUrisText),
+                  application_type: applicationTypeConfig?.id ?? application.settings?.oauth?.application_type,
+              },
+          };
+
+    return {
+        name: form.name.trim(),
+        description: form.description.trim(),
+        domain: form.domain.trim() || undefined,
+        settings,
+        ...(picture !== undefined ? { picture } : {}),
+        ...(background !== undefined ? { background } : {}),
+    };
+}
+
+export function isApplicationGeneralReadOnly(application: ApplicationListItem): boolean {
+    return application.status === 'ARCHIVED' || application.origin === 'KUBERNETES';
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/utils/queryKeys.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/utils/queryKeys.ts
@@ -14,6 +14,23 @@
  * limitations under the License.
  */
 
+export const applicationDetailKeys = {
+    all: ['application-detail'] as const,
+    detail: (envId: string, applicationId: string) => [...applicationDetailKeys.all, envId, applicationId] as const,
+    typeConfig: (envId: string, applicationId: string) => [...applicationDetailKeys.all, 'type-config', envId, applicationId] as const,
+    certificates: (envId: string, applicationId: string) => [...applicationDetailKeys.all, 'certificates', envId, applicationId] as const,
+} as const;
+
+export const applicationPermissionKeys = {
+    all: ['application-permissions'] as const,
+    detail: (envId: string, applicationId: string) => [...applicationPermissionKeys.all, envId, applicationId] as const,
+} as const;
+
+export const currentUserKeys = {
+    all: ['current-user'] as const,
+    detail: () => [...currentUserKeys.all, 'detail'] as const,
+} as const;
+
 export const applicationListKeys = {
     all: ['application-list'] as const,
     search: (envId: string, query: string, status: string, page: number, perPage: number) =>

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/shared/hooks/useDetailBasePath.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/shared/hooks/useDetailBasePath.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useLocation } from 'react-router-dom';
+
+/**
+ * Returns the base path up to and including `/<segment>/<id>`, slicing off
+ * any child route segments. Used by detail layout components to build sidebar
+ * navigation links that are stable regardless of the active child route.
+ */
+export function useDetailBasePath(segment: string, id: string | undefined): string {
+    const { pathname } = useLocation();
+    if (!id) return pathname;
+    const marker = `/${segment}/${id}`;
+    const idx = pathname.indexOf(marker);
+    return idx >= 0 ? pathname.slice(0, idx + marker.length) : pathname;
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/shared/hooks/usePermissionServiceSnapshot.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/shared/hooks/usePermissionServiceSnapshot.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { permissionService } from '@gravitee/gamma-modules-sdk';
+import { useSyncExternalStore } from 'react';
+
+/** Re-renders when {@link permissionService} loads or clears a scope. */
+export function usePermissionServiceSnapshot(): number {
+    return useSyncExternalStore(
+        listener => permissionService.subscribe(listener),
+        () => permissionService.getSnapshot(),
+        () => permissionService.getSnapshot(),
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/ApplicationDetailGeneralPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/ApplicationDetailGeneralPage.tsx
@@ -1,0 +1,78 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Alert, AlertDescription, Skeleton } from '@gravitee/graphene-core';
+import { CircleCheckIcon } from '@gravitee/graphene-core/icons';
+import { useEffect, useState } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+
+import { ApplicationGeneralContent } from '../features/applications/components/general/ApplicationGeneralContent';
+import { useApplicationDetailContext } from '../features/applications/context/ApplicationDetailContext';
+
+export interface ApplicationCreateLocationState {
+    created?: boolean;
+    applicationName?: string;
+}
+
+export function ApplicationDetailGeneralPage() {
+    const location = useLocation();
+    const navigate = useNavigate();
+    const { application, isLoading } = useApplicationDetailContext();
+    const [createdMessage] = useState<string | null>(() => {
+        const state = location.state as ApplicationCreateLocationState | null;
+        return state?.created && state.applicationName ? state.applicationName : null;
+    });
+
+    useEffect(() => {
+        if (location.state) {
+            navigate('.', { replace: true, state: null });
+        }
+    }, [location.state, navigate]);
+
+    if (isLoading) {
+        return (
+            <div className="space-y-6">
+                {createdMessage ? (
+                    <Alert className="border-success/30 bg-success/5">
+                        <CircleCheckIcon className="size-4 text-success" aria-hidden />
+                        <AlertDescription className="text-success">
+                            Application &quot;{createdMessage}&quot; has been created successfully.
+                        </AlertDescription>
+                    </Alert>
+                ) : null}
+                <Skeleton className="h-10 w-64" />
+                <Skeleton className="h-96 w-full" />
+            </div>
+        );
+    }
+
+    if (!application) {
+        return <p className="text-sm text-muted-foreground">Application not found or you may not have access.</p>;
+    }
+
+    return (
+        <div className="space-y-6">
+            {createdMessage ? (
+                <Alert className="border-success/30 bg-success/5">
+                    <CircleCheckIcon className="size-4 text-success" aria-hidden />
+                    <AlertDescription className="text-success">
+                        Application &quot;{createdMessage}&quot; has been created successfully.
+                    </AlertDescription>
+                </Alert>
+            ) : null}
+            <ApplicationGeneralContent application={application} />
+        </div>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/ApplicationsPage.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/ApplicationsPage.spec.tsx
@@ -21,16 +21,22 @@ import { MemoryRouter } from 'react-router-dom';
 import { ApplicationsPage } from './ApplicationsPage';
 import { useApplicationList } from '../features/applications/hooks/useApplicationList';
 import { useApplicationStats } from '../features/applications/hooks/useApplicationStats';
+import { useOrganizationAdmin } from '../features/applications/hooks/useOrganizationAdmin';
+import { useRestoreApplication } from '../features/applications/hooks/useRestoreApplication';
 
 jest.mock('@gravitee/gamma-modules-sdk', () => ({
     useHasPermission: jest.fn(),
 }));
 jest.mock('../features/applications/hooks/useApplicationList');
 jest.mock('../features/applications/hooks/useApplicationStats');
+jest.mock('../features/applications/hooks/useOrganizationAdmin');
+jest.mock('../features/applications/hooks/useRestoreApplication');
 
 const mockUseHasPermission = jest.mocked(useHasPermission);
 const mockUseApplicationList = jest.mocked(useApplicationList);
 const mockUseApplicationStats = jest.mocked(useApplicationStats);
+const mockUseOrganizationAdmin = jest.mocked(useOrganizationAdmin);
+const mockUseRestoreApplication = jest.mocked(useRestoreApplication);
 
 const STUB_STATS = {
     active: 0,
@@ -78,7 +84,12 @@ function renderPage() {
 describe('ApplicationsPage', () => {
     beforeEach(() => {
         mockUseHasPermission.mockReturnValue(true);
+        mockUseOrganizationAdmin.mockReturnValue({ isAdmin: true, isLoading: false });
         mockUseApplicationStats.mockReturnValue(STUB_STATS);
+        mockUseRestoreApplication.mockReturnValue({
+            mutate: jest.fn(),
+            isPending: false,
+        } as ReturnType<typeof useRestoreApplication>);
     });
 
     afterEach(() => {

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/ApplicationsPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/ApplicationsPage.tsx
@@ -21,6 +21,7 @@ import { ApplicationsEmptyLanding } from '../features/applications/components';
 import { ApplicationsListView } from '../features/applications/components/list';
 import { useApplicationList } from '../features/applications/hooks/useApplicationList';
 import { useApplicationStats } from '../features/applications/hooks/useApplicationStats';
+import { useOrganizationAdmin } from '../features/applications/hooks/useOrganizationAdmin';
 import type { ApplicationStatus } from '../features/applications/types/application';
 import type { ApplicationsListLocationState } from '../features/applications/types/navigation';
 import { SuccessBanner } from '../features/shared/components';
@@ -34,6 +35,7 @@ export function ApplicationsPage() {
     const navigate = useNavigate();
     const location = useLocation();
     const canCreate = useHasPermission({ anyOf: ['environment-application-c'] });
+    const { isAdmin: canManageArchived, isLoading: isAdminLoading } = useOrganizationAdmin();
 
     const [successMessage, setSuccessMessage] = useState<string | null>(null);
     const [search, setSearch] = useState('');
@@ -46,6 +48,13 @@ export function ApplicationsPage() {
         const timer = setTimeout(() => setDebouncedSearch(search), SEARCH_DEBOUNCE_MS);
         return () => clearTimeout(timer);
     }, [search]);
+
+    useEffect(() => {
+        if (!isAdminLoading && !canManageArchived && status === 'ARCHIVED') {
+            setStatus(DEFAULT_STATUS);
+            setPage(DEFAULT_PAGE);
+        }
+    }, [canManageArchived, isAdminLoading, status]);
 
     useEffect(() => {
         const state = location.state as ApplicationsListLocationState | null;
@@ -125,6 +134,8 @@ export function ApplicationsPage() {
                 onPerPageChange={handlePerPageChange}
                 onRegisterApplication={handleRegisterApplication}
                 canCreate={canCreate}
+                canManageArchived={canManageArchived}
+                canRestore={canManageArchived}
             />
         </div>
     );

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/shared/gamma-modules-sdk.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/shared/gamma-modules-sdk.ts
@@ -34,8 +34,8 @@ export const permissionService = {
     clear: (_scope: string): void => {},
     reset: (): void => {},
     getAllPermissions: (): string[] => [],
-    hasAnyOf: (): boolean => true,
-    hasAllOf: (): boolean => true,
+    hasAnyOf: (_required?: string[]): boolean => true,
+    hasAllOf: (_required?: string[]): boolean => true,
     subscribe:
         (_listener: () => void): (() => void) =>
         () => {},
@@ -59,9 +59,12 @@ export function PermissionGate({
  * e.g. `normalizeCrudMapRecord('api', { DEFINITION: ['R','U'] })` → `['api-definition-r', 'api-definition-u']`
  */
 export function normalizeCrudMapRecord(scope: string, record: Record<string, string[] | string>): string[] {
-    return Object.entries(record).flatMap(([resource, ops]) => {
-        const operations = Array.isArray(ops) ? ops : [ops];
-        return operations.map(op => `${scope}-${resource.toLowerCase()}-${op.toLowerCase()}`);
+    return Object.entries(record).flatMap(([key, crudValues]) => {
+        const keyPart = key.toLowerCase();
+        if (Array.isArray(crudValues)) {
+            return crudValues.map(letter => `${scope}-${keyPart}-${letter.toLowerCase()}`);
+        }
+        return crudValues.split('').map(letter => `${scope}-${keyPart}-${letter.toLowerCase()}`);
     });
 }
 


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-XXX

## Description

Extends the Gamma Platform Applications experience with organization-admin archived list management and a full Application detail shell, including an implemented General settings tab aligned with the APIM console.

Archived applications (org admins): Active/Archived status filter, archived-specific table columns (name, archived date), and restore action with confirmation dialog.
Active applications list: Row click navigates to detail; actions menu offers View Details and Manage Subscriptions.
Application detail routing: Nested routes under /applications/:applicationId with permission-aware sidebar navigation, tab guards, and placeholder pages for tabs not yet implemented.
General tab: Editable application details, OAuth client settings, certificate management (add/revoke/grace period), and lifecycle (delete); read-only for archived and Kubernetes-origin applications.


## Additional context


https://github.com/user-attachments/assets/504f68fb-1a58-4d2a-963c-5aa95b7d96ef


_Route structure (reference)_

/applications
├── (index)           → ApplicationsPage
├── new               → RegisterApplicationPage
└── :applicationId
    ├── (index)       → redirect to first permitted implemented tab
    ├── general       → ApplicationDetailGeneralPage  ✓ implemented
    ├── overview      → placeholder
    ├── user-permissions → placeholder
    └── subscriptions → placeholder