### PR TITLE
feat(authz-ui): REST client + entity / policy / schema hooks

### DIFF
--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/app/features/policy-structure/entity-types.ts
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/app/features/policy-structure/entity-types.ts
@@ -1,0 +1,132 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Entity schema types ported from prototype schema-data.ts.
+ * Only schema metadata (categories, entity definitions, types) — no mock instances.
+ */
+
+// ---------- Categories --------------------------------------------------------
+
+export type EntityCategoryId = 'principal' | 'mcp' | 'api' | 'agent' | 'llm' | 'event' | 'custom';
+
+export interface EntityCategory {
+    id: EntityCategoryId;
+    label: string;
+    tone: string;
+}
+
+export const CATEGORIES: EntityCategory[] = [
+    { id: 'principal', label: 'Principals', tone: 'text-blue-600 dark:text-blue-400' },
+    { id: 'mcp', label: 'MCP', tone: 'text-teal-600 dark:text-teal-400' },
+    { id: 'api', label: 'APIs', tone: 'text-indigo-600 dark:text-indigo-400' },
+    { id: 'agent', label: 'Agents', tone: 'text-orange-600 dark:text-orange-400' },
+    { id: 'llm', label: 'LLMs', tone: 'text-fuchsia-600 dark:text-fuchsia-400' },
+    { id: 'event', label: 'Events', tone: 'text-cyan-600 dark:text-cyan-400' },
+    { id: 'custom', label: 'Custom', tone: 'text-slate-600 dark:text-slate-400' },
+];
+
+export function getCategory(id: EntityCategoryId): EntityCategory | undefined {
+    return CATEGORIES.find(c => c.id === id);
+}
+
+// ---------- Entity types ------------------------------------------------------
+//
+// Only the *category* of each known entity name lives here — it controls UI
+// presentation (sidebar grouping, icon, accent color). The full schema (which
+// attributes exist on each entity, which entities can be parents of others) is
+// authoritative on the server: load it through `useEntitySchema(envId)` which
+// parses the GAPL `schemaText` returned by `GET .../authz/schema`.
+
+const ENTITY_CATEGORIES: Readonly<Record<string, EntityCategoryId>> = {
+    // ---- Principals ----
+    User: 'principal',
+    Group: 'principal',
+    ServiceAccount: 'principal',
+    AgentIdentity: 'principal',
+
+    // ---- MCP ----
+    MCPServer: 'mcp',
+    MCPTool: 'mcp',
+    MCPPrompt: 'mcp',
+    MCPResource: 'mcp',
+
+    // ---- APIs ----
+    API: 'api',
+    Endpoint: 'api',
+    DataField: 'api',
+
+    // ---- Agents ----
+    Agent: 'agent',
+    AgentSkill: 'agent',
+    AgentTool: 'agent',
+    AgentMemory: 'agent',
+    AgentKnowledge: 'agent',
+
+    // ---- LLMs ----
+    LLMRoute: 'llm',
+    LLMModel: 'llm',
+    LLMProvider: 'llm',
+
+    // ---- Events ----
+    EventStream: 'event',
+    Topic: 'event',
+    SchemaField: 'event',
+
+    // ---- Custom ----
+    Application: 'custom',
+    Asset: 'custom',
+    Resource: 'custom',
+};
+
+export function getEntityCategoryId(name: string): EntityCategoryId | undefined {
+    return ENTITY_CATEGORIES[name];
+}
+
+// ---------- Instance types ----------------------------------------------------
+
+export type AttrValue = string | number | boolean;
+
+/**
+ * Where an entity record came from.
+ *   - `local`     : hand-created in Authorization (fully editable).
+ *   - `scim`      : synced from an external IdP via SCIM (read-only).
+ *   - `directory` : synced from the built-in Gravitee User Directory (read-only).
+ */
+export type EntitySource = 'local' | 'scim' | 'directory';
+
+export interface EntityInstance {
+    uid: { type: string; id: string };
+    /** Human-readable display name (falls back to attrs.name). */
+    displayName?: string;
+    attrs: Record<string, AttrValue>;
+    parents: Array<{ type: string; id: string }>;
+    /** Where this record was materialized from. Drives editability. */
+    source: EntitySource;
+    /**
+     * Identity provider/source label for principals:
+     *  - SCIM: the IdP name (e.g. `Okta`, `Azure AD`).
+     *  - Directory: the directory name (e.g. `Gravitee User Directory`).
+     */
+    principalProvider?: string;
+    /** ISO timestamp of last import/sync (stored as _importedAt in backend attributes). */
+    importedAt?: string;
+    /** Backend record id (used for update/delete). Set after fromBackend(). */
+    _backendId?: string;
+    /** Backend createdAt ISO. */
+    createdAt?: string;
+    /** Backend updatedAt ISO. */
+    updatedAt?: string;
+}

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/lib/__tests__/entity-adapter.test.ts
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/lib/__tests__/entity-adapter.test.ts
@@ -1,0 +1,270 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, expect, it } from 'vitest';
+import type { EntityResponse } from '../api/authz-api.types';
+import { parseEntityUid, formatEntityUid, fromBackend, toBackend, META_KEYS } from '../entity-adapter';
+
+// ---------- parseEntityUid ---------------------------------------------------
+
+describe('parseEntityUid', () => {
+    // Canonical dotted form — what the backend EntityIdValidator accepts.
+    it('parses dotted user form', () => {
+        expect(parseEntityUid('user.alice')).toEqual({ type: 'User', id: 'alice' });
+    });
+
+    it('parses dotted group form', () => {
+        expect(parseEntityUid('group.engineering')).toEqual({ type: 'Group', id: 'engineering' });
+    });
+
+    it('parses SCIM 3-segment dotted form (kind.connector.slug)', () => {
+        // For SCIM mirrors the id keeps the full tail so a from→to round-trip
+        // reproduces the canonical entityId verbatim.
+        expect(parseEntityUid('user.okta.alice')).toEqual({ type: 'User', id: 'okta.alice' });
+    });
+
+    it('maps the mcp short kind back to MCPServer', () => {
+        expect(parseEntityUid('mcp.flight-mcp')).toEqual({ type: 'MCPServer', id: 'flight-mcp' });
+    });
+
+    // Legacy Type::"id" form — tolerated for backwards compat with test fixtures
+    // and any pre-existing data; the backend would have rejected this on save.
+    it('parses legacy unquoted form', () => {
+        expect(parseEntityUid('User::alice')).toEqual({ type: 'User', id: 'alice' });
+    });
+
+    it('parses legacy quoted form', () => {
+        expect(parseEntityUid('User::"alice"')).toEqual({ type: 'User', id: 'alice' });
+    });
+
+    it('parses legacy quoted id with escaped inner quote', () => {
+        expect(parseEntityUid('User::"alice\\"bob"')).toEqual({ type: 'User', id: 'alice"bob' });
+    });
+
+    it('returns Unknown type when neither dotted nor legacy form matches', () => {
+        const result = parseEntityUid('justsomething');
+        expect(result.type).toBe('Unknown');
+        expect(result.id).toBe('justsomething');
+    });
+
+    it('returns Unknown type when first dotted segment is not a recognised kind', () => {
+        const result = parseEntityUid('badprefix.something');
+        expect(result.type).toBe('Unknown');
+        expect(result.id).toBe('badprefix.something');
+    });
+});
+
+// ---------- formatEntityUid --------------------------------------------------
+
+describe('formatEntityUid', () => {
+    it('formats to canonical dotted form', () => {
+        expect(formatEntityUid({ type: 'User', id: 'alice' })).toBe('user.alice');
+    });
+
+    it('collapses MCPServer to the mcp prefix the backend expects', () => {
+        expect(formatEntityUid({ type: 'MCPServer', id: 'flight-mcp' })).toBe('mcp.flight-mcp');
+    });
+
+    it('keeps multi-segment ids intact (SCIM mirror layout)', () => {
+        // Round-tripping a SCIM-sourced uid must reproduce the canonical 3-seg form.
+        expect(formatEntityUid({ type: 'User', id: 'okta.alice' })).toBe('user.okta.alice');
+    });
+
+    it('round-trips a 2-segment local uid through parse', () => {
+        const uid = { type: 'Group', id: 'engineering' };
+        const formatted = formatEntityUid(uid);
+        const parsed = parseEntityUid(formatted);
+        expect(parsed).toEqual(uid);
+    });
+
+    it('round-trips a SCIM 3-segment uid through parse', () => {
+        const uid = { type: 'User', id: 'okta.alice' };
+        const formatted = formatEntityUid(uid);
+        const parsed = parseEntityUid(formatted);
+        expect(parsed).toEqual(uid);
+    });
+});
+
+// ---------- Meta key separation in fromBackend --------------------------------
+
+describe('fromBackend', () => {
+    const base: EntityResponse = {
+        id: 'backend-id-1',
+        environmentId: 'DEFAULT',
+        uid: 'user.alice',
+        attributes: { _kind: 'user' },
+        parents: [],
+        createdAt: '2025-01-01T00:00:00.000Z',
+        updatedAt: '2025-01-02T00:00:00.000Z',
+    };
+
+    it('parses dotted uid with _kind override and strips the kind prefix', () => {
+        const inst = fromBackend(base);
+        expect(inst.uid).toEqual({ type: 'User', id: 'alice' });
+    });
+
+    it('parses SCIM 3-segment uid, keeping connector.slug as the id', () => {
+        // Regression for #8 — a SCIM-sourced principal must round-trip without
+        // re-wrapping its dotted entityId. The id keeps the connector segment.
+        const inst = fromBackend({ ...base, uid: 'user.okta.alice', attributes: { _kind: 'user', _connector: 'okta' } });
+        expect(inst.uid).toEqual({ type: 'User', id: 'okta.alice' });
+    });
+
+    it('falls back to dotted-prefix inference when _kind is absent', () => {
+        const inst = fromBackend({ ...base, uid: 'group.eng', attributes: {} });
+        expect(inst.uid).toEqual({ type: 'Group', id: 'eng' });
+    });
+
+    it('defaults source to local when not in attributes', () => {
+        const inst = fromBackend(base);
+        expect(inst.source).toBe('local');
+    });
+
+    it('extracts _source meta key', () => {
+        const inst = fromBackend({ ...base, attributes: { _kind: 'user', _source: 'scim' } });
+        expect(inst.source).toBe('scim');
+        expect(inst.attrs['_source']).toBeUndefined();
+    });
+
+    it('extracts _displayName meta key', () => {
+        const inst = fromBackend({ ...base, attributes: { _kind: 'user', _displayName: 'Alice Admin', name: 'alice' } });
+        expect(inst.displayName).toBe('Alice Admin');
+        expect(inst.attrs['_displayName']).toBeUndefined();
+        expect(inst.attrs['name']).toBe('alice');
+    });
+
+    it('does not leak any META_KEY into attrs', () => {
+        const allMeta: Record<string, unknown> = {};
+        for (const k of META_KEYS) allMeta[k] = 'test';
+        const inst = fromBackend({ ...base, attributes: { ...allMeta, regular: 'value' } });
+        for (const k of META_KEYS) {
+            expect(inst.attrs[k]).toBeUndefined();
+        }
+        expect(inst.attrs['regular']).toBe('value');
+    });
+
+    it('parses dotted parents', () => {
+        const inst = fromBackend({ ...base, parents: ['group.engineering', 'group.ops'] });
+        expect(inst.parents).toEqual([
+            { type: 'Group', id: 'engineering' },
+            { type: 'Group', id: 'ops' },
+        ]);
+    });
+
+    it('parses legacy quoted parents (backwards-compat)', () => {
+        const inst = fromBackend({ ...base, parents: ['Group::"engineering"', 'Group::ops'] });
+        expect(inst.parents).toEqual([
+            { type: 'Group', id: 'engineering' },
+            { type: 'Group', id: 'ops' },
+        ]);
+    });
+
+    it('preserves backend id', () => {
+        const inst = fromBackend(base);
+        expect(inst._backendId).toBe('backend-id-1');
+    });
+});
+
+// ---------- toBackend --------------------------------------------------------
+
+describe('toBackend', () => {
+    it('formats uid in canonical dotted form', () => {
+        const req = toBackend({
+            uid: { type: 'User', id: 'alice' },
+            attrs: {},
+            parents: [],
+            source: 'local',
+        });
+        expect(req.uid).toBe('user.alice');
+    });
+
+    it('does NOT write _source when source is local', () => {
+        const req = toBackend({
+            uid: { type: 'User', id: 'alice' },
+            attrs: {},
+            parents: [],
+            source: 'local',
+        });
+        expect(req.attributes['_source']).toBeUndefined();
+    });
+
+    it('writes _source when source is not local', () => {
+        const req = toBackend({
+            uid: { type: 'User', id: 'alice' },
+            attrs: {},
+            parents: [],
+            source: 'scim',
+        });
+        expect(req.attributes['_source']).toBe('scim');
+    });
+
+    it('writes _displayName when set', () => {
+        const req = toBackend({
+            uid: { type: 'User', id: 'alice' },
+            displayName: 'Alice Admin',
+            attrs: {},
+            parents: [],
+            source: 'local',
+        });
+        expect(req.attributes['_displayName']).toBe('Alice Admin');
+    });
+
+    it('formats parents in canonical dotted form', () => {
+        const req = toBackend({
+            uid: { type: 'User', id: 'alice' },
+            attrs: {},
+            parents: [{ type: 'Group', id: 'engineering' }],
+            source: 'local',
+        });
+        expect(req.parents).toEqual(['group.engineering']);
+    });
+
+    it('round-trips local user from backend → ui → backend without corruption', () => {
+        const response: EntityResponse = {
+            id: 'x',
+            environmentId: 'DEFAULT',
+            uid: 'group.engineering',
+            attributes: { _kind: 'group', name: 'Engineering', _displayName: 'Engineering Team' },
+            parents: [],
+            createdAt: '',
+            updatedAt: '',
+        };
+        const inst = fromBackend(response);
+        const req = toBackend(inst);
+        expect(req.uid).toBe('group.engineering');
+        expect(req.attributes['name']).toBe('Engineering');
+        expect(req.attributes['_displayName']).toBe('Engineering Team');
+    });
+
+    it('round-trips a SCIM 3-segment principal without re-wrapping', () => {
+        // Regression for #8 — the bug was that fromBackend kept `id = "user.okta.alice"`
+        // and toBackend then produced `"User::"user.okta.alice""` (legacy wrap of the
+        // dotted form), corrupting the canonical entityId on every UI write.
+        const response: EntityResponse = {
+            id: 'x',
+            environmentId: 'DEFAULT',
+            uid: 'user.okta.alice',
+            attributes: { _kind: 'user', _connector: 'okta', _source: 'scim' },
+            parents: ['group.okta.engineering'],
+            createdAt: '',
+            updatedAt: '',
+        };
+        const inst = fromBackend(response);
+        const req = toBackend(inst);
+        expect(req.uid).toBe('user.okta.alice');
+        expect(req.parents).toEqual(['group.okta.engineering']);
+        expect(req.attributes['_source']).toBe('scim');
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/lib/__tests__/policy-entity-refs.test.ts
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/lib/__tests__/policy-entity-refs.test.ts
@@ -1,0 +1,194 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, expect, it } from 'vitest';
+import type { EntityInstance } from '../../app/features/policy-structure/entity-types';
+import type { PolicyResponse } from '../api/authz-api.types';
+import { buildPolicyEntityRefs, extractEntityRefsFromPolicyText, type PolicyRef } from '../policy-entity-refs';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makePolicy(overrides: Partial<PolicyResponse> = {}): PolicyResponse {
+    return {
+        id: overrides.id ?? 'pol-1',
+        environmentId: 'DEFAULT',
+        name: overrides.name ?? 'Policy 1',
+        description: null,
+        policyText: overrides.policyText ?? '',
+        type: overrides.type ?? 'API',
+        target: overrides.target ?? null,
+        status: overrides.status ?? 'DRAFT',
+        createdAt: '2025-01-01T00:00:00.000Z',
+        updatedAt: '2025-01-01T00:00:00.000Z',
+        ...overrides,
+    };
+}
+
+function makeEntity(type: string, id: string): EntityInstance {
+    return {
+        uid: { type, id },
+        attrs: {},
+        parents: [],
+        source: 'local',
+    };
+}
+
+// ---------------------------------------------------------------------------
+// extractEntityRefsFromPolicyText
+// ---------------------------------------------------------------------------
+
+describe('extractEntityRefsFromPolicyText', () => {
+    it('returns empty array for empty input', () => {
+        expect(extractEntityRefsFromPolicyText('')).toEqual([]);
+    });
+
+    it('extracts a single Type::"id" reference', () => {
+        const refs = extractEntityRefsFromPolicyText('principal == User::"alice"');
+        expect(refs).toEqual([{ type: 'User', id: 'alice', clause: 'principal' }]);
+    });
+
+    it('classifies clause as principal / action / resource', () => {
+        const text = `permit (
+              principal == User::"alice",
+              action == action::"read",
+              resource in [Endpoint::"flights", Endpoint::"bookings"]
+            );`;
+        const refs = extractEntityRefsFromPolicyText(text);
+        const principalRefs = refs.filter(r => r.clause === 'principal');
+        const actionRefs = refs.filter(r => r.clause === 'action');
+        const resourceRefs = refs.filter(r => r.clause === 'resource');
+        expect(principalRefs).toEqual([{ type: 'User', id: 'alice', clause: 'principal' }]);
+        expect(actionRefs).toEqual([{ type: 'action', id: 'read', clause: 'action' }]);
+        expect(resourceRefs).toEqual([
+            { type: 'Endpoint', id: 'flights', clause: 'resource' },
+            { type: 'Endpoint', id: 'bookings', clause: 'resource' },
+        ]);
+    });
+
+    it('returns empty list for malformed / non-policy text without throwing', () => {
+        const refs = extractEntityRefsFromPolicyText('this is not a valid policy {{{');
+        expect(refs).toEqual([]);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// buildPolicyEntityRefs
+// ---------------------------------------------------------------------------
+
+describe('buildPolicyEntityRefs', () => {
+    it('returns an empty map when no entities or policies are given', () => {
+        expect(buildPolicyEntityRefs([], [])).toEqual(new Map());
+        expect(buildPolicyEntityRefs([makeEntity('User', 'alice')], [])).toEqual(new Map([['User::alice', []]]));
+        expect(buildPolicyEntityRefs([], [makePolicy()])).toEqual(new Map());
+    });
+
+    it('returns no matches when policy text mentions other entities', () => {
+        const entities = [makeEntity('User', 'alice')];
+        const policies = [makePolicy({ policyText: 'permit ( principal == User::"bob" );' })];
+        const map = buildPolicyEntityRefs(entities, policies);
+        expect(map.get('User::alice')).toEqual([]);
+    });
+
+    it('finds a single matching policy and includes clause info', () => {
+        const entities = [makeEntity('User', 'alice')];
+        const policies = [
+            makePolicy({
+                id: 'p-read',
+                name: 'Read access',
+                policyText: 'permit ( principal == User::"alice", action == action::"read" );',
+            }),
+        ];
+        const refs = buildPolicyEntityRefs(entities, policies).get('User::alice') as PolicyRef[];
+        expect(refs).toHaveLength(1);
+        expect(refs[0].policy.id).toBe('p-read');
+        expect(refs[0].clauses).toEqual(['principal']);
+    });
+
+    it('finds multiple distinct policies that reference the same entity', () => {
+        const entities = [makeEntity('User', 'alice')];
+        const policies = [
+            makePolicy({ id: 'p1', policyText: 'permit ( principal == User::"alice" );' }),
+            makePolicy({ id: 'p2', policyText: 'forbid ( principal == User::"alice" );' }),
+            makePolicy({ id: 'p3', policyText: 'permit ( principal == User::"bob" );' }),
+        ];
+        const refs = buildPolicyEntityRefs(entities, policies).get('User::alice') as PolicyRef[];
+        expect(refs.map(r => r.policy.id).sort()).toEqual(['p1', 'p2']);
+    });
+
+    it('distinguishes principal vs action vs resource matches', () => {
+        const entities = [makeEntity('User', 'alice'), makeEntity('Endpoint', 'flights')];
+        const policies = [
+            makePolicy({
+                id: 'p1',
+                policyText: `permit (
+                    principal == User::"alice",
+                    action == action::"read",
+                    resource == Endpoint::"flights"
+                );`,
+            }),
+        ];
+        const map = buildPolicyEntityRefs(entities, policies);
+        const aliceRefs = map.get('User::alice') as PolicyRef[];
+        const flightsRefs = map.get('Endpoint::flights') as PolicyRef[];
+        expect(aliceRefs).toHaveLength(1);
+        expect(aliceRefs[0].clauses).toEqual(['principal']);
+        expect(flightsRefs).toHaveLength(1);
+        expect(flightsRefs[0].clauses).toEqual(['resource']);
+    });
+
+    it('records both clause kinds when an entity appears as principal AND resource in one policy', () => {
+        const entities = [makeEntity('User', 'alice')];
+        const policies = [
+            makePolicy({
+                id: 'p1',
+                policyText: `permit (
+                    principal == User::"alice",
+                    action == action::"impersonate",
+                    resource == User::"alice"
+                );`,
+            }),
+        ];
+        const refs = buildPolicyEntityRefs(entities, policies).get('User::alice') as PolicyRef[];
+        expect(refs).toHaveLength(1);
+        expect(refs[0].clauses.sort()).toEqual(['principal', 'resource']);
+    });
+
+    it('handles malformed policy text gracefully (no throw, no false positive)', () => {
+        const entities = [makeEntity('User', 'alice')];
+        const policies = [
+            makePolicy({ id: 'p-bad', policyText: 'this is not a policy at all }}}' }),
+            makePolicy({ id: 'p-good', policyText: 'permit ( principal == User::"alice" );' }),
+        ];
+        const map = buildPolicyEntityRefs(entities, policies);
+        const refs = map.get('User::alice') as PolicyRef[];
+        expect(refs).toHaveLength(1);
+        expect(refs[0].policy.id).toBe('p-good');
+    });
+
+    it('treats list refs (resource in [A::"x", B::"y"]) the same as scalar refs', () => {
+        const entities = [makeEntity('Endpoint', 'a'), makeEntity('Endpoint', 'b')];
+        const policies = [
+            makePolicy({
+                id: 'p1',
+                policyText: 'permit ( resource in [Endpoint::"a", Endpoint::"b"] );',
+            }),
+        ];
+        const map = buildPolicyEntityRefs(entities, policies);
+        expect((map.get('Endpoint::a') as PolicyRef[])[0].policy.id).toBe('p1');
+        expect((map.get('Endpoint::b') as PolicyRef[])[0].policy.id).toBe('p1');
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/lib/api/authz-api-client.ts
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/lib/api/authz-api-client.ts
@@ -1,0 +1,224 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import type { ValidationErrorResponse } from './authz-api.types';
+
+interface BootstrapConfig {
+    /** e.g. "http://localhost:8083/gamma" — root of the Gamma REST API. */
+    gammaBaseURL: string;
+    /** e.g. "http://localhost:8083/management" — root of the legacy Management API. */
+    managementBaseURL: string;
+    organizationId: string;
+}
+
+function stripTrailingSlash(url: string): string {
+    return url.endsWith('/') ? url.slice(0, -1) : url;
+}
+
+// CSRF token storage.
+//
+// TODO(authz-csrf): the token is currently kept in `localStorage` as a
+// pragmatic session-bridge so the prototype works against the upstream
+// Gravitee management cookie scheme. This is NOT the long-term plan —
+// CSRF tokens should be issued by the server as a `Secure; SameSite=Strict`
+// cookie (or read from a `Set-Cookie`-mirrored header) so they cannot be
+// exfiltrated by XSS. Switch this once the backend cookie endpoint lands;
+// at that point both helpers below should be replaced with cookie reads.
+function getCsrfToken(): string | null {
+    return localStorage.getItem('XSRF-TOKEN');
+}
+
+function setCsrfToken(value: string): void {
+    localStorage.setItem('XSRF-TOKEN', value);
+}
+
+export class ApiError extends Error {
+    constructor(
+        public readonly status: number,
+        message: string,
+        public readonly validation?: ValidationErrorResponse,
+    ) {
+        super(message);
+        this.name = 'ApiError';
+    }
+}
+
+export interface AuthzApiClient {
+    get: <T>(path: string) => Promise<T>;
+    post: <T>(path: string, body?: unknown) => Promise<T>;
+    put: <T>(path: string, body: unknown) => Promise<T>;
+    delete: <T>(path: string) => Promise<T>;
+}
+
+/**
+ * Returns the REST root used by this module.
+ *
+ *   - {@link AuthzApiClients.core}: the per-organization Gamma SPI tree at
+ *     {@code {gammaBaseURL}/organizations/{org}}. The authz REST resources are
+ *     mounted underneath by {@code GammaModulesResource} via the SPI, so the
+ *     service layer composes paths as
+ *     {@code /environments/{env}/modules/authz/...}.
+ *
+ * Shares a single bootstrap fetch, CSRF token bucket, and error
+ * normalisation path with whatever else this module hits.
+ */
+export interface AuthzApiClients {
+    readonly core: AuthzApiClient;
+}
+
+export function createAuthzApiClients(fetchFn: typeof fetch = fetch): AuthzApiClients {
+    // We cache the in-flight PROMISE rather than just the resolved value.
+    //
+    // Caching only the resolved value let parallel callers (6–9 hooks mounting
+    // simultaneously on a fresh page) each fire their own /constants.json +
+    // /ui/bootstrap pair before any of them populated the cache, producing
+    // the bootstrap-thrashing seen in APIM logs. Caching the promise
+    // de-duplicates concurrent calls into a single network round-trip while
+    // keeping the same observable behaviour (every caller still awaits a
+    // BootstrapConfig).
+    //
+    // On error we clear the cache so a transient failure doesn't permanently
+    // poison subsequent calls.
+    let cachedPromise: Promise<BootstrapConfig> | null = null;
+
+    function loadBootstrapConfig(): Promise<BootstrapConfig> {
+        if (cachedPromise) {
+            return cachedPromise;
+        }
+
+        cachedPromise = (async () => {
+            const constantsRes = await fetchFn('/constants.json');
+            if (!constantsRes.ok) {
+                throw new Error(`Failed to fetch constants.json: ${constantsRes.status}`);
+            }
+
+            const { gammaBaseURL: gammaBaseURLFromConstants } = (await constantsRes.json()) as {
+                gammaBaseURL: string;
+            };
+
+            const bootstrapRes = await fetchFn(`${stripTrailingSlash(gammaBaseURLFromConstants)}/ui/bootstrap`);
+            if (!bootstrapRes.ok) {
+                throw new Error(`Failed to fetch bootstrap config: ${bootstrapRes.status}`);
+            }
+
+            const bootstrap = (await bootstrapRes.json()) as {
+                gammaBaseURL?: string;
+                managementBaseURL: string;
+                organizationId: string;
+            };
+
+            return {
+                gammaBaseURL: stripTrailingSlash(bootstrap.gammaBaseURL ?? gammaBaseURLFromConstants),
+                managementBaseURL: stripTrailingSlash(bootstrap.managementBaseURL),
+                organizationId: bootstrap.organizationId,
+            };
+        })().catch(err => {
+            cachedPromise = null;
+            throw err;
+        });
+
+        return cachedPromise;
+    }
+
+    async function request<T>(buildUrl: (cfg: BootstrapConfig) => string, path: string, init?: RequestInit): Promise<T> {
+        const config = await loadBootstrapConfig();
+        const baseUrl = buildUrl(config);
+
+        const headers = new Headers(init?.headers);
+        headers.set('X-Requested-With', 'XMLHttpRequest');
+
+        const csrf = getCsrfToken();
+        if (csrf) {
+            headers.set('X-Xsrf-Token', csrf);
+        }
+
+        const res = await fetchFn(`${baseUrl}${path}`, {
+            ...init,
+            headers,
+            credentials: 'include',
+        });
+
+        const newCsrf = res.headers.get('X-Xsrf-Token');
+        if (newCsrf) {
+            setCsrfToken(newCsrf);
+        }
+
+        if (!res.ok) {
+            let validation: ValidationErrorResponse | undefined;
+            try {
+                const text = await res.text();
+                if (text) {
+                    const parsed = JSON.parse(text) as ValidationErrorResponse;
+                    if (typeof parsed.message === 'string') {
+                        validation = parsed;
+                    }
+                }
+            } catch {
+                // ignore
+            }
+            throw new ApiError(res.status, validation?.message ?? `${init?.method ?? 'GET'} ${path} failed`, validation);
+        }
+
+        if (res.status === 204) {
+            return undefined as T;
+        }
+
+        const text = await res.text();
+        if (!text) {
+            return undefined as T;
+        }
+
+        return JSON.parse(text) as T;
+    }
+
+    function clientFor(buildUrl: (cfg: BootstrapConfig) => string): AuthzApiClient {
+        return {
+            get: <T>(path: string) => request<T>(buildUrl, path),
+            post: <T>(path: string, body?: unknown) =>
+                request<T>(buildUrl, path, {
+                    method: 'POST',
+                    headers: body !== undefined ? { 'Content-Type': 'application/json' } : {},
+                    body: body !== undefined ? JSON.stringify(body) : undefined,
+                }),
+            put: <T>(path: string, body: unknown) =>
+                request<T>(buildUrl, path, {
+                    method: 'PUT',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify(body),
+                }),
+            delete: <T>(path: string) =>
+                request<T>(buildUrl, path, {
+                    method: 'DELETE',
+                }),
+        };
+    }
+
+    return {
+        // Authz is mounted by GammaModulesResource under the per-org SPI tree,
+        // so requests go to /gamma/organizations/{org}/{path}. The service layer
+        // prefixes `path` with `/environments/{env}/modules/authz/...` to match
+        // the backend's environment-scoped sub-resource locator.
+        core: clientFor(cfg => `${cfg.gammaBaseURL}/organizations/${cfg.organizationId}`),
+    };
+}
+
+const clients = createAuthzApiClients();
+
+/**
+ * Canonical Gamma authz REST kernel ({@code /gamma/authz/*}). Use for
+ * entity / policy / schema CRUD — these endpoints are shared by every Gamma
+ * module, not just this one.
+ */
+export const authzCoreApiClient: AuthzApiClient = clients.core;

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/lib/api/authz-api.service.ts
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/lib/api/authz-api.service.ts
@@ -310,7 +310,7 @@ export const authzApiService = {
         return {
             environmentId,
             schemaText: c.schema ?? '',
-            updatedAt: null as unknown as string,
+            updatedAt: null,
         };
     },
 

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/lib/api/authz-api.service.ts
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/lib/api/authz-api.service.ts
@@ -1,0 +1,384 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { authzCoreApiClient } from './authz-api-client';
+import type {
+    EntityResponse,
+    PagedResponse,
+    PolicyRequest,
+    PolicyResponse,
+    PolicyStatus,
+    PolicyType,
+    SchemaResponse,
+} from './authz-api.types';
+
+export const DEFAULT_PER_PAGE = 10;
+export const MAX_PER_PAGE = 100;
+
+export interface PaginationParams {
+    readonly page?: number;
+    readonly perPage?: number;
+}
+
+export interface PolicyListParams extends PaginationParams {
+    readonly type?: PolicyType;
+    readonly status?: PolicyStatus;
+}
+
+// =============================================================================
+// Adapter layer
+// =============================================================================
+//
+// The canonical Gamma authz REST kernel (`/gamma/authz`) speaks a smaller,
+// platform-shared domain (Entity{entityId,kind,source}, Policy{kind,entityId})
+// than the richer shape the UI was originally built for (entity.uid:string,
+// policy.type:'MCP'|'AGENT'|…|'CUSTOM', policy.target:{id,label}). Rather than
+// fork the UI to the canonical shape — which would cascade into every page
+// and component — we map both directions here and keep the UI contract stable.
+//
+// Mapping rules:
+//   - PolicyKind:GLOBAL  ↔ UI type:'CUSTOM' (target = null)
+//   - PolicyKind:RESOURCE ↔ UI type derived from `entityId` prefix:
+//       "mcp.*"   → MCP
+//       "agent.*" → AGENT
+//       "llm.*"   → LLM
+//       "api.*"   → API
+//       "event.*" → EVENT
+//       anything else (incl. legacy "User::alice" form) → CUSTOM
+//   - Entity.entityId ↔ UI uid (string). UI entity-adapter does its own
+//     `_kind` attribute → structured uid.type lookup, so we surface
+//     `kind`/`source` as `_kind`/`_source` attributes when adapting from
+//     canonical → UI, and strip them on the way back.
+//   - Status transitions (DRAFT → DEPLOYED → DISABLED) live on dedicated
+//     canonical endpoints (`/deploy`, `/disable`); UI submits them as part
+//     of the policy payload, so we fan out after the base PUT/POST.
+// =============================================================================
+
+// ---- Canonical shapes (server) ---------------------------------------------
+
+interface CanonicalEntity {
+    readonly id: string;
+    readonly entityId: string;
+    readonly kind: 'PRINCIPAL' | 'RESOURCE';
+    readonly attributes: Record<string, unknown>;
+    readonly parents: readonly string[];
+    readonly source: string;
+    readonly environmentId: string;
+    readonly createdAt: string;
+    readonly updatedAt: string;
+}
+
+interface CanonicalPolicy {
+    readonly id: string;
+    readonly name: string;
+    readonly kind: 'GLOBAL' | 'RESOURCE';
+    readonly entityId: string | null;
+    readonly policyText: string;
+    readonly status: PolicyStatus;
+    readonly environmentId: string;
+    readonly createdAt: string;
+    readonly updatedAt: string;
+}
+
+interface CanonicalSchema {
+    readonly schema: string;
+}
+
+/**
+ * Server-side paged response shape — same wire contract as the legacy UI
+ * {@code PagedResponse<T>} so a single deserialise step yields the value
+ * we hand back to the hook layer without further restructuring.
+ */
+interface CanonicalPagedResponse<T> {
+    readonly data: readonly T[];
+    readonly total: number;
+    readonly page: number;
+    readonly perPage: number;
+}
+
+/**
+ * Normalises a list endpoint response to a paged shape regardless of whether
+ * the deployed backend speaks the new {@code PagedResponseDto<T>} contract
+ * or still returns a bare {@code List<T>}. The platform paging change ships
+ * across multiple modules (authz-api, authz-core, authz-rest) and a rolling
+ * restart can leave UI and rest-api temporarily out of sync; this guard
+ * stops a stale rest-api from blowing up the list pages with
+ * "Cannot read properties of undefined (reading 'map')".
+ *
+ * <p>When the legacy shape is detected we fabricate the paging envelope from
+ * what we got: total = array length, page = requested page (or 1), perPage =
+ * requested perPage (or the array length). The client paginates the resulting
+ * slice locally — same behaviour as pre-migration.
+ */
+function adaptPagedListResponse<T>(
+    raw: CanonicalPagedResponse<T> | readonly T[],
+    requestedPage: number | undefined,
+    requestedPerPage: number | undefined,
+): CanonicalPagedResponse<T> {
+    if (Array.isArray(raw)) {
+        const items = raw as readonly T[];
+        const page = requestedPage ?? 1;
+        const perPage = requestedPerPage ?? items.length;
+        const start = Math.max(0, (page - 1) * perPage);
+        return {
+            data: perPage > 0 ? items.slice(start, start + perPage) : items,
+            total: items.length,
+            page,
+            perPage,
+        };
+    }
+    return raw as CanonicalPagedResponse<T>;
+}
+
+interface CanonicalPolicyRequest {
+    readonly name: string;
+    readonly kind: 'GLOBAL' | 'RESOURCE';
+    readonly entityId: string | null;
+    readonly policyText: string;
+}
+
+interface CanonicalUpdatePolicyRequest {
+    readonly name: string;
+    readonly policyText: string;
+}
+
+// ---- Path builders ----------------------------------------------------------
+
+// Authz is mounted at /gamma/organizations/{org}/environments/{env}/modules/authz
+// by GammaModulesResource (SPI). The client base URL already covers the
+// `/organizations/{org}` prefix, so this builder fills in the env scope and
+// the module mount.
+function corePath(environmentId: string, suffix: string): string {
+    return `/environments/${encodeURIComponent(environmentId)}/modules/authz${suffix}`;
+}
+
+// ---- Derivation helpers ----------------------------------------------------
+
+export function deriveServiceType(entityId: string | null | undefined): PolicyType {
+    if (!entityId) return 'CUSTOM';
+    const prefix = entityId.split('.')[0]?.toLowerCase();
+    switch (prefix) {
+        case 'mcp':
+            return 'MCP';
+        case 'agent':
+            return 'AGENT';
+        case 'llm':
+            return 'LLM';
+        case 'api':
+            return 'API';
+        case 'event':
+            return 'EVENT';
+        default:
+            return 'CUSTOM';
+    }
+}
+
+// ---- Entity adapters --------------------------------------------------------
+
+function adaptEntityResponse(c: CanonicalEntity): EntityResponse {
+    // Surface canonical root-level kind/source as attributes so the existing
+    // entity-adapter (which already speaks _kind / _source) doesn't have to
+    // know we migrated. _source overrides nothing — if attributes already
+    // carry it (SCIM does), the canonical root just confirms.
+    const attrs: Record<string, unknown> = { ...c.attributes };
+    if (c.source && attrs._source == null) {
+        attrs._source = c.source;
+    }
+    return {
+        id: c.id,
+        environmentId: c.environmentId,
+        uid: c.entityId,
+        attributes: attrs,
+        parents: [...c.parents],
+        createdAt: c.createdAt,
+        updatedAt: c.updatedAt,
+    };
+}
+
+// ---- Policy adapters --------------------------------------------------------
+
+function adaptPolicyResponse(c: CanonicalPolicy): PolicyResponse {
+    const type = deriveServiceType(c.entityId);
+    return {
+        id: c.id,
+        environmentId: c.environmentId,
+        name: c.name,
+        description: null,
+        policyText: c.policyText,
+        type,
+        // We don't have a separate display label on the canonical side — the
+        // target picker is fed by entities, so the entity adapter will fill in
+        // a richer label later. For now the entityId doubles as the label.
+        target: c.entityId ? { id: c.entityId, label: c.entityId } : null,
+        status: c.status,
+        createdAt: c.createdAt,
+        updatedAt: c.updatedAt,
+    };
+}
+
+function adaptCreatePolicyRequest(r: PolicyRequest): CanonicalPolicyRequest {
+    // Custom → GLOBAL (no target). Anything else → RESOURCE bound to the
+    // picked target's entityId.
+    const isGlobal = r.type === 'CUSTOM' || r.target == null;
+    return {
+        name: r.name,
+        kind: isGlobal ? 'GLOBAL' : 'RESOURCE',
+        entityId: isGlobal ? null : (r.target?.id ?? null),
+        policyText: r.policyText,
+    };
+}
+
+function adaptUpdatePolicyRequest(r: PolicyRequest): CanonicalUpdatePolicyRequest {
+    return {
+        name: r.name,
+        policyText: r.policyText,
+    };
+}
+
+/**
+ * Apply the requested status by calling the dedicated transition endpoint.
+ * Returns the policy after the transition (canonical → UI shape).
+ *
+ * The canonical model has only two transition verbs: deploy → DEPLOYED,
+ * disable → DISABLED. DRAFT is the implicit state after create/update.
+ * We fire transitions optimistically: if the policy is already in the
+ * requested state the backend short-circuits, so a redundant call is cheap.
+ */
+async function applyStatusTransition(
+    environmentId: string,
+    id: string,
+    status: PolicyStatus | null | undefined,
+): Promise<CanonicalPolicy | null> {
+    if (status === 'DEPLOYED') {
+        return authzCoreApiClient.post<CanonicalPolicy>(corePath(environmentId, `/policies/${encodeURIComponent(id)}/deploy`));
+    }
+    if (status === 'DISABLED') {
+        return authzCoreApiClient.post<CanonicalPolicy>(corePath(environmentId, `/policies/${encodeURIComponent(id)}/disable`));
+    }
+    // DRAFT or undefined: leave whatever the base POST/PUT returned.
+    return null;
+}
+
+// ---- Query string helpers ---------------------------------------------------
+
+function pagingQuery(params?: PaginationParams): string {
+    const q = new URLSearchParams();
+    if (params?.page !== undefined) q.set('page', String(params.page));
+    if (params?.perPage !== undefined) q.set('perPage', String(params.perPage));
+    const qs = q.toString();
+    return qs ? `?${qs}` : '';
+}
+
+function policyListQuery(params?: PolicyListParams): string {
+    const q = new URLSearchParams();
+    if (params?.page !== undefined) q.set('page', String(params.page));
+    if (params?.perPage !== undefined) q.set('perPage', String(params.perPage));
+    // status is the only UI-meaningful filter the backend can apply.
+    // The UI 'type' (MCP/AGENT/…) is derived from the entityId prefix
+    // on the client because the canonical model has no concept of it.
+    if (params?.status !== undefined) q.set('status', params.status);
+    const qs = q.toString();
+    return qs ? `?${qs}` : '';
+}
+
+// =============================================================================
+// Public service
+// =============================================================================
+
+export const authzApiService = {
+    // ── Schema ──────────────────────────────────────────────────────────────
+    //
+    // Canonical returns { schema }. UI expects { environmentId, schemaText,
+    // updatedAt }. environmentId is what the caller already knows; updatedAt
+    // is informational only and not surfaced by the canonical endpoint, so we
+    // null it out — pages that show "last edited X ago" gracefully render
+    // nothing when it's null.
+    getSchema: async (environmentId: string): Promise<SchemaResponse> => {
+        const c = await authzCoreApiClient.get<CanonicalSchema>(corePath(environmentId, '/schema'));
+        return {
+            environmentId,
+            schemaText: c.schema ?? '',
+            updatedAt: null as unknown as string,
+        };
+    },
+
+    // ── Policies ────────────────────────────────────────────────────────────
+    //
+    // Server-side paging through ?page/?perPage. Status is forwarded to the
+    // backend as a query filter (?status=…); the UI `type` discriminator
+    // (MCP/AGENT/…) has no canonical equivalent and is derived from the
+    // entityId prefix client-side — for that filter we fetch the matching
+    // page and post-filter what came back. That trades a tiny over-fetch
+    // for keeping the canonical contract narrow.
+    listPolicies: async (environmentId: string, params?: PolicyListParams): Promise<PagedResponse<PolicyResponse>> => {
+        const path = corePath(environmentId, '/policies') + policyListQuery(params);
+        const raw = await authzCoreApiClient.get<CanonicalPagedResponse<CanonicalPolicy> | readonly CanonicalPolicy[]>(path);
+        const response = adaptPagedListResponse(raw, params?.page, params?.perPage);
+        let mapped = response.data.map(adaptPolicyResponse);
+        let total = response.total;
+        if (params?.type !== undefined) {
+            const before = mapped.length;
+            mapped = mapped.filter(p => p.type === params.type);
+            // total is approximate when we post-filter; downsize by what
+            // we dropped on this page so the UI doesn't enable a "next"
+            // for a page-load that already came back partial.
+            total = Math.max(0, total - (before - mapped.length));
+        }
+        return {
+            data: mapped,
+            total,
+            page: response.page,
+            perPage: response.perPage,
+        };
+    },
+
+    createPolicy: async (environmentId: string, request: PolicyRequest): Promise<PolicyResponse> => {
+        const created = await authzCoreApiClient.post<CanonicalPolicy>(
+            corePath(environmentId, '/policies'),
+            adaptCreatePolicyRequest(request),
+        );
+        const afterTransition = await applyStatusTransition(environmentId, created.id, request.status ?? null);
+        return adaptPolicyResponse(afterTransition ?? created);
+    },
+
+    updatePolicy: async (environmentId: string, id: string, request: PolicyRequest): Promise<PolicyResponse> => {
+        const updated = await authzCoreApiClient.put<CanonicalPolicy>(
+            corePath(environmentId, `/policies/${encodeURIComponent(id)}`),
+            adaptUpdatePolicyRequest(request),
+        );
+        const afterTransition = await applyStatusTransition(environmentId, id, request.status ?? null);
+        return adaptPolicyResponse(afterTransition ?? updated);
+    },
+
+    deletePolicy: (environmentId: string, id: string) =>
+        authzCoreApiClient.delete<void>(corePath(environmentId, `/policies/${encodeURIComponent(id)}`)),
+
+    // ── Entities ────────────────────────────────────────────────────────────
+    //
+    // Server-side paging through ?page/?perPage. The backend slices in
+    // Mongo (skip/limit + count) so a 100k-entity env doesn't drag the
+    // whole result into the UI memory just to render 25 rows.
+    listEntities: async (environmentId: string, params?: PaginationParams): Promise<PagedResponse<EntityResponse>> => {
+        const path = corePath(environmentId, '/entities') + pagingQuery(params);
+        const raw = await authzCoreApiClient.get<CanonicalPagedResponse<CanonicalEntity> | readonly CanonicalEntity[]>(path);
+        const response = adaptPagedListResponse(raw, params?.page, params?.perPage);
+        return {
+            data: response.data.map(adaptEntityResponse),
+            total: response.total,
+            page: response.page,
+            perPage: response.perPage,
+        };
+    },
+};

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/lib/api/authz-api.types.ts
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/lib/api/authz-api.types.ts
@@ -1,0 +1,79 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+export type PolicyType = 'MCP' | 'AGENT' | 'LLM' | 'API' | 'EVENT' | 'CUSTOM';
+export type PolicyStatus = 'DRAFT' | 'DEPLOYED' | 'DISABLED';
+
+export interface PolicyTarget {
+    readonly id: string;
+    readonly label: string;
+}
+
+export interface PolicyResponse {
+    readonly id: string;
+    readonly environmentId: string;
+    readonly name: string;
+    readonly description: string | null;
+    readonly policyText: string;
+    readonly type: PolicyType;
+    readonly target: PolicyTarget | null;
+    readonly status: PolicyStatus;
+    readonly createdAt: string;
+    readonly updatedAt: string;
+}
+
+export interface PolicyRequest {
+    readonly name: string;
+    readonly description?: string | null;
+    readonly policyText: string;
+    readonly type: PolicyType;
+    readonly target?: PolicyTarget | null;
+    readonly status?: PolicyStatus | null;
+}
+
+export interface EntityResponse {
+    readonly id: string;
+    readonly environmentId: string;
+    readonly uid: string;
+    readonly attributes: Record<string, unknown>;
+    readonly parents: string[];
+    readonly createdAt: string;
+    readonly updatedAt: string;
+}
+
+export interface EntityRequest {
+    readonly uid: string;
+    readonly attributes: Record<string, unknown>;
+    readonly parents: string[];
+}
+
+export interface SchemaResponse {
+    readonly environmentId: string;
+    readonly schemaText: string;
+    readonly updatedAt: string;
+}
+
+export interface PagedResponse<T> {
+    readonly data: readonly T[];
+    readonly total: number;
+    readonly page: number;
+    readonly perPage: number;
+}
+
+export interface ValidationErrorResponse {
+    readonly message: string;
+    readonly status: number;
+    readonly errors: readonly string[];
+}

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/lib/api/authz-api.types.ts
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/lib/api/authz-api.types.ts
@@ -62,7 +62,7 @@ export interface EntityRequest {
 export interface SchemaResponse {
     readonly environmentId: string;
     readonly schemaText: string;
-    readonly updatedAt: string;
+    readonly updatedAt: string | null;
 }
 
 export interface PagedResponse<T> {

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/lib/api/query-keys.ts
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/lib/api/query-keys.ts
@@ -1,0 +1,30 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+export const authzQueryKeys = {
+    all: ['authz'] as const,
+    entities: {
+        all: (environmentId: string) => ['authz', 'entities', environmentId] as const,
+        page: (environmentId: string, page: number, perPage: number) =>
+            ['authz', 'entities', environmentId, page, perPage] as const,
+    },
+    policies: {
+        all: (environmentId: string) => ['authz', 'policies', environmentId] as const,
+        page: (environmentId: string, page: number, perPage: number, type?: string, status?: string) =>
+            ['authz', 'policies', environmentId, page, perPage, type, status] as const,
+    },
+    schema: (environmentId: string) => ['authz', 'schema', environmentId] as const,
+    entityOptions: (environmentId: string) => ['authz', 'entity-options', environmentId] as const,
+} as const;

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/lib/chip-option.ts
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/lib/chip-option.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Option shape consumed by the chip combobox in the policy editor.
+ * Lives in `lib/` (not under `app/features/`) because hooks like
+ * `useEntityOptions` build options before any feature code is loaded.
+ */
+export interface ChipOption {
+    readonly id: string;
+    readonly label: string;
+    readonly group: string;
+    readonly description?: string;
+}

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/lib/entity-adapter.ts
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/lib/entity-adapter.ts
@@ -1,0 +1,263 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Bidirectional adapter between the backend EntityResponse / EntityRequest
+ * and the frontend EntityInstance used in all UI components.
+ *
+ * Canonical backend uid format — dotted: `<lowercase-kind>.<id>` (e.g.
+ * `user.alice`, `group.engineering`, `mcpserver.flight-mcp`). SCIM-sourced
+ * principals carry a 3-segment form `<kind>.<connector>.<slug>` (e.g.
+ * `user.okta.alice`); for those the structured uid keeps the full tail
+ * (`okta.alice`) as `id` so a fromBackend → toBackend round-trip preserves
+ * the canonical entityId verbatim.
+ *
+ * Server-side validation rejects anything outside `[a-z0-9._-]+`
+ * (see `EntityIdValidator` in `gravitee-gamma-authorization-core`); the
+ * legacy `Type::"id"` form this adapter used to produce was failing every
+ * create with a 400 — that's bug #8 from the review, fixed here.
+ *
+ * Meta fields that have no backend column are stored inside `attributes`
+ * under reserved underscore-prefixed keys: `_source`, `_principalProvider`,
+ * `_displayName`, `_importedAt`. These are NEVER shown in the visible
+ * attributes table.
+ */
+import type { AttrValue, EntityInstance, EntitySource } from '../app/features/policy-structure/entity-types';
+import type { EntityRequest, EntityResponse } from './api/authz-api.types';
+
+// ---------- Meta key constants ------------------------------------------------
+
+export const META_KEYS = new Set([
+    '_source',
+    '_principalProvider',
+    '_displayName',
+    '_importedAt',
+    '_kind',
+    '_connector',
+    '_url',
+    '_syncedAt',
+    '_provider',
+    '_proxyApiId',
+]);
+
+/**
+ * Maps a kind hint (lowercased — either the `_kind` attribute or the first
+ * dotted segment of the entityId) to the structured uid type the UI's
+ * categories table speaks. Returns undefined when the hint is missing or unknown.
+ */
+function kindToType(kind: unknown): string | undefined {
+    if (typeof kind !== 'string') return undefined;
+    const k = kind.toLowerCase();
+    if (k === 'user') return 'User';
+    if (k === 'group') return 'Group';
+    if (k === 'serviceaccount' || k === 'service-account' || k === 'service_account') return 'ServiceAccount';
+    if (k === 'agentidentity' || k === 'agent') return 'AgentIdentity';
+    if (k === 'mcp' || k === 'mcpserver') return 'MCPServer';
+    if (k === 'llm' || k === 'llmroute') return 'LLMRoute';
+    // APIM-managed proxies (api.*) live under the schema's API type so the
+    // editor can pre-select them as policy targets. Custom hand-rolled
+    // entities use the `resource.*` prefix and surface under the dedicated
+    // Resource type so the two buckets stay distinct.
+    if (k === 'api') return 'API';
+    if (k === 'resource') return 'Resource';
+    // actions are managed on their own page; tag them so EntitiesPage can hide them
+    if (k === 'action') return 'Action';
+    return undefined;
+}
+
+/** Inverse of {@link kindToType}: structured uid type → lowercase backend kind segment. */
+function typeToKind(type: string): string {
+    const t = type.toLowerCase();
+    // Camel-case structured types collapse into their lowercase canonical name.
+    if (t === 'serviceaccount') return 'serviceaccount';
+    if (t === 'agentidentity') return 'agent';
+    if (t === 'mcpserver') return 'mcp';
+    if (t === 'llmroute') return 'llm';
+    return t;
+}
+
+// ---------- UID parsing / formatting ------------------------------------------
+
+/**
+ * Parse a backend uid string into a structured `{ type, id }` pair.
+ *
+ * Accepts both layouts the platform has seen:
+ * - canonical dotted: `user.alice`, `group.engineering`, `user.okta.alice`
+ *   (kind inferred from first segment; id is everything after the first dot)
+ * - legacy quoted/unquoted: `User::alice`, `User::"alice"` — tolerated for
+ *   any in-flight test fixture, but the platform's EntityIdValidator would
+ *   reject this on save, so it never actually round-trips at runtime.
+ *
+ * Returns `{type: 'Unknown', id: <whole input>}` when no kind can be inferred —
+ * the caller is expected to consult `_kind` in attributes for the override.
+ */
+export function parseEntityUid(uid: string): { type: string; id: string } {
+    const sep = uid.indexOf('::');
+    if (sep >= 0) {
+        // Legacy Type::"id" form. Kept for backwards-compat with tests and any
+        // pre-existing fixture; production data is dotted because the backend
+        // validator rejects this layout on write.
+        const type = uid.slice(0, sep);
+        const rawId = uid.slice(sep + 2);
+        const id = rawId.startsWith('"') && rawId.endsWith('"') ? rawId.slice(1, -1).replace(/\\"/g, '"') : rawId;
+        return { type, id };
+    }
+
+    // Canonical dotted form: first segment hints kind, rest is the id.
+    const dot = uid.indexOf('.');
+    if (dot > 0) {
+        const inferred = kindToType(uid.slice(0, dot));
+        if (inferred) {
+            return { type: inferred, id: uid.slice(dot + 1) };
+        }
+    }
+
+    return { type: 'Unknown', id: uid };
+}
+
+/**
+ * Format a structured uid back to the canonical backend form
+ * `<lowercase-kind>.<id>`. The id is passed through unchanged because the
+ * server-side validator (`[a-z0-9._-]+`) wouldn't have accepted invalid
+ * characters on the way in either; we deliberately do NOT silently re-slugify
+ * here so a corrupted id surfaces as a 400 from the backend rather than a
+ * silent collision.
+ */
+export function formatEntityUid(u: { type: string; id: string }): string {
+    return `${typeToKind(u.type)}.${u.id}`;
+}
+
+// ---------- fromBackend -------------------------------------------------------
+
+/**
+ * Convert a backend EntityResponse to the richer frontend EntityInstance.
+ *
+ * - Splits reserved meta keys out of attributes.
+ * - Parses parents from string form to structured objects.
+ * - For dotted entityIds, strips the kind prefix from the structured `id`
+ *   when an explicit `_kind` attribute matches the prefix — keeps round-trip
+ *   stable for both local (`user.alice`) and SCIM-sourced
+ *   (`user.okta.alice`) layouts.
+ */
+export function fromBackend(e: EntityResponse): EntityInstance {
+    // Separate meta from regular attributes.
+    const attrs: Record<string, AttrValue> = {};
+    let source: EntitySource = 'local';
+    let principalProvider: string | undefined;
+    let displayName: string | undefined;
+    let importedAt: string | undefined;
+    let kindOverride: string | undefined;
+
+    for (const [k, v] of Object.entries(e.attributes)) {
+        if (k === '_source') {
+            source = v as string as EntitySource;
+        } else if (k === '_principalProvider' || k === '_provider' || k === '_connector') {
+            principalProvider = v as string;
+        } else if (k === '_displayName') {
+            displayName = v as string;
+        } else if (k === '_importedAt' || k === '_syncedAt') {
+            importedAt = v as string;
+        } else if (k === '_kind') {
+            kindOverride = kindToType(v);
+        } else if (k === '_url' || k === '_proxyApiId') {
+            // meta — drop from visible attrs
+        } else {
+            // Only carry over values that are valid AttrValue primitives.
+            if (typeof v === 'string' || typeof v === 'number' || typeof v === 'boolean') {
+                attrs[k] = v;
+            }
+        }
+    }
+
+    const uid = resolveUid(e.uid, kindOverride);
+
+    const parents = e.parents.map(p => {
+        const parsed = parseEntityUid(p);
+        if (parsed.type !== 'Unknown') return parsed;
+        const segs = p.split('.');
+        if (segs.length >= 2) {
+            const inferred = kindToType(segs[0]);
+            if (inferred) return { type: inferred, id: p };
+        }
+        return parsed;
+    });
+
+    return {
+        uid,
+        displayName,
+        attrs,
+        parents,
+        source,
+        principalProvider,
+        importedAt,
+        _backendId: e.id,
+        createdAt: e.createdAt,
+        updatedAt: e.updatedAt,
+    };
+}
+
+/**
+ * Resolve the structured uid using the optional `_kind` attribute as the
+ * source of truth for the type. Strips a matching dotted prefix from the
+ * entityId so `user.alice` with `_kind=user` resolves to
+ * `{type: 'User', id: 'alice'}` (round-trippable) rather than
+ * `{type: 'User', id: 'user.alice'}` (which would re-wrap on save).
+ */
+function resolveUid(rawUid: string, kindOverride: string | undefined): { type: string; id: string } {
+    const parsedFromUid = parseEntityUid(rawUid);
+    if (!kindOverride) {
+        return parsedFromUid;
+    }
+    const expectedPrefix = typeToKind(kindOverride) + '.';
+    const id = rawUid.startsWith(expectedPrefix) ? rawUid.slice(expectedPrefix.length) : rawUid;
+    return { type: kindOverride, id };
+}
+
+// ---------- toBackend ---------------------------------------------------------
+
+/**
+ * Convert a frontend EntityInstance back to an EntityRequest for POST/PUT.
+ * Packs meta fields back into `attributes` under reserved underscore keys.
+ */
+export function toBackend(e: EntityInstance): EntityRequest {
+    const uid = formatEntityUid(e.uid);
+
+    const attributes: Record<string, unknown> = { ...e.attrs };
+
+    // Only store meta keys that have non-default values.
+    if (e.source && e.source !== 'local') {
+        attributes['_source'] = e.source;
+    }
+    if (e.principalProvider) {
+        attributes['_principalProvider'] = e.principalProvider;
+    }
+    if (e.displayName) {
+        attributes['_displayName'] = e.displayName;
+    }
+    if (e.importedAt) {
+        attributes['_importedAt'] = e.importedAt;
+    }
+
+    const parents = e.parents.map(p => formatEntityUid(p));
+
+    return { uid, attributes, parents };
+}
+
+// ---------- Helpers -----------------------------------------------------------
+
+/** Stable key for a ui entity (used as React key and lookup). */
+export function entityKeyOf(uid: { type: string; id: string }): string {
+    return `${uid.type}::${uid.id}`;
+}

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/lib/hooks/__tests__/useEntities.test.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/lib/hooks/__tests__/useEntities.test.tsx
@@ -13,7 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { act, render, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
 import { useEffect } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { useEntities, type UseEntitiesResult } from '../useEntities';
@@ -26,6 +28,11 @@ vi.mock('../../api/authz-api.service', () => ({
         listEntities: (env: string, params?: unknown) => listSpy(env, params),
     },
 }));
+
+function makeWrapper() {
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    return ({ children }: { children: ReactNode }) => <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+}
 
 function Probe({ env }: { env: string }) {
     const state = useEntities(env);
@@ -46,7 +53,7 @@ describe('useEntities', () => {
     it('loads entities on mount with default pagination', async () => {
         listSpy.mockResolvedValue({ data: [], total: 0, page: 1, perPage: 10 });
 
-        const { getByTestId } = render(<Probe env="env-1" />);
+        const { getByTestId } = render(<Probe env="env-1" />, { wrapper: makeWrapper() });
 
         await waitFor(() => expect(getByTestId('total').textContent).toBe('0'));
         expect(listSpy).toHaveBeenCalledWith('env-1', { page: 1, perPage: 10 });
@@ -55,7 +62,7 @@ describe('useEntities', () => {
     it('sets error when listEntities fails', async () => {
         listSpy.mockRejectedValue(new Error('fail'));
 
-        const { getByTestId } = render(<Probe env="env-1" />);
+        const { getByTestId } = render(<Probe env="env-1" />, { wrapper: makeWrapper() });
 
         await waitFor(() => expect(getByTestId('error').textContent).toBe('fail'));
     });
@@ -70,7 +77,7 @@ describe('useEntities', () => {
         );
 
         const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
-        const { unmount } = render(<Probe env="env-unmount" />);
+        const { unmount } = render(<Probe env="env-unmount" />, { wrapper: makeWrapper() });
         unmount();
 
         resolveFn({ data: [], total: 0, page: 1, perPage: 10 });
@@ -90,7 +97,8 @@ describe('useEntities', () => {
             return <span data-testid="total">{state.data?.total ?? 'null'}</span>;
         }
 
-        const { rerender, getByTestId } = render(<PerPageProbe perPage={10} />);
+        const wrapper = makeWrapper();
+        const { rerender, getByTestId } = render(<PerPageProbe perPage={10} />, { wrapper });
         await waitFor(() => expect(getByTestId('total').textContent).toBe('50'));
 
         rerender(<PerPageProbe perPage={50} />);
@@ -112,7 +120,7 @@ describe('useEntities', () => {
             return null;
         }
 
-        render(<CaptureProbe />);
+        render(<CaptureProbe />, { wrapper: makeWrapper() });
         await waitFor(() => expect(listSpy).toHaveBeenCalledTimes(1));
 
         await act(async () => {
@@ -133,7 +141,8 @@ describe('useEntities', () => {
         );
         listSpy.mockImplementationOnce(() => Promise.resolve({ data: [], total: 9, page: 1, perPage: 10 }));
 
-        const { rerender, getByTestId } = render(<Probe env="env-A" />);
+        const wrapper = makeWrapper();
+        const { rerender, getByTestId } = render(<Probe env="env-A" />, { wrapper });
         rerender(<Probe env="env-B" />);
 
         await waitFor(() => expect(getByTestId('total').textContent).toBe('9'));

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/lib/hooks/__tests__/useEntities.test.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/lib/hooks/__tests__/useEntities.test.tsx
@@ -1,0 +1,146 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { act, render, waitFor } from '@testing-library/react';
+import { useEffect } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useEntities, type UseEntitiesResult } from '../useEntities';
+
+const listSpy = vi.fn();
+
+vi.mock('../../api/authz-api.service', () => ({
+    DEFAULT_PER_PAGE: 10,
+    authzApiService: {
+        listEntities: (env: string, params?: unknown) => listSpy(env, params),
+    },
+}));
+
+function Probe({ env }: { env: string }) {
+    const state = useEntities(env);
+    return (
+        <div>
+            <span data-testid="loading">{String(state.isLoading)}</span>
+            <span data-testid="total">{state.data?.total ?? 'null'}</span>
+            <span data-testid="error">{state.error ?? 'none'}</span>
+        </div>
+    );
+}
+
+beforeEach(() => {
+    listSpy.mockReset();
+});
+
+describe('useEntities', () => {
+    it('loads entities on mount with default pagination', async () => {
+        listSpy.mockResolvedValue({ data: [], total: 0, page: 1, perPage: 10 });
+
+        const { getByTestId } = render(<Probe env="env-1" />);
+
+        await waitFor(() => expect(getByTestId('total').textContent).toBe('0'));
+        expect(listSpy).toHaveBeenCalledWith('env-1', { page: 1, perPage: 10 });
+    });
+
+    it('sets error when listEntities fails', async () => {
+        listSpy.mockRejectedValue(new Error('fail'));
+
+        const { getByTestId } = render(<Probe env="env-1" />);
+
+        await waitFor(() => expect(getByTestId('error').textContent).toBe('fail'));
+    });
+
+    it('does not warn after unmount during in-flight fetch', async () => {
+        let resolveFn: (value: unknown) => void = () => undefined;
+        listSpy.mockImplementation(
+            () =>
+                new Promise(resolve => {
+                    resolveFn = resolve;
+                }),
+        );
+
+        const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+        const { unmount } = render(<Probe env="env-unmount" />);
+        unmount();
+
+        resolveFn({ data: [], total: 0, page: 1, perPage: 10 });
+        await Promise.resolve();
+        await Promise.resolve();
+
+        const noisy = errorSpy.mock.calls.some(args => args.some(a => typeof a === 'string' && a.includes('unmounted')));
+        expect(noisy).toBe(false);
+        errorSpy.mockRestore();
+    });
+
+    it('refetches when initialPerPage changes', async () => {
+        listSpy.mockResolvedValue({ data: [], total: 50, page: 1, perPage: 10 });
+
+        function PerPageProbe({ perPage }: { perPage: number }) {
+            const state = useEntities('env-pp', perPage);
+            return <span data-testid="total">{state.data?.total ?? 'null'}</span>;
+        }
+
+        const { rerender, getByTestId } = render(<PerPageProbe perPage={10} />);
+        await waitFor(() => expect(getByTestId('total').textContent).toBe('50'));
+
+        rerender(<PerPageProbe perPage={50} />);
+        await waitFor(() => expect(listSpy).toHaveBeenCalledTimes(2));
+
+        expect(listSpy).toHaveBeenNthCalledWith(1, 'env-pp', { page: 1, perPage: 10 });
+        expect(listSpy).toHaveBeenNthCalledWith(2, 'env-pp', { page: 1, perPage: 50 });
+    });
+
+    it('internal setPerPage still works', async () => {
+        listSpy.mockResolvedValue({ data: [], total: 0, page: 1, perPage: 10 });
+
+        const ref: { current: UseEntitiesResult | undefined } = { current: undefined };
+        function CaptureProbe() {
+            const state = useEntities('env-set', 10);
+            useEffect(() => {
+                ref.current = state;
+            });
+            return null;
+        }
+
+        render(<CaptureProbe />);
+        await waitFor(() => expect(listSpy).toHaveBeenCalledTimes(1));
+
+        await act(async () => {
+            ref.current?.setPerPage(25);
+        });
+
+        await waitFor(() => expect(listSpy).toHaveBeenCalledTimes(2));
+        expect(listSpy).toHaveBeenNthCalledWith(2, 'env-set', { page: 1, perPage: 25 });
+    });
+
+    it('ignores stale response after env change', async () => {
+        let resolveStale: (value: unknown) => void = () => undefined;
+        listSpy.mockImplementationOnce(
+            () =>
+                new Promise(resolve => {
+                    resolveStale = resolve;
+                }),
+        );
+        listSpy.mockImplementationOnce(() => Promise.resolve({ data: [], total: 9, page: 1, perPage: 10 }));
+
+        const { rerender, getByTestId } = render(<Probe env="env-A" />);
+        rerender(<Probe env="env-B" />);
+
+        await waitFor(() => expect(getByTestId('total').textContent).toBe('9'));
+
+        resolveStale({ data: [], total: 999, page: 1, perPage: 10 });
+        await Promise.resolve();
+        await Promise.resolve();
+        expect(getByTestId('total').textContent).toBe('9');
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/lib/hooks/__tests__/useEntityOptions.test.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/lib/hooks/__tests__/useEntityOptions.test.tsx
@@ -13,7 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { EntityResponse, PagedResponse } from '../../api/authz-api.types';
 import { useEntityOptions, type UseEntityOptionsOpts } from '../useEntityOptions';
@@ -25,6 +27,11 @@ vi.mock('../../api/authz-api.service', () => ({
         listEntities: (env: string, params?: unknown) => listEntitiesSpy(env, params),
     },
 }));
+
+function makeWrapper() {
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    return ({ children }: { children: ReactNode }) => <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+}
 
 function entity(uid: string, attributes: Record<string, unknown> = {}): EntityResponse {
     return {
@@ -73,7 +80,7 @@ describe('useEntityOptions', () => {
     it('returns empty options and no error for an empty list', async () => {
         listEntitiesSpy.mockResolvedValue(paged([]));
 
-        const { getByTestId } = render(<Probe env="env-1" />);
+        const { getByTestId } = render(<Probe env="env-1" />, { wrapper: makeWrapper() });
 
         await waitFor(() => expect(getByTestId('loading').textContent).toBe('false'));
         expect(getByTestId('count').textContent).toBe('0');
@@ -90,7 +97,7 @@ describe('useEntityOptions', () => {
             ]),
         );
 
-        const { getByTestId } = render(<Probe env="env-1" />);
+        const { getByTestId } = render(<Probe env="env-1" />, { wrapper: makeWrapper() });
 
         await waitFor(() => expect(getByTestId('count').textContent).toBe('3'));
         const items = getByTestId('options').querySelectorAll('li');
@@ -108,7 +115,7 @@ describe('useEntityOptions', () => {
     it('filters options by typeFilter', async () => {
         listEntitiesSpy.mockResolvedValue(paged([entity('User::"alice"'), entity('Group::"admins"'), entity('AgentIdentity::"agent-1"')]));
 
-        const { getByTestId } = render(<Probe env="env-1" opts={{ typeFilter: ['User'] }} />);
+        const { getByTestId } = render(<Probe env="env-1" opts={{ typeFilter: ['User'] }} />, { wrapper: makeWrapper() });
 
         await waitFor(() => expect(getByTestId('count').textContent).toBe('1'));
         const items = getByTestId('options').querySelectorAll('li');
@@ -119,7 +126,7 @@ describe('useEntityOptions', () => {
         const data = Array.from({ length: 200 }, (_, i) => entity(`User::"u${i}"`));
         listEntitiesSpy.mockResolvedValue(paged(data, 503));
 
-        const { getByTestId } = render(<Probe env="env-1" />);
+        const { getByTestId } = render(<Probe env="env-1" />, { wrapper: makeWrapper() });
 
         await waitFor(() => expect(getByTestId('count').textContent).toBe('200'));
         expect(getByTestId('error').textContent).toMatch(/too many entities/i);
@@ -135,7 +142,7 @@ describe('useEntityOptions', () => {
         );
         const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
 
-        const { unmount } = render(<Probe env="env-1" />);
+        const { unmount } = render(<Probe env="env-1" />, { wrapper: makeWrapper() });
         unmount();
         resolveFn(paged([entity('User::"alice"')]));
         await Promise.resolve();
@@ -149,7 +156,8 @@ describe('useEntityOptions', () => {
     it('refetches when typeFilter changes by value (not reference)', async () => {
         listEntitiesSpy.mockResolvedValue(paged([entity('User::"alice"'), entity('Group::"admins"')]));
 
-        const { rerender, getByTestId } = render(<Probe env="env-1" opts={{ typeFilter: ['User'] }} />);
+        const wrapper = makeWrapper();
+        const { rerender, getByTestId } = render(<Probe env="env-1" opts={{ typeFilter: ['User'] }} />, { wrapper });
         await waitFor(() => expect(getByTestId('count').textContent).toBe('1'));
         const callsAfterFirst = listEntitiesSpy.mock.calls.length;
 

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/lib/hooks/__tests__/useEntityOptions.test.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/lib/hooks/__tests__/useEntityOptions.test.tsx
@@ -1,0 +1,169 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { render, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { EntityResponse, PagedResponse } from '../../api/authz-api.types';
+import { useEntityOptions, type UseEntityOptionsOpts } from '../useEntityOptions';
+
+const listEntitiesSpy = vi.fn();
+vi.mock('../../api/authz-api.service', () => ({
+    DEFAULT_PER_PAGE: 10,
+    authzApiService: {
+        listEntities: (env: string, params?: unknown) => listEntitiesSpy(env, params),
+    },
+}));
+
+function entity(uid: string, attributes: Record<string, unknown> = {}): EntityResponse {
+    return {
+        id: `id-${uid}`,
+        environmentId: 'DEFAULT',
+        uid,
+        attributes,
+        parents: [],
+        createdAt: new Date(0).toISOString(),
+        updatedAt: new Date(0).toISOString(),
+    };
+}
+
+function paged(data: readonly EntityResponse[], total = data.length): PagedResponse<EntityResponse> {
+    return { data, total, page: 1, perPage: 200 };
+}
+
+interface ProbeProps {
+    readonly env: string;
+    readonly opts?: UseEntityOptionsOpts;
+}
+
+function Probe({ env, opts }: ProbeProps) {
+    const state = useEntityOptions(env, opts);
+    return (
+        <div>
+            <span data-testid="loading">{String(state.isLoading)}</span>
+            <span data-testid="count">{state.options.length}</span>
+            <span data-testid="error">{state.error ?? 'none'}</span>
+            <ul data-testid="options">
+                {state.options.map(o => (
+                    <li key={o.id} data-group={o.group} data-label={o.label} data-description={o.description ?? ''}>
+                        {o.id}
+                    </li>
+                ))}
+            </ul>
+        </div>
+    );
+}
+
+beforeEach(() => {
+    listEntitiesSpy.mockReset();
+});
+
+describe('useEntityOptions', () => {
+    it('returns empty options and no error for an empty list', async () => {
+        listEntitiesSpy.mockResolvedValue(paged([]));
+
+        const { getByTestId } = render(<Probe env="env-1" />);
+
+        await waitFor(() => expect(getByTestId('loading').textContent).toBe('false'));
+        expect(getByTestId('count').textContent).toBe('0');
+        expect(getByTestId('error').textContent).toBe('none');
+        expect(listEntitiesSpy).toHaveBeenCalledWith('env-1', { page: 1, perPage: 200 });
+    });
+
+    it('groups options by entity type parsed from uid', async () => {
+        listEntitiesSpy.mockResolvedValue(
+            paged([
+                entity('User::"alice"', { email: 'alice@example.com' }),
+                entity('Group::"admins"'),
+                entity('ServiceAccount::"deploy-bot"', { _source: 'imported', role: 'ci' }),
+            ]),
+        );
+
+        const { getByTestId } = render(<Probe env="env-1" />);
+
+        await waitFor(() => expect(getByTestId('count').textContent).toBe('3'));
+        const items = getByTestId('options').querySelectorAll('li');
+        expect(items[0].getAttribute('data-group')).toBe('User');
+        expect(items[0].getAttribute('data-label')).toBe('alice');
+        expect(items[0].id || items[0].textContent).toBe('User::"alice"');
+        expect(items[0].getAttribute('data-description')).toBe('email=alice@example.com');
+        expect(items[1].getAttribute('data-group')).toBe('Group');
+        expect(items[1].getAttribute('data-description')).toBe('');
+        expect(items[2].getAttribute('data-group')).toBe('ServiceAccount');
+        // Meta keys prefixed with `_` must be skipped in the description.
+        expect(items[2].getAttribute('data-description')).toBe('role=ci');
+    });
+
+    it('filters options by typeFilter', async () => {
+        listEntitiesSpy.mockResolvedValue(paged([entity('User::"alice"'), entity('Group::"admins"'), entity('AgentIdentity::"agent-1"')]));
+
+        const { getByTestId } = render(<Probe env="env-1" opts={{ typeFilter: ['User'] }} />);
+
+        await waitFor(() => expect(getByTestId('count').textContent).toBe('1'));
+        const items = getByTestId('options').querySelectorAll('li');
+        expect(items[0].getAttribute('data-group')).toBe('User');
+    });
+
+    it('sets error when total exceeds page size and still returns the loaded slice', async () => {
+        const data = Array.from({ length: 200 }, (_, i) => entity(`User::"u${i}"`));
+        listEntitiesSpy.mockResolvedValue(paged(data, 503));
+
+        const { getByTestId } = render(<Probe env="env-1" />);
+
+        await waitFor(() => expect(getByTestId('count').textContent).toBe('200'));
+        expect(getByTestId('error').textContent).toMatch(/too many entities/i);
+    });
+
+    it('does not warn after unmount during in-flight fetch', async () => {
+        let resolveFn: (v: PagedResponse<EntityResponse>) => void = () => undefined;
+        listEntitiesSpy.mockImplementation(
+            () =>
+                new Promise<PagedResponse<EntityResponse>>(resolve => {
+                    resolveFn = resolve;
+                }),
+        );
+        const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+        const { unmount } = render(<Probe env="env-1" />);
+        unmount();
+        resolveFn(paged([entity('User::"alice"')]));
+        await Promise.resolve();
+        await Promise.resolve();
+
+        const noisy = errorSpy.mock.calls.some(args => args.some(a => typeof a === 'string' && a.includes('unmounted')));
+        expect(noisy).toBe(false);
+        errorSpy.mockRestore();
+    });
+
+    it('refetches when typeFilter changes by value (not reference)', async () => {
+        listEntitiesSpy.mockResolvedValue(paged([entity('User::"alice"'), entity('Group::"admins"')]));
+
+        const { rerender, getByTestId } = render(<Probe env="env-1" opts={{ typeFilter: ['User'] }} />);
+        await waitFor(() => expect(getByTestId('count').textContent).toBe('1'));
+        const callsAfterFirst = listEntitiesSpy.mock.calls.length;
+
+        // Same values, fresh array literal — must NOT refetch.
+        rerender(<Probe env="env-1" opts={{ typeFilter: ['User'] }} />);
+        await Promise.resolve();
+        expect(listEntitiesSpy.mock.calls.length).toBe(callsAfterFirst);
+
+        // Different filter — must refetch (or at least re-derive options).
+        rerender(<Probe env="env-1" opts={{ typeFilter: ['Group'] }} />);
+        await waitFor(() => {
+            const items = getByTestId('options').querySelectorAll('li');
+            expect(items.length).toBe(1);
+            expect(items[0].getAttribute('data-group')).toBe('Group');
+        });
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/lib/hooks/__tests__/usePolicies.test.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/lib/hooks/__tests__/usePolicies.test.tsx
@@ -13,7 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { act, render, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
 import { useEffect } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { usePolicies, type UsePoliciesResult } from '../usePolicies';
@@ -25,6 +27,11 @@ vi.mock('../../api/authz-api.service', () => ({
         listPolicies: (env: string, params?: unknown) => listSpy(env, params),
     },
 }));
+
+function makeWrapper() {
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    return ({ children }: { children: ReactNode }) => <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+}
 
 function Probe({ env, type }: { env: string; type?: 'MCP' | 'AGENT' | 'LLM' | 'API' | 'EVENT' | 'CUSTOM' }) {
     const state = usePolicies(env, { type });
@@ -44,14 +51,14 @@ beforeEach(() => {
 describe('usePolicies', () => {
     it('calls listPolicies with env + type on mount', async () => {
         listSpy.mockResolvedValue({ data: [], total: 0, page: 1, perPage: 10 });
-        const { getByTestId } = render(<Probe env="env-1" type="MCP" />);
+        const { getByTestId } = render(<Probe env="env-1" type="MCP" />, { wrapper: makeWrapper() });
         await waitFor(() => expect(getByTestId('total').textContent).toBe('0'));
         expect(listSpy).toHaveBeenCalledWith('env-1', { page: 1, perPage: 10, type: 'MCP', status: undefined });
     });
 
     it('captures error into state', async () => {
         listSpy.mockRejectedValue(new Error('boom'));
-        const { getByTestId } = render(<Probe env="env-1" />);
+        const { getByTestId } = render(<Probe env="env-1" />, { wrapper: makeWrapper() });
         await waitFor(() => expect(getByTestId('error').textContent).toBe('boom'));
     });
 
@@ -65,7 +72,7 @@ describe('usePolicies', () => {
         );
 
         const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
-        const { unmount } = render(<Probe env="env-1" />);
+        const { unmount } = render(<Probe env="env-1" />, { wrapper: makeWrapper() });
         unmount();
 
         resolveFn({ data: [], total: 0, page: 1, perPage: 10 });
@@ -85,7 +92,8 @@ describe('usePolicies', () => {
             return <span data-testid="total">{state.data?.total ?? 'null'}</span>;
         }
 
-        const { rerender, getByTestId } = render(<PerPageProbe perPage={10} />);
+        const wrapper = makeWrapper();
+        const { rerender, getByTestId } = render(<PerPageProbe perPage={10} />, { wrapper });
         await waitFor(() => expect(getByTestId('total').textContent).toBe('50'));
 
         rerender(<PerPageProbe perPage={50} />);
@@ -107,7 +115,7 @@ describe('usePolicies', () => {
             return null;
         }
 
-        render(<CaptureProbe />);
+        render(<CaptureProbe />, { wrapper: makeWrapper() });
         await waitFor(() => expect(listSpy).toHaveBeenCalledTimes(1));
 
         await act(async () => {
@@ -128,7 +136,8 @@ describe('usePolicies', () => {
         );
         listSpy.mockImplementationOnce(() => Promise.resolve({ data: [], total: 7, page: 1, perPage: 10 }));
 
-        const { rerender, getByTestId } = render(<Probe env="env-A" />);
+        const wrapper = makeWrapper();
+        const { rerender, getByTestId } = render(<Probe env="env-A" />, { wrapper });
         rerender(<Probe env="env-B" />);
 
         await waitFor(() => expect(getByTestId('total').textContent).toBe('7'));

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/lib/hooks/__tests__/usePolicies.test.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/lib/hooks/__tests__/usePolicies.test.tsx
@@ -1,0 +1,141 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { act, render, waitFor } from '@testing-library/react';
+import { useEffect } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { usePolicies, type UsePoliciesResult } from '../usePolicies';
+
+const listSpy = vi.fn();
+vi.mock('../../api/authz-api.service', () => ({
+    DEFAULT_PER_PAGE: 10,
+    authzApiService: {
+        listPolicies: (env: string, params?: unknown) => listSpy(env, params),
+    },
+}));
+
+function Probe({ env, type }: { env: string; type?: 'MCP' | 'AGENT' | 'LLM' | 'API' | 'EVENT' | 'CUSTOM' }) {
+    const state = usePolicies(env, { type });
+    return (
+        <div>
+            <span data-testid="loading">{String(state.isLoading)}</span>
+            <span data-testid="total">{state.data?.total ?? 'null'}</span>
+            <span data-testid="error">{state.error ?? 'none'}</span>
+        </div>
+    );
+}
+
+beforeEach(() => {
+    listSpy.mockReset();
+});
+
+describe('usePolicies', () => {
+    it('calls listPolicies with env + type on mount', async () => {
+        listSpy.mockResolvedValue({ data: [], total: 0, page: 1, perPage: 10 });
+        const { getByTestId } = render(<Probe env="env-1" type="MCP" />);
+        await waitFor(() => expect(getByTestId('total').textContent).toBe('0'));
+        expect(listSpy).toHaveBeenCalledWith('env-1', { page: 1, perPage: 10, type: 'MCP', status: undefined });
+    });
+
+    it('captures error into state', async () => {
+        listSpy.mockRejectedValue(new Error('boom'));
+        const { getByTestId } = render(<Probe env="env-1" />);
+        await waitFor(() => expect(getByTestId('error').textContent).toBe('boom'));
+    });
+
+    it('does not warn after unmount during in-flight fetch', async () => {
+        let resolveFn: (value: unknown) => void = () => undefined;
+        listSpy.mockImplementation(
+            () =>
+                new Promise(resolve => {
+                    resolveFn = resolve;
+                }),
+        );
+
+        const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+        const { unmount } = render(<Probe env="env-1" />);
+        unmount();
+
+        resolveFn({ data: [], total: 0, page: 1, perPage: 10 });
+        await Promise.resolve();
+        await Promise.resolve();
+
+        const noisy = errorSpy.mock.calls.some(args => args.some(a => typeof a === 'string' && a.includes('unmounted')));
+        expect(noisy).toBe(false);
+        errorSpy.mockRestore();
+    });
+
+    it('refetches when initialPerPage changes', async () => {
+        listSpy.mockResolvedValue({ data: [], total: 50, page: 1, perPage: 10 });
+
+        function PerPageProbe({ perPage }: { perPage: number }) {
+            const state = usePolicies('env-pp', { initialPerPage: perPage });
+            return <span data-testid="total">{state.data?.total ?? 'null'}</span>;
+        }
+
+        const { rerender, getByTestId } = render(<PerPageProbe perPage={10} />);
+        await waitFor(() => expect(getByTestId('total').textContent).toBe('50'));
+
+        rerender(<PerPageProbe perPage={50} />);
+        await waitFor(() => expect(listSpy).toHaveBeenCalledTimes(2));
+
+        expect(listSpy).toHaveBeenNthCalledWith(1, 'env-pp', { page: 1, perPage: 10, type: undefined, status: undefined });
+        expect(listSpy).toHaveBeenNthCalledWith(2, 'env-pp', { page: 1, perPage: 50, type: undefined, status: undefined });
+    });
+
+    it('internal setPerPage still works', async () => {
+        listSpy.mockResolvedValue({ data: [], total: 0, page: 1, perPage: 10 });
+
+        const ref: { current: UsePoliciesResult | undefined } = { current: undefined };
+        function CaptureProbe() {
+            const state = usePolicies('env-set', { initialPerPage: 10 });
+            useEffect(() => {
+                ref.current = state;
+            });
+            return null;
+        }
+
+        render(<CaptureProbe />);
+        await waitFor(() => expect(listSpy).toHaveBeenCalledTimes(1));
+
+        await act(async () => {
+            ref.current?.setPerPage(25);
+        });
+
+        await waitFor(() => expect(listSpy).toHaveBeenCalledTimes(2));
+        expect(listSpy).toHaveBeenNthCalledWith(2, 'env-set', { page: 1, perPage: 25, type: undefined, status: undefined });
+    });
+
+    it('ignores stale response after env change', async () => {
+        let resolveStale: (value: unknown) => void = () => undefined;
+        listSpy.mockImplementationOnce(
+            () =>
+                new Promise(resolve => {
+                    resolveStale = resolve;
+                }),
+        );
+        listSpy.mockImplementationOnce(() => Promise.resolve({ data: [], total: 7, page: 1, perPage: 10 }));
+
+        const { rerender, getByTestId } = render(<Probe env="env-A" />);
+        rerender(<Probe env="env-B" />);
+
+        await waitFor(() => expect(getByTestId('total').textContent).toBe('7'));
+
+        resolveStale({ data: [], total: 999, page: 1, perPage: 10 });
+        await Promise.resolve();
+        await Promise.resolve();
+        expect(getByTestId('total').textContent).toBe('7');
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/lib/hooks/__tests__/useSchema.test.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/lib/hooks/__tests__/useSchema.test.tsx
@@ -13,7 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { ApiError } from '../../api/authz-api-client';
 import { useSchema } from '../useSchema';
@@ -26,6 +28,11 @@ vi.mock('../../api/authz-api.service', () => ({
         getSchema: (env: string) => getSchemaSpy(env),
     },
 }));
+
+function makeWrapper() {
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    return ({ children }: { children: ReactNode }) => <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+}
 
 function Probe({ env }: { env: string }) {
     const state = useSchema(env);
@@ -51,7 +58,7 @@ describe('useSchema', () => {
             updatedAt: '2026-04-24T00:00:00Z',
         });
 
-        const { getByTestId } = render(<Probe env="env-1" />);
+        const { getByTestId } = render(<Probe env="env-1" />, { wrapper: makeWrapper() });
 
         await waitFor(() => expect(getByTestId('schemaText').textContent).toBe('entity User {};'));
         expect(getByTestId('notFound').textContent).toBe('false');
@@ -60,7 +67,7 @@ describe('useSchema', () => {
     it('treats 404 as notFound, not error', async () => {
         getSchemaSpy.mockRejectedValue(new ApiError(404, 'Not found'));
 
-        const { getByTestId } = render(<Probe env="env-1" />);
+        const { getByTestId } = render(<Probe env="env-1" />, { wrapper: makeWrapper() });
 
         await waitFor(() => expect(getByTestId('notFound').textContent).toBe('true'));
         expect(getByTestId('error').textContent).toBe('none');
@@ -69,7 +76,7 @@ describe('useSchema', () => {
     it('captures non-404 errors', async () => {
         getSchemaSpy.mockRejectedValue(new Error('boom'));
 
-        const { getByTestId } = render(<Probe env="env-1" />);
+        const { getByTestId } = render(<Probe env="env-1" />, { wrapper: makeWrapper() });
 
         await waitFor(() => expect(getByTestId('error').textContent).toBe('boom'));
     });
@@ -83,7 +90,7 @@ describe('useSchema', () => {
                 }),
         );
         const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
-        const { unmount } = render(<Probe env="env-1" />);
+        const { unmount } = render(<Probe env="env-1" />, { wrapper: makeWrapper() });
         unmount();
 
         resolveFn({ environmentId: 'env-1', schemaText: 'x', updatedAt: '' });
@@ -111,7 +118,8 @@ describe('useSchema', () => {
             }),
         );
 
-        const { rerender, getByTestId } = render(<Probe env="env-A" />);
+        const wrapper = makeWrapper();
+        const { rerender, getByTestId } = render(<Probe env="env-A" />, { wrapper });
         rerender(<Probe env="env-B" />);
 
         await waitFor(() => expect(getByTestId('schemaText').textContent).toBe('fresh'));

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/lib/hooks/__tests__/useSchema.test.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/lib/hooks/__tests__/useSchema.test.tsx
@@ -1,0 +1,124 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { render, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ApiError } from '../../api/authz-api-client';
+import { useSchema } from '../useSchema';
+
+const getSchemaSpy = vi.fn();
+
+vi.mock('../../api/authz-api.service', () => ({
+    DEFAULT_PER_PAGE: 10,
+    authzApiService: {
+        getSchema: (env: string) => getSchemaSpy(env),
+    },
+}));
+
+function Probe({ env }: { env: string }) {
+    const state = useSchema(env);
+    return (
+        <div>
+            <span data-testid="loading">{String(state.isLoading)}</span>
+            <span data-testid="schemaText">{state.schema?.schemaText ?? 'null'}</span>
+            <span data-testid="notFound">{String(state.notFound)}</span>
+            <span data-testid="error">{state.error ?? 'none'}</span>
+        </div>
+    );
+}
+
+beforeEach(() => {
+    getSchemaSpy.mockReset();
+});
+
+describe('useSchema', () => {
+    it('loads schema on mount', async () => {
+        getSchemaSpy.mockResolvedValue({
+            environmentId: 'env-1',
+            schemaText: 'entity User {};',
+            updatedAt: '2026-04-24T00:00:00Z',
+        });
+
+        const { getByTestId } = render(<Probe env="env-1" />);
+
+        await waitFor(() => expect(getByTestId('schemaText').textContent).toBe('entity User {};'));
+        expect(getByTestId('notFound').textContent).toBe('false');
+    });
+
+    it('treats 404 as notFound, not error', async () => {
+        getSchemaSpy.mockRejectedValue(new ApiError(404, 'Not found'));
+
+        const { getByTestId } = render(<Probe env="env-1" />);
+
+        await waitFor(() => expect(getByTestId('notFound').textContent).toBe('true'));
+        expect(getByTestId('error').textContent).toBe('none');
+    });
+
+    it('captures non-404 errors', async () => {
+        getSchemaSpy.mockRejectedValue(new Error('boom'));
+
+        const { getByTestId } = render(<Probe env="env-1" />);
+
+        await waitFor(() => expect(getByTestId('error').textContent).toBe('boom'));
+    });
+
+    it('does not warn after unmount during in-flight fetch', async () => {
+        let resolveFn: (value: unknown) => void = () => undefined;
+        getSchemaSpy.mockImplementation(
+            () =>
+                new Promise(resolve => {
+                    resolveFn = resolve;
+                }),
+        );
+        const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+        const { unmount } = render(<Probe env="env-1" />);
+        unmount();
+
+        resolveFn({ environmentId: 'env-1', schemaText: 'x', updatedAt: '' });
+        await Promise.resolve();
+        await Promise.resolve();
+
+        const noisy = errorSpy.mock.calls.some(args => args.some(a => typeof a === 'string' && a.includes('unmounted')));
+        expect(noisy).toBe(false);
+        errorSpy.mockRestore();
+    });
+
+    it('ignores stale response after env change', async () => {
+        let resolveStale: (value: unknown) => void = () => undefined;
+        getSchemaSpy.mockImplementationOnce(
+            () =>
+                new Promise(resolve => {
+                    resolveStale = resolve;
+                }),
+        );
+        getSchemaSpy.mockImplementationOnce(() =>
+            Promise.resolve({
+                environmentId: 'env-B',
+                schemaText: 'fresh',
+                updatedAt: '2026-01-01',
+            }),
+        );
+
+        const { rerender, getByTestId } = render(<Probe env="env-A" />);
+        rerender(<Probe env="env-B" />);
+
+        await waitFor(() => expect(getByTestId('schemaText').textContent).toBe('fresh'));
+
+        resolveStale({ environmentId: 'env-A', schemaText: 'stale', updatedAt: '' });
+        await Promise.resolve();
+        await Promise.resolve();
+        expect(getByTestId('schemaText').textContent).toBe('fresh');
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/lib/hooks/useEntities.ts
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/lib/hooks/useEntities.ts
@@ -1,0 +1,76 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useCallback, useEffect, useState } from 'react';
+import { authzApiService, DEFAULT_PER_PAGE } from '../api/authz-api.service';
+import type { EntityResponse, PagedResponse } from '../api/authz-api.types';
+
+export interface UseEntitiesResult {
+    readonly data: PagedResponse<EntityResponse> | null;
+    readonly isLoading: boolean;
+    readonly error: string | undefined;
+    readonly page: number;
+    readonly perPage: number;
+    readonly setPage: (page: number) => void;
+    readonly setPerPage: (perPage: number) => void;
+    readonly reload: () => void;
+}
+
+export function useEntities(environmentId: string, initialPerPage = DEFAULT_PER_PAGE): UseEntitiesResult {
+    const [page, setPage] = useState(1);
+    // Resync perPage from prop on every change so callers can drive it as a controlled value.
+    const [perPage, setPerPage] = useState(initialPerPage);
+    useEffect(() => {
+        setPerPage(initialPerPage);
+    }, [initialPerPage]);
+    const [data, setData] = useState<PagedResponse<EntityResponse> | null>(null);
+    const [isLoading, setIsLoading] = useState(true);
+    const [error, setError] = useState<string | undefined>(undefined);
+    const [nonce, setNonce] = useState(0);
+
+    useEffect(() => {
+        let cancelled = false;
+        // Gate setState to break cascading renders when nothing actually
+        // changes (isLoading already true / error already undefined).
+        if (!isLoading) setIsLoading(true);
+        if (error !== undefined) setError(undefined);
+
+        authzApiService
+            .listEntities(environmentId, { page, perPage })
+            .then(res => {
+                if (cancelled) return;
+                setData(res);
+            })
+            .catch(e => {
+                if (cancelled) return;
+                setError(e instanceof Error ? e.message : 'Failed to load entities');
+                setData(null);
+            })
+            .finally(() => {
+                if (!cancelled) setIsLoading(false);
+            });
+
+        return () => {
+            cancelled = true;
+        };
+        // isLoading/error intentionally excluded — they are read for gating
+        // setState; including them would re-trigger the effect.
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [environmentId, page, perPage, nonce]);
+
+    const reload = useCallback(() => setNonce(n => n + 1), []);
+
+    return { data, isLoading, error, page, perPage, setPage, setPerPage, reload };
+}

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/lib/hooks/useEntities.ts
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/lib/hooks/useEntities.ts
@@ -13,9 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { useCallback, useEffect, useState } from 'react';
+import { keepPreviousData, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useCallback, useState } from 'react';
 import { authzApiService, DEFAULT_PER_PAGE } from '../api/authz-api.service';
 import type { EntityResponse, PagedResponse } from '../api/authz-api.types';
+import { authzQueryKeys } from '../api/query-keys';
 
 export interface UseEntitiesResult {
     readonly data: PagedResponse<EntityResponse> | null;
@@ -30,47 +32,38 @@ export interface UseEntitiesResult {
 
 export function useEntities(environmentId: string, initialPerPage = DEFAULT_PER_PAGE): UseEntitiesResult {
     const [page, setPage] = useState(1);
-    // Resync perPage from prop on every change so callers can drive it as a controlled value.
     const [perPage, setPerPage] = useState(initialPerPage);
-    useEffect(() => {
+    const [lastInitialPerPage, setLastInitialPerPage] = useState(initialPerPage);
+
+    // Adjust perPage during render (React recommended pattern) rather than a
+    // secondary useEffect, avoiding the extra render cycle that the effect causes.
+    if (initialPerPage !== lastInitialPerPage) {
+        setLastInitialPerPage(initialPerPage);
         setPerPage(initialPerPage);
-    }, [initialPerPage]);
-    const [data, setData] = useState<PagedResponse<EntityResponse> | null>(null);
-    const [isLoading, setIsLoading] = useState(true);
-    const [error, setError] = useState<string | undefined>(undefined);
-    const [nonce, setNonce] = useState(0);
+    }
 
-    useEffect(() => {
-        let cancelled = false;
-        // Gate setState to break cascading renders when nothing actually
-        // changes (isLoading already true / error already undefined).
-        if (!isLoading) setIsLoading(true);
-        if (error !== undefined) setError(undefined);
+    const queryClient = useQueryClient();
 
-        authzApiService
-            .listEntities(environmentId, { page, perPage })
-            .then(res => {
-                if (cancelled) return;
-                setData(res);
-            })
-            .catch(e => {
-                if (cancelled) return;
-                setError(e instanceof Error ? e.message : 'Failed to load entities');
-                setData(null);
-            })
-            .finally(() => {
-                if (!cancelled) setIsLoading(false);
-            });
+    const query = useQuery({
+        queryKey: authzQueryKeys.entities.page(environmentId, page, perPage),
+        queryFn: () => authzApiService.listEntities(environmentId, { page, perPage }),
+        staleTime: 30_000,
+        placeholderData: keepPreviousData,
+    });
 
-        return () => {
-            cancelled = true;
-        };
-        // isLoading/error intentionally excluded — they are read for gating
-        // setState; including them would re-trigger the effect.
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [environmentId, page, perPage, nonce]);
+    const reload = useCallback(
+        () => void queryClient.invalidateQueries({ queryKey: authzQueryKeys.entities.all(environmentId) }),
+        [environmentId, queryClient],
+    );
 
-    const reload = useCallback(() => setNonce(n => n + 1), []);
-
-    return { data, isLoading, error, page, perPage, setPage, setPerPage, reload };
+    return {
+        data: query.data ?? null,
+        isLoading: query.isLoading,
+        error: query.error instanceof Error ? query.error.message : query.error ? String(query.error) : undefined,
+        page,
+        perPage,
+        setPage,
+        setPerPage,
+        reload,
+    };
 }

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/lib/hooks/useEntityOptions.ts
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/lib/hooks/useEntityOptions.ts
@@ -1,0 +1,148 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useEffect, useMemo, useRef, useState } from 'react';
+import type { ChipOption } from '../chip-option';
+import { authzApiService } from '../api/authz-api.service';
+import type { EntityResponse } from '../api/authz-api.types';
+import { parseEntityUid } from '../entity-adapter';
+
+export interface UseEntityOptionsResult {
+    readonly options: readonly ChipOption[];
+    readonly isLoading: boolean;
+    readonly error: string | undefined;
+}
+
+export interface UseEntityOptionsOpts {
+    /** Optional restrict to specific entity types (e.g. `['User', 'Group']`). */
+    readonly typeFilter?: readonly string[];
+}
+
+/**
+ * Maximum number of entities fetched in a single page. The chip picker is not
+ * a paginated browser — once we exceed this we surface an error so the user
+ * knows the picker may be incomplete. The list endpoint is paginated; for now
+ * we deliberately fetch a single (large) page rather than aggregating to keep
+ * the hook simple and fast.
+ */
+const PER_PAGE = 200;
+
+/**
+ * Build a short, human-readable summary of an entity's attributes for the
+ * chip option description. Returns up to two `key=value` pairs (skipping
+ * meta keys prefixed with `_`) so the dropdown stays scannable.
+ */
+function summarizeAttributes(attrs: Record<string, unknown>): string | undefined {
+    const entries = Object.entries(attrs).filter(([k]) => !k.startsWith('_'));
+    if (entries.length === 0) return undefined;
+    const parts = entries.slice(0, 2).map(([k, v]) => {
+        const rendered = typeof v === 'string' ? v : JSON.stringify(v);
+        return `${k}=${rendered}`;
+    });
+    return parts.join(', ');
+}
+
+function toChipOption(entity: EntityResponse): ChipOption {
+    const { type, id } = parseEntityUid(entity.uid);
+    return {
+        // ChipOption.id must equal the canonical GAPL UID (`User::"alice"`)
+        // that `parseGaplToStatements` emits — the two sides have to agree on
+        // the same key for selected chips to highlight after switch-to-visual
+        // or after save+reload. The backend stores entity.uid in dot form
+        // (`user.alice`), so we explicitly reformat here.
+        id: `${type}::"${id}"`,
+        label: id,
+        group: type,
+        description: summarizeAttributes(entity.attributes),
+    };
+}
+
+/**
+ * Selector hook that turns the live list of entities into chip options for
+ * the principal combobox in the policy builder.
+ *
+ * Behaviour:
+ * - Calls `listEntities(environmentId, { page: 1, perPage: 200 })` once per
+ *   `(environmentId, typeFilter)` pair.
+ * - If `typeFilter` is given, drops options whose entity type is not in the
+ *   filter. The filter is compared by stable string key, so callers may pass
+ *   a fresh array literal on each render.
+ * - If the backend reports `total > 200`, returns the loaded slice plus an
+ *   `error` string telling the user to refine the schema or filter by type.
+ * - Cancellation-safe: aborts in-flight on unmount or when the deps change.
+ */
+export function useEntityOptions(environmentId: string, opts?: UseEntityOptionsOpts): UseEntityOptionsResult {
+    const typeFilter = opts?.typeFilter;
+    // Stable string key for the typeFilter dependency: callers can pass a
+    // fresh array literal (`['User', 'Group']`) without retriggering the
+    // effect on every render.
+    const typeFilterKey = useMemo(() => (typeFilter ? JSON.stringify([...typeFilter].sort()) : ''), [typeFilter]);
+
+    const [allOptions, setAllOptions] = useState<readonly ChipOption[]>([]);
+    const [isLoading, setIsLoading] = useState(true);
+    const [error, setError] = useState<string | undefined>(undefined);
+
+    const mountedRef = useRef(true);
+    useEffect(() => {
+        mountedRef.current = true;
+        return () => {
+            mountedRef.current = false;
+        };
+    }, []);
+
+    useEffect(() => {
+        let cancelled = false;
+        // Gate setState to break cascading renders when nothing actually
+        // changes (isLoading already true / error already undefined).
+        if (!isLoading) setIsLoading(true);
+        if (error !== undefined) setError(undefined);
+
+        authzApiService
+            .listEntities(environmentId, { page: 1, perPage: PER_PAGE })
+            .then(res => {
+                if (cancelled) return;
+                const mapped = res.data.map(toChipOption);
+                setAllOptions(mapped);
+                if (res.total > PER_PAGE) {
+                    setError('Too many entities for chip picker; consider refining schema or filtering by type.');
+                } else {
+                    setError(undefined);
+                }
+            })
+            .catch(e => {
+                if (cancelled) return;
+                setAllOptions([]);
+                setError(e instanceof Error ? e.message : 'Failed to load entities');
+            })
+            .finally(() => {
+                if (!cancelled) setIsLoading(false);
+            });
+
+        return () => {
+            cancelled = true;
+        };
+        // typeFilterKey is intentionally a dependency so changing the filter
+        // refetches. isLoading/error read for gating setState.
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [environmentId, typeFilterKey]);
+
+    const options = useMemo(() => {
+        if (!typeFilter || typeFilter.length === 0) return allOptions;
+        const allow = new Set(typeFilter);
+        return allOptions.filter(o => allow.has(o.group));
+    }, [allOptions, typeFilter, typeFilterKey]); // eslint-disable-line react-hooks/exhaustive-deps
+
+    return { options, isLoading, error };
+}

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/lib/hooks/useEntityOptions.ts
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/lib/hooks/useEntityOptions.ts
@@ -13,11 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { useMemo } from 'react';
 import type { ChipOption } from '../chip-option';
 import { authzApiService } from '../api/authz-api.service';
 import type { EntityResponse } from '../api/authz-api.types';
 import { parseEntityUid } from '../entity-adapter';
+import { authzQueryKeys } from '../api/query-keys';
 
 export interface UseEntityOptionsResult {
     readonly options: readonly ChipOption[];
@@ -30,20 +32,8 @@ export interface UseEntityOptionsOpts {
     readonly typeFilter?: readonly string[];
 }
 
-/**
- * Maximum number of entities fetched in a single page. The chip picker is not
- * a paginated browser — once we exceed this we surface an error so the user
- * knows the picker may be incomplete. The list endpoint is paginated; for now
- * we deliberately fetch a single (large) page rather than aggregating to keep
- * the hook simple and fast.
- */
 const PER_PAGE = 200;
 
-/**
- * Build a short, human-readable summary of an entity's attributes for the
- * chip option description. Returns up to two `key=value` pairs (skipping
- * meta keys prefixed with `_`) so the dropdown stays scannable.
- */
 function summarizeAttributes(attrs: Record<string, unknown>): string | undefined {
     const entries = Object.entries(attrs).filter(([k]) => !k.startsWith('_'));
     if (entries.length === 0) return undefined;
@@ -57,11 +47,6 @@ function summarizeAttributes(attrs: Record<string, unknown>): string | undefined
 function toChipOption(entity: EntityResponse): ChipOption {
     const { type, id } = parseEntityUid(entity.uid);
     return {
-        // ChipOption.id must equal the canonical GAPL UID (`User::"alice"`)
-        // that `parseGaplToStatements` emits — the two sides have to agree on
-        // the same key for selected chips to highlight after switch-to-visual
-        // or after save+reload. The backend stores entity.uid in dot form
-        // (`user.alice`), so we explicitly reformat here.
         id: `${type}::"${id}"`,
         label: id,
         group: type,
@@ -69,80 +54,34 @@ function toChipOption(entity: EntityResponse): ChipOption {
     };
 }
 
-/**
- * Selector hook that turns the live list of entities into chip options for
- * the principal combobox in the policy builder.
- *
- * Behaviour:
- * - Calls `listEntities(environmentId, { page: 1, perPage: 200 })` once per
- *   `(environmentId, typeFilter)` pair.
- * - If `typeFilter` is given, drops options whose entity type is not in the
- *   filter. The filter is compared by stable string key, so callers may pass
- *   a fresh array literal on each render.
- * - If the backend reports `total > 200`, returns the loaded slice plus an
- *   `error` string telling the user to refine the schema or filter by type.
- * - Cancellation-safe: aborts in-flight on unmount or when the deps change.
- */
 export function useEntityOptions(environmentId: string, opts?: UseEntityOptionsOpts): UseEntityOptionsResult {
     const typeFilter = opts?.typeFilter;
-    // Stable string key for the typeFilter dependency: callers can pass a
-    // fresh array literal (`['User', 'Group']`) without retriggering the
-    // effect on every render.
+    // Stable string key for the typeFilter: callers can pass a fresh array
+    // literal on every render without causing a new network fetch.
     const typeFilterKey = useMemo(() => (typeFilter ? JSON.stringify([...typeFilter].sort()) : ''), [typeFilter]);
 
-    const [allOptions, setAllOptions] = useState<readonly ChipOption[]>([]);
-    const [isLoading, setIsLoading] = useState(true);
-    const [error, setError] = useState<string | undefined>(undefined);
+    const query = useQuery({
+        // typeFilterKey in the query key: different filter values → different
+        // cache entry + re-fetch. Same values (fresh array reference) → same
+        // key → no re-fetch.
+        queryKey: [...authzQueryKeys.entityOptions(environmentId), typeFilterKey],
+        queryFn: () => authzApiService.listEntities(environmentId, { page: 1, perPage: PER_PAGE }),
+        staleTime: 30_000,
+    });
 
-    const mountedRef = useRef(true);
-    useEffect(() => {
-        mountedRef.current = true;
-        return () => {
-            mountedRef.current = false;
-        };
-    }, []);
+    const allOptions = useMemo(() => query.data?.data.map(toChipOption) ?? [], [query.data]);
 
-    useEffect(() => {
-        let cancelled = false;
-        // Gate setState to break cascading renders when nothing actually
-        // changes (isLoading already true / error already undefined).
-        if (!isLoading) setIsLoading(true);
-        if (error !== undefined) setError(undefined);
-
-        authzApiService
-            .listEntities(environmentId, { page: 1, perPage: PER_PAGE })
-            .then(res => {
-                if (cancelled) return;
-                const mapped = res.data.map(toChipOption);
-                setAllOptions(mapped);
-                if (res.total > PER_PAGE) {
-                    setError('Too many entities for chip picker; consider refining schema or filtering by type.');
-                } else {
-                    setError(undefined);
-                }
-            })
-            .catch(e => {
-                if (cancelled) return;
-                setAllOptions([]);
-                setError(e instanceof Error ? e.message : 'Failed to load entities');
-            })
-            .finally(() => {
-                if (!cancelled) setIsLoading(false);
-            });
-
-        return () => {
-            cancelled = true;
-        };
-        // typeFilterKey is intentionally a dependency so changing the filter
-        // refetches. isLoading/error read for gating setState.
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [environmentId, typeFilterKey]);
+    const tooMany = (query.data?.total ?? 0) > PER_PAGE;
 
     const options = useMemo(() => {
         if (!typeFilter || typeFilter.length === 0) return allOptions;
         const allow = new Set(typeFilter);
         return allOptions.filter(o => allow.has(o.group));
-    }, [allOptions, typeFilter, typeFilterKey]); // eslint-disable-line react-hooks/exhaustive-deps
+    }, [allOptions, typeFilter]);
 
-    return { options, isLoading, error };
+    const networkError =
+        query.error instanceof Error ? query.error.message : query.error ? String(query.error) : undefined;
+    const error = networkError ?? (tooMany ? 'Too many entities for chip picker; consider refining schema or filtering by type.' : undefined);
+
+    return { options, isLoading: query.isLoading, error };
 }

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/lib/hooks/usePolicies.ts
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/lib/hooks/usePolicies.ts
@@ -1,0 +1,124 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { authzApiService, DEFAULT_PER_PAGE, type PolicyListParams } from '../api/authz-api.service';
+import type { PagedResponse, PolicyRequest, PolicyResponse, PolicyStatus, PolicyType } from '../api/authz-api.types';
+
+export interface UsePoliciesOptions {
+    readonly type?: PolicyType;
+    readonly status?: PolicyStatus;
+    readonly initialPerPage?: number;
+}
+
+export interface UsePoliciesResult {
+    readonly data: PagedResponse<PolicyResponse> | null;
+    readonly isLoading: boolean;
+    readonly error: string | undefined;
+    readonly page: number;
+    readonly perPage: number;
+    readonly setPage: (page: number) => void;
+    readonly setPerPage: (perPage: number) => void;
+    readonly create: (request: PolicyRequest) => Promise<PolicyResponse>;
+    readonly update: (id: string, request: PolicyRequest) => Promise<PolicyResponse>;
+    readonly remove: (id: string) => Promise<void>;
+    readonly reload: () => void;
+}
+
+export function usePolicies(environmentId: string, options: UsePoliciesOptions = {}): UsePoliciesResult {
+    const mountedRef = useRef(true);
+    const { type, status, initialPerPage = DEFAULT_PER_PAGE } = options;
+    const [page, setPage] = useState(1);
+    // Resync perPage from prop on every change so callers can drive it as a controlled value.
+    const [perPage, setPerPage] = useState(initialPerPage);
+    useEffect(() => {
+        setPerPage(initialPerPage);
+    }, [initialPerPage]);
+    const [data, setData] = useState<PagedResponse<PolicyResponse> | null>(null);
+    const [isLoading, setIsLoading] = useState(true);
+    const [error, setError] = useState<string | undefined>(undefined);
+    const [nonce, setNonce] = useState(0);
+
+    useEffect(() => {
+        mountedRef.current = true;
+        return () => {
+            mountedRef.current = false;
+        };
+    }, []);
+
+    useEffect(() => {
+        let cancelled = false;
+        // Gate setState to break cascading renders when nothing actually
+        // changes (isLoading already true / error already undefined).
+        if (!isLoading) setIsLoading(true);
+        if (error !== undefined) setError(undefined);
+
+        const params: PolicyListParams = { page, perPage, type, status };
+        authzApiService
+            .listPolicies(environmentId, params)
+            .then(res => {
+                if (cancelled) return;
+                setData(res);
+            })
+            .catch(e => {
+                if (cancelled) return;
+                setError(e instanceof Error ? e.message : 'Failed to load policies');
+                setData(null);
+            })
+            .finally(() => {
+                if (!cancelled) setIsLoading(false);
+            });
+
+        return () => {
+            cancelled = true;
+        };
+        // isLoading/error intentionally excluded — they are read for gating
+        // setState; including them would re-trigger the effect.
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [environmentId, type, status, page, perPage, nonce]);
+
+    const reload = useCallback(() => setNonce(n => n + 1), []);
+
+    const create = useCallback(
+        async (request: PolicyRequest) => {
+            const created = await authzApiService.createPolicy(environmentId, request);
+            if (!mountedRef.current) return created;
+            reload();
+            return created;
+        },
+        [environmentId, reload],
+    );
+
+    const update = useCallback(
+        async (id: string, request: PolicyRequest) => {
+            const updated = await authzApiService.updatePolicy(environmentId, id, request);
+            if (!mountedRef.current) return updated;
+            reload();
+            return updated;
+        },
+        [environmentId, reload],
+    );
+
+    const remove = useCallback(
+        async (id: string) => {
+            await authzApiService.deletePolicy(environmentId, id);
+            if (!mountedRef.current) return;
+            reload();
+        },
+        [environmentId, reload],
+    );
+
+    return { data, isLoading, error, page, perPage, setPage, setPerPage, create, update, remove, reload };
+}

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/lib/hooks/usePolicies.ts
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/lib/hooks/usePolicies.ts
@@ -13,9 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { keepPreviousData, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useCallback, useState } from 'react';
 import { authzApiService, DEFAULT_PER_PAGE, type PolicyListParams } from '../api/authz-api.service';
 import type { PagedResponse, PolicyRequest, PolicyResponse, PolicyStatus, PolicyType } from '../api/authz-api.types';
+import { authzQueryKeys } from '../api/query-keys';
 
 export interface UsePoliciesOptions {
     readonly type?: PolicyType;
@@ -38,87 +40,72 @@ export interface UsePoliciesResult {
 }
 
 export function usePolicies(environmentId: string, options: UsePoliciesOptions = {}): UsePoliciesResult {
-    const mountedRef = useRef(true);
     const { type, status, initialPerPage = DEFAULT_PER_PAGE } = options;
     const [page, setPage] = useState(1);
-    // Resync perPage from prop on every change so callers can drive it as a controlled value.
     const [perPage, setPerPage] = useState(initialPerPage);
-    useEffect(() => {
+    const [lastInitialPerPage, setLastInitialPerPage] = useState(initialPerPage);
+
+    // Adjust perPage during render (React recommended pattern) rather than a
+    // secondary useEffect, avoiding the extra render cycle that the effect causes.
+    if (initialPerPage !== lastInitialPerPage) {
+        setLastInitialPerPage(initialPerPage);
         setPerPage(initialPerPage);
-    }, [initialPerPage]);
-    const [data, setData] = useState<PagedResponse<PolicyResponse> | null>(null);
-    const [isLoading, setIsLoading] = useState(true);
-    const [error, setError] = useState<string | undefined>(undefined);
-    const [nonce, setNonce] = useState(0);
+    }
 
-    useEffect(() => {
-        mountedRef.current = true;
-        return () => {
-            mountedRef.current = false;
-        };
-    }, []);
+    const queryClient = useQueryClient();
 
-    useEffect(() => {
-        let cancelled = false;
-        // Gate setState to break cascading renders when nothing actually
-        // changes (isLoading already true / error already undefined).
-        if (!isLoading) setIsLoading(true);
-        if (error !== undefined) setError(undefined);
+    const params: PolicyListParams = { page, perPage, type, status };
+    const query = useQuery({
+        queryKey: authzQueryKeys.policies.page(environmentId, page, perPage, type, status),
+        queryFn: () => authzApiService.listPolicies(environmentId, params),
+        staleTime: 30_000,
+        placeholderData: keepPreviousData,
+    });
 
-        const params: PolicyListParams = { page, perPage, type, status };
-        authzApiService
-            .listPolicies(environmentId, params)
-            .then(res => {
-                if (cancelled) return;
-                setData(res);
-            })
-            .catch(e => {
-                if (cancelled) return;
-                setError(e instanceof Error ? e.message : 'Failed to load policies');
-                setData(null);
-            })
-            .finally(() => {
-                if (!cancelled) setIsLoading(false);
-            });
+    const invalidate = useCallback(
+        () => queryClient.invalidateQueries({ queryKey: authzQueryKeys.policies.all(environmentId) }),
+        [environmentId, queryClient],
+    );
 
-        return () => {
-            cancelled = true;
-        };
-        // isLoading/error intentionally excluded — they are read for gating
-        // setState; including them would re-trigger the effect.
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [environmentId, type, status, page, perPage, nonce]);
-
-    const reload = useCallback(() => setNonce(n => n + 1), []);
+    const reload = useCallback(() => void invalidate(), [invalidate]);
 
     const create = useCallback(
         async (request: PolicyRequest) => {
             const created = await authzApiService.createPolicy(environmentId, request);
-            if (!mountedRef.current) return created;
-            reload();
+            void invalidate();
             return created;
         },
-        [environmentId, reload],
+        [environmentId, invalidate],
     );
 
     const update = useCallback(
         async (id: string, request: PolicyRequest) => {
             const updated = await authzApiService.updatePolicy(environmentId, id, request);
-            if (!mountedRef.current) return updated;
-            reload();
+            void invalidate();
             return updated;
         },
-        [environmentId, reload],
+        [environmentId, invalidate],
     );
 
     const remove = useCallback(
         async (id: string) => {
             await authzApiService.deletePolicy(environmentId, id);
-            if (!mountedRef.current) return;
-            reload();
+            void invalidate();
         },
-        [environmentId, reload],
+        [environmentId, invalidate],
     );
 
-    return { data, isLoading, error, page, perPage, setPage, setPerPage, create, update, remove, reload };
+    return {
+        data: query.data ?? null,
+        isLoading: query.isLoading,
+        error: query.error instanceof Error ? query.error.message : query.error ? String(query.error) : undefined,
+        page,
+        perPage,
+        setPage,
+        setPerPage,
+        create,
+        update,
+        remove,
+        reload,
+    };
 }

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/lib/hooks/useSchema.ts
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/lib/hooks/useSchema.ts
@@ -13,10 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { useEffect, useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
 import { ApiError } from '../api/authz-api-client';
 import { authzApiService } from '../api/authz-api.service';
 import type { SchemaResponse } from '../api/authz-api.types';
+import { authzQueryKeys } from '../api/query-keys';
 
 export interface UseSchemaResult {
     readonly schema: SchemaResponse | null;
@@ -25,41 +26,31 @@ export interface UseSchemaResult {
     readonly error: string | undefined;
 }
 
+const NOT_FOUND = Symbol('schema-not-found');
+type SchemaQueryResult = SchemaResponse | typeof NOT_FOUND;
+
 export function useSchema(environmentId: string): UseSchemaResult {
-    const [schema, setSchema] = useState<SchemaResponse | null>(null);
-    const [notFound, setNotFound] = useState(false);
-    const [isLoading, setIsLoading] = useState(true);
-    const [error, setError] = useState<string | undefined>(undefined);
+    const query = useQuery<SchemaQueryResult>({
+        queryKey: authzQueryKeys.schema(environmentId),
+        queryFn: async () => {
+            try {
+                return await authzApiService.getSchema(environmentId);
+            } catch (e) {
+                // 404 is a legitimate "no schema yet" state, not a transport error.
+                if (e instanceof ApiError && e.status === 404) return NOT_FOUND;
+                throw e;
+            }
+        },
+        staleTime: 30_000,
+    });
 
-    useEffect(() => {
-        let cancelled = false;
-        setIsLoading(true);
-        setError(undefined);
+    const notFound = query.data === NOT_FOUND;
+    const schema = !notFound && query.data ? (query.data as SchemaResponse) : null;
 
-        authzApiService
-            .getSchema(environmentId)
-            .then(res => {
-                if (cancelled) return;
-                setSchema(res);
-                setNotFound(false);
-            })
-            .catch(e => {
-                if (cancelled) return;
-                if (e instanceof ApiError && e.status === 404) {
-                    setSchema(null);
-                    setNotFound(true);
-                } else {
-                    setError(e instanceof Error ? e.message : 'Failed to load schema');
-                }
-            })
-            .finally(() => {
-                if (!cancelled) setIsLoading(false);
-            });
-
-        return () => {
-            cancelled = true;
-        };
-    }, [environmentId]);
-
-    return { schema, notFound, isLoading, error };
+    return {
+        schema,
+        notFound,
+        isLoading: query.isLoading,
+        error: query.error instanceof Error ? query.error.message : query.error ? String(query.error) : undefined,
+    };
 }

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/lib/hooks/useSchema.ts
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/lib/hooks/useSchema.ts
@@ -1,0 +1,65 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useEffect, useState } from 'react';
+import { ApiError } from '../api/authz-api-client';
+import { authzApiService } from '../api/authz-api.service';
+import type { SchemaResponse } from '../api/authz-api.types';
+
+export interface UseSchemaResult {
+    readonly schema: SchemaResponse | null;
+    readonly notFound: boolean;
+    readonly isLoading: boolean;
+    readonly error: string | undefined;
+}
+
+export function useSchema(environmentId: string): UseSchemaResult {
+    const [schema, setSchema] = useState<SchemaResponse | null>(null);
+    const [notFound, setNotFound] = useState(false);
+    const [isLoading, setIsLoading] = useState(true);
+    const [error, setError] = useState<string | undefined>(undefined);
+
+    useEffect(() => {
+        let cancelled = false;
+        setIsLoading(true);
+        setError(undefined);
+
+        authzApiService
+            .getSchema(environmentId)
+            .then(res => {
+                if (cancelled) return;
+                setSchema(res);
+                setNotFound(false);
+            })
+            .catch(e => {
+                if (cancelled) return;
+                if (e instanceof ApiError && e.status === 404) {
+                    setSchema(null);
+                    setNotFound(true);
+                } else {
+                    setError(e instanceof Error ? e.message : 'Failed to load schema');
+                }
+            })
+            .finally(() => {
+                if (!cancelled) setIsLoading(false);
+            });
+
+        return () => {
+            cancelled = true;
+        };
+    }, [environmentId]);
+
+    return { schema, notFound, isLoading, error };
+}

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/lib/policy-entity-refs.ts
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/lib/policy-entity-refs.ts
@@ -1,0 +1,161 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Policy ↔ Entity cross-reference utilities.
+ *
+ * Pure, side-effect-free helpers that scan the GAPL `policyText` of each
+ * policy for `Type::"id"` references and group them by the clause they
+ * appear in (principal / action / resource). Used by the Entities table
+ * to show "which policies reference this entity?" without any backend
+ * cross-reference endpoint.
+ *
+ * The scanner is intentionally lenient: it does NOT validate the policy
+ * grammar and never throws on malformed input. If the text cannot be
+ * parsed cleanly we simply emit no refs for that policy.
+ */
+
+import type { EntityInstance } from '../app/features/policy-structure/entity-types';
+import type { PolicyResponse } from './api/authz-api.types';
+import { formatEntityUid } from './entity-adapter';
+
+export type PolicyClause = 'principal' | 'action' | 'resource';
+
+export interface EntityRefInPolicy {
+    /** Entity type, e.g. `User`, `Endpoint`. */
+    readonly type: string;
+    /** Entity id, e.g. `alice`. */
+    readonly id: string;
+    /** Which top-level GAPL clause the reference appears in. */
+    readonly clause: PolicyClause;
+}
+
+export interface PolicyRef {
+    readonly policy: PolicyResponse;
+    /** Distinct clauses (principal/action/resource) where the entity appears. */
+    readonly clauses: PolicyClause[];
+}
+
+// ---------------------------------------------------------------------------
+// Tokeniser — extract `Type::"id"` references with their surrounding clause.
+// ---------------------------------------------------------------------------
+
+const CLAUSE_KEYWORDS: PolicyClause[] = ['principal', 'action', 'resource'];
+
+/**
+ * Scan the policy text for every `Type::"id"` token, classifying each by the
+ * nearest preceding clause keyword (`principal`, `action`, `resource`).
+ *
+ * Lenient: malformed input (unbalanced braces, garbage) returns whatever
+ * tokens could be matched — never throws.
+ */
+export function extractEntityRefsFromPolicyText(text: string): EntityRefInPolicy[] {
+    if (!text || typeof text !== 'string') return [];
+
+    const refs: EntityRefInPolicy[] = [];
+
+    // Match either a clause keyword or a Type::"id" token, in order.
+    // We walk through the text linearly and remember the last seen clause.
+    // Keyword must NOT be immediately followed by `::` — otherwise it's the
+    // type-prefix of a Type::"id" token (e.g. `action::"read"`), not a clause.
+    const tokenRe = /\b(principal|action|resource)\b(?!::)|([A-Za-z_][A-Za-z0-9_]*)::"([^"]*)"/g;
+
+    let currentClause: PolicyClause | null = null;
+    let m: RegExpExecArray | null;
+    try {
+        while ((m = tokenRe.exec(text)) !== null) {
+            const [, keyword, type, id] = m;
+            if (keyword) {
+                currentClause = keyword as PolicyClause;
+                continue;
+            }
+            if (type !== undefined && id !== undefined) {
+                // If there's no clause context yet, fall back to 'resource' — but
+                // tests assume a well-formed policy where principal/action/resource
+                // always precedes refs. If not, default to 'resource' is harmless
+                // because no entity-side filter looks for clause-less refs.
+                if (currentClause && CLAUSE_KEYWORDS.includes(currentClause)) {
+                    refs.push({ type, id, clause: currentClause });
+                }
+            }
+        }
+    } catch {
+        return refs;
+    }
+
+    return refs;
+}
+
+// ---------------------------------------------------------------------------
+// Build map: Type::id -> [PolicyRef, …]
+// ---------------------------------------------------------------------------
+
+function entityKey(type: string, id: string): string {
+    return `${type}::${id}`;
+}
+
+/**
+ * For each entity, find the policies whose GAPL text references it in any
+ * clause. Returns a map keyed by `Type::id` so the EntitiesPage can do an
+ * O(1) lookup per row.
+ *
+ * - Policies with malformed `policyText` simply contribute no refs.
+ * - Multiple references to the same entity in the same policy are folded
+ *   into a single `PolicyRef` whose `clauses` array lists each distinct
+ *   clause kind.
+ * - Entities with no matching policy still appear in the map with an empty
+ *   array, so callers can distinguish "no matches" from "not yet computed".
+ */
+export function buildPolicyEntityRefs(entities: readonly EntityInstance[], policies: readonly PolicyResponse[]): Map<string, PolicyRef[]> {
+    const result = new Map<string, PolicyRef[]>();
+    for (const e of entities) {
+        result.set(entityKey(e.uid.type, e.uid.id), []);
+    }
+    if (entities.length === 0 || policies.length === 0) return result;
+
+    // Pre-extract refs per policy so we don't re-scan the text per entity.
+    const policyRefs: Array<{ policy: PolicyResponse; refs: EntityRefInPolicy[] }> = policies.map(p => ({
+        policy: p,
+        refs: extractEntityRefsFromPolicyText(p.policyText ?? ''),
+    }));
+
+    for (const e of entities) {
+        const key = entityKey(e.uid.type, e.uid.id);
+        const entityUid = formatEntityUid(e.uid);
+        const matches: PolicyRef[] = [];
+
+        for (const { policy, refs } of policyRefs) {
+            const clauseSet = new Set<PolicyClause>();
+            for (const r of refs) {
+                if (r.type === e.uid.type && r.id === e.uid.id) {
+                    clauseSet.add(r.clause);
+                }
+            }
+            // Policy.target.id is the explicit target attachment (e.g. policy created via
+            // "+ Create Policy for LLM" → target.id="llm.gog"). Treat it as a resource-clause
+            // reference even when the policyText body uses the unbound `resource` keyword.
+            if (policy.target?.id === entityUid) {
+                clauseSet.add('resource');
+            }
+            if (clauseSet.size > 0) {
+                matches.push({ policy, clauses: Array.from(clauseSet) });
+            }
+        }
+
+        result.set(key, matches);
+    }
+
+    return result;
+}


### PR DESCRIPTION
Adds the backend integration layer for the authz UI: the REST client talks to the canonical `/gamma/authz` endpoints with bootstrap-driven URL resolution and CSRF handling; React hooks expose entities, schema, and policies to the rest of the module. Nothing on screen yet — the list pages stay placeholders until the follow-up PR wires them in.

API
- authz-api-client: bootstrap + constants.json fetch, in-flight promise cache, CSRF header / cookie roundtrip, ApiError surface (status + validation payload)
- authz-api.types: PolicyType / Status / EntityRequest / PolicyRequest / ValidationErrorResponse and friends
- authz-api.service: typed wrappers over the canonical core endpoints (entities CRUD, schema GET, policies CRUD + deploy/disable transitions) and a paged-response normaliser that tolerates the old bare-array shape during rolling restarts

Entity adapter
- entity-adapter: parses canonical `Type::"slug"` and dotted `kind.slug` UIDs into structured { type, id } pairs and back to the canonical backend form; round-trip tested
- policy-entity-refs: scanner that pulls `Type::"id"` references out of GAPL policy text grouped by clause (principal / action / resource) — used by the Entities table later to answer "which policies reference this entity?"
- chip-option: small ChipOption interface for combobox options, shared between hooks and (later) the policy editor

Hooks (live data for downstream UI)
- useEntities: paged entity listing with reload semantics
- useEntityOptions: maps the entity collection to canonical `Type::"slug"` ChipOption ids for the policy editor; supports type filtering and surfaces an error when more than 200 rows would be needed
- useSchema: GAPL schema fetch
- usePolicies: list + create + update + delete + deploy/disable transitions
- entity-types: principal / resource enum constants

All hooks + adapter come with vitest specs.

## Issue

https://gravitee.atlassian.net/browse/APIM-XXX

## Description

A small description of what you did in that PR.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

