### PR TITLE
chore(4.11.x): bump gravitee-apim-repository-bridge from 8.0.0 to 8.1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -314,7 +314,7 @@
         <gravitee-resource-ai-vector-store-aws-s3.version>1.0.0</gravitee-resource-ai-vector-store-aws-s3.version>
         <gravitee-resource-ai-model-text-embedding.version>1.0.0</gravitee-resource-ai-model-text-embedding.version>
         <gravitee-policy-ai-semantic-caching.version>1.1.0</gravitee-policy-ai-semantic-caching.version>
-        <gravitee-apim-repository-bridge.version>8.0.0</gravitee-apim-repository-bridge.version>
+        <gravitee-apim-repository-bridge.version>8.1.0</gravitee-apim-repository-bridge.version>
         <gravitee-secretprovider-hc-vault.version>2.1.0</gravitee-secretprovider-hc-vault.version>
         <gravitee-secretprovider-aws.version>2.0.0</gravitee-secretprovider-aws.version>
         <gravitee-service-secrets.version>3.0.1</gravitee-service-secrets.version>


### PR DESCRIPTION
Bumps **gravitee-apim-repository-bridge** from \`8.0.0\` to \`8.1.0\` on \`4.11.x\`.

\`8.1.0\` adds a configurable per-request timeout on the bridge HTTP client (\`management.http.requestTimeout\`, default 60 s) so a slow/hung mAPI cannot keep gateway sync waiting indefinitely.

## Jira

[APIM-14170](https://gravitee.atlassian.net/browse/APIM-14170)

## Related bridge PRs

- gravitee-io/gravitee-apim-repository-bridge#128 (main → 8.1.0, **this consumer**)
- gravitee-io/gravitee-apim-repository-bridge#129 (alpha → 9.0.0-alpha.2)
- gravitee-io/gravitee-apim-repository-bridge#130 (7.1.x → 7.1.1)
- gravitee-io/gravitee-apim-repository-bridge#131 (7.0.x → 7.0.1)

[APIM-14170]: https://gravitee.atlassian.net/browse/APIM-14170?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ