### PR TITLE
feat(gamma-apim): add reporter settings page

### DIFF
--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/app/AppRoutes.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/app/AppRoutes.tsx
@@ -54,6 +54,7 @@ import { ApiNotificationsPage } from '../features/apis/pages/detail/notification
 import { ApiPlanFormPage } from '../features/apis/pages/detail/plans/ApiPlanFormPage';
 import { ApiPlansPage } from '../features/apis/pages/detail/plans/ApiPlansPage';
 import { ApiPropertiesPage } from '../features/apis/pages/detail/properties/ApiPropertiesPage';
+import { ApiReporterSettingsPage } from '../features/apis/pages/detail/reporter-settings/ApiReporterSettingsPage';
 import { UserPermissionsPage } from '../features/apis/pages/detail/user-permissions/UserPermissionsPage';
 import { ScratchWizardPage } from '../features/apis/pages/ScratchWizardPage';
 import { TemplateWizardPage } from '../features/apis/pages/TemplateWizardPage';
@@ -117,7 +118,7 @@ export function AppRoutes() {
                                     element={<ApiDetailPlaceholderPage title="Health Check Dashboard" />}
                                 />
                             </Route>
-                            <Route path="reporter-settings" element={<ApiDetailPlaceholderPage title="Reporter Settings" />} />
+                            <Route path="reporter-settings" element={<ApiReporterSettingsPage />} />
                             <Route path="policy-studio" element={<ApiDetailPlaceholderPage title="Policy Studio" />} />
                             <Route path="documentation" element={<ApiDetailPlaceholderPage title="Documentation" />} />
                             <Route path="plans">

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/api-products/components/apis/AddApiToProductDialog.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/api-products/components/apis/AddApiToProductDialog.tsx
@@ -17,7 +17,7 @@ import { Badge, Button, Dialog, DialogContent, DialogFooter, DialogHeader, Dialo
 import { GlobeIcon, InfoIcon, SearchIcon, XIcon } from '@gravitee/graphene-core/icons';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 
-import type { ApiListItem } from '../../../apis/types/api';
+import type { ApiListItem } from '../../../apis/types';
 import { useApisAvailableForProduct } from '../../hooks/useApiProductApis';
 
 interface AddApiToProductDialogProps {

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/api-products/hooks/useApiProductApis.ts
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/api-products/hooks/useApiProductApis.ts
@@ -16,7 +16,7 @@
 import { useEnvironment } from '@gravitee/gamma-modules-sdk';
 import { keepPreviousData, useQuery } from '@tanstack/react-query';
 
-import type { ApiListResponse } from '../../apis/types/api';
+import type { ApiListResponse } from '../../apis/types';
 import { getApiProductApis, searchApisAllowedInProducts } from '../services/apiProduct';
 import { apiProductKeys } from '../utils/queryKeys';
 

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/api-products/pages/detail/apis/ApiProductApisPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/api-products/pages/detail/apis/ApiProductApisPage.tsx
@@ -54,7 +54,7 @@ import {
 import { useEffect, useId, useState } from 'react';
 import { useParams } from 'react-router-dom';
 
-import type { ApiListItem } from '../../../../apis/types/api';
+import type { ApiListItem } from '../../../../apis/types';
 import { AddApiToProductDialog } from '../../../components/apis/AddApiToProductDialog';
 import { useApiProductDetailContext } from '../../../context/ApiProductDetailContext';
 import { useApiProductApis } from '../../../hooks/useApiProductApis';

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/api-products/services/apiProduct.ts
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/api-products/services/apiProduct.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import { apimFetchJsonV2 } from '../../../shared/api/apimClient';
-import type { ApiListResponse } from '../../apis/types/api';
+import type { ApiListResponse } from '../../apis/types';
 import type {
     ApiProductListItem,
     ApiProductListResponse,

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/components/detail/ApiDetailLayout.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/components/detail/ApiDetailLayout.tsx
@@ -22,7 +22,7 @@ import { useDetailBasePath } from '../../../../shared/hooks/useDetailBasePath';
 import { ApiDetailContext } from '../../context/ApiDetailContext';
 import { useApiDetail } from '../../hooks/useApiDetail';
 import { useApiPermissions } from '../../hooks/useApiPermissions';
-import type { ApiDetailDto } from '../../types/api';
+import type { ApiDetailDto } from '../../types';
 
 function StateIndicator({ state }: { state: ApiDetailDto['state'] }) {
     switch (state) {

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/components/list/ApiListTable.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/components/list/ApiListTable.spec.tsx
@@ -18,7 +18,7 @@ import userEvent from '@testing-library/user-event';
 import { MemoryRouter, useNavigate } from 'react-router-dom';
 
 import { ApiListTable } from './ApiListTable';
-import type { ApiListItem } from '../../types/api';
+import type { ApiListItem } from '../../types';
 
 jest.mock('react-router-dom', () => ({
     ...jest.requireActual('react-router-dom'),

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/components/list/ApiListTable.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/components/list/ApiListTable.tsx
@@ -31,7 +31,7 @@ import {
 import { AlertCircleIcon, CircleCheckIcon, CircleXIcon, MoreHorizontalIcon, RefreshCwIcon } from '@gravitee/graphene-core/icons';
 import { useNavigate } from 'react-router-dom';
 
-import type { ApiDeploymentState, ApiListItem, ApiState } from '../../types/api';
+import type { ApiDeploymentState, ApiListItem, ApiState } from '../../types';
 import { getApiAccessPath } from '../../utils/apiAccess';
 
 // ─── Status helpers ───────────────────────────────────────────────────────────

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/components/list/ApisListView.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/components/list/ApisListView.tsx
@@ -19,7 +19,7 @@ import { useId } from 'react';
 
 import { ApiListTable } from './ApiListTable';
 import { ApiStatsCards } from './ApiStatsCards';
-import type { ApiListItem } from '../../types/api';
+import type { ApiListItem } from '../../types';
 
 interface ApisListViewProps {
     readonly apis: ApiListItem[];

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/constants/alertConstants.ts
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/constants/alertConstants.ts
@@ -22,7 +22,7 @@ import type {
     AlertRuleId,
     AlertStringOperator,
     AlertTimeUnit,
-} from '../types/api';
+} from '../types';
 
 // ─── Rule definitions ──────────────────────────────────────────────────────────
 

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/context/ApiDetailContext.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/context/ApiDetailContext.tsx
@@ -15,7 +15,7 @@
  */
 import { createContext, useContext } from 'react';
 
-import type { ApiDetailDto } from '../types/api';
+import type { ApiDetailDto } from '../types';
 
 export type ApiDetailContextValue = {
     readonly api: ApiDetailDto | null;

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/hooks/useApiEntrypoints.ts
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/hooks/useApiEntrypoints.ts
@@ -19,7 +19,7 @@ import { useParams } from 'react-router-dom';
 
 import { useApiDetailContext } from '../context/ApiDetailContext';
 import { getExposedEntrypoints, updateApiListeners } from '../services/entrypoints';
-import type { HttpListener } from '../types/api';
+import type { HttpListener } from '../types';
 import { apiDetailKeys, apiEntrypointKeys } from '../utils/queryKeys';
 
 export function useApiEntrypoints(showConfig: boolean) {

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/hooks/useApiGeneralMutations.ts
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/hooks/useApiGeneralMutations.ts
@@ -30,7 +30,7 @@ import {
     updateApiGeneral,
     updateApiPicture,
 } from '../services/apis';
-import type { ApiDetailDto } from '../types/api';
+import type { ApiDetailDto } from '../types';
 import { apiDetailKeys } from '../utils/queryKeys';
 
 interface ApiGeneralSideEffects {

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/hooks/useApiList.ts
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/hooks/useApiList.ts
@@ -17,7 +17,7 @@ import { useEnvironment } from '@gravitee/gamma-modules-sdk';
 import { keepPreviousData, useQuery } from '@tanstack/react-query';
 
 import { searchApis } from '../services/apiList';
-import type { ApiListResponse } from '../types/api';
+import type { ApiListResponse } from '../types';
 import { apiListKeys } from '../utils/queryKeys';
 
 export function useApiList({

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/hooks/useCreateApiProxy.ts
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/hooks/useCreateApiProxy.ts
@@ -18,7 +18,7 @@ import { useMutation } from '@tanstack/react-query';
 
 import { ApimApiError } from '../../../shared/api/apimClient';
 import { createApiPlan, createApiProxy, publishApiPlan, startApiProxy } from '../services/apiProxy';
-import type { ApiProxyCreated } from '../types/api';
+import type { ApiProxyCreated } from '../types';
 import type { ApiProxyDraft } from '../types/apiCreation';
 import { mapFormToCreateRequest, mapFormToPlanRequest } from '../utils/apiProxyMapper';
 import { apiProxyKeys } from '../utils/queryKeys';

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/detail/alerts/AggregationConditionForm.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/detail/alerts/AggregationConditionForm.tsx
@@ -16,7 +16,7 @@
 import { Input, Label, Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@gravitee/graphene-core';
 
 import { AGGREGATION_FUNCTIONS, ALERT_OPERATORS, TIME_UNITS, type AlertMetricDefinition } from '../../../constants/alertConstants';
-import type { AlertAggregationFunction, AlertFormCondition, AlertOperator, AlertTimeUnit } from '../../../types/api';
+import type { AlertAggregationFunction, AlertFormCondition, AlertOperator, AlertTimeUnit } from '../../../types';
 
 interface Props {
     condition: AlertFormCondition;

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/detail/alerts/AlertFormPage.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/detail/alerts/AlertFormPage.spec.tsx
@@ -21,7 +21,7 @@ import { MemoryRouter, Route, Routes } from 'react-router-dom';
 
 import { AlertFormPage } from './AlertFormPage';
 import { createAlertTrigger, listAlerts, updateAlertTrigger } from '../../../services/alerts';
-import type { AlertTrigger } from '../../../types/api';
+import type { AlertTrigger } from '../../../types';
 
 // ─── SDK / context mocks ──────────────────────────────────────────────────────
 

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/detail/alerts/AlertsTab.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/detail/alerts/AlertsTab.tsx
@@ -39,7 +39,7 @@ import { MissingDataConditionForm } from './MissingDataConditionForm';
 import { RateConditionForm } from './RateConditionForm';
 import { SimpleConditionForm } from './SimpleConditionForm';
 import { ALERT_RULES, API_METRICS, type AlertMetricDefinition, type AlertRuleDefinition } from '../../../constants/alertConstants';
-import type { AlertFormCondition, AlertFormTimeframe, AlertRuleId, AlertSeverity } from '../../../types/api';
+import type { AlertFormCondition, AlertFormTimeframe, AlertRuleId, AlertSeverity } from '../../../types';
 
 const DAY_LABELS = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
 

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/detail/alerts/ApiAlertsPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/detail/alerts/ApiAlertsPage.tsx
@@ -49,7 +49,7 @@ import { useNavigate, useParams } from 'react-router-dom';
 
 import { ALERT_RULES } from '../../../constants/alertConstants';
 import { deleteAlertTrigger, listAlerts, updateAlertTrigger, alertTriggerToFormData } from '../../../services/alerts';
-import type { AlertTrigger } from '../../../types/api';
+import type { AlertTrigger } from '../../../types';
 import { apiAlertKeys } from '../../../utils/queryKeys';
 
 const CAPABILITIES = [

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/detail/alerts/FilterRow.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/detail/alerts/FilterRow.tsx
@@ -36,7 +36,7 @@ import {
     isStringMetric,
     type AlertMetricDefinition,
 } from '../../../constants/alertConstants';
-import type { AlertConditionType, AlertFormCondition, AlertOperator, AlertStringOperator } from '../../../types/api';
+import type { AlertConditionType, AlertFormCondition, AlertOperator, AlertStringOperator } from '../../../types';
 
 interface Props {
     filter: AlertFormCondition;

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/detail/alerts/HistoryTab.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/detail/alerts/HistoryTab.tsx
@@ -27,7 +27,7 @@ import {
     TableRow,
 } from '@gravitee/graphene-core';
 
-import type { AlertHistoryPage } from '../../../types/api';
+import type { AlertHistoryPage } from '../../../types';
 
 export interface HistoryTabProps {
     historyPage: AlertHistoryPage | undefined;

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/detail/alerts/MissingDataConditionForm.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/detail/alerts/MissingDataConditionForm.tsx
@@ -16,7 +16,7 @@
 import { Input, Label, Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@gravitee/graphene-core';
 
 import { TIME_UNITS } from '../../../constants/alertConstants';
-import type { AlertFormCondition, AlertTimeUnit } from '../../../types/api';
+import type { AlertFormCondition, AlertTimeUnit } from '../../../types';
 
 interface Props {
     condition: AlertFormCondition;

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/detail/alerts/NotificationsTab.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/detail/alerts/NotificationsTab.tsx
@@ -38,7 +38,7 @@ import type { Dispatch, SetStateAction } from 'react';
 
 import { DAMPENING_MODES, NOTIFICATION_CHANNELS, TIME_UNITS } from '../../../constants/alertConstants';
 import type { AlertFormData } from '../../../services/alerts';
-import type { AlertDampeningMode, AlertFormNotification, AlertNotificationChannel, AlertTimeUnit } from '../../../types/api';
+import type { AlertDampeningMode, AlertFormNotification, AlertNotificationChannel, AlertTimeUnit } from '../../../types';
 
 const CHANNEL_META: Record<
     AlertNotificationChannel,

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/detail/alerts/RateConditionForm.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/detail/alerts/RateConditionForm.tsx
@@ -22,7 +22,7 @@ import {
     isStringMetric,
     type AlertMetricDefinition,
 } from '../../../constants/alertConstants';
-import type { AlertFormCondition, AlertOperator, AlertStringOperator, AlertTimeUnit } from '../../../types/api';
+import type { AlertFormCondition, AlertOperator, AlertStringOperator, AlertTimeUnit } from '../../../types';
 
 interface Props {
     condition: AlertFormCondition;

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/detail/alerts/SimpleConditionForm.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/detail/alerts/SimpleConditionForm.tsx
@@ -21,7 +21,7 @@ import {
     getConditionTypesForMetric,
     type AlertMetricDefinition,
 } from '../../../constants/alertConstants';
-import type { AlertConditionType, AlertFormCondition, AlertOperator, AlertStringOperator } from '../../../types/api';
+import type { AlertConditionType, AlertFormCondition, AlertOperator, AlertStringOperator } from '../../../types';
 
 interface Props {
     condition: AlertFormCondition;

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/detail/alerts/useAlertForm.ts
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/detail/alerts/useAlertForm.ts
@@ -44,7 +44,7 @@ import type {
     AlertNotificationChannel,
     AlertRuleId,
     AlertSeverity,
-} from '../../../types/api';
+} from '../../../types';
 import { apiAlertKeys } from '../../../utils/queryKeys';
 
 function getDefaultCondition(ruleId: AlertRuleId): AlertFormCondition[] {

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/detail/cors/ApiCorsPage.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/detail/cors/ApiCorsPage.spec.tsx
@@ -21,7 +21,7 @@ import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { ApiCorsPage } from './ApiCorsPage';
 import { useApiDetail } from '../../../hooks/useApiDetail';
 import { updateApiCors } from '../../../services/apis';
-import type { Cors } from '../../../types/api';
+import type { Cors } from '../../../types';
 
 // ─── SDK / context mocks ──────────────────────────────────────────────────────
 

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/detail/cors/ApiCorsPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/detail/cors/ApiCorsPage.tsx
@@ -25,7 +25,7 @@ import { InfoTooltip } from './InfoTooltip';
 import { ToggleRow } from './ToggleRow';
 import { useApiDetail } from '../../../hooks/useApiDetail';
 import { updateApiCors } from '../../../services/apis';
-import type { Cors } from '../../../types/api';
+import type { Cors } from '../../../types';
 import { apiDetailKeys } from '../../../utils/queryKeys';
 
 // ─── Constants ────────────────────────────────────────────────────────────────

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/detail/deployment/DeploymentHistoryPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/detail/deployment/DeploymentHistoryPage.tsx
@@ -47,7 +47,7 @@ import { SingleEventDialog } from './SingleEventDialog';
 import { formatDate } from './utils';
 import { useApiEvents } from '../../../hooks/useApiEvents';
 import { rollbackApi } from '../../../services/apis';
-import type { ApiEvent } from '../../../types/api';
+import type { ApiEvent } from '../../../types';
 import { apiEventsKeys } from '../../../utils/queryKeys';
 
 const PAGE_SIZE_OPTIONS = [10, 20, 25, 50, 100];

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/detail/deployment/DiffDialog.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/detail/deployment/DiffDialog.tsx
@@ -21,7 +21,7 @@ import { LineDiffView } from './LineDiffView';
 import { SideBySideView } from './SideBySideView';
 import type { DiffMode } from './types';
 import { computeSideBySideDiff, computeUnifiedDiff, extractDefinition, formatDate, hasDiffChanges } from './utils';
-import type { ApiEvent } from '../../../types/api';
+import type { ApiEvent } from '../../../types';
 
 type Props = Readonly<{
     left: ApiEvent;

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/detail/deployment/SingleEventDialog.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/detail/deployment/SingleEventDialog.tsx
@@ -27,7 +27,7 @@ import { XIcon } from '@gravitee/graphene-core/icons';
 import { useMemo } from 'react';
 
 import { extractDefinition, formatDate } from './utils';
-import type { ApiEvent } from '../../../types/api';
+import type { ApiEvent } from '../../../types';
 
 type Props = Readonly<{
     event: ApiEvent;

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/detail/deployment/utils.ts
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/detail/deployment/utils.ts
@@ -16,7 +16,7 @@
 import { diffLines } from 'diff';
 
 import type { SideLine, UnifiedLine } from './types';
-import type { ApiEvent } from '../../../types/api';
+import type { ApiEvent } from '../../../types';
 
 export function formatDate(iso: string): string {
     return new Date(iso).toLocaleString(undefined, {

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/detail/entrypoints/ApiEntrypointsPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/detail/entrypoints/ApiEntrypointsPage.tsx
@@ -27,7 +27,7 @@ import { validatePath } from './types';
 import { VirtualHostsCard } from './VirtualHostsCard';
 import { useApiDetailContext } from '../../../context/ApiDetailContext';
 import { useApiEntrypoints } from '../../../hooks/useApiEntrypoints';
-import type { ApiDetailDto, HttpListener } from '../../../types/api';
+import type { ApiDetailDto, HttpListener } from '../../../types';
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/detail/failover/ApiFailoverPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/detail/failover/ApiFailoverPage.tsx
@@ -37,7 +37,7 @@ import { NumberField } from './NumberField';
 import { ToggleSetting } from './ToggleSetting';
 import { useApiDetailContext } from '../../../context/ApiDetailContext';
 import { updateApiFailover } from '../../../services/apis';
-import type { Failover } from '../../../types/api';
+import type { Failover } from '../../../types';
 import { apiDetailKeys } from '../../../utils/queryKeys';
 import { InfoTooltip } from '../cors/InfoTooltip';
 

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/detail/general/ApiGeneralPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/detail/general/ApiGeneralPage.tsx
@@ -46,7 +46,7 @@ import { useApiDetailContext } from '../../../context/ApiDetailContext';
 import { useApiGeneralMutations } from '../../../hooks/useApiGeneralMutations';
 import { useEnvCategories } from '../../../hooks/useEnvCategories';
 import { exportApiDefinition } from '../../../services/apis';
-import type { ApiDetailDto } from '../../../types/api';
+import type { ApiDetailDto } from '../../../types';
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/detail/general/CategorySelectInput.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/detail/general/CategorySelectInput.tsx
@@ -17,7 +17,7 @@ import { Badge, Checkbox, Popover, PopoverContent, PopoverTrigger, Skeleton } fr
 import { ChevronDownIcon, XIcon } from '@gravitee/graphene-core/icons';
 import { useRef, useState } from 'react';
 
-import type { EnvCategory } from '../../../types/api';
+import type { EnvCategory } from '../../../types';
 
 interface CategorySelectInputProps {
     id?: string;

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/detail/overview/ApiOverviewChecklist.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/detail/overview/ApiOverviewChecklist.tsx
@@ -17,7 +17,7 @@ import { ActivityIcon, GlobeIcon, LockIcon, NetworkIcon, UsersIcon, WorkflowIcon
 import { useMemo } from 'react';
 
 import { OverviewChecklistCard, type OverviewChecklistItem } from '../../../../../shared/components/OverviewChecklistCard';
-import type { AlertTrigger, ApiDetailDto } from '../../../types/api';
+import type { AlertTrigger, ApiDetailDto } from '../../../types';
 import type { MembersResponse } from '../../../types/members.types';
 
 function buildChecklistItems(

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/detail/properties/ApiPropertiesPage.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/detail/properties/ApiPropertiesPage.spec.tsx
@@ -21,7 +21,7 @@ import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { ApiPropertiesPage } from './ApiPropertiesPage';
 import { useApiDetail } from '../../../hooks/useApiDetail';
 import { updateApiProperties } from '../../../services/apis';
-import type { Property } from '../../../types/api';
+import type { Property } from '../../../types';
 
 // ─── SDK / context mocks ──────────────────────────────────────────────────────
 

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/detail/properties/ApiPropertiesPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/detail/properties/ApiPropertiesPage.tsx
@@ -65,7 +65,7 @@ import { useParams } from 'react-router-dom';
 
 import { useApiDetail } from '../../../hooks/useApiDetail';
 import { updateApiProperties } from '../../../services/apis';
-import type { Property } from '../../../types/api';
+import type { Property } from '../../../types';
 import { parsePropertiesStringFormat } from '../../../utils/propertiesParser';
 import { apiDetailKeys } from '../../../utils/queryKeys';
 

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/detail/reporter-settings/ApiReporterSettingsPage.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/detail/reporter-settings/ApiReporterSettingsPage.spec.tsx
@@ -1,0 +1,152 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useHasPermission } from '@gravitee/gamma-modules-sdk';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+
+import { ApiReporterSettingsPage } from './ApiReporterSettingsPage';
+import { useApiDetail } from '../../../hooks/useApiDetail';
+import { updateApiAnalytics } from '../../../services/apis';
+import type { Analytics } from '../../../types';
+
+// ─── SDK / context mocks ──────────────────────────────────────────────────────
+
+jest.mock('@gravitee/gamma-modules-sdk', () => ({
+    useEnvironment: jest.fn(() => ({ id: 'DEFAULT' })),
+    useHasPermission: jest.fn(() => true),
+}));
+
+jest.mock('../../../hooks/useApiDetail', () => ({
+    useApiDetail: jest.fn(),
+}));
+
+jest.mock('@gravitee/graphene-core/icons', () => new Proxy({}, { get: () => () => null }));
+
+// ─── React Query mock ─────────────────────────────────────────────────────────
+
+jest.mock('@tanstack/react-query', () => ({
+    useMutation: jest.fn(config => ({
+        mutate: jest.fn(async args => {
+            await config.mutationFn(args);
+            config.onSuccess?.();
+        }),
+        isPending: false,
+    })),
+    useQueryClient: jest.fn(() => ({ invalidateQueries: jest.fn() })),
+}));
+
+// ─── Service mock ─────────────────────────────────────────────────────────────
+
+jest.mock('../../../services/apis', () => ({
+    updateApiAnalytics: jest.fn(() => Promise.resolve()),
+}));
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+const mockUseHasPermission = useHasPermission as jest.Mock;
+const mockUseApiDetail = useApiDetail as jest.Mock;
+const mockUpdateApiAnalytics = updateApiAnalytics as jest.Mock;
+
+const BASE_ANALYTICS: Analytics = {
+    enabled: true,
+    logging: {
+        mode: { entrypoint: true, endpoint: false },
+        phase: { request: true, response: false },
+        content: { headers: false, payload: false },
+    },
+    tracing: { enabled: false, verbose: false },
+    otelLogs: { enabled: false },
+    sampling: { type: 'COUNT', value: '100' },
+};
+
+function renderPage(analytics: Analytics = BASE_ANALYTICS) {
+    mockUseApiDetail.mockReturnValue({
+        data: { id: 'api-1', name: 'Test API', analytics },
+        isLoading: false,
+        isError: false,
+    });
+    render(
+        <MemoryRouter initialEntries={['/apis/api-1/reporter-settings']}>
+            <Routes>
+                <Route path="apis/:apiId/reporter-settings" element={<ApiReporterSettingsPage />} />
+            </Routes>
+        </MemoryRouter>,
+    );
+}
+
+beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseHasPermission.mockReturnValue(true);
+    mockUpdateApiAnalytics.mockResolvedValue(undefined);
+});
+
+// ─── 1. Renders page heading ──────────────────────────────────────────────────
+
+it('renders the Reporter Settings page heading', () => {
+    renderPage();
+
+    expect(screen.getByRole('heading', { name: /reporter settings/i })).not.toBeNull();
+});
+
+// ─── 2. Permission: hides Save button when read-only ─────────────────────────
+
+it('hides the Save button when the user lacks api-definition-u', () => {
+    mockUseHasPermission.mockReturnValue(false);
+    renderPage();
+
+    expect(screen.queryByRole('button', { name: /save changes/i })).toBeNull();
+});
+
+// ─── 3. Verbose disabled when tracing not enabled ────────────────────────────
+
+it('keeps the Verbose switch disabled when analytics is on but tracing is off', () => {
+    renderPage({ ...BASE_ANALYTICS, tracing: { enabled: false, verbose: false } });
+
+    const verboseSwitch = screen.getByRole('switch', { name: /verbose/i });
+    expect(verboseSwitch).toBeDisabled();
+});
+
+// ─── 4. Verbose warning visible when both tracing and verbose are on ──────────
+
+it('shows the verbose warning banner when tracing and verbose are both enabled', () => {
+    renderPage({ ...BASE_ANALYTICS, tracing: { enabled: true, verbose: true } });
+
+    expect(screen.getByText(/verbose mode significantly increases trace size/i)).not.toBeNull();
+});
+
+// ─── 5. Save preserves sampling ───────────────────────────────────────────────
+
+it('calls updateApiAnalytics with sampling preserved from the loaded API', async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    await user.click(screen.getByRole('button', { name: /save changes/i }));
+
+    await waitFor(() => expect(mockUpdateApiAnalytics).toHaveBeenCalledTimes(1));
+
+    const [, , sentAnalytics] = mockUpdateApiAnalytics.mock.calls[0];
+    expect(sentAnalytics.sampling).toEqual({ type: 'COUNT', value: '100' });
+});
+
+// ─── 6. OTel Logs disabled when tracing not enabled ──────────────────────────
+
+it('keeps the OTel Logs switch disabled when tracing is off', () => {
+    renderPage({ ...BASE_ANALYTICS, tracing: { enabled: false } });
+
+    const otelSwitch = screen.getByRole('switch', { name: /otel logs/i });
+    expect(otelSwitch).toBeDisabled();
+});

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/detail/reporter-settings/ApiReporterSettingsPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/detail/reporter-settings/ApiReporterSettingsPage.tsx
@@ -1,0 +1,388 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useEnvironment, useHasPermission } from '@gravitee/gamma-modules-sdk';
+import {
+    Alert,
+    AlertDescription,
+    Button,
+    Card,
+    CardContent,
+    CardHeader,
+    CardTitle,
+    Input,
+    Label,
+    Skeleton,
+    Switch,
+} from '@gravitee/graphene-core';
+import { ActivityIcon, TriangleAlertIcon } from '@gravitee/graphene-core/icons';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useEffect, useRef, useState } from 'react';
+import { useParams } from 'react-router-dom';
+
+import { SpanRedactionRules } from './SpanRedactionRules';
+import { useApiDetail } from '../../../hooks/useApiDetail';
+import { updateApiAnalytics } from '../../../services/apis';
+import type { Analytics, RedactionRule } from '../../../types';
+import { apiDetailKeys } from '../../../utils/queryKeys';
+
+// ─── Row ──────────────────────────────────────────────────────────────────────
+
+function SettingRow({
+    id,
+    label,
+    description,
+    checked,
+    disabled,
+    onCheckedChange,
+}: {
+    id: string;
+    label: string;
+    description?: string;
+    checked: boolean;
+    disabled?: boolean;
+    onCheckedChange: (v: boolean) => void;
+}) {
+    return (
+        <div className="flex items-start justify-between gap-4">
+            <div className="min-w-0">
+                <Label htmlFor={id} className="text-sm font-medium">
+                    {label}
+                </Label>
+                {description && <p className="text-xs text-muted-foreground mt-0.5 max-w-xl">{description}</p>}
+            </div>
+            <Switch id={id} checked={checked} onCheckedChange={onCheckedChange} disabled={disabled} />
+        </div>
+    );
+}
+
+// ─── Page ─────────────────────────────────────────────────────────────────────
+
+export function ApiReporterSettingsPage() {
+    const { apiId } = useParams<{ apiId: string }>();
+    const env = useEnvironment();
+    const queryClient = useQueryClient();
+
+    const canEdit = useHasPermission({ anyOf: ['api-definition-u'] });
+    const { data: api, isLoading, isError } = useApiDetail(apiId);
+
+    // ─── Form state ───────────────────────────────────────────────────────────
+    const [enabled, setEnabled] = useState(false);
+    const [entrypoint, setEntrypoint] = useState(false);
+    const [endpoint, setEndpoint] = useState(false);
+    const [request, setRequest] = useState(false);
+    const [response, setResponse] = useState(false);
+    const [headers, setHeaders] = useState(false);
+    const [payload, setPayload] = useState(false);
+    const [condition, setCondition] = useState('');
+    const [tracingEnabled, setTracingEnabled] = useState(false);
+    const [tracingVerbose, setTracingVerbose] = useState(false);
+    const [otelLogsEnabled, setOtelLogsEnabled] = useState(false);
+    const [redactionRules, setRedactionRules] = useState<RedactionRule[]>([]);
+    const [saveError, setSaveError] = useState<string | null>(null);
+
+    // Initialize form once per apiId — prevents background refetches from wiping in-progress edits
+    const initializedForApiIdRef = useRef<string | undefined>(undefined);
+
+    useEffect(() => {
+        if (!api || initializedForApiIdRef.current === apiId) return;
+        initializedForApiIdRef.current = apiId;
+        const a = api.analytics;
+        setEnabled(a?.enabled ?? false);
+        setEntrypoint(a?.logging?.mode?.entrypoint ?? false);
+        setEndpoint(a?.logging?.mode?.endpoint ?? false);
+        setRequest(a?.logging?.phase?.request ?? false);
+        setResponse(a?.logging?.phase?.response ?? false);
+        setHeaders(a?.logging?.content?.headers ?? false);
+        setPayload(a?.logging?.content?.payload ?? false);
+        setCondition(a?.logging?.condition ?? '');
+        setTracingEnabled(a?.tracing?.enabled ?? false);
+        setTracingVerbose(a?.tracing?.verbose ?? false);
+        setOtelLogsEnabled(a?.otelLogs?.enabled ?? false);
+        setRedactionRules(a?.tracing?.redaction?.rules ?? []);
+    }, [api, apiId]);
+
+    // ─── Derived disabled states ───────────────────────────────────────────────
+    const loggingFieldsDisabled = !enabled || (!entrypoint && !endpoint);
+    const tracingVerboseDisabled = !enabled || !tracingEnabled;
+    const otelLogsDisabled = !enabled || !tracingEnabled;
+
+    // ─── Mutation ─────────────────────────────────────────────────────────────
+    const mutation = useMutation({
+        mutationFn: (analytics: Analytics) => updateApiAnalytics(env!.id, apiId!, analytics),
+        onSuccess: () => {
+            queryClient.invalidateQueries({ queryKey: apiDetailKeys.detail(env?.id ?? '', apiId ?? '') });
+            initializedForApiIdRef.current = undefined;
+            setSaveError(null);
+        },
+        onError: (e: Error) => {
+            setSaveError(e.message || 'Failed to save reporter settings.');
+        },
+    });
+
+    const handleSave = () => {
+        mutation.mutate({
+            enabled,
+            logging: {
+                mode: { entrypoint, endpoint },
+                phase: { request, response },
+                content: { headers, payload },
+                ...(condition.trim() ? { condition: condition.trim() } : {}),
+            },
+            tracing: {
+                ...(api?.analytics?.tracing ?? {}),
+                enabled: tracingEnabled,
+                verbose: tracingVerbose,
+                redaction: {
+                    ...(api?.analytics?.tracing?.redaction ?? {}),
+                    rules: redactionRules,
+                },
+            },
+            otelLogs: { enabled: otelLogsEnabled },
+            sampling: api?.analytics?.sampling,
+        });
+    };
+
+    // ─── Loading ──────────────────────────────────────────────────────────────
+    if (isLoading) {
+        return (
+            <div className="space-y-6 p-6">
+                <div className="flex items-start justify-between gap-4">
+                    <div className="space-y-2">
+                        <Skeleton className="h-8 w-48 rounded" />
+                        <Skeleton className="h-4 w-80 rounded" />
+                    </div>
+                    <Skeleton className="h-8 w-28 rounded" />
+                </div>
+                <Skeleton className="h-14 w-full rounded-lg" />
+                <Skeleton className="h-64 w-full rounded-lg" />
+                <Skeleton className="h-40 w-full rounded-lg" />
+            </div>
+        );
+    }
+
+    if (isError) {
+        return (
+            <div className="p-6">
+                <Card className="border-destructive/30">
+                    <CardContent className="pt-4 pb-4">
+                        <p className="text-sm text-destructive">Failed to load reporter settings. Please try again.</p>
+                    </CardContent>
+                </Card>
+            </div>
+        );
+    }
+
+    return (
+        <div className="space-y-6 p-6">
+            {/* ─── Header ─────────────────────────────────────────────────── */}
+            <div className="flex items-start justify-between gap-4">
+                <div className="space-y-1">
+                    <h1 className="text-2xl font-semibold">Reporter Settings</h1>
+                    <p className="text-sm text-muted-foreground">
+                        Control how request and response data is reported for logs and analytics pipelines.
+                    </p>
+                </div>
+                {canEdit && (
+                    <Button size="sm" onClick={handleSave} disabled={mutation.isPending}>
+                        {mutation.isPending ? 'Saving…' : 'Save changes'}
+                    </Button>
+                )}
+            </div>
+
+            {/* ─── Save error ──────────────────────────────────────────────── */}
+            {saveError && (
+                <Alert variant="destructive">
+                    <AlertDescription>{saveError}</AlertDescription>
+                </Alert>
+            )}
+
+            {/* ─── Info banner ─────────────────────────────────────────────── */}
+            <Alert>
+                <AlertDescription>
+                    <span className="font-semibold">Logging smartly — </span>
+                    Enabling detailed logging increases storage and can affect gateway performance. Use payload logging and verbose tracing
+                    only when needed.
+                </AlertDescription>
+            </Alert>
+
+            {/* ─── Settings card ───────────────────────────────────────────── */}
+            <Card>
+                <CardHeader>
+                    <div className="flex items-start justify-between gap-4">
+                        <div>
+                            <CardTitle className="text-base">Settings</CardTitle>
+                            <p className="text-sm text-muted-foreground mt-0.5">Adjust reporter behavior for this API proxy.</p>
+                        </div>
+                        <Switch
+                            id="reporter-enabled"
+                            checked={enabled}
+                            onCheckedChange={setEnabled}
+                            disabled={!canEdit}
+                            aria-label="Enable analytics"
+                        />
+                    </div>
+                </CardHeader>
+                <CardContent className="space-y-0 divide-y divide-border">
+                    {/* Logging mode */}
+                    <div className="space-y-4 pb-6">
+                        <div>
+                            <p className="text-sm font-medium">Logging mode</p>
+                            <p className="text-xs text-muted-foreground mt-0.5">
+                                Choose which connection leg to include in reported events.
+                            </p>
+                        </div>
+                        <SettingRow
+                            id="reporter-entrypoint"
+                            label="Entrypoint"
+                            description="Client → gateway"
+                            checked={entrypoint}
+                            disabled={!enabled || !canEdit}
+                            onCheckedChange={setEntrypoint}
+                        />
+                        <SettingRow
+                            id="reporter-endpoint"
+                            label="Endpoint"
+                            description="Gateway → upstream"
+                            checked={endpoint}
+                            disabled={!enabled || !canEdit}
+                            onCheckedChange={setEndpoint}
+                        />
+                    </div>
+
+                    {/* Logging phase */}
+                    <div className="space-y-4 py-6">
+                        <div>
+                            <p className="text-sm font-medium">Logging phase</p>
+                            <p className="text-xs text-muted-foreground mt-0.5">Which lifecycle phases to capture.</p>
+                        </div>
+                        <SettingRow
+                            id="reporter-request"
+                            label="Request"
+                            checked={request}
+                            disabled={loggingFieldsDisabled || !canEdit}
+                            onCheckedChange={setRequest}
+                        />
+                        <SettingRow
+                            id="reporter-response"
+                            label="Response"
+                            checked={response}
+                            disabled={loggingFieldsDisabled || !canEdit}
+                            onCheckedChange={setResponse}
+                        />
+                    </div>
+
+                    {/* Content data */}
+                    <div className="space-y-4 py-6">
+                        <div>
+                            <p className="text-sm font-medium">Content data</p>
+                            <p className="text-xs text-muted-foreground mt-0.5">
+                                Optional inclusion of headers and bodies in log payloads.
+                            </p>
+                        </div>
+                        <SettingRow
+                            id="reporter-headers"
+                            label="Headers"
+                            checked={headers}
+                            disabled={loggingFieldsDisabled || !canEdit}
+                            onCheckedChange={setHeaders}
+                        />
+                        <SettingRow
+                            id="reporter-payload"
+                            label="Payload"
+                            checked={payload}
+                            disabled={loggingFieldsDisabled || !canEdit}
+                            onCheckedChange={setPayload}
+                        />
+                    </div>
+
+                    {/* Display conditions */}
+                    <div className="space-y-3 pt-6">
+                        <div>
+                            <p className="text-sm font-medium">Display conditions</p>
+                            <p className="text-xs text-muted-foreground mt-0.5">
+                                Expression Language filter for the request phase (optional).
+                            </p>
+                        </div>
+                        <div className="space-y-1.5">
+                            <Label htmlFor="reporter-condition" className="text-xs text-muted-foreground">
+                                Request phase condition
+                            </Label>
+                            <Input
+                                id="reporter-condition"
+                                value={condition}
+                                onChange={e => setCondition(e.target.value)}
+                                disabled={loggingFieldsDisabled || !canEdit}
+                                placeholder="{#request.headers['Content-Type'][0] == 'application/json'}"
+                            />
+                            <p className="text-xs text-muted-foreground">Supports EL expressions. Leave empty to log all requests.</p>
+                        </div>
+                    </div>
+                </CardContent>
+            </Card>
+
+            {/* ─── OpenTelemetry card ──────────────────────────────────────── */}
+            <Card>
+                <CardHeader>
+                    <CardTitle className="flex items-center gap-2 text-base">
+                        <ActivityIcon className="size-4 text-primary" />
+                        OpenTelemetry
+                    </CardTitle>
+                    <p className="text-sm text-muted-foreground mt-0.5">Configure distributed tracing and OTel log correlation.</p>
+                </CardHeader>
+                <CardContent className="space-y-4">
+                    <SettingRow
+                        id="reporter-tracing-enabled"
+                        label="Trace enabled"
+                        description="Enable OpenTelemetry tracing for this API. Captures execution spans and conditions."
+                        checked={tracingEnabled}
+                        disabled={!enabled || !canEdit}
+                        onCheckedChange={setTracingEnabled}
+                    />
+                    <SettingRow
+                        id="reporter-tracing-verbose"
+                        label="Verbose"
+                        description="Adds detailed span events with headers, context attributes, and policy execution details. Enable only for deep debugging — increases trace size significantly."
+                        checked={tracingVerbose}
+                        disabled={tracingVerboseDisabled || !canEdit}
+                        onCheckedChange={setTracingVerbose}
+                    />
+                    {tracingEnabled && tracingVerbose && (
+                        <Alert variant="destructive">
+                            <TriangleAlertIcon className="size-4" />
+                            <AlertDescription>
+                                Verbose mode significantly increases trace size. Disable after debugging is complete.
+                            </AlertDescription>
+                        </Alert>
+                    )}
+                    <SettingRow
+                        id="reporter-otel-logs"
+                        label="OTel Logs"
+                        description="Emit request and response payloads as OTel log records correlated to the active trace. Enables log-to-trace linking in Grafana and other OTel-compatible backends."
+                        checked={otelLogsEnabled}
+                        disabled={otelLogsDisabled || !canEdit}
+                        onCheckedChange={setOtelLogsEnabled}
+                    />
+
+                    {tracingEnabled && tracingVerbose && (
+                        <div className="pt-2 border-t border-border">
+                            <SpanRedactionRules key={apiId} rules={redactionRules} disabled={!canEdit} onChange={setRedactionRules} />
+                        </div>
+                    )}
+                </CardContent>
+            </Card>
+        </div>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/detail/reporter-settings/SpanRedactionRules.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/detail/reporter-settings/SpanRedactionRules.tsx
@@ -1,0 +1,411 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+    Alert,
+    AlertDescription,
+    Badge,
+    Button,
+    Dialog,
+    DialogContent,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+    Input,
+    Label,
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+    Table,
+    TableBody,
+    TableCell,
+    TableHead,
+    TableHeader,
+    TableRow,
+} from '@gravitee/graphene-core';
+import { PencilIcon, PlusIcon, Trash2Icon } from '@gravitee/graphene-core/icons';
+import { useState } from 'react';
+
+import type { MaskingType, RedactionRule } from '../../../types';
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+const PREVIEW_SAMPLE = 'ABCDEFGHIJ1234';
+
+function buildPartialPreview(prefix: number, suffix: number, maskChar: string): string {
+    const char = maskChar || '*';
+    const len = PREVIEW_SAMPLE.length;
+    if (prefix + suffix >= len) return PREVIEW_SAMPLE;
+    return PREVIEW_SAMPLE.slice(0, prefix) + char.repeat(len - prefix - suffix) + PREVIEW_SAMPLE.slice(len - suffix);
+}
+
+function maskingDescription(rule: RedactionRule): string {
+    const s = rule.maskingStrategy;
+    if (!s || s.type === 'FULL') {
+        return `Replace with ${s?.replacement ?? '[REDACTED]'}`;
+    }
+    const prefix = s.prefixLength ?? 0;
+    const suffix = s.suffixLength ?? 0;
+    const char = s.replacement ?? '*';
+    return `Keep ${prefix}+${suffix} chars, mask with '${char}'`;
+}
+
+// ─── Dialog form state ────────────────────────────────────────────────────────
+
+interface DialogForm {
+    pattern: string;
+    maskingType: MaskingType;
+    fullReplacement: string;
+    prefixLength: number;
+    suffixLength: number;
+    maskChar: string;
+    valuePattern: string;
+    patternError: string | null;
+}
+
+const DEFAULT_FORM: DialogForm = {
+    pattern: '',
+    maskingType: 'FULL',
+    fullReplacement: '',
+    prefixLength: 0,
+    suffixLength: 0,
+    maskChar: '*',
+    valuePattern: '',
+    patternError: null,
+};
+
+function formFromRule(rule: RedactionRule): DialogForm {
+    const s = rule.maskingStrategy;
+    const isPartial = s?.type === 'PARTIAL';
+    return {
+        pattern: rule.attributeNamePattern,
+        maskingType: s?.type ?? 'FULL',
+        fullReplacement: !isPartial ? (s?.replacement ?? '') : '',
+        prefixLength: s?.prefixLength ?? 0,
+        suffixLength: s?.suffixLength ?? 0,
+        maskChar: isPartial ? (s?.replacement ?? '*') : '*',
+        valuePattern: rule.valuePattern ?? '',
+        patternError: null,
+    };
+}
+
+// ─── Rule dialog ──────────────────────────────────────────────────────────────
+
+interface RuleDialogProps {
+    open: boolean;
+    isEdit: boolean;
+    form: DialogForm;
+    onFormChange: (f: DialogForm) => void;
+    onSave: () => void;
+    onClose: () => void;
+}
+
+function RuleDialog({ open, isEdit, form, onFormChange, onSave, onClose }: RuleDialogProps) {
+    const set = (partial: Partial<DialogForm>) => onFormChange({ ...form, ...partial });
+    const isPartial = form.maskingType === 'PARTIAL';
+    const preview = isPartial ? buildPartialPreview(form.prefixLength, form.suffixLength, form.maskChar) : null;
+
+    return (
+        <Dialog open={open} onOpenChange={open => !open && onClose()}>
+            <DialogContent showCloseButton>
+                <DialogHeader>
+                    <DialogTitle>{isEdit ? 'Edit redaction rule' : 'New redaction rule'}</DialogTitle>
+                </DialogHeader>
+
+                <div className="space-y-2 py-1">
+                    {/* Attribute name pattern */}
+                    <div className="space-y-2">
+                        <Label htmlFor="rd-pattern">
+                            Attribute Name Pattern{' '}
+                            <span className="text-destructive" aria-hidden>
+                                *
+                            </span>
+                        </Label>
+                        <Input
+                            id="rd-pattern"
+                            value={form.pattern}
+                            onChange={e => set({ pattern: e.target.value, patternError: null })}
+                            placeholder="e.g. api-key"
+                        />
+                        {form.patternError && <p className="text-xs text-destructive">{form.patternError}</p>}
+                        <p className="text-xs text-muted-foreground">
+                            Short name matches any namespace · <code>*</code> = one segment · <code>**</code> = any depth · prefix with{' '}
+                            <code>regex:</code> for exact match
+                        </p>
+                    </div>
+
+                    {/* Masking type */}
+                    <div className="space-y-2">
+                        <Label htmlFor="rd-masking">Masking Type</Label>
+                        <Select value={form.maskingType} onValueChange={(v: MaskingType) => set({ maskingType: v })}>
+                            <SelectTrigger id="rd-masking">
+                                <SelectValue />
+                            </SelectTrigger>
+                            <SelectContent>
+                                <SelectItem value="FULL">Full Mask — replace entire value</SelectItem>
+                                <SelectItem value="PARTIAL">Partial Mask — keep prefix / suffix visible</SelectItem>
+                            </SelectContent>
+                        </Select>
+                    </div>
+
+                    {/* Full: replacement text */}
+                    {!isPartial && (
+                        <div className="space-y-2">
+                            <Label htmlFor="rd-replacement">Replacement Text</Label>
+                            <Input
+                                id="rd-replacement"
+                                value={form.fullReplacement}
+                                onChange={e => set({ fullReplacement: e.target.value })}
+                                placeholder="[REDACTED]"
+                            />
+                            <p className="text-xs text-muted-foreground">Leave blank to use the default: [REDACTED]</p>
+                        </div>
+                    )}
+
+                    {/* Partial: prefix / suffix / mask char + preview */}
+                    {isPartial && (
+                        <div className="space-y-2">
+                            <div className="grid grid-cols-3 gap-3">
+                                <div className="space-y-2">
+                                    <Label htmlFor="rd-prefix">Prefix chars</Label>
+                                    <Input
+                                        id="rd-prefix"
+                                        type="number"
+                                        min={0}
+                                        value={form.prefixLength}
+                                        onChange={e => set({ prefixLength: Math.max(0, Number(e.target.value) || 0) })}
+                                    />
+                                </div>
+                                <div className="space-y-2">
+                                    <Label htmlFor="rd-suffix">Suffix chars</Label>
+                                    <Input
+                                        id="rd-suffix"
+                                        type="number"
+                                        min={0}
+                                        value={form.suffixLength}
+                                        onChange={e => set({ suffixLength: Math.max(0, Number(e.target.value) || 0) })}
+                                    />
+                                </div>
+                                <div className="space-y-2">
+                                    <Label htmlFor="rd-maskchar">Mask char</Label>
+                                    <Input
+                                        id="rd-maskchar"
+                                        value={form.maskChar}
+                                        maxLength={1}
+                                        onChange={e => set({ maskChar: e.target.value })}
+                                        placeholder="*"
+                                    />
+                                </div>
+                            </div>
+                            <div className="rounded-md bg-muted px-3 py-2 text-xs">
+                                Preview: <code>{preview}</code>
+                            </div>
+                        </div>
+                    )}
+
+                    {/* Value filter */}
+                    <div className="space-y-2">
+                        <Label htmlFor="rd-value-pattern">Value Filter (optional)</Label>
+                        <Input
+                            id="rd-value-pattern"
+                            value={form.valuePattern}
+                            onChange={e => set({ valuePattern: e.target.value })}
+                            placeholder="e.g. ^Bearer "
+                        />
+                        <p className="text-xs text-muted-foreground">
+                            Regex (partial match). Rule fires only when the attribute value matches.
+                        </p>
+                    </div>
+                </div>
+
+                <DialogFooter>
+                    <Button variant="ghost" onClick={onClose}>
+                        Cancel
+                    </Button>
+                    <Button onClick={onSave}>{isEdit ? 'Save' : 'Add'}</Button>
+                </DialogFooter>
+            </DialogContent>
+        </Dialog>
+    );
+}
+
+// ─── Panel ────────────────────────────────────────────────────────────────────
+
+type RuleRow = RedactionRule & { _id: string };
+
+export interface SpanRedactionRulesProps {
+    rules: RedactionRule[];
+    disabled?: boolean;
+    onChange: (rules: RedactionRule[]) => void;
+}
+
+export function SpanRedactionRules({ rules, disabled, onChange }: SpanRedactionRulesProps) {
+    // Lazy-init: rows are seeded from the prop once on mount (same intent as initializedForApiIdRef
+    // on the parent page — prevents background refetches from wiping in-progress edits).
+    const [rows, setRows] = useState<RuleRow[]>(() => rules.map(r => ({ ...r, _id: crypto.randomUUID() })));
+
+    const [dialogOpen, setDialogOpen] = useState(false);
+    const [editId, setEditId] = useState<string | null>(null);
+    const [form, setForm] = useState<DialogForm>(DEFAULT_FORM);
+
+    const commit = (next: RuleRow[]) => {
+        setRows(next);
+        onChange(next.map(({ _id, ...r }) => r));
+    };
+
+    const openAdd = () => {
+        setEditId(null);
+        setForm(DEFAULT_FORM);
+        setDialogOpen(true);
+    };
+
+    const openEdit = (id: string) => {
+        const row = rows.find(r => r._id === id);
+        if (!row) return;
+        setEditId(id);
+        setForm(formFromRule(row));
+        setDialogOpen(true);
+    };
+
+    const closeDialog = () => {
+        setDialogOpen(false);
+        setEditId(null);
+    };
+
+    const removeRow = (id: string) => commit(rows.filter(r => r._id !== id));
+
+    const existingPatterns = rows.filter(r => r._id !== editId).map(r => r.attributeNamePattern);
+
+    const handleSave = () => {
+        const pattern = form.pattern.trim();
+        if (!pattern) {
+            setForm(f => ({ ...f, patternError: 'Pattern is required.' }));
+            return;
+        }
+        if (existingPatterns.includes(pattern)) {
+            setForm(f => ({ ...f, patternError: 'A rule with this pattern already exists.' }));
+            return;
+        }
+
+        const isPartial = form.maskingType === 'PARTIAL';
+        const rule: RedactionRule = {
+            attributeNamePattern: pattern,
+            maskingStrategy: isPartial
+                ? {
+                      type: 'PARTIAL',
+                      prefixLength: form.prefixLength,
+                      suffixLength: form.suffixLength,
+                      replacement: form.maskChar || '*',
+                  }
+                : {
+                      type: 'FULL',
+                      ...(form.fullReplacement.trim() ? { replacement: form.fullReplacement.trim() } : {}),
+                  },
+            ...(form.valuePattern.trim() ? { valuePattern: form.valuePattern.trim() } : {}),
+        };
+
+        if (editId) {
+            commit(rows.map(r => (r._id === editId ? { ...rule, _id: editId } : r)));
+        } else {
+            commit([...rows, { ...rule, _id: crypto.randomUUID() }]);
+        }
+        closeDialog();
+    };
+
+    return (
+        <div className="space-y-3">
+            <div className="flex items-center justify-between">
+                <p className="text-sm font-medium">Span Attribute Redaction</p>
+                {!disabled && (
+                    <Button variant="outline" size="sm" onClick={openAdd}>
+                        <PlusIcon className="size-3.5" aria-hidden />
+                        Add rule
+                    </Button>
+                )}
+            </div>
+
+            <Alert>
+                <AlertDescription>
+                    Global redaction rules are always applied first. Rules defined here are API-specific and appended after them.
+                </AlertDescription>
+            </Alert>
+
+            {rows.length === 0 ? (
+                <p className="text-xs text-muted-foreground py-2">No redaction rules — span attributes are exported as-is.</p>
+            ) : (
+                <Table>
+                    <TableHeader>
+                        <TableRow>
+                            <TableHead className="w-8">#</TableHead>
+                            <TableHead>Attribute Pattern</TableHead>
+                            <TableHead>Masking</TableHead>
+                            <TableHead>Value Filter</TableHead>
+                            {!disabled && <TableHead className="w-20" />}
+                        </TableRow>
+                    </TableHeader>
+                    <TableBody>
+                        {rows.map((row, i) => (
+                            <TableRow key={row._id}>
+                                <TableCell>
+                                    <Badge variant="secondary">{i + 1}</Badge>
+                                </TableCell>
+                                <TableCell>
+                                    <code className="text-xs">{row.attributeNamePattern}</code>
+                                </TableCell>
+                                <TableCell className="text-xs">{maskingDescription(row)}</TableCell>
+                                <TableCell className="text-xs">
+                                    {row.valuePattern ? <code>{row.valuePattern}</code> : <span className="text-muted-foreground">—</span>}
+                                </TableCell>
+                                {!disabled && (
+                                    <TableCell>
+                                        <div className="flex gap-1">
+                                            <Button
+                                                variant="ghost"
+                                                size="icon-sm"
+                                                aria-label={`Edit rule ${i + 1}`}
+                                                onClick={() => openEdit(row._id)}
+                                            >
+                                                <PencilIcon className="size-3.5" />
+                                            </Button>
+                                            <Button
+                                                variant="ghost"
+                                                size="icon-sm"
+                                                aria-label={`Delete rule ${i + 1}`}
+                                                onClick={() => removeRow(row._id)}
+                                            >
+                                                <Trash2Icon className="size-3.5 text-destructive" />
+                                            </Button>
+                                        </div>
+                                    </TableCell>
+                                )}
+                            </TableRow>
+                        ))}
+                    </TableBody>
+                </Table>
+            )}
+
+            <RuleDialog
+                open={dialogOpen}
+                isEdit={editId !== null}
+                form={form}
+                onFormChange={setForm}
+                onSave={handleSave}
+                onClose={closeDialog}
+            />
+        </div>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/services/alerts.ts
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/services/alerts.ts
@@ -26,7 +26,7 @@ import type {
     AlertOperator,
     AlertStringOperator,
     AlertTrigger,
-} from '../types/api';
+} from '../types';
 
 // ─── Condition converters ──────────────────────────────────────────────────────
 

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/services/apiList.ts
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/services/apiList.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import { apimFetchJsonV2 } from '../../../shared/api/apimClient';
-import type { ApiListResponse, ApiSearchQuery } from '../types/api';
+import type { ApiListResponse, ApiSearchQuery } from '../types';
 
 const JSON_HEADERS = { 'Content-Type': 'application/json' };
 

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/services/apiProxy.ts
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/services/apiProxy.ts
@@ -21,7 +21,7 @@ import type {
     CreateApiProxyRequest,
     PathToVerify,
     VerifyApiPathResponse,
-} from '../types/api';
+} from '../types';
 
 const JSON_HEADERS = { 'Content-Type': 'application/json' };
 

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/services/apis.ts
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/services/apis.ts
@@ -14,7 +14,16 @@
  * limitations under the License.
  */
 import { apimFetchJsonV2 } from '../../../shared/api/apimClient';
-import type { ApiDetailDto, ApiEventsPage, DuplicateApiOptions, Cors, DynamicPropertyConfig, Failover, Property } from '../types/api';
+import type {
+    Analytics,
+    ApiDetailDto,
+    ApiEventsPage,
+    DuplicateApiOptions,
+    Cors,
+    DynamicPropertyConfig,
+    Failover,
+    Property,
+} from '../types';
 
 const JSON_HEADERS = { 'Content-Type': 'application/json' };
 
@@ -159,6 +168,15 @@ export async function updateApiCors(environmentId: string, apiId: string, cors: 
         method: 'PUT',
         headers: JSON_HEADERS,
         body: JSON.stringify({ ...current, listeners: updatedListeners.length > 0 ? updatedListeners : current.listeners }),
+    });
+}
+
+export async function updateApiAnalytics(environmentId: string, apiId: string, analytics: Analytics): Promise<void> {
+    const current = await apimFetchJsonV2<Record<string, unknown>>(environmentId, `/apis/${encodeURIComponent(apiId)}`);
+    await apimFetchJsonV2(environmentId, `/apis/${encodeURIComponent(apiId)}`, {
+        method: 'PUT',
+        headers: JSON_HEADERS,
+        body: JSON.stringify({ ...current, analytics }),
     });
 }
 

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/services/entrypoints.ts
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/services/entrypoints.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import { apimFetchJsonV2 } from '../../../shared/api/apimClient';
-import type { ApiDetailDto, ExposedEntrypoint, HttpListener } from '../types/api';
+import type { ApiDetailDto, ExposedEntrypoint, HttpListener } from '../types';
 
 const JSON_HEADERS = { 'Content-Type': 'application/json' };
 

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/types/alert.ts
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/types/alert.ts
@@ -1,0 +1,139 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export type AlertSeverity = 'INFO' | 'WARNING' | 'CRITICAL';
+
+export type AlertRuleId =
+    | 'REQUEST@METRICS_SIMPLE_CONDITION'
+    | 'REQUEST@MISSING_DATA'
+    | 'REQUEST@METRICS_AGGREGATION'
+    | 'REQUEST@METRICS_RATE'
+    | 'ENDPOINT_HEALTH_CHECK@API_HC_ENDPOINT_STATUS_CHANGED';
+
+export type AlertConditionType = 'STRING' | 'THRESHOLD' | 'THRESHOLD_RANGE' | 'COMPARE' | 'AGGREGATION' | 'RATE' | 'MISSING_DATA';
+
+export type AlertOperator = 'LT' | 'LTE' | 'GTE' | 'GT';
+export type AlertStringOperator = 'EQUALS' | 'NOT_EQUALS' | 'STARTS_WITH' | 'ENDS_WITH' | 'CONTAINS' | 'MATCHES';
+export type AlertAggregationFunction = 'COUNT' | 'AVG' | 'MIN' | 'MAX' | 'P50' | 'P90' | 'P95' | 'P99';
+export type AlertTimeUnit = 'SECONDS' | 'MINUTES' | 'HOURS';
+export type AlertDampeningMode = 'STRICT_COUNT' | 'RELAXED_COUNT' | 'RELAXED_TIME' | 'STRICT_TIME';
+export type AlertNotificationChannel = 'email-notifier' | 'slack-notifier' | 'default-email' | 'webhook-notifier';
+
+/** Denormalized condition used as form state — flat for easy React updates. */
+export interface AlertFormCondition {
+    type: AlertConditionType;
+    property?: string;
+    operator?: AlertOperator | AlertStringOperator;
+    threshold?: number;
+    thresholdLow?: number;
+    thresholdHigh?: number;
+    pattern?: string;
+    property2?: string;
+    multiplier?: number;
+    duration?: number;
+    timeUnit?: AlertTimeUnit;
+    aggregationFunction?: AlertAggregationFunction;
+    /** RATE only — operator for the comparison (inner) condition */
+    rateOperator?: AlertOperator;
+    /** RATE only — rate percentage threshold (0-100) */
+    rateThreshold?: number;
+}
+
+/** Simplified notification shape used in form state. */
+export interface AlertFormNotification {
+    channel: AlertNotificationChannel;
+    target: string;
+}
+
+/** Timeframe used in form state. */
+export interface AlertFormTimeframe {
+    days: number[];
+    startHour: number;
+    endHour: number;
+}
+
+export interface AlertDampening {
+    mode: AlertDampeningMode;
+    trueEvaluations?: number;
+    totalEvaluations?: number;
+    duration?: number;
+    timeUnit?: AlertTimeUnit;
+}
+
+/** The raw API shape for a condition (sent to / received from the server). */
+export interface AlertApiCondition {
+    type: AlertConditionType;
+    property?: string;
+    operator?: AlertOperator | AlertStringOperator;
+    threshold?: number;
+    thresholdLow?: number;
+    thresholdHigh?: number;
+    operatorLow?: 'INCLUSIVE' | 'EXCLUSIVE';
+    operatorHigh?: 'INCLUSIVE' | 'EXCLUSIVE';
+    pattern?: string;
+    property2?: string;
+    multiplier?: number;
+    duration?: number;
+    timeUnit?: AlertTimeUnit;
+    function?: AlertAggregationFunction;
+    comparison?: AlertApiCondition;
+}
+
+/** API notification payload shape. */
+export interface AlertApiNotification {
+    type: string;
+    configuration?: Record<string, unknown>;
+}
+
+/** API notification period shape. */
+export interface AlertApiPeriod {
+    days: number[];
+    beginHour: number;
+    endHour: number;
+    zoneId?: string;
+}
+
+/** Full alert trigger entity returned by the API. */
+export interface AlertTrigger {
+    id?: string;
+    name: string;
+    description?: string;
+    severity: AlertSeverity;
+    enabled: boolean;
+    source: string;
+    type: string;
+    conditions?: AlertApiCondition[];
+    filters?: AlertApiCondition[];
+    notifications?: AlertApiNotification[];
+    notificationPeriods?: AlertApiPeriod[];
+    dampening?: AlertDampening;
+    counters?: Record<string, number>;
+    last_alert_at?: string | null;
+    last_alert_message?: string | null;
+    created_at?: string;
+    updated_at?: string;
+}
+
+export interface AlertHistoryEvent {
+    id: string;
+    message: string;
+    createdAt: string;
+}
+
+export interface AlertHistoryPage {
+    content: AlertHistoryEvent[];
+    totalElements: number;
+}

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/types/analytics.ts
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/types/analytics.ts
@@ -1,0 +1,56 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export interface AnalyticsLogging {
+    mode?: { entrypoint?: boolean; endpoint?: boolean };
+    phase?: { request?: boolean; response?: boolean };
+    content?: { headers?: boolean; payload?: boolean };
+    condition?: string;
+}
+
+export type MaskingType = 'FULL' | 'PARTIAL';
+
+export interface MaskingStrategy {
+    type: MaskingType;
+    /** FULL: replacement text (defaults to [REDACTED]); PARTIAL: mask character (defaults to *) */
+    replacement?: string;
+    prefixLength?: number;
+    suffixLength?: number;
+}
+
+export interface RedactionRule {
+    attributeNamePattern: string;
+    maskingStrategy?: MaskingStrategy;
+    /** Regex partial-match filter; rule only fires when the attribute value matches */
+    valuePattern?: string;
+}
+
+export interface AnalyticsTracing {
+    enabled?: boolean;
+    verbose?: boolean;
+    redaction?: {
+        defaultReplacement?: string;
+        rules?: RedactionRule[];
+    };
+}
+
+export interface Analytics {
+    enabled?: boolean;
+    logging?: AnalyticsLogging;
+    tracing?: AnalyticsTracing;
+    otelLogs?: { enabled?: boolean };
+    sampling?: { type?: string; value?: string };
+}

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/types/api.ts
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/types/api.ts
@@ -14,6 +14,9 @@
  * limitations under the License.
  */
 
+import type { Analytics } from './analytics';
+import type { PlanSecurity } from './plan';
+
 export interface PathToVerify {
     path: string;
     host?: string;
@@ -67,13 +70,6 @@ export interface HttpEndpointGroup {
     type: 'http-proxy';
     sharedConfiguration: Record<string, unknown>;
     endpoints: HttpEndpoint[];
-}
-
-export type PlanSecurityType = 'KEY_LESS' | 'API_KEY' | 'JWT' | 'OAUTH2' | 'MTLS';
-
-export interface PlanSecurity {
-    type: PlanSecurityType;
-    configuration?: Record<string, unknown>;
 }
 
 export interface CreateApiProxyRequest {
@@ -207,6 +203,7 @@ export interface ApiDetailDto {
     background?: string;
     properties?: Property[];
     services?: { dynamicProperty?: DynamicPropertyConfig };
+    analytics?: Analytics;
     listeners?: HttpListener[];
     endpointGroups?: ApiEndpointGroup[];
     failover?: Failover;
@@ -277,130 +274,4 @@ export interface DynamicPropertyConfig {
 
 export interface ExposedEntrypoint {
     value: string;
-}
-
-// ─── Alert types ──────────────────────────────────────────────────────────────
-
-export type AlertSeverity = 'INFO' | 'WARNING' | 'CRITICAL';
-
-export type AlertRuleId =
-    | 'REQUEST@METRICS_SIMPLE_CONDITION'
-    | 'REQUEST@MISSING_DATA'
-    | 'REQUEST@METRICS_AGGREGATION'
-    | 'REQUEST@METRICS_RATE'
-    | 'ENDPOINT_HEALTH_CHECK@API_HC_ENDPOINT_STATUS_CHANGED';
-
-export type AlertConditionType = 'STRING' | 'THRESHOLD' | 'THRESHOLD_RANGE' | 'COMPARE' | 'AGGREGATION' | 'RATE' | 'MISSING_DATA';
-
-export type AlertOperator = 'LT' | 'LTE' | 'GTE' | 'GT';
-export type AlertStringOperator = 'EQUALS' | 'NOT_EQUALS' | 'STARTS_WITH' | 'ENDS_WITH' | 'CONTAINS' | 'MATCHES';
-export type AlertAggregationFunction = 'COUNT' | 'AVG' | 'MIN' | 'MAX' | 'P50' | 'P90' | 'P95' | 'P99';
-export type AlertTimeUnit = 'SECONDS' | 'MINUTES' | 'HOURS';
-export type AlertDampeningMode = 'STRICT_COUNT' | 'RELAXED_COUNT' | 'RELAXED_TIME' | 'STRICT_TIME';
-export type AlertNotificationChannel = 'email-notifier' | 'slack-notifier' | 'default-email' | 'webhook-notifier';
-
-/** Denormalized condition used as form state — flat for easy React updates. */
-export interface AlertFormCondition {
-    type: AlertConditionType;
-    property?: string;
-    operator?: AlertOperator | AlertStringOperator;
-    threshold?: number;
-    thresholdLow?: number;
-    thresholdHigh?: number;
-    pattern?: string;
-    property2?: string;
-    multiplier?: number;
-    duration?: number;
-    timeUnit?: AlertTimeUnit;
-    aggregationFunction?: AlertAggregationFunction;
-    /** RATE only — operator for the comparison (inner) condition */
-    rateOperator?: AlertOperator;
-    /** RATE only — rate percentage threshold (0-100) */
-    rateThreshold?: number;
-}
-
-/** Simplified notification shape used in form state. */
-export interface AlertFormNotification {
-    channel: AlertNotificationChannel;
-    target: string;
-}
-
-/** Timeframe used in form state. */
-export interface AlertFormTimeframe {
-    days: number[];
-    startHour: number;
-    endHour: number;
-}
-
-export interface AlertDampening {
-    mode: AlertDampeningMode;
-    trueEvaluations?: number;
-    totalEvaluations?: number;
-    duration?: number;
-    timeUnit?: AlertTimeUnit;
-}
-
-/** The raw API shape for a condition (sent to / received from the server). */
-export interface AlertApiCondition {
-    type: AlertConditionType;
-    property?: string;
-    operator?: AlertOperator | AlertStringOperator;
-    threshold?: number;
-    thresholdLow?: number;
-    thresholdHigh?: number;
-    operatorLow?: 'INCLUSIVE' | 'EXCLUSIVE';
-    operatorHigh?: 'INCLUSIVE' | 'EXCLUSIVE';
-    pattern?: string;
-    property2?: string;
-    multiplier?: number;
-    duration?: number;
-    timeUnit?: AlertTimeUnit;
-    function?: AlertAggregationFunction;
-    comparison?: AlertApiCondition;
-}
-
-/** API notification payload shape. */
-export interface AlertApiNotification {
-    type: string;
-    configuration?: Record<string, unknown>;
-}
-
-/** API notification period shape. */
-export interface AlertApiPeriod {
-    days: number[];
-    beginHour: number;
-    endHour: number;
-    zoneId?: string;
-}
-
-/** Full alert trigger entity returned by the API. */
-export interface AlertTrigger {
-    id?: string;
-    name: string;
-    description?: string;
-    severity: AlertSeverity;
-    enabled: boolean;
-    source: string;
-    type: string;
-    conditions?: AlertApiCondition[];
-    filters?: AlertApiCondition[];
-    notifications?: AlertApiNotification[];
-    notificationPeriods?: AlertApiPeriod[];
-    dampening?: AlertDampening;
-    counters?: Record<string, number>;
-    last_alert_at?: string | null;
-    last_alert_message?: string | null;
-    created_at?: string;
-    updated_at?: string;
-}
-
-export interface AlertHistoryEvent {
-    id: string;
-    message: string;
-    createdAt: string;
-}
-
-export interface AlertHistoryPage {
-    content: AlertHistoryEvent[];
-    totalElements: number;
 }

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/types/index.ts
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/types/index.ts
@@ -13,9 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { apimFetchJsonV1Env } from '../../../shared/api/apimClient';
-import type { EnvCategory } from '../types';
 
-export async function getEnvCategories(environmentId: string): Promise<EnvCategory[]> {
-    return apimFetchJsonV1Env<EnvCategory[]>(environmentId, '/configuration/categories');
-}
+export * from './alert';
+export * from './analytics';
+export * from './api';
+export * from './apiCreation';
+export * from './auditLogs.types';
+export * from './broadcast';
+export * from './members.types';
+export * from './notification';
+export * from './plan';
+export * from './subscription';

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/utils/apiAccess.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/utils/apiAccess.spec.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import { getApiAccessPath } from './apiAccess';
-import type { ApiListItem } from '../types/api';
+import type { ApiListItem } from '../types';
 
 function makeApi(overrides: Partial<ApiListItem> = {}): ApiListItem {
     return { id: '1', name: 'Test API', apiVersion: '1.0', type: 'PROXY', definitionVersion: 'V4', ...overrides };

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/utils/apiAccess.ts
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/utils/apiAccess.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import type { ApiListItem } from '../types/api';
+import type { ApiListItem } from '../types';
 
 /**
  * Extracts the primary access path from an API's listeners.

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/utils/apiProxyMapper.ts
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/utils/apiProxyMapper.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import type { CreateApiPlanRequest, CreateApiProxyRequest, HttpListener, PlanSecurity } from '../types/api';
+import type { CreateApiPlanRequest, CreateApiProxyRequest, HttpListener, PlanSecurity } from '../types';
 import type { ApiProxyDraft } from '../types/apiCreation';
 
 export const GATEWAY_URL_PLACEHOLDER = 'https://gateway.company.com';

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/dashboard/components/DashboardRecentActivity.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/dashboard/components/DashboardRecentActivity.tsx
@@ -16,7 +16,7 @@
 import { Badge, Button, Card, CardContent, Skeleton } from '@gravitee/graphene-core';
 import { ArrowRightIcon, TriangleAlertIcon } from '@gravitee/graphene-core/icons';
 
-import type { ApiDeploymentState, ApiListItem, ApiState } from '../../apis/types/api';
+import type { ApiDeploymentState, ApiListItem, ApiState } from '../../apis/types';
 import { useDashboardRecentApis } from '../hooks/useDashboardRecentApis';
 
 // ─── State helpers ────────────────────────────────────────────────────────────

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/dashboard/components/DashboardSearchCard.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/dashboard/components/DashboardSearchCard.tsx
@@ -23,7 +23,7 @@ import { searchApiProducts } from '../../api-products/services/apiProduct';
 import type { ApiProductListItem } from '../../api-products/types/apiProduct';
 import { apiProductKeys } from '../../api-products/utils/queryKeys';
 import { searchApis } from '../../apis/services/apiList';
-import type { ApiListItem } from '../../apis/types/api';
+import type { ApiListItem } from '../../apis/types';
 import { apiListKeys } from '../../apis/utils/queryKeys';
 
 const MAX_RESULTS = 5;

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/dashboard/hooks/useDashboardRecentApis.ts
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/dashboard/hooks/useDashboardRecentApis.ts
@@ -17,7 +17,7 @@ import { useEnvironment } from '@gravitee/gamma-modules-sdk';
 import { useQuery } from '@tanstack/react-query';
 
 import { searchApis } from '../../apis/services/apiList';
-import type { ApiListItem } from '../../apis/types/api';
+import type { ApiListItem } from '../../apis/types';
 import { apiListKeys } from '../../apis/utils/queryKeys';
 
 const RECENT_PAGE = 1;

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/settings/services/organizationTags.ts
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/settings/services/organizationTags.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import { apimFetchJsonOrg } from '../../../shared/api/apimClient';
-import type { OrgShardingTag } from '../../apis/types/api';
+import type { OrgShardingTag } from '../../apis/types';
 
 export async function getOrgTags(): Promise<OrgShardingTag[]> {
     return apimFetchJsonOrg<OrgShardingTag[]>(`/configuration/tags`);


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/GMA-235

## Description

- Replace placeholder route with full reporter settings page
- Logging toggles: mode (entrypoint/endpoint), phase, content, condition
- OpenTelemetry section: trace enabled, verbose with warning, OTel logs
- SpanRedactionRules panel: table + add/edit/delete dialog with full/partial masking
- updateApiAnalytics service using GET-then-PUT pattern
- Preserves sampling field and redaction rules in save payload
- Spec: permissions, cascade toggle behavior, sampling preservation

Commit 2:

- Extract Alert* types from api.ts → types/alert.ts
- Extract Analytics/Masking/Redaction types from api.ts → types/analytics.ts
- Add types/index.ts barrel so all consumers use a single import path
- Slim api.ts to core API entity types only
- Deduplicate PlanSecurity (was defined in both api.ts and plan.ts)
- Update all existing import paths from 'types/api' to 'types'

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

