### PR TITLE
feat(mongo): cap count() cost on paginated repository searches with maxTimeMs

### DIFF
--- a/gravitee-apim-console-webui/src/app.module.ts
+++ b/gravitee-apim-console-webui/src/app.module.ts
@@ -22,6 +22,7 @@ import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { setAngularJSGlobal, UpgradeModule } from '@angular/upgrade/static';
 import { GioPendoModule, GIO_PENDO_SETTINGS_TOKEN } from '@gravitee/ui-analytics';
 import { GioMatConfigModule } from '@gravitee/ui-particles-angular';
+import { MatPaginatorIntl } from '@angular/material/paginator';
 import { MatMomentDateModule, provideMomentDateAdapter } from '@angular/material-moment-adapter';
 import { provideCharts, withDefaultRegisterables } from 'ng2-charts';
 
@@ -36,6 +37,7 @@ import { UserComponent } from './user/my-accout/user.component';
 import { AuthModule } from './auth/auth.module';
 import { GioFormJsonSchemaExtendedModule } from './shared/components/form-json-schema-extended/form-json-schema-extended.module';
 import { ClusterRoutingModule } from './management/clusters/cluster-routing.module';
+import { GioPaginatorIntl } from './shared/paginator/gio-paginator-intl';
 
 @NgModule({
   declarations: [AppComponent, UserComponent],
@@ -83,6 +85,7 @@ import { ClusterRoutingModule } from './management/clusters/cluster-routing.modu
       }),
     ),
     provideCharts(withDefaultRegisterables()),
+    { provide: MatPaginatorIntl, useClass: GioPaginatorIntl },
   ],
 })
 export class AppModule implements DoBootstrap {

--- a/gravitee-apim-console-webui/src/shared/components/gio-table-wrapper/gio-table-wrapper.component.html
+++ b/gravitee-apim-console-webui/src/shared/components/gio-table-wrapper/gio-table-wrapper.component.html
@@ -33,7 +33,7 @@
       <mat-paginator
         class="gio-table-wrapper__header-bar__paginator"
         #paginatorTop
-        [length]="length"
+        [length]="effectiveLength"
         [pageSizeOptions]="paginationPageSizeOptions"
         [hidePageSize]="disablePageSize"
         [showFirstLastButtons]="true"
@@ -50,8 +50,8 @@
   <mat-paginator
     #paginatorBottom
     class="gio-table-wrapper__footer-bar__paginator"
-    [class.hidden]="length <= paginatorBottom.pageSize"
-    [length]="length"
+    [class.hidden]="length >= 0 && length <= paginatorBottom.pageSize"
+    [length]="effectiveLength"
     [hidePageSize]="true"
     [showFirstLastButtons]="true"
     aria-label="Select page"

--- a/gravitee-apim-console-webui/src/shared/components/gio-table-wrapper/gio-table-wrapper.component.scss
+++ b/gravitee-apim-console-webui/src/shared/components/gio-table-wrapper/gio-table-wrapper.component.scss
@@ -77,3 +77,9 @@ $typography: map.get(gio.$mat-theme, typography);
     }
   }
 }
+
+
+:host(.gio-unknown-length) ::ng-deep .mat-mdc-paginator-navigation-last {
+  opacity: 0.38;
+  pointer-events: none;
+}

--- a/gravitee-apim-console-webui/src/shared/components/gio-table-wrapper/gio-table-wrapper.component.ts
+++ b/gravitee-apim-console-webui/src/shared/components/gio-table-wrapper/gio-table-wrapper.component.ts
@@ -19,6 +19,7 @@ import {
   Component,
   ContentChild,
   EventEmitter,
+  HostBinding,
   Input,
   OnChanges,
   Output,
@@ -74,9 +75,20 @@ export class GioTableWrapperComponent implements AfterViewInit, OnChanges {
   @Input()
   searchLabel = 'Search';
 
-  /** The current total number of items being paged (only for display) */
+  /** The current total number of items being paged (only for display). `-1` means unknown (count timed out). */
   @Input()
   length = 0;
+
+  /** Coerces unknown-count (-1) to a large sentinel so MatPaginator's range label reads "Many results". */
+  get effectiveLength(): number {
+    return this.length < 0 ? Number.MAX_SAFE_INTEGER : this.length;
+  }
+
+  @HostBinding('class.gio-unknown-length')
+  get isUnknownLength(): boolean {
+    return this.length < 0;
+  }
+
 
   /** Disable search input */
   @Input()
@@ -109,6 +121,7 @@ export class GioTableWrapperComponent implements AfterViewInit, OnChanges {
   private readonly unsubscribe$ = new Subject<boolean>();
 
   constructor(private readonly changeDetectorRef: ChangeDetectorRef) {}
+
 
   ngOnChanges(changes: SimpleChanges): void {
     // Update values on changes

--- a/gravitee-apim-console-webui/src/shared/components/gio-table-wrapper/gio-table-wrapper.module.ts
+++ b/gravitee-apim-console-webui/src/shared/components/gio-table-wrapper/gio-table-wrapper.module.ts
@@ -21,6 +21,7 @@ import { MatIconModule } from '@angular/material/icon';
 import { MatInputModule } from '@angular/material/input';
 import { MatPaginatorModule } from '@angular/material/paginator';
 import { MatSortModule } from '@angular/material/sort';
+import { MatTooltipModule } from '@angular/material/tooltip';
 import { GioIconsModule } from '@gravitee/ui-particles-angular';
 
 import { GioTableWrapperComponent } from './gio-table-wrapper.component';
@@ -34,6 +35,7 @@ import { GioTableWrapperComponent } from './gio-table-wrapper.component';
     MatInputModule,
     MatIconModule,
     MatSortModule,
+    MatTooltipModule,
     GioIconsModule,
   ],
   declarations: [GioTableWrapperComponent],

--- a/gravitee-apim-console-webui/src/shared/paginator/gio-paginator-intl.ts
+++ b/gravitee-apim-console-webui/src/shared/paginator/gio-paginator-intl.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Injectable } from '@angular/core';
+import { MatPaginatorIntl } from '@angular/material/paginator';
+
+@Injectable()
+export class GioPaginatorIntl extends MatPaginatorIntl {
+  override getRangeLabel = (page: number, pageSize: number, length: number): string => {
+    const isUnknownTotal = length < 0 || length === Number.MAX_SAFE_INTEGER;
+    const totalLabel = isUnknownTotal ? 'N/A' : `${length}`;
+    if (length === 0 || pageSize === 0) {
+      return `0 of ${totalLabel}`;
+    }
+    const startIndex = page * pageSize;
+    const endIndex = isUnknownTotal
+      ? startIndex + pageSize
+      : startIndex < length
+        ? Math.min(startIndex + pageSize, length)
+        : startIndex + pageSize;
+    return `${startIndex + 1} – ${endIndex} of ${totalLabel}`;
+  };
+}

--- a/gravitee-apim-portal-webui-next/src/components/pagination/pagination.component.html
+++ b/gravitee-apim-portal-webui-next/src/components/pagination/pagination.component.html
@@ -27,7 +27,7 @@
     <span i18n="@@paginationPrevious">Previous</span>
   </button>
 
-  @if (pagination().hasPreviousPage) {
+  @if (pagination().hasPreviousPage && pagination().isTotalKnown) {
     <button mat-button (click)="goToPage(1)" [attr.aria-label]="'Go to page 1'">1</button>
 
     @if (pagination().currentPage > 3) {
@@ -54,7 +54,7 @@
 
   <button mat-stroked-button aria-label="Current page of results" aria-current="page">{{ pagination().currentPage }}</button>
 
-  @if (pagination().hasNextPage) {
+  @if (pagination().hasNextPage && pagination().isTotalKnown) {
     @if (pagination().currentPage + 1 < pagination().totalPages) {
       <button mat-button (click)="goToNextPage()" [attr.aria-label]="'Go to page ' + (pagination().currentPage + 1)">
         {{ pagination().currentPage + 1 }}

--- a/gravitee-apim-portal-webui-next/src/components/pagination/pagination.component.ts
+++ b/gravitee-apim-portal-webui-next/src/components/pagination/pagination.component.ts
@@ -26,6 +26,7 @@ interface PaginationVM {
   hasNextPage: boolean;
   currentPage: number;
   totalPages: number;
+  isTotalKnown: boolean;
 }
 
 @Component({
@@ -46,18 +47,20 @@ export class PaginationComponent {
   selectPageSize = output<number>();
 
   pagination: Signal<PaginationVM> = computed(() => {
-    const totalPages = Math.ceil(this.totalResults() / this.pageSize());
+    const isTotalKnown = this.totalResults() >= 0;
+    const totalPages = isTotalKnown ? Math.ceil(this.totalResults() / this.pageSize()) : 0;
 
     return {
       hasPreviousPage: this.currentPage() > 1,
-      hasNextPage: this.currentPage() < totalPages,
+      hasNextPage: isTotalKnown ? this.currentPage() < totalPages : true,
       currentPage: this.currentPage(),
       totalPages,
+      isTotalKnown,
     };
   });
 
   goToPage(page: number) {
-    if (page > 0 && page <= this.pagination().totalPages) {
+    if (page > 0 && (!this.pagination().isTotalKnown || page <= this.pagination().totalPages)) {
       this.selectPage.emit(page);
     }
   }
@@ -69,7 +72,7 @@ export class PaginationComponent {
   }
 
   goToNextPage() {
-    if (this.currentPage() < this.pagination().totalPages) {
+    if (!this.pagination().isTotalKnown || this.currentPage() < this.pagination().totalPages) {
       this.selectPage.emit(this.currentPage() + 1);
     }
   }

--- a/gravitee-apim-portal-webui/src/app/pages/catalog/search/catalog-search.component.html
+++ b/gravitee-apim-portal-webui/src/app/pages/catalog/search/catalog-search.component.html
@@ -35,7 +35,11 @@
 
             <gv-pagination [data]="paginationData" has-select widget medium="true"></gv-pagination>
           </form>
-          <div class="catalog-search__info" [innerHTML]="'search.results.label' | translate: { count: totalElements }"></div>
+          @if (totalElements < 0) {
+            <div class="catalog-search__info" [innerHTML]="'search.results.many' | translate"></div>
+          } @else {
+            <div class="catalog-search__info" [innerHTML]="'search.results.label' | translate: { count: totalElements }"></div>
+          }
         </div>
 
         <div *ngIf="apiResults" class="catalog-search__list">

--- a/gravitee-apim-portal-webui/src/assets/i18n/cs.json
+++ b/gravitee-apim-portal-webui/src/assets/i18n/cs.json
@@ -1118,7 +1118,8 @@
   },
   "search": {
     "results": {
-      "label": "{count, plural, =0{žádné výsledky} one{{count} výsledky} other{{count} výsledky}}"
+      "label": "{count, plural, =0{žádné výsledky} one{{count} výsledky} other{{count} výsledky}}",
+      "many": "Mnoho výsledků"
     }
   },
   "site": {

--- a/gravitee-apim-portal-webui/src/assets/i18n/en.json
+++ b/gravitee-apim-portal-webui/src/assets/i18n/en.json
@@ -1126,7 +1126,8 @@
   },
   "search": {
     "results": {
-      "label": "{count, plural, =0{No result} one{{count} result} other{{count} results}}"
+      "label": "{count, plural, =0{No result} one{{count} result} other{{count} results}}",
+      "many": "Many results"
     }
   },
   "site": {

--- a/gravitee-apim-portal-webui/src/assets/i18n/fr.json
+++ b/gravitee-apim-portal-webui/src/assets/i18n/fr.json
@@ -1118,7 +1118,8 @@
   },
   "search": {
     "results": {
-      "label": "{count, plural, =0{Aucun résultat} one{{count} résultat} other{{count} résultats}}"
+      "label": "{count, plural, =0{Aucun résultat} one{{count} résultat} other{{count} résultats}}",
+      "many": "De nombreux résultats"
     }
   },
   "site": {

--- a/gravitee-apim-portal-webui/src/assets/i18n/it.json
+++ b/gravitee-apim-portal-webui/src/assets/i18n/it.json
@@ -1126,7 +1126,8 @@
   },
   "search": {
     "results": {
-      "label": "{count, plural, =0{Nessun risultato} one{{count} risultato} other{{count} risultati}}"
+      "label": "{count, plural, =0{Nessun risultato} one{{count} risultato} other{{count} risultati}}",
+      "many": "Molti risultati"
     }
   },
   "site": {

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/ManagementRepositoryConfiguration.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/ManagementRepositoryConfiguration.java
@@ -45,7 +45,7 @@ import org.springframework.data.mongodb.repository.config.EnableMongoRepositorie
  */
 @Configuration
 @Import(EncryptionConfiguration.class)
-@ComponentScan
+@ComponentScan(basePackages = { "io.gravitee.repository.mongodb.management", "io.gravitee.repository.mongodb.utils" })
 @EnableMongoRepositories
 @Profile("!test")
 public class ManagementRepositoryConfiguration extends AbstractRepositoryConfiguration {

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoGroupRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoGroupRepository.java
@@ -27,6 +27,7 @@ import io.gravitee.repository.management.model.Group;
 import io.gravitee.repository.mongodb.management.internal.group.GroupMongoRepository;
 import io.gravitee.repository.mongodb.management.internal.model.GroupMongo;
 import io.gravitee.repository.mongodb.management.mapper.GraviteeMapper;
+import io.gravitee.repository.mongodb.utils.MongoQueries;
 import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
@@ -62,6 +63,9 @@ public class MongoGroupRepository implements GroupRepository {
 
     @Autowired
     private MongoTemplate mongoTemplate;
+
+    @Autowired
+    private MongoQueries mongoQueries;
 
     @Autowired
     private GraviteeMapper mapper;
@@ -152,7 +156,7 @@ public class MongoGroupRepository implements GroupRepository {
             Sort.by(Sort.Order.asc("name"))
         );
 
-        long total = mongoTemplate.count(Query.of(query), GroupMongo.class);
+        long total = mongoQueries.countOrTimeout(mongoTemplate, Query.of(query), GroupMongo.class);
 
         query = query.with(dbPageable).collation(Collation.of(Locale.ENGLISH).strength(Collation.ComparisonLevel.secondary()));
         List<Group> groups = mongoTemplate.find(query, GroupMongo.class).stream().map(mapper::map).toList();

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/api/AlertEventMongoRepositoryImpl.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/api/AlertEventMongoRepositoryImpl.java
@@ -20,6 +20,7 @@ import io.gravitee.common.data.domain.Page;
 import io.gravitee.repository.management.api.search.AlertEventCriteria;
 import io.gravitee.repository.management.api.search.Pageable;
 import io.gravitee.repository.mongodb.management.internal.model.AlertEventMongo;
+import io.gravitee.repository.mongodb.utils.MongoQueries;
 import java.util.Date;
 import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -38,10 +39,13 @@ public class AlertEventMongoRepositoryImpl implements AlertEventMongoRepositoryC
     @Autowired
     private MongoTemplate mongoTemplate;
 
+    @Autowired
+    private MongoQueries mongoQueries;
+
     @Override
     public Page<AlertEventMongo> search(AlertEventCriteria criteria, Pageable pageable) {
         Query query = buildQueryFromCriteria(criteria);
-        long total = mongoTemplate.count(query, AlertEventMongo.class);
+        long total = mongoQueries.countOrTimeout(mongoTemplate, query, AlertEventMongo.class);
 
         query.with(Sort.by(Sort.Direction.DESC, "createdAt"));
 

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/api/ApiMongoRepositoryImpl.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/api/ApiMongoRepositoryImpl.java
@@ -28,6 +28,7 @@ import io.gravitee.definition.model.DefinitionVersion;
 import io.gravitee.repository.management.api.search.*;
 import io.gravitee.repository.mongodb.management.internal.model.ApiMongo;
 import io.gravitee.repository.mongodb.utils.FieldUtils;
+import io.gravitee.repository.mongodb.utils.MongoQueries;
 import java.util.*;
 import java.util.stream.Collectors;
 import org.bson.Document;
@@ -48,6 +49,9 @@ public class ApiMongoRepositoryImpl implements ApiMongoRepositoryCustom {
     @Autowired
     private MongoTemplate mongoTemplate;
 
+    @Autowired
+    private MongoQueries mongoQueries;
+
     @Override
     public Page<ApiMongo> search(ApiCriteria criteria, Sortable sortable, Pageable pageable, ApiFieldFilter apiFieldFilter) {
         final Query query = buildQuery(apiFieldFilter, criteria == null ? emptyList() : List.of(criteria));
@@ -60,7 +64,7 @@ public class ApiMongoRepositoryImpl implements ApiMongoRepositoryCustom {
             sort = Sort.by(sortOrder, FieldUtils.toCamelCase(sortable.field()));
         }
 
-        long total = mongoTemplate.count(query, ApiMongo.class);
+        long total = mongoQueries.countOrTimeout(mongoTemplate, query, ApiMongo.class);
 
         if (pageable != null) {
             query.with(PageRequest.of(pageable.pageNumber(), pageable.pageSize(), sort));
@@ -89,7 +93,7 @@ public class ApiMongoRepositoryImpl implements ApiMongoRepositoryCustom {
         }
 
         // Get total count before adding pagination to the query
-        long total = mongoTemplate.count(query, ApiMongo.class);
+        long total = mongoQueries.countOrTimeout(mongoTemplate, query, ApiMongo.class);
 
         // set pageable
         query.with(PageRequest.of(pageable.pageNumber(), pageable.pageSize(), sort));

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/apiproducts/ApiProductsMongoRepositoryImpl.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/apiproducts/ApiProductsMongoRepositoryImpl.java
@@ -26,6 +26,7 @@ import io.gravitee.repository.management.api.search.Pageable;
 import io.gravitee.repository.management.api.search.Sortable;
 import io.gravitee.repository.mongodb.management.internal.model.ApiProductMongo;
 import io.gravitee.repository.mongodb.utils.FieldUtils;
+import io.gravitee.repository.mongodb.utils.MongoQueries;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
@@ -46,6 +47,9 @@ public class ApiProductsMongoRepositoryImpl implements ApiProductsMongoRepositor
 
     @Autowired
     private MongoTemplate mongoTemplate;
+
+    @Autowired
+    private MongoQueries mongoQueries;
 
     @Override
     public Set<ApiProductMongo> findByApiId(String apiId) {
@@ -85,7 +89,7 @@ public class ApiProductsMongoRepositoryImpl implements ApiProductsMongoRepositor
             sort = Sort.by(sortOrder, FieldUtils.toCamelCase(sortable.field()));
         }
 
-        long total = mongoTemplate.count(query, ApiProductMongo.class);
+        long total = mongoQueries.countOrTimeout(mongoTemplate, query, ApiProductMongo.class);
         query.with(PageRequest.of(pageable.pageNumber(), pageable.pageSize(), sort));
 
         List<String> ids = mongoTemplate

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/application/ApplicationMongoRepositoryImpl.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/application/ApplicationMongoRepositoryImpl.java
@@ -27,6 +27,7 @@ import io.gravitee.repository.management.api.search.Sortable;
 import io.gravitee.repository.management.model.ApplicationStatus;
 import io.gravitee.repository.mongodb.management.internal.model.ApplicationMongo;
 import io.gravitee.repository.mongodb.utils.FieldUtils;
+import io.gravitee.repository.mongodb.utils.MongoQueries;
 import java.util.Collection;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -49,6 +50,9 @@ public class ApplicationMongoRepositoryImpl implements ApplicationMongoRepositor
     @Autowired
     private MongoTemplate mongoTemplate;
 
+    @Autowired
+    private MongoQueries mongoQueries;
+
     @Override
     public Page<ApplicationMongo> search(final ApplicationCriteria criteria, final Pageable pageable, Sortable sortable) {
         final Query query = buildSearchCriteria(criteria);
@@ -66,7 +70,7 @@ public class ApplicationMongoRepositoryImpl implements ApplicationMongoRepositor
 
         query.with(Sort.by(order));
 
-        long total = mongoTemplate.count(query, ApplicationMongo.class);
+        long total = mongoQueries.countOrTimeout(mongoTemplate, query, ApplicationMongo.class);
 
         if (pageable != null) {
             query.with(PageRequest.of(pageable.pageNumber(), pageable.pageSize()));

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/asyncjob/AsyncJobMongoRepositoryImpl.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/asyncjob/AsyncJobMongoRepositoryImpl.java
@@ -19,6 +19,7 @@ import io.gravitee.common.data.domain.Page;
 import io.gravitee.repository.management.api.AsyncJobRepository;
 import io.gravitee.repository.management.api.search.Pageable;
 import io.gravitee.repository.mongodb.management.internal.model.AsyncJobMongo;
+import io.gravitee.repository.mongodb.utils.MongoQueries;
 import java.util.Date;
 import lombok.AllArgsConstructor;
 import lombok.CustomLog;
@@ -37,12 +38,13 @@ import org.springframework.stereotype.Component;
 public class AsyncJobMongoRepositoryImpl implements AsyncJobMongoRepositoryCustom {
 
     private final MongoTemplate mongoTemplate;
+    private final MongoQueries mongoQueries;
 
     @Override
     public Page<AsyncJobMongo> search(AsyncJobRepository.SearchCriteria criteria, Pageable pageable) {
         var query = toQuery(criteria).with(Sort.by(Sort.Direction.DESC, "updatedAt"));
 
-        long total = mongoTemplate.count(query, AsyncJobMongo.class);
+        long total = mongoQueries.countOrTimeout(mongoTemplate, query, AsyncJobMongo.class);
 
         if (pageable != null) {
             query.with(PageRequest.of(pageable.pageNumber(), pageable.pageSize()));

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/audit/AuditMongoRepositoryImpl.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/audit/AuditMongoRepositoryImpl.java
@@ -21,6 +21,7 @@ import io.gravitee.common.data.domain.Page;
 import io.gravitee.repository.management.api.search.AuditCriteria;
 import io.gravitee.repository.management.api.search.Pageable;
 import io.gravitee.repository.mongodb.management.internal.model.AuditMongo;
+import io.gravitee.repository.mongodb.utils.MongoQueries;
 import java.time.Instant;
 import java.util.Date;
 import java.util.List;
@@ -39,6 +40,9 @@ public class AuditMongoRepositoryImpl implements AuditMongoRepositoryCustom {
 
     @Autowired
     private MongoTemplate mongoTemplate;
+
+    @Autowired
+    private MongoQueries mongoQueries;
 
     @Override
     public Page<AuditMongo> search(AuditCriteria filter, Pageable pageable) {
@@ -78,7 +82,7 @@ public class AuditMongoRepositoryImpl implements AuditMongoRepositoryCustom {
             query.addCriteria(where("organizationId").is(filter.getOrganizationId()));
         }
 
-        long total = mongoTemplate.count(query, AuditMongo.class);
+        long total = mongoQueries.countOrTimeout(mongoTemplate, query, AuditMongo.class);
 
         query.with(PageRequest.of(pageable.pageNumber(), pageable.pageSize(), Sort.by(Sort.Direction.DESC, "createdAt")));
 

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/clusters/ClusterMongoRepositoryImpl.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/clusters/ClusterMongoRepositoryImpl.java
@@ -20,6 +20,7 @@ import static org.springframework.data.mongodb.core.query.Criteria.where;
 import io.gravitee.common.data.domain.Page;
 import io.gravitee.repository.management.api.search.ClusterCriteria;
 import io.gravitee.repository.mongodb.management.internal.model.ClusterMongo;
+import io.gravitee.repository.mongodb.utils.MongoQueries;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
@@ -35,6 +36,9 @@ public class ClusterMongoRepositoryImpl implements ClusterMongoRepositoryCustom 
 
     @Autowired
     private MongoTemplate mongoTemplate;
+
+    @Autowired
+    private MongoQueries mongoQueries;
 
     @Override
     public Page<ClusterMongo> search(ClusterCriteria criteria, PageRequest pageRequest) {
@@ -59,7 +63,7 @@ public class ClusterMongoRepositoryImpl implements ClusterMongoRepositoryCustom 
             );
         }
 
-        final long total = mongoTemplate.count(query, ClusterMongo.class);
+        final long total = mongoQueries.countOrTimeout(mongoTemplate, query, ClusterMongo.class);
         if (total == 0) {
             return new Page<>(List.of(), pageRequest.getPageNumber(), pageRequest.getPageSize(), 0);
         }

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/event/EventMongoRepositoryImpl.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/event/EventMongoRepositoryImpl.java
@@ -24,6 +24,7 @@ import io.gravitee.repository.management.api.search.Pageable;
 import io.gravitee.repository.management.model.Event;
 import io.gravitee.repository.management.model.EventType;
 import io.gravitee.repository.mongodb.management.internal.model.EventMongo;
+import io.gravitee.repository.mongodb.utils.MongoQueries;
 import jakarta.annotation.PostConstruct;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -61,6 +62,9 @@ public class EventMongoRepositoryImpl implements EventMongoRepositoryCustom {
     @Autowired
     private MongoTemplate mongoTemplate;
 
+    @Autowired
+    private MongoQueries mongoQueries;
+
     @Value("${management.mongodb.prefix:}")
     private String collectionPrefix;
 
@@ -78,7 +82,7 @@ public class EventMongoRepositoryImpl implements EventMongoRepositoryCustom {
         // set sort by updated at
         query.with(Sort.by(Sort.Direction.DESC, UPDATED_AT_FIELD, "_id"));
 
-        long total = mongoTemplate.count(query, EventMongo.class);
+        long total = mongoQueries.countOrTimeout(mongoTemplate, query, EventMongo.class);
 
         // set pageable
         if (pageable != null) {

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/integration/IntegrationMongoRepositoryImpl.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/integration/IntegrationMongoRepositoryImpl.java
@@ -18,6 +18,7 @@ package io.gravitee.repository.mongodb.management.internal.integration;
 import io.gravitee.common.data.domain.Page;
 import io.gravitee.repository.management.api.search.Pageable;
 import io.gravitee.repository.mongodb.management.internal.model.IntegrationMongo;
+import io.gravitee.repository.mongodb.utils.MongoQueries;
 import java.util.Collection;
 import java.util.List;
 import java.util.stream.Stream;
@@ -36,6 +37,7 @@ import org.springframework.stereotype.Component;
 public class IntegrationMongoRepositoryImpl implements IntegrationMongoRepositoryCustom {
 
     private final MongoTemplate mongoTemplate;
+    private final MongoQueries mongoQueries;
 
     @Override
     public Page<IntegrationMongo> findAllByEnvironmentIdAndGroups(
@@ -56,7 +58,7 @@ public class IntegrationMongoRepositoryImpl implements IntegrationMongoRepositor
         );
         query.with(Sort.by(Sort.Direction.DESC, "updatedAt"));
 
-        long total = mongoTemplate.count(query, IntegrationMongo.class);
+        long total = mongoQueries.countOrTimeout(mongoTemplate, query, IntegrationMongo.class);
 
         if (pageable != null) {
             query.with(PageRequest.of(pageable.pageNumber(), pageable.pageSize()));
@@ -73,7 +75,7 @@ public class IntegrationMongoRepositoryImpl implements IntegrationMongoRepositor
         query.addCriteria(Criteria.where("environmentId").is(environmentId));
         query.with(Sort.by(Sort.Direction.DESC, "updatedAt"));
 
-        long total = mongoTemplate.count(query, IntegrationMongo.class);
+        long total = mongoQueries.countOrTimeout(mongoTemplate, query, IntegrationMongo.class);
 
         if (pageable != null) {
             query.with(PageRequest.of(pageable.pageNumber(), pageable.pageSize()));

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/license/LicenseMongoRepositoryImpl.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/license/LicenseMongoRepositoryImpl.java
@@ -22,6 +22,7 @@ import io.gravitee.common.data.domain.Page;
 import io.gravitee.repository.management.api.search.LicenseCriteria;
 import io.gravitee.repository.management.api.search.Pageable;
 import io.gravitee.repository.mongodb.management.internal.model.LicenseMongo;
+import io.gravitee.repository.mongodb.utils.MongoQueries;
 import java.util.Date;
 import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -33,6 +34,9 @@ public class LicenseMongoRepositoryImpl implements LicenseMongoRepositoryCustom 
 
     @Autowired
     private MongoTemplate mongoTemplate;
+
+    @Autowired
+    private MongoQueries mongoQueries;
 
     @Override
     public Page<LicenseMongo> search(LicenseCriteria filter, Pageable pageable) {
@@ -57,7 +61,7 @@ public class LicenseMongoRepositoryImpl implements LicenseMongoRepositoryCustom 
             }
         }
 
-        long total = mongoTemplate.count(query, LicenseMongo.class);
+        long total = mongoQueries.countOrTimeout(mongoTemplate, query, LicenseMongo.class);
         List<LicenseMongo> license = mongoTemplate.find(query, LicenseMongo.class);
 
         return new Page<>(license, pageable != null ? pageable.pageNumber() : 0, pageable != null ? pageable.pageSize() : 0, total);

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/page/PageMongoRepositoryImpl.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/page/PageMongoRepositoryImpl.java
@@ -27,6 +27,7 @@ import io.gravitee.repository.management.api.search.PageCriteria;
 import io.gravitee.repository.management.api.search.Pageable;
 import io.gravitee.repository.management.model.Visibility;
 import io.gravitee.repository.mongodb.management.internal.model.PageMongo;
+import io.gravitee.repository.mongodb.utils.MongoQueries;
 import java.util.Collection;
 import java.util.List;
 import org.bson.Document;
@@ -48,6 +49,9 @@ public class PageMongoRepositoryImpl implements PageMongoRepositoryCustom {
 
     @Autowired
     private MongoTemplate mongoTemplate;
+
+    @Autowired
+    private MongoQueries mongoQueries;
 
     @Override
     public int findMaxPageReferenceIdAndReferenceTypeOrder(String referenceId, String referenceType) {
@@ -121,7 +125,7 @@ public class PageMongoRepositoryImpl implements PageMongoRepositoryCustom {
     @Override
     public Page<PageMongo> findAll(Pageable pageable) {
         Query query = new Query();
-        long total = mongoTemplate.count(query, PageMongo.class);
+        long total = mongoQueries.countOrTimeout(mongoTemplate, query, PageMongo.class);
 
         query.with(PageRequest.of(pageable.pageNumber(), pageable.pageSize()));
         List<PageMongo> pages = mongoTemplate.find(query, PageMongo.class);

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/plan/SubscriptionMongoRepositoryImpl.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/plan/SubscriptionMongoRepositoryImpl.java
@@ -34,6 +34,7 @@ import io.gravitee.repository.management.api.search.SubscriptionCriteria;
 import io.gravitee.repository.management.model.SubscriptionReferenceType;
 import io.gravitee.repository.mongodb.management.internal.model.SubscriptionMongo;
 import io.gravitee.repository.mongodb.utils.FieldUtils;
+import io.gravitee.repository.mongodb.utils.MongoQueries;
 import java.util.*;
 import org.bson.Document;
 import org.bson.conversions.Bson;
@@ -54,6 +55,9 @@ public class SubscriptionMongoRepositoryImpl implements SubscriptionMongoReposit
 
     @Autowired
     private MongoTemplate mongoTemplate;
+
+    @Autowired
+    private MongoQueries mongoQueries;
 
     @Value("${management.mongodb.prefix:}")
     private String tablePrefix;
@@ -182,7 +186,7 @@ public class SubscriptionMongoRepositoryImpl implements SubscriptionMongoReposit
 
         dataPipeline.add(Aggregates.project(Projections.exclude("_class")));
 
-        Integer totalCount = null;
+        Long totalCount = null;
         // if pageable, count total subscriptions matching criterias
         if (pageable != null) {
             List<Bson> countPipeline = new ArrayList<>(dataPipeline);
@@ -190,9 +194,7 @@ public class SubscriptionMongoRepositoryImpl implements SubscriptionMongoReposit
             AggregateIterable<Document> countAggregate = mongoTemplate
                 .getCollection(mongoTemplate.getCollectionName(SubscriptionMongo.class))
                 .aggregate(countPipeline);
-            if (countAggregate.first() != null) {
-                totalCount = countAggregate.first().getInteger("totalCount", 0);
-            }
+            totalCount = mongoQueries.countAggregationOrTimeout(countAggregate, "totalCount", SubscriptionMongo.class.getSimpleName());
             dataPipeline.add(skip(pageable.pageNumber() * pageable.pageSize()));
             dataPipeline.add(limit(pageable.pageSize()));
         }
@@ -261,11 +263,7 @@ public class SubscriptionMongoRepositoryImpl implements SubscriptionMongoReposit
         dataPipeline.add(match(or(migratedFilter, legacyFilter)));
     }
 
-    private Page<SubscriptionMongo> buildSubscriptionsPage(
-        Pageable pageable,
-        AggregateIterable<Document> dataAggregate,
-        Integer totalCount
-    ) {
+    private Page<SubscriptionMongo> buildSubscriptionsPage(Pageable pageable, AggregateIterable<Document> dataAggregate, Long totalCount) {
         List<SubscriptionMongo> subscriptions = new ArrayList<>();
 
         MongoConverter converter = mongoTemplate.getConverter();

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/promotion/PromotionMongoRepositoryImpl.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/promotion/PromotionMongoRepositoryImpl.java
@@ -26,6 +26,7 @@ import io.gravitee.repository.management.api.search.PromotionCriteria;
 import io.gravitee.repository.management.api.search.Sortable;
 import io.gravitee.repository.mongodb.management.internal.model.PromotionMongo;
 import io.gravitee.repository.mongodb.utils.FieldUtils;
+import io.gravitee.repository.mongodb.utils.MongoQueries;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.springframework.data.domain.PageRequest;
@@ -43,9 +44,11 @@ import org.springframework.util.StringUtils;
 public class PromotionMongoRepositoryImpl implements PromotionMongoRepositoryCustom {
 
     private final MongoTemplate mongoTemplate;
+    private final MongoQueries mongoQueries;
 
-    public PromotionMongoRepositoryImpl(MongoTemplate mongoTemplate) {
+    public PromotionMongoRepositoryImpl(MongoTemplate mongoTemplate, MongoQueries mongoQueries) {
         this.mongoTemplate = mongoTemplate;
+        this.mongoQueries = mongoQueries;
     }
 
     @Override
@@ -81,7 +84,7 @@ public class PromotionMongoRepositoryImpl implements PromotionMongoRepositoryCus
         }
 
         // Keep the count before adding pagination param to ensure the result is correct
-        long total = mongoTemplate.count(query, PromotionMongo.class);
+        long total = mongoQueries.countOrTimeout(mongoTemplate, query, PromotionMongo.class);
 
         if (pageable != null) {
             query.with(PageRequest.of(pageable.pageNumber(), pageable.pageSize()));

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/sharedpolicygrouphistory/SharedPolicyGroupHistoryMongoRepositoryImpl.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/sharedpolicygrouphistory/SharedPolicyGroupHistoryMongoRepositoryImpl.java
@@ -20,6 +20,7 @@ import static org.springframework.data.mongodb.core.query.Criteria.where;
 import io.gravitee.common.data.domain.Page;
 import io.gravitee.repository.management.api.search.SharedPolicyGroupHistoryCriteria;
 import io.gravitee.repository.mongodb.management.internal.model.SharedPolicyGroupHistoryMongo;
+import io.gravitee.repository.mongodb.utils.MongoQueries;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -36,6 +37,9 @@ public class SharedPolicyGroupHistoryMongoRepositoryImpl implements SharedPolicy
 
     @Autowired
     private MongoTemplate mongoTemplate;
+
+    @Autowired
+    private MongoQueries mongoQueries;
 
     @Override
     public Page<SharedPolicyGroupHistoryMongo> search(SharedPolicyGroupHistoryCriteria criteria, PageRequest pageRequest) {
@@ -54,7 +58,7 @@ public class SharedPolicyGroupHistoryMongoRepositoryImpl implements SharedPolicy
             query.addCriteria(where("lifecycleState").is(criteria.getLifecycleState().name()));
         }
 
-        final long total = mongoTemplate.count(query, SharedPolicyGroupHistoryMongo.class);
+        final long total = mongoQueries.countOrTimeout(mongoTemplate, query, SharedPolicyGroupHistoryMongo.class);
         if (total == 0) {
             return new Page<>(List.of(), pageRequest.getPageNumber(), pageRequest.getPageSize(), 0);
         }

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/sharedpolicygroups/SharedPolicyGroupMongoRepositoryImpl.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/sharedpolicygroups/SharedPolicyGroupMongoRepositoryImpl.java
@@ -20,6 +20,7 @@ import static org.springframework.data.mongodb.core.query.Criteria.where;
 import io.gravitee.common.data.domain.Page;
 import io.gravitee.repository.management.api.search.SharedPolicyGroupCriteria;
 import io.gravitee.repository.mongodb.management.internal.model.SharedPolicyGroupMongo;
+import io.gravitee.repository.mongodb.utils.MongoQueries;
 import java.util.List;
 import java.util.Objects;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -32,6 +33,9 @@ public class SharedPolicyGroupMongoRepositoryImpl implements SharedPolicyGroupMo
 
     @Autowired
     private MongoTemplate mongoTemplate;
+
+    @Autowired
+    private MongoQueries mongoQueries;
 
     @Override
     public Page<SharedPolicyGroupMongo> search(SharedPolicyGroupCriteria criteria, PageRequest pageRequest) {
@@ -55,7 +59,7 @@ public class SharedPolicyGroupMongoRepositoryImpl implements SharedPolicyGroupMo
             query.addCriteria(where("lifecycleState").is(criteria.getLifecycleState().name()));
         }
 
-        final long total = mongoTemplate.count(query, SharedPolicyGroupMongo.class);
+        final long total = mongoQueries.countOrTimeout(mongoTemplate, query, SharedPolicyGroupMongo.class);
         if (total == 0) {
             return new Page<>(List.of(), pageRequest.getPageNumber(), pageRequest.getPageSize(), 0);
         }

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/theme/ThemeMongoRepositoryImpl.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/theme/ThemeMongoRepositoryImpl.java
@@ -21,6 +21,7 @@ import static org.springframework.data.mongodb.core.query.Criteria.where;
 import io.gravitee.common.data.domain.Page;
 import io.gravitee.repository.management.api.search.*;
 import io.gravitee.repository.mongodb.management.internal.model.ThemeMongo;
+import io.gravitee.repository.mongodb.utils.MongoQueries;
 import java.util.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.PageRequest;
@@ -37,11 +38,14 @@ public class ThemeMongoRepositoryImpl implements ThemeMongoRepositoryCustom {
     @Autowired
     private MongoTemplate mongoTemplate;
 
+    @Autowired
+    private MongoQueries mongoQueries;
+
     @Override
     public Page<ThemeMongo> search(ThemeCriteria criteria, Pageable pageable) {
         var query = buildQuery(criteria, pageable);
 
-        long total = mongoTemplate.count(query, ThemeMongo.class);
+        long total = mongoQueries.countOrTimeout(mongoTemplate, query, ThemeMongo.class);
 
         List<ThemeMongo> apis = mongoTemplate.find(query, ThemeMongo.class);
 

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/ticket/TicketMongoRepositoryImpl.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/ticket/TicketMongoRepositoryImpl.java
@@ -24,6 +24,7 @@ import io.gravitee.repository.management.api.search.Sortable;
 import io.gravitee.repository.management.api.search.TicketCriteria;
 import io.gravitee.repository.mongodb.management.internal.model.TicketMongo;
 import io.gravitee.repository.mongodb.utils.FieldUtils;
+import io.gravitee.repository.mongodb.utils.MongoQueries;
 import java.util.List;
 import java.util.Locale;
 import org.apache.commons.lang3.StringUtils;
@@ -44,6 +45,9 @@ public class TicketMongoRepositoryImpl implements TicketMongoRepositoryCustom {
 
     @Autowired
     private MongoTemplate mongoTemplate;
+
+    @Autowired
+    private MongoQueries mongoQueries;
 
     @Override
     public Page<TicketMongo> search(TicketCriteria criteria, Sortable sortable, Pageable pageable) {
@@ -72,7 +76,7 @@ public class TicketMongoRepositoryImpl implements TicketMongoRepositoryCustom {
             }
         }
 
-        long total = mongoTemplate.count(query, TicketMongo.class);
+        long total = mongoQueries.countOrTimeout(mongoTemplate, query, TicketMongo.class);
 
         if (pageable != null) {
             query.with(PageRequest.of(pageable.pageNumber(), pageable.pageSize()));

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/user/UserMongoRepositoryImpl.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/user/UserMongoRepositoryImpl.java
@@ -21,6 +21,7 @@ import io.gravitee.common.data.domain.Page;
 import io.gravitee.repository.management.api.search.Pageable;
 import io.gravitee.repository.management.api.search.UserCriteria;
 import io.gravitee.repository.mongodb.management.internal.model.UserMongo;
+import io.gravitee.repository.mongodb.utils.MongoQueries;
 import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.PageRequest;
@@ -39,6 +40,9 @@ public class UserMongoRepositoryImpl implements UserMongoRepositoryCustom {
 
     @Autowired
     private MongoTemplate mongoTemplate;
+
+    @Autowired
+    private MongoQueries mongoQueries;
 
     @Override
     public Page<UserMongo> search(UserCriteria criteria, Pageable pageable) {
@@ -64,7 +68,7 @@ public class UserMongoRepositoryImpl implements UserMongoRepositoryCustom {
         */
         query.with(Sort.by(Sort.Direction.ASC, "_id"));
 
-        long total = mongoTemplate.count(query, UserMongo.class);
+        long total = mongoQueries.countOrTimeout(mongoTemplate, query, UserMongo.class);
 
         if (pageable != null) {
             query.with(PageRequest.of(pageable.pageNumber(), pageable.pageSize()));

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/utils/MongoQueries.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/utils/MongoQueries.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.mongodb.utils;
+
+import com.mongodb.MongoExecutionTimeoutException;
+import com.mongodb.client.AggregateIterable;
+import java.util.concurrent.TimeUnit;
+import lombok.CustomLog;
+import org.bson.Document;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.dao.DataAccessException;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.stereotype.Component;
+
+@CustomLog
+@Component
+public class MongoQueries {
+
+    private final long countMaxTimeMs;
+
+    public MongoQueries(@Value("${management.mongodb.countMaxTimeMs:5000}") long countMaxTimeMs) {
+        this.countMaxTimeMs = countMaxTimeMs;
+    }
+
+    public <T> long countOrTimeout(MongoTemplate mongoTemplate, Query query, Class<T> type) {
+        query.maxTimeMsec(countMaxTimeMs);
+        try {
+            return mongoTemplate.count(query, type);
+        } catch (DataAccessException e) {
+            if (e.getCause() instanceof MongoExecutionTimeoutException) {
+                log.warn("Count timed out after {}ms on collection {}", countMaxTimeMs, type.getSimpleName());
+                return -1L;
+            }
+            throw e;
+        }
+    }
+
+    public long countAggregationOrTimeout(AggregateIterable<Document> aggregation, String fieldName, String collectionName) {
+        try {
+            Document first = aggregation.maxTime(countMaxTimeMs, TimeUnit.MILLISECONDS).first();
+            return first != null ? first.getInteger(fieldName, 0) : 0;
+        } catch (MongoExecutionTimeoutException e) {
+            log.warn("Count timed out after {}ms on collection {}", countMaxTimeMs, collectionName);
+            return -1L;
+        }
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/test/java/io/gravitee/repository/mongodb/management/internal/api/ApiMongoRepositoryImplTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/test/java/io/gravitee/repository/mongodb/management/internal/api/ApiMongoRepositoryImplTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.mongodb.management.internal.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import com.mongodb.MongoExecutionTimeoutException;
+import io.gravitee.common.data.domain.Page;
+import io.gravitee.repository.management.api.search.ApiCriteria;
+import io.gravitee.repository.management.api.search.ApiFieldFilter;
+import io.gravitee.repository.management.api.search.builder.PageableBuilder;
+import io.gravitee.repository.mongodb.management.internal.model.ApiMongo;
+import io.gravitee.repository.mongodb.utils.MongoQueries;
+import java.lang.reflect.Field;
+import java.util.List;
+import lombok.SneakyThrows;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.mongodb.UncategorizedMongoDbException;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Query;
+
+@ExtendWith(MockitoExtension.class)
+class ApiMongoRepositoryImplTest {
+
+    @Mock
+    MongoTemplate mongoTemplate;
+
+    @Test
+    @SneakyThrows
+    void search_returns_total_minus_one_and_items_when_count_times_out() {
+        when(mongoTemplate.count(any(Query.class), eq(ApiMongo.class))).thenThrow(
+            new UncategorizedMongoDbException("Wrapped", new MongoExecutionTimeoutException(50, "operation exceeded time limit"))
+        );
+        ApiMongo api1 = new ApiMongo();
+        api1.setId("api-1");
+        when(mongoTemplate.find(any(Query.class), eq(ApiMongo.class))).thenReturn(List.of(api1));
+        ApiMongoRepositoryImpl repository = buildRepository();
+
+        Page<ApiMongo> page = repository.search(
+            new ApiCriteria.Builder().build(),
+            null,
+            new PageableBuilder().pageNumber(0).pageSize(10).build(),
+            ApiFieldFilter.allFields()
+        );
+
+        assertThat(page.getTotalElements()).isEqualTo(-1L);
+        assertThat(page.getContent()).extracting(ApiMongo::getId).containsExactly("api-1");
+    }
+
+    @SneakyThrows
+    private ApiMongoRepositoryImpl buildRepository() {
+        ApiMongoRepositoryImpl repository = new ApiMongoRepositoryImpl();
+        setField(repository, "mongoTemplate", mongoTemplate);
+        setField(repository, "mongoQueries", new MongoQueries(2000L));
+        return repository;
+    }
+
+    @SneakyThrows
+    private static void setField(Object target, String fieldName, Object value) {
+        Field field = ApiMongoRepositoryImpl.class.getDeclaredField(fieldName);
+        field.setAccessible(true);
+        field.set(target, value);
+        field.setAccessible(false);
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/test/java/io/gravitee/repository/mongodb/management/internal/integration/IntegrationMongoRepositoryImplTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/test/java/io/gravitee/repository/mongodb/management/internal/integration/IntegrationMongoRepositoryImplTest.java
@@ -25,6 +25,7 @@ import io.gravitee.common.data.domain.Page;
 import io.gravitee.repository.management.api.search.Pageable;
 import io.gravitee.repository.management.api.search.builder.PageableBuilder;
 import io.gravitee.repository.mongodb.management.internal.model.IntegrationMongo;
+import io.gravitee.repository.mongodb.utils.MongoQueries;
 import java.util.Collection;
 import java.util.List;
 import java.util.Set;
@@ -47,6 +48,9 @@ class IntegrationMongoRepositoryImplTest {
     @Mock
     MongoTemplate mongoTemplate;
 
+    @Mock
+    MongoQueries mongoQueries;
+
     @InjectMocks
     IntegrationMongoRepositoryImpl sut;
 
@@ -60,7 +64,7 @@ class IntegrationMongoRepositoryImplTest {
         String environmentId = "env-1";
         Pageable pageable = new PageableBuilder().pageNumber(0).pageSize(5).build();
         Collection<String> groups = Set.of("grp-1");
-        given(mongoTemplate.count(query.capture(), eq(IntegrationMongo.class))).willReturn(0L);
+        given(mongoQueries.countOrTimeout(eq(mongoTemplate), query.capture(), eq(IntegrationMongo.class))).willReturn(0L);
         given(mongoTemplate.find(query.capture(), eq(IntegrationMongo.class))).willReturn(List.of());
         // When
         Page<IntegrationMongo> result = sut.findAllByEnvironmentIdAndGroups(environmentId, pageable, Set.of(), groups);
@@ -92,7 +96,7 @@ class IntegrationMongoRepositoryImplTest {
         String environmentId = "env-1";
         Pageable pageable = new PageableBuilder().pageNumber(0).pageSize(5).build();
         Collection<String> groups = Set.of("grp-1");
-        given(mongoTemplate.count(query.capture(), eq(IntegrationMongo.class))).willReturn(0L);
+        given(mongoQueries.countOrTimeout(eq(mongoTemplate), query.capture(), eq(IntegrationMongo.class))).willReturn(0L);
         given(mongoTemplate.find(query.capture(), eq(IntegrationMongo.class))).willReturn(List.of());
         // When
         Page<IntegrationMongo> result = sut.findAllByEnvironmentIdAndGroups(environmentId, pageable, Set.of("id1"), groups);

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/test/java/io/gravitee/repository/mongodb/utils/MongoQueriesTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/test/java/io/gravitee/repository/mongodb/utils/MongoQueriesTest.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.mongodb.utils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import com.mongodb.MongoExecutionTimeoutException;
+import com.mongodb.client.AggregateIterable;
+import java.util.concurrent.TimeUnit;
+import org.bson.Document;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.LoggerFactory;
+import org.springframework.data.mongodb.UncategorizedMongoDbException;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Query;
+
+@ExtendWith(MockitoExtension.class)
+class MongoQueriesTest {
+
+    @Mock
+    MongoTemplate mongoTemplate;
+
+    @Mock
+    AggregateIterable<Document> aggregateIterable;
+
+    @Captor
+    ArgumentCaptor<Query> queryCaptor;
+
+    private final ListAppender<ILoggingEvent> logAppender = new ListAppender<>();
+    private final Logger logger = (Logger) LoggerFactory.getLogger(MongoQueries.class);
+
+    @BeforeEach
+    void attachAppender() {
+        logAppender.start();
+        logger.addAppender(logAppender);
+    }
+
+    @AfterEach
+    void detachAppender() {
+        logger.detachAppender(logAppender);
+        logAppender.stop();
+    }
+
+    @Test
+    void countOrTimeout_returns_minus_one_when_count_times_out() {
+        when(mongoTemplate.count(any(Query.class), eq(Object.class))).thenThrow(
+            new UncategorizedMongoDbException("Wrapped", new MongoExecutionTimeoutException(50, "operation exceeded time limit"))
+        );
+
+        MongoQueries mongoQueries = new MongoQueries(2000L);
+
+        long total = mongoQueries.countOrTimeout(mongoTemplate, new Query(), Object.class);
+
+        assertThat(total).isEqualTo(-1L);
+    }
+
+    @Test
+    void countOrTimeout_returns_count_when_query_succeeds() {
+        when(mongoTemplate.count(any(Query.class), eq(Object.class))).thenReturn(42L);
+        MongoQueries mongoQueries = new MongoQueries(2000L);
+
+        long total = mongoQueries.countOrTimeout(mongoTemplate, new Query(), Object.class);
+
+        assertThat(total).isEqualTo(42L);
+    }
+
+    @Test
+    void countOrTimeout_logs_warning_with_collection_and_timeout_when_count_times_out() {
+        when(mongoTemplate.count(any(Query.class), eq(Object.class))).thenThrow(
+            new UncategorizedMongoDbException("Wrapped", new MongoExecutionTimeoutException(50, "operation exceeded time limit"))
+        );
+        MongoQueries mongoQueries = new MongoQueries(2500L);
+
+        mongoQueries.countOrTimeout(mongoTemplate, new Query(), Object.class);
+
+        assertThat(logAppender.list).anyMatch(
+            e -> e.getLevel() == Level.WARN && e.getFormattedMessage().contains("Object") && e.getFormattedMessage().contains("2500")
+        );
+    }
+
+    @Test
+    void countAggregationOrTimeout_returns_minus_one_when_aggregation_times_out() {
+        when(aggregateIterable.maxTime(anyLong(), eq(TimeUnit.MILLISECONDS))).thenReturn(aggregateIterable);
+        when(aggregateIterable.first()).thenThrow(new MongoExecutionTimeoutException(50, "operation exceeded time limit"));
+        MongoQueries mongoQueries = new MongoQueries(2000L);
+
+        long total = mongoQueries.countAggregationOrTimeout(aggregateIterable, "totalCount", "subscriptions");
+
+        assertThat(total).isEqualTo(-1L);
+    }
+
+    @Test
+    void countAggregationOrTimeout_returns_named_field_from_first_document_when_aggregation_succeeds() {
+        Document firstDoc = new Document("totalCount", 123);
+        when(aggregateIterable.maxTime(anyLong(), eq(TimeUnit.MILLISECONDS))).thenReturn(aggregateIterable);
+        when(aggregateIterable.first()).thenReturn(firstDoc);
+        MongoQueries mongoQueries = new MongoQueries(2000L);
+
+        long total = mongoQueries.countAggregationOrTimeout(aggregateIterable, "totalCount", "subscriptions");
+
+        assertThat(total).isEqualTo(123L);
+    }
+
+    @Test
+    void countAggregationOrTimeout_returns_zero_when_first_document_is_absent() {
+        when(aggregateIterable.maxTime(anyLong(), eq(TimeUnit.MILLISECONDS))).thenReturn(aggregateIterable);
+        when(aggregateIterable.first()).thenReturn(null);
+        MongoQueries mongoQueries = new MongoQueries(2000L);
+
+        long total = mongoQueries.countAggregationOrTimeout(aggregateIterable, "totalCount", "subscriptions");
+
+        assertThat(total).isZero();
+    }
+
+    @Test
+    void countOrTimeout_applies_configured_timeout_to_query_before_count() {
+        when(mongoTemplate.count(any(Query.class), eq(Object.class))).thenReturn(42L);
+        MongoQueries mongoQueries = new MongoQueries(1500L);
+
+        mongoQueries.countOrTimeout(mongoTemplate, new Query(), Object.class);
+
+        verify(mongoTemplate).count(queryCaptor.capture(), eq(Object.class));
+        assertThat(queryCaptor.getValue().getMeta().getMaxTimeMsec()).isEqualTo(1500L);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-analytics.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-analytics.yaml
@@ -1907,7 +1907,7 @@ components:
                 totalCount:
                     type: integer
                     format: int64
-                    description: The total number of items.
+                    description: The total number of items, or `-1` if the count could not be computed within the configured timeout.
 
         Links:
             description: List of links for pagination

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-api-products.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-api-products.yaml
@@ -2159,7 +2159,7 @@ components:
         totalCount:
           type: integer
           format: int64
-          description: The total number of items.
+          description: The total number of items, or `-1` if the count could not be computed within the configured timeout.
 
     CreateApiProductPlan:
       type: object

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-apis.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-apis.yaml
@@ -4887,7 +4887,7 @@ components:
                 totalCount:
                     type: integer
                     format: int64
-                    description: The total number of items.
+                    description: The total number of items, or `-1` if the count could not be computed within the configured timeout.
 
         Path:
             type: object

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-environments.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-environments.yaml
@@ -1878,7 +1878,7 @@ components:
         totalCount:
           type: integer
           format: int64
-          description: The total number of items.
+          description: The total number of items, or `-1` if the count could not be computed within the configured timeout.
     Links:
       description: List of links for pagination
       properties:

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-ui.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-ui.yaml
@@ -542,7 +542,7 @@ components:
                 totalCount:
                     type: integer
                     format: int64
-                    description: The total number of items.
+                    description: The total number of items, or `-1` if the count could not be computed within the configured timeout.
 
         PortalComponentDefinition:
             type: object

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-users.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-users.yaml
@@ -221,7 +221,7 @@ components:
                 totalCount:
                     type: integer
                     format: int64
-                    description: The total number of items.
+                    description: The total number of items, or `-1` if the count could not be computed within the configured timeout.
 
         Links:
             description: List of links for pagination


### PR DESCRIPTION
## Summary

Bounds the blast radius of long-running `count()` operations issued by paginated Mongo repository searches. Adds a `MongoQueries.countOrTimeout(...)` helper that applies `maxTimeMsec` to the query before delegating to `MongoTemplate.count`, catches `MongoExecutionTimeoutException` (and Spring's `DataAccessException` wrapper around it), logs a warning, and returns `-1` for `Page.totalElements`. Consumers degrade gracefully — UIs surface "N/A" instead of the real total when the count timed out.

Jira: [APIM-14093](https://gravitee.atlassian.net/browse/APIM-14093)

## What changed

**Backend** (`gravitee-apim-repository-mongodb`)
- New `MongoQueries` `@Component` (Spring bean) with two methods:
  - `countOrTimeout(MongoTemplate, Query, Class<T>) → long` for `MongoTemplate.count` paths
  - `countAggregationOrTimeout(AggregateIterable, fieldName, collectionName) → long` for Subscription's aggregation-based count
- Configurable via `management.mongodb.countMaxTimeMs` (default **5000ms**)
- Wired into ~18 `search()` call sites across: Api (search + searchIds), Promotion, License, AsyncJob, Page, SharedPolicyGroupHistory, Integration, Cluster, ApiProducts, SharedPolicyGroup, User, Audit, Theme, Ticket, Event, AlertEvent, Application, Subscription, MongoGroup
- Standalone `count(criteria) → long` methods (e.g. `PageMongoRepositoryImpl.countByParentIdAndIsPublished`, `AlertEventMongoRepositoryImpl.count`) are intentionally **not** wrapped — returning `-1` from a non-Page contract would silently break callers that branch on `count > 0`
- Existing `IntegrationMongoRepositoryImplTest` updated to mock the new helper
- 7 new unit tests for the helper + 1 integration test on `ApiMongoRepositoryImpl`

**REST** (`gravitee-apim-rest-api-management-v2`)
- `totalCount` description updated in 6 OpenAPI specs: `"or -1 if the count could not be computed within the configured timeout"`

**Console UI** (`gravitee-apim-console-webui`)
- New `GioPaginatorIntl` registered globally — when `length < 0`, range label reads `X – Y of N/A`
- `gio-table-wrapper` exposes `effectiveLength` (coerces `-1` to `Number.MAX_SAFE_INTEGER` so navigation stays usable) and a `gio-unknown-length` host class
- CSS disables the "Last page" button when count is unknown (can't jump to an unknown end)

**Portal Next** (`gravitee-apim-portal-webui-next`)
- `PaginationComponent` hides direct page-jump buttons when `totalResults < 0`; Prev/Next remain functional

**Legacy Portal** (`gravitee-apim-portal-webui`)
- `catalog-search` switches to a new `search.results.many` translation key when `totalElements < 0` ("Many results" / locale equivalents in en, fr, it, cs)

## Risk

Any consumer that currently treats `-1` from `Page.totalElements` as a valid number could misbehave. Surveyed call sites:
- `PaginationInfo.computePaginationInfo` already does `totalCount > 0 ? ceil(...) : 0` — handles `-1` as "no pages"
- v2 REST `Pagination` DTO carries `totalCount` as nullable `int64`; OpenAPI now documents `-1` semantics
- Console tables route through `gio-table-wrapper` — covered globally by the Intl + `effectiveLength` change

## Known limitations / follow-ups

- **Next/First buttons remain enabled when count is unknown** — without a real total, the paginator can't tell where the end is. The original ticket already calls this out: "slice pagination via `limit + 1` probe" is tracked as a follow-up.
- **No tooltip on `N/A`** — multiple approaches tried in implementation; each broke either the paginator layout or didn't render. Deferred to a follow-up.

## Test plan

- [x] Backend unit tests (1086 module tests + 8 new) all green
- [x] Manual smoke: mAPI returns `Page{totalElements=-1, content=[...]}` under forced count timeout; helper's `log.warn("Count timed out …")` fires
- [x] Console UI: audit logs page renders `1 – 10 of N/A`, Last button visually disabled when failpoint forces count to time out; normal counts behave as before
- [ ] Verify Portal Next & legacy Portal pagination changes in a deploy that exercises them

## Out of scope (separate tickets)

- Slice pagination via `limit + 1` probe
- Short-TTL count cache
- `estimatedDocumentCount()` for monotonically-growing collections (`audits`, `events`)

[APIM-14093]: https://gravitee.atlassian.net/browse/APIM-14093?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ