### PR TITLE
fix(distributed-sync): ensure initialSync is marked true on primary n…

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/DefaultSyncManager.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/DefaultSyncManager.java
@@ -206,9 +206,7 @@ public class DefaultSyncManager extends AbstractService<SyncManager> implements 
                     .doOnComplete(() -> {
                         lastSyncOnError.set(false);
                         lastSyncErrorMessage.set(null);
-                        if (nextFromTime == -1) {
-                            initialSync.set(true);
-                        }
+                        initialSync.set(true);
                         nextFromTime = nextToTime;
 
                         log.debug(

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/DefaultSyncManager.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/DefaultSyncManager.java
@@ -67,7 +67,8 @@ public class DefaultSyncManager extends AbstractService<SyncManager> implements 
     private final TimeUnit unit;
 
     private final AtomicLong syncCounter = new AtomicLong(0);
-    private final AtomicBoolean initialSync = new AtomicBoolean(false);
+    /** Set after any successful sync; used only by {@link #syncDone()} for the sync-process health probe. */
+    private final AtomicBoolean syncReadyForProbe = new AtomicBoolean(false);
     private final AtomicLong totalSyncOnErrorCounter = new AtomicLong(0);
     private final AtomicBoolean lastSyncOnError = new AtomicBoolean(false);
 
@@ -206,7 +207,7 @@ public class DefaultSyncManager extends AbstractService<SyncManager> implements 
                     .doOnComplete(() -> {
                         lastSyncOnError.set(false);
                         lastSyncErrorMessage.set(null);
-                        initialSync.set(true);
+                        syncReadyForProbe.set(true);
                         nextFromTime = nextToTime;
 
                         log.debug(
@@ -245,7 +246,7 @@ public class DefaultSyncManager extends AbstractService<SyncManager> implements 
     }
 
     public boolean syncDone() {
-        return initialSync.get();
+        return syncReadyForProbe.get();
     }
 
     public long totalSyncOnError() {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/DefaultSyncManagerTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/DefaultSyncManagerTest.java
@@ -19,10 +19,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
+import io.gravitee.gateway.services.sync.process.distributed.service.DistributedSyncService;
 import io.gravitee.gateway.services.sync.process.distributed.service.NoopDistributedSyncService;
 import io.gravitee.gateway.services.sync.process.repository.handler.SyncHandler;
 import io.gravitee.node.api.Node;
+import io.gravitee.repository.distributedsync.model.DistributedSyncState;
 import io.reactivex.rxjava3.core.Completable;
+import io.reactivex.rxjava3.core.Maybe;
 import io.reactivex.rxjava3.plugins.RxJavaPlugins;
 import io.reactivex.rxjava3.schedulers.TestScheduler;
 import io.vertx.ext.web.Route;
@@ -82,6 +85,26 @@ class DefaultSyncManagerTest {
         inOrder.verify(route).handler(argThat(argument -> argument instanceof SyncHandler));
         inOrder.verify(synchronizer1).synchronize(eq(-1L), any(), anySet());
         inOrder.verify(synchronizer2).synchronize(eq(-1L), any(), anySet());
+        assertThat(cut.syncDone()).isTrue();
+    }
+
+    @Test
+    void should_report_sync_done_on_primary_node_when_restoring_existing_distributed_state() throws Exception {
+        DistributedSyncService distributedSyncService = mock(DistributedSyncService.class);
+        when(distributedSyncService.isEnabled()).thenReturn(true);
+        when(distributedSyncService.isPrimaryNode()).thenReturn(true);
+        when(distributedSyncService.ready()).thenReturn(Completable.complete());
+        when(distributedSyncService.state()).thenReturn(Maybe.just(DistributedSyncState.builder().from(1_000L).to(2_000L).build()));
+        when(distributedSyncService.storeState(anyLong(), anyLong())).thenReturn(Completable.complete());
+
+        RepositorySynchronizer synchronizer = spy(new FakeSynchronizer(Completable.complete(), 1));
+        synchronizers.add(synchronizer);
+
+        cut = new DefaultSyncManager(router, node, synchronizers, null, distributedSyncService, 5, TimeUnit.SECONDS, 1);
+        cut.start();
+
+        verify(synchronizer).synchronize(eq(1_000L), any(), anySet());
+        assertThat(cut.syncDone()).isTrue();
     }
 
     @Test


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-14159

## Description

### Why
The previous `if (nextFromTime == -1)` guard left initialSync stuck at false for the primary node on every restart, which kept the `sync-process` probe unhealthy forever and made Kubernetes startup probes fail.

### What

- Mark the initial sync as done after any successful synchronization, including the very first one on a primary node that restored its position from the distributed sync state (where nextFromTime is already != -1 at this point).
- Renames the `initialSync` flag to `syncReadyForProbe` to more accurately reflect its true purpose: signaling to Kubernetes startup/health probes that the node has successfully completed at least one synchronization cycle and is healthy.


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

