### PR TITLE
fix(console): load v4 APIs in audit type filter via Management API v2

### DIFF
--- a/gravitee-apim-console-webui/src/management/audit/env-audit.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/audit/env-audit.component.spec.ts
@@ -28,8 +28,7 @@ import { EnvAuditModule } from './env-audit.module';
 
 import { fakeMetadataPageAudit } from '../../entities/audit/Audit.fixture';
 import { CONSTANTS_TESTING, GioTestingModule } from '../../shared/testing';
-import { Api } from '../../entities/api/Api';
-import { fakeApi } from '../../entities/api/Api.fixture';
+import { Api, fakeApiV4 } from '../../entities/management-api-v2';
 import { GioTableWrapperHarness } from '../../shared/components/gio-table-wrapper/gio-table-wrapper.harness';
 
 describe('EnvAuditComponent', () => {
@@ -100,13 +99,14 @@ describe('EnvAuditComponent', () => {
 
     expectAuditListRequest({ referenceType: 'API' });
 
-    expectApiGetAllByEnvRequest([fakeApi({ id: 'api1', name: 'api1' })]);
+    const v4Api = fakeApiV4({ id: 'v4-api-id', name: 'My V4 API' });
+    expectApiGetAllByEnvRequest([v4Api]);
 
     // 3. Expect API selection works and trigger new AuditListRequest
     const apiIdSelect = await loader.getHarness(MatSelectHarness.with({ selector: '[formControlName=apiId]' }));
 
-    await apiIdSelect.clickOptions({ text: 'api1' });
-    expectAuditListRequest({ referenceType: 'API', apiId: 'api1' });
+    await apiIdSelect.clickOptions({ text: 'My V4 API' });
+    expectAuditListRequest({ referenceType: 'API', apiId: 'v4-api-id' });
   });
 
   it('should display audit logs with from & to range', async () => {
@@ -188,8 +188,8 @@ describe('EnvAuditComponent', () => {
   }
 
   function expectApiGetAllByEnvRequest(apis: Api[]) {
-    const req = httpTestingController.expectOne(`${CONSTANTS_TESTING.env.baseURL}/apis`);
+    const req = httpTestingController.expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/apis?page=1`);
     expect(req.request.method).toEqual('GET');
-    req.flush(apis);
+    req.flush({ data: apis });
   }
 });

--- a/gravitee-apim-console-webui/src/management/audit/env-audit.component.ts
+++ b/gravitee-apim-console-webui/src/management/audit/env-audit.component.ts
@@ -20,7 +20,7 @@ import { BehaviorSubject, EMPTY, Subject } from 'rxjs';
 import { catchError, debounceTime, distinctUntilChanged, switchMap, takeUntil, tap, throttleTime } from 'rxjs/operators';
 import { Moment } from 'moment';
 
-import { ApiService } from '../../services-ngx/api.service';
+import { ApiV2Service } from '../../services-ngx/api-v2.service';
 import { ApplicationService } from '../../services-ngx/application.service';
 import { AuditService } from '../../services-ngx/audit.service';
 import { SnackBarService } from '../../services-ngx/snack-bar.service';
@@ -64,7 +64,7 @@ export class EnvAuditComponent implements OnInit, OnDestroy {
 
   public eventsName$ = this.auditService.getAllEventsName();
 
-  public apis$ = this.apiService.getAll();
+  public apis$ = this.apiV2Service.listAll();
 
   public applications$ = this.applicationService.getAll();
 
@@ -98,7 +98,7 @@ export class EnvAuditComponent implements OnInit, OnDestroy {
 
   constructor(
     private auditService: AuditService,
-    private apiService: ApiService,
+    private readonly apiV2Service: ApiV2Service,
     private applicationService: ApplicationService,
     private snackBarService: SnackBarService,
   ) {}

--- a/gravitee-apim-console-webui/src/organization/configuration/audit/org-settings-audit.component.spec.ts
+++ b/gravitee-apim-console-webui/src/organization/configuration/audit/org-settings-audit.component.spec.ts
@@ -30,8 +30,7 @@ import { OrganizationSettingsModule } from '../organization-settings.module';
 import { fakeMetadataPageAudit } from '../../../entities/audit/Audit.fixture';
 import { fakeEnvironment } from '../../../entities/environment/environment.fixture';
 import { Environment } from '../../../entities/environment/environment';
-import { Api } from '../../../entities/api/Api';
-import { fakeApi } from '../../../entities/api/Api.fixture';
+import { Api, fakeApiV4 } from '../../../entities/management-api-v2';
 import { GioTableWrapperHarness } from '../../../shared/components/gio-table-wrapper/gio-table-wrapper.harness';
 
 describe('OrgSettingsAuditComponent', () => {
@@ -117,14 +116,14 @@ describe('OrgSettingsAuditComponent', () => {
     expectAuditListRequest({ referenceType: 'API' });
 
     expectEnvironmentGetAllRequest([fakeEnvironment({ id: 'envA', name: 'envA' }), fakeEnvironment({ id: 'envB', name: 'envB' })]);
-    expectApiGetAllByEnvRequest('envA', [fakeApi({ id: 'envA_api1', name: 'envA_api1' })]);
-    expectApiGetAllByEnvRequest('envB', [fakeApi({ id: 'envB_api1', name: 'envB_api1' })]);
+    expectApiGetAllByEnvRequest('envA', [fakeApiV4({ id: 'envA_api1', name: 'envA_api1' })]);
+    expectApiGetAllByEnvRequest('envB', [fakeApiV4({ id: 'envB_v4_api', name: 'envB V4 API' })]);
 
     // 3. Expect API selection works and trigger new AuditListRequest
     const apiIdSelect = await loader.getHarness(MatSelectHarness.with({ selector: '[formControlName=apiId]' }));
 
-    await apiIdSelect.clickOptions({ text: 'envB_api1' });
-    expectAuditListRequest({ referenceType: 'API', apiId: 'envB_api1' });
+    await apiIdSelect.clickOptions({ text: 'envB V4 API' });
+    expectAuditListRequest({ referenceType: 'API', apiId: 'envB_v4_api' });
   });
 
   it('should display audit logs with from & to range', async () => {
@@ -213,8 +212,8 @@ describe('OrgSettingsAuditComponent', () => {
   }
 
   function expectApiGetAllByEnvRequest(envId: string, apis: Api[]) {
-    const req = httpTestingController.expectOne(`${CONSTANTS_TESTING.org.baseURL}/environments/${envId}/apis`);
+    const req = httpTestingController.expectOne(`${CONSTANTS_TESTING.v2BaseURL}/environments/${envId}/apis?page=1`);
     expect(req.request.method).toEqual('GET');
-    req.flush(apis);
+    req.flush({ data: apis });
   }
 });

--- a/gravitee-apim-console-webui/src/organization/configuration/audit/org-settings-audit.component.ts
+++ b/gravitee-apim-console-webui/src/organization/configuration/audit/org-settings-audit.component.ts
@@ -19,8 +19,8 @@ import { isEqual, mapValues } from 'lodash';
 import { BehaviorSubject, EMPTY, forkJoin, Observable, Subject } from 'rxjs';
 import { catchError, debounceTime, distinctUntilChanged, shareReplay, switchMap, takeUntil, tap, throttleTime } from 'rxjs/operators';
 
-import { Api } from '../../../entities/api';
-import { ApiService } from '../../../services-ngx/api.service';
+import { Api } from '../../../entities/management-api-v2';
+import { ApiV2Service } from '../../../services-ngx/api-v2.service';
 import { ApplicationService } from '../../../services-ngx/application.service';
 import { AuditService } from '../../../services-ngx/audit.service';
 import { EnvironmentService } from '../../../services-ngx/environment.service';
@@ -74,7 +74,7 @@ export class OrgSettingsAuditComponent implements OnInit, OnDestroy {
         envs.reduce(
           (res, env) => ({
             ...res,
-            [env.name]: this.apiService.getAll({
+            [env.name]: this.apiV2Service.listAll({
               environmentId: env.id,
             }),
           }),
@@ -133,7 +133,7 @@ export class OrgSettingsAuditComponent implements OnInit, OnDestroy {
 
   constructor(
     private auditService: AuditService,
-    private apiService: ApiService,
+    private readonly apiV2Service: ApiV2Service,
     private applicationService: ApplicationService,
     private environmentService: EnvironmentService,
     private snackBarService: SnackBarService,

--- a/gravitee-apim-console-webui/src/services-ngx/api-v2.service.spec.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/api-v2.service.spec.ts
@@ -23,6 +23,7 @@ import { CONSTANTS_TESTING, GioTestingModule } from '../shared/testing';
 import {
   ApiTransferOwnership,
   DuplicateApiOptions,
+  fakeApiV2,
   fakeApiV4,
   fakeBaseApplication,
   fakeCreateApiV4,
@@ -288,6 +289,116 @@ describe('ApiV2Service', () => {
       });
       req.flush({
         data: [fakeApi],
+      });
+    });
+  });
+
+  describe('listAll', () => {
+    it('should call the current environment v2 API', done => {
+      const fakeApi = fakeApiV4();
+
+      apiV2Service.listAll().subscribe(apis => {
+        expect(apis).toEqual([fakeApi]);
+        done();
+      });
+
+      const req = httpTestingController.expectOne({
+        url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis?page=1`,
+        method: 'GET',
+      });
+
+      req.flush({ data: [fakeApi] });
+    });
+
+    it('should call the v2 API for a specific environment', done => {
+      const environmentId = 'env-id';
+      const fakeApi = fakeApiV4();
+
+      apiV2Service.listAll({ environmentId }).subscribe(apis => {
+        expect(apis).toEqual([fakeApi]);
+        done();
+      });
+
+      const req = httpTestingController.expectOne({
+        url: `${CONSTANTS_TESTING.v2BaseURL}/environments/${environmentId}/apis?page=1`,
+        method: 'GET',
+      });
+
+      req.flush({ data: [fakeApi] });
+    });
+
+    it('should return an empty array when response has no data', done => {
+      apiV2Service.listAll().subscribe(apis => {
+        expect(apis).toEqual([]);
+        done();
+      });
+
+      const req = httpTestingController.expectOne({
+        url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis?page=1`,
+        method: 'GET',
+      });
+
+      req.flush({});
+    });
+
+    it('should return both v2 and v4 APIs when the response contains a mix', done => {
+      const v2Api = fakeApiV2({ id: 'v2-api-id', name: 'My V2 API' });
+      const v4Api = fakeApiV4({ id: 'v4-api-id', name: 'My V4 API' });
+
+      apiV2Service.listAll().subscribe(apis => {
+        expect(apis).toEqual([v2Api, v4Api]);
+        done();
+      });
+
+      const req = httpTestingController.expectOne({
+        url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis?page=1`,
+        method: 'GET',
+      });
+
+      req.flush({ data: [v2Api, v4Api] });
+    });
+
+    it('should paginate through every page until pageCount is reached', done => {
+      const pageOneApis = [fakeApiV2({ id: 'page-1-v2', name: 'page-1-v2' }), fakeApiV4({ id: 'page-1-v4', name: 'page-1-v4' })];
+      const pageTwoApis = [fakeApiV4({ id: 'page-2-v4', name: 'page-2-v4' })];
+
+      apiV2Service.listAll().subscribe(apis => {
+        expect(apis).toEqual([...pageOneApis, ...pageTwoApis]);
+        done();
+      });
+
+      const reqPage1 = httpTestingController.expectOne({
+        url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis?page=1`,
+        method: 'GET',
+      });
+      reqPage1.flush({
+        data: pageOneApis,
+        pagination: { page: 1, pageCount: 2, totalCount: 3 },
+      });
+
+      const reqPage2 = httpTestingController.expectOne({
+        url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis?page=2`,
+        method: 'GET',
+      });
+      reqPage2.flush({
+        data: pageTwoApis,
+        pagination: { page: 2, pageCount: 2, totalCount: 3 },
+      });
+    });
+
+    it('should stop after one request when pageCount is 1', done => {
+      apiV2Service.listAll().subscribe(apis => {
+        expect(apis).toEqual([]);
+        done();
+      });
+
+      const req = httpTestingController.expectOne({
+        url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis?page=1`,
+        method: 'GET',
+      });
+      req.flush({
+        data: [],
+        pagination: { page: 1, pageCount: 1, totalCount: 0 },
       });
     });
   });

--- a/gravitee-apim-console-webui/src/services-ngx/api-v2.service.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/api-v2.service.ts
@@ -15,8 +15,8 @@
  */
 import { HttpClient, HttpParams } from '@angular/common/http';
 import { Inject, Injectable } from '@angular/core';
-import { BehaviorSubject, from, mergeMap, Observable, of } from 'rxjs';
-import { distinctUntilChanged, filter, map, shareReplay, switchMap, tap } from 'rxjs/operators';
+import { BehaviorSubject, EMPTY, from, mergeMap, Observable, of } from 'rxjs';
+import { distinctUntilChanged, expand, filter, map, reduce, shareReplay, switchMap, tap } from 'rxjs/operators';
 import { isEqual } from 'lodash';
 
 import { Constants } from '../entities/Constants';
@@ -175,6 +175,35 @@ export class ApiV2Service {
         ...(manageOnly ? {} : { manageOnly: false }),
       },
     });
+  }
+
+  /**
+   * Lists every API in an environment regardless of definition version (v1, v2, v4, federated, federated agent).
+   *
+   * Use this instead of `ApiService.getAll()`, which relies on the legacy Management v1 endpoint and
+   * silently omits v4+ APIs.
+   *
+   * The method paginates through the v2 endpoint using the `pageCount` returned in the response and
+   * emits a single aggregated `Api[]` once every page has been fetched.
+   */
+  listAll(params: { environmentId?: string } = {}): Observable<Api[]> {
+    const baseURL = params.environmentId
+      ? `${this.constants.v2BaseURL}/environments/${params.environmentId}`
+      : this.constants.env.v2BaseURL;
+
+    const fetchPage = (page: number): Observable<ApisResponse> =>
+      this.http.get<ApisResponse>(`${baseURL}/apis`, {
+        params: { page },
+      });
+
+    return fetchPage(1).pipe(
+      expand(response => {
+        const currentPage = response.pagination?.page ?? 1;
+        const pageCount = response.pagination?.pageCount ?? 1;
+        return currentPage < pageCount ? fetchPage(currentPage + 1) : EMPTY;
+      }),
+      reduce((acc, response) => acc.concat(response.data ?? []), [] as Api[]),
+    );
   }
 
   updatePicture(apiId: string, newImage: string): Observable<void> {


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-14074

## Description

The environment and organisation audit screens used the v1 APIs endpoint, which only returns v2 APIs. Switch to ApiV2Service.listAll() so the API dropdown includes v4 APIs (APIM-14074).

## Additional context


#### Pre fix: 


https://github.com/user-attachments/assets/7d66538f-76db-484a-85a4-7c5bee7e86c8


#### Post fix: 


https://github.com/user-attachments/assets/6512e491-f0fe-4c4d-a875-19c97110ef09

