### PR TITLE
fix(native-api): preserve allowMultiJwtOauth2Subscriptions on update

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/model/AbstractUpdateApi.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/model/AbstractUpdateApi.java
@@ -47,6 +47,8 @@ public abstract class AbstractUpdateApi {
 
     protected boolean disableMembershipNotifications;
 
+    protected boolean allowMultiJwtOauth2Subscriptions;
+
     @Builder.Default
     protected Set<String> groups = Set.of();
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/use_case/UpdateNativeApiUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/use_case/UpdateNativeApiUseCase.java
@@ -92,6 +92,7 @@ public class UpdateNativeApiUseCase {
                 .categories(updateNativeApi.getCategories())
                 .groups(updateNativeApi.getGroups())
                 .disableMembershipNotifications(updateNativeApi.isDisableMembershipNotifications())
+                .allowMultiJwtOauth2Subscriptions(updateNativeApi.isAllowMultiJwtOauth2Subscriptions())
                 .apiDefinitionValue(
                     currentApi.getApiDefinitionValue() instanceof NativeApi nativeApi
                         ? nativeApi

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/UpdateNativeApiUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/UpdateNativeApiUseCaseTest.java
@@ -275,6 +275,7 @@ public class UpdateNativeApiUseCaseTest {
             )
             .analytics(NativeAnalytics.builder().enabled(false).build())
             .disableMembershipNotifications(true)
+            .allowMultiJwtOauth2Subscriptions(true)
             .build();
 
         var auditInfo = AuditInfoFixtures.anAuditInfo(ORGANIZATION_ID, ENVIRONMENT_ID, "user-does-not-exist");
@@ -290,6 +291,7 @@ public class UpdateNativeApiUseCaseTest {
             .categories(Set.of("new"))
             .groups(Set.of("new"))
             .disableMembershipNotifications(true)
+            .allowMultiJwtOauth2Subscriptions(true)
             .apiDefinitionNativeV4(
                 existingApi
                     .getApiDefinitionNativeV4()
@@ -337,6 +339,7 @@ public class UpdateNativeApiUseCaseTest {
                 assertThat(api.getCategories()).containsExactly("new-key");
                 assertThat(api.getGroups()).containsExactly("new");
                 assertThat(api.isDisableMembershipNotifications()).isEqualTo(true);
+                assertThat(api.isAllowMultiJwtOauth2Subscriptions()).isEqualTo(true);
             })
             .extracting(Api::getApiDefinitionNativeV4)
             .satisfies(definition -> {


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-13801

## Description

Previously, the `allowMultiJwtOauth2Subscriptions` property was dropped when updating a Native V4 API because it was missing from the `UpdateNativeApi` domain model and its corresponding use-case mapping. 

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

