### PR TITLE
feat: add gravitee.request.id and gravitee.transaction.id as OTel span attributes

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/reactive/core/tracing/AbstractTracingHook.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/reactive/core/tracing/AbstractTracingHook.java
@@ -34,6 +34,8 @@ import java.util.Map;
 public abstract class AbstractTracingHook implements HttpHook {
 
     public static final String SPAN_PHASE_ATTR = "gravitee.execution.phase";
+    public static final String SPAN_REQUEST_ID_ATTR = "gravitee.request.id";
+    public static final String SPAN_TRANSACTION_ID_ATTR = "gravitee.transaction.id";
     public static final String ATTR_INTERNAL_TRACING_SPAN = "tracing-span-%s";
 
     @Override
@@ -92,6 +94,12 @@ public abstract class AbstractTracingHook implements HttpHook {
         Map<String, String> attributes = new HashMap<>();
         if (executionPhase != null) {
             attributes.put(SPAN_PHASE_ATTR, executionPhase.getLabel());
+        }
+        if (ctx.request() != null) {
+            attributes.put(SPAN_REQUEST_ID_ATTR, ctx.request().id());
+            if (ctx.request().transactionId() != null) {
+                attributes.put(SPAN_TRANSACTION_ID_ATTR, ctx.request().transactionId());
+            }
         }
         return attributes;
     }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-core/src/test/java/io/gravitee/gateway/reactive/core/tracing/TracingHookTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-core/src/test/java/io/gravitee/gateway/reactive/core/tracing/TracingHookTest.java
@@ -15,6 +15,8 @@
  */
 package io.gravitee.gateway.reactive.core.tracing;
 
+import static io.gravitee.gateway.reactive.core.tracing.AbstractTracingHook.SPAN_REQUEST_ID_ATTR;
+import static io.gravitee.gateway.reactive.core.tracing.AbstractTracingHook.SPAN_TRANSACTION_ID_ATTR;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -22,17 +24,21 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
 
 import io.gravitee.gateway.reactive.api.ExecutionFailure;
 import io.gravitee.gateway.reactive.api.ExecutionPhase;
 import io.gravitee.gateway.reactive.api.tracing.Tracer;
 import io.gravitee.gateway.reactive.core.context.DefaultExecutionContext;
+import io.gravitee.gateway.reactive.core.context.MutableRequest;
 import io.gravitee.node.api.opentelemetry.Span;
+import io.gravitee.node.api.opentelemetry.internal.InternalRequest;
 import io.gravitee.node.opentelemetry.tracer.noop.NoOpSpan;
 import io.gravitee.node.opentelemetry.tracer.noop.NoOpTracer;
 import io.gravitee.reporter.api.v4.metric.Metrics;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 
 /**
  * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
@@ -54,11 +60,35 @@ class TracingHookTest {
     }
 
     @Test
+    public void span_attribute_constants_have_expected_values() {
+        assertThat(SPAN_REQUEST_ID_ATTR).isEqualTo("gravitee.request.id");
+        assertThat(SPAN_TRANSACTION_ID_ATTR).isEqualTo("gravitee.transaction.id");
+    }
+
+    @Test
     public void should_start_span_on_pre_step() {
         tracingHook.pre("any", ctx, ExecutionPhase.REQUEST).test().assertComplete();
 
         verify(spyNoopTracer).startSpanFrom(any(), any());
         assertThat(ctx.<Span>getInternalAttribute("tracing-span-any")).isNotNull();
+    }
+
+    @Test
+    public void should_include_request_id_and_transaction_id_in_span_attributes() {
+        var mockRequest = mock(MutableRequest.class);
+        when(mockRequest.id()).thenReturn("test-req-id");
+        when(mockRequest.transactionId()).thenReturn("test-tx-id");
+        ctx = new DefaultExecutionContext(mockRequest, null);
+        ctx.metrics(mock(Metrics.class));
+        ctx.tracer(new Tracer(null, spyNoopTracer));
+
+        tracingHook.pre("any", ctx, ExecutionPhase.REQUEST).test().assertComplete();
+
+        var captor = ArgumentCaptor.forClass(InternalRequest.class);
+        verify(spyNoopTracer).startSpanFrom(any(), captor.capture());
+        assertThat(captor.getValue().attributes())
+            .containsEntry(SPAN_REQUEST_ID_ATTR, "test-req-id")
+            .containsEntry(SPAN_TRANSACTION_ID_ATTR, "test-tx-id");
     }
 
     @Test

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactive/reactor/processor/DefaultPlatformProcessorChainFactory.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactive/reactor/processor/DefaultPlatformProcessorChainFactory.java
@@ -22,6 +22,7 @@ import io.gravitee.gateway.reactive.reactor.processor.connection.ConnectionDrain
 import io.gravitee.gateway.reactive.reactor.processor.forward.XForwardProcessor;
 import io.gravitee.gateway.reactive.reactor.processor.metrics.MetricsProcessor;
 import io.gravitee.gateway.reactive.reactor.processor.tracing.TraceContextProcessor;
+import io.gravitee.gateway.reactive.reactor.processor.tracing.TracingPreProcessor;
 import io.gravitee.gateway.reactive.reactor.processor.transaction.TransactionPreProcessorFactory;
 import io.gravitee.gateway.report.ReporterService;
 import io.gravitee.node.api.Node;
@@ -38,6 +39,7 @@ public class DefaultPlatformProcessorChainFactory extends AbstractPlatformProces
 
     private final boolean xForwardProcessor;
     private final boolean traceContext;
+    private final boolean tracesEnabled;
     private final GatewayConfiguration gatewayConfiguration;
     private final ConnectionDrainManager connectionDrainManager;
 
@@ -50,13 +52,15 @@ public class DefaultPlatformProcessorChainFactory extends AbstractPlatformProces
         Node node,
         String port,
         GatewayConfiguration gatewayConfiguration,
-        ConnectionDrainManager connectionDrainManager
+        ConnectionDrainManager connectionDrainManager,
+        boolean tracesEnabled
     ) {
         super(transactionHandlerFactory, reporterService, eventProducer, node, port);
         this.traceContext = traceContext;
         this.xForwardProcessor = xForwardProcessor;
         this.gatewayConfiguration = gatewayConfiguration;
         this.connectionDrainManager = connectionDrainManager;
+        this.tracesEnabled = tracesEnabled;
     }
 
     @Override
@@ -64,6 +68,9 @@ public class DefaultPlatformProcessorChainFactory extends AbstractPlatformProces
         List<Processor> preProcessorList = new ArrayList<>();
         preProcessorList.add(new ConnectionDrainProcessor(connectionDrainManager));
         preProcessorList.add(transactionHandlerFactory.create());
+        if (tracesEnabled) {
+            preProcessorList.add(new TracingPreProcessor());
+        }
         preProcessorList.add(new MetricsProcessor(gatewayConfiguration));
 
         if (xForwardProcessor) {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactive/reactor/processor/tracing/TracingPreProcessor.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactive/reactor/processor/tracing/TracingPreProcessor.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.reactive.reactor.processor.tracing;
+
+import static io.gravitee.gateway.reactive.api.context.InternalContextAttributes.ATTR_INTERNAL_TRACING_ROOT_SPAN;
+
+import io.gravitee.gateway.reactive.core.context.HttpExecutionContextInternal;
+import io.gravitee.gateway.reactive.core.processor.Processor;
+import io.gravitee.gateway.reactive.core.tracing.AbstractTracingHook;
+import io.gravitee.node.api.opentelemetry.Span;
+import io.reactivex.rxjava3.core.Completable;
+
+/**
+ * Enriches the root OTel span with Gravitee request identifiers once they are available.
+ *
+ * <p>The root span is created in {@code DefaultHttpRequestDispatcher.doOnSubscribe()} and stored
+ * under {@code ATTR_INTERNAL_TRACING_ROOT_SPAN} before the pre-processor chain runs. At that point
+ * {@code transactionId} has not yet been assigned by
+ * {@link io.gravitee.gateway.reactive.reactor.processor.transaction.TransactionPreProcessor}.
+ * This processor runs immediately after {@code TransactionPreProcessor}, so both
+ * {@code gravitee.request.id} and {@code gravitee.transaction.id} are guaranteed to be set.
+ *
+ * <p>This processor is only registered when OTel traces are enabled. When tracing is disabled the
+ * root span is never stored in context, so this processor would be a no-op regardless.
+ *
+ * @author GraviteeSource Team
+ */
+public class TracingPreProcessor implements Processor {
+
+    @Override
+    public String getId() {
+        return "processor-tracing";
+    }
+
+    @Override
+    public Completable execute(final HttpExecutionContextInternal ctx) {
+        return Completable.fromRunnable(() -> {
+            Span rootSpan = ctx.getInternalAttribute(ATTR_INTERNAL_TRACING_ROOT_SPAN);
+            if (rootSpan != null && ctx.request() != null) {
+                rootSpan.withAttribute(AbstractTracingHook.SPAN_REQUEST_ID_ATTR, ctx.request().id());
+                if (ctx.request().transactionId() != null) {
+                    rootSpan.withAttribute(AbstractTracingHook.SPAN_TRANSACTION_ID_ATTR, ctx.request().transactionId());
+                }
+            }
+        });
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactor/spring/ReactorConfiguration.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactor/spring/ReactorConfiguration.java
@@ -148,7 +148,8 @@ public class ReactorConfiguration {
             node,
             httpPort,
             gatewayConfiguration,
-            connectionDrainManager
+            connectionDrainManager,
+            openTelemetryConfiguration.isTracesEnabled()
         );
     }
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/test/java/io/gravitee/gateway/reactive/reactor/processor/DefaultPlatformProcessorChainFactoryTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/test/java/io/gravitee/gateway/reactive/reactor/processor/DefaultPlatformProcessorChainFactoryTest.java
@@ -34,6 +34,7 @@ import io.gravitee.gateway.reactive.reactor.processor.metrics.MetricsProcessor;
 import io.gravitee.gateway.reactive.reactor.processor.reporter.ReporterProcessor;
 import io.gravitee.gateway.reactive.reactor.processor.responsetime.ResponseTimeProcessor;
 import io.gravitee.gateway.reactive.reactor.processor.tracing.TraceContextProcessor;
+import io.gravitee.gateway.reactive.reactor.processor.tracing.TracingPreProcessor;
 import io.gravitee.gateway.reactive.reactor.processor.transaction.TransactionPreProcessor;
 import io.gravitee.gateway.reactive.reactor.processor.transaction.TransactionPreProcessorFactory;
 import io.gravitee.gateway.report.ReporterService;
@@ -94,16 +95,18 @@ class DefaultPlatformProcessorChainFactoryTest {
                 node,
                 "8080",
                 gatewayConfiguration,
-                connectionDrainManager
+                connectionDrainManager,
+                true
             );
             List<Processor> processors = platformProcessorChainFactory.buildPreProcessorList();
 
-            assertEquals(5, processors.size());
+            assertEquals(6, processors.size());
             assertInstanceOf(ConnectionDrainProcessor.class, processors.get(0));
             assertInstanceOf(TransactionPreProcessor.class, processors.get(1));
-            assertInstanceOf(MetricsProcessor.class, processors.get(2));
-            assertInstanceOf(XForwardProcessor.class, processors.get(3));
-            assertInstanceOf(TraceContextProcessor.class, processors.get(4));
+            assertInstanceOf(TracingPreProcessor.class, processors.get(2));
+            assertInstanceOf(MetricsProcessor.class, processors.get(3));
+            assertInstanceOf(XForwardProcessor.class, processors.get(4));
+            assertInstanceOf(TraceContextProcessor.class, processors.get(5));
         }
 
         @Test
@@ -117,7 +120,32 @@ class DefaultPlatformProcessorChainFactoryTest {
                 node,
                 "8080",
                 gatewayConfiguration,
-                connectionDrainManager
+                connectionDrainManager,
+                true
+            );
+            List<Processor> processors = platformProcessorChainFactory.buildPreProcessorList();
+
+            assertEquals(5, processors.size());
+            assertInstanceOf(ConnectionDrainProcessor.class, processors.get(0));
+            assertInstanceOf(TransactionPreProcessor.class, processors.get(1));
+            assertInstanceOf(TracingPreProcessor.class, processors.get(2));
+            assertInstanceOf(MetricsProcessor.class, processors.get(3));
+            assertInstanceOf(XForwardProcessor.class, processors.get(4));
+        }
+
+        @Test
+        void should_not_have_TracingPreProcessor_when_otlp_is_disabled() {
+            DefaultPlatformProcessorChainFactory platformProcessorChainFactory = new DefaultPlatformProcessorChainFactory(
+                transactionHandlerFactory,
+                false,
+                true,
+                reporterService,
+                eventProducer,
+                node,
+                "8080",
+                gatewayConfiguration,
+                connectionDrainManager,
+                false
             );
             List<Processor> processors = platformProcessorChainFactory.buildPreProcessorList();
 
@@ -143,7 +171,8 @@ class DefaultPlatformProcessorChainFactoryTest {
                 node,
                 "8080",
                 gatewayConfiguration,
-                connectionDrainManager
+                connectionDrainManager,
+                false
             );
             when(eventProducer.isEmpty()).thenReturn(true);
 
@@ -165,7 +194,8 @@ class DefaultPlatformProcessorChainFactoryTest {
                 node,
                 "8080",
                 gatewayConfiguration,
-                connectionDrainManager
+                connectionDrainManager,
+                false
             );
             when(eventProducer.isEmpty()).thenReturn(false);
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/test/java/io/gravitee/gateway/reactive/reactor/processor/tracing/TracingPreProcessorTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/test/java/io/gravitee/gateway/reactive/reactor/processor/tracing/TracingPreProcessorTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.reactive.reactor.processor.tracing;
+
+import static io.gravitee.gateway.reactive.api.context.InternalContextAttributes.ATTR_INTERNAL_TRACING_ROOT_SPAN;
+import static io.gravitee.gateway.reactive.core.tracing.AbstractTracingHook.SPAN_REQUEST_ID_ATTR;
+import static io.gravitee.gateway.reactive.core.tracing.AbstractTracingHook.SPAN_TRANSACTION_ID_ATTR;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.gateway.reactive.reactor.processor.AbstractProcessorTest;
+import io.gravitee.node.api.opentelemetry.Span;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author GraviteeSource Team
+ */
+class TracingPreProcessorTest extends AbstractProcessorTest {
+
+    private TracingPreProcessor processor;
+    private Span rootSpan;
+
+    @BeforeEach
+    public void setUp() {
+        processor = new TracingPreProcessor();
+        rootSpan = mock(Span.class);
+    }
+
+    @Test
+    void should_set_request_id_and_transaction_id_on_root_span() {
+        when(mockRequest.id()).thenReturn("req-id");
+        when(mockRequest.transactionId()).thenReturn("tx-id");
+        when(rootSpan.withAttribute(SPAN_REQUEST_ID_ATTR, "req-id")).thenReturn(rootSpan);
+        when(rootSpan.withAttribute(SPAN_TRANSACTION_ID_ATTR, "tx-id")).thenReturn(rootSpan);
+        ctx.putInternalAttribute(ATTR_INTERNAL_TRACING_ROOT_SPAN, rootSpan);
+
+        processor.execute(ctx).test().assertComplete();
+
+        verify(rootSpan).withAttribute(SPAN_REQUEST_ID_ATTR, "req-id");
+        verify(rootSpan).withAttribute(SPAN_TRANSACTION_ID_ATTR, "tx-id");
+    }
+
+    @Test
+    void should_set_only_request_id_when_transaction_id_is_null() {
+        when(mockRequest.id()).thenReturn("req-id");
+        when(mockRequest.transactionId()).thenReturn(null);
+        when(rootSpan.withAttribute(SPAN_REQUEST_ID_ATTR, "req-id")).thenReturn(rootSpan);
+        ctx.putInternalAttribute(ATTR_INTERNAL_TRACING_ROOT_SPAN, rootSpan);
+
+        processor.execute(ctx).test().assertComplete();
+
+        verify(rootSpan).withAttribute(SPAN_REQUEST_ID_ATTR, "req-id");
+        verify(rootSpan, never()).withAttribute(SPAN_TRANSACTION_ID_ATTR, null);
+    }
+
+    @Test
+    void should_do_nothing_when_no_root_span_in_context() {
+        processor.execute(ctx).test().assertComplete();
+
+        verify(rootSpan, never()).withAttribute(SPAN_REQUEST_ID_ATTR, "req-id");
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/main/java/io/gravitee/gateway/reactive/debug/reactor/processor/DebugPlatformProcessorChainFactory.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/main/java/io/gravitee/gateway/reactive/debug/reactor/processor/DebugPlatformProcessorChainFactory.java
@@ -59,7 +59,8 @@ public class DebugPlatformProcessorChainFactory extends DefaultPlatformProcessor
             node,
             port,
             gatewayConfiguration,
-            connectionDrainManager
+            connectionDrainManager,
+            tracing
         );
         this.eventRepository = eventRepository;
         this.objectMapper = objectMapper;


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-14173

## Description

Adds **_gravitee.request.id_** and **_gravitee.transaction.id_** as attributes on all OTel spans.

Sub-spans are enriched via AbstractTracingHook.spanAttributes(). 
The root span is enriched by a new **_TracingPreProcessor_** that runs right after TransactionPreProcessor, since the root span is created before the **_pre-processor_** chain runs and **_transactionId_** is null at that point.

## Additional context


https://github.com/user-attachments/assets/162d8056-e74b-4480-b07e-d408d62a6a94



<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

