### PR TITLE
feat(portal): add application invitations list in portal

### DIFF
--- a/gravitee-apim-portal-webui-next/src/app/app.routes.ts
+++ b/gravitee-apim-portal-webui-next/src/app/app.routes.ts
@@ -25,6 +25,7 @@ import { ApiTabSubscriptionsComponent } from './api/api-details/api-tab-subscrip
 import { SubscriptionsDetailsComponent } from './api/api-details/api-tab-subscriptions/subscriptions-details/subscriptions-details.component';
 import { SubscriptionsTableComponent } from './api/api-details/api-tab-subscriptions/subscriptions-table/subscriptions-table.component';
 import { ApiComponent } from './api/api.component';
+import { ApplicationTabInvitationsComponent } from './dashboard/application-details/application-tab-invitations/application-tab-invitations.component';
 import { ConfigureConsumerComponent } from '../components/subscription/webhook/configure-consumer/configure-consumer.component';
 import { anonymousGuard } from '../guards/anonymous.guard';
 import { authGuard } from '../guards/auth.guard';
@@ -37,6 +38,7 @@ import { ApplicationTabLogsComponent } from './dashboard/application-details/app
 import { ApplicationTabMembersComponent } from './dashboard/application-details/application-tab-members/application-tab-members.component';
 import { ApplicationTabSettingsComponent } from './dashboard/application-details/application-tab-settings/application-tab-settings.component';
 import { DashboardComponent } from './dashboard/dashboard.component';
+import { DocumentationSubscribeComponent } from './documentation/components/documentation-subscribe/documentation-subscribe.component';
 import { RegistrationConfirmationComponent } from './registration/registration-confirmation/registration-confirmation.component';
 import { ServiceUnavailableComponent } from './service-unavailable/service-unavailable.component';
 import { NavigationPageFullWidthComponent } from '../components/navigation-page-full-width/navigation-page-full-width.component';
@@ -46,7 +48,6 @@ import { apiResolver } from '../resolvers/api.resolver';
 import { applicationPermissionResolver, applicationResolver, applicationTypeResolver } from '../resolvers/application.resolver';
 import { homepageContentResolver } from '../resolvers/homepage-content.resolver';
 import { CatalogComponent } from './catalog/catalog.component';
-import { DocumentationSubscribeComponent } from './documentation/components/documentation-subscribe/documentation-subscribe.component';
 import { DocumentationComponent } from './documentation/components/documentation.component';
 import { documentationResolver } from './documentation/resolvers/documentation.resolver';
 import { LogInComponent } from './log-in/log-in.component';
@@ -213,6 +214,10 @@ export const routes: Routes = [
           {
             path: 'members',
             component: ApplicationTabMembersComponent,
+          },
+          {
+            path: 'invitations',
+            component: ApplicationTabInvitationsComponent,
           },
         ],
       },

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-invitations/application-tab-invitations.component.harness.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-invitations/application-tab-invitations.component.harness.ts
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ComponentHarness, TestElement } from '@angular/cdk/testing';
+
+import { LoaderHarness } from '../../../../components/loader/loader.harness';
+import { PaginatedTableHarness } from '../../../../components/paginated-table/paginated-table.harness';
+
+export class ApplicationTabInvitationsComponentHarness extends ComponentHarness {
+  public static readonly hostSelector = 'app-application-tab-invitations';
+
+  private readonly locateLoader = this.locatorForOptional(LoaderHarness);
+  private readonly locateSectionTitle = this.locatorForOptional('[data-testid="invitations-section-title"]');
+  private readonly locateErrorMessage = this.locatorForOptional('[data-testid="invitations-list-error"]');
+  private readonly locateEmptyState = this.locatorForOptional('[data-testid="invitations-empty-state"]');
+  private readonly locatePaginatedTable = this.locatorForOptional(PaginatedTableHarness);
+
+  public async getLoader(): Promise<LoaderHarness | null> {
+    return this.locateLoader();
+  }
+
+  public async getSectionTitle(): Promise<TestElement | null> {
+    return this.locateSectionTitle();
+  }
+
+  public async getErrorMessage(): Promise<TestElement | null> {
+    return this.locateErrorMessage();
+  }
+
+  public async getEmptyState(): Promise<TestElement | null> {
+    return this.locateEmptyState();
+  }
+
+  public async getPaginatedTable(): Promise<PaginatedTableHarness | null> {
+    return this.locatePaginatedTable();
+  }
+}

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-invitations/application-tab-invitations.component.html
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-invitations/application-tab-invitations.component.html
@@ -1,0 +1,59 @@
+<!--
+
+    Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+@if (canRead()) {
+  <h4 class="next-gen-h4 invitations__title" data-testid="invitations-section-title" i18n="@@applicationInvitationsTitle">
+    Invitations ({{ totalElements() }})
+  </h4>
+  @if (invitationsResource.isLoading()) {
+    <app-loader />
+  } @else if (invitationsResource.error()) {
+    <div class="invitations__error next-gen-body" role="alert" data-testid="invitations-list-error" i18n="@@invitationsListError">
+      An error occurred while loading invitations. Try again later or contact your Portal administrator.
+    </div>
+  } @else if (totalElements() === 0) {
+    <div class="invitations__empty-state" data-testid="invitations-empty-state">
+      <p class="next-gen-body" i18n="@@invitationsEmptyState">No pending invitations found.</p>
+    </div>
+  } @else {
+    <app-paginated-table
+      [columns]="tableColumns"
+      [rows]="rows()"
+      [totalElements]="totalElements()"
+      [currentPage]="currentPage()"
+      [pageSize]="pageSize()"
+      [navigable]="false"
+      (pageChange)="onPageChange($event)"
+      (pageSizeChange)="onPageSizeChange($event)"
+    >
+      <ng-template appTableCell="email" let-row>
+        <span class="invitations__email">
+          <span class="invitations__email-icon-container" aria-hidden="true" data-testid="invitation-email-icon">
+            <mat-icon class="invitations__email-icon">mail_outline</mat-icon>
+          </span>
+          <span class="next-gen-small" data-testid="invitation-email">{{ row.email }}</span>
+        </span>
+      </ng-template>
+      <ng-template appTableCell="role" let-row>
+        <span class="next-gen-small" data-testid="invitation-role">{{ row.role }}</span>
+      </ng-template>
+      <ng-template appTableCell="actions">
+        <span data-testid="invitation-actions"></span>
+      </ng-template>
+    </app-paginated-table>
+  }
+}

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-invitations/application-tab-invitations.component.scss
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-invitations/application-tab-invitations.component.scss
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@use '../../../../scss/theme/index' as app-theme;
+
+.invitations {
+  &__title {
+    margin: 0 0 16px;
+  }
+
+  &__empty-state {
+    padding: 24px 0;
+    text-align: center;
+    color: app-theme.$paragraph-color;
+  }
+
+  &__error {
+    padding: 24px 0;
+    color: app-theme.$error-main-color;
+  }
+
+  &__email {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+
+  &__email-icon-container {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 32px;
+    height: 32px;
+    border: 1px solid app-theme.$user-avatar-border-color;
+    border-radius: app-theme.$user-avatar-container-shape;
+    color: app-theme.$user-avatar-text-color;
+    flex-shrink: 0;
+  }
+
+  &__email-icon {
+    width: 18px;
+    height: 18px;
+    font-size: 18px;
+    line-height: 18px;
+  }
+}

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-invitations/application-tab-invitations.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-invitations/application-tab-invitations.component.spec.ts
@@ -1,0 +1,194 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { provideHttpClient } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { provideRouter } from '@angular/router';
+
+import { ApplicationTabInvitationsComponent } from './application-tab-invitations.component';
+import { ApplicationTabInvitationsComponentHarness } from './application-tab-invitations.component.harness';
+import { ApplicationInvitationsResponse } from '../../../../entities/application/application-invitation';
+import {
+  fakeApplicationInvitation,
+  fakeApplicationInvitationsResponse,
+} from '../../../../entities/application/application-invitation.fixture';
+import { fakeUserApplicationPermissions } from '../../../../entities/permission/permission.fixtures';
+import { ConfigService } from '../../../../services/config.service';
+import { TESTING_BASE_URL } from '../../../../testing/app-testing.module';
+
+describe('ApplicationTabInvitationsComponent', () => {
+  let fixture: ComponentFixture<ApplicationTabInvitationsComponent>;
+  let httpTestingController: HttpTestingController;
+  const applicationId = 'app-1';
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ApplicationTabInvitationsComponent],
+      providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        provideNoopAnimations(),
+        provideRouter([]),
+        { provide: ConfigService, useValue: { baseURL: TESTING_BASE_URL } },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ApplicationTabInvitationsComponent);
+    httpTestingController = TestBed.inject(HttpTestingController);
+    fixture.componentRef.setInput('applicationId', applicationId);
+    fixture.componentRef.setInput('userApplicationPermissions', fakeUserApplicationPermissions({ MEMBER: ['R'] }));
+  });
+
+  afterEach(() => httpTestingController.verify());
+
+  async function getHarness(): Promise<ApplicationTabInvitationsComponentHarness> {
+    return TestbedHarnessEnvironment.harnessForFixture(fixture, ApplicationTabInvitationsComponentHarness);
+  }
+
+  async function flush(response: ApplicationInvitationsResponse): Promise<ApplicationTabInvitationsComponentHarness> {
+    fixture.detectChanges();
+    const request = httpTestingController.expectOne(req => req.url.includes('invitations/_search'));
+    expect(request.request.method).toBe('POST');
+    expect(request.request.params.get('page')).toBe(`${fixture.componentInstance.currentPage()}`);
+    expect(request.request.params.get('size')).toBe(`${fixture.componentInstance.pageSize()}`);
+    expect(request.request.body).toEqual({ filters: {} });
+    request.flush(response);
+    await fixture.whenStable();
+    fixture.detectChanges();
+    return getHarness();
+  }
+
+  it('should display invitations table', async () => {
+    const harness = await flush(fakeApplicationInvitationsResponse([fakeApplicationInvitation()]));
+    expect(await harness.getPaginatedTable()).not.toBeNull();
+  });
+
+  it('should show invitation data columns and an empty actions column', () => {
+    expect(fixture.componentInstance.tableColumns.map(column => column.id)).toEqual(['email', 'role', 'actions']);
+  });
+
+  it('should show section title with total invitation count from paginate metadata', async () => {
+    await flush(fakeApplicationInvitationsResponse([fakeApplicationInvitation()], 42));
+    const harness = await getHarness();
+    const title = await harness.getSectionTitle();
+    expect(title).not.toBeNull();
+    expect((await title!.text())?.replace(/\s+/g, ' ').trim()).toBe('Invitations (42)');
+  });
+
+  it('should fall back to pagination metadata total', async () => {
+    await flush({
+      data: [fakeApplicationInvitation()],
+      metadata: {
+        pagination: {
+          total: 7,
+        },
+      },
+    });
+    const harness = await getHarness();
+    const title = await harness.getSectionTitle();
+    expect(title).not.toBeNull();
+    expect((await title!.text())?.replace(/\s+/g, ' ').trim()).toBe('Invitations (7)');
+  });
+
+  it('should show Invitations (0) in section title when the list is empty', async () => {
+    await flush(fakeApplicationInvitationsResponse([]));
+    const harness = await getHarness();
+    const title = await harness.getSectionTitle();
+    expect(title).not.toBeNull();
+    expect((await title!.text())?.replace(/\s+/g, ' ').trim()).toBe('Invitations (0)');
+  });
+
+  it('should show loader until the first search response', async () => {
+    fixture.detectChanges();
+    expect(fixture.nativeElement.querySelector('app-loader')).not.toBeNull();
+    const harness = await flush(fakeApplicationInvitationsResponse([fakeApplicationInvitation()]));
+    expect(await harness.getLoader()).toBeNull();
+  });
+
+  it('should show an accessible error message when search fails', async () => {
+    fixture.detectChanges();
+    const request = httpTestingController.expectOne(req => req.url.includes('invitations/_search'));
+    request.flush({ error: 'Server error' }, { status: 500, statusText: 'Internal Server Error' });
+    await fixture.whenStable();
+    fixture.detectChanges();
+    const harness = await getHarness();
+    const alert = await harness.getErrorMessage();
+    expect(alert).not.toBeNull();
+    expect(await alert!.getAttribute('role')).toBe('alert');
+  });
+
+  it('should show empty state when no invitations are returned', async () => {
+    const harness = await flush(fakeApplicationInvitationsResponse([]));
+    expect(await harness.getEmptyState()).not.toBeNull();
+    expect(await harness.getPaginatedTable()).toBeNull();
+  });
+
+  it('should hide the table and not call service when user lacks MEMBER[R] permission', async () => {
+    fixture.componentRef.setInput('userApplicationPermissions', fakeUserApplicationPermissions({ MEMBER: [] }));
+    fixture.detectChanges();
+    httpTestingController.expectNone(req => req.url.includes('invitations/_search'));
+    const harness = await getHarness();
+    expect(await harness.getPaginatedTable()).toBeNull();
+  });
+
+  it('should render invitation email icon, email and role cells', async () => {
+    const harness = await flush(fakeApplicationInvitationsResponse([fakeApplicationInvitation({ email: 'bob@example.com', role: 'POC' })]));
+    const table = await harness.getPaginatedTable();
+    const roleCell = await table!.getCellElement(0, 'role');
+    const emailIcon = fixture.nativeElement.querySelector('[data-testid="invitation-email-icon"]');
+    const email = fixture.nativeElement.querySelector('[data-testid="invitation-email"]');
+    expect(emailIcon).not.toBeNull();
+    expect(email.textContent.trim()).toBe('bob@example.com');
+    expect((await roleCell!.text()).trim()).toBe('POC');
+  });
+
+  it('should render empty actions cell', async () => {
+    const harness = await flush(fakeApplicationInvitationsResponse([fakeApplicationInvitation()]));
+    const table = await harness.getPaginatedTable();
+    const actionsCell = await table!.getCellElement(0, 'actions');
+    expect((await actionsCell!.text()).trim()).toBe('');
+  });
+
+  it('should POST with page=2 when page changes', async () => {
+    await flush(fakeApplicationInvitationsResponse([fakeApplicationInvitation()], 25));
+    fixture.componentInstance.onPageChange(2);
+    fixture.detectChanges();
+    const request = httpTestingController.expectOne(req => req.url.includes('invitations/_search') && req.params.get('page') === '2');
+    expect(request.request.method).toBe('POST');
+    request.flush(fakeApplicationInvitationsResponse([fakeApplicationInvitation({ id: 'invitation-p2' })]));
+    await fixture.whenStable();
+  });
+
+  it('should reset page to 1 when page size changes', async () => {
+    await flush(fakeApplicationInvitationsResponse([fakeApplicationInvitation()], 25));
+    fixture.componentInstance.onPageChange(2);
+    fixture.detectChanges();
+    httpTestingController
+      .expectOne(req => req.url.includes('invitations/_search') && req.params.get('page') === '2')
+      .flush(fakeApplicationInvitationsResponse([fakeApplicationInvitation({ id: 'invitation-p2' })]));
+    await fixture.whenStable();
+
+    fixture.componentInstance.onPageSizeChange(25);
+    fixture.detectChanges();
+    const request = httpTestingController.expectOne(
+      req => req.url.includes('invitations/_search') && req.params.get('page') === '1' && req.params.get('size') === '25',
+    );
+    request.flush(fakeApplicationInvitationsResponse([fakeApplicationInvitation({ id: 'invitation-size-25' })]));
+    await fixture.whenStable();
+  });
+});

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-invitations/application-tab-invitations.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-invitations/application-tab-invitations.component.ts
@@ -1,0 +1,110 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Component, computed, inject, input, signal } from '@angular/core';
+import { rxResource } from '@angular/core/rxjs-interop';
+import { MatIcon } from '@angular/material/icon';
+import { of } from 'rxjs';
+
+import { LoaderComponent } from '../../../../components/loader/loader.component';
+import { PaginatedTableComponent, TableColumn } from '../../../../components/paginated-table/paginated-table.component';
+import { TableCellDirective } from '../../../../components/paginated-table/table-cell.directive';
+import { ApplicationInvitation, ApplicationInvitationsResponse } from '../../../../entities/application/application-invitation';
+import { UserApplicationPermissions } from '../../../../entities/permission/permission';
+import { ApplicationInvitationService } from '../../../../services/application-invitation.service';
+
+interface InvitationTableRow {
+  id: string;
+  email: string;
+  role: string;
+}
+
+interface InvitationsRequestParams {
+  applicationId: string;
+  page: number;
+  size: number;
+}
+
+@Component({
+  selector: 'app-application-tab-invitations',
+  standalone: true,
+  imports: [LoaderComponent, MatIcon, PaginatedTableComponent, TableCellDirective],
+  templateUrl: './application-tab-invitations.component.html',
+  styleUrl: './application-tab-invitations.component.scss',
+})
+export class ApplicationTabInvitationsComponent {
+  private readonly applicationInvitationService = inject(ApplicationInvitationService);
+
+  readonly applicationId = input.required<string>();
+  readonly userApplicationPermissions = input.required<UserApplicationPermissions>();
+
+  readonly currentPage = signal(1);
+  readonly pageSize = signal(10);
+
+  readonly tableColumns: TableColumn[] = [
+    { id: 'email', label: $localize`:@@applicationInvitationsColumnEmail:Email` },
+    { id: 'role', label: $localize`:@@applicationInvitationsColumnRole:Role` },
+    { id: 'actions', label: $localize`:@@applicationInvitationsColumnActions:Actions` },
+  ];
+
+  readonly canRead = computed(() => this.userApplicationPermissions().MEMBER?.includes('R') ?? false);
+
+  protected readonly invitationsResource = rxResource<ApplicationInvitationsResponse | undefined, InvitationsRequestParams | null>({
+    params: () =>
+      this.canRead()
+        ? {
+            applicationId: this.applicationId(),
+            page: this.currentPage(),
+            size: this.pageSize(),
+          }
+        : null,
+    stream: ({ params }) =>
+      params
+        ? this.applicationInvitationService.searchApplicationInvitations(params.applicationId, params.page, params.size)
+        : of(undefined),
+  });
+
+  readonly rows = computed<InvitationTableRow[]>(() => {
+    if (this.invitationsResource.error()) {
+      return [];
+    }
+    return (this.invitationsResource.value()?.data ?? []).map(invitation => this.toRow(invitation));
+  });
+
+  readonly totalElements = computed(() => {
+    if (this.invitationsResource.error()) {
+      return 0;
+    }
+    const response = this.invitationsResource.value();
+    return response?.metadata?.paginateMetaData?.totalElements ?? response?.metadata?.pagination?.total ?? response?.data?.length ?? 0;
+  });
+
+  onPageChange(page: number): void {
+    this.currentPage.set(page);
+  }
+
+  onPageSizeChange(size: number): void {
+    this.pageSize.set(size);
+    this.currentPage.set(1);
+  }
+
+  private toRow(invitation: ApplicationInvitation): InvitationTableRow {
+    return {
+      id: invitation.id,
+      email: invitation.email,
+      role: invitation.role,
+    };
+  }
+}

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application.component.html
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application.component.html
@@ -37,6 +37,17 @@
           ><span class="next-gen-small-bold" i18n="@@appMembers">Members</span></a
         >
       }
+      @if (canViewInvitationsTab()) {
+        <a
+          mat-tab-link
+          [routerLink]="['.', 'invitations']"
+          routerLinkActive
+          #invitationsActive="routerLinkActive"
+          [active]="invitationsActive.isActive"
+          data-testid="application-invitations-tab"
+          ><span class="next-gen-small-bold" i18n="@@appInvitations">Invitations</span></a
+        >
+      }
       <a mat-tab-link [routerLink]="['.', 'logs']" routerLinkActive #logsActive="routerLinkActive" [active]="logsActive.isActive"
         ><span class="next-gen-small-bold" i18n="@@appAnalyticsAndLogs">Logs</span></a
       >

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application.component.spec.ts
@@ -66,15 +66,32 @@ describe('ApplicationComponent', () => {
     expect(await loader.getHarnessOrNull(TestIdHarness.for('application-members-tab'))).not.toBeNull();
   });
 
+  it('should render Invitations tab when user has MEMBER read permission', async () => {
+    fixture.detectChanges();
+    expect(await loader.getHarnessOrNull(TestIdHarness.for('application-invitations-tab'))).not.toBeNull();
+  });
+
   it('should not render Members tab when user lacks MEMBER read permission', async () => {
     fixture.componentRef.setInput('userApplicationPermissions', fakeUserApplicationPermissions({ MEMBER: [] }));
     fixture.detectChanges();
     expect(await loader.getHarnessOrNull(TestIdHarness.for('application-members-tab'))).toBeNull();
   });
 
+  it('should not render Invitations tab when user lacks MEMBER read permission', async () => {
+    fixture.componentRef.setInput('userApplicationPermissions', fakeUserApplicationPermissions({ MEMBER: [] }));
+    fixture.detectChanges();
+    expect(await loader.getHarnessOrNull(TestIdHarness.for('application-invitations-tab'))).toBeNull();
+  });
+
   it('should not render Members tab when MEMBER has no R flag', async () => {
     fixture.componentRef.setInput('userApplicationPermissions', fakeUserApplicationPermissions({ MEMBER: ['U'] }));
     fixture.detectChanges();
     expect(await loader.getHarnessOrNull(TestIdHarness.for('application-members-tab'))).toBeNull();
+  });
+
+  it('should not render Invitations tab when MEMBER has no R flag', async () => {
+    fixture.componentRef.setInput('userApplicationPermissions', fakeUserApplicationPermissions({ MEMBER: ['U'] }));
+    fixture.detectChanges();
+    expect(await loader.getHarnessOrNull(TestIdHarness.for('application-invitations-tab'))).toBeNull();
   });
 });

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application.component.ts
@@ -35,6 +35,7 @@ export default class ApplicationComponent {
   readonly userApplicationPermissions = input.required<UserApplicationPermissions>();
 
   readonly canViewMembersTab = computed(() => this.userApplicationPermissions().MEMBER?.includes('R') ?? false);
+  readonly canViewInvitationsTab = computed(() => this.userApplicationPermissions().MEMBER?.includes('R') ?? false);
 
   constructor() {
     effect(() => {

--- a/gravitee-apim-portal-webui-next/src/entities/application/application-invitation.fixture.ts
+++ b/gravitee-apim-portal-webui-next/src/entities/application/application-invitation.fixture.ts
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { isFunction } from 'lodash';
+
+import { ApplicationInvitation, ApplicationInvitationsResponse } from './application-invitation';
+
+export function fakeApplicationInvitation(
+  modifier?: Partial<ApplicationInvitation> | ((base: ApplicationInvitation) => ApplicationInvitation),
+): ApplicationInvitation {
+  const base: ApplicationInvitation = {
+    id: 'invitation-id',
+    email: 'alice@example.com',
+    role: 'USER',
+  };
+  return isFunction(modifier) ? modifier(base) : { ...base, ...modifier };
+}
+
+export function fakeApplicationInvitationsResponse(
+  invitations: ApplicationInvitation[] = [fakeApplicationInvitation()],
+  total = invitations.length,
+): ApplicationInvitationsResponse {
+  return {
+    data: invitations,
+    metadata: {
+      paginateMetaData: {
+        totalElements: total,
+      },
+      pagination: {
+        current_page: 1,
+        size: 10,
+        total,
+      },
+    },
+  };
+}

--- a/gravitee-apim-portal-webui-next/src/entities/application/application-invitation.ts
+++ b/gravitee-apim-portal-webui-next/src/entities/application/application-invitation.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+export interface ApplicationInvitation {
+  id: string;
+  email: string;
+  role: string;
+}
+
+export interface ApplicationInvitationsSearchFilters {
+  email?: string;
+}
+
+export interface ApplicationInvitationsResponse {
+  data?: ApplicationInvitation[];
+  metadata?: {
+    paginateMetaData?: {
+      totalElements?: number;
+    };
+    pagination?: {
+      current_page?: number;
+      size?: number;
+      total?: number;
+    };
+  };
+  links?: unknown;
+}

--- a/gravitee-apim-portal-webui-next/src/services/application-invitation.service.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/services/application-invitation.service.spec.ts
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { HttpTestingController } from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+
+import { ApplicationInvitationService } from './application-invitation.service';
+import { fakeApplicationInvitationsResponse } from '../entities/application/application-invitation.fixture';
+import { AppTestingModule, TESTING_BASE_URL } from '../testing/app-testing.module';
+
+describe('ApplicationInvitationService', () => {
+  let service: ApplicationInvitationService;
+  let httpTestingController: HttpTestingController;
+  const applicationId = 'app-1';
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [AppTestingModule],
+    });
+    service = TestBed.inject(ApplicationInvitationService);
+    httpTestingController = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpTestingController.verify();
+  });
+
+  it('should search application invitations with default pagination', done => {
+    const response = fakeApplicationInvitationsResponse();
+
+    service.searchApplicationInvitations(applicationId).subscribe(res => {
+      expect(res).toMatchObject(response);
+      done();
+    });
+
+    const req = httpTestingController.expectOne(`${TESTING_BASE_URL}/applications/${applicationId}/invitations/_search?page=1&size=10`);
+    expect(req.request.method).toEqual('POST');
+    expect(req.request.body).toEqual({ filters: {} });
+    req.flush(response);
+  });
+
+  it('should search application invitations with pagination and filters', done => {
+    const response = fakeApplicationInvitationsResponse();
+
+    service.searchApplicationInvitations(applicationId, 2, 25, { email: 'alice@example.com' }).subscribe(res => {
+      expect(res).toMatchObject(response);
+      done();
+    });
+
+    const req = httpTestingController.expectOne(`${TESTING_BASE_URL}/applications/${applicationId}/invitations/_search?page=2&size=25`);
+    expect(req.request.method).toEqual('POST');
+    expect(req.request.body).toEqual({ filters: { email: 'alice@example.com' } });
+    req.flush(response);
+  });
+});

--- a/gravitee-apim-portal-webui-next/src/services/application-invitation.service.ts
+++ b/gravitee-apim-portal-webui-next/src/services/application-invitation.service.ts
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { HttpClient } from '@angular/common/http';
+import { inject, Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+
+import { ConfigService } from './config.service';
+import { ApplicationInvitationsResponse, ApplicationInvitationsSearchFilters } from '../entities/application/application-invitation';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class ApplicationInvitationService {
+  private readonly http = inject(HttpClient);
+  private readonly configService = inject(ConfigService);
+
+  searchApplicationInvitations(
+    applicationId: string,
+    page = 1,
+    size = 10,
+    filters: ApplicationInvitationsSearchFilters = {},
+  ): Observable<ApplicationInvitationsResponse> {
+    return this.http.post<ApplicationInvitationsResponse>(
+      `${this.configService.baseURL}/applications/${applicationId}/invitations/_search`,
+      { filters },
+      {
+        params: { page, size },
+      },
+    );
+  }
+}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-13762

## Summary

- Added the pending application invitations list in the new Developer Portal.
- Displays invitation email and role, with the email cell aligned to the design using an envelope icon in an avatar-like container.
- Added an empty `Actions` column as a placeholder for future invitation actions.
- Kept pagination and permission-based visibility for users with `MEMBER[R]`.


https://github.com/user-attachments/assets/8c7bd374-7262-4f41-9cf3-ab687979910f

