### PR TITLE
feat(repository,rest-api): Elasticsearch impl of TracingRepository + OTEL_TRACES scope

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/README.adoc
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/README.adoc
@@ -9,3 +9,91 @@ To do so you can use the following commands:
 * ES 8.x: `mvn clean test -Delasticsearch.version=8.17.2` (Default)
 * OS 1.x: `mvn clean test -Dsearch.type=opensearch -Dopensearch.version=1.3.9`
 * OS 2.x: `mvn clean test -Dsearch.type=opensearch -Dopensearch.version=2`
+
+== Tracing repository (`Scope.OTEL_TRACES`)
+
+This plugin also implements the APIM `TracingRepository` SPI, querying OpenTelemetry traces written to Elasticsearch by an OpenTelemetry Collector configured with the `elasticsearch` exporter in `mapping.mode: otel`. Documents use the OTel-native snake_case field names (`trace_id`, `span_id`, `parent_span_id`, `@timestamp`, `duration`, `status.code`, `attributes.*`, `resource.attributes.*`, `events[]`).
+
+=== Configuration
+
+In `gravitee.yml`:
+
+[source,yaml]
+----
+otel-traces:
+  type: elasticsearch
+  elasticsearch:
+    # Spans data stream / index template. {orgId} and {envId} are substituted from the caller's QueryContext
+    # at query time, lowercased — same convention as IndexNameUtils.format on the analytics side. Use a single
+    # placeholder for an org-scoped index (recommended), or both for full isolation.
+    index: traces-apim.otel-{orgId}
+    endpoints:
+      - http://localhost:9200
+    # security:
+    #   username: elastic
+    #   password: changeme
+    # http:
+    #   timeout: 10000
+    # ssl, http.proxy, …: same shape as the analytics block; see RepositoryConfiguration for the full list.
+----
+
+The `otel-traces.elasticsearch.*` block is **independent** from `analytics.elasticsearch.*` — same per-scope pattern as the Redis plugin (`ratelimit.redis.*` vs `distributed-sync.redis.*`). No fallback: tracing can be enabled even when analytics targets a different repository (Mongo, JDBC, none), or vice-versa. If the same ES cluster backs both, the operator duplicates the endpoint/auth values in each block.
+
+NOTE: The OTel collector's `elasticsearch` exporter in `mapping.mode: otel` writes span events to a separate logs data stream (it forces `data_stream.type = logs` for events). This repository returns spans only — span events live behind the future `LogsRepository` SPI (see `OTEL_LOGS` scope), and the consumer use case is responsible for fetching and stitching them onto the matching spans.
+
+=== Org and env scoping
+
+The repository maps APIM's two-level identity (`QueryContext.orgId` / `QueryContext.envId`) onto two distinct mechanisms — same shape as the Tempo adapter so the model is consistent across backends:
+
+* **Org → index name** (hard partition): `orgId` is substituted into the `otel-traces.elasticsearch.index` template. Two orgs never share an index.
+* **Soft scopes (env, module, …) → resource-attribute filters** inside the org: the caller (e.g. the gamma APIM use case) declares these as an explicit `Map<String, String>` of resource-attribute filters and passes it via `TraceSearchCriteria.resourceAttributeFilters()` for `searchTraces`, or as the third argument of `getTrace(qc, traceId, filters)`. Each entry becomes a `term { resource.attributes.<key>: <value> }` filter in the ES query. The repository has no built-in knowledge of which keys belong here — anything the caller puts in the map is emitted as a resource filter. Producers must emit those keys as resource attributes on every span (typically via `services.opentelemetry.extraAttributes` in the gateway / management API config); without them the resource filter rejects every span.
+
+The mapping from APIM concepts (env id, module) to specific OTel attribute keys lives in the caller (`ApimTraceResourceFilters` in `gravitee-gamma-module-apim`), not in this adapter. Callers can also pass arbitrary span-attribute filters (e.g. `gravitee.api.id` for a per-API view) via `TraceSearchCriteria.attributeFilters` — those land on `attributes.<key>` rather than `resource.attributes.<key>`.
+
+=== Index templates, mappings & retention (ILM)
+
+This repository is **reader-only**. It does not author index templates, field mappings, or ILM policies — those live with the producer or the cluster operator:
+
+* **Mappings & index template**: applied by whoever writes the spans.
+  - *Self-managed OTel Collector*: the `elasticsearch` exporter (`mapping.mode: otel`) applies the template at startup — field mappings, `data_stream: {}` declaration, dynamic templates for `attributes.*`, etc. Configurable via the exporter's `mapping_settings_template` and related options.
+  - *Elastic Cloud managed OTLP endpoint* (`<deployment>.cloud.es.io/otlp/v1/traces`): Elastic handles template + mapping management server-side, no operator action needed.
+* **ILM policy (retention)**: bound to the data stream via `index.lifecycle.name` on the index template.
+  - *Self-managed OTel Collector*: no default policy. Operator pushes a policy via `_ilm/policy/...` and binds it on the template (`index.lifecycle.name: traces-apim-policy`).
+  - *Elastic Cloud managed OTLP*: ships with sensible defaults (`traces@lifecycle`, `logs@lifecycle`); customize via Kibana or the `_ilm/policy/...` API if the default retention doesn't fit.
+
+If queries return no data, check (in this order): (1) the data stream `traces-apim.otel-<orgId>` exists, (2) the OTel collector or OTLP endpoint is actively writing to it, (3) the template's mapping mode is `otel` (not `ecs`), (4) the ILM policy hasn't already deleted the documents you're looking for.
+
+=== OTel Collector configuration snippet
+
+A minimal OTel Collector pipeline that writes traces matching the default index template:
+
+[source,yaml]
+----
+receivers:
+  otlp:
+    protocols:
+      http:
+        endpoint: 0.0.0.0:4318
+      grpc:
+        endpoint: 0.0.0.0:4317
+
+exporters:
+  elasticsearch:
+    endpoints: ["http://elasticsearch:9200"]
+    mapping:
+      mode: otel
+    # Per-tenant data stream. Replace `<orgId>` with the actual organization id, or use traces_dynamic_index +
+    # an attribute to derive it from each span.
+    traces_index: traces-apim.otel-<orgId>
+
+processors:
+  batch:
+    timeout: 1s
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [elasticsearch]
+----

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/pom.xml
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/pom.xml
@@ -231,6 +231,42 @@
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
+
+        <!-- Tracing IT: shared TracingRepository contract test + JUnit 4 vintage runner used by AbstractRepositoryTest -->
+        <dependency>
+            <groupId>io.gravitee.apim.repository</groupId>
+            <artifactId>gravitee-apim-repository-test</artifactId>
+            <version>${project.version}</version>
+            <classifier>tests</classifier>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- Tracing IT: OTel SDK + OTLP HTTP exporter push fixture spans to the OTel Collector container -->
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-sdk</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-exporter-otlp</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/ElasticsearchRepositoryProvider.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/ElasticsearchRepositoryProvider.java
@@ -18,6 +18,7 @@ package io.gravitee.repository.elasticsearch;
 import io.gravitee.platform.repository.api.RepositoryProvider;
 import io.gravitee.platform.repository.api.Scope;
 import io.gravitee.repository.elasticsearch.spring.ElasticsearchRepositoryConfiguration;
+import io.gravitee.repository.elasticsearch.tracing.spring.TracingConfiguration;
 import lombok.CustomLog;
 
 /**
@@ -34,13 +35,19 @@ public class ElasticsearchRepositoryProvider implements RepositoryProvider {
 
     @Override
     public Scope[] scopes() {
-        return new Scope[] { Scope.ANALYTICS };
+        return new Scope[] { Scope.ANALYTICS, Scope.OTEL_TRACES };
     }
 
     @Override
     public Class<?> configuration(Scope scope) {
+        // Distinct configuration classes per scope are mandatory: the platform creates one application context per
+        // scope and promotes its singletons into the parent bean factory. Returning the same class for both scopes
+        // double-registers every bean (e.g. analyticsRepository, client, …) and fails with a bean-name conflict.
         if (scope == Scope.ANALYTICS) {
             return ElasticsearchRepositoryConfiguration.class;
+        }
+        if (scope == Scope.OTEL_TRACES) {
+            return TracingConfiguration.class;
         }
         log.debug("Skipping unhandled repository scope {}", scope);
         return null;

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/client/ElasticsearchHttpClientFactory.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/client/ElasticsearchHttpClientFactory.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.elasticsearch.client;
+
+import io.gravitee.elasticsearch.client.http.ClientSslConfiguration;
+import io.gravitee.elasticsearch.client.http.HttpClient;
+import io.gravitee.elasticsearch.client.http.HttpClientConfiguration;
+import io.gravitee.elasticsearch.client.http.HttpClientJksSslConfiguration;
+import io.gravitee.elasticsearch.client.http.HttpClientPemSslConfiguration;
+import io.gravitee.elasticsearch.client.http.HttpClientPfxSslConfiguration;
+import io.gravitee.elasticsearch.config.Endpoint;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.CustomLog;
+import org.springframework.core.env.Environment;
+
+/**
+ * Per-scope Elasticsearch {@link HttpClient} factory — mirrors the {@code RedisConnectionFactory} pattern:
+ * instantiated once per Spring scope ({@code ANALYTICS}, {@code OTEL_TRACES}, …) with the scope name as the
+ * property-prefix root, then reads every connection setting from {@link Environment} on demand. Keeps
+ * scope wiring straightforward (a single 2-arg constructor instead of a 19-arg record + adapter), and lets
+ * each scope's {@code @Configuration} declare exactly one ES-specific concern — the scope it lives in —
+ * by passing {@link io.gravitee.platform.repository.api.Scope#getName()} as the prefix.
+ * <p>
+ * The full property prefix is {@code <scopeName>.elasticsearch.} — so {@code Scope.ANALYTICS.getName()}
+ * yields {@code analytics.elasticsearch.*}, {@code Scope.OTEL_TRACES.getName()} yields
+ * {@code otel-traces.elasticsearch.*}, and so on. Each scope's property block is independent — no
+ * fallback across scopes, so an operator can wire one of them and leave the others on a different
+ * backend (Mongo, JDBC, none).
+ *
+ * @author GraviteeSource Team
+ */
+@CustomLog
+public class ElasticsearchHttpClientFactory {
+
+    private static final String DEFAULT_ELASTICSEARCH_ENDPOINT = "http://localhost:9200";
+
+    private final Environment environment;
+    private final String propertyPrefix;
+
+    public ElasticsearchHttpClientFactory(Environment environment, String scopeName) {
+        this.environment = environment;
+        this.propertyPrefix = scopeName + ".elasticsearch.";
+    }
+
+    public HttpClient createHttpClient() {
+        return new HttpClient(buildHttpClientConfiguration());
+    }
+
+    /**
+     * Exposed as {@code protected} so unit tests can assert on the intermediate {@link HttpClientConfiguration}
+     * (endpoints, credentials, SSL config, proxy) without reflecting into the resulting client. Mirrors
+     * {@code RedisConnectionFactory.buildRedisClientOptions()}.
+     */
+    protected HttpClientConfiguration buildHttpClientConfiguration() {
+        HttpClientConfiguration cfg = new HttpClientConfiguration();
+        cfg.setEndpoints(readEndpoints());
+        cfg.setUsername(readProperty("security.username", String.class, null));
+        cfg.setPassword(readProperty("security.password", String.class, null));
+        cfg.setRequestTimeout(readProperty("http.timeout", Long.class, 10_000L));
+
+        cfg.setProxyType(readProperty("http.proxy.type", String.class, "HTTP"));
+        cfg.setProxyHttpHost(readProperty("http.proxy.http.host", String.class, System.getProperty("http.proxyHost", "localhost")));
+        cfg.setProxyHttpPort(
+            readProperty("http.proxy.http.port", int.class, Integer.parseInt(System.getProperty("http.proxyPort", "3128")))
+        );
+        cfg.setProxyHttpUsername(readProperty("http.proxy.http.username", String.class, null));
+        cfg.setProxyHttpPassword(readProperty("http.proxy.http.password", String.class, null));
+        cfg.setProxyHttpsHost(readProperty("http.proxy.https.host", String.class, System.getProperty("https.proxyHost", "localhost")));
+        cfg.setProxyHttpsPort(
+            readProperty("http.proxy.https.port", int.class, Integer.parseInt(System.getProperty("https.proxyPort", "3128")))
+        );
+        cfg.setProxyHttpsUsername(readProperty("http.proxy.https.username", String.class, null));
+        cfg.setProxyHttpsPassword(readProperty("http.proxy.https.password", String.class, null));
+        cfg.setProxyConfigured(isProxyConfigured());
+
+        configureSsl(cfg);
+        return cfg;
+    }
+
+    private void configureSsl(HttpClientConfiguration cfg) {
+        String keystoreType = readProperty("ssl.keystore.type", String.class, null);
+        if (keystoreType == null) {
+            return;
+        }
+        if (keystoreType.equalsIgnoreCase(ClientSslConfiguration.JKS_KEYSTORE_TYPE)) {
+            cfg.setSslConfig(
+                new HttpClientJksSslConfiguration(
+                    readProperty("ssl.keystore.path", String.class, null),
+                    readProperty("ssl.keystore.password", String.class, null)
+                )
+            );
+        } else if (keystoreType.equalsIgnoreCase(ClientSslConfiguration.PFX_KEYSTORE_TYPE)) {
+            cfg.setSslConfig(
+                new HttpClientPfxSslConfiguration(
+                    readProperty("ssl.keystore.path", String.class, null),
+                    readProperty("ssl.keystore.password", String.class, null)
+                )
+            );
+        } else if (keystoreType.equalsIgnoreCase(ClientSslConfiguration.PEM_KEYSTORE_TYPE)) {
+            cfg.setSslConfig(
+                new HttpClientPemSslConfiguration(
+                    readIndexedListProperty("ssl.keystore.certs"),
+                    readIndexedListProperty("ssl.keystore.keys")
+                )
+            );
+        }
+    }
+
+    /**
+     * Resolves the ES endpoints from the {@code endpoints[N]} indexed property block, falling back to a
+     * single default ({@value DEFAULT_ELASTICSEARCH_ENDPOINT}) when the operator didn't configure any —
+     * matches the analytics convention so local dev / unit tests don't need a property file.
+     */
+    private List<Endpoint> readEndpoints() {
+        List<Endpoint> endpoints = new ArrayList<>();
+        for (int idx = 0; environment.containsProperty(propertyPrefix + "endpoints[" + idx + "]"); idx++) {
+            endpoints.add(new Endpoint(readProperty("endpoints[" + idx + "]", String.class, null)));
+        }
+        if (endpoints.isEmpty()) {
+            endpoints.add(new Endpoint(DEFAULT_ELASTICSEARCH_ENDPOINT));
+        }
+        return endpoints;
+    }
+
+    /**
+     * Indexed list properties ({@code prop[0]=a, prop[1]=b, …}) with a fallback to the single-value form
+     * for back-compat with the analytics convention.
+     */
+    private List<String> readIndexedListProperty(String suffix) {
+        List<String> values = new ArrayList<>();
+        for (int idx = 0; environment.containsProperty(propertyPrefix + suffix + "[" + idx + "]"); idx++) {
+            values.add(readProperty(suffix + "[" + idx + "]", String.class, null));
+        }
+        if (values.isEmpty() && environment.containsProperty(propertyPrefix + suffix)) {
+            values.add(readProperty(suffix, String.class, null));
+        }
+        return values;
+    }
+
+    /**
+     * "Proxy is configured" iff any of the proxy properties under {@code http.proxy.*} was explicitly set
+     * in the operator's config. Avoids the Spring-environment-walking that the analytics-only
+     * {@code RepositoryConfiguration.isProxyConfigured()} did — same behaviour, but per-scope.
+     */
+    private boolean isProxyConfigured() {
+        return (
+            environment.containsProperty(propertyPrefix + "http.proxy.type") ||
+            environment.containsProperty(propertyPrefix + "http.proxy.http.host") ||
+            environment.containsProperty(propertyPrefix + "http.proxy.https.host") ||
+            environment.containsProperty(propertyPrefix + "http.proxy.http.port") ||
+            environment.containsProperty(propertyPrefix + "http.proxy.https.port")
+        );
+    }
+
+    private <T> T readProperty(String name, Class<T> type, T defaultValue) {
+        return environment.getProperty(propertyPrefix + name, type, defaultValue);
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/spring/ElasticsearchRepositoryConfiguration.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/spring/ElasticsearchRepositoryConfiguration.java
@@ -18,12 +18,6 @@ package io.gravitee.repository.elasticsearch.spring;
 import static java.lang.String.format;
 
 import io.gravitee.elasticsearch.client.Client;
-import io.gravitee.elasticsearch.client.http.ClientSslConfiguration;
-import io.gravitee.elasticsearch.client.http.HttpClient;
-import io.gravitee.elasticsearch.client.http.HttpClientConfiguration;
-import io.gravitee.elasticsearch.client.http.HttpClientJksSslConfiguration;
-import io.gravitee.elasticsearch.client.http.HttpClientPemSslConfiguration;
-import io.gravitee.elasticsearch.client.http.HttpClientPfxSslConfiguration;
 import io.gravitee.elasticsearch.exception.ElasticsearchException;
 import io.gravitee.elasticsearch.index.ILMIndexNameGenerator;
 import io.gravitee.elasticsearch.index.IndexNameGenerator;
@@ -31,7 +25,9 @@ import io.gravitee.elasticsearch.index.MultiTypeIndexNameGenerator;
 import io.gravitee.elasticsearch.index.PerTypeIndexNameGenerator;
 import io.gravitee.elasticsearch.templating.freemarker.FreeMarkerComponent;
 import io.gravitee.elasticsearch.version.ElasticsearchInfo;
+import io.gravitee.platform.repository.api.Scope;
 import io.gravitee.repository.elasticsearch.analytics.spring.AnalyticsConfiguration;
+import io.gravitee.repository.elasticsearch.client.ElasticsearchHttpClientFactory;
 import io.gravitee.repository.elasticsearch.configuration.RepositoryConfiguration;
 import io.gravitee.repository.elasticsearch.healthcheck.spring.HealthCheckConfiguration;
 import io.gravitee.repository.elasticsearch.log.spring.LogConfiguration;
@@ -45,6 +41,7 @@ import lombok.CustomLog;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
+import org.springframework.core.env.Environment;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
@@ -83,46 +80,11 @@ public class ElasticsearchRepositoryConfiguration {
     }
 
     @Bean
-    public Client client(RepositoryConfiguration repositoryConfiguration) {
-        HttpClientConfiguration clientConfiguration = new HttpClientConfiguration();
-        clientConfiguration.setEndpoints(repositoryConfiguration.getEndpoints());
-        clientConfiguration.setUsername(repositoryConfiguration.getUsername());
-        clientConfiguration.setPassword(repositoryConfiguration.getPassword());
-        clientConfiguration.setRequestTimeout(repositoryConfiguration.getRequestTimeout());
-
-        clientConfiguration.setProxyType(repositoryConfiguration.getProxyType());
-        clientConfiguration.setProxyHttpHost(repositoryConfiguration.getProxyHttpHost());
-        clientConfiguration.setProxyHttpPort(repositoryConfiguration.getProxyHttpPort());
-        clientConfiguration.setProxyHttpUsername(repositoryConfiguration.getProxyHttpUsername());
-        clientConfiguration.setProxyHttpPassword(repositoryConfiguration.getProxyHttpPassword());
-        clientConfiguration.setProxyHttpsHost(repositoryConfiguration.getProxyHttpsHost());
-        clientConfiguration.setProxyHttpsPort(repositoryConfiguration.getProxyHttpsPort());
-        clientConfiguration.setProxyHttpsUsername(repositoryConfiguration.getProxyHttpsUsername());
-        clientConfiguration.setProxyHttpsPassword(repositoryConfiguration.getProxyHttpsPassword());
-        clientConfiguration.setProxyConfigured(repositoryConfiguration.isProxyConfigured());
-
-        if (repositoryConfiguration.getSslKeystoreType() != null) {
-            if (repositoryConfiguration.getSslKeystoreType().equalsIgnoreCase(ClientSslConfiguration.JKS_KEYSTORE_TYPE)) {
-                clientConfiguration.setSslConfig(
-                    new HttpClientJksSslConfiguration(
-                        repositoryConfiguration.getSslKeystore(),
-                        repositoryConfiguration.getSslKeystorePassword()
-                    )
-                );
-            } else if (repositoryConfiguration.getSslKeystoreType().equalsIgnoreCase(ClientSslConfiguration.PFX_KEYSTORE_TYPE)) {
-                clientConfiguration.setSslConfig(
-                    new HttpClientPfxSslConfiguration(
-                        repositoryConfiguration.getSslKeystore(),
-                        repositoryConfiguration.getSslKeystorePassword()
-                    )
-                );
-            } else if (repositoryConfiguration.getSslKeystoreType().equalsIgnoreCase(ClientSslConfiguration.PEM_KEYSTORE_TYPE)) {
-                clientConfiguration.setSslConfig(
-                    new HttpClientPemSslConfiguration(repositoryConfiguration.getSslPemCerts(), repositoryConfiguration.getSslPemKeys())
-                );
-            }
-        }
-        return new HttpClient(clientConfiguration);
+    public Client client(Environment environment) {
+        // RepositoryConfiguration still owns analytics' index-naming / ILM / retention concerns and is
+        // injected into other @Beans below; the client wiring is now scope-prefixed (analytics.elasticsearch.*)
+        // through the shared factory, mirroring how the OTEL_TRACES scope reads otel-traces.elasticsearch.*.
+        return new ElasticsearchHttpClientFactory(environment, Scope.ANALYTICS.getName()).createHttpClient();
     }
 
     @Bean

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/tracing/ElasticsearchTracingRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/tracing/ElasticsearchTracingRepository.java
@@ -1,0 +1,567 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.elasticsearch.tracing;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.gravitee.elasticsearch.client.Client;
+import io.gravitee.elasticsearch.model.Aggregation;
+import io.gravitee.elasticsearch.model.SearchHit;
+import io.gravitee.elasticsearch.model.SearchResponse;
+import io.gravitee.elasticsearch.utils.IndexNameUtils;
+import io.gravitee.repository.common.query.QueryContext;
+import io.gravitee.repository.tracing.api.TracingRepository;
+import io.gravitee.repository.tracing.model.Trace;
+import io.gravitee.repository.tracing.model.TraceSearchCriteria;
+import io.gravitee.repository.tracing.model.TraceSpan;
+import io.gravitee.repository.tracing.model.TraceSpanEvent;
+import io.reactivex.rxjava3.core.Maybe;
+import io.reactivex.rxjava3.core.Single;
+import java.time.Instant;
+import java.time.format.DateTimeParseException;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import lombok.CustomLog;
+
+/**
+ * Elasticsearch-backed {@link TracingRepository} reading spans written by the OpenTelemetry Collector's
+ * {@code elasticsearch} exporter in {@code mapping.mode: otel} (snake_case fields: {@code trace_id},
+ * {@code span_id}, {@code parent_span_id}, {@code @timestamp}, {@code duration}, {@code status.code},
+ * {@code attributes.*}, {@code resource.attributes.*}, {@code events[]}).
+ * <p>
+ * Tenancy: the configured index template (default {@code traces-apim.otel-{orgId}}) is resolved against the caller's
+ * {@link QueryContext} before each search — operators are expected to point the OTel collector at the matching
+ * per-tenant index/data stream.
+ *
+ * @author GraviteeSource Team
+ */
+@CustomLog
+public class ElasticsearchTracingRepository implements TracingRepository {
+
+    private static final int MAX_SPANS_PER_TRACE = 1000;
+
+    /**
+     * Hard cap on the trace-id terms aggregation size. ES {@code search.max_buckets} defaults to 10 000 and a
+     * caller-supplied {@code criteria.limit()} larger than that returns a {@code circuit_breaking_exception} from
+     * the coordinator. 200 keeps the UI's listing fast while staying well under the bucket limit.
+     */
+    private static final int MAX_SEARCH_RESULTS = 200;
+
+    /** Span-attribute key set by both backends so callers don't have to know about backend-specific status fields. */
+    private static final String OTEL_STATUS_CODE_ATTR = "otel.status_code";
+
+    private static final JsonNodeFactory JSON = JsonNodeFactory.instance;
+
+    private final String indexTemplate;
+    private final Client client;
+
+    public ElasticsearchTracingRepository(String indexTemplate, Client client) {
+        this.indexTemplate = indexTemplate;
+        this.client = client;
+    }
+
+    @Override
+    public Single<List<Trace>> searchTraces(QueryContext queryContext, TraceSearchCriteria criteria) {
+        String index = resolveIndex(indexTemplate, queryContext);
+        String body = buildSearchTracesBody(criteria);
+        return client.search(index, null, body).map(ElasticsearchTracingRepository::parseSearchTracesResponse);
+    }
+
+    @Override
+    public Maybe<Trace> getTrace(QueryContext queryContext, String traceId, Map<String, String> resourceAttributeFilters) {
+        Map<String, String> safeFilters = resourceAttributeFilters == null ? Map.of() : resourceAttributeFilters;
+        String index = resolveIndex(indexTemplate, queryContext);
+        String body = buildGetTraceBody(traceId, safeFilters);
+        // Span events live in a separate OTel "logs" data stream (the collector elasticsearch exporter forces
+        // {@code data_stream.type = logs} for events regardless of the pipeline they arrived on). Fetching and
+        // stitching them is the LogsRepository's job — handled in a follow-up PR; this repo only returns spans.
+        return client
+            .search(index, null, body)
+            .flatMapMaybe(response -> {
+                Trace trace = parseGetTraceResponse(traceId, response);
+                return trace == null ? Maybe.empty() : Maybe.just(trace);
+            });
+    }
+
+    private String resolveIndex(String template, QueryContext queryContext) {
+        // Mirrors the analytics plugin's index-naming convention: IndexNameUtils.format substitutes
+        // {orgId} / {envId} with the lowercased values from QueryContext.placeholder(). ES data streams
+        // require lowercase names — the OTel collector writes to lowercase too, so a caller orgId of
+        // "DEFAULT" resolves to traces-apim.otel-default, not -DEFAULT.
+        return IndexNameUtils.format(template, queryContext.placeholder());
+    }
+
+    /**
+     * Composes a {@code _search} body that:
+     * <ul>
+     *   <li>filters by time window + attribute filters + resource-attribute filters (env, module, …);</li>
+     *   <li>aggregates by {@code trace_id} (terms agg) ordered by min start time desc, sized to the criteria limit;</li>
+     *   <li>nests a {@code top_hits} sub-agg sorted parent-first to grab the root span's summary fields,
+     *       a {@code min(@timestamp)} for the trace start, and a {@code filter} agg counting error-status spans.</li>
+     * </ul>
+     */
+    static String buildSearchTracesBody(TraceSearchCriteria criteria) {
+        ObjectNode root = JSON.objectNode();
+        root.put("size", 0);
+        root.set("query", buildQuery(criteria));
+
+        ObjectNode aggs = JSON.objectNode();
+        ObjectNode tracesAgg = JSON.objectNode();
+        ObjectNode termsAgg = JSON.objectNode();
+        termsAgg.put("field", "trace_id");
+        // Bound caller-supplied limit so a runaway value can't trip ES's max_buckets circuit breaker.
+        termsAgg.put("size", Math.min(criteria.limit(), MAX_SEARCH_RESULTS));
+        ObjectNode order = JSON.objectNode();
+        order.put("trace_start", "desc");
+        termsAgg.set("order", order);
+        tracesAgg.set("terms", termsAgg);
+
+        ObjectNode subAggs = JSON.objectNode();
+        subAggs.set("trace_start", minAgg("@timestamp"));
+        subAggs.set("root_span", rootSpanTopHitsAgg());
+        subAggs.set("error_count", errorFilterAgg());
+        tracesAgg.set("aggs", subAggs);
+
+        aggs.set("traces", tracesAgg);
+        root.set("aggs", aggs);
+        return root.toString();
+    }
+
+    /**
+     * Composes a {@code _search} body for fetch-by-id. The caller-declared {@code resourceAttributeFilters} are
+     * emitted as resource-side {@code term} clauses so a caller in env A doesn't see a trace from env B even if
+     * they know its id — defence in depth on top of the per-tenant index resolved upstream. An empty map means
+     * "no resource scoping" (matches whatever document carries that trace id in the resolved index).
+     */
+    static String buildGetTraceBody(String traceId, Map<String, String> resourceAttributeFilters) {
+        ObjectNode root = JSON.objectNode();
+        root.put("size", MAX_SPANS_PER_TRACE);
+        root.set("query", buildGetTraceQuery(traceId, resourceAttributeFilters));
+
+        ArrayNode sort = JSON.arrayNode();
+        ObjectNode sortField = JSON.objectNode();
+        ObjectNode order = JSON.objectNode();
+        order.put("order", "asc");
+        sortField.set("@timestamp", order);
+        sort.add(sortField);
+        root.set("sort", sort);
+        return root.toString();
+    }
+
+    private static ObjectNode buildGetTraceQuery(String traceId, Map<String, String> resourceAttributeFilters) {
+        if (resourceAttributeFilters.isEmpty()) {
+            ObjectNode query = JSON.objectNode();
+            ObjectNode term = JSON.objectNode();
+            term.put("trace_id", traceId);
+            query.set("term", term);
+            return query;
+        }
+        ArrayNode filters = JSON.arrayNode();
+        ObjectNode traceIdTerm = JSON.objectNode();
+        ObjectNode traceIdInner = JSON.objectNode();
+        traceIdInner.put("trace_id", traceId);
+        traceIdTerm.set("term", traceIdInner);
+        filters.add(traceIdTerm);
+        for (Map.Entry<String, String> entry : resourceAttributeFilters.entrySet()) {
+            filters.add(buildResourceTermFilter(entry.getKey(), entry.getValue()));
+        }
+        ObjectNode bool = JSON.objectNode();
+        bool.set("filter", filters);
+        ObjectNode query = JSON.objectNode();
+        query.set("bool", bool);
+        return query;
+    }
+
+    private static ObjectNode buildQuery(TraceSearchCriteria criteria) {
+        ObjectNode bool = JSON.objectNode();
+        ArrayNode filter = JSON.arrayNode();
+
+        if (criteria.start() != null || criteria.end() != null) {
+            ObjectNode rangeFilter = JSON.objectNode();
+            ObjectNode range = JSON.objectNode();
+            ObjectNode timestampRange = JSON.objectNode();
+            if (criteria.start() != null) {
+                timestampRange.put("gte", criteria.start().toString());
+            }
+            if (criteria.end() != null) {
+                timestampRange.put("lte", criteria.end().toString());
+            }
+            range.set("@timestamp", timestampRange);
+            rangeFilter.set("range", range);
+            filter.add(rangeFilter);
+        }
+
+        for (Map.Entry<String, String> tag : criteria.attributeFilters().entrySet()) {
+            filter.add(buildTagTermFilter(tag.getKey(), tag.getValue()));
+        }
+
+        // Caller-declared resource-attribute filters are emitted on resource.attributes.<key> unconditionally —
+        // no prefix heuristics or hardcoded key lists. Anything the caller says is a resource filter, is one.
+        for (Map.Entry<String, String> entry : criteria.resourceAttributeFilters().entrySet()) {
+            filter.add(buildResourceTermFilter(entry.getKey(), entry.getValue()));
+        }
+
+        if (filter.isEmpty()) {
+            ObjectNode matchAll = JSON.objectNode();
+            matchAll.set("match_all", JSON.objectNode());
+            return matchAll;
+        }
+        bool.set("filter", filter);
+        ObjectNode query = JSON.objectNode();
+        query.set("bool", bool);
+        return query;
+    }
+
+    private static ObjectNode buildResourceTermFilter(String key, String value) {
+        ObjectNode termFilter = JSON.objectNode();
+        ObjectNode term = JSON.objectNode();
+        term.put("resource.attributes." + key, value);
+        termFilter.set("term", term);
+        return termFilter;
+    }
+
+    /**
+     * Span-attribute filter — always targets {@code attributes.<key>}, no key-prefix heuristics. Callers that
+     * need to match on {@code resource.attributes.*} (service identity, env, module, …) must declare those via
+     * {@link TraceSearchCriteria#resourceAttributeFilters()}; mis-routing a {@code service.name} filter into the
+     * span-attribute namespace would silently return zero results.
+     */
+    private static ObjectNode buildTagTermFilter(String key, String value) {
+        ObjectNode termFilter = JSON.objectNode();
+        ObjectNode term = JSON.objectNode();
+        term.put("attributes." + key, value);
+        termFilter.set("term", term);
+        return termFilter;
+    }
+
+    private static ObjectNode minAgg(String field) {
+        ObjectNode agg = JSON.objectNode();
+        ObjectNode min = JSON.objectNode();
+        min.put("field", field);
+        agg.set("min", min);
+        return agg;
+    }
+
+    private static ObjectNode rootSpanTopHitsAgg() {
+        ObjectNode agg = JSON.objectNode();
+        ObjectNode topHits = JSON.objectNode();
+        topHits.put("size", 1);
+        // Spans without a parent_span_id sort first, then by earliest @timestamp — covers the common case where a
+        // trace has exactly one root and the rare case where a missing parent_span_id is omitted entirely.
+        ArrayNode sort = JSON.arrayNode();
+        ObjectNode parentSort = JSON.objectNode();
+        ObjectNode parentSortOrder = JSON.objectNode();
+        parentSortOrder.put("order", "asc");
+        parentSortOrder.put("missing", "_first");
+        parentSort.set("parent_span_id", parentSortOrder);
+        sort.add(parentSort);
+        ObjectNode timestampSort = JSON.objectNode();
+        ObjectNode timestampSortOrder = JSON.objectNode();
+        timestampSortOrder.put("order", "asc");
+        timestampSort.set("@timestamp", timestampSortOrder);
+        sort.add(timestampSort);
+        topHits.set("sort", sort);
+        agg.set("top_hits", topHits);
+        return agg;
+    }
+
+    private static ObjectNode errorFilterAgg() {
+        ObjectNode agg = JSON.objectNode();
+        ObjectNode filter = JSON.objectNode();
+        ObjectNode terms = JSON.objectNode();
+        ArrayNode values = JSON.arrayNode();
+        // The OTel ES exporter has shipped the status field as the short ("Error"), the proto-enum
+        // ("STATUS_CODE_ERROR"), or the numeric ("2") form across versions; accept all three so the bucket
+        // count stays correct regardless of which collector build the operator runs. Mirrors the per-span
+        // normalisation in normalizeStatusCode.
+        values.add("Error");
+        values.add("STATUS_CODE_ERROR");
+        values.add("2");
+        terms.set("status.code", values);
+        filter.set("terms", terms);
+        agg.set("filter", filter);
+        return agg;
+    }
+
+    private static List<Trace> parseSearchTracesResponse(SearchResponse response) {
+        if (response.getAggregations() == null) {
+            return List.of();
+        }
+        Aggregation tracesAgg = response.getAggregations().get("traces");
+        if (tracesAgg == null || tracesAgg.getBuckets() == null) {
+            return List.of();
+        }
+
+        List<Trace> traces = new ArrayList<>(tracesAgg.getBuckets().size());
+        for (JsonNode bucket : tracesAgg.getBuckets()) {
+            Trace trace = parseTraceBucket(bucket);
+            if (trace != null) {
+                traces.add(trace);
+            }
+        }
+        return traces;
+    }
+
+    private static Trace parseTraceBucket(JsonNode bucket) {
+        String traceId = textOrNull(bucket.get("key"));
+        if (traceId == null) {
+            return null;
+        }
+
+        Instant traceStart = parseInstant(bucket.path("trace_start").path("value_as_string"));
+
+        JsonNode rootHits = bucket.path("root_span").path("hits").path("hits");
+        if (!rootHits.isArray() || rootHits.isEmpty()) {
+            return null;
+        }
+        JsonNode rootSource = rootHits.get(0).path("_source");
+
+        String rootService = readResourceServiceName(rootSource);
+        String rootOperation = textOrNull(rootSource.get("name"));
+        long durationNanos = rootSource.path("duration").asLong(0L);
+
+        boolean hasError = bucket.path("error_count").path("doc_count").asLong(0L) > 0L;
+
+        return new Trace(traceId, traceStart, durationNanos, rootService, rootOperation, hasError, List.of());
+    }
+
+    private static Trace parseGetTraceResponse(String traceId, SearchResponse response) {
+        if (
+            response.getSearchHits() == null || response.getSearchHits().getHits() == null || response.getSearchHits().getHits().isEmpty()
+        ) {
+            return null;
+        }
+
+        List<TraceSpan> spans = new ArrayList<>(response.getSearchHits().getHits().size());
+        boolean hasError = false;
+        TraceSpan rootSpan = null;
+        for (SearchHit hit : response.getSearchHits().getHits()) {
+            JsonNode source = hit.getSource();
+            if (source == null) {
+                continue;
+            }
+            TraceSpan span = parseSpan(source);
+            spans.add(span);
+            if (rootSpan == null && (span.parentSpanId() == null || span.parentSpanId().isEmpty())) {
+                rootSpan = span;
+            }
+            if ("ERROR".equals(span.attributes().get(OTEL_STATUS_CODE_ATTR))) {
+                hasError = true;
+            }
+        }
+
+        if (rootSpan == null) {
+            // No span has an empty parent — fall back to the earliest by start time so the trace summary still resolves.
+            rootSpan = spans
+                .stream()
+                .min(Comparator.comparing(TraceSpan::startTime, Comparator.nullsLast(Comparator.naturalOrder())))
+                .orElse(null);
+        }
+
+        Instant traceStart = rootSpan != null ? rootSpan.startTime() : null;
+        long durationNanos = rootSpan != null ? rootSpan.durationNanos() : 0L;
+        String rootService = rootSpan != null ? rootSpan.serviceName() : null;
+        String rootOperation = rootSpan != null ? rootSpan.operationName() : null;
+
+        return new Trace(traceId, traceStart, durationNanos, rootService, rootOperation, hasError, spans);
+    }
+
+    private static TraceSpan parseSpan(JsonNode source) {
+        String traceId = textOrNull(source.get("trace_id"));
+        String spanId = textOrNull(source.get("span_id"));
+        String parentSpanId = textOrNull(source.get("parent_span_id"));
+        String operationName = textOrNull(source.get("name"));
+        String serviceName = readResourceServiceName(source);
+        Instant startTime = parseInstant(source.path("@timestamp"));
+        long durationNanos = source.path("duration").asLong(0L);
+        Map<String, String> attributes = flattenStringMap(source.path("attributes"), "");
+        // Mirror the node-side Tempo impl: copy the OTLP status into a stable span attribute (UNSET/OK/ERROR) so a
+        // UI / contract caller doesn't have to know about backend-specific status fields. The OTel collector
+        // exporter writes status.code as either the short form ("Error") or the proto enum ("STATUS_CODE_ERROR"),
+        // and either as a flat dotted key or a nested object — normalizeStatusCode handles both shapes.
+        String statusCode = normalizeStatusCode(source);
+        if (statusCode != null) {
+            attributes.put(OTEL_STATUS_CODE_ATTR, statusCode);
+        }
+        List<TraceSpanEvent> events = parseEvents(source.path("events"));
+        return TraceSpan.of(traceId, spanId, parentSpanId, operationName, serviceName, startTime, durationNanos, attributes, events);
+    }
+
+    /**
+     * Reads the OTLP status code from an ES document in any of the formats the collector might write:
+     * <ul>
+     *   <li>nested object: {@code "status": {"code": "Error"}} (OTel mapping mode, recent versions)</li>
+     *   <li>flat dotted key: {@code "status.code": "Error"} (some older / flattened mappings)</li>
+     * </ul>
+     * The value is normalised to the proto-enum-suffix form ({@code UNSET}/{@code OK}/{@code ERROR}) regardless of
+     * whether the source carried the short form ({@code Error}) or the long form ({@code STATUS_CODE_ERROR}).
+     * Returns {@code null} when the field is absent — callers should treat that as "unset / unknown".
+     */
+    private static String normalizeStatusCode(JsonNode source) {
+        String raw = textOrNull(source.path("status").path("code"));
+        if (raw == null) {
+            raw = textOrNull(source.get("status.code"));
+        }
+        if (raw == null) {
+            return null;
+        }
+        return switch (raw) {
+            case "Error", "STATUS_CODE_ERROR", "2" -> "ERROR";
+            case "Ok", "STATUS_CODE_OK", "1" -> "OK";
+            case "Unset", "STATUS_CODE_UNSET", "0" -> "UNSET";
+            default -> raw;
+        };
+    }
+
+    private static List<TraceSpanEvent> parseEvents(JsonNode eventsNode) {
+        if (!eventsNode.isArray() || eventsNode.isEmpty()) {
+            // ArrayList (not List.of()) so a future LogsRepository pass can append events fetched from the
+            // separate OTel logs data stream — the collector in mapping.mode: otel writes span events there
+            // rather than inline, so the inline array is usually empty.
+            return new ArrayList<>();
+        }
+        List<TraceSpanEvent> events = new ArrayList<>(eventsNode.size());
+        for (JsonNode eventNode : eventsNode) {
+            String name = textOrNull(eventNode.get("name"));
+            // OTel mode writes the event time under "timestamp"; some collector versions also emit "time".
+            Instant time = parseInstant(eventNode.path("timestamp"));
+            if (time == null) {
+                time = parseInstant(eventNode.path("time"));
+            }
+            Map<String, String> attributes = flattenStringMap(eventNode.path("attributes"), "");
+            events.add(new TraceSpanEvent(name, time, attributes));
+        }
+        return events;
+    }
+
+    /**
+     * OTel-mode documents store {@code attributes} either as a JSON object (newer collector versions) or as an
+     * array of {@code {key, value}} pairs (older versions). This walks both into a flat key→string map; nested
+     * objects are dot-flattened (e.g. {@code http.status_code = "200"}).
+     */
+    private static Map<String, String> flattenStringMap(JsonNode node, String prefix) {
+        Map<String, String> result = new HashMap<>();
+        if (node == null || node.isMissingNode() || node.isNull()) {
+            return result;
+        }
+        if (node.isObject()) {
+            Iterator<Map.Entry<String, JsonNode>> it = node.fields();
+            while (it.hasNext()) {
+                Map.Entry<String, JsonNode> entry = it.next();
+                String key = prefix.isEmpty() ? entry.getKey() : prefix + "." + entry.getKey();
+                JsonNode value = entry.getValue();
+                if (value.isObject()) {
+                    result.putAll(flattenStringMap(value, key));
+                } else if (!value.isNull()) {
+                    result.put(key, value.asText());
+                }
+            }
+        } else if (node.isArray()) {
+            for (JsonNode element : node) {
+                JsonNode keyNode = element.get("key");
+                JsonNode valueNode = element.get("value");
+                if (keyNode == null || valueNode == null) {
+                    continue;
+                }
+                String key = prefix.isEmpty() ? keyNode.asText() : prefix + "." + keyNode.asText();
+                // OTLP/JSON shape: { "key": "...", "value": { "stringValue": "..." } | { "intValue": ... } | ... }
+                JsonNode unwrapped = unwrapOtlpValue(valueNode);
+                if (unwrapped != null && !unwrapped.isNull()) {
+                    result.put(key, unwrapped.asText());
+                }
+            }
+        }
+        return result;
+    }
+
+    private static JsonNode unwrapOtlpValue(JsonNode valueNode) {
+        if (valueNode.isObject()) {
+            for (String typedField : List.of("stringValue", "intValue", "doubleValue", "boolValue")) {
+                JsonNode typed = valueNode.get(typedField);
+                if (typed != null && !typed.isNull()) {
+                    return typed;
+                }
+            }
+            return null;
+        }
+        return valueNode;
+    }
+
+    /**
+     * The OTel collector's elasticsearch exporter (mapping.mode: otel) writes resource attributes as a flat map of
+     * dotted keys, so {@code service.name} arrives at {@code resource.attributes["service.name"]} — i.e. the dot is
+     * part of the JSON key, not a nesting boundary. Older nested-object encodings ({@code resource.attributes.service.name})
+     * are still around in some pipelines, so check both shapes.
+     */
+    private static String readResourceServiceName(JsonNode source) {
+        JsonNode flat = source.path("resource").path("attributes").get("service.name");
+        if (flat != null && !flat.isMissingNode() && !flat.isNull()) {
+            return flat.asText();
+        }
+        return textOrNull(source.path("resource").path("attributes").path("service").path("name"));
+    }
+
+    private static String textOrNull(JsonNode node) {
+        if (node == null || node.isMissingNode() || node.isNull()) {
+            return null;
+        }
+        return node.asText();
+    }
+
+    private static Instant parseInstant(JsonNode node) {
+        String text = textOrNull(node);
+        if (text == null) {
+            return null;
+        }
+        try {
+            return Instant.parse(text);
+        } catch (DateTimeParseException e) {
+            // The OTel collector's elasticsearch exporter (otel mapping mode) writes @timestamp as
+            // "<epoch-millis>.<sub-ms-digits>" (e.g. "1778515640168.675208") — epoch ms with sub-millisecond
+            // fractional digits, NOT an ISO 8601 instant. Older collectors emit plain integer epoch ms. Split on
+            // the decimal point and parse each side as Long so we keep full precision (Double would lose digits
+            // past ~15 significant figures, drifting the resulting Instant by tens of nanoseconds).
+            return parseEpochMillisDecimalString(text);
+        }
+    }
+
+    private static Instant parseEpochMillisDecimalString(String text) {
+        try {
+            int dot = text.indexOf('.');
+            if (dot < 0) {
+                return Instant.ofEpochMilli(Long.parseLong(text));
+            }
+            long epochMillis = Long.parseLong(text.substring(0, dot));
+            String fractionalMs = text.substring(dot + 1);
+            // Sub-millisecond digits: pad / truncate to 6 chars and interpret as the nano-suffix below the ms.
+            // "675208" → 675208 ns past the millisecond boundary; "67" → 670000 ns; "67520823" → 675208 ns.
+            String padded = (fractionalMs + "000000").substring(0, 6);
+            long extraNanos = Long.parseLong(padded);
+            return Instant.ofEpochMilli(epochMillis).plusNanos(extraNanos);
+        } catch (NumberFormatException ex) {
+            // Silently returning null would let spans render with null startTime — the trace then sorts wrong
+            // and the root-span fallback kicks in without any signal. Warn so operators can diagnose by grep.
+            log.warn("Unexpected @timestamp format, span timestamp will be null: '{}'", text);
+            return null;
+        }
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/tracing/spring/TracingConfiguration.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/tracing/spring/TracingConfiguration.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.elasticsearch.tracing.spring;
+
+import io.gravitee.elasticsearch.client.Client;
+import io.gravitee.platform.repository.api.Scope;
+import io.gravitee.repository.elasticsearch.client.ElasticsearchHttpClientFactory;
+import io.gravitee.repository.elasticsearch.spring.ElasticsearchRepositoryConfiguration;
+import io.gravitee.repository.elasticsearch.tracing.ElasticsearchTracingRepository;
+import io.gravitee.repository.tracing.api.TracingRepository;
+import io.vertx.rxjava3.core.Vertx;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
+
+/**
+ * Spring configuration loaded for the {@code OTEL_TRACES} scope. Self-contained on purpose — the platform's
+ * repository plugin handler creates one application context per scope and promotes its singletons into the parent
+ * bean factory; if this class shared bean names with {@link ElasticsearchRepositoryConfiguration} (the
+ * {@code ANALYTICS} config), starting MAPI with both scopes pointed at this plugin would fail with
+ * "there is already object […] bound under bean name 'client'".
+ * <p>
+ * Connection settings (endpoints, credentials, SSL, proxy) and the index template live under the dedicated
+ * {@code otel-traces.elasticsearch.*} property block — no fallback to {@code analytics.elasticsearch.*}, so
+ * tracing can be enabled even when analytics targets a different repository (Mongo, JDBC, none). The actual
+ * property reads happen inside {@link ElasticsearchHttpClientFactory}, scoped by
+ * {@link Scope#OTEL_TRACES}.{@code getName()} — mirrors the per-scope factory pattern used by the Redis plugin
+ * for its rate-limit and distributed-sync scopes.
+ *
+ * @author GraviteeSource Team
+ */
+@Configuration
+public class TracingConfiguration {
+
+    @Bean
+    public Vertx tracingVertxRx(io.vertx.core.Vertx vertx) {
+        return Vertx.newInstance(vertx);
+    }
+
+    @Bean
+    public Client tracingClient(Environment environment) {
+        return new ElasticsearchHttpClientFactory(environment, Scope.OTEL_TRACES.getName()).createHttpClient();
+    }
+
+    @Bean
+    public TracingRepository tracingRepository(
+        @Value("${otel-traces.elasticsearch.index:traces-apim.otel-{orgId}}") String indexTemplate,
+        Client tracingClient
+    ) {
+        return new ElasticsearchTracingRepository(indexTemplate, tracingClient);
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/ElasticsearchRepositoryProviderTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/ElasticsearchRepositoryProviderTest.java
@@ -34,14 +34,16 @@ public class ElasticsearchRepositoryProviderTest {
     }
 
     @Test
-    public void shouldReturnAnalyticsScope() {
-        assertThat(provider.scopes()).containsExactly(Scope.ANALYTICS);
+    public void shouldReturnAnalyticsAndTracingScopes() {
+        assertThat(provider.scopes()).containsExactly(Scope.ANALYTICS, Scope.OTEL_TRACES);
     }
 
     @Test
     public void shouldReturnElasticSearchConfigurationClass() {
-        Class<?> configClass = provider.configuration(Scope.ANALYTICS);
-        assertThat(configClass).isEqualTo(ElasticsearchRepositoryConfiguration.class);
+        assertThat(provider.configuration(Scope.ANALYTICS)).isEqualTo(ElasticsearchRepositoryConfiguration.class);
+        assertThat(provider.configuration(Scope.OTEL_TRACES)).isEqualTo(
+            io.gravitee.repository.elasticsearch.tracing.spring.TracingConfiguration.class
+        );
     }
 
     @Test

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/client/ElasticsearchHttpClientFactoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/client/ElasticsearchHttpClientFactoryTest.java
@@ -1,0 +1,183 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.elasticsearch.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.elasticsearch.client.http.HttpClientConfiguration;
+import io.gravitee.elasticsearch.client.http.HttpClientJksSslConfiguration;
+import io.gravitee.elasticsearch.client.http.HttpClientPemSslConfiguration;
+import io.gravitee.elasticsearch.client.http.HttpClientPfxSslConfiguration;
+import io.gravitee.elasticsearch.config.Endpoint;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.env.MockEnvironment;
+
+class ElasticsearchHttpClientFactoryTest {
+
+    private static final String SCOPE_NAME = "otel-traces";
+    private static final String PROPERTY_PREFIX = SCOPE_NAME + ".elasticsearch.";
+
+    private MockEnvironment environment;
+    private ElasticsearchHttpClientFactory factory;
+
+    @BeforeEach
+    void setUp() {
+        environment = new MockEnvironment();
+        factory = new ElasticsearchHttpClientFactory(environment, SCOPE_NAME);
+    }
+
+    @Test
+    void should_default_to_localhost_endpoint_when_none_configured() {
+        // Local dev / unit tests shouldn't need a property file just to spin up a client — the factory
+        // falls back to the canonical localhost endpoint when no indexed endpoints[] block was set.
+        HttpClientConfiguration cfg = new TestElasticsearchHttpClientFactory(environment, SCOPE_NAME).buildHttpClientConfiguration();
+
+        assertThat(cfg.getEndpoints()).extracting(Endpoint::getUrl).containsExactly("http://localhost:9200");
+    }
+
+    @Test
+    void should_read_endpoint_credentials_and_timeout_from_scoped_property_prefix() {
+        // The full property prefix is "<scopeName>.elasticsearch." — pin every connection setting against
+        // it so a future rename of the suffix (e.g. "endpoints" → "hosts") fails this test loudly instead
+        // of silently dropping credentials in production.
+        environment.setProperty(PROPERTY_PREFIX + "endpoints[0]", "http://es-a:9200");
+        environment.setProperty(PROPERTY_PREFIX + "endpoints[1]", "http://es-b:9200");
+        environment.setProperty(PROPERTY_PREFIX + "security.username", "user");
+        environment.setProperty(PROPERTY_PREFIX + "security.password", "pass");
+        environment.setProperty(PROPERTY_PREFIX + "http.timeout", "7500");
+
+        HttpClientConfiguration cfg = new TestElasticsearchHttpClientFactory(environment, SCOPE_NAME).buildHttpClientConfiguration();
+
+        assertThat(cfg.getEndpoints()).extracting(Endpoint::getUrl).containsExactly("http://es-a:9200", "http://es-b:9200");
+        assertThat(cfg.getUsername()).isEqualTo("user");
+        assertThat(cfg.getPassword()).isEqualTo("pass");
+        assertThat(cfg.getRequestTimeout()).isEqualTo(7500L);
+    }
+
+    @Test
+    void should_wire_jks_ssl_when_keystore_type_is_jks() {
+        // JKS branch — the factory must build the matching SslConfiguration subclass so the underlying
+        // transport actually negotiates with the right keystore type.
+        environment.setProperty(PROPERTY_PREFIX + "ssl.keystore.type", "JKS");
+        environment.setProperty(PROPERTY_PREFIX + "ssl.keystore.path", "/path/to/keystore.jks");
+        environment.setProperty(PROPERTY_PREFIX + "ssl.keystore.password", "jksPass");
+
+        HttpClientConfiguration cfg = new TestElasticsearchHttpClientFactory(environment, SCOPE_NAME).buildHttpClientConfiguration();
+
+        assertThat(cfg.getSslConfig()).isInstanceOf(HttpClientJksSslConfiguration.class);
+    }
+
+    @Test
+    void should_wire_pfx_ssl_when_keystore_type_is_pfx() {
+        environment.setProperty(PROPERTY_PREFIX + "ssl.keystore.type", "PFX");
+        environment.setProperty(PROPERTY_PREFIX + "ssl.keystore.path", "/path/to/keystore.pfx");
+        environment.setProperty(PROPERTY_PREFIX + "ssl.keystore.password", "pfxPass");
+
+        HttpClientConfiguration cfg = new TestElasticsearchHttpClientFactory(environment, SCOPE_NAME).buildHttpClientConfiguration();
+
+        assertThat(cfg.getSslConfig()).isInstanceOf(HttpClientPfxSslConfiguration.class);
+    }
+
+    @Test
+    void should_wire_pem_ssl_with_indexed_cert_and_key_paths_when_keystore_type_is_pem() {
+        // PEM keystores carry multiple cert / key paths via indexed property lists. Make sure both
+        // entries flow through so a multi-cert deployment isn't silently truncated.
+        environment.setProperty(PROPERTY_PREFIX + "ssl.keystore.type", "PEM");
+        environment.setProperty(PROPERTY_PREFIX + "ssl.keystore.certs[0]", "/cert-a");
+        environment.setProperty(PROPERTY_PREFIX + "ssl.keystore.certs[1]", "/cert-b");
+        environment.setProperty(PROPERTY_PREFIX + "ssl.keystore.keys[0]", "/key-a");
+
+        HttpClientConfiguration cfg = new TestElasticsearchHttpClientFactory(environment, SCOPE_NAME).buildHttpClientConfiguration();
+
+        assertThat(cfg.getSslConfig()).isInstanceOf(HttpClientPemSslConfiguration.class);
+    }
+
+    @Test
+    void should_leave_ssl_unset_when_keystore_type_is_absent() {
+        // No keystore configured = plaintext HTTP. The factory must NOT default to a JKS/PEM placeholder,
+        // otherwise transport negotiation fails before any request even leaves the gateway.
+        HttpClientConfiguration cfg = new TestElasticsearchHttpClientFactory(environment, SCOPE_NAME).buildHttpClientConfiguration();
+
+        assertThat(cfg.getSslConfig()).isNull();
+    }
+
+    @Test
+    void should_leave_ssl_unset_when_keystore_type_is_unknown() {
+        // Defensive: an unrecognised keystore type (config typo, future SSL type) falls through silently
+        // rather than crashing — operator can fix the property without bouncing the gateway.
+        environment.setProperty(PROPERTY_PREFIX + "ssl.keystore.type", "UNKNOWN");
+
+        HttpClientConfiguration cfg = new TestElasticsearchHttpClientFactory(environment, SCOPE_NAME).buildHttpClientConfiguration();
+
+        assertThat(cfg.getSslConfig()).isNull();
+    }
+
+    @Test
+    void should_mark_proxy_configured_when_any_http_proxy_property_is_present() {
+        // isProxyConfigured drives whether the proxy block is applied at all — if the operator declared
+        // ANY proxy property under http.proxy.*, the client should honour it.
+        environment.setProperty(PROPERTY_PREFIX + "http.proxy.http.host", "proxy.test");
+
+        HttpClientConfiguration cfg = new TestElasticsearchHttpClientFactory(environment, SCOPE_NAME).buildHttpClientConfiguration();
+
+        assertThat(cfg.isProxyConfigured()).isTrue();
+        assertThat(cfg.getProxyHttpHost()).isEqualTo("proxy.test");
+    }
+
+    @Test
+    void should_mark_proxy_unconfigured_when_no_proxy_property_was_set() {
+        // No proxy properties → factory must not assume one. Otherwise traffic would route through the
+        // default localhost:3128 even in operators' production deployments that don't proxy.
+        HttpClientConfiguration cfg = new TestElasticsearchHttpClientFactory(environment, SCOPE_NAME).buildHttpClientConfiguration();
+
+        assertThat(cfg.isProxyConfigured()).isFalse();
+    }
+
+    @Test
+    void should_scope_property_prefix_per_factory_instance() {
+        // Two factories with different scopes don't see each other's properties — the prefix isolation
+        // is what lets analytics and OTEL_TRACES live side-by-side in the same Spring application context.
+        environment.setProperty("analytics.elasticsearch.security.username", "analytics-user");
+        environment.setProperty(PROPERTY_PREFIX + "security.username", "tracing-user");
+
+        HttpClientConfiguration analyticsCfg = new TestElasticsearchHttpClientFactory(
+            environment,
+            "analytics"
+        ).buildHttpClientConfiguration();
+        HttpClientConfiguration tracingCfg = new TestElasticsearchHttpClientFactory(environment, SCOPE_NAME).buildHttpClientConfiguration();
+
+        assertThat(analyticsCfg.getUsername()).isEqualTo("analytics-user");
+        assertThat(tracingCfg.getUsername()).isEqualTo("tracing-user");
+    }
+
+    /**
+     * Test-side subclass exposing the {@code protected buildHttpClientConfiguration()} so we can assert on
+     * the configuration without instantiating a real {@link io.gravitee.elasticsearch.client.http.HttpClient}
+     * (which would try to open Vert.x resources we'd then have to clean up).
+     */
+    private static class TestElasticsearchHttpClientFactory extends ElasticsearchHttpClientFactory {
+
+        TestElasticsearchHttpClientFactory(org.springframework.core.env.Environment environment, String scopeName) {
+            super(environment, scopeName);
+        }
+
+        @Override
+        public HttpClientConfiguration buildHttpClientConfiguration() {
+            return super.buildHttpClientConfiguration();
+        }
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/tracing/ElasticsearchTracingRepositoryIT.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/tracing/ElasticsearchTracingRepositoryIT.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.elasticsearch.tracing;
+
+import io.gravitee.repository.tracing.TracingRepositoryTest;
+
+/**
+ * Runs the shared {@link TracingRepositoryTest} contract against the Elasticsearch implementation: the production
+ * {@link ElasticsearchTracingRepository} queries an Elasticsearch testcontainer fed by an OTel Collector container
+ * (configured for {@code mapping.mode: otel}), with fixtures seeded over OTLP HTTP by
+ * {@link ElasticsearchTracingTestRepositoryInitializer}. {@code ElasticsearchTracingTest*} beans are picked up by
+ * {@code AbstractRepositoryTest}'s {@code .*TestRepository.*} component scan.
+ *
+ * @author GraviteeSource Team
+ */
+public class ElasticsearchTracingRepositoryIT extends TracingRepositoryTest {}

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/tracing/ElasticsearchTracingRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/tracing/ElasticsearchTracingRepositoryTest.java
@@ -1,0 +1,400 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.elasticsearch.tracing;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.gravitee.elasticsearch.client.Client;
+import io.gravitee.elasticsearch.model.Aggregation;
+import io.gravitee.elasticsearch.model.SearchHit;
+import io.gravitee.elasticsearch.model.SearchHits;
+import io.gravitee.elasticsearch.model.SearchResponse;
+import io.gravitee.repository.common.query.QueryContext;
+import io.gravitee.repository.tracing.model.Trace;
+import io.gravitee.repository.tracing.model.TraceSearchCriteria;
+import io.gravitee.repository.tracing.model.TraceSpan;
+import io.reactivex.rxjava3.core.Single;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+
+class ElasticsearchTracingRepositoryTest {
+
+    private static final QueryContext QUERY_CONTEXT = new QueryContext("test-org", "test-env");
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private Client client;
+    private ElasticsearchTracingRepository repository;
+
+    @BeforeEach
+    void setUp() {
+        client = Mockito.mock(Client.class);
+        repository = new ElasticsearchTracingRepository("traces-apim.otel-{orgId}", client);
+    }
+
+    private void stubBackends(SearchResponse traceResponse) {
+        when(client.search(any(), any(), any())).thenReturn(Single.just(traceResponse));
+    }
+
+    @Test
+    void searchTraces_should_substitute_orgId_in_index_and_build_aggregation_query() throws Exception {
+        when(client.search(any(), any(), any())).thenReturn(Single.just(new SearchResponse()));
+
+        // Pin the wire shape: attributeFilters go to attributes.* unconditionally, resourceAttributeFilters
+        // go to resource.attributes.* — no key-prefix heuristics. Service identity (a resource concept) must
+        // be declared explicitly by the caller via resourceAttributeFilters.
+        TraceSearchCriteria criteria = new TraceSearchCriteria(
+            Map.of("http.status_code", "200"),
+            5,
+            Instant.parse("2026-04-30T09:00:00Z"),
+            Instant.parse("2026-04-30T11:00:00Z"),
+            Map.of("service.name", "test-service", "gravitee.environment.id", "test-env")
+        );
+
+        repository.searchTraces(QUERY_CONTEXT, criteria).blockingGet();
+
+        ArgumentCaptor<String> indexCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<String> bodyCaptor = ArgumentCaptor.forClass(String.class);
+        Mockito.verify(client).search(indexCaptor.capture(), eq(null), bodyCaptor.capture());
+
+        assertThat(indexCaptor.getValue()).isEqualTo("traces-apim.otel-test-org");
+
+        JsonNode body = MAPPER.readTree(bodyCaptor.getValue());
+        JsonNode filter = body.path("query").path("bool").path("filter");
+        // Clause order: time range, then attribute filters, then resource-attribute filters.
+        assertThat(filter.get(0).path("range").path("@timestamp").path("gte").asText()).isEqualTo("2026-04-30T09:00:00Z");
+        assertThat(filter.get(1).path("term").path("attributes.http.status_code").asText()).isEqualTo("200");
+        // service.name + gravitee.environment.id both land on resource.attributes.* — gather both into a set
+        // since the resource-filter iteration order is the criteria map's iteration order (unspecified for
+        // Map.of) and we only care about contents, not order.
+        java.util.Map<String, String> resourceClauses = new java.util.HashMap<>();
+        for (int i = 2; i < 4; i++) {
+            JsonNode term = filter.get(i).path("term");
+            term.fields().forEachRemaining(e -> resourceClauses.put(e.getKey(), e.getValue().asText()));
+        }
+        assertThat(resourceClauses)
+            .containsEntry("resource.attributes.service.name", "test-service")
+            .containsEntry("resource.attributes.gravitee.environment.id", "test-env");
+        assertThat(body.path("aggs").path("traces").path("terms").path("field").asText()).isEqualTo("trace_id");
+        assertThat(body.path("aggs").path("traces").path("terms").path("size").asInt()).isEqualTo(5);
+    }
+
+    @Test
+    void searchTraces_should_cap_aggregation_size_when_caller_requests_more_than_max_search_results() throws Exception {
+        // Defensive cap on the terms-agg size: ES coordinator's search.max_buckets defaults to 10 000 and a
+        // larger value is rejected with circuit_breaking_exception. 200 mirrors the impl constant.
+        when(client.search(any(), any(), any())).thenReturn(Single.just(new SearchResponse()));
+
+        TraceSearchCriteria criteria = new TraceSearchCriteria(Map.of(), 100_000, null, null, Map.of());
+
+        repository.searchTraces(QUERY_CONTEXT, criteria).blockingGet();
+
+        ArgumentCaptor<String> bodyCaptor = ArgumentCaptor.forClass(String.class);
+        Mockito.verify(client).search(any(), eq(null), bodyCaptor.capture());
+        JsonNode body = MAPPER.readTree(bodyCaptor.getValue());
+        assertThat(body.path("aggs").path("traces").path("terms").path("size").asInt()).isEqualTo(200);
+    }
+
+    @Test
+    void searchTraces_should_map_aggregation_buckets_to_traces() {
+        SearchResponse response = new SearchResponse();
+        response.setAggregations(Map.of("traces", buildTracesAggregation()));
+        when(client.search(any(), any(), any())).thenReturn(Single.just(response));
+
+        TraceSearchCriteria criteria = new TraceSearchCriteria(Map.of(), 20, null, null, Map.of());
+        List<Trace> traces = repository.searchTraces(QUERY_CONTEXT, criteria).blockingGet();
+
+        assertThat(traces).hasSize(1);
+        Trace trace = traces.get(0);
+        assertThat(trace.traceId()).isEqualTo("a1b2c3d4");
+        assertThat(trace.rootService()).isEqualTo("test-service");
+        assertThat(trace.rootOperation()).isEqualTo("GET /ok");
+        assertThat(trace.durationNanos()).isEqualTo(5_000_000L);
+        assertThat(trace.hasError()).isFalse();
+        assertThat(trace.startTime()).isEqualTo(Instant.parse("2026-04-30T10:00:00Z"));
+        assertThat(trace.spans()).isEmpty();
+    }
+
+    @Test
+    void getTrace_should_wrap_query_in_bool_filter_when_resource_filters_present() throws Exception {
+        SearchResponse response = new SearchResponse();
+        SearchHits hits = new SearchHits();
+        SearchHit hit = new SearchHit();
+        hit.setSource(buildSpanSource());
+        hits.setHits(List.of(hit));
+        response.setSearchHits(hits);
+        stubBackends(response);
+
+        Trace trace = repository.getTrace(QUERY_CONTEXT, "a1b2c3d4", Map.of("gravitee.environment.id", "test-env")).blockingGet();
+
+        ArgumentCaptor<String> bodyCaptor = ArgumentCaptor.forClass(String.class);
+        Mockito.verify(client).search(any(), eq(null), bodyCaptor.capture());
+        JsonNode body = MAPPER.readTree(bodyCaptor.getValue());
+        // With resource filters set, getTrace switches from a top-level term to a bool.filter so both the trace_id
+        // and the resource clauses land in the same query.
+        JsonNode filter = body.path("query").path("bool").path("filter");
+        assertThat(filter.get(0).path("term").path("trace_id").asText()).isEqualTo("a1b2c3d4");
+        assertThat(filter.get(1).path("term").path("resource.attributes.gravitee.environment.id").asText()).isEqualTo("test-env");
+
+        assertThat(trace).isNotNull();
+        assertThat(trace.traceId()).isEqualTo("a1b2c3d4");
+        assertThat(trace.spans()).hasSize(1);
+        TraceSpan span = trace.spans().get(0);
+        assertThat(span.spanId()).isEqualTo("span-1");
+        assertThat(span.serviceName()).isEqualTo("test-service");
+        assertThat(span.attributes()).containsEntry("http.status_code", "200");
+        // OTel status normalised to UNSET/OK/ERROR and injected as a span attribute (mirrors the Tempo impl), so
+        // a UI / contract caller sees the same attribute regardless of which backend serves the request.
+        assertThat(span.attributes()).containsEntry("otel.status_code", "OK");
+        assertThat(span.events()).hasSize(1);
+        assertThat(span.events().get(0).name()).isEqualTo("exception");
+    }
+
+    @Test
+    void getTrace_should_mark_trace_has_error_when_any_span_has_error_short_form_status() {
+        // The OTel ES exporter (otel mapping mode, recent versions) writes status.code as the short form ("Error"),
+        // not the proto-enum-suffix form ("STATUS_CODE_ERROR"). Both must work.
+        SearchResponse response = new SearchResponse();
+        SearchHits hits = new SearchHits();
+        SearchHit hit = new SearchHit();
+        Map<String, Object> source = new HashMap<>();
+        source.put("trace_id", "a1b2c3d4");
+        source.put("span_id", "span-err");
+        source.put("name", "errored");
+        source.put("@timestamp", "2026-04-30T10:00:00Z");
+        source.put("duration", 1L);
+        source.put("status", Map.of("code", "Error"));
+        hit.setSource(MAPPER.valueToTree(source));
+        hits.setHits(List.of(hit));
+        response.setSearchHits(hits);
+        stubBackends(response);
+
+        Trace trace = repository.getTrace(QUERY_CONTEXT, "a1b2c3d4", Map.of()).blockingGet();
+
+        assertThat(trace).isNotNull();
+        assertThat(trace.hasError()).isTrue();
+        assertThat(trace.spans().get(0).attributes()).containsEntry("otel.status_code", "ERROR");
+    }
+
+    @Test
+    void parseInstant_should_handle_otel_epoch_millis_decimal_string() {
+        // OTel ES exporter (otel mapping mode) writes @timestamp as "<epoch-ms>.<sub-ms-digits>" — a decimal-shaped
+        // string of epoch ms with sub-millisecond precision. The parser must extract both pieces to produce a
+        // correct Instant.
+        SearchResponse response = new SearchResponse();
+        SearchHits hits = new SearchHits();
+        SearchHit hit = new SearchHit();
+        Map<String, Object> source = new HashMap<>();
+        source.put("trace_id", "a1b2c3d4");
+        source.put("span_id", "span-1");
+        source.put("name", "POST /proxy");
+        source.put("@timestamp", "1778515640168.675208");
+        source.put("duration", 11107458L);
+        hit.setSource(MAPPER.valueToTree(source));
+        hits.setHits(List.of(hit));
+        response.setSearchHits(hits);
+        stubBackends(response);
+
+        Trace trace = repository.getTrace(QUERY_CONTEXT, "a1b2c3d4", Map.of()).blockingGet();
+
+        assertThat(trace).isNotNull();
+        assertThat(trace.startTime()).isEqualTo(Instant.ofEpochSecond(1778515640L, 168_675_208L));
+        assertThat(trace.spans().get(0).startTime()).isEqualTo(Instant.ofEpochSecond(1778515640L, 168_675_208L));
+    }
+
+    @Test
+    void getTrace_should_complete_empty_when_no_hits() {
+        SearchResponse response = new SearchResponse();
+        SearchHits hits = new SearchHits();
+        hits.setHits(List.of());
+        response.setSearchHits(hits);
+        stubBackends(response);
+
+        Trace trace = repository.getTrace(QUERY_CONTEXT, "missing", Map.of()).blockingGet();
+
+        assertThat(trace).isNull();
+    }
+
+    @Test
+    void resolveIndex_should_lowercase_placeholder_values_to_match_data_stream_convention() {
+        when(client.search(any(), any(), any())).thenReturn(Single.just(new SearchResponse()));
+        // QueryContext orgId comes through as the caller-provided casing — typically "DEFAULT" for the default org.
+        // OTel collectors write to lowercase data-stream names (ES data streams require lowercase), so the index
+        // must resolve to traces-apim.otel-default regardless of input casing.
+        QueryContext upperCase = new QueryContext("DEFAULT", "PROD");
+        ElasticsearchTracingRepository repo = new ElasticsearchTracingRepository("traces-apim.otel-{orgId}-{envId}", client);
+
+        repo.searchTraces(upperCase, new TraceSearchCriteria(Map.of(), 20, null, null, Map.of())).blockingGet();
+
+        ArgumentCaptor<String> indexCaptor = ArgumentCaptor.forClass(String.class);
+        Mockito.verify(client).search(indexCaptor.capture(), eq(null), any());
+        assertThat(indexCaptor.getValue()).isEqualTo("traces-apim.otel-default-prod");
+    }
+
+    @Test
+    void searchTraces_should_emit_resource_attribute_filters_on_resource_side() throws Exception {
+        // resourceAttributeFilters are an explicit caller signal — the impl emits them on resource.attributes.*
+        // without any prefix heuristic or hardcoded key list. Span tags stay on attributes.*.
+        when(client.search(any(), any(), any())).thenReturn(Single.just(new SearchResponse()));
+        TraceSearchCriteria criteria = new TraceSearchCriteria(
+            Map.of("http.method", "GET"),
+            20,
+            null,
+            null,
+            Map.of("gravitee.module", "apim")
+        );
+
+        repository.searchTraces(QUERY_CONTEXT, criteria).blockingGet();
+
+        ArgumentCaptor<String> bodyCaptor = ArgumentCaptor.forClass(String.class);
+        Mockito.verify(client).search(any(), eq(null), bodyCaptor.capture());
+        JsonNode body = MAPPER.readTree(bodyCaptor.getValue());
+        JsonNode filter = body.path("query").path("bool").path("filter");
+        boolean hasResourceModuleFilter = false;
+        boolean hasSpanHttpMethodFilter = false;
+        for (JsonNode clause : filter) {
+            JsonNode term = clause.path("term");
+            if ("apim".equals(term.path("resource.attributes.gravitee.module").asText(null))) hasResourceModuleFilter = true;
+            if ("GET".equals(term.path("attributes.http.method").asText(null))) hasSpanHttpMethodFilter = true;
+        }
+        assertThat(hasResourceModuleFilter).as("gravitee.module → resource.attributes.gravitee.module").isTrue();
+        assertThat(hasSpanHttpMethodFilter).as("http.method → attributes.http.method").isTrue();
+    }
+
+    @Test
+    void searchTraces_should_match_all_when_no_filters_provided() throws Exception {
+        when(client.search(any(), any(), any())).thenReturn(Single.just(new SearchResponse()));
+
+        repository.searchTraces(QUERY_CONTEXT, new TraceSearchCriteria(Map.of(), 20, null, null, Map.of())).blockingGet();
+
+        ArgumentCaptor<String> bodyCaptor = ArgumentCaptor.forClass(String.class);
+        Mockito.verify(client).search(any(), eq(null), bodyCaptor.capture());
+        JsonNode body = MAPPER.readTree(bodyCaptor.getValue());
+        // No time range, no attribute filters, no resource filters → match_all rather than an empty bool.filter
+        // (ES rejects empty filter arrays).
+        assertThat(body.path("query").has("match_all")).isTrue();
+    }
+
+    @Test
+    void getTrace_should_use_top_level_term_when_no_resource_filters() throws Exception {
+        SearchResponse response = new SearchResponse();
+        SearchHits hits = new SearchHits();
+        hits.setHits(List.of());
+        response.setSearchHits(hits);
+        stubBackends(response);
+
+        repository.getTrace(QUERY_CONTEXT, "a1b2c3d4", Map.of()).blockingGet();
+
+        ArgumentCaptor<String> bodyCaptor = ArgumentCaptor.forClass(String.class);
+        Mockito.verify(client).search(any(), eq(null), bodyCaptor.capture());
+        JsonNode body = MAPPER.readTree(bodyCaptor.getValue());
+        // Falls back to the simpler top-level term query — the bool wrapping is only added when resource filters
+        // are present.
+        assertThat(body.path("query").path("term").path("trace_id").asText()).isEqualTo("a1b2c3d4");
+    }
+
+    @Test
+    void searchTraces_should_emit_empty_list_when_aggregation_missing() {
+        SearchResponse response = new SearchResponse();
+        when(client.search(any(), any(), any())).thenReturn(Single.just(response));
+
+        List<Trace> traces = repository
+            .searchTraces(QUERY_CONTEXT, new TraceSearchCriteria(Map.of(), 20, null, null, Map.of()))
+            .blockingGet();
+
+        assertThat(traces).isEmpty();
+    }
+
+    private static Aggregation buildTracesAggregation() {
+        Aggregation traces = new Aggregation();
+        Map<String, Object> bucket = new HashMap<>();
+        bucket.put("key", "a1b2c3d4");
+        Map<String, Object> traceStart = new HashMap<>();
+        traceStart.put("value_as_string", "2026-04-30T10:00:00Z");
+        bucket.put("trace_start", traceStart);
+
+        Map<String, Object> rootSpan = new HashMap<>();
+        Map<String, Object> rootSpanHits = new HashMap<>();
+        Map<String, Object> rootSpanHitsHits = new HashMap<>();
+        Map<String, Object> rootSource = new HashMap<>();
+        rootSource.put("name", "GET /ok");
+        rootSource.put("duration", 5_000_000L);
+        Map<String, Object> resource = new HashMap<>();
+        Map<String, Object> resourceAttributes = new HashMap<>();
+        Map<String, Object> resourceService = new HashMap<>();
+        resourceService.put("name", "test-service");
+        resourceAttributes.put("service", resourceService);
+        resource.put("attributes", resourceAttributes);
+        rootSource.put("resource", resource);
+        rootSpanHitsHits.put("_source", rootSource);
+        rootSpanHits.put("hits", List.of(rootSpanHitsHits));
+        rootSpan.put("hits", rootSpanHits);
+        bucket.put("root_span", rootSpan);
+
+        Map<String, Object> errorCount = new HashMap<>();
+        errorCount.put("doc_count", 0);
+        bucket.put("error_count", errorCount);
+
+        traces.setBuckets(List.of(MAPPER.valueToTree(bucket)));
+        return traces;
+    }
+
+    private static JsonNode buildSpanSource() {
+        Map<String, Object> source = new HashMap<>();
+        source.put("trace_id", "a1b2c3d4");
+        source.put("span_id", "span-1");
+        source.put("name", "GET /ok");
+        source.put("@timestamp", "2026-04-30T10:00:00Z");
+        source.put("duration", 5_000_000L);
+
+        Map<String, Object> attributes = new HashMap<>();
+        attributes.put("http.status_code", "200");
+        source.put("attributes", attributes);
+
+        Map<String, Object> resource = new HashMap<>();
+        Map<String, Object> resourceAttributes = new HashMap<>();
+        Map<String, Object> resourceService = new HashMap<>();
+        resourceService.put("name", "test-service");
+        resourceAttributes.put("service", resourceService);
+        resource.put("attributes", resourceAttributes);
+        source.put("resource", resource);
+
+        Map<String, Object> event = new HashMap<>();
+        event.put("name", "exception");
+        event.put("timestamp", "2026-04-30T10:00:01Z");
+        Map<String, Object> eventAttributes = new HashMap<>();
+        eventAttributes.put("exception.type", "RuntimeException");
+        event.put("attributes", eventAttributes);
+        source.put("events", List.of(event));
+
+        Map<String, Object> status = new HashMap<>();
+        status.put("code", "STATUS_CODE_OK");
+        source.put("status", status);
+
+        return MAPPER.valueToTree(source);
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/tracing/ElasticsearchTracingTestRepositoryConfiguration.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/tracing/ElasticsearchTracingTestRepositoryConfiguration.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.elasticsearch.tracing;
+
+import io.gravitee.elasticsearch.client.Client;
+import io.gravitee.elasticsearch.client.http.HttpClient;
+import io.gravitee.elasticsearch.client.http.HttpClientConfiguration;
+import io.gravitee.elasticsearch.config.Endpoint;
+import io.gravitee.repository.tracing.api.TracingRepository;
+import io.vertx.rxjava3.core.Vertx;
+import java.time.Duration;
+import java.util.List;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.Network;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.elasticsearch.ElasticsearchContainer;
+import org.testcontainers.utility.DockerImageName;
+import org.testcontainers.utility.MountableFile;
+
+/**
+ * Test wiring for {@link io.gravitee.repository.tracing.TracingRepositoryTest} against Elasticsearch.
+ * <p>
+ * Stands up an Elasticsearch container plus an OTel Collector container on a shared docker network — the collector
+ * receives OTLP HTTP from {@link ElasticsearchTracingTestRepositoryInitializer} and writes spans into ES via the
+ * {@code elasticsearch} exporter in {@code mapping.mode: otel}, mirroring the production ingestion path. The
+ * production {@link ElasticsearchTracingRepository} then queries ES through the same {@link HttpClient} pipeline used
+ * at runtime.
+ * <p>
+ * The configured {@code traces_index} ({@code traces-apim.otel-test-org}) matches what the contract test's
+ * {@code QueryContext("test-org", "test-env")} resolves through the {@code traces-apim.otel-{orgId}} template.
+ *
+ * @author GraviteeSource Team
+ */
+@Configuration
+public class ElasticsearchTracingTestRepositoryConfiguration {
+
+    static final String ES_NETWORK_ALIAS = "elasticsearch";
+    static final int OTEL_COLLECTOR_OTLP_HTTP_PORT = 4318;
+    private static final int ES_HTTP_PORT = 9200;
+    private static final String ES_IMAGE = "docker.elastic.co/elasticsearch/elasticsearch:8.17.2";
+    // The elasticsearch exporter exposes mapping.mode: otel from 0.116+. The snake_case OTel-native field layout
+    // it produces (trace_id, span_id, parent_span_id, attributes.*, resource.attributes.*, events[]) is what
+    // ElasticsearchTracingRepository parses. Pin to a known-good recent build so the contract test is reproducible.
+    private static final String OTEL_COLLECTOR_IMAGE = "otel/opentelemetry-collector-contrib:0.145.0";
+
+    @Bean
+    public Network tracingTestNetwork() {
+        return Network.newNetwork();
+    }
+
+    @Bean
+    public Vertx tracingTestVertx() {
+        return Vertx.vertx();
+    }
+
+    @Bean(destroyMethod = "stop")
+    public ElasticsearchContainer tracingTestElasticsearchContainer(Network tracingTestNetwork) {
+        ElasticsearchContainer container = new ElasticsearchContainer(DockerImageName.parse(ES_IMAGE))
+            .withEnv("xpack.security.enabled", "false")
+            .withEnv("ES_JAVA_OPTS", "-Xms512m -Xmx512m")
+            .withNetwork(tracingTestNetwork)
+            .withNetworkAliases(ES_NETWORK_ALIAS);
+        container.setWaitStrategy(Wait.forLogMessage(".*started.*", 1).withStartupTimeout(Duration.ofSeconds(180)));
+        container.start();
+        return container;
+    }
+
+    @Bean(destroyMethod = "stop")
+    public GenericContainer<?> tracingTestOtelCollectorContainer(
+        Network tracingTestNetwork,
+        ElasticsearchContainer tracingTestElasticsearchContainer
+    ) {
+        // Depending on tracingTestElasticsearchContainer ensures Spring starts ES first; the collector retries during
+        // its own startup window if ES isn't yet accepting writes.
+        GenericContainer<?> collector = new GenericContainer<>(DockerImageName.parse(OTEL_COLLECTOR_IMAGE))
+            .withNetwork(tracingTestNetwork)
+            .withExposedPorts(OTEL_COLLECTOR_OTLP_HTTP_PORT)
+            .withCopyFileToContainer(
+                MountableFile.forClasspathResource("otel-collector-tracing-config.yaml"),
+                "/etc/otelcol-contrib/config.yaml"
+            )
+            .waitingFor(Wait.forListeningPort().withStartupTimeout(Duration.ofSeconds(60)));
+        collector.start();
+        return collector;
+    }
+
+    @Bean(destroyMethod = "")
+    public Client tracingTestElasticsearchClient(ElasticsearchContainer tracingTestElasticsearchContainer) {
+        HttpClientConfiguration clientConfiguration = new HttpClientConfiguration();
+        clientConfiguration.setEndpoints(
+            List.of(
+                new Endpoint(
+                    "http://" +
+                        tracingTestElasticsearchContainer.getHost() +
+                        ":" +
+                        tracingTestElasticsearchContainer.getMappedPort(ES_HTTP_PORT)
+                )
+            )
+        );
+        clientConfiguration.setRequestTimeout(60_000L);
+        return new HttpClient(clientConfiguration);
+    }
+
+    @Bean
+    public TracingRepository tracingRepository(Client tracingTestElasticsearchClient) {
+        // Matches the collector's traces_index (otel-collector-tracing-config.yaml) once {orgId} is resolved
+        // against the contract test's QueryContext (Fixtures.ORG_ID = "test-org").
+        return new ElasticsearchTracingRepository("traces-apim.otel-{orgId}", tracingTestElasticsearchClient);
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/tracing/ElasticsearchTracingTestRepositoryInitializer.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/tracing/ElasticsearchTracingTestRepositoryInitializer.java
@@ -1,0 +1,185 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.elasticsearch.tracing;
+
+import static io.gravitee.repository.elasticsearch.tracing.ElasticsearchTracingTestRepositoryConfiguration.OTEL_COLLECTOR_OTLP_HTTP_PORT;
+import static io.opentelemetry.api.common.AttributeKey.stringKey;
+import static org.awaitility.Awaitility.await;
+
+import io.gravitee.repository.common.query.QueryContext;
+import io.gravitee.repository.config.TestRepositoryInitializer;
+import io.gravitee.repository.tracing.TracingRepositoryTest.Fixtures;
+import io.gravitee.repository.tracing.api.TracingRepository;
+import io.gravitee.repository.tracing.model.Trace;
+import io.gravitee.repository.tracing.model.TraceSearchCriteria;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.StatusCode;
+import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.exporter.otlp.http.trace.OtlpHttpSpanExporter;
+import io.opentelemetry.sdk.OpenTelemetrySdk;
+import io.opentelemetry.sdk.resources.Resource;
+import io.opentelemetry.sdk.trace.IdGenerator;
+import io.opentelemetry.sdk.trace.SdkTracerProvider;
+import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.testcontainers.containers.GenericContainer;
+
+/**
+ * Pushes the {@link Fixtures} traces into the OTel Collector via OTLP HTTP, then waits for them to become queryable
+ * through the production {@link ElasticsearchTracingRepository} (which queries Elasticsearch directly). The collector
+ * forwards the spans to ES through its {@code elasticsearch} exporter in {@code mapping.mode: otel}, so the
+ * production repository's snake_case field parser sees the same document layout it does at runtime.
+ * <p>
+ * Seeding runs once across the suite — ES persists ingested spans, so re-pushing on every test would inflate
+ * {@code searchTraces} results.
+ *
+ * @author GraviteeSource Team
+ */
+public class ElasticsearchTracingTestRepositoryInitializer implements TestRepositoryInitializer {
+
+    private static final Duration QUERYABLE_POLL_TIMEOUT = Duration.ofSeconds(60);
+    private static final Duration QUERYABLE_POLL_INTERVAL = Duration.ofMillis(500);
+
+    private final GenericContainer<?> otelCollectorContainer;
+    private final TracingRepository tracingRepository;
+
+    private boolean seeded = false;
+
+    @Autowired
+    public ElasticsearchTracingTestRepositoryInitializer(
+        GenericContainer<?> tracingTestOtelCollectorContainer,
+        TracingRepository tracingRepository
+    ) {
+        this.otelCollectorContainer = tracingTestOtelCollectorContainer;
+        this.tracingRepository = tracingRepository;
+    }
+
+    @Override
+    public void setUp() {
+        if (seeded) {
+            return;
+        }
+        seedFixtureTraces();
+        awaitTracesQueryable();
+        seeded = true;
+    }
+
+    @Override
+    public void tearDown() {
+        // ES storage is bound to the container lifecycle (managed by the Spring context), so per-test cleanup is
+        // unnecessary — the suite seeds once and tests share the read-only fixture set.
+    }
+
+    private void seedFixtureTraces() {
+        String otlpEndpoint =
+            "http://" +
+            otelCollectorContainer.getHost() +
+            ":" +
+            otelCollectorContainer.getMappedPort(OTEL_COLLECTOR_OTLP_HTTP_PORT) +
+            "/v1/traces";
+
+        OtlpHttpSpanExporter exporter = OtlpHttpSpanExporter.builder().setEndpoint(otlpEndpoint).build();
+        // The contract test calls with QueryContext("test-org", "test-env"), so the impl auto-injects an env clause
+        // (resource.attributes.gravitee.environment.id = "test-env"). The fixture spans must carry that resource
+        // attribute or the env filter will reject them.
+        SdkTracerProvider tracerProvider = SdkTracerProvider.builder()
+            .setResource(
+                Resource.create(
+                    Attributes.of(stringKey("service.name"), Fixtures.SERVICE_NAME, stringKey("gravitee.environment.id"), Fixtures.ENV_ID)
+                )
+            )
+            .setIdGenerator(new FixtureIdGenerator())
+            .addSpanProcessor(SimpleSpanProcessor.create(exporter))
+            .build();
+
+        try (OpenTelemetrySdk sdk = OpenTelemetrySdk.builder().setTracerProvider(tracerProvider).build()) {
+            Tracer tracer = sdk.getTracer("elasticsearch-tracing-test-fixtures");
+
+            long okStartNanos = nanos(Fixtures.TRACE_OK_START_TIME.getEpochSecond());
+            Span okSpan = tracer
+                .spanBuilder(Fixtures.TRACE_OK_ROOT_OPERATION)
+                .setStartTimestamp(okStartNanos, TimeUnit.NANOSECONDS)
+                .setAttribute("http.status_code", "200")
+                .startSpan();
+            okSpan.end(okStartNanos + Duration.ofMillis(5).toNanos(), TimeUnit.NANOSECONDS);
+
+            long errorStartNanos = nanos(Fixtures.TRACE_ERROR_START_TIME.getEpochSecond());
+            Span errorSpan = tracer
+                .spanBuilder(Fixtures.TRACE_ERROR_ROOT_OPERATION)
+                .setStartTimestamp(errorStartNanos, TimeUnit.NANOSECONDS)
+                .setAttribute("http.status_code", "500")
+                .startSpan();
+            errorSpan.setStatus(StatusCode.ERROR);
+            errorSpan.end(errorStartNanos + Duration.ofMillis(7).toNanos(), TimeUnit.NANOSECONDS);
+
+            tracerProvider.forceFlush().join(10, TimeUnit.SECONDS);
+        }
+    }
+
+    private void awaitTracesQueryable() {
+        QueryContext queryContext = new QueryContext(Fixtures.ORG_ID, Fixtures.ENV_ID);
+        TraceSearchCriteria criteria = new TraceSearchCriteria(Map.of("service.name", Fixtures.SERVICE_NAME), 20, null, null, Map.of());
+
+        await()
+            .atMost(QUERYABLE_POLL_TIMEOUT)
+            .pollInterval(QUERYABLE_POLL_INTERVAL)
+            .until(() -> {
+                List<Trace> traces = tracingRepository.searchTraces(queryContext, criteria).blockingGet();
+                return traces.size() >= 2;
+            });
+    }
+
+    private static long nanos(long epochSeconds) {
+        return epochSeconds * 1_000_000_000L;
+    }
+
+    /**
+     * Hands out the contract's fixture trace IDs to the OTel SDK in the order it asks. Each trace's first span emits
+     * {@link IdGenerator#generateTraceId()} once; subsequent calls fall back to random IDs. Order matches the
+     * sequence in which {@link #seedFixtureTraces()} starts spans (OK first, then error).
+     */
+    private static final class FixtureIdGenerator implements IdGenerator {
+
+        private final AtomicInteger traceCursor = new AtomicInteger();
+        private final AtomicInteger spanCursor = new AtomicInteger();
+
+        @Override
+        public String generateTraceId() {
+            int index = traceCursor.getAndIncrement();
+            return switch (index) {
+                case 0 -> Fixtures.TRACE_OK_ID;
+                case 1 -> Fixtures.TRACE_ERROR_ID;
+                default -> IdGenerator.random().generateTraceId();
+            };
+        }
+
+        @Override
+        public String generateSpanId() {
+            int index = spanCursor.getAndIncrement();
+            return switch (index) {
+                case 0 -> "0000000000000a01";
+                case 1 -> "0000000000000a02";
+                default -> IdGenerator.random().generateSpanId();
+            };
+        }
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/resources/otel-collector-tracing-config.yaml
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/resources/otel-collector-tracing-config.yaml
@@ -1,0 +1,38 @@
+# OTel Collector pipeline used by ElasticsearchTracingRepositoryIT: receives OTLP HTTP traces from the test
+# fixture seeder and writes them to Elasticsearch using OTel-native field names (mapping_mode: otel) so the
+# repository's snake_case parser sees the documents exactly as production does.
+#
+# traces_index is set to traces-apim.otel-test-org because the contract test's QueryContext resolves
+# tracing.elasticsearch.index ("traces-apim.otel-{orgId}") with orgId = Fixtures.ORG_ID = "test-org".
+
+receivers:
+  otlp:
+    protocols:
+      http:
+        endpoint: 0.0.0.0:4318
+
+exporters:
+  elasticsearch:
+    endpoints: ["http://elasticsearch:9200"]
+    mapping:
+      mode: otel
+    traces_index: traces-apim.otel-test-org
+    # Tests need the exporter to flush each push from the OTel SDK immediately and surface errors instead of
+    # silently retrying — production deployments would want different defaults.
+    flush:
+      interval: 1s
+    retry:
+      enabled: false
+    sending_queue:
+      enabled: false
+    timeout: 30s
+processors:
+  batch:
+    timeout: 200ms
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [elasticsearch]

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-repository/src/main/java/io/gravitee/rest/api/repository/plugins/RestApiRepositoryScopeProvider.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-repository/src/main/java/io/gravitee/rest/api/repository/plugins/RestApiRepositoryScopeProvider.java
@@ -27,4 +27,14 @@ public class RestApiRepositoryScopeProvider implements RepositoryScopeProvider {
     public Scope[] getHandledScopes() {
         return new Scope[] { Scope.MANAGEMENT, Scope.ANALYTICS };
     }
+
+    /**
+     * OTEL_TRACES is opt-in: the rest-api can query traces (e.g. via the gamma APIM tracing resource) but startup
+     * must not fail when no provider is wired. Declaring it as optional means the platform loads the matching
+     * {@code RepositoryProvider} when {@code otel-traces.type} is set and silently skips it otherwise.
+     */
+    @Override
+    public Scope[] getOptionalHandledScopes() {
+        return new Scope[] { Scope.OTEL_TRACES };
+    }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-repository/src/test/java/io/gravitee/rest/api/repository/plugins/RestApiRepositoryScopeProviderTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-repository/src/test/java/io/gravitee/rest/api/repository/plugins/RestApiRepositoryScopeProviderTest.java
@@ -30,4 +30,9 @@ public class RestApiRepositoryScopeProviderTest {
     public void shouldReturnManagementAndAnalyticsScopes() {
         Assert.assertArrayEquals(new Scope[] { Scope.MANAGEMENT, Scope.ANALYTICS }, provider.getHandledScopes());
     }
+
+    @Test
+    public void shouldReturnOtelTracesAsOptionalScope() {
+        Assert.assertArrayEquals(new Scope[] { Scope.OTEL_TRACES }, provider.getOptionalHandledScopes());
+    }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/src/main/resources/config/gravitee.yml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/src/main/resources/config/gravitee.yml
@@ -263,6 +263,46 @@ repositories:
 #            username: user
 #            password: secret
 
+# OTel traces repository — feeds the gamma APIM tracing resource. Disabled by default; set type to
+# "elasticsearch" to wire the ES-backed TracingRepository. Configuration is fully independent from
+# analytics (same per-scope pattern as ratelimit.redis / distributed-sync.redis). The ES cluster declared
+# here must be the one the OTel collector / Elastic Cloud OTLP endpoint writes traces to.
+#  otel-traces:
+#    type: elasticsearch # or "none" to disable
+#    elasticsearch:
+#      # Index/data-stream template — {orgId} / {envId} placeholders are substituted (lowercased) from the
+#      # caller's QueryContext at query time, matching the analytics IndexNameUtils.format convention.
+#      # Should match the data-stream name the OTel collector elasticsearch exporter (mapping.mode: otel)
+#      # writes to.
+#      index: traces-apim.otel-{orgId}
+#      endpoints:
+#        - http://${ds.elastic.host}:${ds.elastic.port}
+#      security:
+#        username: user
+#        password: secret
+#      ssl:
+#        keystore:
+#          type: jks # jks, pkcs12 or pem
+#          path: ${gravitee.home}/security/keystore.jks
+#          password: secret
+#          # PEM only:
+#          # certs: [/path/to/cert1.pem, /path/to/cert2.pem]
+#          # keys:  [/path/to/key1.pem,  /path/to/key2.pem]
+#      http:
+#        timeout: 10000 # in milliseconds
+#        proxy:
+#          type: HTTP #HTTP, SOCK4, SOCK5
+#          http:
+#            host: localhost
+#            port: 3128
+#            username: user
+#            password: secret
+#          https:
+#            host: localhost
+#            port: 3128
+#            username: user
+#            password: secret
+
 services:
   core:
     http:

--- a/helm/templates/api/api-configmap.yaml
+++ b/helm/templates/api/api-configmap.yaml
@@ -130,6 +130,43 @@ data:
         type: none
         {{- end }}
 
+      {{- if ne .Values.api.otelTraces.type "none" }}
+      otel-traces:
+        type: {{ .Values.api.otelTraces.type }}
+        {{- if (eq .Values.api.otelTraces.type "elasticsearch") }}
+        elasticsearch:
+          {{- with .Values.api.otelTraces.elasticsearch.endpoints }}
+          endpoints:
+            {{ toYaml . | nindent 12 | trim -}}
+          {{- end }}
+          {{- if .Values.api.otelTraces.elasticsearch.http }}
+          http:
+            {{- if .Values.api.otelTraces.elasticsearch.http.timeout }}
+            timeout: {{ .Values.api.otelTraces.elasticsearch.http.timeout }}
+            {{- end }}
+          {{- end }}
+          {{- if .Values.api.otelTraces.elasticsearch.security }}
+          security:
+            username: {{ .Values.api.otelTraces.elasticsearch.security.username }}
+            password: {{ .Values.api.otelTraces.elasticsearch.security.password }}
+          {{- end }}
+          {{- if .Values.api.otelTraces.elasticsearch.ssl }}
+          ssl:
+            keystore:
+              type: {{ .Values.api.otelTraces.elasticsearch.ssl.keystore.type }}
+              {{- if or .Values.api.otelTraces.elasticsearch.ssl.keystore.path .Values.api.otelTraces.elasticsearch.ssl.keystore.password }}
+              path: {{ .Values.api.otelTraces.elasticsearch.ssl.keystore.path }}
+              password: {{ .Values.api.otelTraces.elasticsearch.ssl.keystore.password }}
+              {{- end }}
+              {{- if or .Values.api.otelTraces.elasticsearch.ssl.keystore.certs .Values.api.otelTraces.elasticsearch.ssl.keystore.keys }}
+              certs: {{ .Values.api.otelTraces.elasticsearch.ssl.keystore.certs }}
+              keys: {{ .Values.api.otelTraces.elasticsearch.ssl.keystore.keys }}
+              {{- end }}
+          {{- end }}
+          index: {{ .Values.api.otelTraces.elasticsearch.index }}
+        {{- end }}
+      {{- end }}
+
     # Secret Manager configuration
     {{- if .Values.secrets }}
     secrets:

--- a/helm/tests/api/configmap_otel_traces_test.yaml
+++ b/helm/tests/api/configmap_otel_traces_test.yaml
@@ -1,0 +1,116 @@
+suite: Test Management API configmap for the OTel traces repository scope
+templates:
+  - "api/api-configmap.yaml"
+tests:
+  - it: Default values render no otel-traces block (type "none")
+    template: api/api-configmap.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ConfigMap
+      - notMatchRegex:
+          path: data["gravitee.yml"]
+          pattern: "otel-traces:"
+
+  - it: Type elasticsearch renders the block with endpoints and index template
+    template: api/api-configmap.yaml
+    set:
+      api:
+        otelTraces:
+          type: elasticsearch
+          elasticsearch:
+            index: traces-apim.otel-{orgId}
+            endpoints:
+              - http://es.example.com:9200
+    asserts:
+      - matchRegex:
+          path: data["gravitee.yml"]
+          pattern: "otel-traces:\\s+type: elasticsearch"
+      - matchRegex:
+          path: data["gravitee.yml"]
+          pattern: "- http://es.example.com:9200"
+      - matchRegex:
+          path: data["gravitee.yml"]
+          pattern: "index: traces-apim.otel-\\{orgId\\}"
+
+  - it: Type elasticsearch renders the security block when set
+    template: api/api-configmap.yaml
+    set:
+      api:
+        otelTraces:
+          type: elasticsearch
+          elasticsearch:
+            index: traces-apim.otel-{orgId}
+            endpoints:
+              - http://es.example.com:9200
+            security:
+              username: elastic
+              password: changeme
+    asserts:
+      - matchRegex:
+          path: data["gravitee.yml"]
+          pattern: "username: elastic"
+      - matchRegex:
+          path: data["gravitee.yml"]
+          pattern: "password: changeme"
+
+  - it: Type elasticsearch renders the SSL keystore block when set
+    template: api/api-configmap.yaml
+    set:
+      api:
+        otelTraces:
+          type: elasticsearch
+          elasticsearch:
+            index: traces-apim.otel-{orgId}
+            endpoints:
+              - https://es.example.com:9200
+            ssl:
+              keystore:
+                type: jks
+                path: /path/to/keystore.jks
+                password: kspw
+    asserts:
+      - matchRegex:
+          path: data["gravitee.yml"]
+          pattern: "type: jks"
+      - matchRegex:
+          path: data["gravitee.yml"]
+          pattern: "path: /path/to/keystore.jks"
+      - matchRegex:
+          path: data["gravitee.yml"]
+          pattern: "password: kspw"
+
+  - it: Type elasticsearch renders the http timeout when set
+    template: api/api-configmap.yaml
+    set:
+      api:
+        otelTraces:
+          type: elasticsearch
+          elasticsearch:
+            index: traces-apim.otel-{orgId}
+            endpoints:
+              - http://es.example.com:9200
+            http:
+              timeout: 30000
+    asserts:
+      - matchRegex:
+          path: data["gravitee.yml"]
+          pattern: "timeout: 30000"
+
+  - it: Type other than elasticsearch (e.g. tempo) still renders the type line but skips ES-specific config
+    template: api/api-configmap.yaml
+    set:
+      api:
+        otelTraces:
+          type: tempo
+    asserts:
+      # The block-level guard is `ne … "none"`, so any non-"none" type renders `otel-traces.type: <value>`
+      # without forcing it through the ES branch. Future impls (PR 4 wires Tempo here) add their own block
+      # next to the elasticsearch one — this test pins that the structure is type-agnostic, not ES-only.
+      - matchRegex:
+          path: data["gravitee.yml"]
+          pattern: "otel-traces:\\s+type: tempo"
+      - notMatchRegex:
+          path: data["gravitee.yml"]
+          pattern: "otel-traces:\\s+type: tempo\\s+elasticsearch:"

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -1130,6 +1130,33 @@ api:
   analytics:
     type: elasticsearch # or none
 
+  # OpenTelemetry traces reader (used by the gamma APIM tracing resource). Disabled by default; set type to
+  # "elasticsearch" to wire the ES-backed TracingRepository. Configuration is independent from `analytics.*` —
+  # tracing can target a different ES cluster (or no analytics at all). The Elasticsearch endpoint chosen must be
+  # the same one the OTel collector / OTLP endpoint writes traces to.
+  otelTraces:
+    type: none # or elasticsearch
+    elasticsearch:
+      # Index/data-stream name template. {orgId} / {envId} are substituted (lowercased) from the caller's
+      # QueryContext at query time, matching the analytics IndexNameUtils.format convention. Should match the
+      # data-stream name the OTel collector elasticsearch exporter (mapping.mode: otel) writes to.
+      index: traces-apim.otel-{orgId}
+      endpoints:
+        - http://elasticsearch:9200
+      # security:
+      #   username: elastic
+      #   password: changeme
+      # ssl:
+      #   keystore:
+      #     type: jks            # jks, pkcs12 or pem
+      #     path: /path/to/keystore.jks
+      #     password: changeme
+      #     # PEM only:
+      #     # certs: [/path/to/cert1.pem, /path/to/cert2.pem]
+      #     # keys:  [/path/to/key1.pem,  /path/to/key2.pem]
+      # http:
+      #   timeout: 10000
+
   # External Authentication settings
   #  auth:
   #    external:

--- a/pom.xml
+++ b/pom.xml
@@ -65,9 +65,9 @@
         <gravitee-integration-api.version>5.1.0</gravitee-integration-api.version>
         <gravitee-json-validation.version>2.2.0</gravitee-json-validation.version>
         <gravitee-kubernetes.version>4.0.0-alpha.1</gravitee-kubernetes.version>
-        <gravitee-node.version>9.0.0-alpha.11</gravitee-node.version>
+        <gravitee-node.version>9.0.0-alpha.12</gravitee-node.version>
         <gravitee-notifier-api.version>2.0.0</gravitee-notifier-api.version>
-        <gravitee-platform-repository-api.version>1.4.0</gravitee-platform-repository-api.version>
+        <gravitee-platform-repository-api.version>2.0.0</gravitee-platform-repository-api.version>
         <gravitee-plugin.version>5.1.2</gravitee-plugin.version>
         <gravitee-plugin-common-configurations.version>1.3.0</gravitee-plugin-common-configurations.version>
         <gravitee-policy-api.version>1.11.0</gravitee-policy-api.version>


### PR DESCRIPTION
## Issue

N/A — third step of the tracing read-side rollout. Builds on PR 1 (#16942 — TracingRepository SPI, merged).

## Description

Adds an Elasticsearch-backed \`TracingRepository\` reading OTel-native spans (\`mapping.mode: otel\`) written by the OTel collector's \`elasticsearch\` exporter (self-managed) or Elastic Cloud's managed OTLP endpoint. Wires the new \`OTEL_TRACES\` repository scope through the rest-api host so the plugin loads cleanly.

**What this PR does**
- New \`ElasticsearchTracingRepository\` parses snake_case OTel documents (\`trace_id\`, \`span_id\`, \`parent_span_id\`, \`@timestamp\`, \`duration\`, \`status.code\`, \`attributes.*\`, \`resource.attributes.*\`).
- \`searchTraces\` aggregates by \`trace_id\` ordered by trace start desc; sub-aggs grab the root span via \`top_hits\`, the start time via \`min(@timestamp)\`, and the per-trace error count via a filter agg on \`status.code\`.
- \`getTrace\` returns the full span tree for a single id; resource-attribute filters are emitted as resource-side \`term\` clauses (defence in depth on top of the per-tenant index).
- Multi-tenancy: the index template is resolved per call from \`QueryContext\` via the analytics convention (\`IndexNameUtils.format\`), e.g. \`traces-apim.otel-{orgId}\` → \`traces-apim.otel-default\` (lowercased).
- Plugin wiring: \`ElasticsearchRepositoryProvider\` adds \`OTEL_TRACES\` to its scopes; a separate \`TracingConfiguration\` Spring class avoids cross-scope bean-name collisions when both \`ANALYTICS\` and \`OTEL_TRACES\` are wired to this plugin.
- Host wiring: \`RestApiRepositoryScopeProvider\` registers \`OTEL_TRACES\` via \`getOptionalHandledScopes()\` so an APIM deployment without tracing configured still starts up.

**What this PR deliberately does NOT do — split into follow-up PRs**
- *Span events / logs data stream*: the OTel ES exporter writes span events as separate log documents (it forces \`data_stream.type = logs\` for events). Fetching and stitching those is the future \`LogsRepository\`'s job (\`OTEL_LOGS\` scope). This repo returns spans only.
- *Calling both TracingRepository + LogsRepository to assemble a complete trace*: lives in the consumer use case (gamma APIM, PR 6).

## Design choices

**Per-scope config block, no fallback to analytics** — \`otel-traces.elasticsearch.*\` is a fully independent property block (endpoints, security, SSL, HTTP proxy/timeout, index template). Mirrors the Redis plugin's pattern where \`ratelimit.redis.*\` and \`distributed-sync.redis.*\` are standalone. Tracing can target a different ES cluster than analytics (or none at all).

\`\`\`yaml
otel-traces:
  type: elasticsearch
  elasticsearch:
    index: traces-apim.otel-{orgId}
    endpoints:
      - http://localhost:9200
    # security, ssl, http: same shape as the analytics block
\`\`\`

**Index naming via \`IndexNameUtils.format\`** — same regex-based placeholder substitution + lowercasing convention as the analytics plugin (substituted values from \`QueryContext.placeholder()\` get \`.toLowerCase()\` applied so a caller orgId of \`DEFAULT\` resolves to \`traces-apim.otel-default\`, matching what the OTel collector writes).

**No \`IndexNameGenerator\` machinery** — the analytics generators (\`MultiType\` / \`PerType\` / \`ILMIndexNameGenerator\`) all hardcode a \`-<type>\` suffix or \`-<date>\` rotation, neither of which fits OTel data streams (\`traces-<dataset>-<namespace>\` shape where namespace = our orgId, the last segment). The substitution primitive is reused; the assembler isn't. See README "Index templates, mappings & retention (ILM)" for the operator-facing detail.

**Reader-only — operators own mappings + ILM** — the OTel collector (or Elastic Cloud managed OTLP endpoint) applies index templates and field mappings on write. ILM policies are operator-configured via \`index.lifecycle.name\` on the template. This repository neither authors nor maintains them.

## Files touched

- \`gravitee-apim-repository-elasticsearch\`:
  - New: \`tracing/ElasticsearchTracingRepository\`, \`tracing/configuration/TracingInfraConfiguration\`, \`tracing/spring/TracingConfiguration\` (per-scope Spring config with \`tracing\`-prefixed bean names to dodge cross-scope conflicts).
  - Modified: \`ElasticsearchRepositoryProvider\` (declares \`OTEL_TRACES\`), \`ElasticsearchRepositoryConfiguration\` (exposes \`buildHttpClient\` as \`public static\` for reuse).
  - Tests: 11 unit tests + a Testcontainers integration test (ES + OTel Collector on a shared docker network) extending the shared \`TracingRepositoryTest\` contract.
- \`gravitee-apim-rest-api-repository\`: \`RestApiRepositoryScopeProvider\` registers \`OTEL_TRACES\` as optional. New unit test mirrors the gateway-side equivalent.
- \`helm/\`: new \`api.otelTraces.*\` values block (defaults to \`type: none\`); configmap rendering is type-agnostic so a future \`type: tempo\` (PR 4) plugs in without restructuring the template. Six helm unittest scenarios cover default, ES-with-endpoints, security, SSL, http.timeout, and the type-agnostic future-tempo path.

## Additional context

This is **PR 3 of 6** in the tracing read-side rollout (revised plan after introducing the intermediate \`OTEL_LOGS\` scope PR):

1. ✅ TracingRepository SPI (#16942 — merged)
2. 🟡 Gateway producer enrichment (#16946 — in review)
3. ✅ This PR — ES TracingRepository + OTEL_TRACES scope wiring
4. ⬜ TempoTracingRepository plugin + gravitee-node bump
5. ⬜ \`OTEL_LOGS\` scope + LogsRepository SPI + ES impl (intermediate PR)
6. ⬜ gamma-module-apim TracingResource consuming both repos

🤖 Generated with [Claude Code](https://claude.com/claude-code)