### PR TITLE
fix(console): default time range in native connection logs url

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs-native-details/api-runtime-logs-native-details.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs-native-details/api-runtime-logs-native-details.component.spec.ts
@@ -128,15 +128,39 @@ describe('ApiRuntimeLogsNativeDetailsComponent', () => {
     expect(await harness.isBackLinkVisible()).toBe(true);
   });
 
-  it('renders the load-failed banner without firing an HTTP call when from/to query params are missing', async () => {
+  it('fires the detail request with default-period from/to when query params are missing', async () => {
     await setup({});
-    httpTestingController.expectNone(req => req.url.includes(`/logs/native/${REQUEST_ID}`));
+    const req = httpTestingController.expectOne(
+      r =>
+        r.url === `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${API_ID}/logs/native/${REQUEST_ID}` &&
+        Number.isFinite(Number(r.params.get('from'))) &&
+        Number.isFinite(Number(r.params.get('to'))) &&
+        Number(r.params.get('to')) > Number(r.params.get('from')),
+    );
+    req.flush(fakeNativeApiLog({ connectionStatus: 'CONNECTED' }));
     await fixture.whenStable();
     fixture.detectChanges();
 
-    expect(await harness.isLoadFailedBannerVisible()).toBe(true);
+    expect(await harness.isLoadFailedBannerVisible()).toBe(false);
     expect(await harness.isNotFoundBannerVisible()).toBe(false);
-    expect(await harness.isBackLinkVisible()).toBe(true);
+    expect(await harness.isTitleVisible()).toBe(true);
+  });
+
+  // Number('') === 0 — would pass Number.isFinite and silently ship from=0, to=0 without the explicit guard.
+  it('uses the default-period from/to when query params are present but empty strings', async () => {
+    await setup({ from: '', to: '' });
+    const req = httpTestingController.expectOne(
+      r =>
+        r.url === `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${API_ID}/logs/native/${REQUEST_ID}` &&
+        Number(r.params.get('from')) > 0 &&
+        Number(r.params.get('to')) > Number(r.params.get('from')),
+    );
+    req.flush(fakeNativeApiLog({ connectionStatus: 'CONNECTED' }));
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    expect(await harness.isLoadFailedBannerVisible()).toBe(false);
+    expect(await harness.isTitleVisible()).toBe(true);
   });
 
   it('renders a dash for Duration in the connection card when connectionDurationMs is null', async () => {

--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs-native-details/api-runtime-logs-native-details.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs-native-details/api-runtime-logs-native-details.component.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import { Component, inject } from '@angular/core';
-import { ActivatedRoute, RouterLink } from '@angular/router';
+import { ActivatedRoute, Params, RouterLink } from '@angular/router';
 import { AsyncPipe, DatePipe } from '@angular/common';
 import { HttpErrorResponse } from '@angular/common/http';
 import { MatCardModule } from '@angular/material/card';
@@ -23,10 +23,15 @@ import { GioBannerModule, GioIconsModule } from '@gravitee/ui-particles-angular'
 import { Observable, of } from 'rxjs';
 import { catchError, map } from 'rxjs/operators';
 
-import { NATIVE_STATUS_META, isNativeConnectionErrored } from '../runtime-logs-native/api-runtime-logs-native.models';
+import {
+  DEFAULT_NATIVE_LOGS_PERIOD,
+  NATIVE_STATUS_META,
+  isNativeConnectionErrored,
+} from '../runtime-logs-native/api-runtime-logs-native.models';
 import { ApiNativeLogsV2Service } from '../../../../services-ngx/api-native-logs-v2.service';
 import { FormatDurationPipe } from '../../../../shared/pipes/format-duration.pipe';
 import { NativeApiLog } from '../../../../entities/management-api-v2';
+import { timeFrameRangesParams } from '../../../../shared/utils/timeFrameRanges';
 
 type LogState = { kind: 'ok'; log: NativeApiLog } | { kind: 'not-found' } | { kind: 'load-failed' };
 
@@ -43,20 +48,26 @@ export class ApiRuntimeLogsNativeDetailsComponent {
 
   private readonly apiId = this.route.snapshot.params.apiId as string;
   protected readonly requestId = this.route.snapshot.params.requestId as string;
-  private readonly from = Number(this.route.snapshot.queryParams.from);
-  private readonly to = Number(this.route.snapshot.queryParams.to);
+  private readonly range = resolveTimeWindow(this.route.snapshot.queryParams);
 
   protected readonly backQueryParams = this.route.snapshot.queryParams;
 
   protected readonly statusMeta = NATIVE_STATUS_META;
 
-  protected readonly state$: Observable<LogState> =
-    Number.isFinite(this.from) && Number.isFinite(this.to)
-      ? this.logsService.getConnectionLog(this.apiId, this.requestId, this.from, this.to).pipe(
-          map(log => ({ kind: 'ok', log }) as LogState),
-          catchError((err: HttpErrorResponse) => of({ kind: err.status === 404 ? 'not-found' : 'load-failed' } as LogState)),
-        )
-      : of({ kind: 'load-failed' } as LogState);
+  protected readonly state$: Observable<LogState> = this.logsService
+    .getConnectionLog(this.apiId, this.requestId, this.range.from, this.range.to)
+    .pipe(
+      map(log => ({ kind: 'ok', log }) as LogState),
+      catchError((err: HttpErrorResponse) => of({ kind: err.status === 404 ? 'not-found' : 'load-failed' } as LogState)),
+    );
 
   protected readonly isErrored = isNativeConnectionErrored;
+}
+
+function resolveTimeWindow(qp: Params): { from: number; to: number } {
+  const fromQp = qp.from ? Number(qp.from) : NaN;
+  const toQp = qp.to ? Number(qp.to) : NaN;
+  if (Number.isFinite(fromQp) && Number.isFinite(toQp)) return { from: fromQp, to: toQp };
+  const { from, to } = timeFrameRangesParams(DEFAULT_NATIVE_LOGS_PERIOD);
+  return { from, to };
 }

--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs-native/api-runtime-logs-native.component.html
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs-native/api-runtime-logs-native.component.html
@@ -21,7 +21,8 @@
   </div>
 </api-navigation-header>
 
-@if (isReportingDisabled$ | async) {
+@let reportingDisabled = isReportingDisabled$ | async;
+@if (reportingDisabled === true) {
   <gio-banner-info class="banner-warning">
     <div class="banner-warning__content" data-testid="native_logs_reporting_disabled_banner">
       Reporting is disabled
@@ -30,7 +31,7 @@
       >
     </div>
   </gio-banner-info>
-} @else {
+} @else if (reportingDisabled === false) {
   <api-runtime-logs-native-summary [apiId]="apiId" [from]="summaryRange().from" [to]="summaryRange().to" />
 }
 

--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs-native/api-runtime-logs-native.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs-native/api-runtime-logs-native.component.spec.ts
@@ -79,22 +79,43 @@ describe('ApiRuntimeLogsNativeComponent', () => {
       );
   };
 
+  const drainSummary = () => {
+    httpTestingController
+      .match(r => r.url === `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${API_ID}/logs/native/summary`)
+      .forEach(r => r.flush({ countByConnectionStatus: {} }));
+  };
+
+  // Predicate matcher so the assertion survives new query params being appended.
+  const expectInitialNativeLogsRequest = () =>
+    httpTestingController.expectOne(
+      r =>
+        r.url === `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${API_ID}/logs/native` &&
+        r.params.get('page') === '1' &&
+        r.params.get('perPage') === '10' &&
+        !!r.params.get('from') &&
+        !!r.params.get('to'),
+    );
+
   afterEach(() => {
+    // Summary widget's rxResource fires on its own cycle; drain it before verify so each test
+    // doesn't have to. Tests asserting summary behavior do an inline drain first.
+    drainSummary();
     httpTestingController?.verify();
   });
 
-  it('renders empty state when no rows', async () => {
+  it('renders empty state when no rows', fakeAsync(async () => {
     await initComponent();
     expectApiCalls();
     httpTestingController
       .expectOne(req => req.url === `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${API_ID}/logs/native` && req.method === 'GET')
       .flush(fakeEmptyNativeApiLogsResponse());
+    flush();
     fixture.detectChanges();
 
     expect(await harness.getEmptyStateText()).toContain('No data to display');
-  });
+  }));
 
-  it('triggers initial search with apiId and pagination defaults', async () => {
+  it('triggers initial search with apiId and pagination defaults', fakeAsync(async () => {
     await initComponent();
     expectApiCalls();
     const req = httpTestingController.expectOne(
@@ -106,21 +127,38 @@ describe('ApiRuntimeLogsNativeComponent', () => {
     expect(req.request.method).toBe('GET');
     req.flush(fakeNativeApiLogsResponse());
     flushRowAppResolution();
-  });
+    flush();
+  }));
 
-  it('exposes Configure Reporting link', async () => {
+  it('sends numeric from/to derived from the default period when no query params are present', fakeAsync(async () => {
     await initComponent();
     expectApiCalls();
-    httpTestingController
-      .expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/apis/${API_ID}/logs/native?page=1&perPage=10`)
-      .flush(fakeNativeApiLogsResponse());
+    const req = expectInitialNativeLogsRequest();
+    expect(Number.isFinite(Number(req.request.params.get('from')))).toBe(true);
+    expect(Number.isFinite(Number(req.request.params.get('to')))).toBe(true);
+    expect(Number(req.request.params.get('to'))).toBeGreaterThan(Number(req.request.params.get('from')));
+    req.flush(fakeNativeApiLogsResponse());
     flushRowAppResolution();
+    flush();
+
+    expect(routerNavigateSpy).toHaveBeenCalledWith(
+      ['.'],
+      expect.objectContaining({ queryParams: expect.objectContaining({ period: '1d' }) }),
+    );
+  }));
+
+  it('exposes Configure Reporting link', fakeAsync(async () => {
+    await initComponent();
+    expectApiCalls();
+    expectInitialNativeLogsRequest().flush(fakeNativeApiLogsResponse());
+    flushRowAppResolution();
+    flush();
     fixture.detectChanges();
 
     expect(await harness.getConfigureReportingLabel()).toBe('Configure Reporting');
-  });
+  }));
 
-  it('shows reporting-disabled banner and hides the summary widget when reporterMetricsEnabled is false', async () => {
+  it('shows reporting-disabled banner and hides the summary widget when reporterMetricsEnabled is false', fakeAsync(async () => {
     await initComponent();
     httpTestingController.expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/apis/${API_ID}`).flush(
       fakeApiV4({
@@ -138,19 +176,18 @@ describe('ApiRuntimeLogsNativeComponent', () => {
     httpTestingController
       .expectOne(req => req.url === `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${API_ID}/logs/native`)
       .flush(fakeEmptyNativeApiLogsResponse());
+    flush();
     fixture.detectChanges();
 
     expect(await harness.isReportingDisabledBannerVisible()).toBe(true);
     httpTestingController.expectNone(req => req.url === `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${API_ID}/logs/native/summary`);
     expect(fixture.nativeElement.querySelector('api-runtime-logs-native-summary')).toBeNull();
-  });
+  }));
 
   it('refresh re-triggers search', fakeAsync(async () => {
     await initComponent();
     expectApiCalls();
-    httpTestingController
-      .expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/apis/${API_ID}/logs/native?page=1&perPage=10`)
-      .flush(fakeNativeApiLogsResponse());
+    expectInitialNativeLogsRequest().flush(fakeNativeApiLogsResponse());
     flushRowAppResolution();
     flush();
     fixture.detectChanges();
@@ -170,9 +207,7 @@ describe('ApiRuntimeLogsNativeComponent', () => {
   it('filter change triggers search with serialized NativeApiLogsParam shape', fakeAsync(async () => {
     await initComponent();
     expectApiCalls();
-    httpTestingController
-      .expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/apis/${API_ID}/logs/native?page=1&perPage=10`)
-      .flush(fakeNativeApiLogsResponse());
+    expectInitialNativeLogsRequest().flush(fakeNativeApiLogsResponse());
     flushRowAppResolution();
     flush();
     fixture.detectChanges();
@@ -201,9 +236,7 @@ describe('ApiRuntimeLogsNativeComponent', () => {
   it('pagination event triggers search with new page and perPage', fakeAsync(async () => {
     await initComponent();
     expectApiCalls();
-    httpTestingController
-      .expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/apis/${API_ID}/logs/native?page=1&perPage=10`)
-      .flush(fakeNativeApiLogsResponse());
+    expectInitialNativeLogsRequest().flush(fakeNativeApiLogsResponse());
     flushRowAppResolution();
     flush();
     fixture.detectChanges();
@@ -225,18 +258,45 @@ describe('ApiRuntimeLogsNativeComponent', () => {
   it('does not trigger a search OR a summary refetch when timeframe period switches to custom (waits for explicit Apply)', fakeAsync(async () => {
     await initComponent();
     expectApiCalls();
-    httpTestingController
-      .expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/apis/${API_ID}/logs/native?page=1&perPage=10`)
-      .flush(fakeNativeApiLogsResponse());
+    expectInitialNativeLogsRequest().flush(fakeNativeApiLogsResponse());
     flushRowAppResolution();
     flush();
     fixture.detectChanges();
+    drainSummary();
 
     fixture.componentInstance['form'].patchValue({ timeframe: { period: 'custom', from: null, to: null } });
     flush();
 
     httpTestingController.expectNone(req => req.url === `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${API_ID}/logs/native`);
     httpTestingController.expectNone(req => req.url === `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${API_ID}/logs/native/summary`);
+  }));
+
+  it('falls back to the default period when the query param period is unrecognised', fakeAsync(async () => {
+    await initComponent({ period: 'not-a-real-period' });
+    expectApiCalls();
+    const req = expectInitialNativeLogsRequest();
+    req.flush(fakeNativeApiLogsResponse());
+    flushRowAppResolution();
+    flush();
+
+    expect(routerNavigateSpy).toHaveBeenCalledWith(
+      ['.'],
+      expect.objectContaining({ queryParams: expect.objectContaining({ period: '1d' }) }),
+    );
+  }));
+
+  it('falls back to the default period when period=custom is given without from/to', fakeAsync(async () => {
+    await initComponent({ period: 'custom' });
+    expectApiCalls();
+    const req = expectInitialNativeLogsRequest();
+    req.flush(fakeNativeApiLogsResponse());
+    flushRowAppResolution();
+    flush();
+
+    expect(routerNavigateSpy).toHaveBeenCalledWith(
+      ['.'],
+      expect.objectContaining({ queryParams: expect.objectContaining({ period: '1d' }) }),
+    );
   }));
 
   it('hydrates form from query params and fires initial search with from/to derived from preset', fakeAsync(async () => {
@@ -280,9 +340,7 @@ describe('ApiRuntimeLogsNativeComponent', () => {
   it('keeps the search Subject alive after a failed search request', fakeAsync(async () => {
     await initComponent();
     expectApiCalls();
-    httpTestingController
-      .expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/apis/${API_ID}/logs/native?page=1&perPage=10`)
-      .error(new ProgressEvent('Network error'), { status: 500, statusText: 'Internal Server Error' });
+    expectInitialNativeLogsRequest().error(new ProgressEvent('Network error'), { status: 500, statusText: 'Internal Server Error' });
     flush();
     fixture.detectChanges();
 
@@ -298,9 +356,7 @@ describe('ApiRuntimeLogsNativeComponent', () => {
   it('still publishes logs when row name resolution fails', fakeAsync(async () => {
     await initComponent();
     expectApiCalls();
-    httpTestingController
-      .expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/apis/${API_ID}/logs/native?page=1&perPage=10`)
-      .flush(fakeNativeApiLogsResponse());
+    expectInitialNativeLogsRequest().flush(fakeNativeApiLogsResponse());
     httpTestingController
       .match(req => req.url.includes(`${CONSTANTS_TESTING.env.baseURL}/applications/_paged`) && req.params.has('ids'))
       .forEach(req => req.error(new ProgressEvent('Network error'), { status: 500, statusText: 'Internal Server Error' }));

--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs-native/api-runtime-logs-native.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs-native/api-runtime-logs-native.component.ts
@@ -27,7 +27,7 @@ import { EMPTY, Observable, of, ReplaySubject, Subject } from 'rxjs';
 import { isEqual } from 'lodash';
 import moment from 'moment';
 
-import { NATIVE_CONNECTION_STATUSES, NATIVE_STATUS_META } from './api-runtime-logs-native.models';
+import { DEFAULT_NATIVE_LOGS_PERIOD, NATIVE_CONNECTION_STATUSES, NATIVE_STATUS_META } from './api-runtime-logs-native.models';
 import { ApiRuntimeLogsNativeListComponent } from './components/api-runtime-logs-native-list/api-runtime-logs-native-list.component';
 import { ApiRuntimeLogsNativeSummaryComponent } from './components/api-runtime-logs-native-summary/api-runtime-logs-native-summary.component';
 
@@ -106,7 +106,7 @@ export class ApiRuntimeLogsNativeComponent implements OnInit {
   protected readonly rowApplications$ = new ReplaySubject<Application[]>(1);
   protected readonly loading = signal(true);
   protected readonly form = new FormGroup<NativeLogFiltersForm>({
-    timeframe: new FormControl<TimeframeValue | null>({ period: '', from: null, to: null }),
+    timeframe: new FormControl<TimeframeValue | null>({ period: DEFAULT_NATIVE_LOGS_PERIOD, from: null, to: null }),
     applicationIds: new FormControl<string[]>([], { nonNullable: true }),
     planIds: new FormControl<string[]>([], { nonNullable: true }),
     connectionStatuses: new FormControl<NativeConnectionStatus[]>([], { nonNullable: true }),
@@ -247,9 +247,9 @@ export class ApiRuntimeLogsNativeComponent implements OnInit {
 
   private hydrateFormFromQueryParams() {
     const qp = this.activatedRoute.snapshot.queryParams;
-    const period = qp?.period ?? '';
     const fromQp = qp?.from ? moment(Number(qp.from)) : null;
     const toQp = qp?.to ? moment(Number(qp.to)) : null;
+    const period = resolvePeriod(qp.period, fromQp, toQp);
     this.form.patchValue(
       {
         timeframe: { period, from: period === CUSTOM_PERIOD ? fromQp : null, to: period === CUSTOM_PERIOD ? toQp : null },
@@ -278,4 +278,13 @@ function toFromTo(tf: TimeframeValue | null | undefined): { from: number | null;
   }
   const { from, to } = timeFrameRangesParams(tf.period);
   return { from, to };
+}
+
+const KNOWN_PRESETS = new Set<string>(timeFrames.map(t => t.id));
+
+// 'custom' is only valid with finite from/to — otherwise the request would fire unscoped.
+function resolvePeriod(value: unknown, from: moment.Moment | null, to: moment.Moment | null): string {
+  if (value === CUSTOM_PERIOD && from?.isValid() && to?.isValid()) return CUSTOM_PERIOD;
+  if (typeof value === 'string' && KNOWN_PRESETS.has(value)) return value;
+  return DEFAULT_NATIVE_LOGS_PERIOD;
 }

--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs-native/api-runtime-logs-native.models.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs-native/api-runtime-logs-native.models.ts
@@ -15,6 +15,9 @@
  */
 import { NativeConnectionStatus } from '../../../../entities/management-api-v2';
 
+// Used when the URL has no `period` or it's unrecognised.
+export const DEFAULT_NATIVE_LOGS_PERIOD = '1d';
+
 export interface NativeConnectionStatusMeta {
   label: string;
   // gio-badge-* utility class — colors the badge in both the table cell and the summary card.


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-XXX

## Description

When the connection logs page loaded for native APIs, the default timerange missed from the query params in the url resulting in a 400 (bad request) error.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

https://github.com/user-attachments/assets/b2ba0afb-afb1-453d-930c-f7cb7a58bb03



