### PR TITLE
fix: disallow identical start and end dates in date range validator

### DIFF
--- a/gravitee-apim-console-webui/src/shared/components/gio-timeframe/gio-timeframe.component.html
+++ b/gravitee-apim-console-webui/src/shared/components/gio-timeframe/gio-timeframe.component.html
@@ -54,7 +54,7 @@
       <mat-icon [owlDateTimeTrigger]="toDateTimePicker" matSuffix svgIcon="gio:calendar"></mat-icon>
       <owl-date-time #toDateTimePicker></owl-date-time>
       @if (form.hasError('dateRange')) {
-        <mat-error>To date cannot be earlier than From date</mat-error>
+        <mat-error>To date cannot be earlier than or equal to From date</mat-error>
       }
     </mat-form-field>
 

--- a/gravitee-apim-console-webui/src/shared/components/gio-timeframe/gio-timeframe.component.spec.ts
+++ b/gravitee-apim-console-webui/src/shared/components/gio-timeframe/gio-timeframe.component.spec.ts
@@ -122,6 +122,21 @@ describe('GioTimeframeComponent', () => {
     expect(component.disabled).toBe(true);
   });
 
+  it('should be valid when from date is before to date', () => {
+    const fromDate = moment('2024-01-10');
+    const toDate = moment('2024-01-15');
+
+    component.form.patchValue({ from: fromDate, to: toDate });
+    expect(component.form.hasError('dateRange')).toBe(false);
+  });
+
+  it('should not be valid when dates are equal', () => {
+    const date = moment('2024-01-10');
+
+    component.form.patchValue({ from: date, to: date });
+    expect(component.form.hasError('dateRange')).toBe(true);
+  });
+
   it('should hide error and enable Apply when date range becomes valid', () => {
     // Arrange: provide timeFrames and valid custom period
     fixture.componentRef.setInput('timeFrames', [

--- a/gravitee-apim-console-webui/src/shared/validators/date-range.validator.ts
+++ b/gravitee-apim-console-webui/src/shared/validators/date-range.validator.ts
@@ -22,9 +22,9 @@
 import { AbstractControl, FormGroup, ValidationErrors, ValidatorFn } from '@angular/forms';
 import { Moment } from 'moment';
 
-// Internal helper: returns { dateRange: true } if from > to, otherwise null.
+// Internal helper: returns { dateRange: true } if from >= to, otherwise null.
 function validateMomentDateRange(from: Moment | null, to: Moment | null): ValidationErrors | null {
-  if (from && to && from.isAfter(to)) {
+  if (from && to && from.isSameOrAfter(to)) {
     return { dateRange: true };
   }
   return null;

--- a/gravitee-apim-portal-webui-next/projects/gravitee-dashboard/src/lib/components/filter/timeframe-selector/timeframe-selector.component.html
+++ b/gravitee-apim-portal-webui-next/projects/gravitee-dashboard/src/lib/components/filter/timeframe-selector/timeframe-selector.component.html
@@ -52,7 +52,7 @@
       <mat-icon [owlDateTimeTrigger]="toDateTimePicker" matSuffix>edit_calendar</mat-icon>
       <owl-date-time #toDateTimePicker />
       @if (form.hasError('dateRange')) {
-        <mat-error>To date cannot be earlier than From date</mat-error>
+        <mat-error>To date cannot be earlier than or equal to From date</mat-error>
       }
     </mat-form-field>
 

--- a/gravitee-apim-portal-webui-next/projects/gravitee-dashboard/src/lib/components/filter/timeframe-selector/timeframe-selector.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/projects/gravitee-dashboard/src/lib/components/filter/timeframe-selector/timeframe-selector.component.spec.ts
@@ -101,11 +101,11 @@ describe('TimeframeSelectorComponent', () => {
       expect(component.form.hasError('dateRange')).toBe(false);
     });
 
-    it('should be valid when dates are equal', () => {
+    it('should not be valid when dates are equal', () => {
       const date = moment('2024-01-10');
 
       component.form.patchValue({ from: date, to: date });
-      expect(component.form.hasError('dateRange')).toBe(false);
+      expect(component.form.hasError('dateRange')).toBe(true);
     });
   });
 

--- a/gravitee-apim-portal-webui-next/projects/gravitee-dashboard/src/lib/components/filter/timeframe-selector/utils/date-range.validator.ts
+++ b/gravitee-apim-portal-webui-next/projects/gravitee-dashboard/src/lib/components/filter/timeframe-selector/utils/date-range.validator.ts
@@ -16,9 +16,9 @@
 import { AbstractControl, FormGroup, ValidationErrors, ValidatorFn } from '@angular/forms';
 import { Moment } from 'moment';
 
-// Internal helper: returns { dateRange: true } if from > to, otherwise null.
+// Internal helper: returns { dateRange: true } if from >= to, otherwise null.
 function validateMomentDateRange(from: Moment | null, to: Moment | null): ValidationErrors | null {
-  if (from && to && from.isAfter(to)) {
+  if (from && to && from.isSameOrAfter(to)) {
     return { dateRange: true };
   }
   return null;


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-14119

## Description

Disallow identical start and end dates in date range validator.

## Additional context

Before:
<img width="1918" height="837" alt="image" src="https://github.com/user-attachments/assets/473d498c-ea37-486d-a569-89d25f144525" />

After:
<img width="1918" height="837" alt="image" src="https://github.com/user-attachments/assets/7595ef56-09f6-4d3a-98f0-ce78c1e6644d" />


<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

