### PR TITLE
chore(4.10.x): bump gravitee-apim-repository-bridge from 7.1.0 to 7.1.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -306,7 +306,7 @@
         <gravitee-reactor-native-kafka.version>5.0.4</gravitee-reactor-native-kafka.version>
         <gravitee-reactor-mcp-proxy.version>1.1.2</gravitee-reactor-mcp-proxy.version>
         <gravitee-reactor-llm-proxy.version>1.4.1</gravitee-reactor-llm-proxy.version>
-        <gravitee-apim-repository-bridge.version>7.1.0</gravitee-apim-repository-bridge.version>
+        <gravitee-apim-repository-bridge.version>7.1.1</gravitee-apim-repository-bridge.version>
         <gravitee-secretprovider-hc-vault.version>2.1.0</gravitee-secretprovider-hc-vault.version>
         <gravitee-secretprovider-aws.version>2.0.0</gravitee-secretprovider-aws.version>
         <gravitee-service-secrets.version>3.0.1</gravitee-service-secrets.version>


### PR DESCRIPTION
Bumps **gravitee-apim-repository-bridge** from `7.1.0` to `7.1.1` on `4.10.x`.

`7.1.1` adds a configurable per-request timeout on the bridge HTTP client (`management.http.requestTimeout`, default 60 s) so a slow/hung mAPI cannot keep gateway sync waiting indefinitely.

## Jira

[APIM-14170](https://gravitee.atlassian.net/browse/APIM-14170)

## Related bridge PRs

- gravitee-io/gravitee-apim-repository-bridge#128 (main → 8.1.0)
- gravitee-io/gravitee-apim-repository-bridge#129 (alpha → 9.0.0-alpha.2)
- gravitee-io/gravitee-apim-repository-bridge#130 (7.1.x → 7.1.1, **this consumer**)
- gravitee-io/gravitee-apim-repository-bridge#131 (7.0.x → 7.0.1)

[APIM-14170]: https://gravitee.atlassian.net/browse/APIM-14170?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ