### PR TITLE
feat(gamma-apim): add dashboard with summary stats and quick links

### DIFF
--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/api-products/utils/queryKeys.ts
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/api-products/utils/queryKeys.ts
@@ -18,6 +18,7 @@ export const apiProductKeys = {
     all: ['api-products'] as const,
     list: (envId: string, query: string, page: number, perPage: number) =>
         [...apiProductKeys.all, 'list', envId, query, page, perPage] as const,
+    count: (envId: string, filter: object) => [...apiProductKeys.all, 'count', envId, JSON.stringify(filter)] as const,
     detail: (envId: string, productId: string) => [...apiProductKeys.all, 'detail', envId, productId] as const,
     verify: (envId: string, name: string, productId?: string) =>
         [...apiProductKeys.all, 'verify-name', envId, name, productId ?? ''] as const,

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/dashboard/components/DashboardGetStartedCards.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/dashboard/components/DashboardGetStartedCards.tsx
@@ -1,0 +1,117 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Badge, Button, Card, CardContent } from '@gravitee/graphene-core';
+import { ArchiveIcon, ArrowRightIcon, RadioIcon } from '@gravitee/graphene-core/icons';
+import type { LucideIcon } from '@gravitee/graphene-core/icons';
+
+interface GetStartedCardProps {
+    Icon: LucideIcon;
+    title: string;
+    description: string;
+    features: readonly string[];
+    protocols: readonly string[];
+    ctaLabel: string;
+    onCta: () => void;
+}
+
+function GetStartedCard({ Icon, title, description, features, protocols, ctaLabel, onCta }: GetStartedCardProps) {
+    return (
+        <Card className="flex flex-col">
+            <CardContent className="pt-6 pb-6 flex flex-col gap-5 h-full">
+                <div className="rounded-xl bg-primary/10 p-3" style={{ width: 'fit-content' }}>
+                    <Icon className="size-6 text-primary" aria-hidden />
+                </div>
+
+                <div>
+                    <h3 className="text-base font-semibold">{title}</h3>
+                    <p className="text-sm text-muted-foreground mt-1.5 leading-relaxed">{description}</p>
+                </div>
+
+                <ul className="space-y-2 flex-1">
+                    {features.map(feature => (
+                        <li key={feature} className="flex items-center gap-2 text-sm text-muted-foreground">
+                            <span className="size-1.5 rounded-full bg-primary shrink-0" aria-hidden />
+                            {feature}
+                        </li>
+                    ))}
+                </ul>
+
+                <div>
+                    <p className="text-xs text-muted-foreground mb-2">Protocols:</p>
+                    <div className="flex flex-wrap gap-1.5">
+                        {protocols.map(p => (
+                            <Badge key={p} variant="outline" className="text-xs">
+                                {p}
+                            </Badge>
+                        ))}
+                    </div>
+                </div>
+
+                <Button onClick={onCta} className="w-full">
+                    {ctaLabel}
+                    <ArrowRightIcon className="size-4" aria-hidden />
+                </Button>
+            </CardContent>
+        </Card>
+    );
+}
+
+// ─── Static card data ─────────────────────────────────────────────────────────
+
+const API_PROXY_FEATURES = [
+    'Authentication & authorization',
+    'Rate limiting & quotas',
+    'Request / response transformation',
+    'Logging & analytics',
+] as const;
+
+const API_PROXY_PROTOCOLS = ['REST', 'GraphQL', 'gRPC', 'WebSocket'] as const;
+
+const API_PRODUCT_FEATURES = ['Bundle multiple APIs into one surface', 'Subscription & plan management', 'Unified access control'] as const;
+
+const API_PRODUCT_PROTOCOLS = ['HTTP', 'REST', 'GraphQL'] as const;
+
+// ─── Public component ─────────────────────────────────────────────────────────
+
+interface DashboardGetStartedCardsProps {
+    onCreateProxy: () => void;
+    onCreateProduct: () => void;
+}
+
+export function DashboardGetStartedCards({ onCreateProxy, onCreateProduct }: DashboardGetStartedCardsProps) {
+    return (
+        <div className="grid grid-cols-2 gap-4">
+            <GetStartedCard
+                Icon={RadioIcon}
+                title="Expose APIs as HTTP Proxies"
+                description="Secure and observe your backend services with a Gravitee proxy layer. Add authentication, rate limiting, and traffic management in front of any HTTP, GraphQL, gRPC, or WebSocket service."
+                features={API_PROXY_FEATURES}
+                protocols={API_PROXY_PROTOCOLS}
+                ctaLabel="Create API Proxy"
+                onCta={onCreateProxy}
+            />
+            <GetStartedCard
+                Icon={ArchiveIcon}
+                title="Bundle APIs into Products"
+                description="Group multiple APIs into consumable products. Define plans, manage subscriptions, and give developers a unified surface to discover and access your APIs through the developer portal."
+                features={API_PRODUCT_FEATURES}
+                protocols={API_PRODUCT_PROTOCOLS}
+                ctaLabel="Create API Product"
+                onCta={onCreateProduct}
+            />
+        </div>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/dashboard/components/DashboardQuickActions.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/dashboard/components/DashboardQuickActions.tsx
@@ -1,0 +1,91 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ArchiveIcon, BarChart2Icon, RadioIcon } from '@gravitee/graphene-core/icons';
+import type { LucideIcon } from '@gravitee/graphene-core/icons';
+
+// ─── Single tile ──────────────────────────────────────────────────────────────
+
+interface ActionTileProps {
+    Icon: LucideIcon;
+    label: string;
+    description: string;
+    onClick: () => void;
+}
+
+function ActionTile({ Icon, label, description, onClick }: ActionTileProps) {
+    return (
+        <button
+            type="button"
+            onClick={onClick}
+            className="flex flex-col items-start gap-2 rounded-xl border bg-card p-4 text-left transition-colors hover:bg-muted flex-1"
+        >
+            <div className="rounded-lg bg-primary/10 p-2">
+                <Icon className="size-4 text-primary" aria-hidden />
+            </div>
+            <div>
+                <p className="text-sm font-semibold">{label}</p>
+                <p className="text-xs text-muted-foreground mt-0.5">{description}</p>
+            </div>
+        </button>
+    );
+}
+
+// ─── Static tile definitions ──────────────────────────────────────────────────
+
+const TILES = [
+    {
+        key: 'apis' as const,
+        Icon: RadioIcon,
+        label: 'API Proxies',
+        description: 'Browse and manage your APIs',
+    },
+    {
+        key: 'api-products' as const,
+        Icon: ArchiveIcon,
+        label: 'API Products',
+        description: 'Manage product bundles',
+    },
+    {
+        key: 'analytics' as const,
+        Icon: BarChart2Icon,
+        label: 'Analytics',
+        description: 'Traffic, errors & latency',
+    },
+] as const;
+
+// ─── Public component ─────────────────────────────────────────────────────────
+
+interface DashboardQuickActionsProps {
+    onGoToApis: () => void;
+    onGoToApiProducts: () => void;
+    onGoToAnalytics: () => void;
+}
+
+export function DashboardQuickActions({ onGoToApis, onGoToApiProducts, onGoToAnalytics }: DashboardQuickActionsProps) {
+    const handlers: Record<(typeof TILES)[number]['key'], () => void> = {
+        apis: onGoToApis,
+        'api-products': onGoToApiProducts,
+        analytics: onGoToAnalytics,
+    };
+
+    return (
+        <div className="flex gap-3">
+            {TILES.map(({ key, Icon, label, description }) => (
+                <ActionTile key={key} Icon={Icon} label={label} description={description} onClick={handlers[key]} />
+            ))}
+        </div>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/dashboard/components/DashboardRecentActivity.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/dashboard/components/DashboardRecentActivity.tsx
@@ -1,0 +1,139 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Badge, Button, Card, CardContent, Skeleton } from '@gravitee/graphene-core';
+import { ArrowRightIcon, TriangleAlertIcon } from '@gravitee/graphene-core/icons';
+
+import type { ApiDeploymentState, ApiListItem, ApiState } from '../../apis/types/api';
+import { useDashboardRecentApis } from '../hooks/useDashboardRecentApis';
+
+// ─── State helpers ────────────────────────────────────────────────────────────
+
+function DeploymentBadge({ state }: { state?: ApiDeploymentState }) {
+    if (state === 'NEED_REDEPLOY') {
+        return (
+            <Badge variant="outline" className="text-warning border-warning/30 shrink-0 gap-1">
+                <TriangleAlertIcon className="size-3" aria-hidden />
+                Needs redeploy
+            </Badge>
+        );
+    }
+    if (state === 'DEPLOYED') {
+        return (
+            <Badge variant="outline" className="text-success border-success/20 shrink-0">
+                Deployed
+            </Badge>
+        );
+    }
+    return null;
+}
+
+function ApiStateDot({ state }: { state?: ApiState }) {
+    const isRunning = state === 'STARTED';
+    return (
+        <span
+            className={`size-2 rounded-full shrink-0 ${isRunning ? 'bg-success' : 'bg-muted-foreground/40'}`}
+            aria-label={isRunning ? 'Running' : 'Stopped'}
+        />
+    );
+}
+
+// ─── Row ──────────────────────────────────────────────────────────────────────
+
+interface ApiRowProps {
+    api: ApiListItem;
+    onClick: () => void;
+}
+
+function ApiRow({ api, onClick }: ApiRowProps) {
+    return (
+        <button
+            type="button"
+            onClick={onClick}
+            className="w-full flex items-center gap-3 px-3 py-2.5 rounded-lg hover:bg-muted transition-colors text-left"
+        >
+            <ApiStateDot state={api.state} />
+            <div className="flex-1 min-w-0">
+                <p className="text-sm font-medium truncate">{api.name}</p>
+                <p className="text-xs text-muted-foreground truncate">v{api.apiVersion}</p>
+            </div>
+            <DeploymentBadge state={api.deploymentState} />
+        </button>
+    );
+}
+
+// ─── Skeleton ─────────────────────────────────────────────────────────────────
+
+function RecentActivitySkeleton() {
+    return (
+        <div className="space-y-1 px-3 py-1">
+            {Array.from({ length: 5 }).map((_, i) => (
+                <div key={i} className="flex items-center gap-3 py-2.5">
+                    <Skeleton className="size-2 rounded-full shrink-0" />
+                    <div className="flex-1 space-y-1">
+                        <Skeleton className="h-4 w-40 rounded" />
+                        <Skeleton className="h-3 w-16 rounded" />
+                    </div>
+                    <Skeleton className="h-5 w-20 rounded" />
+                </div>
+            ))}
+        </div>
+    );
+}
+
+// ─── Public component ─────────────────────────────────────────────────────────
+
+interface DashboardRecentActivityProps {
+    onNavigateToApi: (apiId: string) => void;
+    onGoToApis: () => void;
+}
+
+export function DashboardRecentActivity({ onNavigateToApi, onGoToApis }: DashboardRecentActivityProps) {
+    const { apis, isLoading, isError } = useDashboardRecentApis();
+
+    return (
+        <Card className="flex flex-col">
+            <CardContent className="pt-5 pb-4 flex flex-col gap-3 h-full">
+                <div className="flex items-center justify-between">
+                    <div>
+                        <p className="text-sm font-semibold">Your APIs</p>
+                        <p className="text-xs text-muted-foreground">APIs you have access to manage</p>
+                    </div>
+                </div>
+
+                {isLoading && <RecentActivitySkeleton />}
+
+                {isError && <p className="text-xs text-muted-foreground px-3 py-4">Unable to load recent APIs.</p>}
+
+                {!isLoading && !isError && apis.length === 0 && <p className="text-xs text-muted-foreground px-3 py-4">No APIs found.</p>}
+
+                {!isLoading && !isError && apis.length > 0 && (
+                    <div className="space-y-0.5">
+                        {apis.map(api => (
+                            <ApiRow key={api.id} api={api} onClick={() => onNavigateToApi(api.id)} />
+                        ))}
+                    </div>
+                )}
+
+                <div className="border-t pt-3 mt-auto">
+                    <Button variant="ghost" size="sm" onClick={onGoToApis} className="w-full justify-between">
+                        View all APIs
+                        <ArrowRightIcon className="size-4" aria-hidden />
+                    </Button>
+                </div>
+            </CardContent>
+        </Card>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/dashboard/components/DashboardSearchCard.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/dashboard/components/DashboardSearchCard.tsx
@@ -1,0 +1,155 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useEnvironment } from '@gravitee/gamma-modules-sdk';
+import { Card, CardContent, Input } from '@gravitee/graphene-core';
+import { ArchiveIcon, RadioIcon, SearchIcon } from '@gravitee/graphene-core/icons';
+import { useQuery } from '@tanstack/react-query';
+import { useDeferredValue, useState } from 'react';
+
+import { searchApiProducts } from '../../api-products/services/apiProduct';
+import type { ApiProductListItem } from '../../api-products/types/apiProduct';
+import { apiProductKeys } from '../../api-products/utils/queryKeys';
+import { searchApis } from '../../apis/services/apiList';
+import type { ApiListItem } from '../../apis/types/api';
+import { apiListKeys } from '../../apis/utils/queryKeys';
+
+const MAX_RESULTS = 5;
+
+// ─── Sub-components ───────────────────────────────────────────────────────────
+
+function SectionLabel({ children }: { children: string }) {
+    return <p className="text-xs font-medium text-muted-foreground px-2 pt-3 pb-1">{children}</p>;
+}
+
+interface ResultRowProps {
+    icon: React.ReactNode;
+    name: string;
+    badge: string;
+    onClick: () => void;
+}
+
+function ResultRow({ icon, name, badge, onClick }: ResultRowProps) {
+    return (
+        <button
+            type="button"
+            onClick={onClick}
+            className="w-full flex items-center gap-3 px-2 py-2 rounded-lg text-left hover:bg-muted transition-colors"
+        >
+            <div className="rounded-md bg-muted p-1.5 shrink-0">{icon}</div>
+            <span className="flex-1 text-sm font-medium truncate">{name}</span>
+            <span className="text-xs text-muted-foreground shrink-0">{badge}</span>
+        </button>
+    );
+}
+
+// ─── Main component ───────────────────────────────────────────────────────────
+
+interface DashboardSearchCardProps {
+    onNavigateToApi: (apiId: string) => void;
+    onNavigateToProduct: (productId: string) => void;
+}
+
+export function DashboardSearchCard({ onNavigateToApi, onNavigateToProduct }: DashboardSearchCardProps) {
+    const env = useEnvironment();
+    const envId = env?.id ?? '';
+    const enabled = Boolean(envId);
+
+    const [input, setInput] = useState('');
+    const deferredInput = useDeferredValue(input);
+    const query = deferredInput.trim();
+    const hasQuery = query.length > 0;
+
+    const apisQuery = useQuery({
+        queryKey: apiListKeys.search(envId, query, 1, MAX_RESULTS),
+        queryFn: () => searchApis(envId, { query }, 1, MAX_RESULTS),
+        enabled: enabled && hasQuery,
+        staleTime: 30_000,
+    });
+
+    const productsQuery = useQuery({
+        queryKey: apiProductKeys.list(envId, query, 1, MAX_RESULTS),
+        queryFn: () => searchApiProducts(envId, { query }, 1, MAX_RESULTS),
+        enabled: enabled && hasQuery,
+        staleTime: 30_000,
+    });
+
+    const apis: ApiListItem[] = apisQuery.data?.data ?? [];
+    const products: ApiProductListItem[] = productsQuery.data?.data ?? [];
+    const isSearching = hasQuery && (apisQuery.isFetching || productsQuery.isFetching);
+    const hasResults = apis.length > 0 || products.length > 0;
+
+    return (
+        <Card>
+            <CardContent className="pt-5 pb-4">
+                <p className="text-sm font-semibold mb-3">Search</p>
+
+                <div className="relative">
+                    <SearchIcon
+                        className="absolute left-3 top-1/2 -translate-y-1/2 size-4 text-muted-foreground pointer-events-none"
+                        aria-hidden
+                    />
+                    <Input
+                        style={{ paddingLeft: '2.25rem' }}
+                        placeholder="Search APIs, API Products…"
+                        value={input}
+                        onChange={e => setInput(e.target.value)}
+                    />
+                </div>
+
+                {hasQuery && (
+                    /* Fixed-height scroll container — results won't push the page layout */
+                    <div className="mt-2 max-h-60 overflow-y-auto rounded-lg border bg-card">
+                        {isSearching && !hasResults && <p className="text-xs text-muted-foreground px-3 py-3">Searching…</p>}
+
+                        {!isSearching && !hasResults && (
+                            <p className="text-xs text-muted-foreground px-3 py-3">No results for &ldquo;{query}&rdquo;</p>
+                        )}
+
+                        {apis.length > 0 && (
+                            <div className="p-1">
+                                <SectionLabel>APIs</SectionLabel>
+                                {apis.map((api: ApiListItem) => (
+                                    <ResultRow
+                                        key={api.id}
+                                        icon={<RadioIcon className="size-3.5 text-primary" aria-hidden />}
+                                        name={api.name}
+                                        badge="API Proxy"
+                                        onClick={() => onNavigateToApi(api.id)}
+                                    />
+                                ))}
+                            </div>
+                        )}
+
+                        {products.length > 0 && (
+                            <div className="p-1">
+                                <SectionLabel>API Products</SectionLabel>
+                                {products.map((product: ApiProductListItem) => (
+                                    <ResultRow
+                                        key={product.id}
+                                        icon={<ArchiveIcon className="size-3.5 text-primary" aria-hidden />}
+                                        name={product.name}
+                                        badge="API Product"
+                                        onClick={() => onNavigateToProduct(product.id)}
+                                    />
+                                ))}
+                            </div>
+                        )}
+                    </div>
+                )}
+            </CardContent>
+        </Card>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/dashboard/components/DashboardSummaryCards.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/dashboard/components/DashboardSummaryCards.tsx
@@ -1,0 +1,60 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Card, CardContent, Skeleton } from '@gravitee/graphene-core';
+import { ArchiveIcon, RadioIcon } from '@gravitee/graphene-core/icons';
+import type { LucideIcon } from '@gravitee/graphene-core/icons';
+
+interface StatCardProps {
+    Icon: LucideIcon;
+    title: string;
+    total: number | null;
+}
+
+function StatCard({ Icon, title, total }: StatCardProps) {
+    return (
+        <Card>
+            <CardContent className="pt-5 pb-5">
+                <div className="flex items-center justify-between">
+                    <div className="flex items-center gap-2">
+                        <div className="rounded-lg bg-primary/10 p-2">
+                            <Icon className="size-5 text-primary" aria-hidden />
+                        </div>
+                        <p className="text-sm font-medium text-muted-foreground">{title}</p>
+                    </div>
+                    {total === null ? (
+                        <Skeleton className="rounded" style={{ height: '2rem', width: '2.5rem' }} />
+                    ) : (
+                        <p className="text-2xl font-semibold">{total}</p>
+                    )}
+                </div>
+            </CardContent>
+        </Card>
+    );
+}
+
+interface DashboardSummaryCardsProps {
+    totalApis: number | null;
+    totalProducts: number | null;
+}
+
+export function DashboardSummaryCards({ totalApis, totalProducts }: DashboardSummaryCardsProps) {
+    return (
+        <div className="grid grid-cols-2 gap-4">
+            <StatCard Icon={RadioIcon} title="Total APIs" total={totalApis} />
+            <StatCard Icon={ArchiveIcon} title="Total API Products" total={totalProducts} />
+        </div>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/dashboard/components/DashboardView.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/dashboard/components/DashboardView.tsx
@@ -1,0 +1,60 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { DashboardGetStartedCards } from './DashboardGetStartedCards';
+import { DashboardQuickActions } from './DashboardQuickActions';
+import { DashboardSummaryCards } from './DashboardSummaryCards';
+
+interface DashboardViewProps {
+    totalApis: number | null;
+    totalProducts: number | null;
+    onCreateProxy: () => void;
+    onCreateProduct: () => void;
+    onGoToApis: () => void;
+    onGoToApiProducts: () => void;
+    onGoToAnalytics: () => void;
+}
+
+export function DashboardView({
+    totalApis,
+    totalProducts,
+    onCreateProxy,
+    onCreateProduct,
+    onGoToApis,
+    onGoToApiProducts,
+    onGoToAnalytics,
+}: DashboardViewProps) {
+    return (
+        <div className="space-y-6">
+            {/* Header */}
+            <div className="space-y-1">
+                <h1 className="text-2xl font-semibold tracking-tight">API Management</h1>
+                <p className="text-sm text-muted-foreground">Manage, secure, and monitor your APIs &amp; API Products</p>
+            </div>
+
+            {/* Summary stats */}
+            <DashboardSummaryCards totalApis={totalApis} totalProducts={totalProducts} />
+
+            {/* Quick actions */}
+            <DashboardQuickActions onGoToApis={onGoToApis} onGoToApiProducts={onGoToApiProducts} onGoToAnalytics={onGoToAnalytics} />
+
+            {/* Get Started */}
+            <section>
+                <h2 className="text-base font-semibold mb-4">Get Started</h2>
+                <DashboardGetStartedCards onCreateProxy={onCreateProxy} onCreateProduct={onCreateProduct} />
+            </section>
+        </div>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/dashboard/components/index.ts
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/dashboard/components/index.ts
@@ -14,3 +14,9 @@
  * limitations under the License.
  */
 export { DashboardEmptyLanding } from './DashboardEmptyLanding';
+export { DashboardGetStartedCards } from './DashboardGetStartedCards';
+export { DashboardQuickActions } from './DashboardQuickActions';
+export { DashboardRecentActivity } from './DashboardRecentActivity';
+export { DashboardSearchCard } from './DashboardSearchCard';
+export { DashboardSummaryCards } from './DashboardSummaryCards';
+export { DashboardView } from './DashboardView';

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/dashboard/hooks/useDashboardRecentApis.ts
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/dashboard/hooks/useDashboardRecentApis.ts
@@ -1,0 +1,49 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useEnvironment } from '@gravitee/gamma-modules-sdk';
+import { useQuery } from '@tanstack/react-query';
+
+import { searchApis } from '../../apis/services/apiList';
+import type { ApiListItem } from '../../apis/types/api';
+import { apiListKeys } from '../../apis/utils/queryKeys';
+
+const RECENT_PAGE = 1;
+const RECENT_PER_PAGE = 6;
+
+export interface DashboardRecentApis {
+    apis: ApiListItem[];
+    isLoading: boolean;
+    isError: boolean;
+}
+
+export function useDashboardRecentApis(): DashboardRecentApis {
+    const env = useEnvironment();
+    const envId = env?.id ?? '';
+    const enabled = Boolean(envId);
+
+    const query = useQuery({
+        queryKey: apiListKeys.search(envId, '', RECENT_PAGE, RECENT_PER_PAGE),
+        queryFn: () => searchApis(envId, {}, RECENT_PAGE, RECENT_PER_PAGE),
+        enabled,
+        staleTime: 60_000,
+    });
+
+    return {
+        apis: query.data?.data ?? [],
+        isLoading: query.isLoading,
+        isError: query.isError,
+    };
+}

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/dashboard/hooks/useDashboardStats.ts
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/dashboard/hooks/useDashboardStats.ts
@@ -1,0 +1,70 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useEnvironment } from '@gravitee/gamma-modules-sdk';
+import { useQuery } from '@tanstack/react-query';
+
+import { searchApiProducts } from '../../api-products/services/apiProduct';
+import { apiProductKeys } from '../../api-products/utils/queryKeys';
+import { searchApis } from '../../apis/services/apiList';
+import { apiListKeys } from '../../apis/utils/queryKeys';
+
+const STATS_PAGE = 1;
+const STATS_PER_PAGE = 1;
+
+export interface DashboardStats {
+    totalApis: number | null;
+    totalProducts: number | null;
+    /** null = data not yet available; true = at least one API or product; false = nothing yet */
+    hasContent: boolean | null;
+    isLoading: boolean;
+    isError: boolean;
+}
+
+export function useDashboardStats(): DashboardStats {
+    const env = useEnvironment();
+    const envId = env?.id ?? '';
+    // Guard on envId too — env may be truthy but id not yet populated
+    const enabled = Boolean(envId);
+
+    const totalApisQuery = useQuery({
+        queryKey: apiListKeys.count(envId, {}),
+        queryFn: () => searchApis(envId, {}, STATS_PAGE, STATS_PER_PAGE),
+        enabled,
+        staleTime: 60_000,
+    });
+
+    // Use apiProductKeys.count — not apiProductKeys.list — to avoid a cache-key
+    // collision with useApiProductList (which shares the list key with sortBy='name').
+    const totalProductsQuery = useQuery({
+        queryKey: apiProductKeys.count(envId, {}),
+        queryFn: () => searchApiProducts(envId, {}, STATS_PAGE, STATS_PER_PAGE),
+        enabled,
+        staleTime: 60_000,
+    });
+
+    const totalApis = totalApisQuery.data?.pagination?.totalCount ?? null;
+    const totalProducts = totalProductsQuery.data?.pagination?.totalCount ?? null;
+
+    const hasContent = totalApis !== null && totalProducts !== null ? totalApis > 0 || totalProducts > 0 : null;
+
+    return {
+        totalApis,
+        totalProducts,
+        hasContent,
+        isLoading: totalApisQuery.isLoading || totalProductsQuery.isLoading,
+        isError: totalApisQuery.isError || totalProductsQuery.isError,
+    };
+}

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/dashboard/pages/DashboardPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/dashboard/pages/DashboardPage.tsx
@@ -13,12 +13,83 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { useNavigate } from 'react-router-dom';
+import { useModuleRouting } from '@gravitee/gamma-modules-sdk/routing';
+import { Alert, AlertDescription, Skeleton } from '@gravitee/graphene-core';
+import { useLocation, useNavigate } from 'react-router-dom';
 
-import { DashboardEmptyLanding } from '../components';
+import { APIM_ROUTE_CONFIG } from '../../../config/routes';
+import { DashboardEmptyLanding, DashboardView } from '../components';
+import { useDashboardStats } from '../hooks/useDashboardStats';
+
+function DashboardPageSkeleton() {
+    return (
+        <div className="space-y-6">
+            <div className="flex items-start justify-between gap-4">
+                <div className="space-y-2">
+                    <Skeleton className="h-8 w-52 rounded" />
+                    <Skeleton className="h-4 w-80 rounded" />
+                </div>
+                <div className="flex gap-2">
+                    <Skeleton className="h-9 w-40 rounded" />
+                    <Skeleton className="h-9 w-36 rounded" />
+                </div>
+            </div>
+            <div className="grid grid-cols-2 gap-4">
+                <Skeleton className="rounded-xl" style={{ height: '8rem' }} />
+                <Skeleton className="rounded-xl" style={{ height: '8rem' }} />
+            </div>
+            <div className="grid grid-cols-2 gap-4">
+                <Skeleton className="rounded-xl" style={{ height: '20rem' }} />
+                <Skeleton className="rounded-xl" style={{ height: '20rem' }} />
+            </div>
+        </div>
+    );
+}
 
 export function DashboardPage() {
     const navigate = useNavigate();
+    const location = useLocation();
+    const { navigateToKey, modulePrefix } = useModuleRouting(APIM_ROUTE_CONFIG);
+    const stats = useDashboardStats();
 
-    return <DashboardEmptyLanding onCreateProxy={() => navigate('apis/new')} />;
+    // Mirror buildModuleNavPath from the SDK: /environments/{env}/{module}/{subPath}
+    const goTo = (subPath: string) => {
+        if (modulePrefix) {
+            const idx = location.pathname.startsWith('/environments/') ? location.pathname.indexOf('/', 14) : -1;
+            const envBase = idx > 0 ? location.pathname.slice(0, idx) : '';
+            navigate(`${envBase}/${modulePrefix}/${subPath}`);
+        } else {
+            navigate(`/${subPath}`);
+        }
+    };
+
+    // Show skeleton while env is resolving (queries idle → isLoading=false in TanStack v5)
+    // or while the first fetch is in-flight. Only drop it once we have a definitive answer.
+    if (stats.hasContent === null && !stats.isError) {
+        return <DashboardPageSkeleton />;
+    }
+
+    if (stats.isError) {
+        return (
+            <Alert variant="destructive" className="max-w-lg">
+                <AlertDescription>Failed to load dashboard data. Please refresh the page.</AlertDescription>
+            </Alert>
+        );
+    }
+
+    if (stats.hasContent) {
+        return (
+            <DashboardView
+                totalApis={stats.totalApis}
+                totalProducts={stats.totalProducts}
+                onCreateProxy={() => goTo('apis/new')}
+                onCreateProduct={() => goTo('api-products/new')}
+                onGoToApis={() => navigateToKey('apis')}
+                onGoToApiProducts={() => navigateToKey('api-products')}
+                onGoToAnalytics={() => navigateToKey('analytics')}
+            />
+        );
+    }
+
+    return <DashboardEmptyLanding onCreateProxy={() => goTo('apis/new')} />;
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/GMA-134


## Description

Replaces the static DashboardEmptyLanding (previously always shown) with a conditional dashboard that activates as soon as the environment has at least one API or API Product.


Changes:
- DashboardPage: detects content via useDashboardStats; shows skeleton while env/queries are resolving, error alert on failure, empty landing when truly empty, and the full dashboard otherwise. Navigation uses modulePrefix to build correct federated paths (fixes goTo routing from the 'dashboard' segment).

- DashboardSummaryCards: two stat cards (Total APIs, Total API Products) using the same text-2xl font-semibold style as ApiStatsCards/ApiProductStatsCards.

- DashboardQuickActions: three flex-row tiles (API Proxies, API Products, Analytics) for fast top-level navigation.

- DashboardGetStartedCards: two equal-width cards explaining HTTP Proxies and API Products, each with a direct "Create" CTA that navigates to the creation flow. Protocol badges retained; Popular/Flexible chips and Developer portal integration bullet removed.

- useDashboardStats: fetches total API and total product counts; hasContent drives the page branch logic. Public/private breakdown queries removed.

- apiProductKeys.count: new query key to avoid cache collision between dashboard stats and the API Products list page.

- DashboardRecentActivity / useDashboardRecentApis / DashboardSearchCard:
  components remain in tree but are no longer rendered by DashboardView
  
  

https://github.com/user-attachments/assets/c425eede-20f8-412a-b461-e96316f5a0d5


  
## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

