### PR TITLE
feat(portal): edit application member role

### DIFF
--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-member-edit-dialog/application-member-edit-dialog.component.harness.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-member-edit-dialog/application-member-edit-dialog.component.harness.ts
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ComponentHarness } from '@angular/cdk/testing';
+import { MatButtonHarness } from '@angular/material/button/testing';
+import { MatSelectHarness } from '@angular/material/select/testing';
+
+export class ApplicationMemberEditDialogHarness extends ComponentHarness {
+  static readonly hostSelector = 'app-application-member-edit-dialog';
+
+  private readonly locateRoleSelect = this.locatorFor(MatSelectHarness.with({ selector: '[data-testid="edit-member-role-select"]' }));
+  private readonly locateCancelButton = this.locatorFor(MatButtonHarness.with({ selector: '[data-testid="edit-member-cancel-button"]' }));
+  private readonly locateSaveButton = this.locatorFor(MatButtonHarness.with({ selector: '[data-testid="edit-member-save-button"]' }));
+  private readonly locateRolesError = this.locatorForOptional('[data-testid="edit-member-roles-error"]');
+  private readonly locateSubmitError = this.locatorForOptional('[data-testid="edit-member-submit-error"]');
+
+  async getRoleValueText(): Promise<string> {
+    return (await this.locateRoleSelect()).getValueText();
+  }
+
+  async getRoleOptionTexts(): Promise<string[]> {
+    const select = await this.locateRoleSelect();
+    await select.open();
+    return Promise.all((await select.getOptions()).map(option => option.getText()));
+  }
+
+  async selectRole(role: string): Promise<void> {
+    const select = await this.locateRoleSelect();
+    await select.open();
+    await select.clickOptions({ text: role });
+  }
+
+  async clickCancel(): Promise<void> {
+    return (await this.locateCancelButton()).click();
+  }
+
+  async clickSave(): Promise<void> {
+    return (await this.locateSaveButton()).click();
+  }
+
+  async isCancelDisabled(): Promise<boolean> {
+    return (await this.locateCancelButton()).isDisabled();
+  }
+
+  async isSaveDisabled(): Promise<boolean> {
+    return (await this.locateSaveButton()).isDisabled();
+  }
+
+  async getRolesErrorText(): Promise<string | null> {
+    const error = await this.locateRolesError();
+    return error ? error.text() : null;
+  }
+
+  async getSubmitErrorText(): Promise<string | null> {
+    const error = await this.locateSubmitError();
+    return error ? error.text() : null;
+  }
+}

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-member-edit-dialog/application-member-edit-dialog.component.html
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-member-edit-dialog/application-member-edit-dialog.component.html
@@ -1,0 +1,87 @@
+<!--
+
+    Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<h2 mat-dialog-title i18n="@@editApplicationMemberDialogTitle">Edit Member</h2>
+
+<mat-dialog-content class="application-member-edit-dialog">
+  <p class="application-member-edit-dialog__description next-gen-body" i18n="@@editApplicationMemberDialogDescription">
+    Update application role for {{ memberDisplayName }}.
+  </p>
+
+  @if (rolesResource.isLoading()) {
+    <div class="application-member-edit-dialog__loading" aria-live="polite" data-testid="edit-member-roles-loading">
+      <mat-progress-spinner diameter="20" mode="indeterminate" />
+      <span class="next-gen-small" i18n="@@editApplicationMemberRolesLoading">Loading roles...</span>
+    </div>
+  } @else if (rolesResource.error()) {
+    <p
+      class="application-member-edit-dialog__error next-gen-small"
+      role="alert"
+      data-testid="edit-member-roles-error"
+      i18n="@@editApplicationMemberRolesError"
+    >
+      An error occurred while loading application roles. Please try again.
+    </p>
+  } @else {
+    <mat-form-field appearance="outline" class="application-member-edit-dialog__field">
+      <mat-label i18n="@@editApplicationMemberRoleLabel">Member Role</mat-label>
+      <mat-select
+        [formControl]="roleControl"
+        data-testid="edit-member-role-select"
+        aria-label="Member role"
+        i18n-aria-label="@@editApplicationMemberRoleAriaLabel"
+      >
+        @for (role of assignableRoles(); track role.name) {
+          <mat-option [value]="role.name">{{ role.name }}</mat-option>
+        }
+      </mat-select>
+      @if (roleControl.hasError('required') && roleControl.touched) {
+        <mat-error i18n="@@editApplicationMemberRoleRequired">Application role is required.</mat-error>
+      }
+    </mat-form-field>
+  }
+
+  @if (submitError(); as error) {
+    <p class="application-member-edit-dialog__error next-gen-small" data-testid="edit-member-submit-error" role="alert">
+      {{ error }}
+    </p>
+  }
+</mat-dialog-content>
+
+<mat-dialog-actions align="end">
+  <button
+    mat-stroked-button
+    type="button"
+    [disabled]="isSubmitting()"
+    (click)="onCancel()"
+    data-testid="edit-member-cancel-button"
+    i18n="@@editApplicationMemberCancelButton"
+  >
+    Cancel
+  </button>
+  <button
+    mat-flat-button
+    color="primary"
+    type="button"
+    [disabled]="!canSubmit()"
+    (click)="onSubmit()"
+    data-testid="edit-member-save-button"
+    i18n="@@editApplicationMemberSaveButton"
+  >
+    Save
+  </button>
+</mat-dialog-actions>

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-member-edit-dialog/application-member-edit-dialog.component.scss
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-member-edit-dialog/application-member-edit-dialog.component.scss
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@use '../../../../scss/theme' as app-theme;
+
+.application-member-edit-dialog {
+  display: flex;
+  width: 480px;
+  max-width: 100%;
+  flex-direction: column;
+  gap: 16px;
+  padding-top: app-theme.$form-field-container-vertical-padding;
+
+  &__description {
+    margin: 0;
+    color: app-theme.$paragraph-color;
+  }
+
+  &__field {
+    width: 100%;
+  }
+
+  &__loading {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    color: app-theme.$paragraph-color;
+  }
+
+  &__error {
+    margin: 0;
+    color: app-theme.$error-main-color;
+  }
+}

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-member-edit-dialog/application-member-edit-dialog.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-member-edit-dialog/application-member-edit-dialog.component.spec.ts
@@ -1,0 +1,167 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { provideHttpClient } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+
+import { ApplicationMemberEditDialogComponent, ApplicationMemberEditDialogData } from './application-member-edit-dialog.component';
+import { ApplicationMemberEditDialogHarness } from './application-member-edit-dialog.component.harness';
+import { APPLICATION_PRIMARY_OWNER_ROLE_NAME, ApplicationRole } from '../../../../entities/application/application';
+import { ConfigService } from '../../../../services/config.service';
+import { TESTING_BASE_URL } from '../../../../testing/app-testing.module';
+
+const APPLICATION_ID = 'app-1';
+const MEMBER_ID = 'member-1';
+const ROLES_URL = `${TESTING_BASE_URL}/configuration/applications/roles`;
+const MEMBER_URL = `${TESTING_BASE_URL}/applications/${APPLICATION_ID}/members/${MEMBER_ID}`;
+
+const DIALOG_DATA: ApplicationMemberEditDialogData = {
+  applicationId: APPLICATION_ID,
+  memberId: MEMBER_ID,
+  memberDisplayName: 'Alice Smith',
+  currentRole: 'USER',
+};
+
+const APPLICATION_ROLES: ApplicationRole[] = [
+  { id: APPLICATION_PRIMARY_OWNER_ROLE_NAME, name: APPLICATION_PRIMARY_OWNER_ROLE_NAME, default: false, system: true },
+  { id: 'EMPTY', name: '', default: false, system: false },
+  { id: 'OWNER', name: 'OWNER', default: false, system: false },
+  { id: 'USER', name: 'USER', default: true, system: false },
+];
+
+describe('ApplicationMemberEditDialogComponent', () => {
+  let fixture: ComponentFixture<ApplicationMemberEditDialogComponent>;
+  let harness: ApplicationMemberEditDialogHarness;
+  let httpTestingController: HttpTestingController;
+  let dialogRef: { close: jest.Mock };
+
+  async function init(
+    data: ApplicationMemberEditDialogData = DIALOG_DATA,
+    roles: ApplicationRole[] | null = APPLICATION_ROLES,
+    createHarness = true,
+  ): Promise<void> {
+    dialogRef = { close: jest.fn() };
+
+    await TestBed.configureTestingModule({
+      imports: [ApplicationMemberEditDialogComponent],
+      providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        provideNoopAnimations(),
+        { provide: ConfigService, useValue: { baseURL: TESTING_BASE_URL } },
+        { provide: MAT_DIALOG_DATA, useValue: data },
+        { provide: MatDialogRef, useValue: dialogRef },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ApplicationMemberEditDialogComponent);
+    httpTestingController = TestBed.inject(HttpTestingController);
+
+    fixture.detectChanges();
+    if (roles) {
+      flushRoles(roles);
+      await fixture.whenStable();
+      fixture.detectChanges();
+    }
+    if (createHarness) {
+      harness = await TestbedHarnessEnvironment.harnessForFixture(fixture, ApplicationMemberEditDialogHarness);
+    }
+  }
+
+  function flushRoles(roles: ApplicationRole[] = APPLICATION_ROLES): void {
+    const req = httpTestingController.expectOne(ROLES_URL);
+    expect(req.request.method).toBe('GET');
+    req.flush({ data: roles });
+  }
+
+  afterEach(() => httpTestingController.verify());
+
+  it('should preselect current role and keep save disabled while unchanged', async () => {
+    await init();
+
+    expect(await harness.getRoleValueText()).toBe('USER');
+    expect(await harness.isSaveDisabled()).toBe(true);
+  });
+
+  it('should offer only assignable roles', async () => {
+    await init();
+
+    expect(await harness.getRoleOptionTexts()).toEqual(['OWNER', 'USER']);
+  });
+
+  it('should enable save when role changes', async () => {
+    await init();
+
+    await harness.selectRole('OWNER');
+
+    expect(await harness.isSaveDisabled()).toBe(false);
+  });
+
+  it('should update member role and close dialog on success', async () => {
+    await init();
+
+    await harness.selectRole('OWNER');
+    await harness.clickSave();
+    fixture.detectChanges();
+
+    const req = httpTestingController.expectOne(MEMBER_URL);
+    expect(req.request.method).toBe('PUT');
+    expect(req.request.body).toEqual({ role: 'OWNER' });
+    req.flush({ id: MEMBER_ID, role: 'OWNER' });
+    await fixture.whenStable();
+
+    expect(dialogRef.close).toHaveBeenCalledWith(true);
+  });
+
+  it('should close dialog without update when cancelled', async () => {
+    await init();
+
+    await harness.clickCancel();
+
+    expect(dialogRef.close).toHaveBeenCalledWith(false);
+    httpTestingController.expectNone(MEMBER_URL);
+  });
+
+  it('should keep dialog open and show inline error when update fails', async () => {
+    await init();
+
+    await harness.selectRole('OWNER');
+    await harness.clickSave();
+    fixture.detectChanges();
+
+    httpTestingController.expectOne(MEMBER_URL).flush({ message: 'Server error' }, { status: 500, statusText: 'Error' });
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    expect(dialogRef.close).not.toHaveBeenCalled();
+    expect(await harness.getSubmitErrorText()).toContain('An error occurred while updating the member role');
+    expect(await harness.isSaveDisabled()).toBe(false);
+  });
+
+  it('should show recoverable roles loading error', async () => {
+    await init(DIALOG_DATA, null, false);
+
+    httpTestingController.expectOne(ROLES_URL).flush({ message: 'Server error' }, { status: 500, statusText: 'Error' });
+    await fixture.whenStable();
+    fixture.detectChanges();
+    harness = await TestbedHarnessEnvironment.harnessForFixture(fixture, ApplicationMemberEditDialogHarness);
+
+    expect(await harness.getRolesErrorText()).toContain('An error occurred while loading application roles');
+  });
+});

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-member-edit-dialog/application-member-edit-dialog.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-member-edit-dialog/application-member-edit-dialog.component.ts
@@ -1,0 +1,110 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Component, computed, DestroyRef, inject, signal } from '@angular/core';
+import { rxResource, takeUntilDestroyed, toSignal } from '@angular/core/rxjs-interop';
+import { FormControl, ReactiveFormsModule, Validators } from '@angular/forms';
+import { MatButtonModule } from '@angular/material/button';
+import { MAT_DIALOG_DATA, MatDialogModule, MatDialogRef } from '@angular/material/dialog';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+import { MatSelectModule } from '@angular/material/select';
+import { startWith } from 'rxjs';
+
+import { isAssignableApplicationRole } from '../../../../entities/application/application';
+import { ApplicationService } from '../../../../services/application.service';
+import { MembershipService } from '../../../../services/membership.service';
+
+export interface ApplicationMemberEditDialogData {
+  applicationId: string;
+  memberId: string;
+  memberDisplayName: string;
+  currentRole: string;
+}
+
+@Component({
+  selector: 'app-application-member-edit-dialog',
+  standalone: true,
+  imports: [MatButtonModule, MatDialogModule, MatFormFieldModule, MatProgressSpinnerModule, MatSelectModule, ReactiveFormsModule],
+  templateUrl: './application-member-edit-dialog.component.html',
+  styleUrl: './application-member-edit-dialog.component.scss',
+})
+export class ApplicationMemberEditDialogComponent {
+  private readonly applicationService = inject(ApplicationService);
+  private readonly destroyRef = inject(DestroyRef);
+  private readonly dialogRef = inject(MatDialogRef<ApplicationMemberEditDialogComponent, boolean>);
+  private readonly membershipService = inject(MembershipService);
+  private readonly data: ApplicationMemberEditDialogData = inject(MAT_DIALOG_DATA);
+
+  readonly memberDisplayName = this.data.memberDisplayName;
+  readonly roleControl = new FormControl(this.data.currentRole, { nonNullable: true, validators: [Validators.required] });
+  readonly submitError = signal<string | null>(null);
+  readonly isSubmitting = signal(false);
+
+  private readonly selectedRole = toSignal(this.roleControl.valueChanges.pipe(startWith(this.roleControl.value)), {
+    initialValue: this.roleControl.value,
+  });
+
+  protected readonly rolesResource = rxResource({
+    stream: () => this.applicationService.getApplicationRoles(),
+  });
+
+  readonly assignableRoles = computed(() => (this.rolesResource.value() ?? []).filter(isAssignableApplicationRole));
+
+  readonly canSubmit = computed(() => {
+    const selectedRole = this.selectedRole();
+    return (
+      !this.isSubmitting() &&
+      !this.rolesResource.isLoading() &&
+      !this.rolesResource.error() &&
+      selectedRole !== this.data.currentRole &&
+      this.assignableRoles().some(role => role.name === selectedRole)
+    );
+  });
+
+  onCancel(): void {
+    this.dialogRef.close(false);
+  }
+
+  onSubmit(): void {
+    this.roleControl.markAsTouched();
+    const role = this.roleControl.value;
+
+    if (!this.canSubmit()) {
+      return;
+    }
+
+    this.isSubmitting.set(true);
+    this.submitError.set(null);
+    this.roleControl.disable({ emitEvent: false });
+
+    this.membershipService
+      .updateApplicationMember(this.data.applicationId, this.data.memberId, { role })
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: () => {
+          this.isSubmitting.set(false);
+          this.dialogRef.close(true);
+        },
+        error: () => {
+          this.isSubmitting.set(false);
+          this.roleControl.enable({ emitEvent: false });
+          this.submitError.set(
+            $localize`:@@editApplicationMemberRoleError:An error occurred while updating the member role. Please try again.`,
+          );
+        },
+      });
+  }
+}

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-members-add-dialog/application-members-add-dialog.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-members-add-dialog/application-members-add-dialog.component.spec.ts
@@ -37,6 +37,7 @@ const MOCK_DATE = new Date(1466424490000);
 const APPLICATION_ROLES: ApplicationRole[] = [
   { id: APPLICATION_PRIMARY_OWNER_ROLE_NAME, name: APPLICATION_PRIMARY_OWNER_ROLE_NAME, default: false, system: true },
   { id: 'SYSTEM_AUDITOR', name: 'SYSTEM_AUDITOR', default: false, system: true },
+  { id: 'EMPTY', name: '', default: false, system: false },
   { id: 'OWNER', name: 'OWNER', default: false, system: false },
   { id: 'USER', name: 'USER', default: true, system: false },
 ];
@@ -121,7 +122,7 @@ describe('ApplicationMembersAddDialogComponent', () => {
     expect(await harness.getRoleValueText()).toBe('USER');
   });
 
-  it('should not offer system application roles', async () => {
+  it('should offer only assignable application roles', async () => {
     await init({
       applicationId: APPLICATION_ID,
     });

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-members-add-dialog/application-members-add-dialog.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-members-add-dialog/application-members-add-dialog.component.ts
@@ -29,7 +29,7 @@ import { MatSelectModule } from '@angular/material/select';
 import { catchError, debounceTime, from, map, mergeMap, Observable, of, startWith, toArray } from 'rxjs';
 
 import { UserCellComponent, UserCellVM } from '../../../../components/user-cell/user-cell.component';
-import { APPLICATION_PRIMARY_OWNER_ROLE_NAME, ApplicationRole } from '../../../../entities/application/application';
+import { isAssignableApplicationRole } from '../../../../entities/application/application';
 import { User, UsersResponse } from '../../../../entities/user/user';
 import { ApplicationService } from '../../../../services/application.service';
 import { MembershipService } from '../../../../services/membership.service';
@@ -123,7 +123,7 @@ export class ApplicationMembersAddDialogComponent {
       params.length > 0 ? this.usersService.searchUsersForApplicationMembership(this.data.applicationId, params) : of(undefined),
   });
 
-  readonly assignableRoles = computed(() => (this.rolesResource.value() ?? []).filter(role => this.isAssignableRole(role)));
+  readonly assignableRoles = computed(() => (this.rolesResource.value() ?? []).filter(isAssignableApplicationRole));
 
   private readonly defaultRoleSelectionEffect = effect(() => {
     if (this.hasInitializedDefaultRole || this.roleControl.value) {
@@ -285,11 +285,6 @@ export class ApplicationMembersAddDialogComponent {
   private clearUserSearchControl(): void {
     queueMicrotask(() => this.userControl.setValue(''));
   }
-
-  private isAssignableRole(role: ApplicationRole): role is ApplicationRole & { name: string } {
-    return !!role.name && !role.system && role.name !== APPLICATION_PRIMARY_OWNER_ROLE_NAME;
-  }
-
   private toSelectedUser(user: User, id: string): SelectedUser {
     const vm = this.toUserCell(user);
     return {

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-members/application-tab-members.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-members/application-tab-members.component.spec.ts
@@ -36,10 +36,12 @@ import { ApplicationService } from '../../../../services/application.service';
 import { ConfigService } from '../../../../services/config.service';
 import { CurrentUserService } from '../../../../services/current-user.service';
 import { TESTING_BASE_URL } from '../../../../testing/app-testing.module';
+import { ApplicationMemberEditDialogHarness } from '../application-member-edit-dialog/application-member-edit-dialog.component.harness';
 
 const CURRENT_USER_ID = 'current-user-id';
 const APPLICATION_ROLES: ApplicationRole[] = [
   { id: APPLICATION_PRIMARY_OWNER_ROLE_NAME, name: APPLICATION_PRIMARY_OWNER_ROLE_NAME, default: false, system: true },
+  { id: 'OWNER', name: 'OWNER', default: false, system: false },
   { id: 'USER', name: 'USER', default: true, system: false },
 ];
 
@@ -57,9 +59,9 @@ describe('ApplicationTabMembersComponent', () => {
         provideHttpClientTesting(),
         provideNoopAnimations(),
         provideRouter([]),
+        { provide: ApplicationService, useValue: { getApplicationRoles: () => of(APPLICATION_ROLES) } },
         { provide: ConfigService, useValue: { baseURL: TESTING_BASE_URL } },
         { provide: CurrentUserService, useValue: { user: () => ({ id: CURRENT_USER_ID }) } },
-        { provide: ApplicationService, useValue: { getApplicationRoles: () => of(APPLICATION_ROLES) } },
       ],
     })
       .overrideProvider(InteractivityChecker, { useValue: { isFocusable: () => true, isTabbable: () => true } })
@@ -86,6 +88,18 @@ describe('ApplicationTabMembersComponent', () => {
     await fixture.whenStable();
     fixture.detectChanges();
     return getHarness();
+  }
+
+  async function openEditDialog(member = fakeMember()): Promise<ApplicationMemberEditDialogHarness> {
+    const membersHarness = await flush(fakeMembersResponse([member]));
+    const table = await membersHarness.getPaginatedTable();
+    const editButton = await table!.getActionButton('edit');
+    expect(editButton).not.toBeNull();
+    await editButton!.click();
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+    return rootLoader.getHarness(ApplicationMemberEditDialogHarness);
   }
 
   it('should display members table', async () => {
@@ -330,6 +344,74 @@ describe('ApplicationTabMembersComponent', () => {
     });
   });
 
+  describe('edit role action', () => {
+    beforeEach(() => {
+      fixture.componentRef.setInput('userApplicationPermissions', fakeUserApplicationPermissions({ MEMBER: ['R', 'U'] }));
+    });
+
+    it('should show edit button when user has MEMBER[U] permission', async () => {
+      const harness = await flush(fakeMembersResponse([fakeMember()]));
+      const table = await harness.getPaginatedTable();
+      const editButton = await table!.getActionButton('edit');
+      expect(editButton).not.toBeNull();
+    });
+
+    it('should not show edit button when user lacks MEMBER[U] permission', async () => {
+      fixture.componentRef.setInput('userApplicationPermissions', fakeUserApplicationPermissions({ MEMBER: ['R'] }));
+      const harness = await flush(fakeMembersResponse([fakeMember()]));
+      const table = await harness.getPaginatedTable();
+      const editButton = await table!.getActionButton('edit');
+      expect(editButton).toBeNull();
+    });
+
+    it('should hide edit button for primary owner', async () => {
+      const harness = await flush(fakeMembersResponse([fakeMember({ role: APPLICATION_PRIMARY_OWNER_ROLE_NAME })]));
+      const table = await harness.getPaginatedTable();
+      const editButton = await table!.getActionButton('edit');
+      expect(editButton).toBeNull();
+    });
+
+    it('should open edit member dialog with current role preselected', async () => {
+      const dialog = await openEditDialog(fakeMember({ role: 'USER' }));
+
+      expect(await dialog.getRoleValueText()).toBe('USER');
+    });
+
+    it('should update member role and reload members table on success', async () => {
+      const member = fakeMember({ id: undefined, role: 'USER', user: { id: 'user-1', display_name: 'Alice Smith', _links: {} } });
+      const dialog = await openEditDialog(member);
+
+      await dialog.selectRole('OWNER');
+      await dialog.clickSave();
+      fixture.detectChanges();
+
+      const updateRequest = httpTestingController.expectOne(
+        request =>
+          request.url === `${TESTING_BASE_URL}/applications/${applicationId}/members/${member.user!.id}` && request.method === 'PUT',
+      );
+      expect(updateRequest.request.body).toEqual({ role: 'OWNER' });
+      updateRequest.flush({ ...member, role: 'OWNER' });
+      await fixture.whenStable();
+      fixture.detectChanges();
+
+      httpTestingController
+        .expectOne(request => request.url.includes('members/_search'))
+        .flush(fakeMembersResponse([{ ...member, role: 'OWNER' }]));
+      await fixture.whenStable();
+    });
+
+    it('should not update member role when edit dialog is cancelled', async () => {
+      const dialog = await openEditDialog(fakeMember({ role: 'USER' }));
+
+      await dialog.selectRole('OWNER');
+      await dialog.clickCancel();
+      fixture.detectChanges();
+
+      httpTestingController.expectNone(request => request.method === 'PUT');
+      httpTestingController.expectNone(request => request.url.includes('members/_search'));
+    });
+  });
+
   describe('delete action', () => {
     beforeEach(() => {
       fixture.componentRef.setInput('userApplicationPermissions', fakeUserApplicationPermissions({ MEMBER: ['R', 'D'] }));
@@ -374,7 +456,7 @@ describe('ApplicationTabMembersComponent', () => {
     });
 
     it('should send DELETE request and reload list on confirm', async () => {
-      const member = fakeMember({ id: 'member-1' });
+      const member = fakeMember({ id: undefined, user: { id: 'user-1', display_name: 'Alice Smith', _links: {} } });
       const harness = await flush(fakeMembersResponse([member]));
       const table = await harness.getPaginatedTable();
       await table!.getActionButton('delete').then(btn => btn!.click());
@@ -385,7 +467,7 @@ describe('ApplicationTabMembersComponent', () => {
       fixture.detectChanges();
 
       httpTestingController
-        .expectOne(r => r.url === `${TESTING_BASE_URL}/applications/${applicationId}/members/${member.id}` && r.method === 'DELETE')
+        .expectOne(r => r.url === `${TESTING_BASE_URL}/applications/${applicationId}/members/${member.user!.id}` && r.method === 'DELETE')
         .flush(null, { status: 204, statusText: 'No Content' });
       fixture.detectChanges();
 

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-members/application-tab-members.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-members/application-tab-members.component.ts
@@ -32,6 +32,10 @@ import { UserApplicationPermissions } from '../../../../entities/permission/perm
 import { CurrentUserService } from '../../../../services/current-user.service';
 import { MembershipService } from '../../../../services/membership.service';
 import {
+  ApplicationMemberEditDialogComponent,
+  ApplicationMemberEditDialogData,
+} from '../application-member-edit-dialog/application-member-edit-dialog.component';
+import {
   ApplicationMembersAddDialogComponent,
   ApplicationMembersAddDialogData,
 } from '../application-members-add-dialog/application-members-add-dialog.component';
@@ -88,22 +92,34 @@ export class ApplicationTabMembersComponent {
 
   readonly canRead = computed(() => this.userApplicationPermissions().MEMBER?.includes('R') ?? false);
   readonly canCreate = computed(() => this.userApplicationPermissions().MEMBER?.includes('C') ?? false);
+  readonly canUpdate = computed(() => this.userApplicationPermissions().MEMBER?.includes('U') ?? false);
   readonly canDelete = computed(() => this.userApplicationPermissions().MEMBER?.includes('D') ?? false);
 
-  readonly actions = computed<TableAction<MemberTableRow>[]>(() =>
-    this.canDelete()
-      ? [
-          {
-            id: 'delete',
-            icon: 'delete_outline',
-            ariaLabel: $localize`:@@deleteMemberAriaLabel:Delete member`,
-            color: 'warn',
-            isVisible: (row: MemberTableRow) => !row.isPrimaryOwner,
-            isDisabled: (row: MemberTableRow) => row.isCurrentUser,
-          },
-        ]
-      : [],
-  );
+  readonly actions = computed<TableAction<MemberTableRow>[]>(() => {
+    const actions: TableAction<MemberTableRow>[] = [];
+
+    if (this.canUpdate()) {
+      actions.push({
+        id: 'edit',
+        icon: 'edit',
+        ariaLabel: $localize`:@@editMemberRoleAriaLabel:Edit member role`,
+        isVisible: (row: MemberTableRow) => !row.isPrimaryOwner,
+      });
+    }
+
+    if (this.canDelete()) {
+      actions.push({
+        id: 'delete',
+        icon: 'delete_outline',
+        ariaLabel: $localize`:@@deleteMemberAriaLabel:Delete member`,
+        color: 'warn',
+        isVisible: (row: MemberTableRow) => !row.isPrimaryOwner,
+        isDisabled: (row: MemberTableRow) => row.isCurrentUser,
+      });
+    }
+
+    return actions;
+  });
 
   protected readonly membersResource = rxResource<MembersResponse | undefined, MembersRequestParams | null>({
     params: () =>
@@ -150,7 +166,9 @@ export class ApplicationTabMembersComponent {
   }
 
   onActionClick({ actionId, row }: { actionId: string; row: MemberTableRow }): void {
-    if (actionId === 'delete') {
+    if (actionId === 'edit') {
+      this.openEditMemberDialog(row);
+    } else if (actionId === 'delete') {
       this.openDeleteConfirmation(row);
     }
   }
@@ -165,6 +183,26 @@ export class ApplicationTabMembersComponent {
       .afterClosed()
       .pipe(
         filter((membersAdded): membersAdded is true => membersAdded === true),
+        tap(() => this.membersResource.reload()),
+        takeUntilDestroyed(this.destroyRef),
+      )
+      .subscribe();
+  }
+
+  private openEditMemberDialog(member: MemberTableRow): void {
+    this.error.set(null);
+    this.matDialog
+      .open<ApplicationMemberEditDialogComponent, ApplicationMemberEditDialogData, boolean>(ApplicationMemberEditDialogComponent, {
+        data: {
+          applicationId: this.applicationId(),
+          memberId: member.id,
+          memberDisplayName: member.user.displayName,
+          currentRole: member.role,
+        },
+      })
+      .afterClosed()
+      .pipe(
+        filter((memberUpdated): memberUpdated is true => memberUpdated === true),
         tap(() => this.membersResource.reload()),
         takeUntilDestroyed(this.destroyRef),
       )
@@ -200,7 +238,7 @@ export class ApplicationTabMembersComponent {
       user?.display_name ??
       (user?.first_name || user?.last_name ? `${user?.first_name ?? ''} ${user?.last_name ?? ''}`.trim() : (user?.id ?? ''));
     return {
-      id: member.id ?? '',
+      id: member.id ?? user?.id ?? '',
       user: {
         displayName,
         email: user?.email,

--- a/gravitee-apim-portal-webui-next/src/entities/application/application.ts
+++ b/gravitee-apim-portal-webui-next/src/entities/application/application.ts
@@ -115,6 +115,8 @@ export interface ApplicationsMetadataSubscriptions {
   [applicationId: string]: Subscription[];
 }
 
+export const APPLICATION_PRIMARY_OWNER_ROLE_NAME = 'PRIMARY_OWNER';
+
 export interface ApplicationRole {
   id?: string;
   name: string;
@@ -122,7 +124,9 @@ export interface ApplicationRole {
   system?: boolean;
 }
 
-export const APPLICATION_PRIMARY_OWNER_ROLE_NAME = 'PRIMARY_OWNER';
+export function isAssignableApplicationRole(role: ApplicationRole): role is ApplicationRole & { name: string } {
+  return !!role.name && !role.system && role.name !== APPLICATION_PRIMARY_OWNER_ROLE_NAME;
+}
 
 export interface ConfigurationApplicationRolesResponse {
   data?: ApplicationRole[];

--- a/gravitee-apim-portal-webui-next/src/services/application.service.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/services/application.service.spec.ts
@@ -90,7 +90,6 @@ describe('ApplicationService', () => {
 
     const req = httpTestingController.expectOne(`${TESTING_BASE_URL}/configuration/applications/roles`);
     expect(req.request.method).toEqual('GET');
-
     req.flush({ data: applicationRoles });
   });
 

--- a/gravitee-apim-portal-webui-next/src/services/membership.service.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/services/membership.service.spec.ts
@@ -104,4 +104,20 @@ describe('MembershipService', () => {
     expect(req.request.body).toEqual({ user: 'user-1', role: 'USER' });
     req.flush(member);
   });
+
+  it('should update an application member role', done => {
+    const memberId = 'member-1';
+    const member: Member = { id: memberId, role: 'OWNER' };
+
+    service.updateApplicationMember(applicationId, memberId, { role: 'OWNER' }).subscribe(res => {
+      expect(res).toEqual(member);
+      done();
+    });
+
+    const req = httpTestingController.expectOne(
+      r => r.url === `${TESTING_BASE_URL}/applications/${applicationId}/members/${memberId}` && r.method === 'PUT',
+    );
+    expect(req.request.body).toEqual({ role: 'OWNER' });
+    req.flush(member);
+  });
 });

--- a/gravitee-apim-portal-webui-next/src/services/membership.service.ts
+++ b/gravitee-apim-portal-webui-next/src/services/membership.service.ts
@@ -42,4 +42,8 @@ export class MembershipService {
   addApplicationMember(applicationId: string, memberInput: MemberInput): Observable<Member> {
     return this.http.post<Member>(`${this.configService.baseURL}/applications/${applicationId}/members`, memberInput);
   }
+
+  updateApplicationMember(applicationId: string, memberId: string, memberInput: MemberInput): Observable<Member> {
+    return this.http.put<Member>(`${this.configService.baseURL}/applications/${applicationId}/members/${memberId}`, memberInput);
+  }
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-14137

## Summary 

Adds role update for active application members in the new Developer Portal.

Changes
- Adds an edit member role dialog with role loading, validation, inline errors, and harness tests.
- Adds MEMBER[U] gated edit action on the application members table.
- Hides role editing for PRIMARY_OWNER.
- Reuses application role configuration and excludes system roles from assignable options.
- Adds PUT /applications/{applicationId}/members/{memberId} support in MembershipService.



https://github.com/user-attachments/assets/dc1d2453-b752-4eb0-a579-a8e0c020cae1


