### PR TITLE
fix: can't change group permission on api

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/api-notification/api-notification.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-notification/api-notification.component.ts
@@ -39,6 +39,7 @@ import { Hooks } from '../../../entities/notification/hooks';
 import { GroupV2Service } from '../../../services-ngx/group-v2.service';
 import { ApiV2Service } from '../../../services-ngx/api-v2.service';
 import { GroupData } from '../user-group-access/members/api-general-members.component';
+import { mapApiGroupsToGroupData } from '../user-group-access/group-data.utils';
 import { CurrentUserService } from '../../../services-ngx/current-user.service';
 
 @Component({
@@ -107,11 +108,7 @@ export class ApiNotificationComponent implements OnInit, OnDestroy {
       .subscribe(([notifiers, notifications, api, groups, primaryOwner, currentUser]) => {
         this.notifiers = notifiers;
         this.notifications$.next(notifications);
-        this.groupData = api.groups?.map(id => ({
-          id,
-          name: groups.data.find(g => g.id === id)?.name,
-          isVisible: true,
-        }));
+        this.groupData = mapApiGroupsToGroupData(api.groups, groups.data);
         this.apiPrimaryOwner = primaryOwner.id;
         this.isApiPrimaryOwner = primaryOwner.id === currentUser.id;
       });

--- a/gravitee-apim-console-webui/src/management/api/user-group-access/group-data.utils.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/user-group-access/group-data.utils.spec.ts
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { isGroupAssociatedWithApi, mapApiGroupsToGroupData } from './group-data.utils';
+
+import { fakeGroup } from '../../../entities/management-api-v2';
+
+describe('group-data.utils', () => {
+  const group = fakeGroup({ id: 'group-uuid', name: 'my-group' });
+
+  describe('mapApiGroupsToGroupData', () => {
+    it('should resolve group id references', () => {
+      expect(mapApiGroupsToGroupData(['group-uuid'], [group])).toEqual([{ id: 'group-uuid', name: 'my-group', isVisible: true }]);
+    });
+
+    it('should resolve group name references (V2 APIs)', () => {
+      expect(mapApiGroupsToGroupData(['my-group'], [group])).toEqual([{ id: 'group-uuid', name: 'my-group', isVisible: true }]);
+    });
+
+    it('should skip unknown references', () => {
+      expect(mapApiGroupsToGroupData(['unknown'], [group])).toEqual([]);
+    });
+  });
+
+  describe('isGroupAssociatedWithApi', () => {
+    it('should match by id or name', () => {
+      expect(isGroupAssociatedWithApi(['group-uuid'], group)).toBe(true);
+      expect(isGroupAssociatedWithApi(['my-group'], group)).toBe(true);
+      expect(isGroupAssociatedWithApi(['other'], group)).toBe(false);
+    });
+  });
+});

--- a/gravitee-apim-console-webui/src/management/api/user-group-access/group-data.utils.ts
+++ b/gravitee-apim-console-webui/src/management/api/user-group-access/group-data.utils.ts
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { GroupData } from './members/api-general-members.component';
+
+import { Group } from '../../../entities/management-api-v2';
+
+/**
+ * Maps API group references to UI group data.
+ * V2 APIs persist group names in {@code api.groups}; V4+ APIs persist group IDs.
+ */
+export function mapApiGroupsToGroupData(apiGroupRefs: string[] | undefined, allGroups: Group[]): GroupData[] {
+  const groupData: GroupData[] = [];
+  for (const ref of apiGroupRefs ?? []) {
+    const group = allGroups.find(g => g.id === ref || g.name === ref);
+    if (group) {
+      groupData.push({ id: group.id, name: group.name, isVisible: true });
+    }
+  }
+  return groupData;
+}
+
+export function isGroupAssociatedWithApi(apiGroupRefs: string[] | undefined, group: Group): boolean {
+  return apiGroupRefs?.some(ref => ref === group.id || ref === group.name) ?? false;
+}

--- a/gravitee-apim-console-webui/src/management/api/user-group-access/groups/api-general-groups.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/user-group-access/groups/api-general-groups.component.spec.ts
@@ -27,7 +27,7 @@ import { ApiGeneralGroupsHarness } from './api-general-groups.harness';
 
 import { CONSTANTS_TESTING, GioTestingModule } from '../../../../shared/testing';
 import { ApiUserGroupModule } from '../api-user-group.module';
-import { Api, fakeApiV4, fakeGroup, fakeGroupsResponse, Group, MembersResponse } from '../../../../entities/management-api-v2';
+import { Api, fakeApiV2, fakeApiV4, fakeGroup, fakeGroupsResponse, Group, MembersResponse } from '../../../../entities/management-api-v2';
 import { GioTestingPermissionProvider } from '../../../../shared/components/gio-permission/gio-permission.service';
 import { ApiGeneralMembersComponent } from '../members/api-general-members.component';
 import { ApiGeneralMembersHarness } from '../members/api-general-members.harness';
@@ -133,6 +133,30 @@ describe('ApiGeneralGroupsComponent', () => {
       mockedReturnedGroups.forEach(id => expectGetGroupMembersRequest(fakeGroup({ id })));
       fixture.detectChanges();
       expect(matDialogSpy.open).toHaveBeenCalled();
+    });
+
+    it('should resolve V2 API group names when loading inherited members', async () => {
+      const groupName = 'my-group';
+      const api = fakeApiV2({ id: apiId, groups: [groupName] });
+      expectApiGetRequest(api);
+      httpTestingController.expectOne({ url: `${CONSTANTS_TESTING.env.v2BaseURL}/groups?page=1&perPage=9999`, method: 'GET' }).flush(
+        fakeGroupsResponse({
+          data: [fakeGroup({ id: groupId1, name: groupName }), fakeGroup({ id: groupId2, name: `${groupId2}-name` })],
+        }),
+      );
+      fixture.detectChanges();
+      expectApiMembersGetRequest(api);
+      expectApiRoleGetRequest();
+      httpTestingController
+        .expectOne({ url: `${CONSTANTS_TESTING.env.v2BaseURL}/groups/${groupId1}/members?page=1&perPage=10`, method: 'GET' })
+        .flush(
+          { httpStatus: 403, message: 'You do not have the permissions to access this resource' },
+          { statusText: 'Forbidden', status: 403 },
+        );
+      fixture.detectChanges();
+
+      expect(await harness.getGroupsLength()).toStrictEqual(1);
+      expect(await harness.getGroupsNames()).toEqual([`Group ${groupName}`]);
     });
 
     it('should not apply group changes if dialog is closed without saving', async () => {

--- a/gravitee-apim-console-webui/src/management/api/user-group-access/groups/api-general-groups.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/user-group-access/groups/api-general-groups.component.ts
@@ -19,6 +19,7 @@ import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
 
 import { GioPermissionService } from '../../../../shared/components/gio-permission/gio-permission.service';
 import { Api, Group } from '../../../../entities/management-api-v2';
+import { isGroupAssociatedWithApi } from '../group-data.utils';
 
 export interface ApiGroupsDialogData {
   api: Api;
@@ -58,7 +59,7 @@ export class ApiGeneralGroupsComponent implements OnInit {
   ngOnInit() {
     this.isReadOnly = this.isKubernetesOrigin || !this.permissionService.hasAnyMatching(['api-member-u']);
 
-    const userGroupList: Group[] = this.groups.filter(group => this.api.groups?.includes(group.id));
+    const userGroupList: Group[] = this.groups.filter(group => isGroupAssociatedWithApi(this.api.groups, group));
     this.form = this.formBuilder.group({
       selectedGroups: {
         value: userGroupList.map(g => g.id),

--- a/gravitee-apim-console-webui/src/management/api/user-group-access/members/api-general-members.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/user-group-access/members/api-general-members.component.ts
@@ -44,6 +44,7 @@ import {
 import { Role } from '../../../../entities/role/role';
 import { GioRoleService } from '../../../../shared/components/gio-role/gio-role.service';
 import { GioTableWrapperFilters } from '../../../../shared/components/gio-table-wrapper/gio-table-wrapper.component';
+import { mapApiGroupsToGroupData } from '../group-data.utils';
 
 class MemberDataSource {
   id: string;
@@ -134,11 +135,7 @@ export class ApiGeneralMembersComponent implements OnInit {
           this.roles = roles ?? [];
           this.defaultRole = roles.find(role => role.default);
           this.roleNames = roles.map(r => r.name) ?? [];
-          this.groupData = api.groups?.map(id => ({
-            id,
-            name: groups.data.find(g => g.id === id)?.name,
-            isVisible: true,
-          }));
+          this.groupData = mapApiGroupsToGroupData(api.groups, groups.data);
           this.initDataSource();
           this.initForm(api);
           if (members?.pagination?.totalCount) {


### PR DESCRIPTION
https://gravitee.atlassian.net/browse/APIM-14110

The bug: V2 APIs store group names in api.groups (e.g. "my-group"), while V4+ APIs store group IDs (e.g. "a1b2-uuid"). Three places in the code were assuming api.groups always contains IDs, so for V2 APIs, the group lookup would always fail and groups would never pre-select or display correctly.