### PR TITLE
feat(mongo): cap count() cost on paginated repository searches with maxTimeMs

### DIFF
--- a/gravitee-apim-console-webui/src/app.module.ts
+++ b/gravitee-apim-console-webui/src/app.module.ts
@@ -22,6 +22,7 @@ import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { setAngularJSGlobal, UpgradeModule } from '@angular/upgrade/static';
 import { GioPendoModule, GIO_PENDO_SETTINGS_TOKEN } from '@gravitee/ui-analytics';
 import { GioMatConfigModule } from '@gravitee/ui-particles-angular';
+import { MatPaginatorIntl } from '@angular/material/paginator';
 import { MatMomentDateModule, provideMomentDateAdapter } from '@angular/material-moment-adapter';
 import { provideCharts, withDefaultRegisterables } from 'ng2-charts';
 
@@ -36,6 +37,7 @@ import { UserComponent } from './user/my-accout/user.component';
 import { AuthModule } from './auth/auth.module';
 import { GioFormJsonSchemaExtendedModule } from './shared/components/form-json-schema-extended/form-json-schema-extended.module';
 import { ClusterRoutingModule } from './management/clusters/cluster-routing.module';
+import { GioPaginatorIntl } from './shared/paginator/gio-paginator-intl';
 
 @NgModule({
   declarations: [AppComponent, UserComponent],
@@ -83,6 +85,7 @@ import { ClusterRoutingModule } from './management/clusters/cluster-routing.modu
       }),
     ),
     provideCharts(withDefaultRegisterables()),
+    { provide: MatPaginatorIntl, useClass: GioPaginatorIntl },
   ],
 })
 export class AppModule implements DoBootstrap {

--- a/gravitee-apim-console-webui/src/index.scss
+++ b/gravitee-apim-console-webui/src/index.scss
@@ -698,3 +698,9 @@ body {
     font-family: 'Libre Franklin', 'Helvetica Neue', Helvetica, Arial, sans-serif;
   }
 }
+
+/* Disable mat-paginator's "Last page" button when count timed out — emitted by gio-table-wrapper. */
+gio-table-wrapper.gio-unknown-length .mat-mdc-paginator-navigation-last {
+  opacity: 0.38;
+  pointer-events: none;
+}

--- a/gravitee-apim-console-webui/src/shared/components/gio-table-wrapper/gio-table-wrapper.component.html
+++ b/gravitee-apim-console-webui/src/shared/components/gio-table-wrapper/gio-table-wrapper.component.html
@@ -33,7 +33,7 @@
       <mat-paginator
         class="gio-table-wrapper__header-bar__paginator"
         #paginatorTop
-        [length]="length"
+        [length]="effectiveLength"
         [pageSizeOptions]="paginationPageSizeOptions"
         [hidePageSize]="disablePageSize"
         [showFirstLastButtons]="true"
@@ -50,8 +50,8 @@
   <mat-paginator
     #paginatorBottom
     class="gio-table-wrapper__footer-bar__paginator"
-    [class.hidden]="length <= paginatorBottom.pageSize"
-    [length]="length"
+    [class.hidden]="length >= 0 && length <= paginatorBottom.pageSize"
+    [length]="effectiveLength"
     [hidePageSize]="true"
     [showFirstLastButtons]="true"
     aria-label="Select page"

--- a/gravitee-apim-console-webui/src/shared/components/gio-table-wrapper/gio-table-wrapper.component.ts
+++ b/gravitee-apim-console-webui/src/shared/components/gio-table-wrapper/gio-table-wrapper.component.ts
@@ -19,6 +19,7 @@ import {
   Component,
   ContentChild,
   EventEmitter,
+  HostBinding,
   Input,
   OnChanges,
   Output,
@@ -74,9 +75,19 @@ export class GioTableWrapperComponent implements AfterViewInit, OnChanges {
   @Input()
   searchLabel = 'Search';
 
-  /** The current total number of items being paged (only for display) */
+  /** The current total number of items being paged (only for display). `-1` means unknown (count timed out). */
   @Input()
   length = 0;
+
+  /** Coerces unknown-count (-1) to a large sentinel so MatPaginator's range label reads "Many results". */
+  get effectiveLength(): number {
+    return this.length < 0 ? Number.MAX_SAFE_INTEGER : this.length;
+  }
+
+  @HostBinding('class.gio-unknown-length')
+  get isUnknownLength(): boolean {
+    return this.length < 0;
+  }
 
   /** Disable search input */
   @Input()

--- a/gravitee-apim-console-webui/src/shared/paginator/gio-paginator-intl.ts
+++ b/gravitee-apim-console-webui/src/shared/paginator/gio-paginator-intl.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Injectable } from '@angular/core';
+import { MatPaginatorIntl } from '@angular/material/paginator';
+
+@Injectable()
+export class GioPaginatorIntl extends MatPaginatorIntl {
+  override getRangeLabel = (page: number, pageSize: number, length: number): string => {
+    const isUnknownTotal = length < 0 || length === Number.MAX_SAFE_INTEGER;
+    const totalLabel = isUnknownTotal ? 'N/A' : `${length}`;
+    if (length === 0 || pageSize === 0) {
+      return `0 of ${totalLabel}`;
+    }
+    const startIndex = page * pageSize;
+    const endIndex = isUnknownTotal
+      ? startIndex + pageSize
+      : startIndex < length
+        ? Math.min(startIndex + pageSize, length)
+        : startIndex + pageSize;
+    return `${startIndex + 1} – ${endIndex} of ${totalLabel}`;
+  };
+}

--- a/gravitee-apim-portal-webui-next/src/components/pagination/pagination.component.html
+++ b/gravitee-apim-portal-webui-next/src/components/pagination/pagination.component.html
@@ -66,10 +66,11 @@
     @if (pagination().totalPages > 4 && pagination().currentPage <= pagination().totalPages - 3) {
       <span class="m3-body-medium" aria-hidden="true">...</span>
     }
-
-    <button mat-button (click)="goToPage(pagination().totalPages)" [attr.aria-label]="'Go to page ' + pagination().totalPages">
-      {{ pagination().totalPages }}
-    </button>
+    @if (pagination().isTotalKnown) {
+      <button mat-button (click)="goToPage(pagination().totalPages)" [attr.aria-label]="'Go to page ' + pagination().totalPages">
+        {{ pagination().totalPages }}
+      </button>
+    }
   }
 
   <button

--- a/gravitee-apim-portal-webui-next/src/components/pagination/pagination.component.ts
+++ b/gravitee-apim-portal-webui-next/src/components/pagination/pagination.component.ts
@@ -26,6 +26,7 @@ interface PaginationVM {
   hasNextPage: boolean;
   currentPage: number;
   totalPages: number;
+  isTotalKnown: boolean;
 }
 
 @Component({
@@ -46,18 +47,20 @@ export class PaginationComponent {
   selectPageSize = output<number>();
 
   pagination: Signal<PaginationVM> = computed(() => {
-    const totalPages = Math.ceil(this.totalResults() / this.pageSize());
+    const isTotalKnown = this.totalResults() >= 0;
+    const totalPages = isTotalKnown ? Math.ceil(this.totalResults() / this.pageSize()) : 0;
 
     return {
       hasPreviousPage: this.currentPage() > 1,
-      hasNextPage: this.currentPage() < totalPages,
+      hasNextPage: isTotalKnown ? this.currentPage() < totalPages : true,
       currentPage: this.currentPage(),
       totalPages,
+      isTotalKnown,
     };
   });
 
   goToPage(page: number) {
-    if (page > 0 && page <= this.pagination().totalPages) {
+    if (page > 0 && (!this.pagination().isTotalKnown || page <= this.pagination().totalPages)) {
       this.selectPage.emit(page);
     }
   }
@@ -69,7 +72,7 @@ export class PaginationComponent {
   }
 
   goToNextPage() {
-    if (this.currentPage() < this.pagination().totalPages) {
+    if (!this.pagination().isTotalKnown || this.currentPage() < this.pagination().totalPages) {
       this.selectPage.emit(this.currentPage() + 1);
     }
   }

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/ManagementRepositoryConfiguration.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/ManagementRepositoryConfiguration.java
@@ -45,7 +45,7 @@ import org.springframework.data.mongodb.repository.config.EnableMongoRepositorie
  */
 @Configuration
 @Import(EncryptionConfiguration.class)
-@ComponentScan
+@ComponentScan(basePackages = { "io.gravitee.repository.mongodb.management", "io.gravitee.repository.mongodb.utils" })
 @EnableMongoRepositories
 @Profile("!test")
 public class ManagementRepositoryConfiguration extends AbstractRepositoryConfiguration {

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoGroupRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoGroupRepository.java
@@ -27,6 +27,7 @@ import io.gravitee.repository.management.model.Group;
 import io.gravitee.repository.mongodb.management.internal.group.GroupMongoRepository;
 import io.gravitee.repository.mongodb.management.internal.model.GroupMongo;
 import io.gravitee.repository.mongodb.management.mapper.GraviteeMapper;
+import io.gravitee.repository.mongodb.utils.MongoQueries;
 import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
@@ -62,6 +63,9 @@ public class MongoGroupRepository implements GroupRepository {
 
     @Autowired
     private MongoTemplate mongoTemplate;
+
+    @Autowired
+    private MongoQueries mongoQueries;
 
     @Autowired
     private GraviteeMapper mapper;
@@ -152,7 +156,7 @@ public class MongoGroupRepository implements GroupRepository {
             Sort.by(Sort.Order.asc("name"))
         );
 
-        long total = mongoTemplate.count(Query.of(query), GroupMongo.class);
+        long total = mongoQueries.countOrTimeout(mongoTemplate, Query.of(query), GroupMongo.class);
 
         query = query.with(dbPageable).collation(Collation.of(Locale.ENGLISH).strength(Collation.ComparisonLevel.secondary()));
         List<Group> groups = mongoTemplate.find(query, GroupMongo.class).stream().map(mapper::map).toList();

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/api/AlertEventMongoRepositoryImpl.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/api/AlertEventMongoRepositoryImpl.java
@@ -20,6 +20,7 @@ import io.gravitee.common.data.domain.Page;
 import io.gravitee.repository.management.api.search.AlertEventCriteria;
 import io.gravitee.repository.management.api.search.Pageable;
 import io.gravitee.repository.mongodb.management.internal.model.AlertEventMongo;
+import io.gravitee.repository.mongodb.utils.MongoQueries;
 import java.util.Date;
 import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -38,10 +39,13 @@ public class AlertEventMongoRepositoryImpl implements AlertEventMongoRepositoryC
     @Autowired
     private MongoTemplate mongoTemplate;
 
+    @Autowired
+    private MongoQueries mongoQueries;
+
     @Override
     public Page<AlertEventMongo> search(AlertEventCriteria criteria, Pageable pageable) {
         Query query = buildQueryFromCriteria(criteria);
-        long total = mongoTemplate.count(query, AlertEventMongo.class);
+        long total = mongoQueries.countOrTimeout(mongoTemplate, query, AlertEventMongo.class);
 
         query.with(Sort.by(Sort.Direction.DESC, "createdAt"));
 

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/api/ApiMongoRepositoryImpl.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/api/ApiMongoRepositoryImpl.java
@@ -28,6 +28,7 @@ import io.gravitee.definition.model.DefinitionVersion;
 import io.gravitee.repository.management.api.search.*;
 import io.gravitee.repository.mongodb.management.internal.model.ApiMongo;
 import io.gravitee.repository.mongodb.utils.FieldUtils;
+import io.gravitee.repository.mongodb.utils.MongoQueries;
 import java.util.*;
 import java.util.stream.Collectors;
 import org.bson.Document;
@@ -48,6 +49,9 @@ public class ApiMongoRepositoryImpl implements ApiMongoRepositoryCustom {
     @Autowired
     private MongoTemplate mongoTemplate;
 
+    @Autowired
+    private MongoQueries mongoQueries;
+
     @Override
     public Page<ApiMongo> search(ApiCriteria criteria, Sortable sortable, Pageable pageable, ApiFieldFilter apiFieldFilter) {
         final Query query = buildQuery(apiFieldFilter, criteria == null ? emptyList() : List.of(criteria));
@@ -60,7 +64,7 @@ public class ApiMongoRepositoryImpl implements ApiMongoRepositoryCustom {
             sort = Sort.by(sortOrder, FieldUtils.toCamelCase(sortable.field()));
         }
 
-        long total = mongoTemplate.count(query, ApiMongo.class);
+        long total = mongoQueries.countOrTimeout(mongoTemplate, query, ApiMongo.class);
 
         if (pageable != null) {
             query.with(PageRequest.of(pageable.pageNumber(), pageable.pageSize(), sort));
@@ -89,7 +93,7 @@ public class ApiMongoRepositoryImpl implements ApiMongoRepositoryCustom {
         }
 
         // Get total count before adding pagination to the query
-        long total = mongoTemplate.count(query, ApiMongo.class);
+        long total = mongoQueries.countOrTimeout(mongoTemplate, query, ApiMongo.class);
 
         // set pageable
         query.with(PageRequest.of(pageable.pageNumber(), pageable.pageSize(), sort));

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/apiproducts/ApiProductsMongoRepositoryImpl.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/apiproducts/ApiProductsMongoRepositoryImpl.java
@@ -26,6 +26,7 @@ import io.gravitee.repository.management.api.search.Pageable;
 import io.gravitee.repository.management.api.search.Sortable;
 import io.gravitee.repository.mongodb.management.internal.model.ApiProductMongo;
 import io.gravitee.repository.mongodb.utils.FieldUtils;
+import io.gravitee.repository.mongodb.utils.MongoQueries;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
@@ -46,6 +47,9 @@ public class ApiProductsMongoRepositoryImpl implements ApiProductsMongoRepositor
 
     @Autowired
     private MongoTemplate mongoTemplate;
+
+    @Autowired
+    private MongoQueries mongoQueries;
 
     @Override
     public Set<ApiProductMongo> findByApiId(String apiId) {
@@ -85,7 +89,7 @@ public class ApiProductsMongoRepositoryImpl implements ApiProductsMongoRepositor
             sort = Sort.by(sortOrder, FieldUtils.toCamelCase(sortable.field()));
         }
 
-        long total = mongoTemplate.count(query, ApiProductMongo.class);
+        long total = mongoQueries.countOrTimeout(mongoTemplate, query, ApiProductMongo.class);
         query.with(PageRequest.of(pageable.pageNumber(), pageable.pageSize(), sort));
 
         List<String> ids = mongoTemplate

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/application/ApplicationMongoRepositoryImpl.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/application/ApplicationMongoRepositoryImpl.java
@@ -27,6 +27,7 @@ import io.gravitee.repository.management.api.search.Sortable;
 import io.gravitee.repository.management.model.ApplicationStatus;
 import io.gravitee.repository.mongodb.management.internal.model.ApplicationMongo;
 import io.gravitee.repository.mongodb.utils.FieldUtils;
+import io.gravitee.repository.mongodb.utils.MongoQueries;
 import java.util.Collection;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -49,6 +50,9 @@ public class ApplicationMongoRepositoryImpl implements ApplicationMongoRepositor
     @Autowired
     private MongoTemplate mongoTemplate;
 
+    @Autowired
+    private MongoQueries mongoQueries;
+
     @Override
     public Page<ApplicationMongo> search(final ApplicationCriteria criteria, final Pageable pageable, Sortable sortable) {
         final Query query = buildSearchCriteria(criteria);
@@ -66,7 +70,7 @@ public class ApplicationMongoRepositoryImpl implements ApplicationMongoRepositor
 
         query.with(Sort.by(order));
 
-        long total = mongoTemplate.count(query, ApplicationMongo.class);
+        long total = mongoQueries.countOrTimeout(mongoTemplate, query, ApplicationMongo.class);
 
         if (pageable != null) {
             query.with(PageRequest.of(pageable.pageNumber(), pageable.pageSize()));

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/asyncjob/AsyncJobMongoRepositoryImpl.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/asyncjob/AsyncJobMongoRepositoryImpl.java
@@ -19,6 +19,7 @@ import io.gravitee.common.data.domain.Page;
 import io.gravitee.repository.management.api.AsyncJobRepository;
 import io.gravitee.repository.management.api.search.Pageable;
 import io.gravitee.repository.mongodb.management.internal.model.AsyncJobMongo;
+import io.gravitee.repository.mongodb.utils.MongoQueries;
 import java.util.Date;
 import lombok.AllArgsConstructor;
 import lombok.CustomLog;
@@ -37,12 +38,13 @@ import org.springframework.stereotype.Component;
 public class AsyncJobMongoRepositoryImpl implements AsyncJobMongoRepositoryCustom {
 
     private final MongoTemplate mongoTemplate;
+    private final MongoQueries mongoQueries;
 
     @Override
     public Page<AsyncJobMongo> search(AsyncJobRepository.SearchCriteria criteria, Pageable pageable) {
         var query = toQuery(criteria).with(Sort.by(Sort.Direction.DESC, "updatedAt"));
 
-        long total = mongoTemplate.count(query, AsyncJobMongo.class);
+        long total = mongoQueries.countOrTimeout(mongoTemplate, query, AsyncJobMongo.class);
 
         if (pageable != null) {
             query.with(PageRequest.of(pageable.pageNumber(), pageable.pageSize()));

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/audit/AuditMongoRepositoryImpl.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/audit/AuditMongoRepositoryImpl.java
@@ -22,6 +22,7 @@ import io.gravitee.common.data.domain.Page;
 import io.gravitee.repository.management.api.search.AuditCriteria;
 import io.gravitee.repository.management.api.search.Pageable;
 import io.gravitee.repository.mongodb.management.internal.model.AuditMongo;
+import io.gravitee.repository.mongodb.utils.MongoQueries;
 import java.time.Instant;
 import java.util.Date;
 import java.util.List;
@@ -43,6 +44,9 @@ public class AuditMongoRepositoryImpl implements AuditMongoRepositoryCustom {
 
     @Autowired
     private MongoTemplate mongoTemplate;
+
+    @Autowired
+    private MongoQueries mongoQueries;
 
     @Value("${services.audit.cleanup.batchSize:1000}")
     private int batchSize;
@@ -85,7 +89,7 @@ public class AuditMongoRepositoryImpl implements AuditMongoRepositoryCustom {
             query.addCriteria(where("organizationId").is(filter.getOrganizationId()));
         }
 
-        long total = mongoTemplate.count(query, AuditMongo.class);
+        long total = mongoQueries.countOrTimeout(mongoTemplate, query, AuditMongo.class);
 
         query.with(PageRequest.of(pageable.pageNumber(), pageable.pageSize(), Sort.by(Sort.Direction.DESC, "createdAt")));
 

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/clusters/ClusterMongoRepositoryImpl.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/clusters/ClusterMongoRepositoryImpl.java
@@ -20,6 +20,7 @@ import static org.springframework.data.mongodb.core.query.Criteria.where;
 import io.gravitee.common.data.domain.Page;
 import io.gravitee.repository.management.api.search.ClusterCriteria;
 import io.gravitee.repository.mongodb.management.internal.model.ClusterMongo;
+import io.gravitee.repository.mongodb.utils.MongoQueries;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
@@ -35,6 +36,9 @@ public class ClusterMongoRepositoryImpl implements ClusterMongoRepositoryCustom 
 
     @Autowired
     private MongoTemplate mongoTemplate;
+
+    @Autowired
+    private MongoQueries mongoQueries;
 
     @Override
     public Page<ClusterMongo> search(ClusterCriteria criteria, PageRequest pageRequest) {
@@ -59,7 +63,7 @@ public class ClusterMongoRepositoryImpl implements ClusterMongoRepositoryCustom 
             );
         }
 
-        final long total = mongoTemplate.count(query, ClusterMongo.class);
+        final long total = mongoQueries.countOrTimeout(mongoTemplate, query, ClusterMongo.class);
         if (total == 0) {
             return new Page<>(List.of(), pageRequest.getPageNumber(), pageRequest.getPageSize(), 0);
         }

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/event/EventMongoRepositoryImpl.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/event/EventMongoRepositoryImpl.java
@@ -24,6 +24,7 @@ import io.gravitee.repository.management.api.search.Pageable;
 import io.gravitee.repository.management.model.Event;
 import io.gravitee.repository.management.model.EventType;
 import io.gravitee.repository.mongodb.management.internal.model.EventMongo;
+import io.gravitee.repository.mongodb.utils.MongoQueries;
 import jakarta.annotation.PostConstruct;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -61,6 +62,9 @@ public class EventMongoRepositoryImpl implements EventMongoRepositoryCustom {
     @Autowired
     private MongoTemplate mongoTemplate;
 
+    @Autowired
+    private MongoQueries mongoQueries;
+
     @Value("${management.mongodb.prefix:}")
     private String collectionPrefix;
 
@@ -78,7 +82,7 @@ public class EventMongoRepositoryImpl implements EventMongoRepositoryCustom {
         // set sort by updated at
         query.with(Sort.by(Sort.Direction.DESC, UPDATED_AT_FIELD, "_id"));
 
-        long total = mongoTemplate.count(query, EventMongo.class);
+        long total = mongoQueries.countOrTimeout(mongoTemplate, query, EventMongo.class);
 
         // set pageable
         if (pageable != null) {

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/integration/IntegrationMongoRepositoryImpl.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/integration/IntegrationMongoRepositoryImpl.java
@@ -18,6 +18,7 @@ package io.gravitee.repository.mongodb.management.internal.integration;
 import io.gravitee.common.data.domain.Page;
 import io.gravitee.repository.management.api.search.Pageable;
 import io.gravitee.repository.mongodb.management.internal.model.IntegrationMongo;
+import io.gravitee.repository.mongodb.utils.MongoQueries;
 import java.util.Collection;
 import java.util.List;
 import java.util.stream.Stream;
@@ -36,6 +37,7 @@ import org.springframework.stereotype.Component;
 public class IntegrationMongoRepositoryImpl implements IntegrationMongoRepositoryCustom {
 
     private final MongoTemplate mongoTemplate;
+    private final MongoQueries mongoQueries;
 
     @Override
     public Page<IntegrationMongo> findAllByEnvironmentIdAndGroups(
@@ -56,7 +58,7 @@ public class IntegrationMongoRepositoryImpl implements IntegrationMongoRepositor
         );
         query.with(Sort.by(Sort.Direction.DESC, "updatedAt"));
 
-        long total = mongoTemplate.count(query, IntegrationMongo.class);
+        long total = mongoQueries.countOrTimeout(mongoTemplate, query, IntegrationMongo.class);
 
         if (pageable != null) {
             query.with(PageRequest.of(pageable.pageNumber(), pageable.pageSize()));
@@ -73,7 +75,7 @@ public class IntegrationMongoRepositoryImpl implements IntegrationMongoRepositor
         query.addCriteria(Criteria.where("environmentId").is(environmentId));
         query.with(Sort.by(Sort.Direction.DESC, "updatedAt"));
 
-        long total = mongoTemplate.count(query, IntegrationMongo.class);
+        long total = mongoQueries.countOrTimeout(mongoTemplate, query, IntegrationMongo.class);
 
         if (pageable != null) {
             query.with(PageRequest.of(pageable.pageNumber(), pageable.pageSize()));

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/license/LicenseMongoRepositoryImpl.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/license/LicenseMongoRepositoryImpl.java
@@ -22,6 +22,7 @@ import io.gravitee.common.data.domain.Page;
 import io.gravitee.repository.management.api.search.LicenseCriteria;
 import io.gravitee.repository.management.api.search.Pageable;
 import io.gravitee.repository.mongodb.management.internal.model.LicenseMongo;
+import io.gravitee.repository.mongodb.utils.MongoQueries;
 import java.util.Date;
 import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -33,6 +34,9 @@ public class LicenseMongoRepositoryImpl implements LicenseMongoRepositoryCustom 
 
     @Autowired
     private MongoTemplate mongoTemplate;
+
+    @Autowired
+    private MongoQueries mongoQueries;
 
     @Override
     public Page<LicenseMongo> search(LicenseCriteria filter, Pageable pageable) {
@@ -57,7 +61,7 @@ public class LicenseMongoRepositoryImpl implements LicenseMongoRepositoryCustom 
             }
         }
 
-        long total = mongoTemplate.count(query, LicenseMongo.class);
+        long total = mongoQueries.countOrTimeout(mongoTemplate, query, LicenseMongo.class);
         List<LicenseMongo> license = mongoTemplate.find(query, LicenseMongo.class);
 
         return new Page<>(license, pageable != null ? pageable.pageNumber() : 0, pageable != null ? pageable.pageSize() : 0, total);

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/page/PageMongoRepositoryImpl.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/page/PageMongoRepositoryImpl.java
@@ -27,6 +27,7 @@ import io.gravitee.repository.management.api.search.PageCriteria;
 import io.gravitee.repository.management.api.search.Pageable;
 import io.gravitee.repository.management.model.Visibility;
 import io.gravitee.repository.mongodb.management.internal.model.PageMongo;
+import io.gravitee.repository.mongodb.utils.MongoQueries;
 import java.util.Collection;
 import java.util.List;
 import org.bson.Document;
@@ -48,6 +49,9 @@ public class PageMongoRepositoryImpl implements PageMongoRepositoryCustom {
 
     @Autowired
     private MongoTemplate mongoTemplate;
+
+    @Autowired
+    private MongoQueries mongoQueries;
 
     @Override
     public int findMaxPageReferenceIdAndReferenceTypeOrder(String referenceId, String referenceType) {
@@ -121,7 +125,7 @@ public class PageMongoRepositoryImpl implements PageMongoRepositoryCustom {
     @Override
     public Page<PageMongo> findAll(Pageable pageable) {
         Query query = new Query();
-        long total = mongoTemplate.count(query, PageMongo.class);
+        long total = mongoQueries.countOrTimeout(mongoTemplate, query, PageMongo.class);
 
         query.with(PageRequest.of(pageable.pageNumber(), pageable.pageSize()));
         List<PageMongo> pages = mongoTemplate.find(query, PageMongo.class);

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/plan/SubscriptionMongoRepositoryImpl.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/plan/SubscriptionMongoRepositoryImpl.java
@@ -35,6 +35,7 @@ import io.gravitee.repository.management.api.search.SubscriptionCursor;
 import io.gravitee.repository.management.model.SubscriptionReferenceType;
 import io.gravitee.repository.mongodb.management.internal.model.SubscriptionMongo;
 import io.gravitee.repository.mongodb.utils.FieldUtils;
+import io.gravitee.repository.mongodb.utils.MongoQueries;
 import java.util.*;
 import org.bson.Document;
 import org.bson.conversions.Bson;
@@ -59,6 +60,9 @@ public class SubscriptionMongoRepositoryImpl implements SubscriptionMongoReposit
     @Autowired
     private MongoTemplate mongoTemplate;
 
+    @Autowired
+    private MongoQueries mongoQueries;
+
     @Value("${management.mongodb.prefix:}")
     private String tablePrefix;
 
@@ -66,7 +70,7 @@ public class SubscriptionMongoRepositoryImpl implements SubscriptionMongoReposit
     public Page<SubscriptionMongo> search(SubscriptionCriteria criteria, final Sortable sortable, final Pageable pageable) {
         List<Bson> filterPipeline = buildFilterPipeline(criteria);
 
-        Integer totalCount = null;
+        Long totalCount = null;
         // if pageable, count total subscriptions matching criteria — counting only needs the $match stages,
         // not the sort or projection that follows, so build the count pipeline before adding those.
         if (pageable != null) {
@@ -75,9 +79,7 @@ public class SubscriptionMongoRepositoryImpl implements SubscriptionMongoReposit
             AggregateIterable<Document> countAggregate = mongoTemplate
                 .getCollection(mongoTemplate.getCollectionName(SubscriptionMongo.class))
                 .aggregate(countPipeline);
-            if (countAggregate.first() != null) {
-                totalCount = countAggregate.first().getInteger("totalCount", 0);
-            }
+            totalCount = mongoQueries.countAggregationOrTimeout(countAggregate, "totalCount", SubscriptionMongo.class.getSimpleName());
         }
 
         List<Bson> dataPipeline = new ArrayList<>(filterPipeline);
@@ -349,11 +351,7 @@ public class SubscriptionMongoRepositoryImpl implements SubscriptionMongoReposit
         dataPipeline.add(match(or(migratedFilter, legacyFilter)));
     }
 
-    private Page<SubscriptionMongo> buildSubscriptionsPage(
-        Pageable pageable,
-        AggregateIterable<Document> dataAggregate,
-        Integer totalCount
-    ) {
+    private Page<SubscriptionMongo> buildSubscriptionsPage(Pageable pageable, AggregateIterable<Document> dataAggregate, Long totalCount) {
         List<SubscriptionMongo> subscriptions = new ArrayList<>();
 
         MongoConverter converter = mongoTemplate.getConverter();

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/promotion/PromotionMongoRepositoryImpl.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/promotion/PromotionMongoRepositoryImpl.java
@@ -26,6 +26,7 @@ import io.gravitee.repository.management.api.search.PromotionCriteria;
 import io.gravitee.repository.management.api.search.Sortable;
 import io.gravitee.repository.mongodb.management.internal.model.PromotionMongo;
 import io.gravitee.repository.mongodb.utils.FieldUtils;
+import io.gravitee.repository.mongodb.utils.MongoQueries;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.springframework.data.domain.PageRequest;
@@ -43,9 +44,11 @@ import org.springframework.util.StringUtils;
 public class PromotionMongoRepositoryImpl implements PromotionMongoRepositoryCustom {
 
     private final MongoTemplate mongoTemplate;
+    private final MongoQueries mongoQueries;
 
-    public PromotionMongoRepositoryImpl(MongoTemplate mongoTemplate) {
+    public PromotionMongoRepositoryImpl(MongoTemplate mongoTemplate, MongoQueries mongoQueries) {
         this.mongoTemplate = mongoTemplate;
+        this.mongoQueries = mongoQueries;
     }
 
     @Override
@@ -81,7 +84,7 @@ public class PromotionMongoRepositoryImpl implements PromotionMongoRepositoryCus
         }
 
         // Keep the count before adding pagination param to ensure the result is correct
-        long total = mongoTemplate.count(query, PromotionMongo.class);
+        long total = mongoQueries.countOrTimeout(mongoTemplate, query, PromotionMongo.class);
 
         if (pageable != null) {
             query.with(PageRequest.of(pageable.pageNumber(), pageable.pageSize()));

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/sharedpolicygrouphistory/SharedPolicyGroupHistoryMongoRepositoryImpl.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/sharedpolicygrouphistory/SharedPolicyGroupHistoryMongoRepositoryImpl.java
@@ -20,6 +20,7 @@ import static org.springframework.data.mongodb.core.query.Criteria.where;
 import io.gravitee.common.data.domain.Page;
 import io.gravitee.repository.management.api.search.SharedPolicyGroupHistoryCriteria;
 import io.gravitee.repository.mongodb.management.internal.model.SharedPolicyGroupHistoryMongo;
+import io.gravitee.repository.mongodb.utils.MongoQueries;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -36,6 +37,9 @@ public class SharedPolicyGroupHistoryMongoRepositoryImpl implements SharedPolicy
 
     @Autowired
     private MongoTemplate mongoTemplate;
+
+    @Autowired
+    private MongoQueries mongoQueries;
 
     @Override
     public Page<SharedPolicyGroupHistoryMongo> search(SharedPolicyGroupHistoryCriteria criteria, PageRequest pageRequest) {
@@ -54,7 +58,7 @@ public class SharedPolicyGroupHistoryMongoRepositoryImpl implements SharedPolicy
             query.addCriteria(where("lifecycleState").is(criteria.getLifecycleState().name()));
         }
 
-        final long total = mongoTemplate.count(query, SharedPolicyGroupHistoryMongo.class);
+        final long total = mongoQueries.countOrTimeout(mongoTemplate, query, SharedPolicyGroupHistoryMongo.class);
         if (total == 0) {
             return new Page<>(List.of(), pageRequest.getPageNumber(), pageRequest.getPageSize(), 0);
         }

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/sharedpolicygroups/SharedPolicyGroupMongoRepositoryImpl.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/sharedpolicygroups/SharedPolicyGroupMongoRepositoryImpl.java
@@ -20,6 +20,7 @@ import static org.springframework.data.mongodb.core.query.Criteria.where;
 import io.gravitee.common.data.domain.Page;
 import io.gravitee.repository.management.api.search.SharedPolicyGroupCriteria;
 import io.gravitee.repository.mongodb.management.internal.model.SharedPolicyGroupMongo;
+import io.gravitee.repository.mongodb.utils.MongoQueries;
 import java.util.List;
 import java.util.Objects;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -32,6 +33,9 @@ public class SharedPolicyGroupMongoRepositoryImpl implements SharedPolicyGroupMo
 
     @Autowired
     private MongoTemplate mongoTemplate;
+
+    @Autowired
+    private MongoQueries mongoQueries;
 
     @Override
     public Page<SharedPolicyGroupMongo> search(SharedPolicyGroupCriteria criteria, PageRequest pageRequest) {
@@ -55,7 +59,7 @@ public class SharedPolicyGroupMongoRepositoryImpl implements SharedPolicyGroupMo
             query.addCriteria(where("lifecycleState").is(criteria.getLifecycleState().name()));
         }
 
-        final long total = mongoTemplate.count(query, SharedPolicyGroupMongo.class);
+        final long total = mongoQueries.countOrTimeout(mongoTemplate, query, SharedPolicyGroupMongo.class);
         if (total == 0) {
             return new Page<>(List.of(), pageRequest.getPageNumber(), pageRequest.getPageSize(), 0);
         }

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/theme/ThemeMongoRepositoryImpl.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/theme/ThemeMongoRepositoryImpl.java
@@ -21,6 +21,7 @@ import static org.springframework.data.mongodb.core.query.Criteria.where;
 import io.gravitee.common.data.domain.Page;
 import io.gravitee.repository.management.api.search.*;
 import io.gravitee.repository.mongodb.management.internal.model.ThemeMongo;
+import io.gravitee.repository.mongodb.utils.MongoQueries;
 import java.util.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.PageRequest;
@@ -37,11 +38,14 @@ public class ThemeMongoRepositoryImpl implements ThemeMongoRepositoryCustom {
     @Autowired
     private MongoTemplate mongoTemplate;
 
+    @Autowired
+    private MongoQueries mongoQueries;
+
     @Override
     public Page<ThemeMongo> search(ThemeCriteria criteria, Pageable pageable) {
         var query = buildQuery(criteria, pageable);
 
-        long total = mongoTemplate.count(query, ThemeMongo.class);
+        long total = mongoQueries.countOrTimeout(mongoTemplate, query, ThemeMongo.class);
 
         List<ThemeMongo> apis = mongoTemplate.find(query, ThemeMongo.class);
 

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/ticket/TicketMongoRepositoryImpl.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/ticket/TicketMongoRepositoryImpl.java
@@ -24,6 +24,7 @@ import io.gravitee.repository.management.api.search.Sortable;
 import io.gravitee.repository.management.api.search.TicketCriteria;
 import io.gravitee.repository.mongodb.management.internal.model.TicketMongo;
 import io.gravitee.repository.mongodb.utils.FieldUtils;
+import io.gravitee.repository.mongodb.utils.MongoQueries;
 import java.util.List;
 import java.util.Locale;
 import org.apache.commons.lang3.StringUtils;
@@ -44,6 +45,9 @@ public class TicketMongoRepositoryImpl implements TicketMongoRepositoryCustom {
 
     @Autowired
     private MongoTemplate mongoTemplate;
+
+    @Autowired
+    private MongoQueries mongoQueries;
 
     @Override
     public Page<TicketMongo> search(TicketCriteria criteria, Sortable sortable, Pageable pageable) {
@@ -72,7 +76,7 @@ public class TicketMongoRepositoryImpl implements TicketMongoRepositoryCustom {
             }
         }
 
-        long total = mongoTemplate.count(query, TicketMongo.class);
+        long total = mongoQueries.countOrTimeout(mongoTemplate, query, TicketMongo.class);
 
         if (pageable != null) {
             query.with(PageRequest.of(pageable.pageNumber(), pageable.pageSize()));

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/user/UserMongoRepositoryImpl.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/user/UserMongoRepositoryImpl.java
@@ -21,6 +21,7 @@ import io.gravitee.common.data.domain.Page;
 import io.gravitee.repository.management.api.search.Pageable;
 import io.gravitee.repository.management.api.search.UserCriteria;
 import io.gravitee.repository.mongodb.management.internal.model.UserMongo;
+import io.gravitee.repository.mongodb.utils.MongoQueries;
 import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.PageRequest;
@@ -39,6 +40,9 @@ public class UserMongoRepositoryImpl implements UserMongoRepositoryCustom {
 
     @Autowired
     private MongoTemplate mongoTemplate;
+
+    @Autowired
+    private MongoQueries mongoQueries;
 
     @Override
     public Page<UserMongo> search(UserCriteria criteria, Pageable pageable) {
@@ -64,7 +68,7 @@ public class UserMongoRepositoryImpl implements UserMongoRepositoryCustom {
         */
         query.with(Sort.by(Sort.Direction.ASC, "_id"));
 
-        long total = mongoTemplate.count(query, UserMongo.class);
+        long total = mongoQueries.countOrTimeout(mongoTemplate, query, UserMongo.class);
 
         if (pageable != null) {
             query.with(PageRequest.of(pageable.pageNumber(), pageable.pageSize()));

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/utils/MongoQueries.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/utils/MongoQueries.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.mongodb.utils;
+
+import com.mongodb.MongoExecutionTimeoutException;
+import com.mongodb.client.AggregateIterable;
+import java.util.concurrent.TimeUnit;
+import lombok.CustomLog;
+import org.bson.Document;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.dao.DataAccessException;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.stereotype.Component;
+
+@CustomLog
+@Component
+public class MongoQueries {
+
+    private final long countMaxTimeMs;
+
+    public MongoQueries(@Value("${management.mongodb.countMaxTimeMs:5000}") long countMaxTimeMs) {
+        this.countMaxTimeMs = countMaxTimeMs;
+    }
+
+    public <T> long countOrTimeout(MongoTemplate mongoTemplate, Query query, Class<T> type) {
+        // Copy so the caller's Query stays clean — subsequent find() reuses the same instance and must not inherit countMaxTimeMs.
+        Query countQuery = Query.of(query).maxTimeMsec(countMaxTimeMs);
+        try {
+            return mongoTemplate.count(countQuery, type);
+        } catch (RuntimeException e) {
+            if (isExecutionTimeout(e)) {
+                log.warn("Count timed out after {}ms on collection {}", countMaxTimeMs, mongoTemplate.getCollectionName(type));
+                return -1L;
+            }
+            throw e;
+        }
+    }
+
+    public long countAggregationOrTimeout(AggregateIterable<Document> aggregation, String fieldName, String collectionName) {
+        try {
+            Document first = aggregation.maxTime(countMaxTimeMs, TimeUnit.MILLISECONDS).first();
+            if (first == null) {
+                return 0L;
+            }
+            // $count can return Integer or Long depending on collection size; treat as Number to avoid ClassCastException.
+            Number value = first.get(fieldName, Number.class);
+            return value != null ? value.longValue() : 0L;
+        } catch (RuntimeException e) {
+            if (isExecutionTimeout(e)) {
+                log.warn("Aggregation count timed out after {}ms on collection {}", countMaxTimeMs, collectionName);
+                return -1L;
+            }
+            throw e;
+        }
+    }
+
+    /**
+     * MongoTemplate paths translate driver exceptions via Spring's MongoExceptionTranslator, wrapping
+     * MongoExecutionTimeoutException inside DataAccessException. Raw-driver paths (AggregateIterable) throw
+     * the unwrapped exception. Check both to stay agnostic to which API surface raised it.
+     */
+    private static boolean isExecutionTimeout(Throwable t) {
+        return (
+            t instanceof MongoExecutionTimeoutException ||
+            (t instanceof DataAccessException && t.getCause() instanceof MongoExecutionTimeoutException)
+        );
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/test/java/io/gravitee/repository/mongodb/management/internal/api/ApiMongoRepositoryImplTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/test/java/io/gravitee/repository/mongodb/management/internal/api/ApiMongoRepositoryImplTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.mongodb.management.internal.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import com.mongodb.MongoExecutionTimeoutException;
+import io.gravitee.common.data.domain.Page;
+import io.gravitee.repository.management.api.search.ApiCriteria;
+import io.gravitee.repository.management.api.search.ApiFieldFilter;
+import io.gravitee.repository.management.api.search.builder.PageableBuilder;
+import io.gravitee.repository.mongodb.management.internal.model.ApiMongo;
+import io.gravitee.repository.mongodb.utils.MongoQueries;
+import java.lang.reflect.Field;
+import java.util.List;
+import lombok.SneakyThrows;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.mongodb.UncategorizedMongoDbException;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Query;
+
+@ExtendWith(MockitoExtension.class)
+class ApiMongoRepositoryImplTest {
+
+    @Mock
+    MongoTemplate mongoTemplate;
+
+    @Test
+    @SneakyThrows
+    void search_returns_total_minus_one_and_items_when_count_times_out() {
+        when(mongoTemplate.count(any(Query.class), eq(ApiMongo.class))).thenThrow(
+            new UncategorizedMongoDbException("Wrapped", new MongoExecutionTimeoutException(50, "operation exceeded time limit"))
+        );
+        ApiMongo api1 = new ApiMongo();
+        api1.setId("api-1");
+        when(mongoTemplate.find(any(Query.class), eq(ApiMongo.class))).thenReturn(List.of(api1));
+        ApiMongoRepositoryImpl repository = buildRepository();
+
+        Page<ApiMongo> page = repository.search(
+            new ApiCriteria.Builder().build(),
+            null,
+            new PageableBuilder().pageNumber(0).pageSize(10).build(),
+            ApiFieldFilter.allFields()
+        );
+
+        assertThat(page.getTotalElements()).isEqualTo(-1L);
+        assertThat(page.getContent()).extracting(ApiMongo::getId).containsExactly("api-1");
+    }
+
+    @SneakyThrows
+    private ApiMongoRepositoryImpl buildRepository() {
+        ApiMongoRepositoryImpl repository = new ApiMongoRepositoryImpl();
+        setField(repository, "mongoTemplate", mongoTemplate);
+        setField(repository, "mongoQueries", new MongoQueries(2000L));
+        return repository;
+    }
+
+    @SneakyThrows
+    private static void setField(Object target, String fieldName, Object value) {
+        Field field = ApiMongoRepositoryImpl.class.getDeclaredField(fieldName);
+        field.setAccessible(true);
+        field.set(target, value);
+        field.setAccessible(false);
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/test/java/io/gravitee/repository/mongodb/management/internal/integration/IntegrationMongoRepositoryImplTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/test/java/io/gravitee/repository/mongodb/management/internal/integration/IntegrationMongoRepositoryImplTest.java
@@ -25,6 +25,7 @@ import io.gravitee.common.data.domain.Page;
 import io.gravitee.repository.management.api.search.Pageable;
 import io.gravitee.repository.management.api.search.builder.PageableBuilder;
 import io.gravitee.repository.mongodb.management.internal.model.IntegrationMongo;
+import io.gravitee.repository.mongodb.utils.MongoQueries;
 import java.util.Collection;
 import java.util.List;
 import java.util.Set;
@@ -47,6 +48,9 @@ class IntegrationMongoRepositoryImplTest {
     @Mock
     MongoTemplate mongoTemplate;
 
+    @Mock
+    MongoQueries mongoQueries;
+
     @InjectMocks
     IntegrationMongoRepositoryImpl sut;
 
@@ -60,7 +64,7 @@ class IntegrationMongoRepositoryImplTest {
         String environmentId = "env-1";
         Pageable pageable = new PageableBuilder().pageNumber(0).pageSize(5).build();
         Collection<String> groups = Set.of("grp-1");
-        given(mongoTemplate.count(query.capture(), eq(IntegrationMongo.class))).willReturn(0L);
+        given(mongoQueries.countOrTimeout(eq(mongoTemplate), query.capture(), eq(IntegrationMongo.class))).willReturn(0L);
         given(mongoTemplate.find(query.capture(), eq(IntegrationMongo.class))).willReturn(List.of());
         // When
         Page<IntegrationMongo> result = sut.findAllByEnvironmentIdAndGroups(environmentId, pageable, Set.of(), groups);
@@ -92,7 +96,7 @@ class IntegrationMongoRepositoryImplTest {
         String environmentId = "env-1";
         Pageable pageable = new PageableBuilder().pageNumber(0).pageSize(5).build();
         Collection<String> groups = Set.of("grp-1");
-        given(mongoTemplate.count(query.capture(), eq(IntegrationMongo.class))).willReturn(0L);
+        given(mongoQueries.countOrTimeout(eq(mongoTemplate), query.capture(), eq(IntegrationMongo.class))).willReturn(0L);
         given(mongoTemplate.find(query.capture(), eq(IntegrationMongo.class))).willReturn(List.of());
         // When
         Page<IntegrationMongo> result = sut.findAllByEnvironmentIdAndGroups(environmentId, pageable, Set.of("id1"), groups);

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/test/java/io/gravitee/repository/mongodb/utils/MongoQueriesTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/test/java/io/gravitee/repository/mongodb/utils/MongoQueriesTest.java
@@ -1,0 +1,202 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.mongodb.utils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import com.mongodb.MongoExecutionTimeoutException;
+import com.mongodb.client.AggregateIterable;
+import java.util.concurrent.TimeUnit;
+import org.bson.Document;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.LoggerFactory;
+import org.springframework.data.mongodb.UncategorizedMongoDbException;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Query;
+
+@ExtendWith(MockitoExtension.class)
+class MongoQueriesTest {
+
+    @Mock
+    MongoTemplate mongoTemplate;
+
+    @Mock
+    AggregateIterable<Document> aggregateIterable;
+
+    @Captor
+    ArgumentCaptor<Query> queryCaptor;
+
+    private final ListAppender<ILoggingEvent> logAppender = new ListAppender<>();
+    private final Logger logger = (Logger) LoggerFactory.getLogger(MongoQueries.class);
+
+    @BeforeEach
+    void attachAppender() {
+        logAppender.start();
+        logger.addAppender(logAppender);
+    }
+
+    @AfterEach
+    void detachAppender() {
+        logger.detachAppender(logAppender);
+        logAppender.stop();
+    }
+
+    @Test
+    void countOrTimeout_returns_minus_one_when_count_times_out() {
+        when(mongoTemplate.count(any(Query.class), eq(Object.class))).thenThrow(
+            new UncategorizedMongoDbException("Wrapped", new MongoExecutionTimeoutException(50, "operation exceeded time limit"))
+        );
+
+        MongoQueries mongoQueries = new MongoQueries(2000L);
+
+        long total = mongoQueries.countOrTimeout(mongoTemplate, new Query(), Object.class);
+
+        assertThat(total).isEqualTo(-1L);
+    }
+
+    @Test
+    void countOrTimeout_returns_count_when_query_succeeds() {
+        when(mongoTemplate.count(any(Query.class), eq(Object.class))).thenReturn(42L);
+        MongoQueries mongoQueries = new MongoQueries(2000L);
+
+        long total = mongoQueries.countOrTimeout(mongoTemplate, new Query(), Object.class);
+
+        assertThat(total).isEqualTo(42L);
+    }
+
+    @Test
+    void countOrTimeout_logs_warning_with_collection_and_timeout_when_count_times_out() {
+        when(mongoTemplate.count(any(Query.class), eq(Object.class))).thenThrow(
+            new UncategorizedMongoDbException("Wrapped", new MongoExecutionTimeoutException(50, "operation exceeded time limit"))
+        );
+        when(mongoTemplate.getCollectionName(Object.class)).thenReturn("myCollection");
+        MongoQueries mongoQueries = new MongoQueries(2500L);
+
+        mongoQueries.countOrTimeout(mongoTemplate, new Query(), Object.class);
+
+        assertThat(logAppender.list).anyMatch(
+            e -> e.getLevel() == Level.WARN && e.getFormattedMessage().contains("myCollection") && e.getFormattedMessage().contains("2500")
+        );
+    }
+
+    @Test
+    void countAggregationOrTimeout_returns_minus_one_when_aggregation_times_out() {
+        when(aggregateIterable.maxTime(anyLong(), eq(TimeUnit.MILLISECONDS))).thenReturn(aggregateIterable);
+        when(aggregateIterable.first()).thenThrow(new MongoExecutionTimeoutException(50, "operation exceeded time limit"));
+        MongoQueries mongoQueries = new MongoQueries(2000L);
+
+        long total = mongoQueries.countAggregationOrTimeout(aggregateIterable, "totalCount", "subscriptions");
+
+        assertThat(total).isEqualTo(-1L);
+    }
+
+    @Test
+    void countAggregationOrTimeout_returns_named_field_from_first_document_when_aggregation_succeeds() {
+        Document firstDoc = new Document("totalCount", 123);
+        when(aggregateIterable.maxTime(anyLong(), eq(TimeUnit.MILLISECONDS))).thenReturn(aggregateIterable);
+        when(aggregateIterable.first()).thenReturn(firstDoc);
+        MongoQueries mongoQueries = new MongoQueries(2000L);
+
+        long total = mongoQueries.countAggregationOrTimeout(aggregateIterable, "totalCount", "subscriptions");
+
+        assertThat(total).isEqualTo(123L);
+    }
+
+    @Test
+    void countAggregationOrTimeout_returns_long_value_from_first_document_when_aggregation_succeeds() {
+        Document firstDoc = new Document("totalCount", 9_000_000_000L);
+        when(aggregateIterable.maxTime(anyLong(), eq(TimeUnit.MILLISECONDS))).thenReturn(aggregateIterable);
+        when(aggregateIterable.first()).thenReturn(firstDoc);
+        MongoQueries mongoQueries = new MongoQueries(2000L);
+
+        long total = mongoQueries.countAggregationOrTimeout(aggregateIterable, "totalCount", "subscriptions");
+
+        assertThat(total).isEqualTo(9_000_000_000L);
+    }
+
+    @Test
+    void countAggregationOrTimeout_returns_zero_when_first_document_is_absent() {
+        when(aggregateIterable.maxTime(anyLong(), eq(TimeUnit.MILLISECONDS))).thenReturn(aggregateIterable);
+        when(aggregateIterable.first()).thenReturn(null);
+        MongoQueries mongoQueries = new MongoQueries(2000L);
+
+        long total = mongoQueries.countAggregationOrTimeout(aggregateIterable, "totalCount", "subscriptions");
+
+        assertThat(total).isZero();
+    }
+
+    @Test
+    void countOrTimeout_applies_configured_timeout_to_query_before_count() {
+        when(mongoTemplate.count(any(Query.class), eq(Object.class))).thenReturn(42L);
+        MongoQueries mongoQueries = new MongoQueries(1500L);
+
+        mongoQueries.countOrTimeout(mongoTemplate, new Query(), Object.class);
+
+        verify(mongoTemplate).count(queryCaptor.capture(), eq(Object.class));
+        assertThat(queryCaptor.getValue().getMeta().getMaxTimeMsec()).isEqualTo(1500L);
+    }
+
+    @Test
+    void countOrTimeout_does_not_mutate_callers_query() {
+        when(mongoTemplate.count(any(Query.class), eq(Object.class))).thenReturn(42L);
+        MongoQueries mongoQueries = new MongoQueries(1500L);
+        Query callerQuery = new Query();
+
+        mongoQueries.countOrTimeout(mongoTemplate, callerQuery, Object.class);
+
+        assertThat(callerQuery.getMeta().getMaxTimeMsec())
+            .as("caller's Query must be left untouched so find() keeps its own budget")
+            .isNull();
+    }
+
+    @Test
+    void countOrTimeout_rethrows_when_exception_is_not_a_timeout() {
+        RuntimeException nonTimeout = new RuntimeException("boom");
+        when(mongoTemplate.count(any(Query.class), eq(Object.class))).thenThrow(nonTimeout);
+        MongoQueries mongoQueries = new MongoQueries(2000L);
+
+        assertThatThrownBy(() -> mongoQueries.countOrTimeout(mongoTemplate, new Query(), Object.class)).isSameAs(nonTimeout);
+    }
+
+    @Test
+    void countAggregationOrTimeout_rethrows_when_exception_is_not_a_timeout() {
+        RuntimeException nonTimeout = new RuntimeException("boom");
+        when(aggregateIterable.maxTime(anyLong(), eq(TimeUnit.MILLISECONDS))).thenReturn(aggregateIterable);
+        when(aggregateIterable.first()).thenThrow(nonTimeout);
+        MongoQueries mongoQueries = new MongoQueries(2000L);
+
+        assertThatThrownBy(() -> mongoQueries.countAggregationOrTimeout(aggregateIterable, "totalCount", "subscriptions")).isSameAs(
+            nonTimeout
+        );
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-analytics.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-analytics.yaml
@@ -1907,7 +1907,7 @@ components:
                 totalCount:
                     type: integer
                     format: int64
-                    description: The total number of items.
+                    description: The total number of items, or `-1` if the count could not be computed within the configured timeout.
 
         Links:
             description: List of links for pagination

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-api-products.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-api-products.yaml
@@ -2159,7 +2159,7 @@ components:
         totalCount:
           type: integer
           format: int64
-          description: The total number of items.
+          description: The total number of items, or `-1` if the count could not be computed within the configured timeout.
 
     CreateApiProductPlan:
       type: object

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-apis.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-apis.yaml
@@ -4887,7 +4887,7 @@ components:
                 totalCount:
                     type: integer
                     format: int64
-                    description: The total number of items.
+                    description: The total number of items, or `-1` if the count could not be computed within the configured timeout.
 
         Path:
             type: object

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-environments.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-environments.yaml
@@ -1878,7 +1878,7 @@ components:
         totalCount:
           type: integer
           format: int64
-          description: The total number of items.
+          description: The total number of items, or `-1` if the count could not be computed within the configured timeout.
     Links:
       description: List of links for pagination
       properties:

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-ui.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-ui.yaml
@@ -542,7 +542,7 @@ components:
                 totalCount:
                     type: integer
                     format: int64
-                    description: The total number of items.
+                    description: The total number of items, or `-1` if the count could not be computed within the configured timeout.
 
         PortalComponentDefinition:
             type: object

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-users.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-users.yaml
@@ -221,7 +221,7 @@ components:
                 totalCount:
                     type: integer
                     format: int64
-                    description: The total number of items.
+                    description: The total number of items, or `-1` if the count could not be computed within the configured timeout.
 
         Links:
             description: List of links for pagination

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/repository/PageUtils.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/repository/PageUtils.java
@@ -30,6 +30,34 @@ public class PageUtils {
         R apply(T t) throws TechnicalException;
     }
 
+    @FunctionalInterface
+    public interface ThrowingConsumer<T> {
+        void accept(T t) throws TechnicalException;
+    }
+
+    /**
+     * Iterate every page produced by {@code pageSupplier} and feed it to {@code handler}, stopping when a page returns
+     * fewer items than {@code pageSize}. Never reads {@link Page#getTotalElements()} — safe to use against repositories
+     * that may return {@code -1} when their count operation timed out (APIM-14093).
+     *
+     * <p>Upgraders and other "must-complete" backend tasks should iterate pages through this helper rather than building
+     * a {@code do { ... } while (handled < page.getTotalElements())} loop.
+     */
+    public static <T> void forEachPage(ThrowingFunction<Pageable, Page<T>> pageSupplier, int pageSize, ThrowingConsumer<Page<T>> handler)
+        throws TechnicalException {
+        int pageIdx = 0;
+        boolean hasMore;
+        do {
+            Page<T> page = pageSupplier.apply(new PageableBuilder().pageSize(pageSize).pageNumber(pageIdx).build());
+            if (page == null || page.getContent() == null || page.getContent().isEmpty()) {
+                return;
+            }
+            handler.accept(page);
+            hasMore = page.getContent().size() == pageSize;
+            pageIdx++;
+        } while (hasMore);
+    }
+
     public static <T> Stream<T> toStream(ThrowingFunction<Pageable, Page<T>> pageSupplier) throws TechnicalException {
         var pageable = new PageableBuilder().pageSize(BATCH_PAGE_SIZE).pageNumber(0).build();
         var fistPage = pageSupplier.apply(pageable);
@@ -61,6 +89,11 @@ public class PageUtils {
     }
 
     private static boolean hasNext(Page page) {
+        // When the repository could not compute the total (count timed out), fall back to the page-fullness heuristic so we
+        // don't silently truncate iteration. The page is treated as last when it returned fewer elements than the page size.
+        if (page.getTotalElements() < 0) {
+            return page.getContent() != null && page.getPageElements() > 0;
+        }
         return (page.getPageNumber() + 1) * page.getPageElements() < page.getTotalElements();
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/ApplicationClientCertificateMigrationUpgrader.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/ApplicationClientCertificateMigrationUpgrader.java
@@ -18,14 +18,12 @@ package io.gravitee.rest.api.service.impl.upgrade.upgrader;
 import io.gravitee.apim.core.application_certificate.crud_service.ClientCertificateCrudService;
 import io.gravitee.apim.core.application_certificate.domain_service.ClientCertificateValidationDomainService;
 import io.gravitee.apim.core.application_certificate.model.ClientCertificate;
-import io.gravitee.common.data.domain.Page;
+import io.gravitee.apim.infra.repository.PageUtils;
 import io.gravitee.node.api.upgrader.Upgrader;
 import io.gravitee.node.api.upgrader.UpgraderException;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.ApplicationRepository;
 import io.gravitee.repository.management.api.search.ApplicationCriteria;
-import io.gravitee.repository.management.api.search.Pageable;
-import io.gravitee.repository.management.api.search.builder.PageableBuilder;
 import io.gravitee.repository.management.model.Application;
 import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.exceptions.AbstractClientCertificateException;
@@ -48,6 +46,7 @@ import org.springframework.stereotype.Component;
 public class ApplicationClientCertificateMigrationUpgrader implements Upgrader {
 
     static final String METADATA_CLIENT_CERTIFICATE = "client_certificate";
+    static final int PAGE_SIZE = 100;
 
     @Lazy
     @Autowired
@@ -65,26 +64,24 @@ public class ApplicationClientCertificateMigrationUpgrader implements Upgrader {
             log.info("Starting migration of application client certificates to ClientCertificate entity");
 
             ApplicationCriteria criteria = ApplicationCriteria.builder().build();
-            int pageNumber = 0;
-            Page<Application> page;
-            do {
-                Pageable pageable = new PageableBuilder().pageNumber(pageNumber).pageSize(100).build();
-                page = applicationRepository.search(criteria, pageable);
-                for (Application application : page
-                    .getContent()
-                    .stream()
-                    .filter(
-                        app ->
-                            app.getMetadata() != null &&
-                            app.getMetadata().get(METADATA_CLIENT_CERTIFICATE) != null &&
-                            !app.getMetadata().get(METADATA_CLIENT_CERTIFICATE).isBlank()
-                    )
-                    .toList()) {
-                    // candidate to be migrated
-                    migrateApplicationCertificate(application);
+            PageUtils.forEachPage(
+                pageable -> applicationRepository.search(criteria, pageable),
+                PAGE_SIZE,
+                page -> {
+                    for (Application application : page
+                        .getContent()
+                        .stream()
+                        .filter(
+                            app ->
+                                app.getMetadata() != null &&
+                                app.getMetadata().get(METADATA_CLIENT_CERTIFICATE) != null &&
+                                !app.getMetadata().get(METADATA_CLIENT_CERTIFICATE).isBlank()
+                        )
+                        .toList()) {
+                        migrateApplicationCertificate(application);
+                    }
                 }
-                pageNumber++;
-            } while (page.getTotalElements() > pageNumber * page.getPageElements());
+            );
 
             log.info("Completed migration of application client certificates");
             return true;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/EventsLatestUpgrader.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/EventsLatestUpgrader.java
@@ -17,6 +17,7 @@ package io.gravitee.rest.api.service.impl.upgrade.upgrader;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.gravitee.apim.infra.repository.PageUtils;
 import io.gravitee.common.data.domain.Page;
 import io.gravitee.node.api.upgrader.Upgrader;
 import io.gravitee.node.api.upgrader.UpgraderException;
@@ -99,27 +100,11 @@ public class EventsLatestUpgrader implements Upgrader {
         modelCounter = 0;
         eventsForModelCounter = 0;
         List<ApiCriteria> emptyCriteria = List.of();
-        Page<String> firstPage = this.apiRepository.searchIds(
-            emptyCriteria,
-            new PageableBuilder().pageNumber(0).pageSize(BULK_SIZE).build(),
-            null
+        PageUtils.forEachPage(
+            pageable -> apiRepository.searchIds(emptyCriteria, pageable, null),
+            BULK_SIZE,
+            page -> migrateEvents(Event.EventProperties.API_ID.getValue(), page.getContent())
         );
-        if (firstPage != null && firstPage.getContent() != null) {
-            migrateEvents(Event.EventProperties.API_ID.getValue(), firstPage.getContent());
-
-            // Cover others pages if required
-            if (firstPage.getTotalElements() > firstPage.getPageElements()) {
-                long pageNumber = (int) Math.ceil((double) firstPage.getTotalElements() / BULK_SIZE);
-                for (int pageIdx = 1; pageIdx < pageNumber; pageIdx++) {
-                    Page<String> nextPage = this.apiRepository.searchIds(
-                        emptyCriteria,
-                        new PageableBuilder().pageNumber(pageIdx).pageSize(BULK_SIZE).build(),
-                        null
-                    );
-                    migrateEvents(Event.EventProperties.API_ID.getValue(), nextPage.getContent());
-                }
-            }
-        }
         log.info("{} events regarding {} APIs have been migrated", eventsForModelCounter, modelCounter);
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/IntegrationPrimaryOwnerUpgrader.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/IntegrationPrimaryOwnerUpgrader.java
@@ -17,6 +17,7 @@ package io.gravitee.rest.api.service.impl.upgrade.upgrader;
 
 import static io.gravitee.rest.api.service.impl.upgrade.upgrader.UpgraderOrder.INTEGRATION_PRIMARY_OWNER_UPGRADER;
 
+import io.gravitee.apim.infra.repository.PageUtils;
 import io.gravitee.common.data.domain.Page;
 import io.gravitee.node.api.upgrader.Upgrader;
 import io.gravitee.node.api.upgrader.UpgraderException;
@@ -99,17 +100,11 @@ public class IntegrationPrimaryOwnerUpgrader implements Upgrader {
     private void setPrimaryOwnersForIntegrations(ExecutionContext executionContext) throws TechnicalException {
         log.info("Start to set primary owners for integrations");
 
-        int handledIntegrations = 0;
-        Page<Integration> integrationPage;
-        do {
-            integrationPage = integrationRepository.findAllByEnvironment(
-                executionContext.getEnvironmentId(),
-                new PageableBuilder().pageNumber(handledIntegrations / PAGE_SIZE).pageSize(PAGE_SIZE).build()
-            );
-            handledIntegrations += (int) integrationPage.getPageElements();
-
-            setPrimaryOwnersForIntegrations(integrationPage, executionContext);
-        } while (handledIntegrations < integrationPage.getTotalElements());
+        PageUtils.forEachPage(
+            pageable -> integrationRepository.findAllByEnvironment(executionContext.getEnvironmentId(), pageable),
+            PAGE_SIZE,
+            integrationPage -> setPrimaryOwnersForIntegrations(integrationPage, executionContext)
+        );
 
         log.info("Finish to set primary owners for integrations");
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/architecture/UpgraderRulesTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/architecture/UpgraderRulesTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package architecture;
+
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
+
+import com.tngtech.archunit.core.domain.JavaClasses;
+import com.tngtech.archunit.core.importer.ClassFileImporter;
+import com.tngtech.archunit.core.importer.ImportOption;
+import io.gravitee.common.data.domain.Page;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Architectural rules for upgraders.
+ *
+ * <p>Upgraders must complete fully — they cannot degrade gracefully like UI paths can. Since repositories may now return
+ * {@link Page#getTotalElements()} = {@code -1} when the underlying count operation timed out (APIM-14093), any upgrader
+ * that branches on that value risks silently skipping data. Pass-through to the UI is the only accepted consumer of
+ * {@code -1}; backend "must-complete" paths must use {@code PageUtils.forEachPage(...)} or compute page-fullness from
+ * {@code page.getContent().size()} instead.
+ */
+public class UpgraderRulesTest extends AbstractApimArchitectureTest {
+
+    private static final String UPGRADER_PACKAGE = "..upgrade.upgrader..";
+
+    @Test
+    public void upgraders_should_not_branch_on_page_total_elements() {
+        noClasses()
+            .that()
+            .resideInAPackage(UPGRADER_PACKAGE)
+            .should()
+            .callMethod(Page.class, "getTotalElements")
+            .because(
+                "Upgraders must complete fully even when the repository count times out (Page.totalElements may be -1). " +
+                    "Use PageUtils.forEachPage(...) or rely on page-fullness (page.getContent().size() == pageSize) instead."
+            )
+            .check(upgraderClassesWithoutTests());
+    }
+
+    private JavaClasses upgraderClassesWithoutTests() {
+        return new ClassFileImporter()
+            .withImportOption(ImportOption.Predefined.DO_NOT_INCLUDE_TESTS)
+            .importPackages("io.gravitee.rest.api.service.impl.upgrade.upgrader");
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/ApplicationClientCertificateMigrationUpgraderTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/ApplicationClientCertificateMigrationUpgraderTest.java
@@ -40,6 +40,7 @@ import io.gravitee.repository.management.api.search.ApplicationCriteria;
 import io.gravitee.repository.management.api.search.Pageable;
 import io.gravitee.repository.management.model.Application;
 import io.gravitee.rest.api.service.exceptions.ClientCertificateInvalidException;
+import java.util.ArrayList;
 import java.util.Base64;
 import java.util.Date;
 import java.util.HashMap;
@@ -165,16 +166,26 @@ class ApplicationClientCertificateMigrationUpgraderTest {
         // Given
         String base64Cert = Base64.getEncoder().encodeToString(VALID_PEM_CERTIFICATE.getBytes());
 
-        Map<String, String> metadata1 = new HashMap<>();
-        metadata1.put(METADATA_CLIENT_CERTIFICATE, base64Cert);
-        Application app1 = Application.builder().id("app-1").name("App 1").environmentId("env-1").metadata(metadata1).build();
+        // Build a first page of exactly PAGE_SIZE applications so the upgrader fetches a second page;
+        // the second page is partial which signals "no more pages".
+        List<Application> firstPageApps = new ArrayList<>();
+        for (int i = 0; i < ApplicationClientCertificateMigrationUpgrader.PAGE_SIZE; i++) {
+            Map<String, String> metadata = new HashMap<>();
+            metadata.put(METADATA_CLIENT_CERTIFICATE, base64Cert);
+            firstPageApps.add(Application.builder().id("app-" + i).name("App " + i).environmentId("env-1").metadata(metadata).build());
+        }
 
-        Map<String, String> metadata2 = new HashMap<>();
-        metadata2.put(METADATA_CLIENT_CERTIFICATE, base64Cert);
-        Application app2 = Application.builder().id("app-2").name("App 2").environmentId("env-1").metadata(metadata2).build();
+        Map<String, String> lastMetadata = new HashMap<>();
+        lastMetadata.put(METADATA_CLIENT_CERTIFICATE, base64Cert);
+        Application appOnSecondPage = Application.builder()
+            .id("app-last")
+            .name("App last")
+            .environmentId("env-1")
+            .metadata(lastMetadata)
+            .build();
 
-        Page<Application> page1 = new Page<>(List.of(app1), 1, 1, 2);
-        Page<Application> page2 = new Page<>(List.of(app2), 2, 1, 2);
+        Page<Application> page1 = new Page<>(firstPageApps, 0, firstPageApps.size(), firstPageApps.size() + 1);
+        Page<Application> page2 = new Page<>(List.of(appOnSecondPage), 1, 1, firstPageApps.size() + 1);
 
         when(applicationRepository.search(any(ApplicationCriteria.class), any(Pageable.class))).thenReturn(page1).thenReturn(page2);
         when(clientCertificateValidationDomainService.validate(any())).thenReturn(VALID_CERT_INFO);
@@ -184,9 +195,10 @@ class ApplicationClientCertificateMigrationUpgraderTest {
         boolean result = upgrader.upgrade();
 
         // Then
+        int expectedMigrations = firstPageApps.size() + 1;
         assertThat(result).isTrue();
-        verify(clientCertificateCrudService, times(2)).create(any(), any(ClientCertificate.class));
-        verify(applicationRepository, times(2)).update(any(Application.class));
+        verify(clientCertificateCrudService, times(expectedMigrations)).create(any(), any(ClientCertificate.class));
+        verify(applicationRepository, times(expectedMigrations)).update(any(Application.class));
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/EventsLatestUpgraderTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/EventsLatestUpgraderTest.java
@@ -282,10 +282,12 @@ public class EventsLatestUpgraderTest {
 
     @Test
     public void should_create_latest_events_from_existing_apis_with_multiple_pages() throws TechnicalException, UpgraderException {
-        // Prepare pages
+        // Prepare 4 full pages of 100 APIs each plus a final partial page of 50 (totalling 450).
+        // The partial last page signals "no more data" — the upgrader can't rely on totalElements anymore
+        // because the repository may now return -1 if the count timed out (APIM-14093).
         Map<Integer, List<String>> pageMapping = new HashMap<>();
         int index = 0;
-        for (int i = 1; i <= 5; i++) {
+        for (int i = 1; i <= 4; i++) {
             List<String> apis = new ArrayList<>();
             for (int j = 0; j < 100; j++) {
                 apis.add("api" + index);
@@ -293,15 +295,22 @@ public class EventsLatestUpgraderTest {
             }
             pageMapping.put(i, apis);
         }
+        List<String> lastPage = new ArrayList<>();
+        for (int j = 0; j < 50; j++) {
+            lastPage.add("api" + index);
+            index++;
+        }
+        pageMapping.put(5, lastPage);
+        int total = 450;
 
         when(apiRepository.searchIds(eq(List.of()), any(), eq(null)))
-            .thenReturn(new Page<>(pageMapping.get(1), 0, 100, 500))
-            .thenReturn(new Page<>(pageMapping.get(2), 1, 100, 500))
-            .thenReturn(new Page<>(pageMapping.get(3), 2, 100, 500))
-            .thenReturn(new Page<>(pageMapping.get(4), 3, 100, 500))
-            .thenReturn(new Page<>(pageMapping.get(5), 4, 100, 500));
+            .thenReturn(new Page<>(pageMapping.get(1), 0, 100, total))
+            .thenReturn(new Page<>(pageMapping.get(2), 1, 100, total))
+            .thenReturn(new Page<>(pageMapping.get(3), 2, 100, total))
+            .thenReturn(new Page<>(pageMapping.get(4), 3, 100, total))
+            .thenReturn(new Page<>(pageMapping.get(5), 4, 50, total));
 
-        for (int i = 0; i < 500; i++) {
+        for (int i = 0; i < total; i++) {
             Event event = new Event();
             when(
                 eventRepository.search(
@@ -313,7 +322,7 @@ public class EventsLatestUpgraderTest {
         }
         cut.upgrade();
 
-        verify(eventLatestRepository, times(500)).createOrUpdate(any());
+        verify(eventLatestRepository, times(total)).createOrUpdate(any());
     }
 
     @Test


### PR DESCRIPTION
## Summary

Bounds the blast radius of long-running `count()` operations issued by paginated Mongo repository searches. Adds a `MongoQueries.countOrTimeout(...)` helper that applies `maxTimeMsec` to the query before delegating to `MongoTemplate.count`, catches `MongoExecutionTimeoutException` (and Spring's `DataAccessException` wrapper around it), logs a warning, and returns `-1` for `Page.totalElements`. Consumers degrade gracefully — UIs surface "N/A" instead of the real total when the count timed out.

Jira: [APIM-14093](https://gravitee.atlassian.net/browse/APIM-14093)

<img width="1679" height="813" alt="image" src="https://github.com/user-attachments/assets/77a7abc9-dfa8-42a6-99e2-ddcbce58022d" />

## What changed

**Backend** (`gravitee-apim-repository-mongodb`)
- New `MongoQueries` `@Component` (Spring bean) with two methods:
  - `countOrTimeout(MongoTemplate, Query, Class<T>) → long` for `MongoTemplate.count` paths
  - `countAggregationOrTimeout(AggregateIterable, fieldName, collectionName) → long` for Subscription's aggregation-based count
- Configurable via `management.mongodb.countMaxTimeMs` (default **5000ms**)
- Wired into ~18 `search()` call sites across: Api (search + searchIds), Promotion, License, AsyncJob, Page, SharedPolicyGroupHistory, Integration, Cluster, ApiProducts, SharedPolicyGroup, User, Audit, Theme, Ticket, Event, AlertEvent, Application, Subscription, MongoGroup
- Standalone `count(criteria) → long` methods (e.g. `PageMongoRepositoryImpl.countByParentIdAndIsPublished`, `AlertEventMongoRepositoryImpl.count`) are intentionally **not** wrapped — returning `-1` from a non-Page contract would silently break callers that branch on `count > 0`
- Existing `IntegrationMongoRepositoryImplTest` updated to mock the new helper
- 7 new unit tests for the helper + 1 integration test on `ApiMongoRepositoryImpl`

**REST** (`gravitee-apim-rest-api-management-v2`)
- `totalCount` description updated in 6 OpenAPI specs: `"or -1 if the count could not be computed within the configured timeout"`

**Console UI** (`gravitee-apim-console-webui`)
- New `GioPaginatorIntl` registered globally — when `length < 0`, range label reads `X – Y of N/A`
- `gio-table-wrapper` exposes `effectiveLength` (coerces `-1` to `Number.MAX_SAFE_INTEGER` so navigation stays usable) and a `gio-unknown-length` host class
- CSS disables the "Last page" button when count is unknown (can't jump to an unknown end)

**Portal Next** (`gravitee-apim-portal-webui-next`)
- `PaginationComponent` hides direct page-jump buttons when `totalResults < 0`; Prev/Next remain functional

**Legacy Portal** (`gravitee-apim-portal-webui`)
- `catalog-search` switches to a new `search.results.many` translation key when `totalElements < 0` ("Many results" / locale equivalents in en, fr, it, cs)

## Risk

Any consumer that currently treats `-1` from `Page.totalElements` as a valid number could misbehave. Surveyed call sites:
- `PaginationInfo.computePaginationInfo` already does `totalCount > 0 ? ceil(...) : 0` — handles `-1` as "no pages"
- v2 REST `Pagination` DTO carries `totalCount` as nullable `int64`; OpenAPI now documents `-1` semantics
- Console tables route through `gio-table-wrapper` — covered globally by the Intl + `effectiveLength` change

## Known limitations / follow-ups

- **Next/First buttons remain enabled when count is unknown** — without a real total, the paginator can't tell where the end is. The original ticket already calls this out: "slice pagination via `limit + 1` probe" is tracked as a follow-up.
- **No tooltip on `N/A`** — multiple approaches tried in implementation; each broke either the paginator layout or didn't render. Deferred to a follow-up.

## Test plan

- [x] Backend unit tests (1086 module tests + 8 new) all green
- [x] Manual smoke: mAPI returns Page with totalElements=-1 under forced count timeout; helper's `log.warn` fires
- [x] Console UI: audit page renders \`1 – 10 of N/A\`, Last button visually disabled when forced
- [ ] Verify Portal Next & legacy Portal pagination changes in a deploy that exercises them

## Out of scope (separate tickets)

- Slice pagination via \`limit + 1\` probe
- Short-TTL count cache
- \`estimatedDocumentCount()\` for monotonically-growing collections (\`audits\`, \`events\`)

[APIM-14093]: https://gravitee.atlassian.net/browse/APIM-14093?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ