### PR TITLE
feat(gateway): add ApiType.EDGE support in sync services and test SDK

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/manager/impl/ApiManagerImpl.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/manager/impl/ApiManagerImpl.java
@@ -88,13 +88,20 @@ public class ApiManagerImpl implements ApiManager {
         this.gatewayConfiguration = gatewayConfiguration;
         this.licenseManager = licenseManager;
         this.apiProductRegistry = apiProductRegistry;
-        deployers = Map.of(
-            Api.class,
-            new ApiDeployer(gatewayConfiguration, dataEncryptor),
-            io.gravitee.gateway.reactive.handlers.api.v4.Api.class,
-            new io.gravitee.gateway.reactive.handlers.api.v4.deployer.ApiDeployer(gatewayConfiguration, dataEncryptor),
-            io.gravitee.gateway.reactive.handlers.api.v4.NativeApi.class,
-            new io.gravitee.gateway.reactive.handlers.api.v4.deployer.NativeApiDeployer(gatewayConfiguration, dataEncryptor)
+        deployers = Map.ofEntries(
+            Map.entry(Api.class, new ApiDeployer(gatewayConfiguration, dataEncryptor)),
+            Map.entry(
+                io.gravitee.gateway.reactive.handlers.api.v4.Api.class,
+                new io.gravitee.gateway.reactive.handlers.api.v4.deployer.ApiDeployer(gatewayConfiguration, dataEncryptor)
+            ),
+            Map.entry(
+                io.gravitee.gateway.reactive.handlers.api.v4.NativeApi.class,
+                new io.gravitee.gateway.reactive.handlers.api.v4.deployer.NativeApiDeployer(gatewayConfiguration, dataEncryptor)
+            ),
+            Map.entry(
+                io.gravitee.gateway.reactive.handlers.api.v4.EdgeApi.class,
+                new io.gravitee.gateway.reactive.handlers.api.v4.deployer.EdgeApiDeployer(gatewayConfiguration, dataEncryptor)
+            )
         );
 
         // Listen to secret discovery events to update APIs when secrets change

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/EdgeApi.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/EdgeApi.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.reactive.handlers.api.v4;
+
+import io.gravitee.definition.model.DefinitionVersion;
+import io.gravitee.gateway.reactor.AbstractReactableApi;
+import java.util.Collections;
+import java.util.Set;
+
+public class EdgeApi extends AbstractReactableApi<io.gravitee.definition.model.v4.edge.EdgeApi> {
+
+    public EdgeApi() {
+        super();
+    }
+
+    public EdgeApi(io.gravitee.definition.model.v4.edge.EdgeApi edgeApi) {
+        super(edgeApi);
+    }
+
+    @Override
+    public String getApiVersion() {
+        return definition.getApiVersion();
+    }
+
+    @Override
+    public DefinitionVersion getDefinitionVersion() {
+        return definition.getDefinitionVersion();
+    }
+
+    @Override
+    public Set<String> getTags() {
+        return definition.getTags();
+    }
+
+    @Override
+    public String getId() {
+        return definition.getId();
+    }
+
+    @Override
+    public String getName() {
+        return definition.getName();
+    }
+
+    @Override
+    public Set<String> getSubscribablePlans() {
+        return Collections.emptySet();
+    }
+
+    @Override
+    public Set<String> getApiKeyPlans() {
+        return Collections.emptySet();
+    }
+
+    @Override
+    public <D> Set<D> dependencies(Class<D> type) {
+        return Collections.emptySet();
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/deployer/EdgeApiDeployer.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/deployer/EdgeApiDeployer.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.reactive.handlers.api.v4.deployer;
+
+import io.gravitee.common.util.DataEncryptor;
+import io.gravitee.gateway.env.GatewayConfiguration;
+import io.gravitee.gateway.reactive.handlers.api.v4.EdgeApi;
+import java.util.List;
+
+public class EdgeApiDeployer extends AbstractApiDeployer<EdgeApi> {
+
+    public EdgeApiDeployer(final GatewayConfiguration gatewayConfiguration, final DataEncryptor dataEncryptor) {
+        super(gatewayConfiguration, dataEncryptor);
+    }
+
+    @Override
+    public void initialize(final EdgeApi edgeApi) {
+        io.gravitee.definition.model.v4.edge.EdgeApi apiDefinition = edgeApi.getDefinition();
+
+        if (apiDefinition.getProperties() != null) {
+            decryptProperties(apiDefinition.getProperties());
+        }
+    }
+
+    @Override
+    public List<String> getPlans(final EdgeApi edgeApi) {
+        return List.of();
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/v4/deployer/EdgeApiDeployerTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/v4/deployer/EdgeApiDeployerTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.reactive.handlers.api.v4.deployer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.common.util.DataEncryptor;
+import io.gravitee.definition.model.v4.edge.EdgeApi;
+import io.gravitee.definition.model.v4.property.Property;
+import io.gravitee.gateway.env.GatewayConfiguration;
+import java.util.List;
+import lombok.SneakyThrows;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@ExtendWith(MockitoExtension.class)
+class EdgeApiDeployerTest {
+
+    @Mock
+    private DataEncryptor dataEncryptor;
+
+    @Mock
+    private GatewayConfiguration gatewayConfiguration;
+
+    private EdgeApiDeployer cut;
+
+    @BeforeEach
+    public void beforeEach() {
+        cut = new EdgeApiDeployer(gatewayConfiguration, dataEncryptor);
+    }
+
+    @Test
+    void should_initialize_without_error_when_no_properties() {
+        final io.gravitee.gateway.reactive.handlers.api.v4.EdgeApi edgeApi = new io.gravitee.gateway.reactive.handlers.api.v4.EdgeApi(
+            EdgeApi.builder().build()
+        );
+        cut.initialize(edgeApi);
+    }
+
+    @SneakyThrows
+    @Test
+    void should_decrypt_properties_on_initialize() {
+        final io.gravitee.gateway.reactive.handlers.api.v4.EdgeApi edgeApi = new io.gravitee.gateway.reactive.handlers.api.v4.EdgeApi(
+            EdgeApi.builder()
+                .properties(
+                    List.of(
+                        Property.builder().key("key1").value("value1").encrypted(true).build(),
+                        Property.builder().key("key2").value("value2").encrypted(true).build(),
+                        Property.builder().key("key3").value("value3").encrypted(false).build()
+                    )
+                )
+                .build()
+        );
+        when(dataEncryptor.decrypt(any())).thenAnswer(invocation -> invocation.getArguments()[0].toString().toUpperCase());
+        cut.initialize(edgeApi);
+        assertThat(edgeApi.getDefinition().getProperties()).contains(
+            Property.builder().key("key1").value("VALUE1").encrypted(false).build(),
+            Property.builder().key("key2").value("VALUE2").encrypted(false).build(),
+            Property.builder().key("key3").value("value3").encrypted(false).build()
+        );
+    }
+
+    @Test
+    void should_return_empty_plans() {
+        final io.gravitee.gateway.reactive.handlers.api.v4.EdgeApi edgeApi = new io.gravitee.gateway.reactive.handlers.api.v4.EdgeApi(
+            EdgeApi.builder().build()
+        );
+        assertThat(cut.getPlans(edgeApi)).isEmpty();
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/distributed/mapper/ApiMapper.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/distributed/mapper/ApiMapper.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.gravitee.definition.model.DefinitionVersion;
 import io.gravitee.definition.model.v4.ApiType;
+import io.gravitee.definition.model.v4.edge.EdgeApi;
 import io.gravitee.definition.model.v4.nativeapi.NativeApi;
 import io.gravitee.gateway.handlers.api.definition.Api;
 import io.gravitee.gateway.reactor.ReactableApi;
@@ -67,6 +68,14 @@ public class ApiMapper {
                     reactableApi ->
                         reactableApi.getDefinitionVersion() == DefinitionVersion.V4 &&
                         ((NativeApi) reactableApi.getDefinition()).getType() == ApiType.NATIVE
+                ),
+            payload ->
+                parseAndAssert(
+                    payload,
+                    io.gravitee.gateway.reactive.handlers.api.v4.EdgeApi.class,
+                    reactableApi ->
+                        reactableApi.getDefinitionVersion() == DefinitionVersion.V4 &&
+                        ((EdgeApi) reactableApi.getDefinition()).getType() == ApiType.EDGE
                 )
         );
     }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/local/mapper/ApiMapper.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/local/mapper/ApiMapper.java
@@ -15,18 +15,17 @@
  */
 package io.gravitee.gateway.services.sync.process.local.mapper;
 
-import static io.gravitee.repository.management.model.Event.EventProperties.API_ID;
 import static io.gravitee.repository.management.model.Event.EventProperties.DEPLOYMENT_NUMBER;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.gravitee.definition.model.DefinitionVersion;
 import io.gravitee.definition.model.v4.ApiType;
+import io.gravitee.definition.model.v4.edge.EdgeApi;
 import io.gravitee.definition.model.v4.nativeapi.NativeApi;
 import io.gravitee.gateway.reactor.ReactableApi;
 import io.gravitee.gateway.services.sync.process.repository.service.EnvironmentService;
 import io.gravitee.repository.management.model.Event;
 import io.gravitee.repository.management.model.LifecycleState;
-import io.reactivex.rxjava3.core.Maybe;
 import java.util.Optional;
 import lombok.CustomLog;
 import lombok.RequiredArgsConstructor;
@@ -57,6 +56,10 @@ public class ApiMapper {
 
                     // Update definition with required information for deployment phase
                     reactableApi = new io.gravitee.gateway.reactive.handlers.api.v4.NativeApi(eventApiDefinition);
+                } else if (api.getType() == ApiType.EDGE) {
+                    var eventApiDefinition = objectMapper.readValue(api.getDefinition(), EdgeApi.class);
+
+                    reactableApi = new io.gravitee.gateway.reactive.handlers.api.v4.EdgeApi(eventApiDefinition);
                 } else if (
                     api.getType() == ApiType.PROXY ||
                     api.getType() == ApiType.LLM_PROXY ||

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/mapper/ApiMapper.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/mapper/ApiMapper.java
@@ -21,6 +21,7 @@ import static io.gravitee.repository.management.model.Event.EventProperties.DEPL
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.gravitee.definition.model.DefinitionVersion;
 import io.gravitee.definition.model.v4.ApiType;
+import io.gravitee.definition.model.v4.edge.EdgeApi;
 import io.gravitee.definition.model.v4.nativeapi.NativeApi;
 import io.gravitee.gateway.reactor.ReactableApi;
 import io.gravitee.gateway.services.sync.process.repository.service.EnvironmentService;
@@ -71,6 +72,10 @@ public class ApiMapper {
 
                         // Update definition with required information for deployment phase
                         reactableApi = new io.gravitee.gateway.reactive.handlers.api.v4.NativeApi(eventApiDefinition);
+                    } else if (api.getType() == ApiType.EDGE) {
+                        var eventApiDefinition = objectMapper.readValue(api.getDefinition(), EdgeApi.class);
+
+                        reactableApi = new io.gravitee.gateway.reactive.handlers.api.v4.EdgeApi(eventApiDefinition);
                     } else if (
                         api.getType() == ApiType.PROXY ||
                         api.getType() == ApiType.A2A_PROXY ||

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/distributed/mapper/ApiMapperTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/distributed/mapper/ApiMapperTest.java
@@ -27,6 +27,7 @@ import io.gravitee.definition.model.v4.ApiType;
 import io.gravitee.gateway.api.service.ApiKey;
 import io.gravitee.gateway.api.service.Subscription;
 import io.gravitee.gateway.reactive.handlers.api.v4.Api;
+import io.gravitee.gateway.reactive.handlers.api.v4.EdgeApi;
 import io.gravitee.gateway.reactive.handlers.api.v4.NativeApi;
 import io.gravitee.gateway.services.sync.process.common.model.SyncAction;
 import io.gravitee.gateway.services.sync.process.repository.synchronizer.api.ApiReactorDeployable;
@@ -131,6 +132,38 @@ class ApiMapperTest {
         apiDef.setDefinitionVersion(DefinitionVersion.V4);
         apiDef.setType(ApiType.NATIVE);
         NativeApi api = new NativeApi(apiDef);
+
+        DistributedEvent distributedEvent = DistributedEvent.builder()
+            .id("apiId")
+            .payload(objectMapper.writeValueAsString(api))
+            .updatedAt(new Date())
+            .type(DistributedEventType.API)
+            .syncAction(DistributedSyncAction.DEPLOY)
+            .build();
+
+        ApiReactorDeployable apiReactorDeployable = ApiReactorDeployable.builder()
+            .apiId("apiId")
+            .reactableApi(api)
+            .syncAction(SyncAction.DEPLOY)
+            .build();
+
+        cut
+            .to(distributedEvent)
+            .test()
+            .assertValue(reactorDeployable -> {
+                assertThat(reactorDeployable).isEqualTo(apiReactorDeployable);
+                return true;
+            });
+    }
+
+    @SneakyThrows
+    @Test
+    void should_return_distributed_event_for_v4_edge_api() {
+        io.gravitee.definition.model.v4.edge.EdgeApi apiDef = new io.gravitee.definition.model.v4.edge.EdgeApi();
+        apiDef.setId("apiId");
+        apiDef.setDefinitionVersion(DefinitionVersion.V4);
+        apiDef.setType(ApiType.EDGE);
+        EdgeApi api = new EdgeApi(apiDef);
 
         DistributedEvent distributedEvent = DistributedEvent.builder()
             .id("apiId")

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/mapper/ApiMapperTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/mapper/ApiMapperTest.java
@@ -28,6 +28,7 @@ import io.gravitee.definition.model.ExecutionMode;
 import io.gravitee.definition.model.Proxy;
 import io.gravitee.definition.model.VirtualHost;
 import io.gravitee.definition.model.v4.ApiType;
+import io.gravitee.definition.model.v4.edge.EdgeApi;
 import io.gravitee.definition.model.v4.nativeapi.NativeApi;
 import io.gravitee.gateway.services.sync.process.repository.service.EnvironmentService;
 import io.gravitee.repository.exceptions.TechnicalException;
@@ -172,6 +173,29 @@ class ApiMapperTest {
             .assertValue(reactableApi -> {
                 assertThat(reactableApi.getId()).isEqualTo(nativeApi.getId());
                 assertThat(reactableApi.getDefinition()).isEqualTo(nativeApi);
+                return true;
+            })
+            .assertComplete();
+    }
+
+    @Test
+    void should_map_edge_api_v4() throws JsonProcessingException {
+        EdgeApi edgeApi = new EdgeApi();
+        edgeApi.setId("id");
+        edgeApi.setType(ApiType.EDGE);
+        edgeApi.setDefinitionVersion(DefinitionVersion.V4);
+
+        repoApiV4.setType(ApiType.EDGE);
+        repoApiV4.setDefinition(objectMapper.writeValueAsString(edgeApi));
+
+        Event event = new Event();
+        event.setPayload(objectMapper.writeValueAsString(repoApiV4));
+        cut
+            .to(event)
+            .test()
+            .assertValue(reactableApi -> {
+                assertThat(reactableApi.getId()).isEqualTo(edgeApi.getId());
+                assertThat(reactableApi.getDefinition()).isEqualTo(edgeApi);
                 return true;
             })
             .assertComplete();

--- a/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/src/main/java/io/gravitee/apim/gateway/tests/sdk/converters/EdgeApiDeploymentPreparer.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/src/main/java/io/gravitee/apim/gateway/tests/sdk/converters/EdgeApiDeploymentPreparer.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.gateway.tests.sdk.converters;
+
+import io.gravitee.definition.model.v4.edge.EdgeApi;
+import io.gravitee.gateway.reactor.ReactableApi;
+import org.junit.platform.commons.PreconditionViolationException;
+
+public class EdgeApiDeploymentPreparer implements ApiDeploymentPreparer<EdgeApi> {
+
+    @Override
+    public ReactableApi<EdgeApi> toReactable(EdgeApi definition, String environmentId) {
+        final io.gravitee.gateway.reactive.handlers.api.v4.EdgeApi api = new io.gravitee.gateway.reactive.handlers.api.v4.EdgeApi(
+            definition
+        );
+        api.setEnvironmentId(environmentId);
+        return api;
+    }
+
+    @Override
+    public void ensureMinimalRequirementForApi(EdgeApi definition) {
+        if (definition.getType() == null) {
+            throw new PreconditionViolationException("'type' field must be defined on a V4 Edge API Definition");
+        }
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/src/main/java/io/gravitee/apim/gateway/tests/sdk/runner/GatewayRunner.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/src/main/java/io/gravitee/apim/gateway/tests/sdk/runner/GatewayRunner.java
@@ -28,6 +28,7 @@ import io.gravitee.apim.gateway.tests.sdk.connector.ConnectorBuilder;
 import io.gravitee.apim.gateway.tests.sdk.connector.EndpointBuilder;
 import io.gravitee.apim.gateway.tests.sdk.container.GatewayTestContainer;
 import io.gravitee.apim.gateway.tests.sdk.converters.ApiDeploymentPreparer;
+import io.gravitee.apim.gateway.tests.sdk.converters.EdgeApiDeploymentPreparer;
 import io.gravitee.apim.gateway.tests.sdk.converters.LegacyApiDeploymentPreparer;
 import io.gravitee.apim.gateway.tests.sdk.converters.NativeApiDeploymentPreparer;
 import io.gravitee.apim.gateway.tests.sdk.converters.V4ApiDeploymentPreparer;
@@ -53,6 +54,7 @@ import io.gravitee.definition.model.DefinitionVersion;
 import io.gravitee.definition.model.ExecutionMode;
 import io.gravitee.definition.model.v4.AbstractApi;
 import io.gravitee.definition.model.v4.ApiType;
+import io.gravitee.definition.model.v4.edge.EdgeApi;
 import io.gravitee.definition.model.v4.nativeapi.NativeApi;
 import io.gravitee.definition.model.v4.sharedpolicygroup.SharedPolicyGroup;
 import io.gravitee.gateway.dictionary.DictionaryManager;
@@ -222,7 +224,9 @@ public class GatewayRunner {
             io.gravitee.definition.model.v4.Api.class,
             new V4ApiDeploymentPreparer(),
             NativeApi.class,
-            new NativeApiDeploymentPreparer()
+            new NativeApiDeploymentPreparer(),
+            EdgeApi.class,
+            new EdgeApiDeploymentPreparer()
         );
     }
 
@@ -694,6 +698,8 @@ public class GatewayRunner {
             AbstractApi api;
             if (apiType == ApiType.NATIVE) {
                 api = graviteeMapper.treeToValue(apiAsJson, NativeApi.class);
+            } else if (apiType == ApiType.EDGE) {
+                api = graviteeMapper.treeToValue(apiAsJson, EdgeApi.class);
             } else {
                 api = graviteeMapper.treeToValue(apiAsJson, io.gravitee.definition.model.v4.Api.class);
             }


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/GMA-334

## Description

Add `ApiType.EDGE` support across the gateway sync services and test SDK so that Edge APIs can be deserialized, mapped, and deployed.

**Changes:**
- **`EdgeApi` ReactableApi** (`gateway-handlers-api/v4`): new `AbstractReactableApi<EdgeApi>` with no plans, policies, or dependencies (Edge APIs are pure routing/proxy definitions)
- **`EdgeApiDeploymentPreparer`** (`tests-sdk/converters`): converts Edge definition to ReactableApi for integration tests
- **`GatewayRunner`**: deserializes `ApiType.EDGE` to `EdgeApi` definition and registers the preparer
- **3 `ApiMapper`s** (local, repository, distributed sync): route `ApiType.EDGE` to the new `EdgeApi` ReactableApi
- **Tests**: added `should_map_edge_api_v4` and `should_return_distributed_event_for_v4_edge_api` in the existing ApiMapperTest classes