### PR TITLE
feat(authz-ui): policy editor sheet — create / edit / deploy flow

### DIFF
--- a/gravitee-gamma/gravitee-gamma-module-authz/package.json
+++ b/gravitee-gamma/gravitee-gamma-module-authz/package.json
@@ -7,6 +7,7 @@
         "@monaco-editor/react": "4.7.0",
         "@tanstack/react-query": "5.100.14",
         "@tanstack/react-table": "8.21.3",
+        "lucide-react": "1.6.0",
         "monaco-editor": "0.52.2",
         "react": "19.2.6",
         "react-dom": "19.2.6",

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/features/policy-management/PolicyEditorSheet.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/features/policy-management/PolicyEditorSheet.tsx
@@ -1,0 +1,420 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Button, Input, Sheet, SheetContent, SheetTitle, Spinner, ToggleGroup, ToggleGroupItem, toast } from '@gravitee/graphene-core';
+import { ListIcon } from '@gravitee/graphene-core/icons';
+// Code2 is not in @gravitee/graphene-core/icons yet.
+import { Code2 } from 'lucide-react';
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { StatusBadge } from '../../components/StatusBadge';
+import { ValidationErrorAlert } from '../../components/ValidationErrorAlert';
+import type { ApiError } from '../../shared/api/authz-api-client';
+import type { PolicyRequest, PolicyResponse, PolicyStatus } from '../../shared/api/authz-api.types';
+import type { ChipOption } from '../../shared/chip-option';
+import { parseGaplToStatements } from '../../shared/gapl-policy-parser';
+import { PolicyBuilder } from './PolicyBuilder';
+import { relativeTime } from './PolicyListTable';
+import type { CatalogEntry, ServicePageConfig } from './ServicePolicyPage';
+import { createEmptyStatement, statementsToGapl, type PolicyStatement } from './statement-to-gapl';
+
+export interface PolicyEditorSheetProps {
+    readonly config: ServicePageConfig;
+    readonly open: boolean;
+    readonly policy: PolicyResponse | null;
+    readonly initialTarget: CatalogEntry | null;
+    readonly submitError: ApiError | Error | null;
+    readonly principalOptions: readonly ChipOption[];
+    readonly actionOptions: readonly ChipOption[];
+    readonly onOpenChange: (open: boolean) => void;
+    readonly onSubmit: (request: PolicyRequest) => Promise<void>;
+    readonly emptyPrincipalsHint?: string;
+    readonly emptyActionsHint?: string;
+    readonly emptyResourcesHint?: string;
+}
+
+const TEMPLATE = 'permit (principal, action, resource);';
+
+type ViewMode = 'visual' | 'code';
+
+export function PolicyEditorSheet({
+    config,
+    open,
+    policy,
+    initialTarget,
+    submitError,
+    principalOptions,
+    actionOptions,
+    onOpenChange,
+    onSubmit,
+    emptyPrincipalsHint,
+    emptyActionsHint,
+    emptyResourcesHint,
+}: PolicyEditorSheetProps) {
+    const [name, setName] = useState('');
+    const [description, setDescription] = useState('');
+    const [status, setStatus] = useState<PolicyStatus>('DRAFT');
+    const [statements, setStatements] = useState<readonly PolicyStatement[]>([createEmptyStatement('permit')]);
+    const [policyText, setPolicyText] = useState(TEMPLATE);
+    const [view, setView] = useState<ViewMode>('visual');
+    const [codeDirty, setCodeDirty] = useState(false);
+    const [submitting, setSubmitting] = useState(false);
+    const [deploying, setDeploying] = useState(false);
+    const [visualDirty, setVisualDirty] = useState(false);
+    const [visualUnavailable, setVisualUnavailable] = useState(false);
+
+    const target = useMemo(
+        () => policy?.target ?? (initialTarget ? { id: initialTarget.id, label: initialTarget.name } : null),
+        [policy?.target, initialTarget],
+    );
+    const resourceOptions = config.resourceOptions ?? [];
+
+    const generatedCode = useMemo(
+        () => statementsToGapl(name || 'new-policy', statements, target ?? undefined),
+        [name, statements, target],
+    );
+
+    useEffect(() => {
+        if (!open) return;
+        setName(policy?.name ?? '');
+        setDescription(policy?.description ?? '');
+        setPolicyText(policy?.policyText ?? TEMPLATE);
+        setStatus(policy?.status ?? 'DRAFT');
+        setCodeDirty(false);
+        setVisualDirty(false);
+
+        if (policy) {
+            const parsed = parseGaplToStatements(policy.policyText);
+            const supported = parsed !== null && parsed.statements.length > 0;
+            if (supported) {
+                setStatements(parsed!.statements);
+                setVisualUnavailable(false);
+                setView('visual');
+            } else {
+                setStatements([createEmptyStatement('permit')]);
+                setVisualUnavailable(true);
+                setView('code');
+            }
+        } else {
+            setStatements([createEmptyStatement('permit')]);
+            setVisualUnavailable(false);
+            setView('visual');
+        }
+    }, [open, policy]);
+
+    useEffect(() => {
+        if (view === 'code' && !codeDirty && policy === null) {
+            setPolicyText(generatedCode);
+        }
+    }, [generatedCode, view, codeDirty, policy]);
+
+    const switchToCode = () => {
+        if (policy && !visualDirty) {
+            setView('code');
+            return;
+        }
+        setPolicyText(generatedCode);
+        setCodeDirty(false);
+        setView('code');
+    };
+
+    const switchToVisual = () => {
+        if (codeDirty) {
+            const parsed = parseGaplToStatements(policyText);
+            if (parsed && parsed.statements.length > 0) {
+                setStatements(parsed.statements);
+                setVisualDirty(false);
+                setCodeDirty(false);
+                setVisualUnavailable(false);
+            } else {
+                setVisualUnavailable(true);
+                setView('code');
+                toast.warning('This GAPL uses features the visual editor cannot represent. Continue in the Code view.');
+                return;
+            }
+        }
+        setView('visual');
+    };
+
+    const handleStatementsChange = (next: readonly PolicyStatement[]) => {
+        setStatements(next);
+        setVisualDirty(true);
+    };
+
+    const buildRequest = (overrideStatus?: PolicyStatus): PolicyRequest => {
+        const finalText =
+            view === 'code' ? policyText : visualDirty || policy === null ? generatedCode : (policy.policyText ?? generatedCode);
+        return {
+            name,
+            description: description || null,
+            policyText: finalText,
+            type: config.type,
+            target: target ?? null,
+            status: overrideStatus ?? status,
+        };
+    };
+
+    const runSubmit = async (status: PolicyStatus | undefined, successMessage: string | null) => {
+        try {
+            await onSubmit(buildRequest(status));
+            if (status) setStatus(status);
+            if (successMessage) toast.success(successMessage);
+        } catch {
+            // submitError prop is rendered by the parent.
+        }
+    };
+
+    const deploy = async () => {
+        setDeploying(true);
+        await runSubmit('DEPLOYED', 'Policy deployed. Gateway sync expected within 30s.');
+        setDeploying(false);
+    };
+
+    // Canonical engine has no DEPLOYED → DRAFT transition; undeploy writes DISABLED.
+    const undeploy = async () => {
+        setDeploying(true);
+        await runSubmit('DISABLED', 'Policy undeployed. Gateway sync will drop it within 30s.');
+        setDeploying(false);
+    };
+
+    const submit = async () => {
+        setSubmitting(true);
+        await runSubmit(undefined, null);
+        setSubmitting(false);
+    };
+
+    const createAndDeploy = async () => {
+        setSubmitting(true);
+        await runSubmit('DEPLOYED', 'Policy created and deployed. Gateway sync expected within 30s.');
+        setSubmitting(false);
+    };
+
+    const lastEdited = (() => {
+        if (!policy?.updatedAt) return '';
+        const rel = relativeTime(policy.updatedAt);
+        return rel === '—' ? '' : ` · last edited ${rel}`;
+    })();
+
+    const headerTitle = (
+        <div className="min-w-0">
+            <div className="flex items-center gap-2">
+                <Input
+                    value={name}
+                    onChange={e => setName(e.target.value)}
+                    placeholder="Policy name"
+                    className="h-8 min-w-56 max-w-lg border-transparent bg-transparent px-1 text-base font-semibold shadow-none focus-visible:border-input"
+                    aria-label="Policy name"
+                />
+                <StatusBadge status={status} />
+            </div>
+            <p className="pl-1 text-xs text-muted-foreground">
+                {config.serviceLabel} policy
+                {lastEdited}
+            </p>
+        </div>
+    );
+
+    const deployedLabel = policy?.status === 'DEPLOYED' ? `Deployed (${relativeTime(policy.updatedAt)})` : null;
+    const deployDisabled = deploying || submitting || name.trim() === '' || policy === null || policy.status === 'DEPLOYED';
+
+    const headerActions = (
+        <>
+            <ViewToggle
+                view={view}
+                onVisual={switchToVisual}
+                onCode={switchToCode}
+                visualDisabled={visualUnavailable}
+                visualDisabledTitle="This policy uses GAPL features that the visual editor cannot represent. Use the Code view to edit it directly."
+            />
+            <Button type="button" size="sm" onClick={deploy} disabled={deployDisabled}>
+                {deploying ? <Spinner className="size-3.5 mr-1.5" /> : null}
+                {deploying ? 'Deploying…' : (deployedLabel ?? 'Deploy to PDP')}
+            </Button>
+            {policy?.status === 'DEPLOYED' ? (
+                <Button
+                    type="button"
+                    size="sm"
+                    variant="outline"
+                    onClick={undeploy}
+                    disabled={deploying || submitting || name.trim() === ''}
+                    className="border-destructive text-destructive hover:bg-destructive/10 hover:text-destructive"
+                >
+                    {deploying ? <Spinner className="size-3.5 mr-1.5" /> : null}
+                    {deploying ? 'Undeploying…' : 'Undeploy'}
+                </Button>
+            ) : null}
+        </>
+    );
+
+    const subHeader = (
+        <div className="shrink-0 border-b px-6 py-2">
+            <Input
+                value={description}
+                onChange={e => setDescription(e.target.value)}
+                placeholder="Description (optional)"
+                className="h-8 border-transparent bg-transparent px-1 text-sm shadow-none focus-visible:border-input"
+                aria-label="Policy description"
+            />
+        </div>
+    );
+
+    const footer = (
+        <div className="flex w-full flex-col gap-2">
+            <ValidationErrorAlert error={submitError} title="Could not save policy" />
+            <div className="flex flex-wrap items-center justify-end gap-2">
+                <Button type="button" variant="outline" onClick={() => onOpenChange(false)} disabled={submitting || deploying}>
+                    Cancel
+                </Button>
+                <Button
+                    type="button"
+                    variant={policy ? 'default' : 'outline'}
+                    onClick={submit}
+                    disabled={submitting || deploying || name.trim() === ''}
+                >
+                    {submitting ? 'Saving…' : policy ? 'Update policy' : 'Create policy'}
+                </Button>
+                {policy ? null : (
+                    <Button type="button" onClick={createAndDeploy} disabled={submitting || deploying || name.trim() === ''}>
+                        {submitting || deploying ? 'Creating…' : 'Create and Deploy policy'}
+                    </Button>
+                )}
+            </div>
+        </div>
+    );
+
+    const ariaLabel = policy ? `Edit policy: ${policy.name}` : `New ${config.type} policy`;
+
+    return (
+        <Sheet open={open} onOpenChange={onOpenChange}>
+            <SheetContent
+                side="right"
+                showCloseButton={false}
+                aria-label={ariaLabel}
+                style={{ width: 'min(720px, 100vw)', maxWidth: 'min(720px, 100vw)' }}
+                className="flex h-full flex-col gap-0 p-0"
+            >
+                <SheetTitle className="sr-only">{ariaLabel}</SheetTitle>
+
+                <div className="flex items-start gap-3 border-b px-6 py-4">
+                    <div className="min-w-0 flex-1">{headerTitle}</div>
+                    <div className="flex flex-none items-center gap-2">{headerActions}</div>
+                </div>
+
+                {subHeader}
+
+                <div className="flex-1 overflow-y-auto px-6 py-5">
+                    {view === 'visual' ? (
+                        <PolicyBuilder
+                            statements={statements}
+                            principalOptions={principalOptions}
+                            actionOptions={actionOptions}
+                            resourceOptions={resourceOptions}
+                            resourceGroups={config.resourceGroups ?? []}
+                            conditionSnippets={config.conditionSnippets}
+                            onChange={handleStatementsChange}
+                            emptyPrincipalsHint={emptyPrincipalsHint}
+                            emptyActionsHint={emptyActionsHint}
+                            emptyResourcesHint={emptyResourcesHint}
+                        />
+                    ) : (
+                        <CodePane
+                            code={policyText}
+                            onCodeChange={next => {
+                                setPolicyText(next);
+                                setCodeDirty(next !== generatedCode);
+                            }}
+                        />
+                    )}
+                </div>
+
+                <div className="border-t bg-muted/40 px-6 py-3.5">{footer}</div>
+            </SheetContent>
+        </Sheet>
+    );
+}
+
+function ViewToggle({
+    view,
+    onVisual,
+    onCode,
+    visualDisabled = false,
+    visualDisabledTitle,
+}: {
+    view: ViewMode;
+    onVisual: () => void;
+    onCode: () => void;
+    visualDisabled?: boolean;
+    visualDisabledTitle?: string;
+}) {
+    return (
+        <ToggleGroup
+            type="single"
+            value={view}
+            onValueChange={v => {
+                if (v === 'visual') onVisual();
+                else if (v === 'code') onCode();
+            }}
+            aria-label="View mode"
+            size="sm"
+        >
+            <ToggleGroupItem value="visual" disabled={visualDisabled} title={visualDisabled ? visualDisabledTitle : undefined}>
+                <ListIcon className="size-3.5" aria-hidden />
+                Visual
+            </ToggleGroupItem>
+            <ToggleGroupItem value="code">
+                <Code2 className="size-3.5" aria-hidden />
+                Code
+            </ToggleGroupItem>
+        </ToggleGroup>
+    );
+}
+
+function CodePane({ code, onCodeChange }: { code: string; onCodeChange: (next: string) => void }) {
+    const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+    const gutterRef = useRef<HTMLDivElement | null>(null);
+    const lineCount = useMemo(() => Math.max(1, code.split('\n').length), [code]);
+
+    const onScroll = () => {
+        if (!textareaRef.current || !gutterRef.current) return;
+        gutterRef.current.scrollTop = textareaRef.current.scrollTop;
+    };
+
+    return (
+        <div className="flex h-full flex-col">
+            <div className="min-h-0 flex-1 overflow-hidden bg-background">
+                <div className="flex h-full font-mono text-sm leading-relaxed">
+                    <div
+                        ref={gutterRef}
+                        className="w-12 shrink-0 overflow-hidden border-r bg-muted/30 py-3 pr-2 text-right text-muted-foreground/70 tabular-nums"
+                    >
+                        {Array.from({ length: lineCount }, (_, i) => (
+                            <div key={i} className="select-none">
+                                {i + 1}
+                            </div>
+                        ))}
+                    </div>
+                    <textarea
+                        ref={textareaRef}
+                        value={code}
+                        onChange={e => onCodeChange(e.target.value)}
+                        onScroll={onScroll}
+                        spellCheck={false}
+                        className="flex-1 resize-none bg-transparent px-3 py-3 outline-none whitespace-pre overflow-auto"
+                        aria-label="GAPL policy text"
+                    />
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/features/policy-management/ServicePolicyPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/features/policy-management/ServicePolicyPage.tsx
@@ -15,6 +15,9 @@
  */
 import { useEnvironment } from '@gravitee/gamma-modules-sdk';
 import {
+    Alert,
+    AlertDescription,
+    AlertTitle,
     Button,
     Dialog,
     DialogContent,
@@ -34,13 +37,34 @@ import {
     SelectValue,
 } from '@gravitee/graphene-core';
 import { PlusIcon, RefreshCwIcon } from '@gravitee/graphene-core/icons';
-import { useDeferredValue, useMemo, useState } from 'react';
+import { useCallback, useDeferredValue, useMemo, useState } from 'react';
 import { KpiTile } from '../../components/KpiTile';
 import { ValidationErrorAlert } from '../../components/ValidationErrorAlert';
-import type { PolicyResponse, PolicyStatus, PolicyType } from '../../shared/api/authz-api.types';
+import type { PolicyRequest, PolicyResponse, PolicyStatus, PolicyType } from '../../shared/api/authz-api.types';
 import type { ChipOption } from '../../shared/chip-option';
+import { parseGaplSchema } from '../../shared/gapl-parser';
+import { useEntities } from '../../shared/hooks/useEntities';
+import { useEntityOptions } from '../../shared/hooks/useEntityOptions';
 import { usePolicies } from '../../shared/hooks/usePolicies';
+import { useSchema } from '../../shared/hooks/useSchema';
+import { PolicyEditorSheet } from './PolicyEditorSheet';
 import { PolicyListTable } from './PolicyListTable';
+
+export type CatalogEntryType = 'MCP' | 'AGENT' | 'LLM' | 'API' | 'EVENT';
+
+export type CatalogEntry = {
+    readonly id: string;
+    readonly name: string;
+    readonly description: string;
+    readonly type: CatalogEntryType;
+    readonly subResources: readonly never[];
+};
+
+const CATALOG_ENTRY_TYPES: readonly CatalogEntryType[] = ['MCP', 'AGENT', 'LLM', 'API', 'EVENT'];
+
+function toCatalogEntryType(type: PolicyType): CatalogEntryType {
+    return CATALOG_ENTRY_TYPES.includes(type as CatalogEntryType) ? (type as CatalogEntryType) : 'API';
+}
 
 type StatusFilter = PolicyStatus | 'ALL';
 
@@ -58,19 +82,44 @@ export interface ServicePageConfig {
     readonly conditionSnippets?: readonly { label: string; snippet: string }[];
 }
 
+type SheetState = { kind: 'closed' } | { kind: 'create'; target: CatalogEntry | null } | { kind: 'edit'; policy: PolicyResponse };
+
+const PRINCIPAL_KINDS: ReadonlySet<string> = new Set([
+    'user',
+    'group',
+    'serviceaccount',
+    'service-account',
+    'service_account',
+    'agent',
+    'agentidentity',
+]);
+
+const DEFAULT_RESOURCE_GROUPS: readonly { key: string; label: string }[] = [
+    { key: 'API', label: 'API' },
+    { key: 'MCP', label: 'MCP' },
+    { key: 'LLM', label: 'LLM' },
+    { key: 'Agent', label: 'Agent' },
+    { key: 'Resource', label: 'Resource' },
+];
+
 export function ServicePolicyPage({ config }: { readonly config: ServicePageConfig }) {
     const env = useEnvironment();
     const [statusFilter, setStatusFilter] = useState<StatusFilter>('ALL');
     const [search, setSearch] = useState('');
     const deferredSearch = useDeferredValue(search);
+    const [sheet, setSheet] = useState<SheetState>({ kind: 'closed' });
+    const [submitError, setSubmitError] = useState<Error | null>(null);
     const [pendingDelete, setPendingDelete] = useState<PolicyResponse | null>(null);
     const [deleting, setDeleting] = useState(false);
     const [deleteError, setDeleteError] = useState<Error | null>(null);
 
-    const policies = usePolicies(env?.id ?? '', {
+    const envId = env?.id ?? '';
+    const policies = usePolicies(envId, {
         type: config.type,
         status: statusFilter === 'ALL' ? undefined : statusFilter,
     });
+    const schema = useSchema(envId);
+    const entities = useEntities(envId, 1000);
 
     const allPolicies = useMemo<readonly PolicyResponse[]>(() => policies.data?.data ?? [], [policies.data]);
 
@@ -89,10 +138,155 @@ export function ServicePolicyPage({ config }: { readonly config: ServicePageConf
             total,
             deployed: allPolicies.filter(p => p.status === 'DEPLOYED').length,
             draft: allPolicies.filter(p => p.status === 'DRAFT').length,
-            uniqueTargets: new Set(allPolicies.map(p => p.target?.id).filter(Boolean)).size,
+            uniqueTargets: new Set(allPolicies.map(p => p.target?.id).filter((id): id is string => Boolean(id))).size,
         }),
         [allPolicies, total],
     );
+
+    const catalog = useMemo(() => {
+        if (!config.hasTarget) {
+            return { entries: [] as CatalogEntry[], isLoading: false, error: undefined as string | undefined };
+        }
+        const prefix = config.type.toLowerCase() + '.';
+        const all = entities.data?.data ?? [];
+        const entries: CatalogEntry[] = all
+            .filter(e => e.uid.toLowerCase().startsWith(prefix))
+            .map(e => {
+                const attrs = e.attributes ?? {};
+                const name =
+                    typeof attrs.displayName === 'string' && attrs.displayName
+                        ? attrs.displayName
+                        : typeof attrs.name === 'string' && attrs.name
+                          ? attrs.name
+                          : e.uid;
+                const description = typeof attrs.description === 'string' ? attrs.description : '';
+                return {
+                    id: e.uid,
+                    name,
+                    description,
+                    type: toCatalogEntryType(config.type),
+                    subResources: [],
+                };
+            });
+        return { entries, isLoading: entities.isLoading, error: entities.error };
+    }, [config.hasTarget, config.type, entities.data, entities.isLoading, entities.error]);
+
+    const actionOptions = useMemo((): readonly ChipOption[] => {
+        const seen = new Set<string>();
+        const merged: ChipOption[] = [];
+        if (schema.schema?.schemaText) {
+            const parsed = parseGaplSchema(schema.schema.schemaText);
+            for (const a of parsed.actions) {
+                const id = `Action::"${a.name}"`;
+                if (!seen.has(id)) {
+                    seen.add(id);
+                    merged.push({ id, label: a.name, group: 'Action' });
+                }
+            }
+        }
+        for (const e of entities.data?.data ?? []) {
+            const kind = (e.attributes?._kind ?? '') as string;
+            const isAction = kind.toLowerCase() === 'action' || (typeof e.uid === 'string' && e.uid.startsWith('action.'));
+            if (!isAction) continue;
+            const name = (e.attributes?.name as string) || e.uid.replace(/^action\./, '');
+            if (!name) continue;
+            const id = `Action::"${name}"`;
+            if (seen.has(id)) continue;
+            seen.add(id);
+            const description = typeof e.attributes?.description === 'string' ? (e.attributes.description as string) : undefined;
+            merged.push({ id, label: name, group: 'Action', description });
+        }
+        return merged;
+    }, [schema.schema, entities.data]);
+
+    const { options: principalOptions } = useEntityOptions(envId, {
+        typeFilter: config.hasTarget ? ['User', 'Group', 'ServiceAccount', 'AgentIdentity'] : undefined,
+    });
+
+    const emptyActionsHint = useMemo<string | undefined>(() => {
+        if (actionOptions.length > 0) return undefined;
+        return 'No actions defined yet. Add some under Policy Structure → Actions, or declare them in the schema.';
+    }, [actionOptions.length]);
+
+    const emptyPrincipalsHint = useMemo<string | undefined>(() => {
+        if (principalOptions.length > 0) return undefined;
+        return 'No principals available. Add Users, Groups, Service Accounts or Agent Identities under Policy Structure → Entities.';
+    }, [principalOptions.length]);
+
+    const serviceResourceOptions = useMemo((): readonly ChipOption[] => {
+        const items: ChipOption[] = [];
+        const typePrefix = config.type.toLowerCase();
+        for (const e of entities.data?.data ?? []) {
+            const kindRaw = (e.attributes?._kind as string | undefined) ?? '';
+            const kind = kindRaw.toLowerCase();
+            const firstSeg = e.uid.includes('.') ? e.uid.slice(0, e.uid.indexOf('.')).toLowerCase() : '';
+            if (PRINCIPAL_KINDS.has(kind) || PRINCIPAL_KINDS.has(firstSeg)) continue;
+            if (kind === 'action' || firstSeg === 'action') continue;
+            if (config.hasTarget && firstSeg !== typePrefix) continue;
+            const attrs = e.attributes ?? {};
+            const label =
+                typeof attrs.displayName === 'string' && attrs.displayName
+                    ? (attrs.displayName as string)
+                    : typeof attrs.name === 'string' && attrs.name
+                      ? (attrs.name as string)
+                      : e.uid.includes('.')
+                        ? e.uid.slice(e.uid.indexOf('.') + 1)
+                        : e.uid;
+            const group =
+                firstSeg === 'mcp'
+                    ? 'MCP'
+                    : firstSeg === 'llm'
+                      ? 'LLM'
+                      : firstSeg === 'agent'
+                        ? 'Agent'
+                        : firstSeg === 'api'
+                          ? 'API'
+                          : 'Resource';
+            const description = typeof attrs.description === 'string' ? (attrs.description as string) : undefined;
+            const labelForUid = e.uid.includes('.') ? e.uid.slice(e.uid.indexOf('.') + 1) : e.uid;
+            items.push({ id: `${group}::"${labelForUid}"`, label, group, description });
+        }
+        items.sort((a, b) => (a.group === b.group ? a.label.localeCompare(b.label) : a.group.localeCompare(b.group)));
+        return items;
+    }, [config.hasTarget, config.type, entities.data]);
+
+    const effectiveConfig = useMemo<ServicePageConfig>(
+        () => ({
+            ...config,
+            resourceOptions: serviceResourceOptions,
+            resourceGroups: config.resourceGroups ?? DEFAULT_RESOURCE_GROUPS,
+        }),
+        [config, serviceResourceOptions],
+    );
+
+    const startCreate = useCallback(() => {
+        setSubmitError(null);
+        setSheet({ kind: 'create', target: null });
+    }, []);
+
+    const submit = useCallback(
+        async (req: PolicyRequest) => {
+            try {
+                if (sheet.kind === 'edit') {
+                    await policies.update(sheet.policy.id, req);
+                } else {
+                    await policies.create(req);
+                }
+                setSheet({ kind: 'closed' });
+                setSubmitError(null);
+            } catch (e) {
+                const err = e instanceof Error ? e : new Error('Save failed');
+                setSubmitError(err);
+                throw err;
+            }
+        },
+        [policies, sheet],
+    );
+
+    const onEdit = useCallback((p: PolicyResponse) => {
+        setSubmitError(null);
+        setSheet({ kind: 'edit', policy: p });
+    }, []);
 
     const confirmDelete = async () => {
         if (!pendingDelete) return;
@@ -113,14 +307,20 @@ export function ServicePolicyPage({ config }: { readonly config: ServicePageConf
         setDeleteError(null);
     };
 
+    const handleReload = useCallback(() => {
+        policies.reload();
+        entities.reload();
+    }, [policies, entities]);
+
     const Icon = config.icon;
     const totalCount = policies.data?.total ?? 0;
     const hasNoPolicies = !policies.isLoading && totalCount === 0 && !deferredSearch && statusFilter === 'ALL';
     const hasNoMatches = !policies.isLoading && filteredPolicies.length === 0 && totalCount > 0;
+    const catalogError = config.hasTarget ? catalog.error : undefined;
 
     return (
         <div className="flex flex-col gap-4" data-testid={`page-policies-${config.type.toLowerCase()}`}>
-            <header className="flex items-start justify-between gap-3">
+            <header className="flex flex-wrap items-start justify-between gap-3">
                 <div className="flex items-start gap-3">
                     {Icon ? <Icon className="mt-1 size-5 text-muted-foreground" /> : null}
                     <div>
@@ -129,10 +329,10 @@ export function ServicePolicyPage({ config }: { readonly config: ServicePageConf
                     </div>
                 </div>
                 <div className="flex items-center gap-2">
-                    <Button type="button" variant="ghost" size="icon" onClick={() => policies.reload()} aria-label="Refresh">
+                    <Button type="button" variant="ghost" size="icon" onClick={handleReload} aria-label="Refresh">
                         <RefreshCwIcon aria-hidden className="size-4" />
                     </Button>
-                    <Button type="button" disabled title="Policy editor lands in the follow-up PR">
+                    <Button type="button" onClick={startCreate}>
                         <PlusIcon aria-hidden className="size-4" />
                         {config.hasTarget ? 'Create policy' : config.createButtonLabel}
                     </Button>
@@ -148,7 +348,7 @@ export function ServicePolicyPage({ config }: { readonly config: ServicePageConf
                 ) : null}
             </div>
 
-            <div className="flex items-center gap-2">
+            <div className="flex flex-wrap items-center gap-2">
                 <Input
                     value={search}
                     onChange={e => setSearch(e.target.value)}
@@ -169,11 +369,25 @@ export function ServicePolicyPage({ config }: { readonly config: ServicePageConf
                 </Select>
             </div>
 
+            {policies.error !== undefined && (
+                <Alert variant="destructive">
+                    <AlertTitle>Could not load policies</AlertTitle>
+                    <AlertDescription>{policies.error}</AlertDescription>
+                </Alert>
+            )}
+
+            {catalogError !== undefined && (
+                <Alert variant="destructive">
+                    <AlertTitle>Could not load catalog</AlertTitle>
+                    <AlertDescription>{catalogError}</AlertDescription>
+                </Alert>
+            )}
+
             {hasNoPolicies ? (
                 <Empty>
                     <EmptyHeader>
                         <EmptyTitle>No policies yet</EmptyTitle>
-                        <EmptyDescription>The editor that creates policies arrives in the next PR.</EmptyDescription>
+                        <EmptyDescription>Create a policy to define who can do what.</EmptyDescription>
                     </EmptyHeader>
                 </Empty>
             ) : hasNoMatches ? (
@@ -193,10 +407,40 @@ export function ServicePolicyPage({ config }: { readonly config: ServicePageConf
                     isLoading={policies.isLoading}
                     onPageChange={policies.setPage}
                     onPerPageChange={policies.setPerPage}
-                    onEdit={noopEdit}
+                    onEdit={onEdit}
                     onDelete={setPendingDelete}
                 />
             )}
+
+            <PolicyEditorSheet
+                config={effectiveConfig}
+                open={sheet.kind !== 'closed'}
+                policy={sheet.kind === 'edit' ? sheet.policy : null}
+                initialTarget={
+                    sheet.kind === 'create'
+                        ? sheet.target
+                        : sheet.kind === 'edit' && sheet.policy.target
+                          ? (catalog.entries.find(e => e.id === sheet.policy.target!.id) ?? {
+                                id: sheet.policy.target.id,
+                                name: sheet.policy.target.label,
+                                description: '',
+                                type: toCatalogEntryType(config.type),
+                                subResources: [],
+                            })
+                          : null
+                }
+                submitError={submitError}
+                principalOptions={principalOptions}
+                actionOptions={actionOptions}
+                emptyPrincipalsHint={emptyPrincipalsHint}
+                emptyActionsHint={emptyActionsHint}
+                onOpenChange={o => {
+                    if (!o) {
+                        setSheet({ kind: 'closed' });
+                    }
+                }}
+                onSubmit={submit}
+            />
 
             <Dialog open={pendingDelete !== null} onOpenChange={open => !open && closeDeleteDialog()}>
                 <DialogContent>
@@ -208,10 +452,16 @@ export function ServicePolicyPage({ config }: { readonly config: ServicePageConf
                     </DialogHeader>
                     {deleteError ? <ValidationErrorAlert error={deleteError} title="Delete failed" /> : null}
                     <DialogFooter>
-                        <Button variant="outline" onClick={closeDeleteDialog} disabled={deleting}>
+                        <Button type="button" variant="outline" onClick={closeDeleteDialog} disabled={deleting}>
                             Cancel
                         </Button>
-                        <Button variant="destructive" onClick={confirmDelete} disabled={deleting}>
+                        <Button
+                            type="button"
+                            variant="destructive"
+                            onClick={confirmDelete}
+                            disabled={deleting}
+                            aria-label={pendingDelete ? `Confirm delete ${pendingDelete.name}` : 'Confirm delete'}
+                        >
                             {deleting ? 'Deleting…' : deleteError ? 'Retry' : 'Delete'}
                         </Button>
                     </DialogFooter>
@@ -219,9 +469,4 @@ export function ServicePolicyPage({ config }: { readonly config: ServicePageConf
             </Dialog>
         </div>
     );
-}
-
-// TODO(authz-ui-editor): wire to the policy editor Sheet in the follow-up PR.
-function noopEdit() {
-    /* no-op until the editor PR lands */
 }

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/features/policy-management/__tests__/PolicyEditorSheet.test.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/features/policy-management/__tests__/PolicyEditorSheet.test.tsx
@@ -1,0 +1,265 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import type { PolicyResponse } from '../../../shared/api/authz-api.types';
+import type { PolicyEditorSheetProps } from '../PolicyEditorSheet';
+import { PolicyEditorSheet } from '../PolicyEditorSheet';
+import type { ServicePageConfig } from '../ServicePolicyPage';
+
+function makePolicy(overrides: Partial<PolicyResponse> = {}): PolicyResponse {
+    return {
+        id: 'p1',
+        environmentId: 'DEFAULT',
+        name: 'Existing Policy',
+        description: null,
+        policyText: 'permit (principal == user::"alice", action == action::"read", resource == tool::"t");',
+        type: 'CUSTOM',
+        target: null,
+        status: 'DRAFT',
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+        ...overrides,
+    };
+}
+
+const config: ServicePageConfig = {
+    type: 'CUSTOM',
+    title: 'Custom Policies',
+    description: 'Test',
+    createButtonLabel: 'Create',
+    searchPlaceholder: 'Search…',
+    hasTarget: false,
+    serviceLabel: 'Custom',
+};
+
+function makeProps(overrides: Partial<PolicyEditorSheetProps> = {}): PolicyEditorSheetProps {
+    return {
+        config,
+        open: true,
+        policy: null,
+        initialTarget: null,
+        submitError: null,
+        principalOptions: [],
+        actionOptions: [],
+        onOpenChange: vi.fn(),
+        onSubmit: vi.fn().mockResolvedValue(undefined),
+        ...overrides,
+    };
+}
+
+describe('PolicyEditorSheet', () => {
+    it('renders when open', () => {
+        render(<PolicyEditorSheet {...makeProps()} />);
+        expect(screen.getByRole('textbox', { name: /policy name/i })).toBeInTheDocument();
+    });
+
+    it('does not render editor content when closed', () => {
+        render(<PolicyEditorSheet {...makeProps({ open: false })} />);
+        expect(screen.queryByRole('textbox', { name: /policy name/i })).not.toBeInTheDocument();
+    });
+
+    it('calls onSubmit with name and type on save', async () => {
+        const onSubmit = vi.fn().mockResolvedValue(undefined);
+
+        render(<PolicyEditorSheet {...makeProps({ onSubmit })} />);
+
+        const nameInput = screen.getByRole('textbox', { name: /policy name/i });
+        await userEvent.clear(nameInput);
+        await userEvent.type(nameInput, 'My Test Policy');
+
+        await userEvent.click(screen.getByRole('button', { name: /create policy/i }));
+
+        await waitFor(() => {
+            expect(onSubmit).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    name: 'My Test Policy',
+                    type: 'CUSTOM',
+                }),
+            );
+        });
+    });
+
+    it('save button is disabled when name is empty', async () => {
+        render(<PolicyEditorSheet {...makeProps()} />);
+
+        const saveBtn = screen.getByRole('button', { name: /create policy/i });
+        // Name starts empty so button should be disabled
+        expect(saveBtn).toBeDisabled();
+    });
+
+    it('calls onOpenChange(false) when cancel clicked', async () => {
+        const onOpenChange = vi.fn();
+
+        render(<PolicyEditorSheet {...makeProps({ onOpenChange })} />);
+
+        await userEvent.click(screen.getByRole('button', { name: /cancel/i }));
+
+        expect(onOpenChange).toHaveBeenCalledWith(false);
+    });
+
+    it('Deploy button is disabled when policy is null (new draft not saved yet)', () => {
+        render(<PolicyEditorSheet {...makeProps()} />);
+
+        const deployBtn = screen.getByRole('button', { name: /deploy to pdp/i });
+        expect(deployBtn).toBeDisabled();
+    });
+
+    it('renders Deploy button enabled when policy is saved (status=DRAFT)', () => {
+        const policy = makePolicy({ status: 'DRAFT' });
+        render(<PolicyEditorSheet {...makeProps({ policy })} />);
+
+        const deployBtn = screen.getByRole('button', { name: /deploy to pdp/i });
+        expect(deployBtn).not.toBeDisabled();
+    });
+
+    it('Deploy click calls onSubmit with status DEPLOYED', async () => {
+        const policy = makePolicy({ status: 'DRAFT' });
+        const onSubmit = vi.fn().mockResolvedValue(undefined);
+
+        render(<PolicyEditorSheet {...makeProps({ policy, onSubmit })} />);
+
+        await userEvent.click(screen.getByRole('button', { name: /deploy to pdp/i }));
+
+        await waitFor(() => {
+            expect(onSubmit).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    status: 'DEPLOYED',
+                }),
+            );
+        });
+    });
+
+    it("Deploy button shows 'Deployed (N min ago)' when status is DEPLOYED", () => {
+        const policy = makePolicy({
+            status: 'DEPLOYED',
+            // 5 minutes ago — relativeTime() returns "5 min ago".
+            updatedAt: new Date(Date.now() - 5 * 60 * 1000).toISOString(),
+        });
+
+        render(<PolicyEditorSheet {...makeProps({ policy })} />);
+
+        const deployBtn = screen.getByRole('button', { name: /deployed \(.+ min ago\)/i });
+        expect(deployBtn).toBeInTheDocument();
+        expect(deployBtn).toBeDisabled();
+    });
+
+    it('toggles to code pane when Code button clicked', async () => {
+        render(<PolicyEditorSheet {...makeProps()} />);
+
+        await userEvent.click(screen.getByRole('radio', { name: /code/i }));
+
+        // Code pane shows a textarea for GAPL
+        expect(screen.getByRole('textbox', { name: /gapl policy text/i })).toBeInTheDocument();
+    });
+
+    it('enables the Visual toggle and seeds visual statements when editing a parseable policy', async () => {
+        const policy = makePolicy();
+        render(<PolicyEditorSheet {...makeProps({ policy })} />);
+
+        // The Visual button should not be disabled.
+        const visualBtn = screen.getByRole('radio', { name: /^visual$/i });
+        expect(visualBtn).not.toBeDisabled();
+
+        // Toggling to Code should preview the visual-derived GAPL and include
+        // the parsed UID — proving the parser actually seeded statements.
+        await userEvent.click(screen.getByRole('radio', { name: /^code$/i }));
+        const code = screen.getByRole('textbox', { name: /gapl policy text/i }) as HTMLTextAreaElement;
+        await waitFor(() => expect(code.value).toContain('user::"alice"'));
+    });
+
+    it('disables the Visual toggle for unparseable GAPL and keeps original policyText', async () => {
+        const exotic = 'permit (principal == user::"a", action == action::"r", resource == tool::"t") unless { false };';
+        const policy = makePolicy({ policyText: exotic });
+        render(<PolicyEditorSheet {...makeProps({ policy })} />);
+
+        const visualBtn = screen.getByRole('radio', { name: /^visual$/i });
+        expect(visualBtn).toBeDisabled();
+        expect(visualBtn).toHaveAttribute('title', expect.stringContaining('visual editor cannot represent'));
+
+        // The code textarea should hold the original GAPL untouched.
+        const code = screen.getByRole('textbox', { name: /gapl policy text/i }) as HTMLTextAreaElement;
+        expect(code.value).toBe(exotic);
+    });
+
+    it('does not auto-overwrite policyText from visual when editing in code view', async () => {
+        // Hand-crafted GAPL with deliberate formatting differences from
+        // statementToGapl's output. After the Bug D fix the editor must
+        // preserve this verbatim until the user actually edits the visual
+        // statements — switching tabs alone never rewrites the buffer.
+        const handcrafted = 'permit (principal == user::"alice", action == action::"read", resource == tool::"t") ;';
+        const policy = makePolicy({ policyText: handcrafted });
+        render(<PolicyEditorSheet {...makeProps({ policy })} />);
+
+        await userEvent.click(screen.getByRole('radio', { name: /^code$/i }));
+        const code = screen.getByRole('textbox', { name: /gapl policy text/i }) as HTMLTextAreaElement;
+        // Bug D — byte-for-byte preservation: switching tabs without
+        // touching the visual side must NOT regenerate the stored GAPL.
+        expect(code.value).toBe(handcrafted);
+    });
+
+    // Bug D — full edit-flow regression: open with valid GAPL, ensure the
+    // visual side is seeded, toggle to Code, then back to Visual, and
+    // confirm the original policyText survives untouched until the user
+    // edits something on the visual side.
+    it('round-trips the edit flow without rewriting the stored GAPL (Bug D)', async () => {
+        const original = 'permit (principal == User::"alice", action == Action::"read", resource == Resource::"r1");';
+        const policy = makePolicy({ policyText: original });
+        render(<PolicyEditorSheet {...makeProps({ policy })} />);
+
+        // Visual toggle is enabled, statements seeded — proves the
+        // GAPL→visual parser ran on open.
+        const visualBtn = screen.getByRole('radio', { name: /^visual$/i });
+        expect(visualBtn).not.toBeDisabled();
+
+        // Toggle to Code.
+        await userEvent.click(screen.getByRole('radio', { name: /^code$/i }));
+        let code = screen.getByRole('textbox', { name: /gapl policy text/i }) as HTMLTextAreaElement;
+        expect(code.value).toBe(original);
+
+        // Toggle back to Visual.
+        await userEvent.click(screen.getByRole('radio', { name: /^visual$/i }));
+        // Toggle to Code again — must STILL be the original, regardless of
+        // how many times the user flips between tabs without editing.
+        await userEvent.click(screen.getByRole('radio', { name: /^code$/i }));
+        code = screen.getByRole('textbox', { name: /gapl policy text/i }) as HTMLTextAreaElement;
+        expect(code.value).toBe(original);
+        // No 'Modified in code' badge either — buffer is in sync with what
+        // the server sent.
+        expect(screen.queryByText(/modified in code/i)).not.toBeInTheDocument();
+    });
+
+    it('does not lowercase the action namespace on save when only metadata changed (Bug D)', async () => {
+        // Stored policy uses uppercase 'Action::' (canonical schema casing).
+        // Saving without touching the GAPL must echo the original text back
+        // unchanged — otherwise the visual roundtrip silently lowercases.
+        const original = 'permit (principal == User::"alice", action == Action::"read", resource == Resource::"r1");';
+        const policy = makePolicy({ policyText: original });
+        const onSubmit = vi.fn().mockResolvedValue(undefined);
+
+        render(<PolicyEditorSheet {...makeProps({ policy, onSubmit })} />);
+        await userEvent.click(screen.getByRole('button', { name: /update policy/i }));
+
+        await waitFor(() => {
+            expect(onSubmit).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    policyText: original,
+                }),
+            );
+        });
+    });
+});


### PR DESCRIPTION
Stitches the foundation, hooks, GAPL engine, and visual builder together into a working policy editor. Sheet wjeżdża z prawej strony, spina Visual ↔ Code view with reactive sync, exposes Save / Deploy / Undeploy through the canonical authz REST endpoints.

PolicyEditorSheet
- Graphene Sheet (side="right", 720px); custom header with editable name input + StatusBadge + Visual/Code ToggleGroup; action row with Deploy/Undeploy gated on the policy's current status
- Subheader carries the optional description input
- Body switches between PolicyBuilder (visual) and a code pane backed by the GAPL Monaco language registered in the earlier PR
- Reactive Visual → Code: while editing in Visual on a brand-new policy, the code buffer is regenerated from the visual statements; for existing policies the buffer stays untouched unless the user edits the visual side (preserves hand-crafted GAPL features)
- Reactive Code → Visual: switchToVisual re-parses the buffer, and warns via sonner toast when the GAPL uses features the visual side cannot represent (advanced when-clauses) — visual stays disabled for that session
- Save / Create / Create-and-Deploy / Undeploy buttons in footer, each gated on policy.name + a loading spinner; success surfaces through sonner toasts ("Policy deployed. Gateway sync expected within 30s.")
- ValidationErrorAlert at the top of the footer for ApiError responses with validation details

ServicePolicyPage (full editor-enabled version, replacing the read- only stub from the list-pages PR)
- Adds the editor sheet + sheet state machine (closed / create / edit), Create button hooked up, row click opens the editor pre- filled with the policy
- Builds principalOptions + actionOptions from the entity collection
  + GAPL schema; resourceOptions filtered by service-type prefix (mcp.* on MCPs page, llm.* on AI Models, …) and emitted in canonical `Type::"slug"` form so chip ids round-trip with the serializer
- Synthesises a CatalogEntry stub when re-hydrating an edited policy's target (only used for the editor header label — resource picking goes through the chip combobox)
- Empty-state hints surfaced into the chip pickers so users know when the picker is empty because there is no data rather than because the picker is broken

+ PolicyEditorSheet vitest spec

## Issue

https://gravitee.atlassian.net/browse/APIM-XXX

## Description

A small description of what you did in that PR.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

