### PR TITLE
Gamma Catalog - Filter APIs by OpenAPI documentation presence

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApisResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApisResource.java
@@ -408,7 +408,8 @@ public class ApisResource extends AbstractResource {
             paginationParam.toPageable(),
             expandDeploymentState,
             manageOnly,
-            expands
+            expands,
+            apiSearchQuery.getHasOpenApiDocumentation()
         );
 
         long totalCount = apis.getTotalElements();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-apis.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-apis.yaml
@@ -4222,6 +4222,10 @@ components:
                   type: boolean
                   description: When set, filters results to only APIs with this allowedInApiProducts value. When true, only returns APIs allowed in API Products. When false, only returns APIs not allowed in API Products. Only applicable for V4 HTTP Proxy APIs.
                   example: true
+                hasOpenApiDocumentation:
+                  type: boolean
+                  description: When set, filters results based on whether the API has at least one published OpenAPI/Swagger documentation page. When true, only returns APIs that publish an OpenAPI documentation page. When false, only returns APIs without one.
+                  example: true
         ApiType:
             type: string
             description: API's type.

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApisResource_SearchApisTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApisResource_SearchApisTest.java
@@ -110,6 +110,7 @@ public class ApisResource_SearchApisTest extends AbstractResourceTest {
                 eq(new PageableImpl(1, 10)),
                 eq(false),
                 eq(true),
+                isNull(),
                 isNull()
             )
         ).thenReturn(new Page<>(List.of(apiEntity), 1, 1, 1));
@@ -151,6 +152,7 @@ public class ApisResource_SearchApisTest extends AbstractResourceTest {
                 eq(new PageableImpl(1, 10)),
                 eq(false),
                 eq(true),
+                isNull(),
                 isNull()
             )
         ).thenReturn(new Page<>(List.of(apiEntity), 1, 1, 1));
@@ -193,6 +195,7 @@ public class ApisResource_SearchApisTest extends AbstractResourceTest {
                 eq(new PageableImpl(1, 10)),
                 eq(false),
                 eq(true),
+                isNull(),
                 isNull()
             )
         ).thenReturn(new Page<>(List.of(apiEntity), 1, 1, 1));
@@ -231,6 +234,7 @@ public class ApisResource_SearchApisTest extends AbstractResourceTest {
                 eq(new PageableImpl(1, 10)),
                 eq(false),
                 eq(true),
+                isNull(),
                 isNull()
             )
         ).thenReturn(new Page<>(List.of(apiEntity), 1, 1, 1));
@@ -282,6 +286,7 @@ public class ApisResource_SearchApisTest extends AbstractResourceTest {
                 eq(new PageableImpl(1, 10)),
                 eq(false),
                 eq(true),
+                isNull(),
                 isNull()
             )
         ).thenReturn(new Page<>(List.of(apiEntity), 1, 1, 1));
@@ -320,6 +325,7 @@ public class ApisResource_SearchApisTest extends AbstractResourceTest {
                 eq(new PageableImpl(1, 10)),
                 eq(false),
                 eq(true),
+                isNull(),
                 isNull()
             )
         ).thenReturn(new Page<>(List.of(apiEntity), 1, 1, 1));
@@ -359,6 +365,7 @@ public class ApisResource_SearchApisTest extends AbstractResourceTest {
                 eq(new PageableImpl(1, 10)),
                 eq(false),
                 eq(true),
+                isNull(),
                 isNull()
             )
         ).thenReturn(new Page<>(List.of(apiEntity), 1, 1, 1));
@@ -403,6 +410,7 @@ public class ApisResource_SearchApisTest extends AbstractResourceTest {
                 eq(new PageableImpl(1, 10)),
                 eq(false),
                 eq(true),
+                isNull(),
                 isNull()
             )
         ).thenReturn(new Page<>(List.of(apiEntity), 1, 1, 1));
@@ -447,7 +455,8 @@ public class ApisResource_SearchApisTest extends AbstractResourceTest {
                 eq(new PageableImpl(1, 10)),
                 eq(true),
                 eq(true),
-                eq(Set.of("deploymentState"))
+                eq(Set.of("deploymentState")),
+                isNull()
             )
         ).thenReturn(new Page<>(List.of(apiEntity), 1, 1, 1));
 
@@ -486,6 +495,7 @@ public class ApisResource_SearchApisTest extends AbstractResourceTest {
                 eq(new PageableImpl(1, 10)),
                 eq(false),
                 eq(true),
+                isNull(),
                 isNull()
             )
         ).thenReturn(new Page<>(List.of(apiEntity), 1, 1, 1));
@@ -554,7 +564,8 @@ public class ApisResource_SearchApisTest extends AbstractResourceTest {
                 eq(new PageableImpl(1, 10)),
                 eq(false),
                 eq(true),
-                eq(Set.of("metadata"))
+                eq(Set.of("metadata")),
+                isNull()
             )
         ).thenReturn(new Page<>(List.of(apiEntity), 1, 1, 1));
 
@@ -591,6 +602,7 @@ public class ApisResource_SearchApisTest extends AbstractResourceTest {
                 eq(new PageableImpl(1, 10)),
                 eq(false),
                 eq(false),
+                isNull(),
                 isNull()
             )
         ).thenReturn(new Page<>(List.of(apiEntity), 1, 1, 1));

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/query_service/api_product/ApiProductSearchQueryServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/query_service/api_product/ApiProductSearchQueryServiceImpl.java
@@ -91,6 +91,6 @@ public class ApiProductSearchQueryServiceImpl implements ApiProductSearchQuerySe
             queryBuilder.setSort(sortable);
         }
 
-        return apiSearchService.search(executionContext, userId, isAdmin, queryBuilder, pageable, false, true, null);
+        return apiSearchService.search(executionContext, userId, isAdmin, queryBuilder, pageable, false, true, null, null);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/search/SearchEngineServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/search/SearchEngineServiceImpl.java
@@ -353,4 +353,21 @@ public class SearchEngineServiceImpl implements SearchEngineService {
 
         return results.orElse(new SearchResult(List.of()));
     }
+
+    @Override
+    public SearchResult searchPageReference(final ExecutionContext executionContext, Query<PageEntity> query) {
+        return searchers
+            .stream()
+            .filter(searcher -> searcher.handle(PageEntity.class))
+            .findFirst()
+            .flatMap(searcher -> {
+                try {
+                    return Optional.of(searcher.searchReference(executionContext, query));
+                } catch (TechnicalException te) {
+                    log.error("Unexpected error while searching page references", te);
+                    return Optional.empty();
+                }
+            })
+            .orElse(new SearchResult(List.of()));
+    }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/search/lucene/searcher/PageDocumentSearcher.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/search/lucene/searcher/PageDocumentSearcher.java
@@ -74,9 +74,9 @@ public class PageDocumentSearcher extends AbstractDocumentSearcher {
         parser.setFuzzyMinSim(0.6f);
 
         BooleanQuery.Builder pageQuery = new BooleanQuery.Builder();
-        BooleanQuery.Builder pageFieldsQuery = new BooleanQuery.Builder();
 
         if (!isBlank(query.getQuery())) {
+            BooleanQuery.Builder pageFieldsQuery = new BooleanQuery.Builder();
             final Query parse = parser.parse(QueryParserBase.escape(query.getQuery()));
             pageFieldsQuery.add(parse, BooleanClause.Occur.SHOULD);
             pageFieldsQuery.add(new WildcardQuery(new Term("name", '*' + query.getQuery() + '*')), BooleanClause.Occur.SHOULD);
@@ -85,9 +85,9 @@ public class PageDocumentSearcher extends AbstractDocumentSearcher {
                 BooleanClause.Occur.SHOULD
             );
             pageFieldsQuery.add(new WildcardQuery(new Term("content", '*' + query.getQuery() + '*')), BooleanClause.Occur.SHOULD);
+            pageQuery.add(pageFieldsQuery.build(), BooleanClause.Occur.MUST);
         }
 
-        pageQuery.add(pageFieldsQuery.build(), BooleanClause.Occur.MUST);
         pageQuery.add(new TermQuery(new Term(FIELD_TYPE, FIELD_TYPE_VALUE)), BooleanClause.Occur.MUST);
         var baseFilterQuery = this.buildFilterQuery(query.getFilters(), Map.of(FIELD_API_TYPE_VALUE, FIELD_REFERENCE_ID));
         baseFilterQuery.ifPresent(q -> pageQuery.add(q, BooleanClause.Occur.FILTER));

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/search/lucene/transformer/IndexablePageDocumentTransformer.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/search/lucene/transformer/IndexablePageDocumentTransformer.java
@@ -47,6 +47,10 @@ public class IndexablePageDocumentTransformer implements DocumentTransformer<Ind
 
         var page = indexable.getPage();
 
+        if (page.getType() != null) {
+            document.add(new StringField(FIELD_PAGE_TYPE, page.getType().name().toLowerCase(), Field.Store.NO));
+        }
+
         if (indexable.getPage().getName() != null) {
             document.add(new StringField(FIELD_NAME, page.getName(), Field.Store.NO));
             document.add(new StringField(FIELD_NAME_LOWERCASE, page.getName().toLowerCase(), Field.Store.NO));

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/search/lucene/transformer/PageDocumentTransformer.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/search/lucene/transformer/PageDocumentTransformer.java
@@ -36,6 +36,7 @@ public class PageDocumentTransformer implements DocumentTransformer<PageEntity> 
     public static final String FIELD_NAME_LOWERCASE = "name_lowercase";
     public static final String FIELD_NAME_SPLIT = "name_split";
     public static final String FIELD_CONTENT = "content";
+    public static final String FIELD_PAGE_TYPE = "page_type";
 
     static final String FIELD_ID = "id";
     static final String FIELD_TYPE = "type";
@@ -50,6 +51,10 @@ public class PageDocumentTransformer implements DocumentTransformer<PageEntity> 
         if (page.getReferenceId() != null) {
             doc.add(new StringField(FIELD_REFERENCE_TYPE, page.getReferenceType().toLowerCase(), Field.Store.NO));
             doc.add(new StringField(FIELD_REFERENCE_ID, page.getReferenceId(), Field.Store.YES));
+        }
+
+        if (page.getType() != null) {
+            doc.add(new StringField(FIELD_PAGE_TYPE, page.getType().toLowerCase(), Field.Store.NO));
         }
 
         if (page.getName() != null) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/search/SearchEngineService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/search/SearchEngineService.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.rest.api.service.search;
 
+import io.gravitee.rest.api.model.PageEntity;
 import io.gravitee.rest.api.model.command.CommandSearchIndexerEntity;
 import io.gravitee.rest.api.model.search.Indexable;
 import io.gravitee.rest.api.service.common.ExecutionContext;
@@ -37,6 +38,12 @@ public interface SearchEngineService {
     void commit();
 
     SearchResult search(ExecutionContext executionContext, Query<? extends Indexable> query);
+
+    /**
+     * Searches the page index and returns the matching documents' {@code reference_id}
+     * (i.e. the parent API id) instead of the page id.
+     */
+    SearchResult searchPageReference(ExecutionContext executionContext, Query<PageEntity> query);
 
     void process(ExecutionContext executionContext, CommandSearchIndexerEntity content);
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/ApiSearchService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/ApiSearchService.java
@@ -67,7 +67,8 @@ public interface ApiSearchService {
         final Pageable pageable,
         final boolean mapToFullGenericApiEntity,
         final boolean manageOnly,
-        final Set<String> expands
+        final Set<String> expands,
+        final Boolean hasOpenApiDocumentation
     );
 
     Collection<String> searchIds(

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/ApiSearchServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/ApiSearchServiceImpl.java
@@ -18,6 +18,7 @@ package io.gravitee.rest.api.service.v4.impl;
 import static io.gravitee.apim.core.utils.CollectionUtils.isNotEmpty;
 import static io.gravitee.apim.core.utils.CollectionUtils.stream;
 import static io.gravitee.rest.api.service.impl.search.lucene.transformer.ApiDocumentTransformer.FIELD_DEFINITION_VERSION;
+import static io.gravitee.rest.api.service.impl.search.lucene.transformer.PageDocumentTransformer.FIELD_PAGE_TYPE;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toMap;
 import static java.util.stream.Collectors.toSet;
@@ -37,6 +38,7 @@ import io.gravitee.repository.management.model.ApiLifecycleState;
 import io.gravitee.repository.management.model.LifecycleState;
 import io.gravitee.repository.management.model.MetadataReferenceType;
 import io.gravitee.repository.management.model.Visibility;
+import io.gravitee.rest.api.model.PageEntity;
 import io.gravitee.rest.api.model.PrimaryOwnerEntity;
 import io.gravitee.rest.api.model.api.ApiQuery;
 import io.gravitee.rest.api.model.common.Pageable;
@@ -68,6 +70,7 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.EnumSet;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -252,7 +255,8 @@ public class ApiSearchServiceImpl extends AbstractService implements ApiSearchSe
         final Pageable pageable,
         final boolean mapToFullGenericApiEntity,
         final boolean manageOnly,
-        final Set<String> expands
+        final Set<String> expands,
+        final Boolean hasOpenApiDocumentation
     ) {
         // Step 1: find apiIds from lucene indexer from 'query' parameter without any pagination and sorting
         var apiQuery = apiQueryBuilder.build();
@@ -263,6 +267,19 @@ public class ApiSearchServiceImpl extends AbstractService implements ApiSearchSe
         }
 
         List<String> apiIds = new LinkedList<>(apiIdsResult.getDocuments());
+
+        // Step 1.5: cross-index resolution of the has-open-api-documentation flag via page docs.
+        if (hasOpenApiDocumentation != null) {
+            Set<String> apiIdsWithOpenApiDoc = findApiIdsWithOpenApiDocumentation();
+            if (hasOpenApiDocumentation) {
+                apiIds.retainAll(apiIdsWithOpenApiDoc);
+            } else {
+                apiIds.removeAll(apiIdsWithOpenApiDoc);
+            }
+            if (apiIds.isEmpty()) {
+                return new Page<>(List.of(), 0, 0, 0);
+            }
+        }
 
         // Step 2: if user is not admin, get list of apiIds in their scope and join with Lucene results
         if (!isAdmin) {
@@ -337,6 +354,15 @@ public class ApiSearchServiceImpl extends AbstractService implements ApiSearchSe
         }
 
         return new Page<>(apiEntityList, pageable.getPageNumber(), apis.size(), apiIds.size());
+    }
+
+    private Set<String> findApiIdsWithOpenApiDocumentation() {
+        Query<PageEntity> pageQuery = QueryBuilder.create(PageEntity.class)
+            .addFilter(FIELD_PAGE_TYPE, "swagger")
+            .addFilter("reference_type", "api")
+            .build();
+        SearchResult result = searchEngineService.searchPageReference(GraviteeContext.getExecutionContext(), pageQuery);
+        return new HashSet<>(result.getDocuments());
     }
 
     private void fetchAndSetMetadata(final ExecutionContext executionContext, final List<GenericApiEntity> apiEntityList) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/search/lucene/transformer/IndexablePageDocumentTransformerTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/search/lucene/transformer/IndexablePageDocumentTransformerTest.java
@@ -62,6 +62,7 @@ public class IndexablePageDocumentTransformerTest {
         document.add(new StringField("type", "page", Field.Store.YES));
         document.add(new StringField("reference_type", "api", Field.Store.NO));
         document.add(new StringField("reference_id", API_ID, Field.Store.YES));
+        document.add(new StringField("page_type", "markdown", Field.Store.NO));
         document.add(new StringField("name", PAGE_NAME, Field.Store.NO));
         document.add(new StringField("name_lowercase", PAGE_NAME.toLowerCase(), Field.Store.NO));
         document.add(new TextField("name_split", PAGE_NAME, Field.Store.NO));

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/search/lucene/transformer/PageDocumentTransformerTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/search/lucene/transformer/PageDocumentTransformerTest.java
@@ -36,4 +36,22 @@ public class PageDocumentTransformerTest {
         Document doc = transformer.transform(page);
         assertThat(doc.get("id")).isEqualTo(page.getId());
     }
+
+    @Test
+    public void shouldIndexPageTypeInLowerCase() {
+        PageEntity page = new PageEntity();
+        page.setId("page-uuid");
+        page.setType("SWAGGER");
+        Document doc = transformer.transform(page);
+        assertThat(doc.getField("page_type")).isNotNull();
+        assertThat(doc.getField("page_type").stringValue()).isEqualTo("swagger");
+    }
+
+    @Test
+    public void shouldNotIndexPageTypeWhenMissing() {
+        PageEntity page = new PageEntity();
+        page.setId("page-uuid");
+        Document doc = transformer.transform(page);
+        assertThat(doc.getField("page_type")).isNull();
+    }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/ApiSearchServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/ApiSearchServiceImplTest.java
@@ -541,4 +541,121 @@ public class ApiSearchServiceImplTest {
         assertNotNull(entities);
         assertEquals(1, entities.size());
     }
+
+    @Test
+    public void should_filter_apis_with_open_api_documentation_when_filter_is_true() throws TechnicalException {
+        var api1 = new Api();
+        api1.setId("api1");
+        api1.setEnvironmentId("DEFAULT");
+        api1.setDefinitionVersion(DefinitionVersion.V4);
+        api1.setType(ApiType.MESSAGE);
+        var api2 = new Api();
+        api2.setId("api2");
+        api2.setEnvironmentId("DEFAULT");
+        api2.setDefinitionVersion(DefinitionVersion.V4);
+        api2.setType(ApiType.MESSAGE);
+
+        when(searchEngineService.search(any(), any())).thenReturn(
+            new io.gravitee.rest.api.service.impl.search.SearchResult(List.of("api1", "api2"), 2)
+        );
+        when(searchEngineService.searchPageReference(any(), any())).thenReturn(
+            new io.gravitee.rest.api.service.impl.search.SearchResult(List.of("api1"), 1)
+        );
+        when(apiRepository.search(any(ApiCriteria.class), eq(ApiFieldFilter.allFields()))).thenReturn(List.of(api1));
+
+        UserEntity admin = new UserEntity();
+        admin.setId("admin");
+        when(primaryOwnerService.getPrimaryOwners(any(), any())).thenReturn(Map.of("api1", new PrimaryOwnerEntity(admin)));
+
+        var queryBuilder = io.gravitee.rest.api.service.search.query.QueryBuilder.create(ApiEntity.class);
+
+        var page = apiSearchService.search(
+            GraviteeContext.getExecutionContext(),
+            "admin",
+            true,
+            queryBuilder,
+            new io.gravitee.rest.api.model.common.PageableImpl(1, 25),
+            false,
+            true,
+            Set.of(),
+            true
+        );
+
+        assertNotNull(page);
+        assertEquals(1, page.getContent().size());
+        assertEquals("api1", page.getContent().get(0).getId());
+    }
+
+    @Test
+    public void should_exclude_apis_with_open_api_documentation_when_filter_is_false() throws TechnicalException {
+        var api2 = new Api();
+        api2.setId("api2");
+        api2.setEnvironmentId("DEFAULT");
+        api2.setDefinitionVersion(DefinitionVersion.V4);
+        api2.setType(ApiType.MESSAGE);
+
+        when(searchEngineService.search(any(), any())).thenReturn(
+            new io.gravitee.rest.api.service.impl.search.SearchResult(List.of("api1", "api2"), 2)
+        );
+        when(searchEngineService.searchPageReference(any(), any())).thenReturn(
+            new io.gravitee.rest.api.service.impl.search.SearchResult(List.of("api1"), 1)
+        );
+        when(apiRepository.search(any(ApiCriteria.class), eq(ApiFieldFilter.allFields()))).thenReturn(List.of(api2));
+
+        UserEntity admin = new UserEntity();
+        admin.setId("admin");
+        when(primaryOwnerService.getPrimaryOwners(any(), any())).thenReturn(Map.of("api2", new PrimaryOwnerEntity(admin)));
+
+        var queryBuilder = io.gravitee.rest.api.service.search.query.QueryBuilder.create(ApiEntity.class);
+
+        var page = apiSearchService.search(
+            GraviteeContext.getExecutionContext(),
+            "admin",
+            true,
+            queryBuilder,
+            new io.gravitee.rest.api.model.common.PageableImpl(1, 25),
+            false,
+            true,
+            Set.of(),
+            false
+        );
+
+        assertNotNull(page);
+        assertEquals(1, page.getContent().size());
+        assertEquals("api2", page.getContent().get(0).getId());
+    }
+
+    @Test
+    public void should_not_query_pages_when_open_api_filter_is_absent() throws TechnicalException {
+        var api1 = new Api();
+        api1.setId("api1");
+        api1.setEnvironmentId("DEFAULT");
+        api1.setDefinitionVersion(DefinitionVersion.V4);
+        api1.setType(ApiType.MESSAGE);
+
+        when(searchEngineService.search(any(), any())).thenReturn(
+            new io.gravitee.rest.api.service.impl.search.SearchResult(List.of("api1"), 1)
+        );
+        when(apiRepository.search(any(ApiCriteria.class), eq(ApiFieldFilter.allFields()))).thenReturn(List.of(api1));
+
+        UserEntity admin = new UserEntity();
+        admin.setId("admin");
+        when(primaryOwnerService.getPrimaryOwners(any(), any())).thenReturn(Map.of("api1", new PrimaryOwnerEntity(admin)));
+
+        var queryBuilder = io.gravitee.rest.api.service.search.query.QueryBuilder.create(ApiEntity.class);
+
+        apiSearchService.search(
+            GraviteeContext.getExecutionContext(),
+            "admin",
+            true,
+            queryBuilder,
+            new io.gravitee.rest.api.model.common.PageableImpl(1, 25),
+            false,
+            true,
+            Set.of(),
+            null
+        );
+
+        verify(searchEngineService, times(0)).searchPageReference(any(), any());
+    }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/ApiSearchService_SearchIdsTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/ApiSearchService_SearchIdsTest.java
@@ -17,6 +17,7 @@ package io.gravitee.rest.api.service.v4.impl;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/ApiSearchService_SearchTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/ApiSearchService_SearchTest.java
@@ -189,6 +189,7 @@ public class ApiSearchService_SearchTest {
             new PageableImpl(1, 10),
             false,
             true,
+            null,
             null
         );
 
@@ -236,6 +237,7 @@ public class ApiSearchService_SearchTest {
             new PageableImpl(1, 10),
             false,
             true,
+            null,
             null
         );
 
@@ -294,6 +296,7 @@ public class ApiSearchService_SearchTest {
             new PageableImpl(2, 2),
             false,
             true,
+            null,
             null
         );
 
@@ -354,6 +357,7 @@ public class ApiSearchService_SearchTest {
             new PageableImpl(1, 10),
             false,
             true,
+            null,
             null
         );
 
@@ -400,6 +404,7 @@ public class ApiSearchService_SearchTest {
             new PageableImpl(1, 10),
             false,
             true,
+            null,
             null
         );
 
@@ -446,6 +451,7 @@ public class ApiSearchService_SearchTest {
             new PageableImpl(1, 10),
             false,
             true,
+            null,
             null
         );
 
@@ -500,6 +506,7 @@ public class ApiSearchService_SearchTest {
             new PageableImpl(1, 2),
             true,
             true,
+            null,
             null
         );
 
@@ -568,7 +575,8 @@ public class ApiSearchService_SearchTest {
             new PageableImpl(1, 2),
             false,
             true,
-            Set.of(ApiService.EXPAND_METADATA)
+            Set.of(ApiService.EXPAND_METADATA),
+            null
         );
 
         assertThat(apis.getContent()).hasSize(2);
@@ -601,6 +609,7 @@ public class ApiSearchService_SearchTest {
             new PageableImpl(1, 1),
             false,
             true,
+            null,
             null
         );
 


### PR DESCRIPTION
## Issue

  https://gravitee.atlassian.net/browse/GMA-158

  ## Description
  
  Adds a new `hasOpenApiDocumentation` filter to `POST /management/v2/environments/{envId}/apis/_search`. When set, the search restricts results to APIs that publish (or do not publish) at least one OpenAPI/Swagger documentation page.

  Behind the scenes this required three building blocks (one per commit):

  1. **`page_type` indexed on the page Lucene document.** Both legacy and indexable page transformers now persist the page kind (`SWAGGER`, `MARKDOWN`, …) lowercased. No DB migration nor manual reindex — the Lucene directory is recreated at startup (`OpenMode.CREATE`).
  2. **`SearchEngineService.searchPageReference(...)`** — a typed entry point that runs a `Query<PageEntity>` and returns the matching documents' `reference_id` (parent API id) instead of the page id. `PageDocumentSearcher` is also adjusted so that filter-only page queries no longer emit an empty `BooleanQuery` MUST clause that would match nothing.
  3. **`ApiSearchService.search(...)` gains a `Boolean hasOpenApiDocumentation` parameter** that, when set, intersects (true) or excludes (false) the result with the set of API ids resolved through `searchPageReference` using filters `page_type=swagger ∧ reference_type=api`.
  4. **REST resource & OpenAPI contract** — `ApiSearchQuery` gets the optional Boolean and `ApisResource` forwards it.

  ## Additional context

  - The filter is intentionally exposed on the v2 management API only.
  - `null` keeps the current behaviour (no constraint on documentation), `true` and `false` partition the result set.
  - Cross-environment safety: the page lookup is environment-agnostic but API ids are UUIDs, so the subsequent intersection with the env-scoped API search naturally drops out-of-env matches.

