### PR TITLE
feat(gamma-platform-ui): Subscriptions in applications under platform module

### DIFF
--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/app/AppRoutes.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/app/AppRoutes.tsx
@@ -24,13 +24,20 @@ import { applicationDetailTabElement } from '../config/applicationDetailPages';
 import { NAV_GROUPS } from '../config/navigation';
 import { PLATFORM_ROUTE_CONFIG } from '../config/routes';
 import { ApplicationDetailIndexRedirect, ApplicationDetailLayout } from '../features/applications/components/detail';
+import { ApplicationDetailSubscriptionPage } from '../pages/ApplicationDetailSubscriptionPage';
 import { ApplicationsPage } from '../pages/ApplicationsPage';
 import { DashboardPage } from '../pages/DashboardPage';
 import { RegisterApplicationPage } from '../pages/RegisterApplicationPage';
+import { retryTransientRequest } from '../shared/api/queryRetry';
 import { ConsoleSettingsProvider } from '../shared/console-settings';
 import { useEnvironmentPermissions } from '../shared/hooks/useEnvironmentPermissions';
 
-const queryClient = new QueryClient();
+const queryClient = new QueryClient({
+    defaultOptions: {
+        queries: { retry: retryTransientRequest },
+        mutations: { retry: retryTransientRequest },
+    },
+});
 
 const APPLICATION_DETAIL_TABS = flattenApplicationDetailNavItems(APPLICATION_NAV_GROUPS);
 
@@ -77,6 +84,7 @@ export function AppRoutes() {
                                 {APPLICATION_DETAIL_TABS.map(tab => (
                                     <Route key={tab.path} path={tab.path} element={applicationDetailTabElement(tab.path, tab.label)} />
                                 ))}
+                                <Route path="subscriptions/:subscriptionId" element={<ApplicationDetailSubscriptionPage />} />
                                 <Route path="*" element={<ApplicationDetailIndexRedirect />} />
                             </Route>
                         </Route>

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/config/applicationDetailNavigation.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/config/applicationDetailNavigation.spec.ts
@@ -43,6 +43,10 @@ describe('applicationDetailNavigation permissions', () => {
         expect(getApplicationDetailTabPermissions('general')).toEqual(['application-definition-r']);
     });
 
+    it('maps subscriptions tab to application-subscription-r', () => {
+        expect(getApplicationDetailTabPermissions('subscriptions')).toEqual(['application-subscription-r']);
+    });
+
     it('filters nav groups by permission', () => {
         const filtered = filterApplicationDetailNavGroups(APPLICATION_NAV_GROUPS, hasDefinitionRead);
         expect(filtered.map(g => g.label)).toEqual(['General']);

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/config/applicationDetailPages.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/config/applicationDetailPages.tsx
@@ -17,10 +17,12 @@ import type { ComponentType } from 'react';
 
 import { ApplicationDetailPlaceholderPage } from '../features/applications/components/detail';
 import { ApplicationDetailGeneralPage } from '../pages/ApplicationDetailGeneralPage';
+import { ApplicationDetailSubscriptionsPage } from '../pages/ApplicationDetailSubscriptionsPage';
 
 /** Tab paths with a dedicated page implementation (keys drive routing and landing redirect). */
 export const APPLICATION_DETAIL_PAGES = {
     general: ApplicationDetailGeneralPage,
+    subscriptions: ApplicationDetailSubscriptionsPage,
 } as const satisfies Record<string, ComponentType>;
 
 export type ApplicationDetailImplementedPath = keyof typeof APPLICATION_DETAIL_PAGES;

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/subscriptions/ApplicationSubscriptionApiKeysCard.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/subscriptions/ApplicationSubscriptionApiKeysCard.tsx
@@ -1,0 +1,239 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+    Button,
+    Card,
+    CardContent,
+    CardDescription,
+    CardHeader,
+    CardTitle,
+    DataTablePagination,
+    Skeleton,
+    Table,
+    TableBody,
+    TableCell,
+    TableHead,
+    TableHeader,
+    TableRow,
+    Tooltip,
+    TooltipContent,
+    TooltipTrigger,
+} from '@gravitee/graphene-core';
+import { CircleCheckIcon, CircleXIcon, ClockIcon, CopyIcon, RefreshCwIcon } from '@gravitee/graphene-core/icons';
+import { useEffect, useMemo, useState } from 'react';
+
+import type { ApplicationSubscriptionApiKeyRow } from '../../types/applicationSubscription';
+import { formatApplicationDateTime } from '../../utils/applicationFormatters';
+
+const DEFAULT_PAGE_SIZE = 10;
+
+function ApiKeyStatusIcon({ isValid }: Readonly<{ isValid: boolean }>) {
+    const label = isValid ? 'Valid' : 'Revoked or Expired';
+    return (
+        <Tooltip>
+            <TooltipTrigger asChild>
+                <span className="inline-flex cursor-default" aria-label={label}>
+                    {isValid ? (
+                        <CircleCheckIcon className="size-4 text-success" aria-hidden />
+                    ) : (
+                        <CircleXIcon className="size-4 text-destructive" aria-hidden />
+                    )}
+                </span>
+            </TooltipTrigger>
+            <TooltipContent>{label}</TooltipContent>
+        </Tooltip>
+    );
+}
+
+export function ApplicationSubscriptionApiKeysCard({
+    apiKeys,
+    isLoading,
+    readOnly,
+    renewPending,
+    expireAvailable,
+    onRenew,
+    onRevoke,
+    onExpire,
+}: Readonly<{
+    apiKeys: ApplicationSubscriptionApiKeyRow[];
+    isLoading: boolean;
+    readOnly: boolean;
+    renewPending: boolean;
+    /** When false, expire uses Management API v2 parent resolution — hide or disable if unknown. */
+    expireAvailable: boolean;
+    onRenew: () => void;
+    onRevoke: (apiKey: ApplicationSubscriptionApiKeyRow) => void;
+    onExpire: (apiKey: ApplicationSubscriptionApiKeyRow) => void;
+}>) {
+    const [page, setPage] = useState(1);
+    const [pageSize, setPageSize] = useState(DEFAULT_PAGE_SIZE);
+
+    const sortedKeys = useMemo(() => [...apiKeys].sort((a, b) => Number(b.isValid) - Number(a.isValid)), [apiKeys]);
+    const totalCount = sortedKeys.length;
+    const paginatedKeys = useMemo(() => {
+        const start = (page - 1) * pageSize;
+        return sortedKeys.slice(start, start + pageSize);
+    }, [sortedKeys, page, pageSize]);
+
+    useEffect(() => {
+        setPage(1);
+    }, [apiKeys]);
+
+    useEffect(() => {
+        const maxPage = Math.max(1, Math.ceil(totalCount / pageSize));
+        if (page > maxPage) {
+            setPage(1);
+        }
+    }, [page, pageSize, totalCount]);
+
+    const handlePageSizeChange = (size: number) => {
+        setPageSize(size);
+        setPage(1);
+    };
+
+    return (
+        <Card>
+            <CardHeader className="pb-3">
+                <CardTitle className="text-base">API Keys</CardTitle>
+                <CardDescription>Keys issued for this subscription. Renew, expire, or revoke as needed.</CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-4 p-6 pt-0">
+                <div className="flex justify-end">
+                    <DataTablePagination
+                        page={page}
+                        pageSize={pageSize}
+                        totalCount={totalCount}
+                        pageSizeOptions={[10, 25, 50, 100]}
+                        onPageChange={setPage}
+                        onPageSizeChange={handlePageSizeChange}
+                    />
+                </div>
+                <Table aria-label="API keys table">
+                    <TableHeader>
+                        <TableRow>
+                            <TableHead className="w-10" aria-label="Status" />
+                            <TableHead>Key</TableHead>
+                            <TableHead className="w-[200px]">Created at</TableHead>
+                            <TableHead className="w-[200px]">Revoked/Expired at</TableHead>
+                            <TableHead className="w-[180px] text-right">Actions</TableHead>
+                        </TableRow>
+                    </TableHeader>
+                    <TableBody>
+                        {isLoading ? (
+                            Array.from({ length: pageSize }).map((_, index) => (
+                                <TableRow key={index}>
+                                    <TableCell colSpan={5} className="h-12">
+                                        <Skeleton className="h-4 w-32" />
+                                    </TableCell>
+                                </TableRow>
+                            ))
+                        ) : paginatedKeys.length > 0 ? (
+                            paginatedKeys.map(apiKey => (
+                                <TableRow key={apiKey.id} className={apiKey.isValid ? undefined : 'text-muted-foreground'}>
+                                    <TableCell className="w-10">
+                                        <ApiKeyStatusIcon isValid={apiKey.isValid} />
+                                    </TableCell>
+                                    <TableCell>
+                                        <div className="flex items-center gap-2">
+                                            <code
+                                                className={`rounded px-2 py-1 font-mono text-sm ${
+                                                    apiKey.isValid ? 'bg-muted' : 'bg-muted/50'
+                                                }`}
+                                            >
+                                                {apiKey.maskedKey}
+                                            </code>
+                                            <Button
+                                                type="button"
+                                                variant="ghost"
+                                                size="icon"
+                                                className="size-7 shrink-0"
+                                                aria-label="Copy API key"
+                                                onClick={() => void navigator.clipboard?.writeText(apiKey.key)}
+                                            >
+                                                <CopyIcon className="size-3.5" aria-hidden />
+                                            </Button>
+                                        </div>
+                                    </TableCell>
+                                    <TableCell className="text-sm whitespace-nowrap">
+                                        {formatApplicationDateTime(apiKey.createdAt)}
+                                    </TableCell>
+                                    <TableCell className="text-sm whitespace-nowrap">{formatApplicationDateTime(apiKey.endDate)}</TableCell>
+                                    <TableCell className="text-right">
+                                        {!readOnly && apiKey.isValid ? (
+                                            <div className="flex justify-end gap-1">
+                                                <Button
+                                                    type="button"
+                                                    variant="outline"
+                                                    size="sm"
+                                                    className="text-destructive"
+                                                    onClick={() => onRevoke(apiKey)}
+                                                >
+                                                    Revoke
+                                                </Button>
+                                                <Button
+                                                    type="button"
+                                                    variant="outline"
+                                                    size="sm"
+                                                    disabled={!expireAvailable}
+                                                    onClick={() => onExpire(apiKey)}
+                                                    title={!expireAvailable ? 'Cannot resolve API for this subscription.' : undefined}
+                                                >
+                                                    <ClockIcon className="size-3.5" aria-hidden />
+                                                    Expire
+                                                </Button>
+                                            </div>
+                                        ) : null}
+                                    </TableCell>
+                                </TableRow>
+                            ))
+                        ) : (
+                            <TableRow>
+                                <TableCell colSpan={5} className="h-16 text-center text-sm text-muted-foreground">
+                                    No API keys
+                                </TableCell>
+                            </TableRow>
+                        )}
+                    </TableBody>
+                </Table>
+
+                <div className="flex flex-wrap items-center justify-between gap-4">
+                    {!readOnly ? (
+                        <Button
+                            type="button"
+                            variant="outline"
+                            size="sm"
+                            disabled={renewPending || !sortedKeys.some(k => k.isValid)}
+                            onClick={onRenew}
+                        >
+                            <RefreshCwIcon className="size-3.5" aria-hidden />
+                            Renew
+                        </Button>
+                    ) : (
+                        <span />
+                    )}
+                    <DataTablePagination
+                        page={page}
+                        pageSize={pageSize}
+                        totalCount={totalCount}
+                        pageSizeOptions={[10, 25, 50, 100]}
+                        onPageChange={setPage}
+                        onPageSizeChange={handlePageSizeChange}
+                    />
+                </div>
+            </CardContent>
+        </Card>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/subscriptions/ApplicationSubscriptionCloseDialog.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/subscriptions/ApplicationSubscriptionCloseDialog.spec.tsx
@@ -1,0 +1,54 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { render, screen } from '@testing-library/react';
+
+import { ApplicationSubscriptionCloseDialog } from './ApplicationSubscriptionCloseDialog';
+import type { ApplicationSubscriptionCloseTarget } from '../../types/applicationSubscription';
+
+const baseTarget: ApplicationSubscriptionCloseTarget = {
+    id: 'sub-1',
+    referenceTypeLabel: 'API',
+    securityType: 'API Key',
+    isSharedApiKey: false,
+};
+
+function renderDialog(subscription: ApplicationSubscriptionCloseTarget | null) {
+    return render(
+        <ApplicationSubscriptionCloseDialog subscription={subscription} onClose={jest.fn()} onConfirm={jest.fn()} isLoading={false} />,
+    );
+}
+
+describe('ApplicationSubscriptionCloseDialog', () => {
+    it('shows API product wording in the confirmation', () => {
+        renderDialog({ ...baseTarget, referenceTypeLabel: 'API Product' });
+        expect(screen.getByText(/consume this API product anymore/i)).not.toBeNull();
+    });
+
+    it('warns about API keys when plan is API Key and keys are not shared', () => {
+        renderDialog(baseTarget);
+        expect(screen.getByText(/All API keys associated with this subscription will be closed/i)).not.toBeNull();
+    });
+
+    it('omits API key warning for shared API key mode', () => {
+        renderDialog({ ...baseTarget, isSharedApiKey: true });
+        expect(screen.queryByText(/All API keys associated with this subscription will be closed/i)).toBeNull();
+    });
+
+    it('omits API key warning for non API Key security', () => {
+        renderDialog({ ...baseTarget, securityType: 'OAuth2' });
+        expect(screen.queryByText(/All API keys associated with this subscription will be closed/i)).toBeNull();
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/subscriptions/ApplicationSubscriptionCloseDialog.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/subscriptions/ApplicationSubscriptionCloseDialog.tsx
@@ -1,0 +1,72 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+    Button,
+    Dialog,
+    DialogClose,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+} from '@gravitee/graphene-core';
+
+import type { ApplicationSubscriptionCloseTarget } from '../../types/applicationSubscription';
+
+export function ApplicationSubscriptionCloseDialog({
+    subscription,
+    onClose,
+    onConfirm,
+    isLoading,
+    error,
+}: Readonly<{
+    subscription: ApplicationSubscriptionCloseTarget | null;
+    onClose: () => void;
+    onConfirm: () => void;
+    isLoading: boolean;
+    error?: string | null;
+}>) {
+    const referenceLabel = subscription?.referenceTypeLabel === 'API Product' ? 'API product' : 'API';
+    let description = subscription
+        ? `Are you sure you want to close this subscription? The application will not be able to consume this ${referenceLabel} anymore.`
+        : '';
+
+    if (subscription?.securityType === 'API Key' && !subscription.isSharedApiKey) {
+        description += ' All API keys associated with this subscription will be closed and could not be used.';
+    }
+
+    return (
+        <Dialog open={Boolean(subscription)} onOpenChange={open => !open && onClose()}>
+            <DialogContent>
+                <DialogHeader>
+                    <DialogTitle>Close subscription</DialogTitle>
+                    <DialogDescription>{description}</DialogDescription>
+                </DialogHeader>
+                {error ? <p className="text-sm text-destructive">{error}</p> : null}
+                <DialogFooter>
+                    <DialogClose asChild>
+                        <Button type="button" variant="outline" disabled={isLoading}>
+                            Cancel
+                        </Button>
+                    </DialogClose>
+                    <Button type="button" variant="destructive" disabled={isLoading} onClick={onConfirm}>
+                        {isLoading ? 'Closing…' : 'Close subscription'}
+                    </Button>
+                </DialogFooter>
+            </DialogContent>
+        </Dialog>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/subscriptions/ApplicationSubscriptionCreateDialog.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/subscriptions/ApplicationSubscriptionCreateDialog.spec.tsx
@@ -1,0 +1,123 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+
+import { ApplicationSubscriptionCreateDialog } from './ApplicationSubscriptionCreateDialog';
+import {
+    useApplicationApiKeySubscriptions,
+    useCreateApplicationSubscription,
+    useSubscribablePlans,
+    useSubscriptionReferenceSearch,
+} from '../../hooks/useCreateApplicationSubscription';
+import { useEnvironmentPortalConfiguration } from '../../hooks/useEnvironmentPortalConfiguration';
+import type { ApplicationListItem } from '../../types/application';
+
+jest.mock('../../hooks/useCreateApplicationSubscription');
+jest.mock('../../hooks/useEnvironmentPortalConfiguration');
+
+const mockUsePortalConfig = jest.mocked(useEnvironmentPortalConfiguration);
+const mockUseApiKeySubs = jest.mocked(useApplicationApiKeySubscriptions);
+const mockUseSearch = jest.mocked(useSubscriptionReferenceSearch);
+const mockUsePlans = jest.mocked(useSubscribablePlans);
+const mockUseCreate = jest.mocked(useCreateApplicationSubscription);
+
+const application: ApplicationListItem = {
+    id: 'app-1',
+    name: 'Billing',
+    status: 'ACTIVE',
+    type: 'SIMPLE',
+    api_key_mode: 'UNSPECIFIED',
+    created_at: 0,
+    updated_at: 0,
+};
+
+const apiKeyPlan = {
+    id: 'plan-1',
+    name: 'Gold',
+    security: { type: 'API_KEY' },
+};
+
+function renderDialog() {
+    return render(
+        <MemoryRouter>
+            <ApplicationSubscriptionCreateDialog application={application} basePath="/applications/app-1" open onOpenChange={jest.fn()} />
+        </MemoryRouter>,
+    );
+}
+
+async function selectApiReference() {
+    fireEvent.change(screen.getByLabelText(/Search an API or API Product/i), { target: { value: 'pay' } });
+    fireEvent.click(await screen.findByRole('button', { name: /Payments API/i }));
+}
+
+describe('ApplicationSubscriptionCreateDialog', () => {
+    const mutateAsync = jest.fn();
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockUsePortalConfig.mockReturnValue({
+            data: { plan: { security: { sharedApiKey: { enabled: true } } } },
+        } as ReturnType<typeof useEnvironmentPortalConfiguration>);
+        mockUseApiKeySubs.mockReturnValue({
+            data: [{ id: 'sub-1', api: 'other-api', status: 'ACCEPTED' }],
+        } as ReturnType<typeof useApplicationApiKeySubscriptions>);
+        mockUseSearch.mockReturnValue({
+            data: [{ type: 'API', value: { id: 'api-1', name: 'Payments API', apiVersion: 'v1' } }],
+            isFetching: false,
+        } as ReturnType<typeof useSubscriptionReferenceSearch>);
+        mockUsePlans.mockReturnValue({
+            data: { data: [apiKeyPlan] },
+            isLoading: false,
+        } as ReturnType<typeof useSubscribablePlans>);
+        mockUseCreate.mockReturnValue({
+            mutateAsync,
+            isPending: false,
+        } as ReturnType<typeof useCreateApplicationSubscription>);
+    });
+
+    it('shows API key mode choice and sends EXCLUSIVE in payload', async () => {
+        renderDialog();
+        await selectApiReference();
+
+        expect(await screen.findByText(/this choice is permanent/i)).not.toBeNull();
+
+        fireEvent.click(screen.getByRole('button', { name: 'API Key' }));
+        fireEvent.click(screen.getByRole('button', { name: /Create subscription/i }));
+
+        await waitFor(() =>
+            expect(mutateAsync).toHaveBeenCalledWith({
+                planId: 'plan-1',
+                payload: { request: '', apiKeyMode: 'EXCLUSIVE' },
+            }),
+        );
+    });
+
+    it('sends SHARED apiKeyMode when shared mode is selected', async () => {
+        renderDialog();
+        await selectApiReference();
+
+        fireEvent.click(screen.getByRole('button', { name: 'Shared API Key' }));
+        fireEvent.click(screen.getByRole('button', { name: /Create subscription/i }));
+
+        await waitFor(() =>
+            expect(mutateAsync).toHaveBeenCalledWith({
+                planId: 'plan-1',
+                payload: { request: '', apiKeyMode: 'SHARED' },
+            }),
+        );
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/subscriptions/ApplicationSubscriptionCreateDialog.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/subscriptions/ApplicationSubscriptionCreateDialog.tsx
@@ -1,0 +1,452 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+    Badge,
+    Button,
+    cn,
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+    Input,
+    Label,
+    Textarea,
+} from '@gravitee/graphene-core';
+import { SearchIcon } from '@gravitee/graphene-core/icons';
+import { useEffect, useMemo, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+import {
+    useApplicationApiKeySubscriptions,
+    useCreateApplicationSubscription,
+    useSubscribablePlans,
+    useSubscriptionReferenceSearch,
+} from '../../hooks/useCreateApplicationSubscription';
+import { useEnvironmentPortalConfiguration } from '../../hooks/useEnvironmentPortalConfiguration';
+import { isSharedApiKeyEnabled } from '../../services/environmentPortal';
+import type { ApiKeyMode, ApplicationListItem } from '../../types/application';
+import type { SubscribablePlan, SubscriptionReferenceSelection, SubscriptionSearchResultItem } from '../../types/applicationSubscription';
+import {
+    buildSubscriptionCreatePayload,
+    getSubscriptionCreateValidationError,
+    isPlanDisabled,
+    planDisabledReason,
+    shouldShowApiKeyModeChoice,
+} from '../../utils/applicationSubscriptionCreateUtils';
+import { formatSubscriptionSecurityType } from '../../utils/applicationSubscriptionMapper';
+
+function toReferenceSelection(item: SubscriptionSearchResultItem): SubscriptionReferenceSelection {
+    if (item.type === 'API') {
+        return {
+            type: 'API',
+            id: item.value.id,
+            name: item.value.name,
+            version: item.value.apiVersion,
+            isFederated: item.value.definitionVersion === 'FEDERATED',
+        };
+    }
+    return {
+        type: 'API_PRODUCT',
+        id: item.value.id,
+        name: item.value.name,
+        version: item.value.version,
+    };
+}
+
+function referenceVersionLabel(reference: SubscriptionReferenceSelection): string | undefined {
+    return reference.version;
+}
+
+function referenceTypeLabel(reference: SubscriptionReferenceSelection): string {
+    return reference.type === 'API' ? 'API' : 'API Product';
+}
+
+function searchResultVersion(item: SubscriptionSearchResultItem): string | undefined {
+    return item.type === 'API' ? item.value.apiVersion : item.value.version;
+}
+
+function searchResultTypeLabel(item: SubscriptionSearchResultItem): string {
+    return item.type === 'API' ? 'API' : 'API Product';
+}
+
+function searchResultOwner(item: SubscriptionSearchResultItem): string | undefined {
+    return item.value.primaryOwner?.displayName;
+}
+
+const REFERENCE_SEARCH_DEBOUNCE_MS = 400;
+
+function PlanRadioIndicator({ selected }: Readonly<{ selected: boolean }>) {
+    return (
+        <span
+            className={cn(
+                'mt-0.5 flex size-4 shrink-0 items-center justify-center rounded-full border-2',
+                selected ? 'border-primary' : 'border-muted-foreground/50',
+            )}
+            aria-hidden
+        >
+            {selected ? <span className="size-2 rounded-full bg-primary" /> : null}
+        </span>
+    );
+}
+
+function ApiKeyModeOption({
+    label,
+    description,
+    selected,
+    onSelect,
+}: Readonly<{
+    label: string;
+    description: string;
+    selected: boolean;
+    onSelect: () => void;
+}>) {
+    return (
+        <button
+            type="button"
+            onClick={onSelect}
+            className={cn(
+                'flex w-full items-start gap-3 rounded-lg border p-3 text-left transition-colors',
+                selected ? 'border-primary/50 bg-primary/5' : 'hover:bg-accent',
+            )}
+            aria-label={label}
+            aria-pressed={selected}
+        >
+            <PlanRadioIndicator selected={selected} />
+            <div className="min-w-0">
+                <span className="text-sm font-medium">{label}</span>
+                <p className="mt-0.5 text-xs text-muted-foreground">{description}</p>
+            </div>
+        </button>
+    );
+}
+
+export function ApplicationSubscriptionCreateDialog({
+    application,
+    basePath,
+    open,
+    onOpenChange,
+}: Readonly<{
+    application: ApplicationListItem;
+    basePath: string;
+    open: boolean;
+    onOpenChange: (open: boolean) => void;
+}>) {
+    const navigate = useNavigate();
+    const [search, setSearch] = useState('');
+    const [debouncedSearch, setDebouncedSearch] = useState('');
+    const [selectedReference, setSelectedReference] = useState<SubscriptionReferenceSelection | null>(null);
+    const [selectedPlan, setSelectedPlan] = useState<SubscribablePlan | null>(null);
+    const [request, setRequest] = useState('');
+    const [apiKeyMode, setApiKeyMode] = useState<ApiKeyMode | null>(null);
+    const [error, setError] = useState<string | null>(null);
+
+    useEffect(() => {
+        const timer = window.setTimeout(() => setDebouncedSearch(search.trim()), REFERENCE_SEARCH_DEBOUNCE_MS);
+        return () => window.clearTimeout(timer);
+    }, [search]);
+
+    const { data: portalConfig } = useEnvironmentPortalConfiguration();
+    const canUseSharedApiKeys = isSharedApiKeyEnabled(portalConfig);
+    const { data: apiKeySubscriptions = [] } = useApplicationApiKeySubscriptions(application.id, open);
+    const { data: searchResults = [], isFetching: isSearching } = useSubscriptionReferenceSearch(debouncedSearch);
+    const { data: plansResponse, isLoading: isLoadingPlans } = useSubscribablePlans(selectedReference, application.id);
+    const createMutation = useCreateApplicationSubscription(application.id);
+
+    const plans = useMemo(() => plansResponse?.data ?? [], [plansResponse?.data]);
+
+    const showApiKeyModeChoice = useMemo(
+        () =>
+            shouldShowApiKeyModeChoice({
+                applicationApiKeyMode: application.api_key_mode,
+                planSecurityType: selectedPlan?.security?.type,
+                canUseSharedApiKeys,
+                isFederatedApi: selectedReference?.type === 'API' && Boolean(selectedReference.isFederated),
+                selectedReference,
+                apiKeySubscriptions,
+            }),
+        [application.api_key_mode, selectedPlan?.security?.type, canUseSharedApiKeys, selectedReference, apiKeySubscriptions],
+    );
+
+    const reset = () => {
+        setSearch('');
+        setDebouncedSearch('');
+        setSelectedReference(null);
+        setSelectedPlan(null);
+        setRequest('');
+        setApiKeyMode(null);
+        setError(null);
+    };
+
+    useEffect(() => {
+        if (!open) reset();
+    }, [open]);
+
+    useEffect(() => {
+        if (!selectedReference) {
+            setSelectedPlan(null);
+            return;
+        }
+        if (!selectedPlan || !plans.find(p => p.id === selectedPlan.id)) {
+            const firstEnabled = plans.find(plan => !isPlanDisabled(plan));
+            setSelectedPlan(firstEnabled ?? null);
+        }
+    }, [selectedReference, plans, selectedPlan]);
+
+    useEffect(() => {
+        if (!showApiKeyModeChoice) {
+            setApiKeyMode(null);
+        }
+    }, [showApiKeyModeChoice, selectedPlan?.id, selectedReference?.id]);
+
+    const handleOpenChange = (next: boolean) => {
+        onOpenChange(next);
+    };
+
+    const selectReference = (item: SubscriptionSearchResultItem) => {
+        const reference = toReferenceSelection(item);
+        setSelectedReference(reference);
+        setSelectedPlan(null);
+        setApiKeyMode(null);
+        setSearch(reference.name);
+        setError(null);
+    };
+
+    const handleCreate = async () => {
+        if (!selectedReference || !selectedPlan) return;
+        const validationError = getSubscriptionCreateValidationError(selectedPlan, request, showApiKeyModeChoice, apiKeyMode);
+        if (validationError) {
+            setError(validationError);
+            return;
+        }
+
+        setError(null);
+        try {
+            const created = await createMutation.mutateAsync({
+                planId: selectedPlan.id,
+                payload: buildSubscriptionCreatePayload(request, showApiKeyModeChoice, apiKeyMode),
+            });
+            handleOpenChange(false);
+            if (created.id) {
+                navigate(`${basePath}/subscriptions/${created.id}`);
+            }
+        } catch {
+            setError('Failed to create subscription. Please try again.');
+        }
+    };
+
+    const showResults = search.trim().length > 0 && !selectedReference;
+    const referenceLabel = selectedReference ? referenceTypeLabel(selectedReference) : 'API or API Product';
+    const createDisabled =
+        !selectedReference ||
+        !selectedPlan ||
+        isPlanDisabled(selectedPlan) ||
+        createMutation.isPending ||
+        (showApiKeyModeChoice && !apiKeyMode);
+
+    return (
+        <Dialog open={open} onOpenChange={handleOpenChange}>
+            <DialogContent
+                className="gap-4 overflow-hidden sm:max-w-lg"
+                style={{ width: 'min(90vw, 32rem)', maxWidth: 'min(90vw, 32rem)' }}
+            >
+                <DialogHeader className="space-y-1.5 border-b pb-4">
+                    <DialogTitle>Create a subscription</DialogTitle>
+                    <DialogDescription>
+                        Search for an API or API Product, select a plan, and submit a subscription request.
+                    </DialogDescription>
+                </DialogHeader>
+
+                <div className="space-y-5">
+                    <div className="space-y-2">
+                        <Label htmlFor="sub-api-search">Search an API or API Product</Label>
+                        <div className="relative">
+                            <SearchIcon
+                                className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground"
+                                aria-hidden
+                            />
+                            <Input
+                                id="sub-api-search"
+                                placeholder="Search by name..."
+                                className="pl-9"
+                                value={search}
+                                onChange={e => {
+                                    setSearch(e.target.value);
+                                    if (selectedReference && e.target.value !== selectedReference.name) {
+                                        setSelectedReference(null);
+                                        setSelectedPlan(null);
+                                        setApiKeyMode(null);
+                                    }
+                                }}
+                            />
+                        </div>
+                        {showResults ? (
+                            <div className="max-h-[180px] overflow-y-auto rounded-md border">
+                                {isSearching ? (
+                                    <p className="px-3 py-2 text-sm text-muted-foreground">Searching…</p>
+                                ) : searchResults.length === 0 ? (
+                                    <p className="px-3 py-2 text-sm text-muted-foreground">No API or API Product found</p>
+                                ) : (
+                                    searchResults.map(item => {
+                                        const version = searchResultVersion(item);
+                                        const owner = searchResultOwner(item);
+                                        return (
+                                            <button
+                                                key={`${item.type}-${item.value.id}`}
+                                                type="button"
+                                                onClick={() => selectReference(item)}
+                                                className="flex w-full items-start gap-3 border-b px-3 py-2.5 text-left transition-colors last:border-b-0 hover:bg-accent"
+                                            >
+                                                <div className="min-w-0 flex-1">
+                                                    <p className="truncate text-sm font-medium">
+                                                        {item.value.name}
+                                                        {version ? ` — ${version}` : ''}
+                                                        {owner ? ` (${owner})` : ''}
+                                                    </p>
+                                                    <p className="text-[11px] text-muted-foreground">{searchResultTypeLabel(item)}</p>
+                                                </div>
+                                            </button>
+                                        );
+                                    })
+                                )}
+                            </div>
+                        ) : null}
+                        {selectedReference ? (
+                            <Badge variant="secondary" className="text-xs">
+                                {selectedReference.name}
+                                {referenceVersionLabel(selectedReference) ? ` — ${referenceVersionLabel(selectedReference)}` : ''}
+                                <span className="text-muted-foreground"> · {referenceTypeLabel(selectedReference)}</span>
+                            </Badge>
+                        ) : null}
+                    </div>
+
+                    {selectedReference ? (
+                        <div className="space-y-2">
+                            <Label>Select a plan to subscribe</Label>
+                            {isLoadingPlans ? (
+                                <p className="text-sm text-muted-foreground">Loading plans…</p>
+                            ) : plans.length === 0 ? (
+                                <p className="text-sm text-muted-foreground">No subscribable plans for this {referenceLabel}.</p>
+                            ) : (
+                                <div className="max-h-[220px] space-y-2 overflow-y-auto">
+                                    {plans.map(plan => {
+                                        const disabled = isPlanDisabled(plan);
+                                        const reason = planDisabledReason(plan);
+                                        const securityLabel = plan.security?.type
+                                            ? formatSubscriptionSecurityType(plan.security.type)
+                                            : '—';
+                                        return (
+                                            <button
+                                                key={plan.id}
+                                                type="button"
+                                                disabled={disabled}
+                                                onClick={() => !disabled && setSelectedPlan(plan)}
+                                                className={cn(
+                                                    'flex w-full items-start gap-3 rounded-lg border p-3 text-left transition-colors',
+                                                    disabled && 'cursor-not-allowed opacity-60',
+                                                    selectedPlan?.id === plan.id && 'border-primary/50 bg-primary/5',
+                                                )}
+                                                title={reason}
+                                                aria-pressed={selectedPlan?.id === plan.id}
+                                            >
+                                                <PlanRadioIndicator selected={selectedPlan?.id === plan.id} />
+                                                <div className="min-w-0 flex-1">
+                                                    <div className="flex flex-wrap items-baseline gap-x-2.5 gap-y-1">
+                                                        <span className="text-sm font-medium leading-snug text-foreground">
+                                                            {plan.name}
+                                                        </span>
+                                                        <span className="text-xs font-normal leading-snug text-muted-foreground">
+                                                            {securityLabel}
+                                                        </span>
+                                                    </div>
+                                                    {reason ? (
+                                                        <span className="mt-1.5 block text-xs text-amber-600 dark:text-amber-400">
+                                                            {reason}
+                                                        </span>
+                                                    ) : null}
+                                                </div>
+                                            </button>
+                                        );
+                                    })}
+                                </div>
+                            )}
+                        </div>
+                    ) : null}
+
+                    {showApiKeyModeChoice ? (
+                        <div className="space-y-3">
+                            <div className="space-y-1 text-sm">
+                                <p>You have to choose between two modes for your application:</p>
+                                <ul className="list-disc space-y-0.5 pl-5 text-muted-foreground">
+                                    <li>
+                                        <span className="font-medium text-foreground">API Key</span> — a new API key will be generated for
+                                        each subscription
+                                    </li>
+                                    <li>
+                                        <span className="font-medium text-foreground">Shared API Key</span> — each subscription will use the
+                                        same API key
+                                    </li>
+                                </ul>
+                                <p className="text-amber-600 dark:text-amber-400">Please note that this choice is permanent.</p>
+                            </div>
+                            <div className="space-y-2">
+                                <ApiKeyModeOption
+                                    label="API Key"
+                                    description="Generate a dedicated API key for each subscription"
+                                    selected={apiKeyMode === 'EXCLUSIVE'}
+                                    onSelect={() => setApiKeyMode('EXCLUSIVE')}
+                                />
+                                <ApiKeyModeOption
+                                    label="Shared API Key"
+                                    description="Reuse the same API key across subscriptions"
+                                    selected={apiKeyMode === 'SHARED'}
+                                    onSelect={() => setApiKeyMode('SHARED')}
+                                />
+                            </div>
+                        </div>
+                    ) : null}
+
+                    {selectedPlan?.commentRequired ? (
+                        <div className="space-y-2">
+                            <Label htmlFor="sub-request">
+                                Subscription message <span className="text-destructive">*</span>
+                            </Label>
+                            <Textarea
+                                id="sub-request"
+                                value={request}
+                                onChange={e => setRequest(e.target.value)}
+                                placeholder="Fill a message to the API owner"
+                                rows={3}
+                            />
+                        </div>
+                    ) : null}
+
+                    {error ? <p className="text-sm text-destructive">{error}</p> : null}
+                </div>
+
+                <DialogFooter className="border-t pt-4 sm:justify-end gap-2">
+                    <Button type="button" variant="outline" onClick={() => handleOpenChange(false)}>
+                        Cancel
+                    </Button>
+                    <Button type="button" disabled={createDisabled} onClick={() => void handleCreate()}>
+                        {createMutation.isPending ? 'Creating…' : 'Create subscription'}
+                    </Button>
+                </DialogFooter>
+            </DialogContent>
+        </Dialog>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/subscriptions/ApplicationSubscriptionDetailView.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/subscriptions/ApplicationSubscriptionDetailView.tsx
@@ -1,0 +1,315 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+    Alert,
+    AlertDescription,
+    Button,
+    Card,
+    CardContent,
+    CardDescription,
+    CardHeader,
+    CardTitle,
+    Separator,
+    Skeleton,
+} from '@gravitee/graphene-core';
+import { ArrowLeftIcon, PencilIcon, Trash2Icon } from '@gravitee/graphene-core/icons';
+import { useState } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+
+import { ApplicationSubscriptionApiKeysCard } from './ApplicationSubscriptionApiKeysCard';
+import { ApplicationSubscriptionCloseDialog } from './ApplicationSubscriptionCloseDialog';
+import { ApplicationSubscriptionDetailsTable } from './ApplicationSubscriptionDetailsTable';
+import { ApplicationSubscriptionEditRequestDialog } from './ApplicationSubscriptionEditRequestDialog';
+import { ApplicationSubscriptionExpireApiKeyDialog } from './ApplicationSubscriptionExpireApiKeyDialog';
+import { ApplicationSubscriptionRevokeApiKeyDialog } from './ApplicationSubscriptionRevokeApiKeyDialog';
+import { SubscriptionStatusLabel } from './SubscriptionStatusLabel';
+import { useDetailBasePath } from '../../../shared/hooks/useDetailBasePath';
+import {
+    useApplicationSubscriptionApiKeys,
+    useExpireSubscriptionApiKey,
+    useRenewSubscriptionApiKey,
+    useRevokeSubscriptionApiKey,
+} from '../../hooks/useApplicationSubscriptionApiKeys';
+import { useApplicationSubscriptionDetail, useUpdateApplicationSubscription } from '../../hooks/useApplicationSubscriptionDetail';
+import { useApplicationSubscriptionPermissions } from '../../hooks/useApplicationSubscriptionPermissions';
+import { useCloseApplicationSubscription } from '../../hooks/useCloseApplicationSubscription';
+import { resolveSubscriptionApiKeyV2Parent } from '../../services/applicationSubscriptions';
+import type { ApplicationListItem } from '../../types/application';
+import type { ApplicationSubscriptionApiKeyRow } from '../../types/applicationSubscription';
+import { mapDetailToCloseTarget } from '../../utils/applicationSubscriptionDetailMapper';
+import { canCloseSubscription } from '../../utils/applicationSubscriptionMapper';
+
+export function ApplicationSubscriptionDetailView({
+    application,
+    subscriptionId,
+}: Readonly<{
+    application: ApplicationListItem;
+    subscriptionId: string;
+}>) {
+    const navigate = useNavigate();
+    const basePath = useDetailBasePath('applications', application.id);
+    const readOnly = application.status === 'ARCHIVED';
+    const { canUpdate, canDelete } = useApplicationSubscriptionPermissions();
+
+    const { data, isLoading, isError } = useApplicationSubscriptionDetail(application.id, subscriptionId, application.api_key_mode);
+    const updateMutation = useUpdateApplicationSubscription(application.id, subscriptionId);
+    const closeMutation = useCloseApplicationSubscription(application.id);
+
+    const [editOpen, setEditOpen] = useState(false);
+    const [editError, setEditError] = useState<string | null>(null);
+    const [closeTarget, setCloseTarget] = useState<ReturnType<typeof mapDetailToCloseTarget> | null>(null);
+    const [closeError, setCloseError] = useState<string | null>(null);
+    const [revokeTarget, setRevokeTarget] = useState<ApplicationSubscriptionApiKeyRow | null>(null);
+    const [revokeError, setRevokeError] = useState<string | null>(null);
+    const [expireTarget, setExpireTarget] = useState<ApplicationSubscriptionApiKeyRow | null>(null);
+    const [expireError, setExpireError] = useState<string | null>(null);
+    const [renewError, setRenewError] = useState<string | null>(null);
+
+    const detail = data?.detail;
+    const entity = data?.entity;
+    const v2Parent = entity ? resolveSubscriptionApiKeyV2Parent(entity) : null;
+
+    const showApiKeys = Boolean(
+        detail && detail.securityType === 'API Key' && detail.status === 'ACCEPTED' && application.api_key_mode !== 'SHARED',
+    );
+    const showSharedKeysHint = Boolean(detail && detail.securityType === 'API Key' && application.api_key_mode === 'SHARED');
+
+    const apiKeysQuery = useApplicationSubscriptionApiKeys(application.id, subscriptionId, showApiKeys);
+    const renewMutation = useRenewSubscriptionApiKey(application.id, subscriptionId);
+    const revokeMutation = useRevokeSubscriptionApiKey(application.id, subscriptionId);
+    const expireMutation = useExpireSubscriptionApiKey(application.id, subscriptionId, v2Parent);
+
+    if (isLoading) {
+        return (
+            <div className="space-y-5">
+                <Skeleton className="h-8 w-48" />
+                <Skeleton className="h-10 w-72" />
+                <Skeleton className="h-96 w-full" />
+            </div>
+        );
+    }
+
+    if (isError || !detail || !entity) {
+        return (
+            <div className="space-y-4">
+                <Button variant="ghost" size="sm" className="-ml-2 w-fit" asChild>
+                    <Link to={`${basePath}/subscriptions`}>
+                        <ArrowLeftIcon className="size-4" aria-hidden />
+                        Back to subscriptions list
+                    </Link>
+                </Button>
+                <p className="text-sm text-muted-foreground">Subscription not found or you may not have access.</p>
+            </div>
+        );
+    }
+
+    const isKubernetesManaged = detail.origin === 'KUBERNETES';
+    const effectiveReadOnly = readOnly || isKubernetesManaged;
+    const canEdit = !effectiveReadOnly && canUpdate && detail.status === 'PENDING';
+    const canClose = !effectiveReadOnly && canDelete && canCloseSubscription(detail.status);
+    const canManageApiKeys = !effectiveReadOnly && canUpdate;
+    const subtitle = `${detail.apiDisplay} · ${detail.planName}`;
+
+    const handleSaveEdit = async (request: string) => {
+        setEditError(null);
+        try {
+            await updateMutation.mutateAsync({ entity, request });
+            setEditOpen(false);
+        } catch {
+            setEditError('Failed to update subscription. Please try again.');
+        }
+    };
+
+    const handleClose = async () => {
+        if (!closeTarget) return;
+        setCloseError(null);
+        try {
+            await closeMutation.mutateAsync(closeTarget.id);
+            setCloseTarget(null);
+            navigate(`${basePath}/subscriptions`);
+        } catch {
+            setCloseError('Failed to close subscription. Please try again.');
+        }
+    };
+
+    const handleRenew = async () => {
+        setRenewError(null);
+        try {
+            await renewMutation.mutateAsync();
+        } catch {
+            setRenewError('Failed to renew API key. Please try again.');
+        }
+    };
+
+    const handleRevoke = async () => {
+        if (!revokeTarget) return;
+        setRevokeError(null);
+        try {
+            await revokeMutation.mutateAsync(revokeTarget.id);
+            setRevokeTarget(null);
+        } catch {
+            setRevokeError('Failed to revoke API key. Please try again.');
+        }
+    };
+
+    const handleExpireConfirm = async (expirationDate: Date) => {
+        if (!expireTarget) return;
+        setExpireError(null);
+        try {
+            await expireMutation.mutateAsync({ apiKeyId: expireTarget.id, expireAt: expirationDate });
+            setExpireTarget(null);
+        } catch {
+            setExpireError('Failed to update API key expiration. Please try again.');
+        }
+    };
+
+    return (
+        <div className="space-y-5">
+            <Button variant="ghost" size="sm" className="-ml-2 w-fit" asChild>
+                <Link to={`${basePath}/subscriptions`}>
+                    <ArrowLeftIcon className="size-4" aria-hidden />
+                    Back to subscriptions list
+                </Link>
+            </Button>
+
+            <div className="min-w-0 space-y-1">
+                <h1 className="text-2xl font-semibold tracking-tight">Subscription details</h1>
+                <p className="truncate text-sm text-muted-foreground">{subtitle}</p>
+            </div>
+
+            {isKubernetesManaged ? (
+                <Alert>
+                    <AlertDescription>
+                        This subscription was created by the Kubernetes Operator and cannot be managed through the console.
+                    </AlertDescription>
+                </Alert>
+            ) : null}
+
+            <Card>
+                <CardHeader className="pb-3">
+                    <div className="flex flex-wrap items-center justify-between gap-3">
+                        <CardTitle className="text-base">Subscription</CardTitle>
+                        <div className="flex items-center gap-2">
+                            <SubscriptionStatusLabel status={detail.status} />
+                            {canEdit ? (
+                                <Button type="button" variant="outline" size="sm" onClick={() => setEditOpen(true)}>
+                                    <PencilIcon className="size-3.5" aria-hidden />
+                                    Edit subscription message
+                                </Button>
+                            ) : null}
+                        </div>
+                    </div>
+                    <CardDescription>Identifier: {detail.id}</CardDescription>
+                </CardHeader>
+                <CardContent className="px-6 pt-0">
+                    <ApplicationSubscriptionDetailsTable detail={detail} />
+                </CardContent>
+                {canClose ? (
+                    <>
+                        <Separator />
+                        <CardContent className="flex justify-end pt-4">
+                            <Button
+                                type="button"
+                                variant="destructive"
+                                size="sm"
+                                onClick={() => {
+                                    setCloseError(null);
+                                    setCloseTarget(mapDetailToCloseTarget(detail));
+                                }}
+                            >
+                                <Trash2Icon className="size-3.5" aria-hidden />
+                                Close
+                            </Button>
+                        </CardContent>
+                    </>
+                ) : null}
+            </Card>
+
+            {showSharedKeysHint ? (
+                <Card className="border-dashed">
+                    <CardContent className="pt-6 text-sm text-muted-foreground">
+                        This application uses <strong className="text-foreground">shared API keys</strong>. Manage keys at the application
+                        level from User Permissions.
+                    </CardContent>
+                </Card>
+            ) : null}
+
+            {showApiKeys ? (
+                <div className="space-y-2">
+                    {renewError ? <p className="text-sm text-destructive">{renewError}</p> : null}
+                    <ApplicationSubscriptionApiKeysCard
+                        apiKeys={apiKeysQuery.data ?? []}
+                        isLoading={apiKeysQuery.isLoading}
+                        readOnly={!canManageApiKeys}
+                        renewPending={renewMutation.isPending}
+                        expireAvailable={Boolean(v2Parent)}
+                        onRenew={() => void handleRenew()}
+                        onRevoke={apiKey => {
+                            setRevokeError(null);
+                            setRevokeTarget(apiKey);
+                        }}
+                        onExpire={apiKey => {
+                            setExpireError(null);
+                            setExpireTarget(apiKey);
+                        }}
+                    />
+                </div>
+            ) : null}
+
+            <ApplicationSubscriptionEditRequestDialog
+                open={editOpen}
+                initialRequest={detail.request ?? ''}
+                onOpenChange={setEditOpen}
+                onSave={request => void handleSaveEdit(request)}
+                isLoading={updateMutation.isPending}
+                error={editError}
+            />
+
+            <ApplicationSubscriptionCloseDialog
+                subscription={closeTarget}
+                onClose={() => {
+                    setCloseTarget(null);
+                    setCloseError(null);
+                }}
+                onConfirm={() => void handleClose()}
+                isLoading={closeMutation.isPending}
+                error={closeError}
+            />
+
+            <ApplicationSubscriptionRevokeApiKeyDialog
+                apiKey={revokeTarget}
+                onClose={() => {
+                    setRevokeTarget(null);
+                    setRevokeError(null);
+                }}
+                onConfirm={() => void handleRevoke()}
+                isLoading={revokeMutation.isPending}
+                error={revokeError}
+            />
+
+            <ApplicationSubscriptionExpireApiKeyDialog
+                apiKey={expireTarget}
+                onClose={() => {
+                    setExpireTarget(null);
+                    setExpireError(null);
+                }}
+                onConfirm={at => void handleExpireConfirm(at)}
+                isLoading={expireMutation.isPending}
+                error={expireError}
+            />
+        </div>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/subscriptions/ApplicationSubscriptionDetailsTable.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/subscriptions/ApplicationSubscriptionDetailsTable.tsx
@@ -1,0 +1,106 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Button, Table, TableBody, TableCell, TableRow } from '@gravitee/graphene-core';
+import { CopyIcon } from '@gravitee/graphene-core/icons';
+
+import type { ApplicationSubscriptionDetail } from '../../types/applicationSubscription';
+import { formatApplicationDateTime } from '../../utils/applicationFormatters';
+
+function MetadataDetailRow({ metadata }: Readonly<{ metadata?: Record<string, string> }>) {
+    const entries = metadata ? Object.entries(metadata) : [];
+    if (entries.length === 0) {
+        return <DetailRow label="Metadata" value="" />;
+    }
+
+    return (
+        <TableRow className="border-0 hover:bg-transparent">
+            <TableCell className="w-40 border-0 bg-transparent py-3 align-top text-sm text-muted-foreground">Metadata</TableCell>
+            <TableCell className="border-0 bg-transparent py-3 align-top text-sm text-foreground">
+                <div className="space-y-1">
+                    {entries.map(([key, value]) => (
+                        <p key={key} className="text-xs break-all">
+                            <span className="font-mono text-muted-foreground">{key}:</span> {value}
+                        </p>
+                    ))}
+                </div>
+            </TableCell>
+        </TableRow>
+    );
+}
+
+function DetailRow({
+    label,
+    value,
+    copyable = false,
+}: Readonly<{
+    label: string;
+    value: string;
+    copyable?: boolean;
+}>) {
+    const display = value || '—';
+    const canCopy = copyable && display !== '—';
+
+    return (
+        <TableRow className="border-0 hover:bg-transparent">
+            <TableCell className="w-40 border-0 bg-transparent py-3 align-top text-sm text-muted-foreground">{label}</TableCell>
+            <TableCell className="border-0 bg-transparent py-3 align-top text-sm text-foreground">
+                <div className="flex items-start gap-2">
+                    <span className="break-all">{display}</span>
+                    {canCopy ? (
+                        <Button
+                            type="button"
+                            variant="ghost"
+                            size="icon"
+                            className="size-7 shrink-0"
+                            aria-label={`Copy ${label}`}
+                            onClick={() => void navigator.clipboard?.writeText(display)}
+                        >
+                            <CopyIcon className="size-3.5" aria-hidden />
+                        </Button>
+                    ) : null}
+                </div>
+            </TableCell>
+        </TableRow>
+    );
+}
+
+export function ApplicationSubscriptionDetailsTable({ detail }: Readonly<{ detail: ApplicationSubscriptionDetail }>) {
+    return (
+        <Table className="border-0 [&_td]:border-0 [&_tr]:border-0">
+            <TableBody>
+                <DetailRow label="ID" value={detail.id} copyable />
+                <DetailRow label={detail.referenceTypeLabel} value={detail.apiDisplay} copyable />
+                <DetailRow label="Plan" value={detail.planName} copyable />
+                <DetailRow label="Security type" value={detail.securityType} />
+                <DetailRow label="Status" value={detail.status} />
+                <DetailRow label="Subscribed by" value={detail.subscribedBy} />
+                {detail.request ? <DetailRow label="Publisher message to subscriber" value={detail.request} /> : null}
+                {detail.reason ? <DetailRow label="Subscriber message to publisher" value={detail.reason} /> : null}
+                <DetailRow label="Created at" value={formatApplicationDateTime(detail.createdAt)} />
+                <DetailRow label="Processed at" value={formatApplicationDateTime(detail.processedAt)} />
+                {detail.status !== 'REJECTED' ? (
+                    <>
+                        <DetailRow label="Starting at" value={formatApplicationDateTime(detail.startingAt)} />
+                        <DetailRow label="Paused at" value={formatApplicationDateTime(detail.pausedAt)} />
+                        <DetailRow label="Ending at" value={formatApplicationDateTime(detail.endingAt)} />
+                    </>
+                ) : null}
+                <DetailRow label="Closed at" value={formatApplicationDateTime(detail.closedAt)} />
+                <MetadataDetailRow metadata={detail.metadata} />
+            </TableBody>
+        </Table>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/subscriptions/ApplicationSubscriptionEditRequestDialog.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/subscriptions/ApplicationSubscriptionEditRequestDialog.tsx
@@ -1,0 +1,73 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+    Button,
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+    Label,
+    Textarea,
+} from '@gravitee/graphene-core';
+import { useEffect, useState } from 'react';
+
+export function ApplicationSubscriptionEditRequestDialog({
+    open,
+    initialRequest,
+    onOpenChange,
+    onSave,
+    isLoading,
+    error,
+}: Readonly<{
+    open: boolean;
+    initialRequest: string;
+    onOpenChange: (open: boolean) => void;
+    onSave: (request: string) => void;
+    isLoading: boolean;
+    error?: string | null;
+}>) {
+    const [request, setRequest] = useState(initialRequest);
+
+    useEffect(() => {
+        if (open) setRequest(initialRequest);
+    }, [open, initialRequest]);
+
+    return (
+        <Dialog open={open} onOpenChange={onOpenChange}>
+            <DialogContent className="sm:max-w-md" style={{ width: 'min(90vw, 28rem)', maxWidth: 'min(90vw, 28rem)' }}>
+                <DialogHeader>
+                    <DialogTitle>Edit subscription message</DialogTitle>
+                    <DialogDescription>Update this message while the subscription is pending.</DialogDescription>
+                </DialogHeader>
+                <div className="space-y-2 py-2">
+                    <Label htmlFor="edit-subscription-request">Publisher message to subscriber</Label>
+                    <Textarea id="edit-subscription-request" value={request} onChange={e => setRequest(e.target.value)} rows={4} />
+                    {error ? <p className="text-sm text-destructive">{error}</p> : null}
+                </div>
+                <DialogFooter className="sm:justify-end gap-2">
+                    <Button type="button" variant="outline" onClick={() => onOpenChange(false)} disabled={isLoading}>
+                        Cancel
+                    </Button>
+                    <Button type="button" disabled={!request.trim() || isLoading} onClick={() => onSave(request.trim())}>
+                        {isLoading ? 'Saving…' : 'Save changes'}
+                    </Button>
+                </DialogFooter>
+            </DialogContent>
+        </Dialog>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/subscriptions/ApplicationSubscriptionExpireApiKeyDialog.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/subscriptions/ApplicationSubscriptionExpireApiKeyDialog.spec.tsx
@@ -1,0 +1,93 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import { ApplicationSubscriptionExpireApiKeyDialog } from './ApplicationSubscriptionExpireApiKeyDialog';
+import type { ApplicationSubscriptionApiKeyRow } from '../../types/applicationSubscription';
+
+const apiKey: ApplicationSubscriptionApiKeyRow = {
+    id: 'key-1',
+    key: 'secret-key-1234',
+    maskedKey: '••••••••1234',
+    isValid: true,
+    expireAt: new Date('2099-01-01T10:00:00').getTime(),
+};
+
+function renderDialog(overrides: Partial<Parameters<typeof ApplicationSubscriptionExpireApiKeyDialog>[0]> = {}) {
+    return render(
+        <ApplicationSubscriptionExpireApiKeyDialog
+            apiKey={apiKey}
+            onClose={jest.fn()}
+            onConfirm={jest.fn()}
+            isLoading={false}
+            {...overrides}
+        />,
+    );
+}
+
+describe('ApplicationSubscriptionExpireApiKeyDialog', () => {
+    beforeEach(() => {
+        jest.useFakeTimers();
+        jest.setSystemTime(new Date('2025-01-01T12:00:00'));
+    });
+
+    afterEach(() => {
+        jest.useRealTimers();
+    });
+
+    function submitButton() {
+        return screen.getByRole('button', { name: /Change expiration date/i }) as HTMLButtonElement;
+    }
+
+    it('disables submit until the user changes the expiration date', () => {
+        renderDialog();
+        expect(submitButton().disabled).toBe(true);
+    });
+
+    it('enables submit after choosing a future date', () => {
+        renderDialog();
+        const input = screen.getByLabelText(/Expire date/i);
+        fireEvent.change(input, { target: { value: '2099-06-15T14:00' } });
+        expect(submitButton().disabled).toBe(false);
+    });
+
+    it('shows validation when the chosen date is not in the future', () => {
+        renderDialog();
+        const input = screen.getByLabelText(/Expire date/i);
+        fireEvent.change(input, { target: { value: '2020-01-01T00:00' } });
+        expect(screen.getByText(/Date and time must be in the future/i)).not.toBeNull();
+        expect(submitButton().disabled).toBe(true);
+    });
+
+    it('shows validation when the chosen date is not a valid datetime', () => {
+        renderDialog();
+        const input = screen.getByLabelText(/Expire date/i);
+        fireEvent.change(input, { target: { value: '2025-02-31T12:00' } });
+        expect(screen.getByText(/Enter a valid date and time/i)).not.toBeNull();
+        expect(submitButton().disabled).toBe(true);
+    });
+
+    it('submits a strictly parsed local datetime', () => {
+        const onConfirm = jest.fn();
+        renderDialog({ onConfirm });
+        const input = screen.getByLabelText(/Expire date/i);
+
+        fireEvent.change(input, { target: { value: '2099-06-15T14:00' } });
+        fireEvent.click(submitButton());
+
+        expect(onConfirm).toHaveBeenCalledWith(new Date(2099, 5, 15, 14, 0));
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/subscriptions/ApplicationSubscriptionExpireApiKeyDialog.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/subscriptions/ApplicationSubscriptionExpireApiKeyDialog.tsx
@@ -1,0 +1,125 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+    Button,
+    Dialog,
+    DialogClose,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+    Input,
+    Label,
+} from '@gravitee/graphene-core';
+import { useEffect, useMemo, useState } from 'react';
+
+import type { ApplicationSubscriptionApiKeyRow } from '../../types/applicationSubscription';
+import {
+    canSubmitApiKeyExpirationChange,
+    isAfterMinCandidate,
+    parseDatetimeLocalValue,
+} from '../../utils/applicationSubscriptionApiKeyExpireUtils';
+
+function toDatetimeLocalValue(d: Date): string {
+    const pad = (n: number) => String(n).padStart(2, '0');
+    return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
+}
+
+function defaultExpirationDraft(apiKey: ApplicationSubscriptionApiKeyRow): Date {
+    if (apiKey.expireAt !== undefined) {
+        return new Date(apiKey.expireAt);
+    }
+    const d = new Date();
+    d.setDate(d.getDate() + 1);
+    d.setMinutes(0, 0, 0);
+    return d;
+}
+
+export function ApplicationSubscriptionExpireApiKeyDialog({
+    apiKey,
+    onClose,
+    onConfirm,
+    isLoading,
+    error,
+}: Readonly<{
+    apiKey: ApplicationSubscriptionApiKeyRow | null;
+    onClose: () => void;
+    onConfirm: (expirationDate: Date) => void;
+    isLoading: boolean;
+    error?: string | null;
+}>) {
+    const initialLocal = useMemo(() => (apiKey ? toDatetimeLocalValue(defaultExpirationDraft(apiKey)) : ''), [apiKey]);
+    const [value, setValue] = useState(initialLocal);
+    const [dirty, setDirty] = useState(false);
+
+    useEffect(() => {
+        setValue(initialLocal);
+        setDirty(false);
+    }, [initialLocal]);
+
+    const minMs = Date.now() - 60_000;
+    const parsedExpirationDate = useMemo(() => parseDatetimeLocalValue(value), [value]);
+
+    const hasInvalidFormat = dirty && !parsedExpirationDate;
+    const hasInvalidRange = dirty && Boolean(parsedExpirationDate) && !isAfterMinCandidate(value, minMs);
+    const canSubmit = canSubmitApiKeyExpirationChange(dirty, value, minMs);
+
+    return (
+        <Dialog open={Boolean(apiKey)} onOpenChange={open => !open && onClose()}>
+            <DialogContent>
+                <DialogHeader>
+                    <DialogTitle>Change your API Key&apos;s expiration date</DialogTitle>
+                    <DialogDescription>
+                        Set a new expiration for key <span className="font-mono text-foreground">{apiKey?.maskedKey}</span>.
+                    </DialogDescription>
+                </DialogHeader>
+                {apiKey ? (
+                    <div className="space-y-2">
+                        <Label htmlFor="api-key-expire-at">Expire date</Label>
+                        <Input
+                            id="api-key-expire-at"
+                            type="datetime-local"
+                            value={value}
+                            min={toDatetimeLocalValue(new Date())}
+                            onChange={e => {
+                                setValue(e.target.value);
+                                setDirty(true);
+                            }}
+                        />
+                        {hasInvalidFormat ? <p className="text-sm text-destructive">Enter a valid date and time.</p> : null}
+                        {hasInvalidRange ? <p className="text-sm text-destructive">Date and time must be in the future.</p> : null}
+                    </div>
+                ) : null}
+                {error ? <p className="text-sm text-destructive">{error}</p> : null}
+                <DialogFooter>
+                    <DialogClose asChild>
+                        <Button type="button" variant="outline" disabled={isLoading}>
+                            Cancel
+                        </Button>
+                    </DialogClose>
+                    <Button
+                        type="button"
+                        disabled={isLoading || !canSubmit}
+                        onClick={() => apiKey && canSubmit && parsedExpirationDate && onConfirm(parsedExpirationDate)}
+                    >
+                        {isLoading ? 'Saving…' : 'Change expiration date'}
+                    </Button>
+                </DialogFooter>
+            </DialogContent>
+        </Dialog>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/subscriptions/ApplicationSubscriptionMultiSelectFilter.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/subscriptions/ApplicationSubscriptionMultiSelectFilter.tsx
@@ -1,0 +1,86 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Button, Checkbox, cn, Popover, PopoverContent, PopoverTrigger } from '@gravitee/graphene-core';
+import { ChevronDownIcon } from '@gravitee/graphene-core/icons';
+
+const FILTER_FIELD_WIDTH = 'w-[220px]';
+
+function formatSelection(labels: string[], placeholder: string): string {
+    if (labels.length === 0) return placeholder;
+    return labels.join(', ');
+}
+
+export interface MultiSelectOption {
+    value: string;
+    label: string;
+}
+
+export function ApplicationSubscriptionMultiSelectFilter({
+    placeholder,
+    options,
+    selectedValues,
+    onSelectedValuesChange,
+    emptyMessage,
+    ariaLabel,
+}: Readonly<{
+    placeholder: string;
+    options: MultiSelectOption[];
+    selectedValues: string[];
+    onSelectedValuesChange: (values: string[]) => void;
+    emptyMessage?: string;
+    ariaLabel: string;
+}>) {
+    const display = formatSelection(
+        options.filter(o => selectedValues.includes(o.value)).map(o => o.label),
+        placeholder,
+    );
+
+    const toggle = (value: string) => {
+        onSelectedValuesChange(selectedValues.includes(value) ? selectedValues.filter(v => v !== value) : [...selectedValues, value]);
+    };
+
+    return (
+        <Popover>
+            <PopoverTrigger asChild>
+                <Button
+                    type="button"
+                    variant="outline"
+                    aria-label={ariaLabel}
+                    className={cn(FILTER_FIELD_WIDTH, 'h-9 shrink-0 justify-start gap-2 px-3 font-normal')}
+                >
+                    <span className={cn('min-w-0 flex-1 truncate text-left', selectedValues.length === 0 && 'text-muted-foreground')}>
+                        {display}
+                    </span>
+                    <ChevronDownIcon className="size-4 shrink-0 opacity-50" aria-hidden />
+                </Button>
+            </PopoverTrigger>
+            <PopoverContent className="w-[260px] p-3" align="start">
+                {options.length === 0 ? (
+                    <p className="text-xs text-muted-foreground">{emptyMessage ?? 'No options'}</p>
+                ) : (
+                    <div className="max-h-[200px] space-y-2 overflow-y-auto">
+                        {options.map(option => (
+                            <label key={option.value} className="flex cursor-pointer items-center gap-2 text-sm">
+                                <Checkbox checked={selectedValues.includes(option.value)} onCheckedChange={() => toggle(option.value)} />
+                                <span className="truncate">{option.label}</span>
+                            </label>
+                        ))}
+                    </div>
+                )}
+            </PopoverContent>
+        </Popover>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/subscriptions/ApplicationSubscriptionRevokeApiKeyDialog.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/subscriptions/ApplicationSubscriptionRevokeApiKeyDialog.tsx
@@ -1,0 +1,70 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+    Button,
+    Dialog,
+    DialogClose,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+} from '@gravitee/graphene-core';
+
+import type { ApplicationSubscriptionApiKeyRow } from '../../types/applicationSubscription';
+
+export function ApplicationSubscriptionRevokeApiKeyDialog({
+    apiKey,
+    onClose,
+    onConfirm,
+    isLoading,
+    error,
+}: Readonly<{
+    apiKey: ApplicationSubscriptionApiKeyRow | null;
+    onClose: () => void;
+    onConfirm: () => void;
+    isLoading: boolean;
+    error?: string | null;
+}>) {
+    return (
+        <Dialog open={Boolean(apiKey)} onOpenChange={open => !open && onClose()}>
+            <DialogContent>
+                <DialogHeader>
+                    <DialogTitle>Revoke API key?</DialogTitle>
+                    <DialogDescription>
+                        {apiKey ? (
+                            <>
+                                Revoke key <code className="text-foreground">{apiKey.maskedKey}</code>? This cannot be undone without
+                                renewing.
+                            </>
+                        ) : null}
+                    </DialogDescription>
+                </DialogHeader>
+                {error ? <p className="text-sm text-destructive">{error}</p> : null}
+                <DialogFooter>
+                    <DialogClose asChild>
+                        <Button type="button" variant="outline" disabled={isLoading}>
+                            Cancel
+                        </Button>
+                    </DialogClose>
+                    <Button type="button" variant="destructive" disabled={isLoading} onClick={onConfirm}>
+                        {isLoading ? 'Revoking…' : 'Revoke'}
+                    </Button>
+                </DialogFooter>
+            </DialogContent>
+        </Dialog>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/subscriptions/ApplicationSubscriptionStatusDetails.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/subscriptions/ApplicationSubscriptionStatusDetails.tsx
@@ -1,0 +1,53 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Button, Collapsible, CollapsibleContent, CollapsibleTrigger, cn } from '@gravitee/graphene-core';
+import { ChevronDownIcon, InfoIcon } from '@gravitee/graphene-core/icons';
+import { useState } from 'react';
+
+export function ApplicationSubscriptionStatusDetails() {
+    const [open, setOpen] = useState(false);
+
+    return (
+        <Collapsible open={open} onOpenChange={setOpen}>
+            <CollapsibleTrigger asChild>
+                <Button variant="ghost" size="sm" className="-ml-2 h-8 px-2 text-muted-foreground">
+                    <InfoIcon className="mr-1.5 size-4" aria-hidden />
+                    Subscription status details
+                    <ChevronDownIcon className={cn('ml-1 size-4 transition-transform', open && 'rotate-180')} aria-hidden />
+                </Button>
+            </CollapsibleTrigger>
+            <CollapsibleContent>
+                <ul className="mt-2 list-inside list-disc space-y-2 pl-1 text-sm text-muted-foreground">
+                    <li>
+                        <strong className="text-foreground">Accepted</strong> — Subscription is valid and the application can use its
+                        credentials to perform operations on the API.
+                    </li>
+                    <li>
+                        <strong className="text-foreground">Pending</strong> — The application has requested access and is waiting for API
+                        owner approval.
+                    </li>
+                    <li>
+                        <strong className="text-foreground">Rejected</strong> — Subscription is rejected and the application cannot use the
+                        API.
+                    </li>
+                    <li>
+                        <strong className="text-foreground">Closed</strong> — Subscription is closed and the application cannot use the API.
+                    </li>
+                </ul>
+            </CollapsibleContent>
+        </Collapsible>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/subscriptions/ApplicationSubscriptionsTable.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/subscriptions/ApplicationSubscriptionsTable.tsx
@@ -1,0 +1,182 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+    Badge,
+    Button,
+    Skeleton,
+    Table,
+    TableBody,
+    TableCell,
+    TableHead,
+    TableHeader,
+    TableRow,
+    Tooltip,
+    TooltipContent,
+    TooltipProvider,
+    TooltipTrigger,
+} from '@gravitee/graphene-core';
+import { CircleXIcon, EyeIcon } from '@gravitee/graphene-core/icons';
+
+import type { ApplicationSubscriptionTableRow } from '../../types/applicationSubscription';
+import { formatApplicationDateTime } from '../../utils/applicationFormatters';
+import { canCloseSubscription } from '../../utils/applicationSubscriptionMapper';
+
+function SubscriptionStatusBadge({ status }: { status: ApplicationSubscriptionTableRow['status'] }) {
+    const variant =
+        status === 'ACCEPTED'
+            ? 'default'
+            : status === 'PENDING' || status === 'REJECTED'
+              ? 'secondary'
+              : status === 'CLOSED'
+                ? 'destructive'
+                : 'outline';
+
+    return <Badge variant={variant}>{status}</Badge>;
+}
+
+function SkeletonRow() {
+    return (
+        <TableRow>
+            {Array.from({ length: 9 }).map((_, index) => (
+                <TableCell key={index}>
+                    <Skeleton className="h-4 w-24 rounded" />
+                </TableCell>
+            ))}
+        </TableRow>
+    );
+}
+
+export function ApplicationSubscriptionsTable({
+    rows,
+    isLoading,
+    skeletonRowCount,
+    readOnly,
+    canViewDetail,
+    canClose,
+    onView,
+    onClose,
+}: Readonly<{
+    rows: ApplicationSubscriptionTableRow[];
+    isLoading: boolean;
+    skeletonRowCount: number;
+    readOnly: boolean;
+    canViewDetail: boolean;
+    canClose: boolean;
+    onView: (row: ApplicationSubscriptionTableRow) => void;
+    onClose: (row: ApplicationSubscriptionTableRow) => void;
+}>) {
+    return (
+        <div className="overflow-hidden overflow-x-auto rounded-xl border bg-card">
+            <Table aria-label="Subscriptions table">
+                <TableHeader>
+                    <TableRow>
+                        <TableHead>Security type</TableHead>
+                        <TableHead>Plan</TableHead>
+                        <TableHead>API</TableHead>
+                        <TableHead>Created at</TableHead>
+                        <TableHead>Processed at</TableHead>
+                        <TableHead>Started at</TableHead>
+                        <TableHead>Ended at</TableHead>
+                        <TableHead>Status</TableHead>
+                        <TableHead className="w-[88px]" />
+                    </TableRow>
+                </TableHeader>
+                <TableBody>
+                    {isLoading ? Array.from({ length: skeletonRowCount }).map((_, index) => <SkeletonRow key={index} />) : null}
+                    {!isLoading && rows.length === 0 ? (
+                        <TableRow>
+                            <TableCell colSpan={9} className="h-24 text-center text-muted-foreground">
+                                There is no subscription (yet).
+                            </TableCell>
+                        </TableRow>
+                    ) : null}
+                    {!isLoading
+                        ? rows.map(row => (
+                              <TableRow key={row.id}>
+                                  <TableCell>
+                                      <span className="text-sm">{row.securityType}</span>
+                                      {row.isSharedApiKey ? (
+                                          <Badge variant="outline" className="ml-2 text-[10px]">
+                                              Shared
+                                          </Badge>
+                                      ) : null}
+                                  </TableCell>
+                                  <TableCell className="text-sm">{row.planName}</TableCell>
+                                  <TableCell>
+                                      <p className="text-sm font-medium">{row.apiName}</p>
+                                      <p className="text-[11px] text-muted-foreground">
+                                          {row.referenceTypeLabel}
+                                          {row.apiVersion ? ` · v${row.apiVersion}` : ''}
+                                      </p>
+                                  </TableCell>
+                                  <TableCell className="whitespace-nowrap text-sm text-muted-foreground">
+                                      {formatApplicationDateTime(row.createdAt)}
+                                  </TableCell>
+                                  <TableCell className="whitespace-nowrap text-sm text-muted-foreground">
+                                      {formatApplicationDateTime(row.processedAt)}
+                                  </TableCell>
+                                  <TableCell className="whitespace-nowrap text-sm text-muted-foreground">
+                                      {formatApplicationDateTime(row.startingAt)}
+                                  </TableCell>
+                                  <TableCell className="whitespace-nowrap text-sm text-muted-foreground">
+                                      {formatApplicationDateTime(row.endAt)}
+                                  </TableCell>
+                                  <TableCell>
+                                      <SubscriptionStatusBadge status={row.status} />
+                                  </TableCell>
+                                  <TableCell>
+                                      <div className="flex items-center justify-end gap-0.5">
+                                          {canViewDetail ? (
+                                              <Button
+                                                  type="button"
+                                                  variant="ghost"
+                                                  size="icon"
+                                                  className="size-8"
+                                                  aria-label="Subscription details"
+                                                  onClick={() => onView(row)}
+                                              >
+                                                  <EyeIcon className="size-4" aria-hidden />
+                                              </Button>
+                                          ) : null}
+                                          {!readOnly && canClose && canCloseSubscription(row.status) && row.origin !== 'KUBERNETES' ? (
+                                              <TooltipProvider>
+                                                  <Tooltip>
+                                                      <TooltipTrigger asChild>
+                                                          <Button
+                                                              type="button"
+                                                              variant="ghost"
+                                                              size="icon"
+                                                              className="size-8 text-destructive hover:text-destructive"
+                                                              aria-label="Close subscription"
+                                                              onClick={() => onClose(row)}
+                                                          >
+                                                              <CircleXIcon className="size-4" aria-hidden />
+                                                          </Button>
+                                                      </TooltipTrigger>
+                                                      <TooltipContent>Close subscription</TooltipContent>
+                                                  </Tooltip>
+                                              </TooltipProvider>
+                                          ) : null}
+                                      </div>
+                                  </TableCell>
+                              </TableRow>
+                          ))
+                        : null}
+                </TableBody>
+            </Table>
+        </div>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/subscriptions/ApplicationSubscriptionsView.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/subscriptions/ApplicationSubscriptionsView.spec.tsx
@@ -1,0 +1,135 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+
+import { ApplicationSubscriptionsView } from './ApplicationSubscriptionsView';
+import { useApplicationSubscriptionPermissions } from '../../hooks/useApplicationSubscriptionPermissions';
+import { useApplicationSubscriptions, useSubscribedApis } from '../../hooks/useApplicationSubscriptions';
+import { useCloseApplicationSubscription } from '../../hooks/useCloseApplicationSubscription';
+import type { ApplicationListItem } from '../../types/application';
+
+jest.mock('../../hooks/useApplicationSubscriptionPermissions');
+jest.mock('../../hooks/useApplicationSubscriptions', () => ({
+    useApplicationSubscriptions: jest.fn(),
+    useSubscribedApis: jest.fn(),
+}));
+jest.mock('../../hooks/useCloseApplicationSubscription');
+jest.mock('../../../shared/hooks/useDetailBasePath', () => ({
+    useDetailBasePath: () => '/applications/app-1',
+}));
+jest.mock('./ApplicationSubscriptionCreateDialog', () => ({
+    ApplicationSubscriptionCreateDialog: () => <div data-testid="create-dialog" />,
+}));
+jest.mock('./ApplicationSubscriptionCloseDialog', () => ({
+    ApplicationSubscriptionCloseDialog: () => <div data-testid="close-dialog" />,
+}));
+jest.mock('./ApplicationSubscriptionsTable', () => ({
+    ApplicationSubscriptionsTable: () => <div data-testid="subscriptions-table" />,
+}));
+jest.mock('./ApplicationSubscriptionStatusDetails', () => ({
+    ApplicationSubscriptionStatusDetails: () => null,
+}));
+jest.mock('./ApplicationSubscriptionMultiSelectFilter', () => ({
+    ApplicationSubscriptionMultiSelectFilter: () => null,
+}));
+
+const mockUsePermissions = jest.mocked(useApplicationSubscriptionPermissions);
+const mockUseSubscriptions = jest.mocked(useApplicationSubscriptions);
+const mockUseSubscribedApis = jest.mocked(useSubscribedApis);
+const mockUseClose = jest.mocked(useCloseApplicationSubscription);
+
+const application: ApplicationListItem = {
+    id: 'app-1',
+    name: 'Billing',
+    status: 'ACTIVE',
+    type: 'SIMPLE',
+    created_at: 0,
+    updated_at: 0,
+};
+
+function renderView() {
+    return render(
+        <MemoryRouter>
+            <ApplicationSubscriptionsView application={application} />
+        </MemoryRouter>,
+    );
+}
+
+describe('ApplicationSubscriptionsView', () => {
+    beforeEach(() => {
+        mockUseSubscriptions.mockReturnValue({
+            data: { rows: [], totalCount: 0 },
+            isLoading: false,
+            isError: false,
+        } as ReturnType<typeof useApplicationSubscriptions>);
+        mockUseSubscribedApis.mockReturnValue({ data: [] } as ReturnType<typeof useSubscribedApis>);
+        mockUseClose.mockReturnValue({
+            mutateAsync: jest.fn(),
+            isPending: false,
+        } as ReturnType<typeof useCloseApplicationSubscription>);
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('shows Create a subscription when the user can create', () => {
+        mockUsePermissions.mockReturnValue({
+            permissionsReady: true,
+            canRead: true,
+            canCreate: true,
+            canUpdate: false,
+            canDelete: false,
+            canViewDetail: true,
+        });
+        renderView();
+        expect(screen.getByRole('button', { name: /Create a subscription/i })).not.toBeNull();
+        expect(screen.getByTestId('create-dialog')).not.toBeNull();
+    });
+
+    it('hides Create a subscription when the user cannot create', () => {
+        mockUsePermissions.mockReturnValue({
+            permissionsReady: true,
+            canRead: true,
+            canCreate: false,
+            canUpdate: false,
+            canDelete: false,
+            canViewDetail: true,
+        });
+        renderView();
+        expect(screen.queryByRole('button', { name: /Create a subscription/i })).toBeNull();
+        expect(screen.queryByTestId('create-dialog')).toBeNull();
+    });
+
+    it('hides Create a subscription for archived applications', () => {
+        mockUsePermissions.mockReturnValue({
+            permissionsReady: true,
+            canRead: true,
+            canCreate: true,
+            canUpdate: false,
+            canDelete: false,
+            canViewDetail: true,
+        });
+        render(
+            <MemoryRouter>
+                <ApplicationSubscriptionsView application={{ ...application, status: 'ARCHIVED' }} />
+            </MemoryRouter>,
+        );
+        expect(screen.queryByRole('button', { name: /Create a subscription/i })).toBeNull();
+        expect(screen.queryByTestId('create-dialog')).toBeNull();
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/subscriptions/ApplicationSubscriptionsView.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/subscriptions/ApplicationSubscriptionsView.tsx
@@ -1,0 +1,251 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Alert, AlertDescription, Button, DataTablePagination, Input, cn } from '@gravitee/graphene-core';
+import { PlusIcon, RefreshCwIcon } from '@gravitee/graphene-core/icons';
+import { useEffect, useMemo, useState } from 'react';
+import { useNavigate, useSearchParams } from 'react-router-dom';
+
+import { ApplicationSubscriptionCloseDialog } from './ApplicationSubscriptionCloseDialog';
+import { ApplicationSubscriptionCreateDialog } from './ApplicationSubscriptionCreateDialog';
+import { ApplicationSubscriptionMultiSelectFilter } from './ApplicationSubscriptionMultiSelectFilter';
+import { ApplicationSubscriptionsTable } from './ApplicationSubscriptionsTable';
+import { ApplicationSubscriptionStatusDetails } from './ApplicationSubscriptionStatusDetails';
+import { useDetailBasePath } from '../../../shared/hooks/useDetailBasePath';
+import { useApplicationSubscriptionPermissions } from '../../hooks/useApplicationSubscriptionPermissions';
+import { useApplicationSubscriptions, useSubscribedApis } from '../../hooks/useApplicationSubscriptions';
+import { useCloseApplicationSubscription } from '../../hooks/useCloseApplicationSubscription';
+import type { ApplicationListItem } from '../../types/application';
+import type { ApplicationSubscriptionTableRow, SubscriptionStatus } from '../../types/applicationSubscription';
+import { DEFAULT_SUBSCRIPTION_FILTER_STATUSES, SUBSCRIPTION_STATUS_OPTIONS } from '../../utils/applicationSubscriptionConstants';
+import {
+    buildApplicationSubscriptionListSearchParams,
+    parseApplicationSubscriptionListSearchParams,
+} from '../../utils/applicationSubscriptionListSearchParams';
+
+const FILTER_FIELD_WIDTH = 'w-[220px]';
+const API_KEY_DEBOUNCE_MS = 250;
+
+export function ApplicationSubscriptionsView({ application }: Readonly<{ application: ApplicationListItem }>) {
+    const navigate = useNavigate();
+    const [searchParams, setSearchParams] = useSearchParams();
+    const basePath = useDetailBasePath('applications', application.id);
+    const readOnly = application.status === 'ARCHIVED';
+    const { canCreate, canDelete, canViewDetail } = useApplicationSubscriptionPermissions();
+
+    const [apiFilters, setApiFilters] = useState<string[]>(() => parseApplicationSubscriptionListSearchParams(searchParams).apiFilters);
+    const [statusFilters, setStatusFilters] = useState<SubscriptionStatus[]>(
+        () => parseApplicationSubscriptionListSearchParams(searchParams).statusFilters,
+    );
+    const [apiKeyInput, setApiKeyInput] = useState(() => parseApplicationSubscriptionListSearchParams(searchParams).apiKeyInput);
+    const [debouncedApiKey, setDebouncedApiKey] = useState(() => parseApplicationSubscriptionListSearchParams(searchParams).apiKeyInput);
+    const [page, setPage] = useState(() => parseApplicationSubscriptionListSearchParams(searchParams).page);
+    const [pageSize, setPageSize] = useState(() => parseApplicationSubscriptionListSearchParams(searchParams).pageSize);
+    const [createOpen, setCreateOpen] = useState(false);
+    const [closeTarget, setCloseTarget] = useState<ApplicationSubscriptionTableRow | null>(null);
+    const [closeError, setCloseError] = useState<string | null>(null);
+    const canCreateSubscription = !readOnly && canCreate;
+
+    useEffect(() => {
+        const timer = window.setTimeout(() => setDebouncedApiKey(apiKeyInput.trim()), API_KEY_DEBOUNCE_MS);
+        return () => window.clearTimeout(timer);
+    }, [apiKeyInput]);
+
+    useEffect(() => {
+        if (!canCreateSubscription && createOpen) {
+            setCreateOpen(false);
+        }
+    }, [canCreateSubscription, createOpen]);
+
+    useEffect(() => {
+        setPage(1);
+    }, [apiFilters, statusFilters, debouncedApiKey]);
+
+    useEffect(() => {
+        setSearchParams(
+            buildApplicationSubscriptionListSearchParams({
+                page,
+                pageSize,
+                apiFilters,
+                statusFilters,
+                apiKeyInput: debouncedApiKey,
+            }),
+            { replace: true },
+        );
+    }, [apiFilters, debouncedApiKey, page, pageSize, setSearchParams, statusFilters]);
+
+    const filters = useMemo(
+        () => ({
+            apis: apiFilters.length > 0 ? apiFilters : undefined,
+            status: statusFilters.length > 0 ? statusFilters : undefined,
+            apiKey: debouncedApiKey || undefined,
+        }),
+        [apiFilters, statusFilters, debouncedApiKey],
+    );
+
+    const { data, isLoading, isError } = useApplicationSubscriptions(application.id, filters, page, pageSize, application.api_key_mode);
+    const { data: subscribedApis = [] } = useSubscribedApis(application.id);
+    const closeMutation = useCloseApplicationSubscription(application.id);
+
+    const apiOptions = useMemo(
+        () =>
+            subscribedApis
+                .filter(api => api.id && api.name)
+                .map(api => ({ value: api.id!, label: api.name! }))
+                .sort((a, b) => a.label.localeCompare(b.label)),
+        [subscribedApis],
+    );
+
+    const statusOptions = useMemo(() => SUBSCRIPTION_STATUS_OPTIONS.map(s => ({ value: s.id, label: s.name })), []);
+
+    const resetFilters = () => {
+        setApiFilters([]);
+        setStatusFilters([...DEFAULT_SUBSCRIPTION_FILTER_STATUSES]);
+        setApiKeyInput('');
+        setPage(1);
+    };
+
+    const handlePageSizeChange = (size: number) => {
+        setPageSize(size);
+        setPage(1);
+    };
+
+    const handleClose = async () => {
+        if (!closeTarget) return;
+        setCloseError(null);
+        try {
+            await closeMutation.mutateAsync(closeTarget.id);
+            setCloseTarget(null);
+        } catch {
+            setCloseError('Failed to close subscription. Please try again.');
+        }
+    };
+
+    const rows = data?.rows ?? [];
+    const totalCount = data?.totalCount ?? 0;
+
+    return (
+        <div className="space-y-6">
+            <div className="flex items-start justify-between gap-4">
+                <div>
+                    <h1 className="text-2xl font-semibold">Subscriptions</h1>
+                    <p className="mt-1 max-w-2xl text-sm text-muted-foreground">
+                        Retrieve all subscriptions for this application. A subscription represents the plans this application has subscribed
+                        to.
+                    </p>
+                </div>
+                {canCreateSubscription ? (
+                    <Button type="button" size="sm" className="shrink-0" onClick={() => setCreateOpen(true)}>
+                        <PlusIcon className="size-4" aria-hidden />
+                        Create a subscription
+                    </Button>
+                ) : null}
+            </div>
+
+            <ApplicationSubscriptionStatusDetails />
+
+            {isError ? (
+                <Alert variant="destructive">
+                    <AlertDescription>Failed to load subscriptions. Please try again.</AlertDescription>
+                </Alert>
+            ) : null}
+
+            <div className="flex flex-wrap items-center gap-3">
+                <ApplicationSubscriptionMultiSelectFilter
+                    placeholder="API"
+                    ariaLabel="Filter by API"
+                    options={apiOptions}
+                    selectedValues={apiFilters}
+                    onSelectedValuesChange={setApiFilters}
+                    emptyMessage="No subscribed APIs yet"
+                />
+                <ApplicationSubscriptionMultiSelectFilter
+                    placeholder="Status"
+                    ariaLabel="Filter by status"
+                    options={statusOptions}
+                    selectedValues={statusFilters}
+                    onSelectedValuesChange={values => setStatusFilters(values as SubscriptionStatus[])}
+                />
+                <Input
+                    placeholder="API Key"
+                    value={apiKeyInput}
+                    onChange={e => setApiKeyInput(e.target.value)}
+                    className={cn(FILTER_FIELD_WIDTH, 'h-9 shrink-0')}
+                    aria-label="Filter by API key"
+                />
+                <Button type="button" variant="outline" size="sm" className="shrink-0" onClick={resetFilters}>
+                    <RefreshCwIcon className="size-4" aria-hidden />
+                    Reset filters
+                </Button>
+            </div>
+
+            <div className="flex justify-end">
+                <DataTablePagination
+                    page={page}
+                    pageSize={pageSize}
+                    totalCount={totalCount}
+                    pageSizeOptions={[10, 25, 50, 100]}
+                    onPageChange={setPage}
+                    onPageSizeChange={handlePageSizeChange}
+                />
+            </div>
+
+            <ApplicationSubscriptionsTable
+                rows={rows}
+                isLoading={isLoading}
+                skeletonRowCount={pageSize}
+                readOnly={readOnly}
+                canViewDetail={canViewDetail}
+                canClose={canDelete}
+                onView={row => navigate(`${basePath}/subscriptions/${row.id}`)}
+                onClose={row => {
+                    setCloseError(null);
+                    setCloseTarget(row);
+                }}
+            />
+
+            <div className="flex justify-end">
+                <DataTablePagination
+                    page={page}
+                    pageSize={pageSize}
+                    totalCount={totalCount}
+                    pageSizeOptions={[10, 25, 50, 100]}
+                    onPageChange={setPage}
+                    onPageSizeChange={handlePageSizeChange}
+                />
+            </div>
+
+            {canCreateSubscription ? (
+                <ApplicationSubscriptionCreateDialog
+                    application={application}
+                    basePath={basePath}
+                    open={createOpen}
+                    onOpenChange={setCreateOpen}
+                />
+            ) : null}
+
+            <ApplicationSubscriptionCloseDialog
+                subscription={closeTarget}
+                onClose={() => {
+                    setCloseTarget(null);
+                    setCloseError(null);
+                }}
+                onConfirm={() => void handleClose()}
+                isLoading={closeMutation.isPending}
+                error={closeError}
+            />
+        </div>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/subscriptions/SubscriptionStatusLabel.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/subscriptions/SubscriptionStatusLabel.tsx
@@ -1,0 +1,35 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { cn } from '@gravitee/graphene-core';
+
+import type { SubscriptionStatus } from '../../types/applicationSubscription';
+
+export function SubscriptionStatusLabel({ status }: Readonly<{ status: SubscriptionStatus }>) {
+    return (
+        <span
+            className={cn(
+                'inline-flex h-6 items-center rounded-md px-2.5 text-xs font-medium uppercase leading-none',
+                status === 'ACCEPTED' || status === 'PENDING'
+                    ? 'bg-primary text-primary-foreground'
+                    : status === 'CLOSED' || status === 'REJECTED'
+                      ? 'bg-destructive text-destructive-foreground'
+                      : 'bg-muted text-muted-foreground',
+            )}
+        >
+            {status}
+        </span>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/hooks/useApplicationSubscriptionApiKeys.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/hooks/useApplicationSubscriptionApiKeys.ts
@@ -1,0 +1,116 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useEnvironment } from '@gravitee/gamma-modules-sdk';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
+import {
+    expireSubscriptionApiKey,
+    listSubscriptionApiKeys,
+    renewSubscriptionApiKey,
+    revokeSubscriptionApiKey,
+    type SubscriptionApiKeyV2Parent,
+} from '../services/applicationSubscriptions';
+import { mapApiKeysToRows } from '../utils/applicationSubscriptionApiKeyMapper';
+import { applicationSubscriptionKeys } from '../utils/queryKeys';
+
+function apiKeysQueryKey(
+    envId: string | undefined,
+    applicationId: string | undefined,
+    subscriptionId: string | undefined,
+): ReturnType<typeof applicationSubscriptionKeys.apiKeys> | null {
+    if (!envId || !applicationId || !subscriptionId) {
+        return null;
+    }
+    return applicationSubscriptionKeys.apiKeys(envId, applicationId, subscriptionId);
+}
+
+export function useApplicationSubscriptionApiKeys(applicationId: string | undefined, subscriptionId: string | undefined, enabled: boolean) {
+    const env = useEnvironment();
+    const envId = env?.id;
+
+    return useQuery({
+        queryKey: applicationSubscriptionKeys.apiKeys(envId, applicationId, subscriptionId),
+        queryFn: async () => {
+            const entities = await listSubscriptionApiKeys(envId!, applicationId!, subscriptionId!);
+            return mapApiKeysToRows(entities);
+        },
+        enabled: Boolean(enabled && envId && applicationId && subscriptionId),
+    });
+}
+
+export function useRenewSubscriptionApiKey(applicationId: string | undefined, subscriptionId: string | undefined) {
+    const env = useEnvironment();
+    const queryClient = useQueryClient();
+
+    return useMutation({
+        mutationFn: () => {
+            if (!env?.id || !applicationId || !subscriptionId) {
+                throw new Error('Failed to renew API key. Please try again.');
+            }
+            return renewSubscriptionApiKey(env.id, applicationId, subscriptionId);
+        },
+        onSuccess: async () => {
+            const queryKey = apiKeysQueryKey(env?.id, applicationId, subscriptionId);
+            if (queryKey) {
+                await queryClient.refetchQueries({ queryKey });
+            }
+        },
+    });
+}
+
+export function useRevokeSubscriptionApiKey(applicationId: string | undefined, subscriptionId: string | undefined) {
+    const env = useEnvironment();
+    const queryClient = useQueryClient();
+
+    return useMutation({
+        mutationFn: (apiKeyId: string) => {
+            if (!env?.id || !applicationId || !subscriptionId) {
+                throw new Error('Failed to revoke API key. Please try again.');
+            }
+            return revokeSubscriptionApiKey(env.id, applicationId, subscriptionId, apiKeyId);
+        },
+        onSuccess: async () => {
+            const queryKey = apiKeysQueryKey(env?.id, applicationId, subscriptionId);
+            if (queryKey) {
+                await queryClient.refetchQueries({ queryKey });
+            }
+        },
+    });
+}
+
+export function useExpireSubscriptionApiKey(
+    applicationId: string | undefined,
+    subscriptionId: string | undefined,
+    parent: SubscriptionApiKeyV2Parent | null,
+) {
+    const env = useEnvironment();
+    const queryClient = useQueryClient();
+
+    return useMutation({
+        mutationFn: ({ apiKeyId, expireAt }: { apiKeyId: string; expireAt: Date }) => {
+            if (!env?.id || !applicationId || !subscriptionId || !parent) {
+                throw new Error('Failed to update API key expiration. Please try again.');
+            }
+            return expireSubscriptionApiKey(env.id, parent, subscriptionId, apiKeyId, expireAt);
+        },
+        onSuccess: async () => {
+            const queryKey = apiKeysQueryKey(env?.id, applicationId, subscriptionId);
+            if (queryKey) {
+                await queryClient.refetchQueries({ queryKey });
+            }
+        },
+    });
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/hooks/useApplicationSubscriptionDetail.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/hooks/useApplicationSubscriptionDetail.ts
@@ -1,0 +1,71 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useEnvironment } from '@gravitee/gamma-modules-sdk';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
+import { getApplicationSubscription, updateApplicationSubscription } from '../services/applicationSubscriptions';
+import type { ApiKeyMode } from '../types/application';
+import type { ApplicationSubscriptionEntity } from '../types/applicationSubscription';
+import { mapSubscriptionEntityToDetail } from '../utils/applicationSubscriptionDetailMapper';
+import { applicationSubscriptionKeys } from '../utils/queryKeys';
+
+function subscriptionDetailQueryKey(
+    envId: string | undefined,
+    applicationId: string | undefined,
+    subscriptionId: string | undefined,
+): ReturnType<typeof applicationSubscriptionKeys.detail> | null {
+    if (!envId || !applicationId || !subscriptionId) {
+        return null;
+    }
+    return applicationSubscriptionKeys.detail(envId, applicationId, subscriptionId);
+}
+
+export function useApplicationSubscriptionDetail(
+    applicationId: string | undefined,
+    subscriptionId: string | undefined,
+    apiKeyMode: ApiKeyMode | undefined,
+) {
+    const env = useEnvironment();
+    const envId = env?.id;
+
+    return useQuery({
+        queryKey: applicationSubscriptionKeys.detail(envId, applicationId, subscriptionId),
+        queryFn: async () => {
+            const entity = await getApplicationSubscription(envId!, applicationId!, subscriptionId!);
+            return {
+                entity,
+                detail: mapSubscriptionEntityToDetail(entity, apiKeyMode),
+            };
+        },
+        enabled: Boolean(envId && applicationId && subscriptionId),
+    });
+}
+
+export function useUpdateApplicationSubscription(applicationId: string | undefined, subscriptionId: string | undefined) {
+    const env = useEnvironment();
+    const queryClient = useQueryClient();
+
+    return useMutation({
+        mutationFn: ({ entity, request }: { entity: ApplicationSubscriptionEntity; request: string }) =>
+            updateApplicationSubscription(env!.id, applicationId!, subscriptionId!, { ...entity, request }),
+        onSuccess: () => {
+            const queryKey = subscriptionDetailQueryKey(env?.id, applicationId, subscriptionId);
+            if (queryKey) {
+                void queryClient.invalidateQueries({ queryKey });
+            }
+        },
+    });
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/hooks/useApplicationSubscriptionPermissions.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/hooks/useApplicationSubscriptionPermissions.ts
@@ -1,0 +1,44 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useHasPermission } from '@gravitee/gamma-modules-sdk';
+
+import { useApplicationDetailContext } from '../context/ApplicationDetailContext';
+
+/**
+ * Application subscription permissions (console: application-subscription-*).
+ * Waits for {@link useApplicationPermissions} before exposing flags to avoid action flicker.
+ */
+export function useApplicationSubscriptionPermissions() {
+    const { permissionsReady } = useApplicationDetailContext();
+
+    const canRead = useHasPermission({ anyOf: ['application-subscription-r'] });
+    const canCreate = useHasPermission({ anyOf: ['application-subscription-c'] });
+    const canUpdate = useHasPermission({ anyOf: ['application-subscription-u'] });
+    const canDelete = useHasPermission({ anyOf: ['application-subscription-d'] });
+    /** Matches subscriptions tab/outlet (`application-subscription-r`) and subscription GET on the API. */
+    const canViewDetail = canRead;
+
+    const ready = permissionsReady;
+
+    return {
+        permissionsReady: ready,
+        canRead: ready && canRead,
+        canCreate: ready && canCreate,
+        canUpdate: ready && canUpdate,
+        canDelete: ready && canDelete,
+        canViewDetail: ready && canViewDetail,
+    };
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/hooks/useApplicationSubscriptions.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/hooks/useApplicationSubscriptions.ts
@@ -1,0 +1,56 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useEnvironment } from '@gravitee/gamma-modules-sdk';
+import { useQuery } from '@tanstack/react-query';
+
+import { listApplicationSubscriptions, listSubscribedApis } from '../services/applicationSubscriptions';
+import type { ApiKeyMode } from '../types/application';
+import type { ApplicationSubscriptionsFilters } from '../types/applicationSubscription';
+import { mapSubscriptionsPageToRows } from '../utils/applicationSubscriptionMapper';
+import { applicationSubscriptionKeys } from '../utils/queryKeys';
+
+export function useApplicationSubscriptions(
+    applicationId: string | undefined,
+    filters: ApplicationSubscriptionsFilters,
+    page: number,
+    size: number,
+    apiKeyMode: ApiKeyMode | undefined,
+) {
+    const env = useEnvironment();
+
+    return useQuery({
+        queryKey: applicationSubscriptionKeys.list(env?.id ?? '', applicationId ?? '', filters, page, size),
+        queryFn: async () => {
+            const response = await listApplicationSubscriptions(env!.id, applicationId!, filters, page, size);
+            return {
+                rows: mapSubscriptionsPageToRows(response, apiKeyMode),
+                totalCount: response.page?.total_elements ?? 0,
+            };
+        },
+        enabled: Boolean(env && applicationId),
+    });
+}
+
+export function useSubscribedApis(applicationId: string | undefined) {
+    const env = useEnvironment();
+
+    return useQuery({
+        queryKey: applicationSubscriptionKeys.subscribedApis(env?.id ?? '', applicationId ?? ''),
+        queryFn: () => listSubscribedApis(env!.id, applicationId!),
+        enabled: Boolean(env && applicationId),
+        staleTime: 60_000,
+    });
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/hooks/useCloseApplicationSubscription.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/hooks/useCloseApplicationSubscription.ts
@@ -1,0 +1,37 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useEnvironment } from '@gravitee/gamma-modules-sdk';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { closeApplicationSubscription } from '../services/applicationSubscriptions';
+import { applicationDetailKeys, applicationSubscriptionKeys } from '../utils/queryKeys';
+
+export function useCloseApplicationSubscription(applicationId: string | undefined) {
+    const env = useEnvironment();
+    const queryClient = useQueryClient();
+
+    return useMutation({
+        mutationFn: (subscriptionId: string) => closeApplicationSubscription(env!.id, applicationId!, subscriptionId),
+        onSuccess: () => {
+            void queryClient.invalidateQueries({ queryKey: applicationSubscriptionKeys.all });
+            if (applicationId && env?.id) {
+                void queryClient.invalidateQueries({
+                    queryKey: applicationDetailKeys.detail(env.id, applicationId),
+                });
+            }
+        },
+    });
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/hooks/useCreateApplicationSubscription.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/hooks/useCreateApplicationSubscription.spec.tsx
@@ -1,0 +1,183 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useEnvironment, useHasPermission } from '@gravitee/gamma-modules-sdk';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+
+import {
+    useApplicationApiKeySubscriptions,
+    useCanSearchApiProductsForSubscription,
+    useSubscriptionReferenceSearch,
+} from './useCreateApplicationSubscription';
+import { useEnvironmentPermissionsReady } from '../../../shared/hooks/useEnvironmentPermissions';
+import { useApplicationDetailContext } from '../context/ApplicationDetailContext';
+import {
+    listApplicationSubscriptions,
+    searchApiProductsForSubscription,
+    searchApisForSubscription,
+} from '../services/applicationSubscriptions';
+
+jest.mock('@gravitee/gamma-modules-sdk', () => ({
+    useEnvironment: jest.fn(),
+    useHasPermission: jest.fn(),
+}));
+
+jest.mock('../context/ApplicationDetailContext', () => ({
+    useApplicationDetailContext: jest.fn(),
+}));
+
+jest.mock('../../../shared/hooks/useEnvironmentPermissions', () => ({
+    useEnvironmentPermissionsReady: jest.fn(),
+}));
+
+jest.mock('../services/applicationSubscriptions');
+
+const mockUseEnvironment = jest.mocked(useEnvironment);
+const mockUseHasPermission = jest.mocked(useHasPermission);
+const mockUseApplicationDetailContext = jest.mocked(useApplicationDetailContext);
+const mockUseEnvironmentPermissionsReady = jest.mocked(useEnvironmentPermissionsReady);
+const mockSearchApis = jest.mocked(searchApisForSubscription);
+const mockSearchApiProducts = jest.mocked(searchApiProductsForSubscription);
+const mockListApplicationSubscriptions = jest.mocked(listApplicationSubscriptions);
+
+function subscriptionsResponse(ids: string[]): Awaited<ReturnType<typeof listApplicationSubscriptions>> {
+    const data = ids.map(id => ({ id })) as Awaited<ReturnType<typeof listApplicationSubscriptions>>['data'];
+    return {
+        data,
+        page: {
+            current: 1,
+            size: ids.length,
+            per_page: 20,
+            total_pages: 1,
+            total_elements: ids.length,
+        },
+    };
+}
+
+function mockPermissionsReady(application = true, environment = true) {
+    mockUseApplicationDetailContext.mockReturnValue({
+        application: null,
+        isLoading: false,
+        permissionsReady: application,
+        permissionsError: false,
+        refetchPermissions: jest.fn(),
+    });
+    mockUseEnvironmentPermissionsReady.mockReturnValue(environment);
+}
+
+function wrapper({ children }: { children: ReactNode }) {
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+}
+
+describe('useCreateApplicationSubscription hooks', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockUseEnvironment.mockReturnValue({ id: 'DEFAULT' });
+        mockPermissionsReady();
+    });
+
+    describe('useCanSearchApiProductsForSubscription', () => {
+        it('checks environment-api_product-r after application and environment permissions load', () => {
+            mockUseHasPermission.mockReturnValue(true);
+            const { result } = renderHook(() => useCanSearchApiProductsForSubscription());
+            expect(result.current).toBe(true);
+            expect(mockUseHasPermission).toHaveBeenCalledWith({ anyOf: ['environment-api_product-r'] });
+        });
+
+        it('returns false while application permissions are loading', () => {
+            mockPermissionsReady(false, true);
+            mockUseHasPermission.mockReturnValue(true);
+            const { result } = renderHook(() => useCanSearchApiProductsForSubscription());
+            expect(result.current).toBe(false);
+        });
+
+        it('returns false while environment permissions are loading', () => {
+            mockPermissionsReady(true, false);
+            mockUseHasPermission.mockReturnValue(true);
+            const { result } = renderHook(() => useCanSearchApiProductsForSubscription());
+            expect(result.current).toBe(false);
+        });
+    });
+
+    describe('useSubscriptionReferenceSearch', () => {
+        it('merges API and API product hits when permitted', async () => {
+            mockUseHasPermission.mockReturnValue(true);
+            mockSearchApis.mockResolvedValue({ data: [{ id: 'api-2', name: 'Zebra API' }] });
+            mockSearchApiProducts.mockResolvedValue({ data: [{ id: 'prod-1', name: 'Alpha Product' }] });
+
+            const { result } = renderHook(() => useSubscriptionReferenceSearch('alpha'), { wrapper });
+
+            await waitFor(() => expect(result.current.data).toHaveLength(2));
+
+            expect(result.current.data?.[0].value.name).toBe('Alpha Product');
+            expect(result.current.data?.[1].value.name).toBe('Zebra API');
+            expect(mockSearchApiProducts).toHaveBeenCalled();
+        });
+
+        it('searches APIs only when API product permission is missing', async () => {
+            mockUseHasPermission.mockReturnValue(false);
+            mockSearchApis.mockResolvedValue({ data: [{ id: 'api-1', name: 'Only API' }] });
+
+            const { result } = renderHook(() => useSubscriptionReferenceSearch('api'), { wrapper });
+
+            await waitFor(() => expect(result.current.data).toHaveLength(1));
+
+            expect(result.current.data?.[0].type).toBe('API');
+            expect(mockSearchApiProducts).not.toHaveBeenCalled();
+        });
+
+        it('does not run when the query is empty', () => {
+            renderHook(() => useSubscriptionReferenceSearch('   '), { wrapper });
+            expect(mockSearchApis).not.toHaveBeenCalled();
+        });
+
+        it('does not run before permissions are ready', () => {
+            mockPermissionsReady(false, true);
+            mockUseHasPermission.mockReturnValue(true);
+            renderHook(() => useSubscriptionReferenceSearch('alpha'), { wrapper });
+            expect(mockSearchApis).not.toHaveBeenCalled();
+            expect(mockSearchApiProducts).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('useApplicationApiKeySubscriptions', () => {
+        it('loads the first API key subscription page using the console default page size', async () => {
+            mockListApplicationSubscriptions.mockResolvedValueOnce(subscriptionsResponse(['sub-1', 'sub-2']));
+
+            const { result } = renderHook(() => useApplicationApiKeySubscriptions('app-1', true), { wrapper });
+
+            await waitFor(() => expect(result.current.data).toHaveLength(2));
+
+            expect(result.current.data?.map(subscription => subscription.id)).toEqual(['sub-1', 'sub-2']);
+            expect(mockListApplicationSubscriptions).toHaveBeenNthCalledWith(
+                1,
+                'DEFAULT',
+                'app-1',
+                { status: ['ACCEPTED', 'PAUSED', 'PENDING'], securityTypes: ['API_KEY'] },
+                1,
+                20,
+            );
+            expect(mockListApplicationSubscriptions).toHaveBeenCalledTimes(1);
+        });
+
+        it('does not load API key subscriptions when disabled', () => {
+            renderHook(() => useApplicationApiKeySubscriptions('app-1', false), { wrapper });
+            expect(mockListApplicationSubscriptions).not.toHaveBeenCalled();
+        });
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/hooks/useCreateApplicationSubscription.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/hooks/useCreateApplicationSubscription.ts
@@ -1,0 +1,130 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useEnvironment, useHasPermission } from '@gravitee/gamma-modules-sdk';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
+import { useEnvironmentPermissionsReady } from '../../../shared/hooks/useEnvironmentPermissions';
+import { useApplicationDetailContext } from '../context/ApplicationDetailContext';
+import {
+    createApplicationSubscription,
+    listApplicationSubscriptions,
+    listSubscribableApiPlans,
+    listSubscribableApiProductPlans,
+    searchApiProductsForSubscription,
+    searchApisForSubscription,
+} from '../services/applicationSubscriptions';
+import type { NewApplicationSubscriptionPayload, SubscriptionReferenceSelection } from '../types/applicationSubscription';
+import { applicationDetailKeys, applicationSubscriptionKeys } from '../utils/queryKeys';
+
+const API_KEY_SUBSCRIPTIONS_PAGE = 1;
+const API_KEY_SUBSCRIPTIONS_PAGE_SIZE = 20;
+const API_KEY_SUBSCRIPTION_STATUSES = ['ACCEPTED', 'PAUSED', 'PENDING'] as const;
+const API_KEY_SUBSCRIPTIONS_FILTERS = { status: [...API_KEY_SUBSCRIPTION_STATUSES], securityTypes: ['API_KEY'] };
+
+export function useCanSearchApiProductsForSubscription(): boolean {
+    const { permissionsReady: applicationPermissionsReady } = useApplicationDetailContext();
+    const environmentPermissionsReady = useEnvironmentPermissionsReady();
+    const hasPermission = useHasPermission({ anyOf: ['environment-api_product-r'] });
+
+    return applicationPermissionsReady && environmentPermissionsReady && hasPermission;
+}
+
+export function useSubscriptionReferenceSearch(query: string) {
+    const env = useEnvironment();
+    const { permissionsReady: applicationPermissionsReady } = useApplicationDetailContext();
+    const environmentPermissionsReady = useEnvironmentPermissionsReady();
+    const trimmed = query.trim();
+    const permissionsReady = applicationPermissionsReady && environmentPermissionsReady;
+    const canSearchApiProducts = useCanSearchApiProductsForSubscription();
+
+    return useQuery({
+        queryKey: applicationSubscriptionKeys.referenceSearch(env?.id ?? '', trimmed, canSearchApiProducts),
+        queryFn: async () => {
+            const [apisResponse, productsResponse] = await Promise.all([
+                searchApisForSubscription(env!.id, trimmed),
+                canSearchApiProducts ? searchApiProductsForSubscription(env!.id, trimmed) : Promise.resolve({ data: [] }),
+            ]);
+
+            return [
+                ...apisResponse.data.map(value => ({ type: 'API' as const, value })),
+                ...productsResponse.data.map(value => ({ type: 'API_PRODUCT' as const, value })),
+            ].sort((a, b) => a.value.name.localeCompare(b.value.name));
+        },
+        enabled: Boolean(env && trimmed.length > 0 && permissionsReady),
+        staleTime: 30_000,
+    });
+}
+
+export function useSubscribablePlans(reference: SubscriptionReferenceSelection | null, applicationId: string | undefined) {
+    const env = useEnvironment();
+
+    return useQuery({
+        queryKey: applicationSubscriptionKeys.subscribablePlans(
+            env?.id ?? '',
+            reference?.type ?? '',
+            reference?.id ?? '',
+            applicationId ?? '',
+        ),
+        queryFn: () => {
+            if (!env || !reference || !applicationId) {
+                throw new Error('Subscribable plans query requires environment, reference, and application');
+            }
+            return reference.type === 'API'
+                ? listSubscribableApiPlans(env.id, reference.id, applicationId)
+                : listSubscribableApiProductPlans(env.id, reference.id, applicationId);
+        },
+        enabled: Boolean(env && reference && applicationId),
+        staleTime: 30_000,
+    });
+}
+
+export function useApplicationApiKeySubscriptions(applicationId: string | undefined, enabled: boolean) {
+    const env = useEnvironment();
+
+    return useQuery({
+        queryKey: ['application-api-key-subscriptions', env?.id ?? '', applicationId ?? ''],
+        queryFn: async () => {
+            const response = await listApplicationSubscriptions(
+                env!.id,
+                applicationId!,
+                API_KEY_SUBSCRIPTIONS_FILTERS,
+                API_KEY_SUBSCRIPTIONS_PAGE,
+                API_KEY_SUBSCRIPTIONS_PAGE_SIZE,
+            );
+            return response.data ?? [];
+        },
+        enabled: Boolean(env && applicationId && enabled),
+        staleTime: 30_000,
+    });
+}
+
+export function useCreateApplicationSubscription(applicationId: string | undefined) {
+    const env = useEnvironment();
+    const queryClient = useQueryClient();
+
+    return useMutation({
+        mutationFn: ({ planId, payload }: { planId: string; payload: NewApplicationSubscriptionPayload }) =>
+            createApplicationSubscription(env!.id, applicationId!, planId, payload),
+        onSuccess: () => {
+            void queryClient.invalidateQueries({ queryKey: applicationSubscriptionKeys.all });
+            if (applicationId && env?.id) {
+                void queryClient.invalidateQueries({
+                    queryKey: applicationDetailKeys.detail(env.id, applicationId),
+                });
+            }
+        },
+    });
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/hooks/useEnvironmentPortalConfiguration.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/hooks/useEnvironmentPortalConfiguration.ts
@@ -1,0 +1,30 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useEnvironment } from '@gravitee/gamma-modules-sdk';
+import { useQuery } from '@tanstack/react-query';
+
+import { getEnvironmentPortalConfiguration } from '../services/environmentPortal';
+
+export function useEnvironmentPortalConfiguration() {
+    const env = useEnvironment();
+
+    return useQuery({
+        queryKey: ['environment-portal-configuration', env?.id ?? ''],
+        queryFn: () => getEnvironmentPortalConfiguration(env!.id),
+        enabled: Boolean(env?.id),
+        staleTime: 60_000,
+    });
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/services/applicationSubscriptions.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/services/applicationSubscriptions.spec.ts
@@ -1,0 +1,58 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { resolveSubscriptionApiKeyV2Parent } from './applicationSubscriptions';
+
+describe('resolveSubscriptionApiKeyV2Parent', () => {
+    it('resolves API parent from api.id', () => {
+        expect(resolveSubscriptionApiKeyV2Parent({ api: { id: 'api-1', name: 'A' } })).toEqual({
+            kind: 'API',
+            apiId: 'api-1',
+        });
+    });
+
+    it('resolves API parent from referenceType API and referenceId', () => {
+        expect(
+            resolveSubscriptionApiKeyV2Parent({
+                referenceType: 'API',
+                referenceId: 'api-ref',
+            }),
+        ).toEqual({ kind: 'API', apiId: 'api-ref' });
+    });
+
+    it('resolves API product parent from referenceType', () => {
+        expect(
+            resolveSubscriptionApiKeyV2Parent({
+                referenceType: 'API_PRODUCT',
+                referenceId: 'prod-1',
+            }),
+        ).toEqual({ kind: 'API_PRODUCT', apiProductId: 'prod-1' });
+    });
+
+    it('prefers apiProduct.id over referenceId', () => {
+        expect(
+            resolveSubscriptionApiKeyV2Parent({
+                apiProduct: { id: 'prod-embedded', name: 'P' },
+                referenceId: 'prod-ref',
+            }),
+        ).toEqual({ kind: 'API_PRODUCT', apiProductId: 'prod-embedded' });
+    });
+
+    it('returns null when references are missing', () => {
+        expect(resolveSubscriptionApiKeyV2Parent({})).toBeNull();
+        expect(resolveSubscriptionApiKeyV2Parent({ referenceType: 'API_PRODUCT' })).toBeNull();
+        expect(resolveSubscriptionApiKeyV2Parent({ referenceType: 'API' })).toBeNull();
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/services/applicationSubscriptions.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/services/applicationSubscriptions.ts
@@ -1,0 +1,224 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { apimFetchJsonV1Env, apimFetchJsonV2 } from '../../../shared/api/apimClient';
+import type {
+    ApiProductSearchResponse,
+    ApiSearchResponse,
+    ApplicationSubscriptionApiKeyEntity,
+    ApplicationSubscriptionEntity,
+    ApplicationSubscriptionsFilters,
+    ApplicationSubscriptionsPagedResponse,
+    CreatedApplicationSubscription,
+    NewApplicationSubscriptionPayload,
+    SubscribablePlansResponse,
+    SubscribedApi,
+    SubscriptionReferenceType,
+} from '../types/applicationSubscription';
+
+const JSON_HEADERS = { 'Content-Type': 'application/json' };
+
+/** Path parent for Management API v2 subscription API key update (same as console `ApiSubscriptionV2Service`). */
+export type SubscriptionApiKeyV2Parent = { kind: 'API'; apiId: string } | { kind: 'API_PRODUCT'; apiProductId: string };
+
+/**
+ * Resolves the Management API v2 parent resource needed to mutate API keys for
+ * subscriptions backed by either an API or an API Product.
+ */
+export function resolveSubscriptionApiKeyV2Parent(entity: ApplicationSubscriptionEntity): SubscriptionApiKeyV2Parent | null {
+    const ref: SubscriptionReferenceType | undefined = entity.referenceType;
+    if (ref === 'API_PRODUCT' || entity.apiProduct?.id) {
+        const apiProductId = entity.apiProduct?.id ?? entity.referenceId;
+        return apiProductId ? { kind: 'API_PRODUCT', apiProductId } : null;
+    }
+    const apiId = entity.api?.id ?? (ref === 'API' ? entity.referenceId : undefined);
+    return apiId ? { kind: 'API', apiId } : null;
+}
+
+export async function listApplicationSubscriptions(
+    environmentId: string,
+    applicationId: string,
+    filters: ApplicationSubscriptionsFilters | undefined,
+    page: number,
+    size: number,
+): Promise<ApplicationSubscriptionsPagedResponse> {
+    const params = new URLSearchParams({
+        page: String(page),
+        size: String(size),
+    });
+    if (filters?.status && filters.status.length > 0) {
+        params.set('status', filters.status.join(','));
+    }
+    if (filters?.apis && filters.apis.length > 0) {
+        params.set('api', filters.apis.join(','));
+    }
+    if (filters?.apiKey) {
+        params.set('api_key', filters.apiKey);
+    }
+    if (filters?.securityTypes && filters.securityTypes.length > 0) {
+        params.set('security_types', filters.securityTypes.join(','));
+    }
+
+    return apimFetchJsonV1Env<ApplicationSubscriptionsPagedResponse>(
+        environmentId,
+        `/applications/${applicationId}/subscriptions?${params}`,
+    );
+}
+
+export async function listSubscribedApis(environmentId: string, applicationId: string): Promise<SubscribedApi[]> {
+    return apimFetchJsonV1Env<SubscribedApi[]>(environmentId, `/applications/${applicationId}/subscribed`);
+}
+
+export async function searchApisForSubscription(environmentId: string, query: string, page = 1, perPage = 20): Promise<ApiSearchResponse> {
+    const params = new URLSearchParams({ page: String(page), perPage: String(perPage) });
+    return apimFetchJsonV2<ApiSearchResponse>(environmentId, `/apis/_search?${params}`, {
+        method: 'POST',
+        headers: JSON_HEADERS,
+        body: JSON.stringify({ query }),
+    });
+}
+
+export async function searchApiProductsForSubscription(
+    environmentId: string,
+    query: string,
+    page = 1,
+    perPage = 20,
+): Promise<ApiProductSearchResponse> {
+    const params = new URLSearchParams({ page: String(page), perPage: String(perPage) });
+    return apimFetchJsonV2<ApiProductSearchResponse>(environmentId, `/api-products/_search?${params}`, {
+        method: 'POST',
+        headers: JSON_HEADERS,
+        body: JSON.stringify({ query }),
+    });
+}
+
+export async function listSubscribableApiPlans(
+    environmentId: string,
+    apiId: string,
+    applicationId: string,
+): Promise<SubscribablePlansResponse> {
+    const params = new URLSearchParams({ page: '1', perPage: '9999', subscribableBy: applicationId });
+    return apimFetchJsonV2<SubscribablePlansResponse>(environmentId, `/apis/${apiId}/plans?${params}`);
+}
+
+export async function listSubscribableApiProductPlans(
+    environmentId: string,
+    apiProductId: string,
+    applicationId: string,
+): Promise<SubscribablePlansResponse> {
+    const params = new URLSearchParams({ page: '1', perPage: '9999', subscribableBy: applicationId });
+    return apimFetchJsonV2<SubscribablePlansResponse>(environmentId, `/api-products/${apiProductId}/plans?${params}`);
+}
+
+export async function createApplicationSubscription(
+    environmentId: string,
+    applicationId: string,
+    planId: string,
+    payload: NewApplicationSubscriptionPayload,
+): Promise<CreatedApplicationSubscription> {
+    const params = new URLSearchParams({ plan: planId });
+    return apimFetchJsonV1Env<CreatedApplicationSubscription>(environmentId, `/applications/${applicationId}/subscriptions?${params}`, {
+        method: 'POST',
+        headers: JSON_HEADERS,
+        body: JSON.stringify(payload),
+    });
+}
+
+export async function getApplicationSubscription(
+    environmentId: string,
+    applicationId: string,
+    subscriptionId: string,
+): Promise<ApplicationSubscriptionEntity> {
+    return apimFetchJsonV1Env<ApplicationSubscriptionEntity>(
+        environmentId,
+        `/applications/${applicationId}/subscriptions/${subscriptionId}`,
+    );
+}
+
+export async function updateApplicationSubscription(
+    environmentId: string,
+    applicationId: string,
+    subscriptionId: string,
+    subscription: ApplicationSubscriptionEntity,
+): Promise<ApplicationSubscriptionEntity> {
+    return apimFetchJsonV1Env<ApplicationSubscriptionEntity>(
+        environmentId,
+        `/applications/${applicationId}/subscriptions/${subscriptionId}`,
+        {
+            method: 'PUT',
+            headers: JSON_HEADERS,
+            body: JSON.stringify(subscription),
+        },
+    );
+}
+
+export async function closeApplicationSubscription(environmentId: string, applicationId: string, subscriptionId: string): Promise<void> {
+    await apimFetchJsonV1Env<void>(environmentId, `/applications/${applicationId}/subscriptions/${subscriptionId}`, { method: 'DELETE' });
+}
+
+export async function listSubscriptionApiKeys(
+    environmentId: string,
+    applicationId: string,
+    subscriptionId: string,
+): Promise<ApplicationSubscriptionApiKeyEntity[]> {
+    return apimFetchJsonV1Env<ApplicationSubscriptionApiKeyEntity[]>(
+        environmentId,
+        `/applications/${applicationId}/subscriptions/${subscriptionId}/apikeys`,
+    );
+}
+
+export async function renewSubscriptionApiKey(environmentId: string, applicationId: string, subscriptionId: string): Promise<void> {
+    await apimFetchJsonV1Env<void>(environmentId, `/applications/${applicationId}/subscriptions/${subscriptionId}/apikeys/_renew`, {
+        method: 'POST',
+        headers: JSON_HEADERS,
+        body: '{}',
+    });
+}
+
+export async function revokeSubscriptionApiKey(
+    environmentId: string,
+    applicationId: string,
+    subscriptionId: string,
+    apiKeyId: string,
+): Promise<void> {
+    await apimFetchJsonV1Env<void>(
+        environmentId,
+        `/applications/${applicationId}/subscriptions/${subscriptionId}/apikeys/${encodeURIComponent(apiKeyId)}`,
+        { method: 'DELETE' },
+    );
+}
+
+export async function expireSubscriptionApiKey(
+    environmentId: string,
+    parent: SubscriptionApiKeyV2Parent | null,
+    subscriptionId: string,
+    apiKeyId: string,
+    expireAt: Date,
+): Promise<void> {
+    if (!parent) {
+        throw new Error('Missing API/product context for expiring this key');
+    }
+    const encodedSub = encodeURIComponent(subscriptionId);
+    const encodedKey = encodeURIComponent(apiKeyId);
+    const path =
+        parent.kind === 'API'
+            ? `/apis/${encodeURIComponent(parent.apiId)}/subscriptions/${encodedSub}/api-keys/${encodedKey}`
+            : `/api-products/${encodeURIComponent(parent.apiProductId)}/subscriptions/${encodedSub}/api-keys/${encodedKey}`;
+    await apimFetchJsonV2<unknown>(environmentId, path, {
+        method: 'PUT',
+        headers: JSON_HEADERS,
+        body: JSON.stringify({ expireAt: expireAt.toISOString() }),
+    });
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/services/environmentPortal.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/services/environmentPortal.spec.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { isSharedApiKeyEnabled } from './environmentPortal';
+
+describe('environmentPortal', () => {
+    it('detects shared API key feature flag', () => {
+        expect(isSharedApiKeyEnabled({ plan: { security: { sharedApiKey: { enabled: true } } } })).toBe(true);
+        expect(isSharedApiKeyEnabled({ plan: { security: { sharedApiKey: { enabled: false } } } })).toBe(false);
+        expect(isSharedApiKeyEnabled(null)).toBe(false);
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/services/environmentPortal.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/services/environmentPortal.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { apimFetchJsonV1Env } from '../../../shared/api/apimClient';
+
+/** Subset of GET /environments/{envId}/portal (console EnvSettings). */
+export interface EnvironmentPortalConfiguration {
+    plan?: {
+        security?: {
+            sharedApiKey?: {
+                enabled?: boolean;
+            };
+        };
+    };
+}
+
+export async function getEnvironmentPortalConfiguration(environmentId: string): Promise<EnvironmentPortalConfiguration> {
+    return apimFetchJsonV1Env<EnvironmentPortalConfiguration>(environmentId, '/portal');
+}
+
+export function isSharedApiKeyEnabled(config: EnvironmentPortalConfiguration | null | undefined): boolean {
+    return Boolean(config?.plan?.security?.sharedApiKey?.enabled);
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/types/applicationSubscription.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/types/applicationSubscription.ts
@@ -1,0 +1,219 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import type { ApiKeyMode } from './application';
+
+export type SubscriptionStatus = 'PENDING' | 'REJECTED' | 'ACCEPTED' | 'CLOSED' | 'PAUSED' | 'RESUMED';
+
+export type SubscriptionOrigin = 'KUBERNETES' | 'MANAGEMENT';
+
+export type SubscriptionReferenceType = 'API' | 'API_PRODUCT';
+
+export interface SubscriptionPageItem {
+    id?: string;
+    api?: string;
+    plan?: string;
+    application?: string;
+    status?: SubscriptionStatus;
+    processed_at?: number | string;
+    starting_at?: number | string;
+    ending_at?: number | string;
+    created_at?: number | string;
+    security?: string;
+    origin?: SubscriptionOrigin;
+    referenceType?: SubscriptionReferenceType;
+    referenceId?: string;
+}
+
+export interface SubscribedApi {
+    id?: string;
+    name?: string;
+}
+
+export interface ApplicationSubscriptionsFilters {
+    status?: SubscriptionStatus[];
+    apiKey?: string;
+    apis?: string[];
+    securityTypes?: string[];
+}
+
+export interface ApplicationSubscriptionsPagedResponse {
+    data: SubscriptionPageItem[];
+    metadata?: Record<string, Record<string, unknown>>;
+    page: {
+        current: number;
+        size: number;
+        per_page: number;
+        total_pages: number;
+        total_elements: number;
+    };
+}
+
+export interface NewApplicationSubscriptionPayload {
+    request: string;
+    apiKeyMode?: ApiKeyMode;
+}
+
+export interface CreatedApplicationSubscription {
+    id?: string;
+}
+
+export interface ApiSearchHit {
+    id: string;
+    name: string;
+    apiVersion?: string;
+    definitionVersion?: string;
+    primaryOwner?: { displayName?: string };
+}
+
+export interface ApiProductSearchHit {
+    id: string;
+    name: string;
+    version?: string;
+    primaryOwner?: { displayName?: string };
+}
+
+export type SubscriptionSearchResultItem = { type: 'API'; value: ApiSearchHit } | { type: 'API_PRODUCT'; value: ApiProductSearchHit };
+
+export interface ApiSearchResponse {
+    data: ApiSearchHit[];
+}
+
+export interface ApiProductSearchResponse {
+    data: ApiProductSearchHit[];
+}
+
+export type SubscriptionReferenceSelection =
+    | { type: 'API'; id: string; name: string; version?: string; isFederated?: boolean }
+    | { type: 'API_PRODUCT'; id: string; name: string; version?: string };
+
+export interface SubscribablePlan {
+    id: string;
+    name: string;
+    security?: { type?: string };
+    generalConditions?: string | null;
+    commentRequired?: boolean;
+    mode?: string;
+    apiId?: string;
+    apiProductId?: string;
+    definitionVersion?: string;
+}
+
+export interface SubscribablePlansResponse {
+    data: SubscribablePlan[];
+}
+
+export interface ApplicationSubscriptionEntity {
+    id?: string;
+    api?: {
+        id: string;
+        name: string;
+        version?: string;
+        definitionVersion?: string;
+    };
+    apiProduct?: {
+        id: string;
+        name: string;
+        version?: string;
+    };
+    plan?: {
+        id: string;
+        name: string;
+        security?: string;
+    };
+    status?: SubscriptionStatus;
+    processed_at?: number | string;
+    processed_by?: string;
+    subscribed_by?: { id?: string; displayName?: string };
+    request?: string;
+    reason?: string;
+    starting_at?: number | string;
+    ending_at?: number | string;
+    created_at?: number | string;
+    updated_at?: number | string;
+    paused_at?: number | string;
+    closed_at?: number | string;
+    security?: string;
+    origin?: SubscriptionOrigin;
+    referenceType?: SubscriptionReferenceType;
+    referenceId?: string;
+    metadata?: Record<string, string>;
+}
+
+export interface ApplicationSubscriptionCloseTarget {
+    id: string;
+    referenceTypeLabel: string;
+    securityType: string;
+    isSharedApiKey: boolean;
+}
+
+export interface ApplicationSubscriptionApiKeyEntity {
+    id: string;
+    key?: string;
+    revoked?: boolean;
+    revoked_at?: number;
+    expired?: boolean;
+    expire_at?: number;
+    created_at?: number;
+}
+
+export interface ApplicationSubscriptionApiKeyRow {
+    id: string;
+    key: string;
+    maskedKey: string;
+    isValid: boolean;
+    createdAt?: number;
+    /** Revoked at when revoked, otherwise expire at (console `endDate`). */
+    endDate?: number;
+    /** Epoch ms from API when present — used to pre-fill the expire dialog. */
+    expireAt?: number;
+}
+
+export interface ApplicationSubscriptionDetail {
+    id: string;
+    apiDisplay: string;
+    referenceTypeLabel: string;
+    planName: string;
+    securityType: string;
+    status: SubscriptionStatus;
+    subscribedBy: string;
+    request?: string;
+    reason?: string;
+    createdAt?: number | string;
+    processedAt?: number | string;
+    startingAt?: number | string;
+    pausedAt?: number | string;
+    endingAt?: number | string;
+    closedAt?: number | string;
+    origin: SubscriptionOrigin;
+    isSharedApiKey: boolean;
+    metadata?: Record<string, string>;
+}
+
+export interface ApplicationSubscriptionTableRow {
+    id: string;
+    planName: string;
+    securityType: string;
+    isSharedApiKey: boolean;
+    apiName: string;
+    apiVersion?: string;
+    referenceTypeLabel: string;
+    createdAt?: number | string;
+    processedAt?: number | string;
+    startingAt?: number | string;
+    endAt?: number | string;
+    status: SubscriptionStatus;
+    origin: SubscriptionOrigin;
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/utils/applicationSubscriptionApiKeyExpireUtils.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/utils/applicationSubscriptionApiKeyExpireUtils.spec.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { canSubmitApiKeyExpirationChange, isAfterMinCandidate, parseDatetimeLocalValue } from './applicationSubscriptionApiKeyExpireUtils';
+
+describe('applicationSubscriptionApiKeyExpireUtils', () => {
+    const minMs = new Date('2025-06-01T12:00:00').getTime();
+
+    it('accepts only future datetimes', () => {
+        expect(isAfterMinCandidate('2024-01-01T00:00', minMs)).toBe(false);
+        expect(isAfterMinCandidate('invalid', minMs)).toBe(false);
+        expect(isAfterMinCandidate('2025-02-31T12:00', minMs)).toBe(false);
+        expect(isAfterMinCandidate('2025-99-99T12:00', minMs)).toBe(false);
+        expect(isAfterMinCandidate('2099-06-15T12:00', minMs)).toBe(true);
+    });
+
+    it('parses only valid datetime-local values', () => {
+        expect(parseDatetimeLocalValue('2025-06-15T12:30')?.toISOString()).toBe(new Date(2025, 5, 15, 12, 30).toISOString());
+        expect(parseDatetimeLocalValue('2025-02-31T12:00')).toBeNull();
+        expect(parseDatetimeLocalValue('2025-06-15')).toBeNull();
+    });
+
+    it('requires dirty state and non-empty value to submit', () => {
+        expect(canSubmitApiKeyExpirationChange(false, '2099-06-15T12:00', minMs)).toBe(false);
+        expect(canSubmitApiKeyExpirationChange(true, '', minMs)).toBe(false);
+        expect(canSubmitApiKeyExpirationChange(true, '2099-06-15T12:00', minMs)).toBe(true);
+        expect(canSubmitApiKeyExpirationChange(true, '2020-01-01T00:00', minMs)).toBe(false);
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/utils/applicationSubscriptionApiKeyExpireUtils.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/utils/applicationSubscriptionApiKeyExpireUtils.ts
@@ -1,0 +1,50 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+export function parseDatetimeLocalValue(value: string): Date | null {
+    const match = /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2})$/.exec(value);
+    if (!match) {
+        return null;
+    }
+
+    const [, yearValue, monthValue, dayValue, hourValue, minuteValue] = match;
+    const year = Number(yearValue);
+    const month = Number(monthValue);
+    const day = Number(dayValue);
+    const hour = Number(hourValue);
+    const minute = Number(minuteValue);
+    const date = new Date(year, month - 1, day, hour, minute);
+
+    if (
+        date.getFullYear() !== year ||
+        date.getMonth() !== month - 1 ||
+        date.getDate() !== day ||
+        date.getHours() !== hour ||
+        date.getMinutes() !== minute
+    ) {
+        return null;
+    }
+
+    return date;
+}
+
+export function isAfterMinCandidate(value: string, minMs: number): boolean {
+    const date = parseDatetimeLocalValue(value);
+    return Boolean(date && date.getTime() > minMs);
+}
+
+export function canSubmitApiKeyExpirationChange(dirty: boolean, value: string, minMs: number): boolean {
+    return dirty && value !== '' && isAfterMinCandidate(value, minMs);
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/utils/applicationSubscriptionApiKeyMapper.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/utils/applicationSubscriptionApiKeyMapper.spec.ts
@@ -1,0 +1,52 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { mapApiKeyEntityToRow, mapApiKeysToRows, maskApiKey } from './applicationSubscriptionApiKeyMapper';
+
+describe('applicationSubscriptionApiKeyMapper', () => {
+    describe('maskApiKey', () => {
+        it('masks keys longer than four characters', () => {
+            expect(maskApiKey('abcdefghij')).toBe('••••••••ghij');
+        });
+
+        it('returns short keys unchanged', () => {
+            expect(maskApiKey('ab')).toBe('ab');
+        });
+    });
+
+    describe('mapApiKeyEntityToRow', () => {
+        it('returns null without id or key', () => {
+            expect(mapApiKeyEntityToRow({ id: 'k1' })).toBeNull();
+            expect(mapApiKeyEntityToRow({ key: 'secret' })).toBeNull();
+        });
+
+        it('marks revoked and expired keys as invalid', () => {
+            expect(mapApiKeyEntityToRow({ id: '1', key: 'active-key-1234', revoked: true })?.isValid).toBe(false);
+            expect(mapApiKeyEntityToRow({ id: '2', key: 'expired-key-1234', expired: true })?.isValid).toBe(false);
+            expect(mapApiKeyEntityToRow({ id: '3', key: 'valid-key-1234' })?.isValid).toBe(true);
+        });
+
+        it('uses revoked_at as endDate when revoked', () => {
+            const row = mapApiKeyEntityToRow({ id: '1', key: 'key-1234', revoked: true, revoked_at: 99 });
+            expect(row?.endDate).toBe(99);
+        });
+    });
+
+    describe('mapApiKeysToRows', () => {
+        it('filters invalid entities', () => {
+            expect(mapApiKeysToRows([{ id: '1', key: 'abc' }, { id: '2' }])).toHaveLength(1);
+        });
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/utils/applicationSubscriptionApiKeyMapper.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/utils/applicationSubscriptionApiKeyMapper.ts
@@ -1,0 +1,43 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import type { ApplicationSubscriptionApiKeyEntity, ApplicationSubscriptionApiKeyRow } from '../types/applicationSubscription';
+
+export function maskApiKey(key: string): string {
+    if (key.length <= 4) {
+        return key;
+    }
+    return `${'•'.repeat(8)}${key.slice(-4)}`;
+}
+
+export function mapApiKeyEntityToRow(entity: ApplicationSubscriptionApiKeyEntity): ApplicationSubscriptionApiKeyRow | null {
+    if (!entity.id || !entity.key) {
+        return null;
+    }
+
+    return {
+        id: entity.id,
+        key: entity.key,
+        maskedKey: maskApiKey(entity.key),
+        isValid: !entity.revoked && !entity.expired,
+        createdAt: entity.created_at,
+        endDate: entity.revoked ? entity.revoked_at : entity.expire_at,
+        expireAt: entity.expire_at,
+    };
+}
+
+export function mapApiKeysToRows(entities: ApplicationSubscriptionApiKeyEntity[]): ApplicationSubscriptionApiKeyRow[] {
+    return entities.map(mapApiKeyEntityToRow).filter((row): row is ApplicationSubscriptionApiKeyRow => row !== null);
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/utils/applicationSubscriptionConstants.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/utils/applicationSubscriptionConstants.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import type { SubscriptionStatus } from '../types/applicationSubscription';
+
+export const SUBSCRIPTION_STATUS_OPTIONS: { id: SubscriptionStatus; name: string }[] = [
+    { id: 'ACCEPTED', name: 'Accepted' },
+    { id: 'CLOSED', name: 'Closed' },
+    { id: 'PAUSED', name: 'Paused' },
+    { id: 'PENDING', name: 'Pending' },
+    { id: 'REJECTED', name: 'Rejected' },
+    { id: 'RESUMED', name: 'Resumed' },
+];
+
+export const DEFAULT_SUBSCRIPTION_FILTER_STATUSES: SubscriptionStatus[] = ['ACCEPTED', 'PAUSED', 'PENDING', 'RESUMED'];

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/utils/applicationSubscriptionCreateUtils.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/utils/applicationSubscriptionCreateUtils.spec.ts
@@ -1,0 +1,119 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+    buildSubscriptionCreatePayload,
+    getSubscriptionCreateValidationError,
+    isPlanDisabled,
+    planDisabledReason,
+    shouldShowApiKeyModeChoice,
+    subscriptionMatchesPlan,
+} from './applicationSubscriptionCreateUtils';
+import type { SubscribablePlan, SubscriptionPageItem } from '../types/applicationSubscription';
+
+const enabledPlan: SubscribablePlan = { id: 'p1', name: 'Standard', security: { type: 'API_KEY' } };
+
+const apiReference = { type: 'API' as const, id: 'api-1', name: 'Payments' };
+const productReference = { type: 'API_PRODUCT' as const, id: 'prod-1', name: 'Billing' };
+
+describe('applicationSubscriptionCreateUtils', () => {
+    describe('subscriptionMatchesPlan', () => {
+        it('matches API subscriptions by api id', () => {
+            expect(subscriptionMatchesPlan({ api: 'api-1' }, apiReference)).toBe(true);
+            expect(subscriptionMatchesPlan({ api: 'other' }, apiReference)).toBe(false);
+        });
+
+        it('matches API product subscriptions by reference', () => {
+            expect(subscriptionMatchesPlan({ referenceType: 'API_PRODUCT', referenceId: 'prod-1' }, productReference)).toBe(true);
+            expect(subscriptionMatchesPlan({ referenceType: 'API_PRODUCT', referenceId: 'other' }, productReference)).toBe(false);
+        });
+    });
+
+    describe('shouldShowApiKeyModeChoice', () => {
+        const existingApiKeySub: SubscriptionPageItem = { id: 's1', api: 'other-api', status: 'ACCEPTED' };
+
+        it('shows choice for UNSPECIFIED app with existing API key sub on another API', () => {
+            expect(
+                shouldShowApiKeyModeChoice({
+                    applicationApiKeyMode: 'UNSPECIFIED',
+                    planSecurityType: 'API_KEY',
+                    canUseSharedApiKeys: true,
+                    isFederatedApi: false,
+                    selectedReference: apiReference,
+                    apiKeySubscriptions: [existingApiKeySub],
+                }),
+            ).toBe(true);
+        });
+
+        it('hides choice for first API key subscription', () => {
+            expect(
+                shouldShowApiKeyModeChoice({
+                    applicationApiKeyMode: 'UNSPECIFIED',
+                    planSecurityType: 'API_KEY',
+                    canUseSharedApiKeys: true,
+                    isFederatedApi: false,
+                    selectedReference: apiReference,
+                    apiKeySubscriptions: [],
+                }),
+            ).toBe(false);
+        });
+
+        it('hides choice when shared API keys are disabled', () => {
+            expect(
+                shouldShowApiKeyModeChoice({
+                    applicationApiKeyMode: 'UNSPECIFIED',
+                    planSecurityType: 'API_KEY',
+                    canUseSharedApiKeys: false,
+                    isFederatedApi: false,
+                    selectedReference: apiReference,
+                    apiKeySubscriptions: [existingApiKeySub],
+                }),
+            ).toBe(false);
+        });
+    });
+
+    describe('buildSubscriptionCreatePayload', () => {
+        it('includes apiKeyMode only when the choice is shown', () => {
+            expect(buildSubscriptionCreatePayload('hello', true, 'SHARED')).toEqual({
+                request: 'hello',
+                apiKeyMode: 'SHARED',
+            });
+            expect(buildSubscriptionCreatePayload('hello', false, 'SHARED')).toEqual({ request: 'hello' });
+        });
+    });
+
+    it('disables plans with general conditions or PUSH mode', () => {
+        expect(isPlanDisabled({ ...enabledPlan, generalConditions: 'terms' })).toBe(true);
+        expect(isPlanDisabled({ ...enabledPlan, mode: 'PUSH' })).toBe(true);
+        expect(isPlanDisabled(enabledPlan)).toBe(false);
+    });
+
+    it('returns human-readable disabled reasons', () => {
+        expect(planDisabledReason({ ...enabledPlan, generalConditions: 'x' })).toContain('portal');
+        expect(planDisabledReason({ ...enabledPlan, mode: 'PUSH' })).toContain('Push plan');
+        expect(planDisabledReason(enabledPlan)).toBeUndefined();
+    });
+
+    it('requires a request message when commentRequired is set', () => {
+        const plan = { ...enabledPlan, commentRequired: true };
+        expect(getSubscriptionCreateValidationError(plan, '', false, null)).toContain('message to the API owner');
+        expect(getSubscriptionCreateValidationError(plan, 'Need access', false, null)).toBeNull();
+    });
+
+    it('requires apiKeyMode when the choice is shown', () => {
+        expect(getSubscriptionCreateValidationError(enabledPlan, '', true, null)).toContain('Choose whether');
+        expect(getSubscriptionCreateValidationError(enabledPlan, '', true, 'EXCLUSIVE')).toBeNull();
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/utils/applicationSubscriptionCreateUtils.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/utils/applicationSubscriptionCreateUtils.ts
@@ -1,0 +1,100 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import type { ApiKeyMode } from '../types/application';
+import type {
+    NewApplicationSubscriptionPayload,
+    SubscribablePlan,
+    SubscriptionPageItem,
+    SubscriptionReferenceSelection,
+} from '../types/applicationSubscription';
+
+export function isPlanDisabled(plan: SubscribablePlan): boolean {
+    return Boolean(plan.generalConditions) || plan.mode === 'PUSH';
+}
+
+export function planDisabledReason(plan: SubscribablePlan): string | undefined {
+    if (plan.generalConditions) {
+        return 'Plans with general conditions can only be subscribed through the portal.';
+    }
+    if (plan.mode === 'PUSH') {
+        return 'Push plan subscriptions require additional configuration.';
+    }
+    return undefined;
+}
+
+export function subscriptionMatchesPlan(
+    subscription: Pick<SubscriptionPageItem, 'api' | 'referenceType' | 'referenceId'>,
+    reference: SubscriptionReferenceSelection,
+): boolean {
+    if (reference.type === 'API') {
+        return subscription.api === reference.id;
+    }
+    return subscription.referenceType === 'API_PRODUCT' && subscription.referenceId === reference.id;
+}
+
+/**
+ * Prompts for exclusive vs shared API keys only when the first API-key subscription
+ * would make the application mode ambiguous.
+ */
+export function shouldShowApiKeyModeChoice(params: {
+    applicationApiKeyMode: ApiKeyMode | undefined;
+    planSecurityType: string | undefined;
+    canUseSharedApiKeys: boolean;
+    isFederatedApi: boolean;
+    selectedReference: SubscriptionReferenceSelection | null;
+    apiKeySubscriptions: SubscriptionPageItem[];
+}): boolean {
+    const { applicationApiKeyMode, planSecurityType, canUseSharedApiKeys, isFederatedApi, selectedReference, apiKeySubscriptions } = params;
+
+    if (!selectedReference || planSecurityType !== 'API_KEY' || isFederatedApi || !canUseSharedApiKeys) {
+        return false;
+    }
+    if (applicationApiKeyMode !== 'UNSPECIFIED') {
+        return false;
+    }
+
+    return apiKeySubscriptions.some(subscription => !subscriptionMatchesPlan(subscription, selectedReference));
+}
+
+export function buildSubscriptionCreatePayload(
+    request: string,
+    showApiKeyModeChoice: boolean,
+    apiKeyMode: ApiKeyMode | null,
+): NewApplicationSubscriptionPayload {
+    const payload: NewApplicationSubscriptionPayload = { request: request.trim() };
+    if (showApiKeyModeChoice && apiKeyMode) {
+        payload.apiKeyMode = apiKeyMode;
+    }
+    return payload;
+}
+
+export function getSubscriptionCreateValidationError(
+    plan: SubscribablePlan,
+    request: string,
+    showApiKeyModeChoice: boolean,
+    apiKeyMode: ApiKeyMode | null,
+): string | null {
+    if (isPlanDisabled(plan)) {
+        return planDisabledReason(plan) ?? 'This plan cannot be subscribed.';
+    }
+    if (plan.commentRequired && !request.trim()) {
+        return 'The message to the API owner is required';
+    }
+    if (showApiKeyModeChoice && !apiKeyMode) {
+        return 'Choose whether to use a dedicated API key or a shared API key for this application.';
+    }
+    return null;
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/utils/applicationSubscriptionDetailMapper.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/utils/applicationSubscriptionDetailMapper.spec.ts
@@ -1,0 +1,84 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { mapDetailToCloseTarget, mapSubscriptionEntityToDetail } from './applicationSubscriptionDetailMapper';
+import type { ApplicationSubscriptionEntity } from '../types/applicationSubscription';
+
+const baseEntity: ApplicationSubscriptionEntity = {
+    id: 'sub-1',
+    status: 'ACCEPTED',
+    api: { id: 'api-1', name: 'Payments', version: 'v2' },
+    plan: { id: 'plan-1', name: 'Gold', security: 'API_KEY' },
+    subscribed_by: { displayName: 'Alice' },
+    origin: 'MANAGEMENT',
+};
+
+describe('applicationSubscriptionDetailMapper', () => {
+    it('returns null when id or status is missing', () => {
+        expect(mapSubscriptionEntityToDetail({ ...baseEntity, id: undefined }, 'EXCLUSIVE')).toBeNull();
+        expect(mapSubscriptionEntityToDetail({ ...baseEntity, status: undefined }, 'EXCLUSIVE')).toBeNull();
+    });
+
+    it('maps API subscription detail with version in display name', () => {
+        const detail = mapSubscriptionEntityToDetail(baseEntity, 'EXCLUSIVE');
+        expect(detail).toMatchObject({
+            id: 'sub-1',
+            apiDisplay: 'Payments — v2',
+            referenceTypeLabel: 'API',
+            planName: 'Gold',
+            securityType: 'API Key',
+            subscribedBy: 'Alice',
+            isSharedApiKey: false,
+        });
+    });
+
+    it('detects API product via referenceType or apiProduct', () => {
+        const byRef = mapSubscriptionEntityToDetail({ ...baseEntity, referenceType: 'API_PRODUCT', api: undefined }, undefined);
+        const byProduct = mapSubscriptionEntityToDetail(
+            {
+                ...baseEntity,
+                api: undefined,
+                apiProduct: { id: 'prod-1', name: 'Billing' },
+            },
+            undefined,
+        );
+        expect(byRef?.referenceTypeLabel).toBe('API Product');
+        expect(byProduct?.referenceTypeLabel).toBe('API Product');
+        expect(byProduct?.apiDisplay).toBe('Billing');
+    });
+
+    it('sets isSharedApiKey for SHARED mode and API_KEY plan security', () => {
+        expect(mapSubscriptionEntityToDetail(baseEntity, 'SHARED')?.isSharedApiKey).toBe(true);
+        expect(mapSubscriptionEntityToDetail(baseEntity, 'EXCLUSIVE')?.isSharedApiKey).toBe(false);
+        expect(
+            mapSubscriptionEntityToDetail({ ...baseEntity, plan: { id: 'p', name: 'J', security: 'JWT' } }, 'SHARED')?.isSharedApiKey,
+        ).toBe(false);
+    });
+
+    it('passes subscription metadata through', () => {
+        const detail = mapSubscriptionEntityToDetail({ ...baseEntity, metadata: { env: 'prod' } }, 'EXCLUSIVE');
+        expect(detail?.metadata).toEqual({ env: 'prod' });
+    });
+
+    it('maps detail to close target', () => {
+        const detail = mapSubscriptionEntityToDetail(baseEntity, 'EXCLUSIVE')!;
+        expect(mapDetailToCloseTarget(detail)).toEqual({
+            id: 'sub-1',
+            referenceTypeLabel: 'API',
+            securityType: 'API Key',
+            isSharedApiKey: false,
+        });
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/utils/applicationSubscriptionDetailMapper.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/utils/applicationSubscriptionDetailMapper.ts
@@ -1,0 +1,70 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { formatSubscriptionSecurityType } from './applicationSubscriptionMapper';
+import type { ApiKeyMode } from '../types/application';
+import type {
+    ApplicationSubscriptionCloseTarget,
+    ApplicationSubscriptionDetail,
+    ApplicationSubscriptionEntity,
+} from '../types/applicationSubscription';
+
+export function mapSubscriptionEntityToDetail(
+    subscription: ApplicationSubscriptionEntity,
+    apiKeyMode: ApiKeyMode | undefined,
+): ApplicationSubscriptionDetail | null {
+    if (!subscription.id || !subscription.status) return null;
+
+    const isApiProduct = subscription.referenceType === 'API_PRODUCT' || Boolean(subscription.apiProduct);
+    const apiRef = subscription.api ?? subscription.apiProduct;
+    const apiDisplay = apiRef ? (apiRef.version ? `${apiRef.name} — ${apiRef.version}` : apiRef.name) : (subscription.referenceId ?? '—');
+
+    const planSecurity = subscription.plan?.security;
+    const securityType = planSecurity
+        ? formatSubscriptionSecurityType(planSecurity)
+        : subscription.security
+          ? formatSubscriptionSecurityType(subscription.security)
+          : '—';
+
+    return {
+        id: subscription.id,
+        apiDisplay,
+        referenceTypeLabel: isApiProduct ? 'API Product' : 'API',
+        planName: subscription.plan?.name ?? '—',
+        securityType,
+        status: subscription.status,
+        subscribedBy: subscription.subscribed_by?.displayName ?? '—',
+        request: subscription.request,
+        reason: subscription.reason,
+        createdAt: subscription.created_at,
+        processedAt: subscription.processed_at,
+        startingAt: subscription.starting_at,
+        pausedAt: subscription.paused_at,
+        endingAt: subscription.ending_at,
+        closedAt: subscription.closed_at,
+        origin: subscription.origin ?? 'MANAGEMENT',
+        isSharedApiKey: apiKeyMode === 'SHARED' && planSecurity === 'API_KEY',
+        metadata: subscription.metadata,
+    };
+}
+
+export function mapDetailToCloseTarget(detail: ApplicationSubscriptionDetail): ApplicationSubscriptionCloseTarget {
+    return {
+        id: detail.id,
+        referenceTypeLabel: detail.referenceTypeLabel,
+        securityType: detail.securityType,
+        isSharedApiKey: detail.isSharedApiKey,
+    };
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/utils/applicationSubscriptionListSearchParams.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/utils/applicationSubscriptionListSearchParams.spec.ts
@@ -1,0 +1,74 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+    buildApplicationSubscriptionListSearchParams,
+    parseApplicationSubscriptionListSearchParams,
+} from './applicationSubscriptionListSearchParams';
+
+describe('applicationSubscriptionListSearchParams', () => {
+    it('parses console-aligned query params', () => {
+        const params = new URLSearchParams('page=2&size=25&status=ACCEPTED,CLOSED&apis=api-1,api-2&apiKey=key-abc');
+        expect(parseApplicationSubscriptionListSearchParams(params)).toEqual({
+            page: 2,
+            pageSize: 25,
+            apiFilters: ['api-1', 'api-2'],
+            statusFilters: ['ACCEPTED', 'CLOSED'],
+            apiKeyInput: 'key-abc',
+        });
+    });
+
+    it('falls back to defaults when params are missing or invalid', () => {
+        expect(parseApplicationSubscriptionListSearchParams(new URLSearchParams())).toEqual({
+            page: 1,
+            pageSize: 10,
+            apiFilters: [],
+            statusFilters: ['ACCEPTED', 'PAUSED', 'PENDING', 'RESUMED'],
+            apiKeyInput: '',
+        });
+        expect(parseApplicationSubscriptionListSearchParams(new URLSearchParams('page=0&size=-1'))).toMatchObject({
+            page: 1,
+            pageSize: 10,
+        });
+    });
+
+    it('omits default values when building search params', () => {
+        const built = buildApplicationSubscriptionListSearchParams({
+            page: 1,
+            pageSize: 10,
+            apiFilters: [],
+            statusFilters: ['ACCEPTED', 'PAUSED', 'PENDING', 'RESUMED'],
+            apiKeyInput: '',
+        });
+        expect(built.get('status')).toBe('ACCEPTED,PAUSED,PENDING,RESUMED');
+        expect(built.get('page')).toBeNull();
+        expect(built.get('size')).toBeNull();
+    });
+
+    it('serializes non-default filters', () => {
+        const built = buildApplicationSubscriptionListSearchParams({
+            page: 3,
+            pageSize: 50,
+            apiFilters: ['a1'],
+            statusFilters: ['CLOSED'],
+            apiKeyInput: 'k1',
+        });
+        expect(built.get('page')).toBe('3');
+        expect(built.get('size')).toBe('50');
+        expect(built.get('apis')).toBe('a1');
+        expect(built.get('status')).toBe('CLOSED');
+        expect(built.get('apiKey')).toBe('k1');
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/utils/applicationSubscriptionListSearchParams.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/utils/applicationSubscriptionListSearchParams.ts
@@ -1,0 +1,63 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { DEFAULT_SUBSCRIPTION_FILTER_STATUSES } from './applicationSubscriptionConstants';
+import type { SubscriptionStatus } from '../types/applicationSubscription';
+
+export interface ApplicationSubscriptionListUrlState {
+    page: number;
+    pageSize: number;
+    apiFilters: string[];
+    statusFilters: SubscriptionStatus[];
+    apiKeyInput: string;
+}
+
+const DEFAULT_PAGE_SIZE = 10;
+
+function parsePositiveInt(value: string | null, fallback: number): number {
+    if (!value) return fallback;
+    const parsed = Number(value);
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function parseStatusFilters(raw: string | null): SubscriptionStatus[] {
+    if (!raw) return [...DEFAULT_SUBSCRIPTION_FILTER_STATUSES];
+    const values = raw.split(',').filter(Boolean) as SubscriptionStatus[];
+    return values.length > 0 ? values : [...DEFAULT_SUBSCRIPTION_FILTER_STATUSES];
+}
+
+/** Reads subscription list filters from the URL (console: page, size, status, apis, apiKey). */
+export function parseApplicationSubscriptionListSearchParams(params: URLSearchParams): ApplicationSubscriptionListUrlState {
+    return {
+        page: parsePositiveInt(params.get('page'), 1),
+        pageSize: parsePositiveInt(params.get('size'), DEFAULT_PAGE_SIZE),
+        apiFilters: params.get('apis')?.split(',').filter(Boolean) ?? [],
+        statusFilters: parseStatusFilters(params.get('status')),
+        apiKeyInput: params.get('apiKey') ?? '',
+    };
+}
+
+/** Writes subscription list filters to the URL; omits default values to keep URLs short. */
+export function buildApplicationSubscriptionListSearchParams(state: ApplicationSubscriptionListUrlState): URLSearchParams {
+    const next = new URLSearchParams();
+
+    if (state.page > 1) next.set('page', String(state.page));
+    if (state.pageSize !== DEFAULT_PAGE_SIZE) next.set('size', String(state.pageSize));
+    if (state.apiFilters.length > 0) next.set('apis', state.apiFilters.join(','));
+    if (state.statusFilters.length > 0) next.set('status', state.statusFilters.join(','));
+    if (state.apiKeyInput.trim()) next.set('apiKey', state.apiKeyInput.trim());
+
+    return next;
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/utils/applicationSubscriptionMapper.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/utils/applicationSubscriptionMapper.spec.ts
@@ -1,0 +1,141 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+    canCloseSubscription,
+    formatSubscriptionSecurityType,
+    mapSubscriptionToTableRow,
+    mapSubscriptionsPageToRows,
+} from './applicationSubscriptionMapper';
+import type { ApplicationSubscriptionsPagedResponse, SubscriptionPageItem } from '../types/applicationSubscription';
+
+const baseSubscription: SubscriptionPageItem = {
+    id: 'sub-1',
+    plan: 'plan-1',
+    api: 'api-1',
+    status: 'ACCEPTED',
+    created_at: 1000,
+    origin: 'MANAGEMENT',
+};
+
+const metadata: ApplicationSubscriptionsPagedResponse['metadata'] = {
+    'plan-1': { name: 'Gold', securityType: 'API_KEY' },
+    'api-1': { name: 'Payments API', apiVersion: 'v1' },
+    'product-1': { name: 'Billing Product', apiVersion: '2.0' },
+};
+
+describe('applicationSubscriptionMapper', () => {
+    describe('formatSubscriptionSecurityType', () => {
+        it('maps known security types', () => {
+            expect(formatSubscriptionSecurityType('API_KEY')).toBe('API Key');
+            expect(formatSubscriptionSecurityType('JWT')).toBe('JWT');
+        });
+
+        it('returns the raw value for unknown types', () => {
+            expect(formatSubscriptionSecurityType('CUSTOM')).toBe('CUSTOM');
+        });
+    });
+
+    describe('canCloseSubscription', () => {
+        it('allows close for accepted, pending, paused, and resumed', () => {
+            expect(canCloseSubscription('ACCEPTED')).toBe(true);
+            expect(canCloseSubscription('PENDING')).toBe(true);
+            expect(canCloseSubscription('PAUSED')).toBe(true);
+            expect(canCloseSubscription('RESUMED')).toBe(true);
+        });
+
+        it('disallows close for closed and rejected', () => {
+            expect(canCloseSubscription('CLOSED')).toBe(false);
+            expect(canCloseSubscription('REJECTED')).toBe(false);
+            expect(canCloseSubscription(undefined)).toBe(false);
+        });
+    });
+
+    describe('mapSubscriptionToTableRow', () => {
+        it('returns null when id or status is missing', () => {
+            expect(mapSubscriptionToTableRow({ ...baseSubscription, id: undefined }, metadata, 'EXCLUSIVE')).toBeNull();
+            expect(mapSubscriptionToTableRow({ ...baseSubscription, status: undefined }, metadata, 'EXCLUSIVE')).toBeNull();
+        });
+
+        it('maps API subscription with metadata and exclusive API key mode', () => {
+            const row = mapSubscriptionToTableRow(baseSubscription, metadata, 'EXCLUSIVE');
+            expect(row).toEqual({
+                id: 'sub-1',
+                apiName: 'Payments API',
+                apiVersion: 'v1',
+                referenceTypeLabel: 'API',
+                createdAt: 1000,
+                endAt: undefined,
+                planName: 'Gold',
+                securityType: 'API Key',
+                isSharedApiKey: false,
+                processedAt: undefined,
+                startingAt: undefined,
+                status: 'ACCEPTED',
+                origin: 'MANAGEMENT',
+            });
+        });
+
+        it('sets isSharedApiKey only for API_KEY plans in SHARED application mode', () => {
+            const shared = mapSubscriptionToTableRow(baseSubscription, metadata, 'SHARED');
+            const exclusive = mapSubscriptionToTableRow(baseSubscription, metadata, 'EXCLUSIVE');
+            const jwtPlan = mapSubscriptionToTableRow(baseSubscription, { 'plan-1': { securityType: 'JWT' }, 'api-1': {} }, 'SHARED');
+
+            expect(shared?.isSharedApiKey).toBe(true);
+            expect(exclusive?.isSharedApiKey).toBe(false);
+            expect(jwtPlan?.isSharedApiKey).toBe(false);
+        });
+
+        it('uses PUSH security label when plan mode is PUSH', () => {
+            const row = mapSubscriptionToTableRow(baseSubscription, { 'plan-1': { planMode: 'PUSH', securityType: 'API_KEY' } }, undefined);
+            expect(row?.securityType).toBe('PUSH');
+        });
+
+        it('maps API product subscriptions using referenceId metadata', () => {
+            const productSub: SubscriptionPageItem = {
+                ...baseSubscription,
+                referenceType: 'API_PRODUCT',
+                referenceId: 'product-1',
+                api: undefined,
+            };
+            const row = mapSubscriptionToTableRow(productSub, metadata, undefined);
+            expect(row?.referenceTypeLabel).toBe('API Product');
+            expect(row?.apiName).toBe('Billing Product');
+            expect(row?.apiVersion).toBe('2.0');
+        });
+
+        it('falls back to subscription ids when metadata is missing', () => {
+            const row = mapSubscriptionToTableRow(baseSubscription, undefined, undefined);
+            expect(row?.planName).toBe('plan-1');
+            expect(row?.apiName).toBe('api-1');
+        });
+
+        it('uses an empty-state label when security type metadata is missing', () => {
+            const row = mapSubscriptionToTableRow(baseSubscription, { 'plan-1': {}, 'api-1': {} }, undefined);
+            expect(row?.securityType).toBe('—');
+        });
+    });
+
+    describe('mapSubscriptionsPageToRows', () => {
+        it('filters out invalid rows', () => {
+            const response: ApplicationSubscriptionsPagedResponse = {
+                data: [baseSubscription, { plan: 'orphan' }],
+                metadata,
+                page: { current: 1, size: 10, per_page: 10, total_pages: 1, total_elements: 2 },
+            };
+            expect(mapSubscriptionsPageToRows(response, 'EXCLUSIVE')).toHaveLength(1);
+        });
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/utils/applicationSubscriptionMapper.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/utils/applicationSubscriptionMapper.ts
@@ -1,0 +1,87 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import type { ApiKeyMode } from '../types/application';
+import type {
+    ApplicationSubscriptionTableRow,
+    ApplicationSubscriptionsPagedResponse,
+    SubscriptionPageItem,
+    SubscriptionStatus,
+} from '../types/applicationSubscription';
+
+const SECURITY_TYPE_LABELS: Record<string, string> = {
+    API_KEY: 'API Key',
+    OAUTH2: 'OAuth2',
+    JWT: 'JWT',
+    KEY_LESS: 'Keyless',
+    MTLS: 'mTLS',
+    PUSH: 'PUSH',
+};
+
+export function formatSubscriptionSecurityType(securityType: string): string {
+    return SECURITY_TYPE_LABELS[securityType] ?? securityType;
+}
+
+export function canCloseSubscription(status: SubscriptionStatus | undefined): boolean {
+    return status === 'ACCEPTED' || status === 'PENDING' || status === 'PAUSED' || status === 'RESUMED';
+}
+
+function getMetadataRecord(metadata: ApplicationSubscriptionsPagedResponse['metadata'], key: string | undefined): Record<string, unknown> {
+    if (!key || !metadata) return {};
+    return metadata[key] ?? {};
+}
+
+export function mapSubscriptionToTableRow(
+    subscription: SubscriptionPageItem,
+    metadata: ApplicationSubscriptionsPagedResponse['metadata'],
+    apiKeyMode: ApiKeyMode | undefined,
+): ApplicationSubscriptionTableRow | null {
+    if (!subscription.id || !subscription.status) return null;
+
+    const planMetadata = getMetadataRecord(metadata, subscription.plan);
+    const apiMetadataKey =
+        subscription.referenceType === 'API_PRODUCT' ? subscription.referenceId : (subscription.api ?? subscription.referenceId);
+    const apiMetadata = getMetadataRecord(metadata, apiMetadataKey);
+
+    const planMode = planMetadata.planMode as string | undefined;
+    const planSecurityType = planMetadata.securityType as string | undefined;
+    const securityType = planMode === 'PUSH' ? 'PUSH' : planSecurityType ? formatSubscriptionSecurityType(planSecurityType) : '—';
+    const isApiProduct = subscription.referenceType === 'API_PRODUCT';
+
+    return {
+        id: subscription.id,
+        apiName: (apiMetadata.name as string | undefined) ?? subscription.api ?? subscription.referenceId ?? '',
+        apiVersion: apiMetadata.apiVersion as string | undefined,
+        referenceTypeLabel: isApiProduct ? 'API Product' : 'API',
+        createdAt: subscription.created_at,
+        endAt: subscription.ending_at,
+        planName: (planMetadata.name as string | undefined) ?? subscription.plan ?? '',
+        securityType,
+        isSharedApiKey: apiKeyMode === 'SHARED' && planSecurityType === 'API_KEY',
+        processedAt: subscription.processed_at,
+        startingAt: subscription.starting_at,
+        status: subscription.status,
+        origin: subscription.origin ?? 'MANAGEMENT',
+    };
+}
+
+export function mapSubscriptionsPageToRows(
+    response: ApplicationSubscriptionsPagedResponse,
+    apiKeyMode: ApiKeyMode | undefined,
+): ApplicationSubscriptionTableRow[] {
+    return (response.data ?? [])
+        .map(item => mapSubscriptionToTableRow(item, response.metadata, apiKeyMode))
+        .filter((row): row is ApplicationSubscriptionTableRow => row !== null);
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/utils/queryKeys.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/utils/queryKeys.ts
@@ -13,6 +13,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import type { ApplicationSubscriptionsFilters } from '../types/applicationSubscription';
+
+interface ApplicationCountFilter {
+    status?: string;
+    query?: string;
+}
+
+function sorted(values: string[] | undefined): string[] {
+    return [...(values ?? [])].sort();
+}
 
 export const applicationDetailKeys = {
     all: ['application-detail'] as const,
@@ -35,7 +45,35 @@ export const applicationListKeys = {
     all: ['application-list'] as const,
     search: (envId: string, query: string, status: string, page: number, perPage: number) =>
         [...applicationListKeys.all, 'search', envId, query, status, page, perPage] as const,
-    count: (envId: string, filter: object) => [...applicationListKeys.all, 'count', envId, filter] as const,
+    count: (envId: string, filter: ApplicationCountFilter) =>
+        [...applicationListKeys.all, 'count', envId, filter.status ?? '', filter.query ?? ''] as const,
     types: (envId: string) => [...applicationListKeys.all, 'types', envId] as const,
     groups: (envId: string) => [...applicationListKeys.all, 'groups', envId] as const,
+} as const;
+
+export const applicationSubscriptionKeys = {
+    all: ['application-subscriptions'] as const,
+    list: (envId: string, applicationId: string, filters: ApplicationSubscriptionsFilters | undefined, page: number, size: number) =>
+        [
+            ...applicationSubscriptionKeys.all,
+            'list',
+            envId,
+            applicationId,
+            filters?.apiKey ?? '',
+            sorted(filters?.apis),
+            sorted(filters?.status),
+            sorted(filters?.securityTypes),
+            page,
+            size,
+        ] as const,
+    subscribedApis: (envId: string, applicationId: string) =>
+        [...applicationSubscriptionKeys.all, 'subscribed-apis', envId, applicationId] as const,
+    referenceSearch: (envId: string, query: string, includeApiProducts: boolean) =>
+        [...applicationSubscriptionKeys.all, 'reference-search', envId, query, includeApiProducts] as const,
+    subscribablePlans: (envId: string, referenceType: string, referenceId: string, applicationId: string) =>
+        [...applicationSubscriptionKeys.all, 'subscribable-plans', envId, referenceType, referenceId, applicationId] as const,
+    detail: (envId: string | undefined, applicationId: string | undefined, subscriptionId: string | undefined) =>
+        [...applicationSubscriptionKeys.all, 'detail', envId, applicationId, subscriptionId] as const,
+    apiKeys: (envId: string | undefined, applicationId: string | undefined, subscriptionId: string | undefined) =>
+        [...applicationSubscriptionKeys.all, 'api-keys', envId, applicationId, subscriptionId] as const,
 } as const;

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/ApplicationDetailSubscriptionPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/ApplicationDetailSubscriptionPage.tsx
@@ -1,0 +1,41 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Skeleton } from '@gravitee/graphene-core';
+import { useParams } from 'react-router-dom';
+
+import { ApplicationSubscriptionDetailView } from '../features/applications/components/subscriptions/ApplicationSubscriptionDetailView';
+import { useApplicationDetailContext } from '../features/applications/context/ApplicationDetailContext';
+
+export function ApplicationDetailSubscriptionPage() {
+    const { subscriptionId } = useParams<{ subscriptionId: string }>();
+    const { application, isLoading } = useApplicationDetailContext();
+
+    if (isLoading) {
+        return (
+            <div className="space-y-5">
+                <Skeleton className="h-8 w-48" />
+                <Skeleton className="h-10 w-72" />
+                <Skeleton className="h-96 w-full" />
+            </div>
+        );
+    }
+
+    if (!application || !subscriptionId) {
+        return <p className="text-sm text-muted-foreground">Application not found or you may not have access.</p>;
+    }
+
+    return <ApplicationSubscriptionDetailView application={application} subscriptionId={subscriptionId} />;
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/ApplicationDetailSubscriptionsPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/ApplicationDetailSubscriptionsPage.tsx
@@ -1,0 +1,39 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Skeleton } from '@gravitee/graphene-core';
+
+import { ApplicationSubscriptionsView } from '../features/applications/components/subscriptions/ApplicationSubscriptionsView';
+import { useApplicationDetailContext } from '../features/applications/context/ApplicationDetailContext';
+
+export function ApplicationDetailSubscriptionsPage() {
+    const { application, isLoading } = useApplicationDetailContext();
+
+    if (isLoading) {
+        return (
+            <div className="space-y-6">
+                <Skeleton className="h-10 w-64" />
+                <Skeleton className="h-12 w-full" />
+                <Skeleton className="h-96 w-full" />
+            </div>
+        );
+    }
+
+    if (!application) {
+        return <p className="text-sm text-muted-foreground">Application not found or you may not have access.</p>;
+    }
+
+    return <ApplicationSubscriptionsView application={application} />;
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/shared/api/queryRetry.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/shared/api/queryRetry.spec.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { retryTransientRequest } from './queryRetry';
+
+describe('retryTransientRequest', () => {
+    it('retries transient failures twice', () => {
+        expect(retryTransientRequest(0, new Error('network'))).toBe(true);
+        expect(retryTransientRequest(1, new Error('network'))).toBe(true);
+        expect(retryTransientRequest(2, new Error('network'))).toBe(false);
+    });
+
+    it('does not retry client errors', () => {
+        expect(retryTransientRequest(0, { status: 400 })).toBe(false);
+        expect(retryTransientRequest(0, { status: 404 })).toBe(false);
+    });
+
+    it('retries server errors', () => {
+        expect(retryTransientRequest(0, { status: 500 })).toBe(true);
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/shared/api/queryRetry.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/shared/api/queryRetry.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+function statusOf(error: unknown): number | undefined {
+    if (typeof error !== 'object' || error === null || !('status' in error)) {
+        return undefined;
+    }
+    const status = (error as { status?: unknown }).status;
+    return typeof status === 'number' ? status : undefined;
+}
+
+export function retryTransientRequest(failureCount: number, error: unknown): boolean {
+    const status = statusOf(error);
+    if (status !== undefined && status >= 400 && status < 500) {
+        return false;
+    }
+    return failureCount < 2;
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/shared/hooks/useEnvironmentPermissions.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/shared/hooks/useEnvironmentPermissions.ts
@@ -42,3 +42,20 @@ export function useEnvironmentPermissions(): void {
         permissionService.load('environment', permissions);
     }, [permissions]);
 }
+
+/**
+ * True once environment-scoped permissions are loaded into {@link permissionService}.
+ * Shares the query with {@link useEnvironmentPermissions} (deduped by React Query).
+ */
+export function useEnvironmentPermissionsReady(): boolean {
+    const env = useEnvironment();
+
+    const { isSuccess } = useQuery({
+        queryKey: environmentPermissionKeys.detail(env?.id ?? ''),
+        queryFn: () => getEnvironmentPermissions(env!.id),
+        enabled: Boolean(env?.id),
+        staleTime: 60_000,
+    });
+
+    return isSuccess;
+}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-XXX

## Description

Adds Application subscriptions to the Gamma Platform UI (gravitee-gamma-module-platform), bringing list, detail, create, close, and API key management in line with the classic APIM Console. Also fixes a close-subscription confirmation bug in the Angular console when the application uses per-subscription (non-shared) API keys.

**Gamma Platform UI - Application subscriptions**

- **Navigation & routing:** Subscriptions tab on application detail (application-subscription-r), list route, and nested subscriptions/:subscriptionId detail route wired through APPLICATION_DETAIL_PAGES and AppRoutes.
- **List view (ApplicationSubscriptionsView):** Paginated table with URL-synced filters (API, status, API key search with debounce), status legend, permission-gated create/close, and read-only mode for archived applications.
- **Create flow (ApplicationSubscriptionCreateDialog):** Subscribe to APIs or API Products with plan selection, validation, portal-driven shared API key mode, and navigation to the new subscription detail.
- **Detail view (ApplicationSubscriptionDetailView):** Subscription metadata, edit request (pending subscriptions), close, and API key card (renew / revoke / expire) for accepted API-key plans when not in shared key mode; Kubernetes-managed subscriptions are read-only.
- **Data layer:** Management API v1/v2 clients, React Query hooks, mappers/utils, types, and unit tests for services, hooks, mappers, search params, and key dialogs.


## Additional context

Test plan

- [ ] Open an application in Gamma Platform UI → Subscriptions tab appears only with application-subscription-r.
- [ ]  List: filter by API, status, and API key; confirm filters persist in the URL and pagination resets on filter change.
- [ ]  Create subscription (API and API Product if available); verify redirect to detail and list refresh.
- [ ]  Detail: view accepted API-key subscription — renew, revoke, and expire API keys; confirm shared-key applications show the hint instead of per-subscription keys.
- [ ]  Close subscription from list and detail; confirm confirmation copy for non-shared API keys.
- [ ]  Archived application: subscriptions UI is read-only (no create/close/edit).
- [ ]  Kubernetes-origin subscription: detail is read-only.
- [ ]  Angular console: close subscription on non-shared API key plan — confirmation mentions API keys will be closed; shared mode does not show that extra line.
- [ ]  Run platform UI unit tests for new subscription specs (services, hooks, mappers, dialogs).



https://github.com/user-attachments/assets/253a689e-9ac4-483c-bd7d-dc47efccf5b7




<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

