### PR TITLE
refactor(automation-api): mutualize status schemas and add missing fields

### DIFF
--- a/gravitee-apim-rest-api/AGENTS.md
+++ b/gravitee-apim-rest-api/AGENTS.md
@@ -4,12 +4,12 @@
 
 Use this when you add or change **HTTP endpoints** (paths, operations, request/response bodies) in any of these Maven modules (paths in the table are relative to `gravitee-apim-rest-api/`):
 
-| Area                  | Maven module (path suffix)                                                       | OpenAPI spec(s)                                                                                                                                          |
-|-----------------------|----------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Area | Maven module (path suffix) | OpenAPI spec(s) |
+| --- | --- | --- |
 | **Management API v2** | `gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest` | `src/main/resources/openapi/openapi-*.yaml` — several specs by area (e.g. `openapi-apis.yaml`, `openapi-api-products.yaml`, `openapi-environments.yaml`) |
-| **Kafka Explorer**    | `gravitee-apim-rest-api-kafka-explorer`                                          | `src/main/resources/openapi/openapi-kafka-explorer.yaml`                                                                                                 |
-| **Portal API**        | `gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest`               | `src/main/resources/portal-openapi.yaml`                                                                                                                 |
-| **Automation API**    | `gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest`       | `src/main/resources/open-api.yaml`                                                                                                                       |
+| **Kafka Explorer** | `gravitee-apim-rest-api-kafka-explorer` | `src/main/resources/openapi/openapi-kafka-explorer.yaml` |
+| **Portal API** | `gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest` | `src/main/resources/portal-openapi.yaml` |
+| **Automation API** | `gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest` | `src/main/resources/open-api.yaml`|
 
 **What happens**
 

--- a/gravitee-apim-rest-api/AGENTS.md
+++ b/gravitee-apim-rest-api/AGENTS.md
@@ -4,11 +4,12 @@
 
 Use this when you add or change **HTTP endpoints** (paths, operations, request/response bodies) in any of these Maven modules (paths in the table are relative to `gravitee-apim-rest-api/`):
 
-| Area | Maven module (path suffix) | OpenAPI spec(s) |
-| --- | --- | --- |
+| Area                  | Maven module (path suffix)                                                       | OpenAPI spec(s)                                                                                                                                          |
+|-----------------------|----------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------|
 | **Management API v2** | `gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest` | `src/main/resources/openapi/openapi-*.yaml` — several specs by area (e.g. `openapi-apis.yaml`, `openapi-api-products.yaml`, `openapi-environments.yaml`) |
-| **Kafka Explorer** | `gravitee-apim-rest-api-kafka-explorer` | `src/main/resources/openapi/openapi-kafka-explorer.yaml` |
-| **Portal API** | `gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest` | `src/main/resources/portal-openapi.yaml` |
+| **Kafka Explorer**    | `gravitee-apim-rest-api-kafka-explorer`                                          | `src/main/resources/openapi/openapi-kafka-explorer.yaml`                                                                                                 |
+| **Portal API**        | `gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest`               | `src/main/resources/portal-openapi.yaml`                                                                                                                 |
+| **Automation API**    | `gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest`       | `src/main/resources/open-api.yaml`                                                                                                                       |
 
 **What happens**
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/java/io/gravitee/apim/rest/api/automation/mapper/ApiMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/java/io/gravitee/apim/rest/api/automation/mapper/ApiMapper.java
@@ -52,6 +52,7 @@ import java.util.Map;
 import java.util.Objects;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
+import org.mapstruct.MappingTarget;
 import org.mapstruct.factory.Mappers;
 
 /**
@@ -68,13 +69,11 @@ public interface ApiMapper {
     @Mapping(target = "consoleNotificationConfiguration", source = "consoleNotification")
     ApiCRDSpec apiV4SpecToApiCRDSpec(LegacyAPIV4Spec apiV4Spec);
 
-    @Mapping(target = "id", source = "id")
-    @Mapping(target = "crossId", source = "crossId")
-    @Mapping(target = "errors", ignore = true)
-    @Mapping(target = "organizationId", source = "organizationId")
-    @Mapping(target = "environmentId", source = "environmentId")
-    @Mapping(target = "consoleNotification", expression = "java(apiV4Spec.getConsoleNotification())")
-    ApiV4State apiV4SpecToApiV4State(ApiV4Spec apiV4Spec, String id, String crossId, String organizationId, String environmentId);
+    default ApiV4State apiV4SpecToApiV4State(ApiV4Spec apiV4Spec, String id, String crossId, String organizationId, String environmentId) {
+        var state = new ApiV4State(id, environmentId, organizationId, null, crossId);
+        mapApiSpecToState(apiV4Spec, state);
+        return state;
+    }
 
     @Mapping(target = "selectors", expression = "java(mapApiV4SpecSelectors(flowV4))")
     io.gravitee.rest.api.management.v2.rest.model.FlowV4 map(FlowV4 flowV4);
@@ -82,14 +81,24 @@ public interface ApiMapper {
     @Mapping(target = "selectors", expression = "java(mapApiCRDSpecSelectors(flowV4))")
     FlowV4 map(io.gravitee.rest.api.management.v2.rest.model.FlowV4 flowV4);
 
-    @Mapping(target = "id", source = "status.id")
-    @Mapping(target = "crossId", source = "status.crossId")
-    @Mapping(target = "errors", source = "status.errors")
-    @Mapping(target = "plans", source = "spec.plans")
-    @Mapping(target = "state", source = "spec.state")
-    @Mapping(target = "organizationId", source = "status.organizationId")
-    @Mapping(target = "environmentId", source = "status.environmentId")
-    ApiV4State apiV4SpecAndStatusToApiV4State(ApiV4Spec spec, ApiCRDStatus status);
+    default ApiV4State apiV4SpecAndStatusToApiV4State(ApiV4Spec spec, ApiCRDStatus status) {
+        var state = new ApiV4State(
+            status.getId(),
+            status.getEnvironmentId(),
+            status.getOrganizationId(),
+            toErrors(status.getErrors()),
+            status.getCrossId()
+        );
+        mapApiSpecToState(spec, state);
+        return state;
+    }
+
+    @Mapping(target = "id", ignore = true)
+    @Mapping(target = "crossId", ignore = true)
+    @Mapping(target = "errors", ignore = true)
+    @Mapping(target = "organizationId", ignore = true)
+    @Mapping(target = "environmentId", ignore = true)
+    void mapApiSpecToState(ApiV4Spec spec, @MappingTarget ApiV4State state);
 
     Errors toErrors(ApiCRDStatus.Errors apiV4State);
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/java/io/gravitee/apim/rest/api/automation/mapper/ApplicationMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/java/io/gravitee/apim/rest/api/automation/mapper/ApplicationMapper.java
@@ -19,6 +19,7 @@ import io.gravitee.apim.core.application.model.crd.ApplicationCRDStatus;
 import io.gravitee.apim.rest.api.automation.model.ApplicationSpec;
 import io.gravitee.apim.rest.api.automation.model.ApplicationState;
 import io.gravitee.apim.rest.api.automation.model.ClientCertificate;
+import io.gravitee.apim.rest.api.automation.model.Errors;
 import io.gravitee.apim.rest.api.automation.model.Metadata;
 import io.gravitee.rest.api.management.v2.rest.mapper.CollectionFactory;
 import io.gravitee.rest.api.management.v2.rest.mapper.DateMapper;
@@ -30,6 +31,7 @@ import io.gravitee.rest.api.model.clientcertificate.CreateClientCertificate;
 import java.util.List;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
+import org.mapstruct.MappingTarget;
 import org.mapstruct.factory.Mappers;
 
 /**
@@ -50,26 +52,41 @@ public interface ApplicationMapper {
     )
     ApplicationCRDSpec applicationSpecToApplicationCRDSpec(ApplicationSpec applicationSpec);
 
-    @Mapping(target = "id", source = "id")
-    @Mapping(target = "errors", ignore = true)
-    @Mapping(target = "organizationId", source = "organizationId")
-    @Mapping(target = "environmentId", source = "environmentId")
-    ApplicationState applicationSpecToApplicationState(
+    default ApplicationState applicationSpecToApplicationState(
         ApplicationSpec applicationSpec,
         String id,
         String organizationId,
         String environmentId
-    );
+    ) {
+        var state = new ApplicationState(applicationSpec.getPrimaryOwner(), id, environmentId, organizationId, null);
+        mapAppSpecToState(applicationSpec, state);
+        return state;
+    }
 
-    @Mapping(target = "id", source = "status.id")
-    @Mapping(target = "errors", source = "status.errors")
-    @Mapping(target = "organizationId", source = "status.organizationId")
-    @Mapping(target = "environmentId", source = "status.environmentId")
+    default ApplicationState applicationSpecAndStatusToApplicationState(ApplicationSpec spec, ApplicationCRDStatus status) {
+        var state = new ApplicationState(
+            spec.getPrimaryOwner(),
+            status.getId(),
+            status.getEnvironmentId(),
+            status.getOrganizationId(),
+            toErrors(status.getErrors())
+        );
+        mapAppSpecToState(spec, state);
+        return state;
+    }
+
+    @Mapping(target = "id", ignore = true)
+    @Mapping(target = "primaryOwner", ignore = true)
+    @Mapping(target = "errors", ignore = true)
+    @Mapping(target = "organizationId", ignore = true)
+    @Mapping(target = "environmentId", ignore = true)
     @Mapping(
         target = "settings.tls.clientCertificate",
         expression = "java(applicationTLSSettings.getClientCertificate() != null ? applicationTLSSettings.getClientCertificate().stripTrailing() : null)"
     )
-    ApplicationState applicationSpecAndStatusToApplicationState(ApplicationSpec spec, ApplicationCRDStatus status);
+    void mapAppSpecToState(ApplicationSpec spec, @MappingTarget ApplicationState state);
+
+    Errors toErrors(ApplicationCRDStatus.Errors errors);
 
     @Mapping(source = "content", target = "certificate")
     CreateClientCertificate map(ClientCertificate clientCertificate);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/java/io/gravitee/apim/rest/api/automation/mapper/DictionaryMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/java/io/gravitee/apim/rest/api/automation/mapper/DictionaryMapper.java
@@ -34,6 +34,7 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
+import org.mapstruct.MappingTarget;
 import org.mapstruct.Named;
 import org.mapstruct.factory.Mappers;
 
@@ -74,7 +75,8 @@ public interface DictionaryMapper {
         DictionaryState state = new DictionaryState(
             entity.getId(),
             executionContext.getEnvironmentId(),
-            executionContext.getOrganizationId()
+            executionContext.getOrganizationId(),
+            null
         );
         state.setHrid(entity.getKey() != null ? entity.getKey() : entity.getId());
         state.setName(entity.getName());
@@ -95,7 +97,17 @@ public interface DictionaryMapper {
         return state;
     }
 
-    DictionaryState toDictionaryState(DictionarySpec entity);
+    default DictionaryState toDictionaryState(DictionarySpec spec) {
+        var state = new DictionaryState();
+        mapSpecToState(spec, state);
+        return state;
+    }
+
+    @Mapping(target = "id", ignore = true)
+    @Mapping(target = "environmentId", ignore = true)
+    @Mapping(target = "organizationId", ignore = true)
+    @Mapping(target = "errors", ignore = true)
+    void mapSpecToState(DictionarySpec spec, @MappingTarget DictionaryState state);
 
     DictionaryType toSpecType(io.gravitee.rest.api.model.configuration.dictionary.DictionaryType type);
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/java/io/gravitee/apim/rest/api/automation/mapper/GroupMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/java/io/gravitee/apim/rest/api/automation/mapper/GroupMapper.java
@@ -30,6 +30,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
+import org.mapstruct.MappingTarget;
 import org.mapstruct.Named;
 import org.mapstruct.factory.Mappers;
 
@@ -55,33 +56,45 @@ public interface GroupMapper {
     Errors toErrors(GroupCRDStatus.Errors errors);
 
     default GroupState groupSpecAndStatusToGroupState(GroupSpec spec, GroupCRDStatus status, ExecutionContext executionContext) {
-        GroupState state = new GroupState(
+        var state = new GroupState(
             status.getId(),
             executionContext.getEnvironmentId(),
             executionContext.getOrganizationId(),
+            toErrors(status.getErrors()),
             status.getMembers()
         );
-        state.setHrid(spec.getHrid());
-        state.setName(spec.getName());
-        state.setMembers(spec.getMembers());
-        state.setNotifyMembers(spec.getNotifyMembers());
-        state.setErrors(toErrors(status.getErrors()));
+        mapSpecToState(spec, state);
         return state;
     }
 
+    @Mapping(target = "id", ignore = true)
+    @Mapping(target = "environmentId", ignore = true)
+    @Mapping(target = "organizationId", ignore = true)
+    @Mapping(target = "errors", ignore = true)
+    @Mapping(target = "memberCount", ignore = true)
+    void mapSpecToState(GroupSpec spec, @MappingTarget GroupState state);
+
     default GroupState groupToGroupState(Group group, Set<GroupCRDSpec.Member> members, ExecutionContext executionContext) {
-        GroupState state = new GroupState(
+        var state = new GroupState(
             group.getId(),
             executionContext.getEnvironmentId(),
             executionContext.getOrganizationId(),
+            null,
             members != null ? (long) members.size() : 0L
         );
-        state.setHrid(group.getHrid());
-        state.setName(group.getName());
-        state.setNotifyMembers(!group.isDisableMembershipNotifications());
+        mapGroupToState(group, state);
         state.setMembers(members != null ? members.stream().map(this::memberToGroupMember).toList() : null);
         return state;
     }
+
+    @Mapping(target = "id", ignore = true)
+    @Mapping(target = "environmentId", ignore = true)
+    @Mapping(target = "organizationId", ignore = true)
+    @Mapping(target = "errors", ignore = true)
+    @Mapping(target = "memberCount", ignore = true)
+    @Mapping(target = "members", ignore = true)
+    @Mapping(target = "notifyMembers", expression = "java(!group.isDisableMembershipNotifications())")
+    void mapGroupToState(Group group, @MappingTarget GroupState state);
 
     @Named("stringMapToRoleScopeMap")
     default Map<RoleScope, String> stringMapToRoleScopeMap(Map<String, String> roles) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/java/io/gravitee/apim/rest/api/automation/mapper/SharedPolicyGroupMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/java/io/gravitee/apim/rest/api/automation/mapper/SharedPolicyGroupMapper.java
@@ -17,6 +17,7 @@ package io.gravitee.apim.rest.api.automation.mapper;
 
 import io.gravitee.apim.core.shared_policy_group.model.SharedPolicyGroup;
 import io.gravitee.apim.core.shared_policy_group.model.SharedPolicyGroupCRDStatus;
+import io.gravitee.apim.rest.api.automation.model.Errors;
 import io.gravitee.apim.rest.api.automation.model.LegacySharedPolicyGroupSpec;
 import io.gravitee.apim.rest.api.automation.model.SharedPolicyGroupState;
 import io.gravitee.apim.rest.api.automation.model.StepV4;
@@ -41,28 +42,39 @@ public interface SharedPolicyGroupMapper {
     @Mapping(target = "originContext", ignore = true)
     io.gravitee.apim.core.shared_policy_group.model.SharedPolicyGroupCRD map(LegacySharedPolicyGroupSpec spec);
 
-    @Mapping(target = "errors", ignore = true)
-    SharedPolicyGroupState toState(SharedPolicyGroup sharedPolicyGroup);
+    default SharedPolicyGroupState toState(SharedPolicyGroup spg) {
+        var state = new SharedPolicyGroupState(spg.getId(), spg.getEnvironmentId(), spg.getOrganizationId(), null, spg.getCrossId());
+        mapToState(spg, state);
+        return state;
+    }
 
     @Mapping(target = "id", ignore = true)
     @Mapping(target = "crossId", ignore = true)
     @Mapping(target = "errors", ignore = true)
     @Mapping(target = "organizationId", ignore = true)
     @Mapping(target = "environmentId", ignore = true)
-    SharedPolicyGroupState toState(LegacySharedPolicyGroupSpec spec);
+    void mapToState(SharedPolicyGroup spg, @MappingTarget SharedPolicyGroupState state);
 
-    @Mapping(target = "id", source = "status.id")
-    @Mapping(target = "crossId", source = "status.crossId")
-    @Mapping(target = "steps", ignore = true)
-    @Mapping(target = "prerequisiteMessage", ignore = true)
-    @Mapping(target = "phase", ignore = true)
-    @Mapping(target = "name", ignore = true)
-    @Mapping(target = "hrid", ignore = true)
-    @Mapping(target = "description", ignore = true)
-    @Mapping(target = "apiType", ignore = true)
-    @Mapping(target = "organizationId", source = "status.organizationId")
-    @Mapping(target = "environmentId", source = "status.environmentId")
-    SharedPolicyGroupState withStatusInfos(@MappingTarget SharedPolicyGroupState state, SharedPolicyGroupCRDStatus status);
+    default SharedPolicyGroupState toState(LegacySharedPolicyGroupSpec spec, SharedPolicyGroupCRDStatus status) {
+        var state = new SharedPolicyGroupState(
+            status.getId(),
+            status.getEnvironmentId(),
+            status.getOrganizationId(),
+            toErrors(status.getErrors()),
+            status.getCrossId()
+        );
+        mapSpecToState(spec, state);
+        return state;
+    }
+
+    @Mapping(target = "id", ignore = true)
+    @Mapping(target = "crossId", ignore = true)
+    @Mapping(target = "errors", ignore = true)
+    @Mapping(target = "organizationId", ignore = true)
+    @Mapping(target = "environmentId", ignore = true)
+    void mapSpecToState(LegacySharedPolicyGroupSpec spec, @MappingTarget SharedPolicyGroupState state);
+
+    Errors toErrors(SharedPolicyGroupCRDStatus.Errors errors);
 
     @Mapping(target = "configuration", qualifiedByName = "serializeConfiguration")
     Step mapStep(StepV4 step);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/java/io/gravitee/apim/rest/api/automation/mapper/SubscriptionMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/java/io/gravitee/apim/rest/api/automation/mapper/SubscriptionMapper.java
@@ -27,6 +27,7 @@ import io.gravitee.rest.api.management.v2.rest.mapper.DateMapper;
 import io.gravitee.rest.api.management.v2.rest.mapper.OriginContextMapper;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
+import org.mapstruct.MappingTarget;
 import org.mapstruct.factory.Mappers;
 
 /**
@@ -37,13 +38,32 @@ import org.mapstruct.factory.Mappers;
 public interface SubscriptionMapper {
     SubscriptionMapper INSTANCE = Mappers.getMapper(SubscriptionMapper.class);
 
-    @Mapping(target = "id", source = "status.id")
-    @Mapping(target = "errors", source = "status.errors")
-    @Mapping(target = "organizationId", source = "status.organizationId")
-    @Mapping(target = "environmentId", source = "status.environmentId")
-    @Mapping(target = "startingAt", source = "status.startingAt")
-    @Mapping(target = "endingAt", source = "status.endingAt")
-    SubscriptionState subscriptionSpecAndStatusToSubscriptionState(String apiHrid, SubscriptionSpec spec, SubscriptionCRDStatus status);
+    default SubscriptionState subscriptionSpecAndStatusToSubscriptionState(
+        String apiHrid,
+        SubscriptionSpec spec,
+        SubscriptionCRDStatus status
+    ) {
+        var state = new SubscriptionState(
+            status.getId(),
+            status.getEnvironmentId(),
+            status.getOrganizationId(),
+            toErrors(status.getErrors()),
+            apiHrid,
+            status.getStartingAt() != null ? status.getStartingAt().toOffsetDateTime() : null
+        );
+        mapSpecToState(spec, state);
+        state.setEndingAt(status.getEndingAt() != null ? status.getEndingAt().toOffsetDateTime() : null);
+        return state;
+    }
+
+    @Mapping(target = "id", ignore = true)
+    @Mapping(target = "errors", ignore = true)
+    @Mapping(target = "organizationId", ignore = true)
+    @Mapping(target = "environmentId", ignore = true)
+    @Mapping(target = "apiHrid", ignore = true)
+    @Mapping(target = "startingAt", ignore = true)
+    @Mapping(target = "endingAt", ignore = true)
+    void mapSpecToState(SubscriptionSpec spec, @MappingTarget SubscriptionState state);
 
     @Mapping(target = "entrypointConfiguration", qualifiedByName = "deserializeConfiguration")
     SubscriptionConsumerConfiguration toSubscriptionConsumerConfiguration(SubscriptionConfiguration configuration);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/java/io/gravitee/apim/rest/api/automation/resource/ApiSubscriptionResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/java/io/gravitee/apim/rest/api/automation/resource/ApiSubscriptionResource.java
@@ -84,14 +84,17 @@ public class ApiSubscriptionResource extends AbstractResource {
                 throw new SubscriptionNotFoundException(apiHrid);
             }
 
-            SubscriptionState subscriptionState = new SubscriptionState();
-            subscriptionState.setId(subscriptionId);
+            SubscriptionState subscriptionState = new SubscriptionState(
+                subscriptionId,
+                executionContext.getEnvironmentId(),
+                executionContext.getOrganizationId(),
+                null,
+                apiHrid,
+                subscriptionEntity.getStartingAt().toOffsetDateTime()
+            );
             if (!hridContainsUUID) {
                 subscriptionState.setHrid(hrid);
             }
-            subscriptionState.setEnvironmentId(executionContext.getEnvironmentId());
-            subscriptionState.setOrganizationId(executionContext.getOrganizationId());
-            subscriptionState.setApiHrid(apiHrid);
 
             BaseApplicationEntity application = applicationCrudService.findById(
                 subscriptionEntity.getApplicationId(),
@@ -102,7 +105,6 @@ public class ApiSubscriptionResource extends AbstractResource {
             Plan plan = planCrudService.getById(subscriptionEntity.getPlanId());
             subscriptionState.setPlanHrid(plan.getHrid());
 
-            subscriptionState.setStartingAt(subscriptionEntity.getStartingAt().toOffsetDateTime());
             subscriptionState.setEndingAt(
                 subscriptionEntity.getEndingAt() != null ? subscriptionEntity.getEndingAt().toOffsetDateTime() : null
             );

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/java/io/gravitee/apim/rest/api/automation/resource/SharedPolicyGroupsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/java/io/gravitee/apim/rest/api/automation/resource/SharedPolicyGroupsResource.java
@@ -96,18 +96,14 @@ public class SharedPolicyGroupsResource extends AbstractResource {
                             .environmentId(auditInfo.environmentId()),
                     errors -> statusBuilder.errors(SharedPolicyGroupCRDStatus.Errors.fromErrorList(errors))
                 );
-            return Response.ok(
-                SharedPolicyGroupMapper.INSTANCE.withStatusInfos(SharedPolicyGroupMapper.INSTANCE.toState(spec), statusBuilder.build())
-            ).build();
+            return Response.ok(SharedPolicyGroupMapper.INSTANCE.toState(spec, statusBuilder.build())).build();
         }
 
         var output = importSharedPolicyGroupCRDCRDUseCase.execute(
             new ImportSharedPolicyGroupCRDCRDUseCase.Input(auditInfo, sharedPolicyGroupCRD)
         );
 
-        return Response.ok(
-            SharedPolicyGroupMapper.INSTANCE.withStatusInfos(SharedPolicyGroupMapper.INSTANCE.toState(spec), output.status())
-        ).build();
+        return Response.ok(SharedPolicyGroupMapper.INSTANCE.toState(spec, output.status())).build();
     }
 
     @Path("/{hrid}")

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/resources/open-api.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/resources/open-api.yaml
@@ -700,7 +700,7 @@ components:
             maxLength: 64
           uniqueItems: true
           default: [ ]
-          examples: 
+          examples:
             - ["example"]
         metadata:
           type: array
@@ -790,29 +790,7 @@ components:
       description: API state
       allOf:
         - $ref: "#/components/schemas/ApiV4Spec"
-        - type: object
-          properties:
-            errors:
-              $ref: "#/components/schemas/Errors"
-        - type: object
-          properties:
-            id:
-              type: string
-              description: API's uuid.
-            crossId:
-              type: string
-              description: >-
-                When promoting an API from one environment to the other,
-                this ID identifies the API across those different
-                environments.
-            environmentId:
-              description:
-                The environment ID of the API.
-              type: string
-            organizationId:
-              description:
-                The organization ID of the API.
-              type: string
+        - $ref: "#/components/schemas/CrossIdStatus"
     ApplicationSpec:
       description: |
         Defines the desired state of Application. 
@@ -1045,29 +1023,7 @@ components:
       description: Application state that has been created/updated
       allOf:
         - $ref: "#/components/schemas/ApplicationSpec"
-        - type: object
-          properties:
-            errors:
-              $ref: "#/components/schemas/Errors"
-        - type: object
-          properties:
-            id:
-              type: string
-              description: Application's uuid.
-              examples:
-                - 550e8400-e29b-41d4-a716-446655440000
-            environmentId:
-              description: The environment ID of the Application.
-              type: string
-              default: DEFAULT
-              examples:
-                - DEFAULT
-            organizationId:
-              description: The organization ID of the Application.
-              type: string
-              default: DEFAULT
-              examples:
-                - DEFAULT
+        - $ref: "#/components/schemas/BaseStatus"
 
     GroupSpec:
       description: |
@@ -1130,31 +1086,17 @@ components:
         - sourceId
     GroupStatus:
       description: Status information for a group after import.
-      type: object
-      properties:
-        id:
-          type: string
-          description: Group's uuid.
-          readOnly: true
-          examples:
-            - 550e8400-e29b-41d4-a716-446655440000
-        environmentId:
-          type: string
-          description: The environment ID of the API.
-          readOnly: true
-        organizationId:
-          type: string
-          description: The organization ID of the API.
-          readOnly: true
-        memberCount:
-          type: integer
-          format: int64
-          description: Number of members in the group.
-          examples:
-            - 5
-          readOnly: true
-        errors:
-          $ref: "#/components/schemas/Errors"
+      allOf:
+        - $ref: "#/components/schemas/BaseStatus"
+        - type: object
+          properties:
+            memberCount:
+              type: integer
+              format: int64
+              description: Number of members in the group.
+              examples:
+                - 5
+              readOnly: true
 
     GroupState:
       description: Group state combining spec and status after creation/update.
@@ -1163,24 +1105,10 @@ components:
         - $ref: "#/components/schemas/GroupStatus"
 
     DictionaryState:
-      type: object
+      description: Dictionary state
       allOf:
         - $ref: "#/components/schemas/DictionarySpec"
-        - type: object
-          properties:
-            id:
-              type: string
-              readOnly: true
-            environmentId:
-              type: string
-              description: The environment ID of the API.
-              readOnly: true
-            organizationId:
-              type: string
-              description: The organization ID of the API.
-              readOnly: true
-          required:
-            - id
+        - $ref: "#/components/schemas/BaseStatus"
     DictionarySpec:
       description: |
         Specification of a dictionary resource. Allow users to create, update and delete dictionaries. Dictionaries
@@ -1409,62 +1337,34 @@ components:
             }
       required: [entrypointId]
 
-    SubscriptionState:
-      description: State of subscription that has been created/update
+    SubscriptionStatus:
+      description: Status information for a subscription after import.
       allOf:
-        - $ref: "#/components/schemas/SubscriptionSpec"
+        - $ref: "#/components/schemas/BaseStatus"
         - type: object
           properties:
-            errors:
-              $ref: "#/components/schemas/Errors"
-        - type: object
-          properties:
-            id:
-              type: string
-              description: Subscription's uuid.
             apiHrid:
               type: string
               description: The API's Hrid.
               example: demo-api
-            environmentId:
-              description: The environment ID of the Subscription.
-              type: string
-            organizationId:
-              description: The organization ID of the Subscription.
-              type: string
+              readOnly: true
             startingAt:
               type: string
               description: Start validity date time of this Subscription
               format: date-time
               example: "2040-12-25T09:12:28+01:00"
+              readOnly: true
+    SubscriptionState:
+      description: State of subscription that has been created/updated
+      allOf:
+        - $ref: "#/components/schemas/SubscriptionSpec"
+        - $ref: "#/components/schemas/SubscriptionStatus"
 
     SharedPolicyGroupState:
       description: State of Shared Policy Groups that has been created/updated
       allOf:
         - $ref: "#/components/schemas/SharedPolicyGroupSpec"
-        - type: object
-          properties:
-            errors:
-              $ref: "#/components/schemas/Errors"
-        - type: object
-          properties:
-            id:
-              description:
-                The id of the shared policy group.
-              type: string
-            crossId:
-              description:
-                The Cross ID is used to identify a shared policy group that has been promoted from
-                one environment to another.
-              type: string
-            environmentId:
-              description:
-                The environment ID of the shared policy group.
-              type: string
-            organizationId:
-              description:
-                The organization ID of the shared policy group.
-              type: string
+        - $ref: "#/components/schemas/CrossIdStatus"
     SharedPolicyGroupSpec:
       description: Shared Policy Group Spec
       type: object
@@ -1538,11 +1438,13 @@ components:
           items:
             type: string
             maxLength: 64
+          default: []
         excludedGroups:
           description: Access-control, UUID of groups excluded from this plan
           type: array
           items:
             type: string
+          default: []
         selectionRule:
           type: string
           maxLength: 256
@@ -1556,6 +1458,7 @@ components:
             type: string
             maxLength: 64
           uniqueItems: true
+          default: []
         type:
           $ref: '#/components/schemas/PlanType'
         validation:
@@ -1742,6 +1645,7 @@ components:
           items:
             type: string
           uniqueItems: true
+          default: []
         allowMethods:
           description: |
            `Access-Control-Allow-Methods`: Specifies the method or methods allowed when accessing the resource. This is used in response to a preflight request. HTTP methods that are allow to access the resource.
@@ -1759,6 +1663,7 @@ components:
              - OPTIONS
              - TRACE
              - HEAD
+          default: []
         allowOrigin:
           uniqueItems: true
           description: |
@@ -1769,6 +1674,7 @@ components:
             type: string
           examples:
             - ["*","http://api.acme\\.com", ".*\\.api\\.acme\\.com"]
+          default: []
         exposeHeaders:
           description: | 
             `Access-Control-Expose-Headers`: This header lets a server whitelist headers that browsers are allowed to access.
@@ -1778,6 +1684,7 @@ components:
             type: string
           examples:
             - ["Content-Type"]
+          default: []
         maxAge:
           description: How long (in seconds) the results of a preflight request can be cached (-1 if disabled).
           type: integer
@@ -1833,6 +1740,7 @@ components:
           description: The list of Getaway's tenants on which the endpoint can be used.
           items:
             type: string
+          default: []
       required:
         - type
         - name
@@ -1954,6 +1862,7 @@ components:
           examples:
             - [ tag1, tag2 ]
           uniqueItems: true
+          default: []
       required:
         - enabled
     FlowExecution:
@@ -2731,10 +2640,6 @@ components:
         defaultValue:
           type: string
           description: The default value of the metadata if the value is not set.
-        hidden:
-          type: boolean
-          description: if this metadata should be hidden
-          default: false
       required:
         - name
         - format
@@ -2808,6 +2713,36 @@ components:
                 description: The invalid value.
                 examples:
                   - $...faulty
+
+    BaseStatus:
+      description: Base status properties common to all resources.
+      type: object
+      properties:
+        id:
+          type: string
+          description: Resource UUID.
+          readOnly: true
+        environmentId:
+          type: string
+          description: The environment ID.
+          readOnly: true
+        organizationId:
+          type: string
+          description: The organization ID.
+          readOnly: true
+        errors:
+          readOnly: true
+          $ref: "#/components/schemas/Errors"
+    CrossIdStatus:
+      description: Status with cross-environment identifier for promotable resources.
+      allOf:
+        - $ref: "#/components/schemas/BaseStatus"
+        - type: object
+          properties:
+            crossId:
+              type: string
+              description: Identifier used to track this resource across environment promotions.
+              readOnly: true
 
     Errors:
       description: >-
@@ -2894,7 +2829,7 @@ components:
       schema:
         type: boolean
         default: false
-        examples: 
+        examples:
           - true
     hridParam:
       name: hrid

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/resources/open-api.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/resources/open-api.yaml
@@ -739,6 +739,14 @@ components:
           items:
             $ref: '#/components/schemas/PageV4'
           default: [ ]
+        allowedInApiProducts:
+          type: boolean
+          description: Indicates whether this API is allowed to be used in API Products. Only applicable for V4 HTTP Proxy APIs.
+          default: false
+        allowMultiJwtOauth2Subscriptions:
+          type: boolean
+          description: Allow an application to subscribe to more than one JWT/OAuth2 plan (V4 only).
+          default: false
         consoleNotification:
           type: object
           description: Console notification configuration.
@@ -2575,8 +2583,12 @@ components:
             host:
               description: A hostname for which the API will match against SNI.
               type: string
+            port:
+              type: integer
+              minimum: 0
+              description: The port of the listener
           required:
-            - "host"
+            - host
     FailoverV4:
       description: Defines the failover behavior to bypass endpoints when some are slow.
       type: object

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/resources/open-api.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/resources/open-api.yaml
@@ -1484,6 +1484,18 @@ components:
         generalConditionsHrid:
           type: string
           description: API page `hrid` that serves as general conditions documentation of this plan
+        bootstrapPort:
+          type: integer
+          description: Bootstrap port for port-based routing (native Kafka APIs only). Null in host/SNI routing mode.
+          example: 9092
+        brokerRangeStart:
+          type: integer
+          description: Start of broker port range for port-based routing (native Kafka APIs only).
+          example: 9100
+        brokerRangeEnd:
+          type: integer
+          description: End of broker port range for port-based routing (native Kafka APIs only). Must be greater than start port.
+          example: 9102
       required:
         - hrid
         - name

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/resources/open-api.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/resources/open-api.yaml
@@ -1538,6 +1538,14 @@ components:
           type: boolean
           description: Whether or not analytics are enabled.
           default: true
+        reporterMetricsEnabled:
+          type: boolean
+          description: |-
+            Enable the connection-metrics reporter on the gateway. Only applicable to Native v4 APIs; ignored on HTTP v4 requests and omitted from HTTP v4 responses.
+            Server-side default for Native v4 on create is `true`.
+            Independent of the parent `enabled` flag: event-metrics reporting and the connection-metrics reporter are gated separately.
+        otelLogs:
+          $ref: "#/components/schemas/OtelLogsV4"
         sampling:
           $ref: "#/components/schemas/Sampling"
         logging:
@@ -2436,6 +2444,12 @@ components:
             `WINDOWED_COUNT`: x/<ISO-8601 duration> cannot exceed 1 message per second
       required:
         - type
+    OtelLogsV4:
+      type: object
+      properties:
+        enabled:
+          type: boolean
+          description: Enable OpenTelemetry log export for this API (payload capture with traceId/spanId correlation).
     MembershipMemberType:
       type: string
       description: The type of membership

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/ApiCRDMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/ApiCRDMapper.java
@@ -41,7 +41,6 @@ import io.gravitee.rest.api.management.v2.rest.model.PlanCRD;
 import io.gravitee.rest.api.management.v2.rest.model.PlanSecurityType;
 import io.gravitee.rest.api.management.v2.rest.model.PlanType;
 import java.util.List;
-import org.checkerframework.checker.units.qual.A;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.Named;
@@ -72,18 +71,15 @@ public interface ApiCRDMapper {
     ApiCRDSpec map(io.gravitee.apim.core.api.model.crd.ApiCRDSpec coreSpec);
 
     default Analytics mapAnalytics(io.gravitee.apim.core.api.model.crd.ApiCRDSpec coreSpec) {
-        if (coreSpec.getAnalytics() != null) {
-            if (coreSpec.isNative()) {
-                return mpaNative(coreSpec.getNativeAnalytics());
-            } else {
-                return map(coreSpec.getAnalytics());
-            }
+        if (coreSpec.isNative()) {
+            return mapNative(coreSpec.getNativeAnalytics());
+        } else {
+            return map(coreSpec.getAnalytics());
         }
-        return null;
     }
 
     Analytics map(io.gravitee.definition.model.v4.analytics.Analytics analytics);
-    Analytics mpaNative(io.gravitee.definition.model.v4.nativeapi.NativeAnalytics analytics);
+    Analytics mapNative(io.gravitee.definition.model.v4.nativeapi.NativeAnalytics analytics);
 
     @Mapping(target = "security.type", qualifiedByName = "mapSecurityType")
     @Mapping(target = "security.configuration", qualifiedByName = "deserializeConfiguration")

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/ApiCRDMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/ApiCRDMapper.java
@@ -29,6 +29,7 @@ import io.gravitee.definition.model.v4.nativeapi.NativeEndpoint;
 import io.gravitee.definition.model.v4.nativeapi.NativeEndpointGroup;
 import io.gravitee.definition.model.v4.nativeapi.NativeFlow;
 import io.gravitee.definition.model.v4.nativeapi.NativeListener;
+import io.gravitee.rest.api.management.v2.rest.model.Analytics;
 import io.gravitee.rest.api.management.v2.rest.model.ApiCRDSpec;
 import io.gravitee.rest.api.management.v2.rest.model.ApiLifecycleState;
 import io.gravitee.rest.api.management.v2.rest.model.EndpointGroupV4;
@@ -40,6 +41,7 @@ import io.gravitee.rest.api.management.v2.rest.model.PlanCRD;
 import io.gravitee.rest.api.management.v2.rest.model.PlanSecurityType;
 import io.gravitee.rest.api.management.v2.rest.model.PlanType;
 import java.util.List;
+import org.checkerframework.checker.units.qual.A;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.Named;
@@ -47,7 +49,6 @@ import org.mapstruct.factory.Mappers;
 
 @Mapper(
     uses = {
-        AnalyticsMapper.class,
         DateMapper.class,
         ConfigurationSerializationMapper.class,
         EndpointMapper.class,
@@ -67,7 +68,22 @@ public interface ApiCRDMapper {
     ApiCRDMapper INSTANCE = Mappers.getMapper(ApiCRDMapper.class);
 
     @Mapping(target = "lifecycleState", qualifiedByName = "mapLifecycleState")
+    @Mapping(target = "analytics", expression = "java(mapAnalytics(coreSpec))")
     ApiCRDSpec map(io.gravitee.apim.core.api.model.crd.ApiCRDSpec coreSpec);
+
+    default Analytics mapAnalytics(io.gravitee.apim.core.api.model.crd.ApiCRDSpec coreSpec) {
+        if (coreSpec.getAnalytics() != null) {
+            if (coreSpec.isNative()) {
+                return mpaNative(coreSpec.getNativeAnalytics());
+            } else {
+                return map(coreSpec.getAnalytics());
+            }
+        }
+        return null;
+    }
+
+    Analytics map(io.gravitee.definition.model.v4.analytics.Analytics analytics);
+    Analytics mpaNative(io.gravitee.definition.model.v4.nativeapi.NativeAnalytics analytics);
 
     @Mapping(target = "security.type", qualifiedByName = "mapSecurityType")
     @Mapping(target = "security.configuration", qualifiedByName = "deserializeConfiguration")

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/ApiMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/ApiMapper.java
@@ -31,8 +31,10 @@ import io.gravitee.definition.model.v4.endpointgroup.AbstractEndpointGroup;
 import io.gravitee.definition.model.v4.flow.AbstractFlow;
 import io.gravitee.definition.model.v4.listener.AbstractListener;
 import io.gravitee.definition.model.v4.listener.entrypoint.AbstractEntrypoint;
+import io.gravitee.definition.model.v4.nativeapi.NativeAnalytics;
 import io.gravitee.definition.model.v4.service.AbstractApiServices;
 import io.gravitee.node.logging.NodeLoggerFactory;
+import io.gravitee.rest.api.management.v2.rest.model.Analytics;
 import io.gravitee.rest.api.management.v2.rest.model.Api;
 import io.gravitee.rest.api.management.v2.rest.model.ApiFederated;
 import io.gravitee.rest.api.management.v2.rest.model.ApiFederatedAgent;
@@ -354,7 +356,10 @@ public interface ApiMapper {
     @Mapping(target = "flows", expression = "java(mapApiCRDFlows(crd))")
     @Mapping(target = "listeners", expression = "java(mapApiCRDListeners(crd))")
     @Mapping(target = "endpointGroups", expression = "java(mapApiCRDEndpointGroups(crd))")
+    @Mapping(target = "nativeAnalytics", source = "analytics")
     ApiCRDSpec map(io.gravitee.rest.api.management.v2.rest.model.ApiCRDSpec crd);
+
+    NativeAnalytics map(Analytics analytics);
 
     @Mapping(target = "source.configuration", qualifiedByName = "serializeConfiguration")
     @Mapping(target = "source.configurationMap", source = "source.configuration", qualifiedByName = "convertToMapConfiguration")

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/model/ApiCRDSpec.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/model/ApiCRDSpec.java
@@ -121,6 +121,10 @@ public class ApiCRDSpec {
 
     private boolean notifyMembers;
 
+    private boolean allowedInApiProducts;
+
+    private boolean allowMultiJwtOauth2Subscriptions;
+
     private Map<String, PageCRD> pages;
 
     public String getDefinitionVersion() {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/model/ApiCRDSpec.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/model/ApiCRDSpec.java
@@ -20,6 +20,7 @@ import io.gravitee.definition.model.DefinitionVersion;
 import io.gravitee.definition.model.ResponseTemplate;
 import io.gravitee.definition.model.v4.failover.Failover;
 import io.gravitee.definition.model.v4.flow.execution.FlowExecution;
+import io.gravitee.definition.model.v4.nativeapi.NativeAnalytics;
 import io.gravitee.rest.api.model.notification.PortalNotificationConfigEntity;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotEmpty;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/model/PlanCRD.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/model/PlanCRD.java
@@ -69,4 +69,10 @@ public class PlanCRD {
 
     @NotNull
     private PlanMode mode;
+
+    private Integer bootstrapPort;
+
+    private Integer brokerRangeStart;
+
+    private Integer brokerRangeEnd;
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/spring/ResourceContextConfiguration.java
@@ -168,6 +168,7 @@ import io.gravitee.apim.core.plan.domain_service.PlanSynchronizationService;
 import io.gravitee.apim.core.plan.domain_service.PlanValidatorDomainService;
 import io.gravitee.apim.core.plan.domain_service.UpdatePlanDomainService;
 import io.gravitee.apim.core.plan.domain_service.ValidatePlanDomainService;
+import io.gravitee.apim.core.plan.domain_service.VerifyPlanPortRangesDomainService;
 import io.gravitee.apim.core.plan.use_case.CreateApiProductPlanUseCase;
 import io.gravitee.apim.core.plan.use_case.CreatePlanUseCase;
 import io.gravitee.apim.core.plan.use_case.GetPlansUseCase;
@@ -758,7 +759,8 @@ public class ResourceContextConfiguration {
         ApiQueryServiceInMemory apiQueryService,
         ParametersQueryService parametersQueryService,
         PolicyValidationDomainService policyValidationDomainService,
-        PageCrudService pageCrudService
+        PageCrudService pageCrudService,
+        VerifyPlanPortRangesDomainService verifyPlanPortRangesDomainService
     ) {
         ValidateGroupsDomainService groupsValidator = new ValidateGroupsDomainService(groupQueryService);
         return new ValidateApiCRDUseCase(
@@ -775,7 +777,8 @@ public class ResourceContextConfiguration {
                     validationDomainService
                 ),
                 new ValidatePlanDomainService(
-                    new PlanValidatorDomainService(parametersQueryService, policyValidationDomainService, pageCrudService)
+                    new PlanValidatorDomainService(parametersQueryService, policyValidationDomainService, pageCrudService),
+                    verifyPlanPortRangesDomainService
                 ),
                 new ValidatePortalNotificationDomainService(groupsValidator)
             )

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/model/crd/ApiCRDSpec.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/model/crd/ApiCRDSpec.java
@@ -287,6 +287,9 @@ public class ApiCRDSpec {
                         nativePlan.setSelectionRule(planCRD.getSelectionRule());
                         nativePlan.setStatus(planCRD.getStatus());
                         nativePlan.setFlows((List<NativeFlow>) planCRD.getFlows());
+                        nativePlan.setBootstrapPort(planCRD.getBootstrapPort());
+                        nativePlan.setBrokerRangeStart(planCRD.getBrokerRangeStart());
+                        nativePlan.setBrokerRangeEnd(planCRD.getBrokerRangeEnd());
 
                         return nativePlan;
                     },

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/model/crd/ApiCRDSpec.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/model/crd/ApiCRDSpec.java
@@ -37,6 +37,8 @@ import io.gravitee.definition.model.v4.listener.Listener;
 import io.gravitee.definition.model.v4.listener.entrypoint.AbstractEntrypoint;
 import io.gravitee.definition.model.v4.listener.http.HttpListener;
 import io.gravitee.definition.model.v4.listener.subscription.SubscriptionListener;
+import io.gravitee.definition.model.v4.nativeapi.NativeAnalytics;
+import io.gravitee.definition.model.v4.nativeapi.NativeApi;
 import io.gravitee.definition.model.v4.nativeapi.NativeApiServices;
 import io.gravitee.definition.model.v4.nativeapi.NativeEndpointGroup;
 import io.gravitee.definition.model.v4.nativeapi.NativeFlow;
@@ -114,6 +116,8 @@ public class ApiCRDSpec {
     private List<@Valid ? extends AbstractEndpointGroup<? extends AbstractEndpoint>> endpointGroups;
 
     private Analytics analytics;
+
+    private NativeAnalytics nativeAnalytics;
 
     private Failover failover;
 
@@ -205,8 +209,9 @@ public class ApiCRDSpec {
      */
     public io.gravitee.definition.model.v4.nativeapi.NativeApi.NativeApiBuilder<?, ?> toNativeApiDefinitionBuilder() {
         // Currently we can't use MapStruct in core. We will need to discuss as team if we want to introduce a rule to allow MapStruct in core.
-        return io.gravitee.definition.model.v4.nativeapi.NativeApi.builder()
+        return NativeApi.builder()
             .apiVersion(version)
+            .analytics(nativeAnalytics)
             .definitionVersion(DefinitionVersion.V4)
             .endpointGroups(endpointGroups != null ? (List<NativeEndpointGroup>) endpointGroups : null)
             .flows(flows != null ? (List<NativeFlow>) flows : null)
@@ -290,7 +295,6 @@ public class ApiCRDSpec {
                         nativePlan.setBootstrapPort(planCRD.getBootstrapPort());
                         nativePlan.setBrokerRangeStart(planCRD.getBrokerRangeStart());
                         nativePlan.setBrokerRangeEnd(planCRD.getBrokerRangeEnd());
-
                         return nativePlan;
                     },
                     (a, b) -> a,

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/model/crd/ApiCRDSpec.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/model/crd/ApiCRDSpec.java
@@ -123,6 +123,10 @@ public class ApiCRDSpec {
 
     private boolean notifyMembers;
 
+    private Boolean allowedInApiProducts;
+
+    private boolean allowMultiJwtOauth2Subscriptions;
+
     private FlowExecution flowExecution;
 
     private Set<String> categories;
@@ -167,7 +171,8 @@ public class ApiCRDSpec {
                         : OriginContext.Origin.KUBERNETES.name()
                 )
             )
-            .groups(groups);
+            .groups(groups)
+            .allowMultiJwtOauth2Subscriptions(allowMultiJwtOauth2Subscriptions);
     }
 
     /**
@@ -191,7 +196,8 @@ public class ApiCRDSpec {
             .plans(toApiPlans(plans))
             .services(services != null ? new ApiServices(services.getDynamicProperty()) : null)
             .tags(tags)
-            .type(ApiType.valueOf(type));
+            .type(ApiType.valueOf(type))
+            .allowedInApiProducts(allowedInApiProducts);
     }
 
     /**

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/model/crd/PlanCRD.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/model/crd/PlanCRD.java
@@ -69,4 +69,10 @@ public class PlanCRD {
     private List<? extends AbstractFlow> flows = List.of();
 
     private PlanMode mode;
+
+    private Integer bootstrapPort;
+
+    private Integer brokerRangeStart;
+
+    private Integer brokerRangeEnd;
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/model/factory/ApiModelFactory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/model/factory/ApiModelFactory.java
@@ -28,8 +28,10 @@ import io.gravitee.common.utils.TimeProvider;
 import io.gravitee.definition.model.DefinitionVersion;
 import io.gravitee.definition.model.RequestValidation;
 import io.gravitee.definition.model.v4.ApiType;
+import io.gravitee.definition.model.v4.analytics.Analytics;
 import io.gravitee.definition.model.v4.listener.Listener;
 import io.gravitee.definition.model.v4.listener.http.HttpListener;
+import io.gravitee.definition.model.v4.nativeapi.NativeAnalytics;
 import io.gravitee.definition.model.v4.nativeapi.NativeApiServices;
 import io.gravitee.definition.model.v4.nativeapi.NativeEndpointGroup;
 import io.gravitee.definition.model.v4.nativeapi.NativeFlow;
@@ -128,6 +130,7 @@ public class ApiModelFactory {
             .flows(spec.getFlows() != null ? (List<NativeFlow>) spec.getFlows() : null)
             .properties(spec.getProperties())
             .allowMultiJwtOauth2Subscriptions(spec.isAllowMultiJwtOauth2Subscriptions())
+            .analytics(spec.getNativeAnalytics())
             .build();
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/model/factory/ApiModelFactory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/model/factory/ApiModelFactory.java
@@ -127,6 +127,7 @@ public class ApiModelFactory {
             .listeners(spec.getListeners() != null ? (List<NativeListener>) spec.getListeners() : null)
             .flows(spec.getFlows() != null ? (List<NativeFlow>) spec.getFlows() : null)
             .properties(spec.getProperties())
+            .allowMultiJwtOauth2Subscriptions(spec.isAllowMultiJwtOauth2Subscriptions())
             .build();
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/use_case/ImportApiCRDUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/use_case/ImportApiCRDUseCase.java
@@ -418,6 +418,9 @@ public class ImportApiCRDUseCase {
                     .tags(planCRD.getTags())
                     .mode(planCRD.getMode())
                     .name(planCRD.getName())
+                    .bootstrapPort(planCRD.getBootstrapPort())
+                    .brokerRangeStart(planCRD.getBrokerRangeStart())
+                    .brokerRangeEnd(planCRD.getBrokerRangeEnd())
                     .build()
             );
         } else {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/plan/domain_service/ValidatePlanDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/plan/domain_service/ValidatePlanDomainService.java
@@ -25,6 +25,7 @@ import io.gravitee.apim.core.plan.model.factory.PlanModelFactory;
 import io.gravitee.apim.core.validation.Validator;
 import io.gravitee.definition.model.v4.ApiType;
 import io.gravitee.definition.model.v4.listener.AbstractListener;
+import io.gravitee.definition.model.v4.nativeapi.NativePlan;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -42,6 +43,7 @@ import lombok.RequiredArgsConstructor;
 public class ValidatePlanDomainService implements Validator<ValidatePlanDomainService.Input> {
 
     private final PlanValidatorDomainService planValidator;
+    private final VerifyPlanPortRangesDomainService verifyPlanPortRangesDomainService;
 
     public record Input(AuditInfo auditInfo, ApiCRDSpec apiCRDSpec, Map<String, PlanCRD> plans, List<Page> pages) implements
         Validator.Input {
@@ -77,6 +79,18 @@ public class ValidatePlanDomainService implements Validator<ValidatePlanDomainSe
                     plan.getPlanSecurity(),
                     input.apiCRDSpec.getListeners().stream().map(AbstractListener::getType).toList()
                 );
+                if (input.apiCRDSpec.isNative()) {
+                    NativePlan nativePlan = plan.getPlanDefinitionNativeV4();
+                    if (nativePlan != null && nativePlan.getBootstrapPort() != null) {
+                        verifyPlanPortRangesDomainService.verify(
+                            input.auditInfo.environmentId(),
+                            plan.getId(),
+                            nativePlan.getBootstrapPort(),
+                            nativePlan.getBrokerRangeStart(),
+                            nativePlan.getBrokerRangeEnd()
+                        );
+                    }
+                }
 
                 sanitizedPlans.put(k, planCRD);
             } catch (Exception e) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/plan/model/factory/PlanModelFactory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/plan/model/factory/PlanModelFactory.java
@@ -61,6 +61,9 @@ public class PlanModelFactory {
                     .tags(planCRD.getTags())
                     .mode(planCRD.getMode())
                     .name(planCRD.getName())
+                    .bootstrapPort(planCRD.getBootstrapPort())
+                    .brokerRangeStart(planCRD.getBrokerRangeStart())
+                    .brokerRangeEnd(planCRD.getBrokerRangeEnd())
                     .build()
             );
         } else {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/ApiCRDAdapter.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/ApiCRDAdapter.java
@@ -69,6 +69,8 @@ public interface ApiCRDAdapter {
     @Mapping(target = "notifyMembers", expression = "java(!exportEntity.getApiEntity().isDisableMembershipNotifications())")
     @Mapping(target = "consoleNotificationConfiguration", source = "portalNotificationConfig")
     @Mapping(target = "groups", source = "apiEntity.groups")
+    @Mapping(target = "allowedInApiProducts", source = "apiEntity.allowedInApiProducts")
+    @Mapping(target = "allowMultiJwtOauth2Subscriptions", source = "apiEntity.allowMultiJwtOauth2Subscriptions")
     ApiCRDSpec toCRDSpec(ExportApiEntity exportEntity, ApiEntity apiEntity, PortalNotificationConfigEntity portalNotificationConfig);
 
     @Mapping(target = "version", source = "apiEntity.apiVersion")
@@ -80,6 +82,7 @@ public interface ApiCRDAdapter {
     @Mapping(target = "notifyMembers", expression = "java(!exportEntity.getApiEntity().isDisableMembershipNotifications())")
     @Mapping(target = "consoleNotificationConfiguration", source = "portalNotificationConfig")
     @Mapping(target = "groups", source = "apiEntity.groups")
+    @Mapping(target = "allowMultiJwtOauth2Subscriptions", source = "apiEntity.allowMultiJwtOauth2Subscriptions")
     ApiCRDSpec toCRDSpec(ExportApiEntity exportEntity, NativeApiEntity apiEntity, PortalNotificationConfigEntity portalNotificationConfig);
 
     default ApiCRDSpec toCRDSpec(

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/ApiCRDAdapter.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/ApiCRDAdapter.java
@@ -83,6 +83,7 @@ public interface ApiCRDAdapter {
     @Mapping(target = "consoleNotificationConfiguration", source = "portalNotificationConfig")
     @Mapping(target = "groups", source = "apiEntity.groups")
     @Mapping(target = "allowMultiJwtOauth2Subscriptions", source = "apiEntity.allowMultiJwtOauth2Subscriptions")
+    @Mapping(target = "nativeAnalytics", source = "apiEntity.analytics")
     ApiCRDSpec toCRDSpec(ExportApiEntity exportEntity, NativeApiEntity apiEntity, PortalNotificationConfigEntity portalNotificationConfig);
 
     default ApiCRDSpec toCRDSpec(

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/model/factory/ApiModelFactoryTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/model/factory/ApiModelFactoryTest.java
@@ -18,9 +18,18 @@ package io.gravitee.apim.core.api.model.factory;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.gravitee.apim.core.api.model.Api;
+import io.gravitee.apim.core.api.model.crd.ApiCRDSpec;
 import io.gravitee.apim.core.api.model.import_definition.ApiExport;
+import io.gravitee.definition.model.DefinitionContext;
 import io.gravitee.definition.model.DefinitionVersion;
 import io.gravitee.definition.model.v4.ApiType;
+import io.gravitee.definition.model.v4.endpointgroup.Endpoint;
+import io.gravitee.definition.model.v4.endpointgroup.EndpointGroup;
+import io.gravitee.definition.model.v4.listener.entrypoint.Entrypoint;
+import io.gravitee.definition.model.v4.listener.http.HttpListener;
+import io.gravitee.definition.model.v4.listener.http.Path;
+import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
@@ -113,5 +122,50 @@ class ApiModelFactoryTest {
         var definition = api.getApiDefinitionHttpV4();
         assertThat(definition.getType()).isEqualTo(ApiType.PROXY);
         assertThat(definition.getAllowedInApiProducts()).isNull();
+    }
+
+    @Test
+    void fromCrd_should_forward_allowedInApiProducts_and_allowMultiJwtOauth2Subscriptions() {
+        var crd = minimalProxyCrd(true, true);
+
+        Api api = ApiModelFactory.fromCrd(crd, ENVIRONMENT_ID);
+
+        assertThat(api.isAllowMultiJwtOauth2Subscriptions()).isTrue();
+        assertThat(api.getApiDefinitionHttpV4().getAllowedInApiProducts()).isTrue();
+    }
+
+    private static ApiCRDSpec minimalProxyCrd(boolean allowedInApiProducts, boolean allowMultiJwtOauth2Subscriptions) {
+        return ApiCRDSpec.builder()
+            .id("api-id")
+            .name("api")
+            .version("1.0.0")
+            .type("PROXY")
+            .lifecycleState("CREATED")
+            .state("STARTED")
+            .visibility("PRIVATE")
+            .definitionContext(DefinitionContext.builder().origin("KUBERNETES").syncFrom("KUBERNETES").build())
+            .listeners(
+                List.of(
+                    HttpListener.builder()
+                        .paths(List.of(Path.builder().path("/").build()))
+                        .entrypoints(List.of(Entrypoint.builder().type("http-proxy").configuration("{}").build()))
+                        .build()
+                )
+            )
+            .endpointGroups(
+                List.of(
+                    EndpointGroup.builder()
+                        .name("default")
+                        .type("http-proxy")
+                        .endpoints(List.of(Endpoint.builder().name("default").type("http-proxy").configuration("{}").build()))
+                        .build()
+                )
+            )
+            .properties(List.of())
+            .flows(List.of())
+            .plans(Map.of())
+            .allowedInApiProducts(allowedInApiProducts)
+            .allowMultiJwtOauth2Subscriptions(allowMultiJwtOauth2Subscriptions)
+            .build();
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/ImportApiCRDUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/ImportApiCRDUseCaseTest.java
@@ -250,10 +250,7 @@ class ImportApiCRDUseCaseTest {
     CategoryQueryServiceInMemory categoryQueryService = new CategoryQueryServiceInMemory();
 
     ValidateApiDomainService validateApiDomainService = mock(ValidateApiDomainService.class);
-    PlanValidatorDomainService planValidatorDomainService = mock(PlanValidatorDomainService.class);
     PlanSynchronizationService planSynchronizationService = mock(PlanSynchronizationService.class);
-    EventCrudService eventCrudService = mock(EventCrudService.class);
-    EventLatestCrudService eventLatestCrudService = mock(EventLatestCrudService.class);
     PlanQueryServiceInMemory planQueryService = new PlanQueryServiceInMemory(planCrudService);
     IndexerInMemory indexer = new IndexerInMemory();
     UpdateApiDomainService updateApiDomainService;
@@ -265,8 +262,6 @@ class ImportApiCRDUseCaseTest {
     ValidateResourceDomainServiceInMemory validateResourceDomainService = new ValidateResourceDomainServiceInMemory();
     DocumentationValidationDomainService validationDomainService = mock(DocumentationValidationDomainService.class);
     CRDMembersDomainServiceInMemory crdMembersDomainService = new CRDMembersDomainServiceInMemory();
-    MembershipQueryServiceInMemory membershipQueryService = new MembershipQueryServiceInMemory(membershipCrudService);
-    TriggerNotificationDomainServiceInMemory triggerNotificationDomainService = new TriggerNotificationDomainServiceInMemory();
     CategoryDomainService categoryDomainService = mock(CategoryDomainService.class);
     DataEncryptor dataEncryptor = mock(DataEncryptor.class);
     CreateCategoryApiDomainServiceInMemory createCategoryApiDomainService = new CreateCategoryApiDomainServiceInMemory();
@@ -401,7 +396,7 @@ class ImportApiCRDUseCaseTest {
             new ValidateGroupsDomainService(groupQueryService),
             validateResourceDomainService,
             new ValidatePagesDomainService(pageSourceValidator, accessControlValidator, validationDomainService),
-            new ValidatePlanDomainService(planValidatorDomainService),
+            new ValidatePlanDomainService(planValidatorService, verifyPlanPortRanges),
             new ValidatePortalNotificationDomainService(new ValidateGroupsDomainService(groupQueryService))
         );
 


### PR DESCRIPTION
## Summary

- Mutualize duplicated `id`, `environmentId`, `organizationId`, `errors` (and `crossId`) status properties into shared `BaseStatus` and `CrossIdStatus` schemas in the OpenAPI spec
- Fix all MapStruct mappers to handle `readOnly` properties (no setters generated) by constructing `*State` objects via `@JsonCreator` constructor, then delegating remaining mapping to `@MappingTarget` methods
- Fix `ApiSubscriptionResource` and `SharedPolicyGroupsResource` which called non-existent setters on readonly fields
- Add missing APIM properties to OAS (d3c94cd7bff40a83fa91f9d45d3b113a0df42520)

https://gravitee.atlassian.net/browse/GKO-2590
