### PR TITLE
Strip upstream Transfer-Encoding in V3 error responses

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/processor/error/SimpleFailureProcessor.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/processor/error/SimpleFailureProcessor.java
@@ -99,6 +99,9 @@ public class SimpleFailureProcessor extends AbstractProcessor<ExecutionContext> 
                 payload = Buffer.buffer(failure.message());
             }
 
+            // Drop any Transfer-Encoding inherited from upstream: the error body replaces the backend
+            // body and the Content-Length set below is incompatible with chunked framing (RFC 7230 §3.3.3).
+            response.headers().remove(HttpHeaderNames.TRANSFER_ENCODING);
             response.headers().set(HttpHeaderNames.CONTENT_LENGTH, Integer.toString(payload.length()));
             response.headers().set(HttpHeaderNames.CONTENT_TYPE, contentType);
             response.write(payload);


### PR DESCRIPTION
## Description

When the V3 error processor builds an error response after the backend has already started responding (e.g. a condition fails during the response phase), the upstream `Transfer-Encoding: chunked` header was left in place while a fresh `Content-Length` was set for the error body.

Bumping the BOM to 8.3.61 (Netty 4.1.133) made the HTTP/1.1 client strict about this combination — it now throws `ContentLengthNotAllowedException` per RFC 7230 §3.3.3, surfacing a latent bug.

The fix removes `Transfer-Encoding` in `SimpleFailureProcessor` before setting `Content-Length`, since the error body fully replaces the upstream body and the upstream framing is no longer valid.

## Test plan

  - [x] `FlowPhaseExecutionV3IntegrationTest#should_pass_through_correct_flow_condition_remove_header_on_request` passes
  - [x] `HttpRequestTimeoutV4EmulationIntegrationTest#shouldGet504WhenTimeoutFromPlatformResponse` passes
  - [x] Full `FlowPhaseExecutionV3IntegrationTest` class passes
  - [x] Full `HttpRequestTimeoutV4EmulationIntegrationTest` class passes
  - [x] `SimpleFailureProcessorTest` (V3 + reactive) unit tests pass