### PR TITLE
feat(definition): add EdgeApi definition model and ApiType.EDGE

### DIFF
--- a/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/AbstractApi.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/AbstractApi.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.definition.model.v4;
 
+import static io.gravitee.definition.model.v4.AbstractApi.EDGE_LABEL;
 import static io.gravitee.definition.model.v4.AbstractApi.MESSAGE_LABEL;
 import static io.gravitee.definition.model.v4.AbstractApi.NATIVE_LABEL;
 import static io.gravitee.definition.model.v4.AbstractApi.PROXY_LABEL;
@@ -25,6 +26,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import io.gravitee.definition.model.ApiDefinition;
 import io.gravitee.definition.model.DefinitionVersion;
 import io.gravitee.definition.model.Plugin;
+import io.gravitee.definition.model.v4.edge.EdgeApi;
 import io.gravitee.definition.model.v4.listener.AbstractListener;
 import io.gravitee.definition.model.v4.listener.entrypoint.AbstractEntrypoint;
 import io.gravitee.definition.model.v4.nativeapi.NativeApi;
@@ -69,6 +71,7 @@ import lombok.experimental.SuperBuilder;
         @JsonSubTypes.Type(value = Api.class, name = PROXY_LABEL),
         @JsonSubTypes.Type(value = Api.class, name = MESSAGE_LABEL),
         @JsonSubTypes.Type(value = NativeApi.class, name = NATIVE_LABEL),
+        @JsonSubTypes.Type(value = EdgeApi.class, name = EDGE_LABEL),
     }
 )
 public abstract class AbstractApi implements Serializable, ApiDefinition {
@@ -76,6 +79,7 @@ public abstract class AbstractApi implements Serializable, ApiDefinition {
     public static final String PROXY_LABEL = "proxy";
     public static final String MESSAGE_LABEL = "message";
     public static final String NATIVE_LABEL = "native";
+    public static final String EDGE_LABEL = "edge";
 
     @JsonProperty(required = true)
     @NotBlank

--- a/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/ApiType.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/ApiType.java
@@ -28,25 +28,21 @@ import lombok.RequiredArgsConstructor;
 @Getter
 public enum ApiType {
     A2A_PROXY("a2a-proxy"),
+    EDGE("edge"),
     LLM_PROXY("llm-proxy"),
     MCP_PROXY("mcp-proxy"),
     MESSAGE("message"),
     NATIVE("native"),
     PROXY("proxy");
 
-    private static final Map<String, ApiType> LABELS_MAP = Map.of(
-        A2A_PROXY.label,
-        A2A_PROXY,
-        LLM_PROXY.label,
-        LLM_PROXY,
-        MCP_PROXY.label,
-        MCP_PROXY,
-        MESSAGE.label,
-        MESSAGE,
-        NATIVE.label,
-        NATIVE,
-        PROXY.label,
-        PROXY
+    private static final Map<String, ApiType> LABELS_MAP = Map.ofEntries(
+        Map.entry(A2A_PROXY.label, A2A_PROXY),
+        Map.entry(EDGE.label, EDGE),
+        Map.entry(LLM_PROXY.label, LLM_PROXY),
+        Map.entry(MCP_PROXY.label, MCP_PROXY),
+        Map.entry(MESSAGE.label, MESSAGE),
+        Map.entry(NATIVE.label, NATIVE),
+        Map.entry(PROXY.label, PROXY)
     );
 
     @JsonValue

--- a/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/edge/DnsDomain.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/edge/DnsDomain.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.definition.model.v4.edge;
+
+import java.io.Serializable;
+
+public record DnsDomain(String name) implements Serializable {}

--- a/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/edge/EdgeApi.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/edge/EdgeApi.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.definition.model.v4.edge;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.gravitee.definition.model.Plugin;
+import io.gravitee.definition.model.v4.AbstractApi;
+import io.gravitee.definition.model.v4.ApiType;
+import io.gravitee.definition.model.v4.listener.AbstractListener;
+import io.gravitee.definition.model.v4.listener.entrypoint.AbstractEntrypoint;
+import jakarta.validation.constraints.NotNull;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+import lombok.experimental.SuperBuilder;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+@ToString(callSuper = true)
+@EqualsAndHashCode(callSuper = true)
+@SuperBuilder(toBuilder = true)
+public class EdgeApi extends AbstractApi {
+
+    @JsonProperty(required = true)
+    @NotNull
+    @Builder.Default
+    private ApiType type = ApiType.EDGE;
+
+    @NotNull
+    private EdgeProxyDefinition proxy;
+
+    private EdgeShadowAiDefinition shadowAi;
+
+    @Override
+    @JsonIgnore
+    public List<Plugin> getPlugins() {
+        return List.of();
+    }
+
+    @Override
+    @JsonIgnore
+    public List<? extends AbstractListener<? extends AbstractEntrypoint>> getListeners() {
+        return List.of();
+    }
+}

--- a/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/edge/EdgeProxyDefinition.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/edge/EdgeProxyDefinition.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.definition.model.v4.edge;
+
+import java.io.Serializable;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+@ToString
+@EqualsAndHashCode
+@Builder
+public class EdgeProxyDefinition implements Serializable {
+
+    private List<DnsDomain> dnsDomains;
+    private List<EdgeRoute> routes;
+}

--- a/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/edge/EdgeRoute.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/edge/EdgeRoute.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.definition.model.v4.edge;
+
+import java.io.Serializable;
+
+public record EdgeRoute(String pathPrefix, EdgeRouteTarget target) implements Serializable {}

--- a/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/edge/EdgeRouteTarget.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/edge/EdgeRouteTarget.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.definition.model.v4.edge;
+
+public enum EdgeRouteTarget {
+    LLM,
+    PASSTHROUGH,
+}

--- a/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/edge/EdgeShadowAiDefinition.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/edge/EdgeShadowAiDefinition.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.definition.model.v4.edge;
+
+import java.io.Serializable;
+import java.time.Duration;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+@ToString
+@EqualsAndHashCode
+@Builder
+public class EdgeShadowAiDefinition implements Serializable {
+
+    private List<ShadowAiDomain> domains;
+    private Duration reportInterval;
+}

--- a/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/edge/ShadowAiDomain.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/edge/ShadowAiDomain.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.definition.model.v4.edge;
+
+import java.io.Serializable;
+
+public record ShadowAiDomain(String name) implements Serializable {}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/resources/open-api.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/resources/open-api.yaml
@@ -1646,6 +1646,7 @@ components:
         - MESSAGE
       enum:
         - A2A_PROXY
+        - EDGE
         - LLM_PROXY
         - MCP_PROXY
         - MESSAGE

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/LogsEngineMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/LogsEngineMapper.java
@@ -80,7 +80,7 @@ public interface LogsEngineMapper {
             case PROXY -> io.gravitee.rest.api.management.v2.rest.model.logs.engine.EnvironmentApiLog.ApiTypeEnum.HTTP_PROXY;
             case LLM_PROXY -> io.gravitee.rest.api.management.v2.rest.model.logs.engine.EnvironmentApiLog.ApiTypeEnum.LLM_PROXY;
             case MCP_PROXY -> io.gravitee.rest.api.management.v2.rest.model.logs.engine.EnvironmentApiLog.ApiTypeEnum.MCP_PROXY;
-            case A2A_PROXY, MESSAGE, NATIVE -> null;
+            case A2A_PROXY, EDGE, MESSAGE, NATIVE -> null;
         };
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-apis.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-apis.yaml
@@ -4228,6 +4228,7 @@ components:
             example: MESSAGE
             enum:
                 - A2A_PROXY
+                - EDGE
                 - LLM_PROXY
                 - MCP_PROXY
                 - MESSAGE

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-environments.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-environments.yaml
@@ -1691,6 +1691,7 @@ components:
       example: MESSAGE
       enum:
         - A2A_PROXY
+        - EDGE
         - LLM_PROXY
         - MCP_PROXY
         - MESSAGE

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-plugins.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-plugins.yaml
@@ -594,6 +594,7 @@ components:
             example: MESSAGE
             enum:
                 - A2A_PROXY
+                - EDGE
                 - LLM_PROXY
                 - MCP_PROXY
                 - MESSAGE

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/resources/portal-openapi.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/resources/portal-openapi.yaml
@@ -5233,6 +5233,7 @@ components:
             example: PROXY
             enum:
                 - A2A_PROXY
+                - EDGE
                 - LLM_PROXY
                 - MCP_PROXY
                 - PROXY
@@ -7183,6 +7184,7 @@ components:
                     type: string
                     enum:
                         - a2a_proxy
+                        - edge
                         - llm_proxy
                         - mcp_proxy
                         - proxy

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/scoring/use_case/ScoreApiRequestUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/scoring/use_case/ScoreApiRequestUseCase.java
@@ -148,6 +148,7 @@ public class ScoreApiRequestUseCase {
             case GraviteeDefinition.Native ignored -> ScoreRequest.Format.GRAVITEE_NATIVE;
             case GraviteeDefinition.V4 v4 -> switch (v4.api().type()) {
                 case A2A_PROXY, LLM_PROXY, MCP_PROXY, PROXY -> ScoreRequest.Format.GRAVITEE_PROXY;
+                case EDGE -> null;
                 case MESSAGE -> ScoreRequest.Format.GRAVITEE_MESSAGE;
                 case NATIVE -> ScoreRequest.Format.GRAVITEE_NATIVE;
             };

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/search/lucene/utils/LuceneTransformerUtils.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/search/lucene/utils/LuceneTransformerUtils.java
@@ -62,6 +62,7 @@ public final class LuceneTransformerUtils {
         if (definitionVersion == DefinitionVersion.V4) {
             String type = switch (apiType) {
                 case A2A_PROXY -> "A2A_PROXY";
+                case EDGE -> "EDGE";
                 case LLM_PROXY -> "LLM_PROXY";
                 case MCP_PROXY -> "MCP_PROXY";
                 case MESSAGE -> "MESSAGE";

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/ApiLicenseServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/ApiLicenseServiceImpl.java
@@ -70,6 +70,9 @@ public class ApiLicenseServiceImpl implements ApiLicenseService {
                     case NATIVE -> objectMapper
                         .readValue(repositoryApi.getDefinition(), io.gravitee.definition.model.v4.nativeapi.NativeApi.class)
                         .getPlugins();
+                    case EDGE -> objectMapper
+                        .readValue(repositoryApi.getDefinition(), io.gravitee.definition.model.v4.edge.EdgeApi.class)
+                        .getPlugins();
                     case A2A_PROXY, LLM_PROXY, MCP_PROXY, PROXY, MESSAGE -> objectMapper
                         .readValue(repositoryApi.getDefinition(), io.gravitee.definition.model.v4.Api.class)
                         .getPlugins();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/mapper/GenericApiMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/mapper/GenericApiMapper.java
@@ -39,7 +39,7 @@ public class GenericApiMapper {
         return switch (getVersionOfDefault(api)) {
             case V4 -> switch (api.getType()) {
                 case NATIVE -> apiMapper.toNativeEntity(api, primaryOwner);
-                case A2A_PROXY, LLM_PROXY, MCP_PROXY, MESSAGE, PROXY -> apiMapper.toEntity(api, primaryOwner);
+                case A2A_PROXY, EDGE, LLM_PROXY, MCP_PROXY, MESSAGE, PROXY -> apiMapper.toEntity(api, primaryOwner);
             };
             case FEDERATED -> apiMapper.federatedToEntity(api, primaryOwner);
             case FEDERATED_AGENT -> apiMapper.federatedAgentToEntity(api, primaryOwner);
@@ -59,7 +59,7 @@ public class GenericApiMapper {
         return switch (getVersionOfDefault(api)) {
             case V4 -> switch (api.getType()) {
                 case NATIVE -> apiMapper.toNativeEntity(executionContext, api, primaryOwner, withApiFlows, withPlans, withApiCategories);
-                case A2A_PROXY, LLM_PROXY, MCP_PROXY, MESSAGE, PROXY -> apiMapper.toEntity(
+                case A2A_PROXY, EDGE, LLM_PROXY, MCP_PROXY, MESSAGE, PROXY -> apiMapper.toEntity(
                     executionContext,
                     api,
                     primaryOwner,

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/mapper/GenericPlanMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/mapper/GenericPlanMapper.java
@@ -74,6 +74,7 @@ public class GenericPlanMapper {
 
         return switch (apiDefinitionVersion) {
             case V4 -> switch (api.getType()) {
+                case EDGE -> throw new IllegalStateException("EDGE API does not support plans");
                 case A2A_PROXY, LLM_PROXY, MCP_PROXY, PROXY, MESSAGE -> {
                     final Map<String, List<Flow>> flowsByPlanId = flowService != null
                         ? flowService.findByReferences(FlowReferenceType.PLAN, planIds)
@@ -138,6 +139,7 @@ public class GenericPlanMapper {
         var apiDefinitionVersion = api.getDefinitionVersion() != null ? api.getDefinitionVersion() : DefinitionVersion.V2;
         return switch (apiDefinitionVersion) {
             case V4 -> switch (api.getType()) {
+                case EDGE -> throw new IllegalStateException("EDGE API does not support plans");
                 case A2A_PROXY, LLM_PROXY, MCP_PROXY, PROXY, MESSAGE -> planMapper.toEntity(plan, null);
                 case NATIVE -> planMapper.toNativeEntity(plan, null);
             };
@@ -150,6 +152,7 @@ public class GenericPlanMapper {
         var apiDefinitionVersion = api.getDefinitionVersion() != null ? api.getDefinitionVersion() : DefinitionVersion.V2;
         return switch (apiDefinitionVersion) {
             case V4 -> switch (api.getType()) {
+                case EDGE -> throw new IllegalStateException("EDGE API does not support plans");
                 case A2A_PROXY, LLM_PROXY, MCP_PROXY, PROXY, MESSAGE -> handleGenericPlanWithoutFlow(plans);
                 case NATIVE -> plans
                     .stream()

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/scoring/use_case/ScoreApiRequestUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/scoring/use_case/ScoreApiRequestUseCaseTest.java
@@ -48,6 +48,7 @@ import io.gravitee.apim.core.scoring.model.ScoringAssetType;
 import io.gravitee.apim.core.scoring.model.ScoringRuleset;
 import io.gravitee.apim.infra.json.jackson.GraviteeDefinitionJacksonJsonSerializer;
 import io.gravitee.common.utils.TimeProvider;
+import io.gravitee.definition.model.v4.ApiType;
 import io.gravitee.rest.api.service.common.UuidString;
 import io.gravitee.rest.api.service.exceptions.ApiDefinitionVersionNotSupportedException;
 import io.vertx.core.json.JsonObject;
@@ -311,6 +312,37 @@ class ScoreApiRequestUseCaseTest {
                     new ScoreRequest.CustomRuleset(CUSTOM_RULESET_3.payload())
                 );
         });
+    }
+
+    @Test
+    public void should_trigger_scoring_for_edge_api_with_null_format() {
+        // Given
+        var api = givenExistingApi(ApiFixtures.aProxyApiV4());
+        var edgeDefinition = GraviteeDefinition.V4.builder()
+            .api(ApiDescriptor.ApiDescriptorV4.builder().id(MY_API).name(MY_API_NAME).type(ApiType.EDGE).build())
+            .build();
+        when(apiExportDomainService.export(eq(MY_API), eq(AUDIT_INFO), anyCollection())).thenReturn(edgeDefinition);
+
+        // When
+        scoreApiRequestUseCase
+            .execute(new ScoreApiRequestUseCase.Input(api.getId(), AUDIT_INFO))
+            .test()
+            .awaitDone(5, TimeUnit.SECONDS)
+            .assertComplete();
+
+        // Then
+        assertThat(scoringProvider.pendingRequests())
+            .hasSize(1)
+            .first()
+            .satisfies(request -> {
+                assertThat(request.assets())
+                    .hasSize(1)
+                    .first()
+                    .satisfies(asset -> {
+                        assertThat(asset.assetType().type()).isEqualTo(ScoringAssetType.GRAVITEE_DEFINITION);
+                        assertThat(asset.assetType().format()).isNull();
+                    });
+            });
     }
 
     @ParameterizedTest

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/subscription/use_case/AcceptSubscriptionUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/subscription/use_case/AcceptSubscriptionUseCaseTest.java
@@ -610,6 +610,7 @@ class AcceptSubscriptionUseCaseTest {
             case V2 -> ApiFixtures.aProxyApiV2().setId(API_ID);
             case V4 -> switch (apiType) {
                 case A2A_PROXY -> ApiFixtures.anA2AProxyApiV4().setId(API_ID);
+                case EDGE -> throw new IllegalStateException("EDGE API not supported");
                 case LLM_PROXY -> ApiFixtures.aLLMProxyApiV4().setId(API_ID);
                 case MCP_PROXY -> ApiFixtures.aMCPProxyApiV4().setId(API_ID);
                 case PROXY -> ApiFixtures.aProxyApiV4().setId(API_ID);
@@ -638,6 +639,7 @@ class AcceptSubscriptionUseCaseTest {
             case V2 -> PlanFixtures.aPlanV2().setPlanStatus(PlanStatus.PUBLISHED);
             case V4 -> switch (api.getType()) {
                 case A2A_PROXY, LLM_PROXY, MCP_PROXY, PROXY -> PlanFixtures.HttpV4.anApiKey().setPlanStatus(PlanStatus.PUBLISHED);
+                case EDGE -> throw new IllegalStateException("EDGE API not supported");
                 case MESSAGE -> PlanFixtures.HttpV4.aPushPlan().setPlanStatus(PlanStatus.PUBLISHED);
                 case NATIVE -> throw new IllegalStateException("NATIVE API not supported");
             };

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/ApiLicenseServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/ApiLicenseServiceImplTest.java
@@ -73,6 +73,9 @@ public class ApiLicenseServiceImplTest {
     private io.gravitee.definition.model.v4.nativeapi.NativeApi nativeApiV4;
 
     @Mock
+    private io.gravitee.definition.model.v4.edge.EdgeApi edgeApi;
+
+    @Mock
     private io.gravitee.definition.model.Api apiV2;
 
     @Mock
@@ -94,6 +97,7 @@ public class ApiLicenseServiceImplTest {
 
         when(objectMapper.readValue("dummy definition", io.gravitee.definition.model.v4.Api.class)).thenReturn(apiV4);
         when(objectMapper.readValue("dummy definition", io.gravitee.definition.model.v4.nativeapi.NativeApi.class)).thenReturn(nativeApiV4);
+        when(objectMapper.readValue("dummy definition", io.gravitee.definition.model.v4.edge.EdgeApi.class)).thenReturn(edgeApi);
         when(objectMapper.readValue("dummy definition", io.gravitee.definition.model.Api.class)).thenReturn(apiV2);
 
         when(apiV4.getPlugins()).thenReturn(List.of(new Plugin("apiV4-type", "apiV4-id"), new Plugin("another", "plugin")));
@@ -122,6 +126,14 @@ public class ApiLicenseServiceImplTest {
             new LicenseManager.Plugin("another", "plugin")
         );
         verify(licenseManager, times(1)).validatePluginFeatures(eq(executionContext.getOrganizationId()), eq(v4LicensePlugins));
+    }
+
+    @Test
+    public void should_verify_v4_edge_definition() throws Exception {
+        when(repositoryApi.getType()).thenReturn(ApiType.EDGE);
+        when(edgeApi.getPlugins()).thenReturn(List.of());
+        assertDoesNotThrow(() -> apiLicenseService.checkLicense(executionContext, API));
+        verify(licenseManager, times(1)).validatePluginFeatures(eq(executionContext.getOrganizationId()), eq(List.of()));
     }
 
     @Test


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/GMA-331

## Description

Adds the API definition model for the Edge daemon configuration, following the same pattern as `NativeApi` (dedicated `AbstractApi` subclass with its own domain objects).

### Why a new `AbstractApi` subclass?

The Edge daemon configuration (proxy routing, DNS interception, shadow AI monitoring) doesn't fit the existing `Api` model which is built around listeners, endpoint groups, and plans. Like `NativeApi` was introduced for Kafka-native APIs with its own domain objects (`NativeListener`, `NativeEndpointGroup`, etc.), `EdgeApi` carries Edge-specific domain objects without inheriting irrelevant HTTP/messaging concepts.

### What's included

- **`ApiType.EDGE`** — new API type, registered in `AbstractApi`'s `@JsonSubTypes` for polymorphic Jackson deserialization.
- **`EdgeApi`** — extends `AbstractApi`. Carries `EdgeProxyDefinition` (proxy routing config) and `EdgeShadowAiDefinition` (shadow AI monitoring config). Returns empty lists for `getPlugins()` / `getListeners()` since Edge doesn't use those concepts.
- **Rich domain records** instead of primitives — `DnsDomain(name)`, `ShadowAiDomain(name)`, `EdgeRoute(pathPrefix, target)` — so the model can evolve without breaking serialized data.
- **`Duration` for `reportInterval`** instead of `int` seconds — ISO-8601 standard (`PT2M`), self-documenting.
