### PR TITLE
test(mapi-v2): add navigation item setup to portal page content test

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/environment/PortalPageContentsResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/environment/PortalPageContentsResourceTest.java
@@ -22,7 +22,9 @@ import static io.gravitee.common.http.HttpStatusCode.FORBIDDEN_403;
 import static io.gravitee.common.http.HttpStatusCode.OK_200;
 import static org.mockito.Mockito.when;
 
+import fixtures.core.model.PortalNavigationItemFixtures;
 import fixtures.core.model.PortalPageContentFixtures;
+import inmemory.PortalNavigationItemsQueryServiceInMemory;
 import io.gravitee.apim.core.portal_page.model.PortalPageContentId;
 import io.gravitee.apim.core.portal_page.use_case.GetPortalPageContentUseCase;
 import io.gravitee.rest.api.management.v2.rest.resource.AbstractResourceTest;
@@ -57,6 +59,9 @@ class PortalPageContentsResourceTest extends AbstractResourceTest {
     @Inject
     private EnvironmentService environmentService;
 
+    @Inject
+    private PortalNavigationItemsQueryServiceInMemory portalNavigationItemsQueryService;
+
     private WebTarget target;
 
     @Override
@@ -84,6 +89,7 @@ class PortalPageContentsResourceTest extends AbstractResourceTest {
         GraviteeContext.cleanContext();
         portalPageContentQueryService.reset();
         portalPageContentCrudService.reset();
+        portalNavigationItemsQueryService.reset();
     }
 
     @Test
@@ -180,6 +186,18 @@ class PortalPageContentsResourceTest extends AbstractResourceTest {
 
             portalPageContentCrudService.initWith(List.of(content));
             portalPageContentQueryService.initWith(List.of(content));
+
+            var navigationPage = PortalNavigationItemFixtures.aPage(
+                PortalNavigationItemFixtures.PAGE_ID,
+                "Test Page",
+                null,
+                PortalPageContentId.of(CONTENT_ID)
+            )
+                .toBuilder()
+                .organizationId(ORGANIZATION)
+                .environmentId(ENVIRONMENT)
+                .build();
+            portalNavigationItemsQueryService.initWith(List.of(navigationPage));
         }
 
         @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/PortalNavigationItemsQueryServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/PortalNavigationItemsQueryServiceInMemory.java
@@ -63,7 +63,7 @@ public class PortalNavigationItemsQueryServiceInMemory
     @Override
     public List<PortalNavigationItem> search(PortalNavigationItemQueryCriteria criteria) {
         Predicate<PortalNavigationItem> PARENT_ID_FILTER = i -> {
-            if (criteria.getParentId() == null && criteria.getRoot()) {
+            if (criteria.getParentId() == null && Boolean.TRUE.equals(criteria.getRoot())) {
                 return i.getParentId() == null;
             } else if (criteria.getParentId() != null) {
                 return criteria.getParentId().equals(i.getParentId());


### PR DESCRIPTION
## Issue

<!-- no Jira ticket -->

## Description

- Fixed failing `should_update_portal_page_content` test in `PortalPageContentsResourceTest`
- Added a `PortalNavigationPage` linked to `CONTENT_ID` in `UpdatePortalPageContent.setUp()` so the validator's `findNavigationPageByPortalPageContentId` finds the associated navigation item and exercises the full dry-render validation path
- Added `@Autowired PortalNavigationItemsQueryServiceInMemory` field and its `reset()` call in `tearDown()` to prevent cross-test state leakage
