### PR TITLE
[MCP Tool]: migrate openapi to mcp tools from UI to Back

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/mcp_tool/domain_service/OpenApiToMcpToolsDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/mcp_tool/domain_service/OpenApiToMcpToolsDomainService.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.mcp_tool.domain_service;
+
+import io.gravitee.apim.core.mcp_tool.model.OpenApiToMcpToolsResult;
+
+/**
+ * Parses an OpenAPI specification and produces the list of MCP tools its operations
+ * map to. The output shape matches the {@code MCPTool} configuration consumed by the
+ * {@code gravitee-entrypoint-mcp} gateway plugin: tools returned here can be persisted
+ * then handed to the gateway without further transformation.
+ *
+ * <p>Implementations must accept both JSON and YAML payloads, both OpenAPI 3.x and
+ * Swagger 2.0 (transparently converted to 3.0). Non-fatal issues encountered while
+ * parsing are accumulated in {@link OpenApiToMcpToolsResult#errors()} rather than
+ * thrown; a fatal issue (unparseable input, invalid spec, dereferencing failure)
+ * returns an empty tool list with the corresponding error key.
+ */
+public interface OpenApiToMcpToolsDomainService {
+    OpenApiToMcpToolsResult parse(String openApiSpec);
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/mcp_tool/model/McpTool.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/mcp_tool/model/McpTool.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.mcp_tool.model;
+
+import lombok.Builder;
+
+/**
+ * An MCP tool derived from an OpenAPI operation. The shape is aligned byte-for-byte
+ * with the {@code MCPTool} configuration consumed by the {@code gravitee-entrypoint-mcp}
+ * gateway plugin: any tool produced here can be persisted then handed to the gateway
+ * without further transformation.
+ */
+@Builder(toBuilder = true)
+public record McpTool(McpToolDefinition toolDefinition, McpToolGatewayMapping gatewayMapping) {}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/mcp_tool/model/McpToolAnnotations.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/mcp_tool/model/McpToolAnnotations.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.mcp_tool.model;
+
+import lombok.Builder;
+
+@Builder(toBuilder = true)
+public record McpToolAnnotations(
+    String title,
+    Boolean readOnlyHint,
+    Boolean destructiveHint,
+    Boolean idempotentHint,
+    Boolean openWorldHint
+) {}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/mcp_tool/model/McpToolDefinition.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/mcp_tool/model/McpToolDefinition.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.mcp_tool.model;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import lombok.Builder;
+
+@Builder(toBuilder = true)
+public record McpToolDefinition(
+    String name,
+    String description,
+    JsonNode inputSchema,
+    JsonNode outputSchema,
+    McpToolAnnotations annotations
+) {}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/mcp_tool/model/McpToolGatewayMapping.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/mcp_tool/model/McpToolGatewayMapping.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.mcp_tool.model;
+
+import lombok.Builder;
+
+@Builder(toBuilder = true)
+public record McpToolGatewayMapping(McpToolGatewayMappingHttp http) {}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/mcp_tool/model/McpToolGatewayMappingHttp.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/mcp_tool/model/McpToolGatewayMappingHttp.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.mcp_tool.model;
+
+import java.util.List;
+import lombok.Builder;
+
+/**
+ * HTTP-flavoured gateway mapping. The {@code path} uses Express-style placeholders
+ * ({@code :paramName}) — same syntax expected by the {@code gravitee-entrypoint-mcp}
+ * gateway plugin — even though the underlying OpenAPI spec uses {@code {paramName}}.
+ */
+@Builder(toBuilder = true)
+public record McpToolGatewayMappingHttp(
+    String method,
+    String path,
+    String contentType,
+    List<String> pathParams,
+    List<String> queryParams,
+    List<String> headers
+) {}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/mcp_tool/model/OpenApiToMcpToolsResult.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/mcp_tool/model/OpenApiToMcpToolsResult.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.mcp_tool.model;
+
+import java.util.List;
+import lombok.Builder;
+
+@Builder(toBuilder = true)
+public record OpenApiToMcpToolsResult(List<McpTool> result, List<ParseError> errors, String serverDescription) {}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/mcp_tool/model/ParseError.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/mcp_tool/model/ParseError.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.mcp_tool.model;
+
+import lombok.Builder;
+
+/**
+ * A non-fatal error or warning collected while parsing the OpenAPI specification.
+ * The {@code key} mirrors the values used by the front-end parser
+ * ({@code invalidFormat}, {@code invalidSpec}, {@code invalidRefs}, {@code duplicateName})
+ * so both producers expose the same vocabulary.
+ */
+@Builder(toBuilder = true)
+public record ParseError(String key, String message) {
+    public static final String INVALID_FORMAT = "invalidFormat";
+    public static final String INVALID_SPEC = "invalidSpec";
+    public static final String INVALID_REFS = "invalidRefs";
+    public static final String DUPLICATE_NAME = "duplicateName";
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/mcp_tool/OpenApiToMcpToolsDomainServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/mcp_tool/OpenApiToMcpToolsDomainServiceImpl.java
@@ -1,0 +1,462 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.infra.domain_service.mcp_tool;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.gravitee.apim.core.mcp_tool.domain_service.OpenApiToMcpToolsDomainService;
+import io.gravitee.apim.core.mcp_tool.model.McpTool;
+import io.gravitee.apim.core.mcp_tool.model.McpToolAnnotations;
+import io.gravitee.apim.core.mcp_tool.model.McpToolDefinition;
+import io.gravitee.apim.core.mcp_tool.model.McpToolGatewayMapping;
+import io.gravitee.apim.core.mcp_tool.model.McpToolGatewayMappingHttp;
+import io.gravitee.apim.core.mcp_tool.model.OpenApiToMcpToolsResult;
+import io.gravitee.apim.core.mcp_tool.model.ParseError;
+import io.swagger.parser.OpenAPIParser;
+import io.swagger.v3.core.util.Json;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.Operation;
+import io.swagger.v3.oas.models.PathItem;
+import io.swagger.v3.oas.models.headers.Header;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.media.MediaType;
+import io.swagger.v3.oas.models.media.Schema;
+import io.swagger.v3.oas.models.parameters.Parameter;
+import io.swagger.v3.oas.models.parameters.RequestBody;
+import io.swagger.v3.oas.models.responses.ApiResponse;
+import io.swagger.v3.oas.models.responses.ApiResponses;
+import io.swagger.v3.parser.core.models.ParseOptions;
+import io.swagger.v3.parser.core.models.SwaggerParseResult;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.IdentityHashMap;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import lombok.CustomLog;
+import org.springframework.stereotype.Service;
+
+@Service
+@CustomLog
+public class OpenApiToMcpToolsDomainServiceImpl implements OpenApiToMcpToolsDomainService {
+
+    private static final List<String> SUCCESS_STATUS_CODES = List.of("200", "201", "202");
+    private static final Pattern OAS_PATH_PARAM = Pattern.compile("\\{([a-zA-Z0-9_-]+)\\}");
+    private static final ObjectMapper MAPPER = Json.mapper();
+
+    @Override
+    public OpenApiToMcpToolsResult parse(String openApiSpec) {
+        if (openApiSpec == null || openApiSpec.isBlank()) {
+            return error(ParseError.INVALID_FORMAT, "Failed to parse specification");
+        }
+        ParseOutcome outcome = tryParse(openApiSpec);
+        if (outcome.openApi() == null) {
+            return error(outcome.errorKey(), outcome.errorMessage());
+        }
+        return buildResult(outcome.openApi());
+    }
+
+    private static ParseOutcome tryParse(String openApiSpec) {
+        SwaggerParseResult parseResult;
+        try {
+            var options = new ParseOptions();
+            options.setResolve(true);
+            options.setResolveFully(true);
+            parseResult = new OpenAPIParser().readContents(openApiSpec, null, options);
+        } catch (Exception e) {
+            return ParseOutcome.failure(ParseError.INVALID_FORMAT, "Failed to parse specification: " + e.getMessage());
+        }
+        OpenAPI api = parseResult.getOpenAPI();
+        if (api != null) {
+            return ParseOutcome.success(api);
+        }
+        String messages = String.join("; ", Optional.ofNullable(parseResult.getMessages()).orElse(List.of()));
+        String key = messages.toLowerCase(Locale.ROOT).contains("$ref") ? ParseError.INVALID_REFS : ParseError.INVALID_SPEC;
+        return ParseOutcome.failure(key, messages.isBlank() ? "Invalid OpenAPI specification" : messages);
+    }
+
+    private static OpenApiToMcpToolsResult buildResult(OpenAPI api) {
+        List<McpTool> tools = new ArrayList<>();
+        List<ParseError> errors = new ArrayList<>();
+        Set<String> usedNames = new HashSet<>();
+        Map<String, PathItem> paths = Optional.<Map<String, PathItem>>ofNullable(api.getPaths()).orElse(Map.of());
+        paths.forEach((path, pathItem) -> appendToolsForPath(path, pathItem, tools, errors, usedNames));
+        return new OpenApiToMcpToolsResult(tools, errors, buildServerDescription(api.getInfo()));
+    }
+
+    private static void appendToolsForPath(
+        String path,
+        PathItem pathItem,
+        List<McpTool> tools,
+        List<ParseError> errors,
+        Set<String> usedNames
+    ) {
+        if (pathItem == null) return;
+        List<Parameter> pathLevelParams = Optional.ofNullable(pathItem.getParameters()).orElse(List.of());
+        pathItem
+            .readOperationsMap()
+            .forEach((httpMethod, op) -> {
+                if (op == null) return;
+                String method = httpMethod.name().toLowerCase(Locale.ROOT);
+                tools.add(buildTool(path, method, op, pathLevelParams, usedNames, errors));
+            });
+    }
+
+    private static McpTool buildTool(
+        String path,
+        String method,
+        Operation op,
+        List<Parameter> pathLevelParams,
+        Set<String> usedNames,
+        List<ParseError> errors
+    ) {
+        String toolName = disambiguate(computeToolName(op.getOperationId(), method, path), usedNames, errors);
+        ParameterSchema paramSchema = extractParameterSchema(mergeParameters(pathLevelParams, op.getParameters()));
+        var definition = new McpToolDefinition(
+            toolName,
+            buildDescription(op, method, path),
+            buildInputSchema(paramSchema, extractRequestBodySchema(op.getRequestBody())),
+            buildOutputSchema(extractResponseSchema(op.getResponses())),
+            extractAnnotations(op)
+        );
+        return new McpTool(definition, generateGatewayMapping(op, method, path, paramSchema));
+    }
+
+    private static String disambiguate(String baseName, Set<String> usedNames, List<ParseError> errors) {
+        String name = baseName;
+        int suffix = 2;
+        while (!usedNames.add(name)) {
+            name = baseName + "_" + suffix++;
+        }
+        if (!name.equals(baseName)) {
+            errors.add(new ParseError(ParseError.DUPLICATE_NAME, "Duplicate tool name '" + baseName + "' resolved to '" + name + "'"));
+        }
+        return name;
+    }
+
+    private record ParseOutcome(@org.jspecify.annotations.Nullable OpenAPI openApi, String errorKey, String errorMessage) {
+        static ParseOutcome success(OpenAPI api) {
+            return new ParseOutcome(api, "", "");
+        }
+
+        static ParseOutcome failure(String key, String message) {
+            return new ParseOutcome(null, key, message);
+        }
+    }
+
+    private static OpenApiToMcpToolsResult error(String key, String message) {
+        return new OpenApiToMcpToolsResult(List.of(), List.of(new ParseError(key, message)), null);
+    }
+
+    private static String computeToolName(String operationId, String method, String path) {
+        if (operationId != null && !operationId.isBlank()) {
+            return operationId;
+        }
+        return snakeCase(method + "_" + path);
+    }
+
+    private static String snakeCase(String value) {
+        var snake = value.toLowerCase(Locale.ROOT).replaceAll("[^a-z0-9]+", "_");
+        // Linear scan instead of a regex like "^_+|_+$" to avoid a polynomial-backtracking surface
+        // (Sonar java:S5852). Stripping underscores from both ends is O(n) and intent-explicit.
+        int start = 0;
+        int end = snake.length();
+        while (start < end && snake.charAt(start) == '_') start++;
+        while (end > start && snake.charAt(end - 1) == '_') end--;
+        return snake.substring(start, end);
+    }
+
+    private static List<Parameter> mergeParameters(List<Parameter> pathLevel, List<Parameter> operationLevel) {
+        // Operation-level parameters override path-level ones with the same (in, name) key (OpenAPI §4.8.9).
+        Map<String, Parameter> merged = new LinkedHashMap<>();
+        for (Parameter p : pathLevel) {
+            if (p != null && p.getIn() != null && p.getName() != null) {
+                merged.put(p.getIn() + ":" + p.getName(), p);
+            }
+        }
+        if (operationLevel != null) {
+            for (Parameter p : operationLevel) {
+                if (p != null && p.getIn() != null && p.getName() != null) {
+                    merged.put(p.getIn() + ":" + p.getName(), p);
+                }
+            }
+        }
+        return new ArrayList<>(merged.values());
+    }
+
+    private record ParameterSchema(
+        Map<String, JsonNode> pathParams,
+        Map<String, JsonNode> queryParams,
+        Map<String, JsonNode> headers,
+        List<String> required
+    ) {}
+
+    private record ResponseSchema(JsonNode bodySchema, Map<String, JsonNode> headers) {}
+
+    private static ParameterSchema extractParameterSchema(List<Parameter> parameters) {
+        Map<String, JsonNode> pathParams = new LinkedHashMap<>();
+        Map<String, JsonNode> queryParams = new LinkedHashMap<>();
+        Map<String, JsonNode> headers = new LinkedHashMap<>();
+        List<String> required = new ArrayList<>();
+
+        for (Parameter param : parameters) {
+            String name = param.getName();
+            ObjectNode property = schemaToObjectNode(param.getSchema());
+            if (param.getDescription() != null) {
+                property.put("description", param.getDescription());
+            }
+            if (Boolean.TRUE.equals(param.getRequired())) {
+                required.add(name);
+            }
+            switch (param.getIn()) {
+                case "path" -> pathParams.put(name, property);
+                case "query" -> queryParams.put(name, property);
+                case "header" -> headers.put(name, property);
+                default -> {
+                    // cookie or other locations are not surfaced as MCP tool parameters
+                }
+            }
+        }
+
+        return new ParameterSchema(pathParams, queryParams, headers, required);
+    }
+
+    private static JsonNode extractRequestBodySchema(RequestBody requestBody) {
+        if (requestBody == null || requestBody.getContent() == null) {
+            return null;
+        }
+        MediaType jsonMedia = requestBody.getContent().get("application/json");
+        if (jsonMedia == null || jsonMedia.getSchema() == null) {
+            return null;
+        }
+        return schemaToObjectNode(jsonMedia.getSchema());
+    }
+
+    private static ResponseSchema extractResponseSchema(ApiResponses responses) {
+        if (responses == null) {
+            return new ResponseSchema(null, Map.of());
+        }
+        for (String statusCode : SUCCESS_STATUS_CODES) {
+            ApiResponse response = responses.get(statusCode);
+            if (response == null) continue;
+            JsonNode bodySchema = extractJsonResponseBody(response);
+            Map<String, JsonNode> headers = extractResponseHeaders(response);
+            if (bodySchema != null || !headers.isEmpty()) {
+                return new ResponseSchema(bodySchema, headers);
+            }
+        }
+        return new ResponseSchema(null, Map.of());
+    }
+
+    private static JsonNode extractJsonResponseBody(ApiResponse response) {
+        if (response.getContent() == null) {
+            return null;
+        }
+        MediaType jsonMedia = response.getContent().get("application/json");
+        if (jsonMedia == null || jsonMedia.getSchema() == null) {
+            return null;
+        }
+        return schemaToObjectNode(jsonMedia.getSchema());
+    }
+
+    private static Map<String, JsonNode> extractResponseHeaders(ApiResponse response) {
+        if (response.getHeaders() == null || response.getHeaders().isEmpty()) {
+            return Map.of();
+        }
+        Map<String, JsonNode> headers = new LinkedHashMap<>();
+        response
+            .getHeaders()
+            .forEach((name, header) -> {
+                if (header == null || header.getSchema() == null) return;
+                ObjectNode property = schemaToObjectNode(header.getSchema());
+                if (header.getDescription() != null) {
+                    property.put("description", header.getDescription());
+                }
+                headers.put(name, property);
+            });
+        return headers;
+    }
+
+    private static McpToolAnnotations extractAnnotations(Operation operation) {
+        Map<String, Object> extensions = operation.getExtensions();
+        if (extensions == null || extensions.isEmpty()) {
+            return null;
+        }
+        String title = stringExtension(extensions, "x-mcp-title");
+        Boolean readOnly = booleanExtension(extensions, "x-mcp-readOnlyHint");
+        Boolean destructive = booleanExtension(extensions, "x-mcp-destructiveHint");
+        Boolean idempotent = booleanExtension(extensions, "x-mcp-idempotentHint");
+        Boolean openWorld = booleanExtension(extensions, "x-mcp-openWorldHint");
+        if (title == null && readOnly == null && destructive == null && idempotent == null && openWorld == null) {
+            return null;
+        }
+        return new McpToolAnnotations(title, readOnly, destructive, idempotent, openWorld);
+    }
+
+    private static String stringExtension(Map<String, Object> extensions, String key) {
+        Object value = extensions.get(key);
+        return value instanceof String s ? s : null;
+    }
+
+    private static Boolean booleanExtension(Map<String, Object> extensions, String key) {
+        Object value = extensions.get(key);
+        return value instanceof Boolean b ? b : null;
+    }
+
+    private static JsonNode buildInputSchema(ParameterSchema paramSchema, JsonNode bodySchema) {
+        ObjectNode schema = MAPPER.createObjectNode();
+        schema.put("type", "object");
+        ObjectNode properties = schema.putObject("properties");
+        paramSchema.pathParams().forEach(properties::set);
+        paramSchema.queryParams().forEach(properties::set);
+        paramSchema.headers().forEach(properties::set);
+        if (bodySchema != null) {
+            properties.set("bodySchema", bodySchema);
+        }
+        ArrayNode required = schema.putArray("required");
+        paramSchema.required().forEach(required::add);
+        return removeCircularRefs(schema);
+    }
+
+    private static JsonNode buildOutputSchema(ResponseSchema responseSchema) {
+        if (responseSchema.bodySchema() == null && responseSchema.headers().isEmpty()) {
+            return null;
+        }
+        ObjectNode schema = MAPPER.createObjectNode();
+        schema.put("type", "object");
+        ObjectNode properties = schema.putObject("properties");
+        responseSchema.headers().forEach(properties::set);
+        if (responseSchema.bodySchema() != null) {
+            properties.set("bodySchema", responseSchema.bodySchema());
+        }
+        schema.putArray("required");
+        return removeCircularRefs(schema);
+    }
+
+    private static McpToolGatewayMapping generateGatewayMapping(Operation op, String method, String path, ParameterSchema paramSchema) {
+        Matcher m = OAS_PATH_PARAM.matcher(path);
+        String transformedPath = m.replaceAll(":$1");
+        String contentType = determineContentType(op);
+
+        // Empty lists are serialised to null so Jackson (NON_NULL inclusion) drops the field entirely,
+        // matching the front-end behaviour of omitting absent gatewayMapping fields.
+        List<String> pathParamNames = paramSchema.pathParams().isEmpty() ? null : new ArrayList<>(paramSchema.pathParams().keySet());
+        List<String> queryParamNames = paramSchema.queryParams().isEmpty() ? null : new ArrayList<>(paramSchema.queryParams().keySet());
+        List<String> headerNames = paramSchema.headers().isEmpty() ? null : new ArrayList<>(paramSchema.headers().keySet());
+
+        return new McpToolGatewayMapping(
+            new McpToolGatewayMappingHttp(
+                method.toUpperCase(Locale.ROOT),
+                transformedPath,
+                contentType,
+                pathParamNames,
+                queryParamNames,
+                headerNames
+            )
+        );
+    }
+
+    private static String determineContentType(Operation op) {
+        if (op.getRequestBody() == null || op.getRequestBody().getContent() == null) {
+            return null;
+        }
+        var entries = op.getRequestBody().getContent().keySet();
+        if (entries.isEmpty()) {
+            return null;
+        }
+        return entries.iterator().next();
+    }
+
+    private static String buildDescription(Operation op, String method, String path) {
+        String summary = op.getSummary();
+        String description = op.getDescription();
+        if (summary != null && description != null && !summary.isBlank() && !description.isBlank()) {
+            return summary + "\n\n" + description;
+        }
+        if (summary != null && !summary.isBlank()) return summary;
+        if (description != null && !description.isBlank()) return description;
+        return "API for " + method.toUpperCase(Locale.ROOT) + " " + path;
+    }
+
+    private static String buildServerDescription(Info info) {
+        if (info == null) return null;
+        String title = info.getTitle();
+        String description = info.getDescription();
+        if (title != null && !title.isBlank() && description != null && !description.isBlank()) {
+            return title + "\n\n" + description;
+        }
+        if (title != null && !title.isBlank()) return title;
+        if (description != null && !description.isBlank()) return description;
+        return null;
+    }
+
+    private static ObjectNode schemaToObjectNode(Schema<?> schema) {
+        if (schema == null) {
+            return MAPPER.createObjectNode();
+        }
+        try {
+            JsonNode tree = MAPPER.valueToTree(schema);
+            return tree.isObject() ? (ObjectNode) tree : MAPPER.createObjectNode();
+        } catch (Exception e) {
+            log.warn("Failed to serialize schema to JSON node, falling back to empty object: {}", e.getMessage());
+            return MAPPER.createObjectNode();
+        }
+    }
+
+    /**
+     * Walks the JSON tree and replaces any ancestor-revisit with an empty object. Shared
+     * (non-circular) references are preserved. Mirrors the front-end {@code removeCircularRefs}
+     * function so the gateway never receives a schema graph it cannot serialise.
+     */
+    private static JsonNode removeCircularRefs(JsonNode node) {
+        return removeCircularRefs(node, Collections.newSetFromMap(new IdentityHashMap<>()));
+    }
+
+    private static JsonNode removeCircularRefs(JsonNode node, Set<JsonNode> ancestors) {
+        if (node == null || !(node.isObject() || node.isArray())) {
+            return node;
+        }
+        if (ancestors.contains(node)) {
+            return MAPPER.createObjectNode();
+        }
+        Set<JsonNode> nextAncestors = Collections.newSetFromMap(new IdentityHashMap<>());
+        nextAncestors.addAll(ancestors);
+        nextAncestors.add(node);
+        if (node.isArray()) {
+            ArrayNode array = MAPPER.createArrayNode();
+            for (JsonNode item : node) {
+                array.add(removeCircularRefs(item, nextAncestors));
+            }
+            return array;
+        }
+        ObjectNode object = MAPPER.createObjectNode();
+        Iterator<Map.Entry<String, JsonNode>> it = node.fields();
+        while (it.hasNext()) {
+            Map.Entry<String, JsonNode> field = it.next();
+            object.set(field.getKey(), removeCircularRefs(field.getValue(), nextAncestors));
+        }
+        return object;
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/mcp_tool/OpenApiToMcpToolsDomainServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/mcp_tool/OpenApiToMcpToolsDomainServiceImplTest.java
@@ -1,0 +1,295 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.infra.domain_service.mcp_tool;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.gravitee.apim.core.mcp_tool.model.McpTool;
+import io.gravitee.apim.core.mcp_tool.model.McpToolGatewayMappingHttp;
+import io.gravitee.apim.core.mcp_tool.model.OpenApiToMcpToolsResult;
+import io.gravitee.apim.core.mcp_tool.model.ParseError;
+import io.swagger.v3.core.util.Json;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Objects;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class OpenApiToMcpToolsDomainServiceImplTest {
+
+    private final OpenApiToMcpToolsDomainServiceImpl service = new OpenApiToMcpToolsDomainServiceImpl();
+
+    @Test
+    void should_return_invalid_format_when_input_is_blank() {
+        var result = service.parse("");
+
+        assertThat(result.result()).isEmpty();
+        assertThat(result.errors()).singleElement().extracting(ParseError::key).isEqualTo(ParseError.INVALID_FORMAT);
+    }
+
+    @Test
+    void should_return_invalid_spec_when_payload_is_not_an_openapi_document() {
+        var result = service.parse(load("invalid.txt"));
+
+        assertThat(result.result()).isEmpty();
+        assertThat(result.errors()).isNotEmpty();
+        assertThat(result.errors().getFirst().key()).isIn(ParseError.INVALID_SPEC, ParseError.INVALID_FORMAT);
+    }
+
+    @Test
+    void should_extract_server_description_from_info() {
+        var result = service.parse(load("petstore.yaml"));
+
+        assertThat(result.serverDescription()).isEqualTo("Petstore\n\nA minimal petstore API used as parser fixture.");
+    }
+
+    @Test
+    void should_emit_one_tool_per_operation_with_operation_id_as_name() {
+        var result = service.parse(load("petstore.yaml"));
+
+        assertThat(result.result())
+            .extracting(t -> t.toolDefinition().name())
+            .containsExactlyInAnyOrder("listPets", "createPet", "getPet", "deletePet");
+    }
+
+    @Test
+    void should_fallback_to_snake_case_method_and_path_when_operation_id_is_absent() {
+        var result = service.parse(load("no-operation-id.yaml"));
+
+        assertThat(result.result())
+            .extracting(t -> t.toolDefinition().name())
+            .containsExactlyInAnyOrder("get_alpha_beta", "post_alpha_beta");
+    }
+
+    @Test
+    void should_uppercase_http_method_in_gateway_mapping() {
+        var result = service.parse(load("petstore.yaml"));
+
+        assertThat(result.result()).allSatisfy(tool -> assertThat(tool.gatewayMapping().http().method()).matches("^[A-Z]+$"));
+    }
+
+    @Test
+    void should_translate_oas_path_placeholders_into_express_style() {
+        var result = service.parse(load("petstore.yaml"));
+
+        var getPet = toolByName(result, "getPet");
+        assertThat(getPet.gatewayMapping().http().path()).isEqualTo("/pets/:petId");
+    }
+
+    @Test
+    void should_translate_multiple_path_placeholders() {
+        var result = service.parse(load("multi-params.yaml"));
+
+        var tool = result.result().getFirst();
+        assertThat(tool.gatewayMapping().http().path()).isEqualTo("/tenants/:tenantId/users/:userId");
+    }
+
+    @Test
+    void should_classify_parameters_by_location_in_gateway_mapping() {
+        var result = service.parse(load("multi-params.yaml"));
+
+        McpToolGatewayMappingHttp http = result.result().getFirst().gatewayMapping().http();
+        assertThat(http.pathParams()).containsExactly("tenantId", "userId");
+        assertThat(http.queryParams()).containsExactly("includeDisabled");
+        assertThat(http.headers()).containsExactly("X-Tenant-Token");
+    }
+
+    @Test
+    void should_set_contentType_when_request_body_is_present() {
+        var result = service.parse(load("petstore.yaml"));
+
+        var createPet = toolByName(result, "createPet");
+        assertThat(createPet.gatewayMapping().http().contentType()).isEqualTo("application/json");
+    }
+
+    @Test
+    void should_leave_contentType_null_when_no_request_body() {
+        var result = service.parse(load("petstore.yaml"));
+
+        var listPets = toolByName(result, "listPets");
+        assertThat(listPets.gatewayMapping().http().contentType()).isNull();
+    }
+
+    @Test
+    void should_build_input_schema_as_object_with_properties_and_required() {
+        var result = service.parse(load("petstore.yaml"));
+
+        var getPet = toolByName(result, "getPet");
+        var inputSchema = getPet.toolDefinition().inputSchema();
+        assertThat(inputSchema.get("type").asText()).isEqualTo("object");
+        assertThat(inputSchema.get("properties").has("petId")).isTrue();
+        assertThat(inputSchema.get("required")).anySatisfy(node -> assertThat(node.asText()).isEqualTo("petId"));
+    }
+
+    @Test
+    void should_include_request_body_schema_as_bodySchema_property() {
+        var result = service.parse(load("petstore.yaml"));
+
+        var createPet = toolByName(result, "createPet");
+        var inputSchema = createPet.toolDefinition().inputSchema();
+        assertThat(inputSchema.get("properties").has("bodySchema")).isTrue();
+        var bodySchema = inputSchema.get("properties").get("bodySchema");
+        assertThat(bodySchema.get("type").asText()).isEqualTo("object");
+        assertThat(bodySchema.get("properties").has("name")).isTrue();
+    }
+
+    @Test
+    void should_extract_response_schema_as_outputSchema_with_bodySchema_property() {
+        var result = service.parse(load("petstore.yaml"));
+
+        var listPets = toolByName(result, "listPets");
+        var outputSchema = listPets.toolDefinition().outputSchema();
+        assertThat(outputSchema).isNotNull();
+        assertThat(outputSchema.get("properties").has("bodySchema")).isTrue();
+    }
+
+    @Test
+    void should_leave_outputSchema_null_when_no_2xx_body_or_headers() {
+        var result = service.parse(load("petstore.yaml"));
+
+        var deletePet = toolByName(result, "deletePet");
+        assertThat(deletePet.toolDefinition().outputSchema()).isNull();
+    }
+
+    @Test
+    void should_pick_up_x_mcp_annotations() {
+        var result = service.parse(load("petstore.yaml"));
+
+        var getPet = toolByName(result, "getPet");
+        assertThat(getPet.toolDefinition().annotations()).isNotNull();
+        assertThat(getPet.toolDefinition().annotations().readOnlyHint()).isTrue();
+        assertThat(getPet.toolDefinition().annotations().idempotentHint()).isTrue();
+        assertThat(getPet.toolDefinition().annotations().destructiveHint()).isNull();
+
+        var deletePet = toolByName(result, "deletePet");
+        assertThat(deletePet.toolDefinition().annotations()).isNotNull();
+        assertThat(deletePet.toolDefinition().annotations().destructiveHint()).isTrue();
+    }
+
+    @Test
+    void should_leave_annotations_null_when_no_x_mcp_extension() {
+        var result = service.parse(load("petstore.yaml"));
+
+        var listPets = toolByName(result, "listPets");
+        assertThat(listPets.toolDefinition().annotations()).isNull();
+    }
+
+    @Test
+    void should_transparently_convert_swagger_2_to_openapi_3() {
+        var result = service.parse(load("swagger2-with-body.yaml"));
+
+        assertThat(result.result())
+            .extracting(t -> t.toolDefinition().name())
+            .containsExactly("placeOrder");
+        var placeOrder = result.result().getFirst();
+        assertThat(placeOrder.gatewayMapping().http().method()).isEqualTo("POST");
+        assertThat(placeOrder.toolDefinition().inputSchema().get("properties").has("bodySchema")).isTrue();
+    }
+
+    @Test
+    void should_return_empty_tools_when_paths_object_is_empty() {
+        var result = service.parse(load("empty-paths.yaml"));
+
+        assertThat(result.result()).isEmpty();
+        assertThat(result.errors()).isEmpty();
+        assertThat(result.serverDescription()).isEqualTo("Empty");
+    }
+
+    @Test
+    void should_default_description_to_method_and_path_when_summary_and_description_are_missing() {
+        var result = service.parse(load("no-operation-id.yaml"));
+
+        // we used summary "Listing" / "Creation", so this asserts summary wins
+        assertThat(result.result())
+            .extracting(t -> t.toolDefinition().description())
+            .containsExactlyInAnyOrder("Listing", "Creation");
+    }
+
+    /**
+     * Each entry pairs a YAML fixture with a JSON snapshot generated by the front-end
+     * {@code convertOpenApiToMcpTools} util, captured manually from the APIM console.
+     * The Java parser must produce a structurally equivalent JSON tree, otherwise the
+     * gateway plugin (which consumes today's TS output) would reject the payload.
+     *
+     * <p>Known intentional divergences with the front end (Java is the cleaner reference):
+     * <ul>
+     *   <li>For Swagger 2.0 specs with a {@code required} body parameter, the TS keeps the
+     *   body parameter name (e.g. {@code "order"}) in {@code inputSchema.required} even
+     *   though no matching property exists in {@code inputSchema.properties} — a quirk of
+     *   the TS Swagger-2-to-OpenAPI-3 transform. The Java parser leaves {@code required}
+     *   empty in that case.</li>
+     *   <li>On collisions, the TS emits the duplicate-named tool twice in {@code result}.
+     *   The Java parser appends a {@code _2}, {@code _3}, ... suffix to disambiguate while
+     *   still emitting a {@code DUPLICATE_NAME} error. The gateway plugin requires unique
+     *   tool names at runtime, so suffixing is the correct behaviour.</li>
+     * </ul>
+     * Both divergences are safe for the gateway plugin (which routes via
+     * {@code gatewayMapping}) and asserted by dedicated unit tests below.
+     */
+    @ParameterizedTest(name = "matches front-end snapshot: {0}")
+    @ValueSource(strings = { "empty-paths", "multi-params", "no-operation-id", "petstore", "swagger2-with-body" })
+    void should_match_front_end_snapshot(String fixtureBaseName) throws IOException {
+        var oas = load(fixtureBaseName + ".yaml");
+        var actual = service.parse(oas);
+
+        JsonNode actualTree = Json.mapper().valueToTree(actual);
+        JsonNode expectedTree = Json.mapper().readTree(load("expected/" + fixtureBaseName + ".expected.json"));
+
+        assertThat(actualTree).as("parser output should match the front-end snapshot for %s", fixtureBaseName).isEqualTo(expectedTree);
+    }
+
+    @Test
+    void should_suffix_colliding_tool_names_and_emit_a_duplicate_error() {
+        var result = service.parse(load("duplicate-names.yaml"));
+
+        assertThat(result.result())
+            .extracting(t -> t.toolDefinition().name())
+            .containsExactly("getUser", "getUser_2", "getUser_3");
+        assertThat(result.errors())
+            .hasSize(2)
+            .allSatisfy(err -> assertThat(err.key()).isEqualTo(ParseError.DUPLICATE_NAME))
+            .extracting(ParseError::message)
+            .containsExactly(
+                "Duplicate tool name 'getUser' resolved to 'getUser_2'",
+                "Duplicate tool name 'getUser' resolved to 'getUser_3'"
+            );
+    }
+
+    private static McpTool toolByName(OpenApiToMcpToolsResult result, String name) {
+        return result
+            .result()
+            .stream()
+            .filter(t -> Objects.equals(t.toolDefinition().name(), name))
+            .findFirst()
+            .orElseThrow();
+    }
+
+    private static String load(String fixtureName) {
+        try (var stream = OpenApiToMcpToolsDomainServiceImplTest.class.getResourceAsStream("oas-fixtures/" + fixtureName)) {
+            if (stream == null) {
+                throw new IllegalStateException("Fixture not found on classpath: " + fixtureName);
+            }
+            return new String(stream.readAllBytes(), StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            throw new IllegalStateException("Failed to read fixture: " + fixtureName, e);
+        }
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/apim/infra/domain_service/mcp_tool/oas-fixtures/duplicate-names.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/apim/infra/domain_service/mcp_tool/oas-fixtures/duplicate-names.yaml
@@ -1,0 +1,35 @@
+openapi: 3.0.3
+info:
+  title: Dupes
+  version: '1.0'
+paths:
+  /users:
+    get:
+      operationId: getUser
+      responses:
+        '200':
+          description: OK
+  /users/{id}:
+    get:
+      operationId: getUser
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: OK
+  /users/{id}/profile:
+    get:
+      operationId: getUser
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: OK

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/apim/infra/domain_service/mcp_tool/oas-fixtures/empty-paths.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/apim/infra/domain_service/mcp_tool/oas-fixtures/empty-paths.yaml
@@ -1,0 +1,5 @@
+openapi: 3.0.3
+info:
+  title: Empty
+  version: '0.0.1'
+paths: {}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/apim/infra/domain_service/mcp_tool/oas-fixtures/expected/empty-paths.expected.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/apim/infra/domain_service/mcp_tool/oas-fixtures/expected/empty-paths.expected.json
@@ -1,0 +1,5 @@
+{
+  "result": [],
+  "errors": [],
+  "serverDescription": "Empty"
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/apim/infra/domain_service/mcp_tool/oas-fixtures/expected/multi-params.expected.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/apim/infra/domain_service/mcp_tool/oas-fixtures/expected/multi-params.expected.json
@@ -1,0 +1,50 @@
+{
+    "result": [
+        {
+            "toolDefinition": {
+                "name": "getTenantUser",
+                "description": "API for GET /tenants/{tenantId}/users/{userId}",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "tenantId": {
+                            "type": "string"
+                        },
+                        "userId": {
+                            "type": "string"
+                        },
+                        "includeDisabled": {
+                            "type": "boolean"
+                        },
+                        "X-Tenant-Token": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "tenantId",
+                        "userId",
+                        "X-Tenant-Token"
+                    ]
+                }
+            },
+            "gatewayMapping": {
+                "http": {
+                    "method": "GET",
+                    "path": "/tenants/:tenantId/users/:userId",
+                    "pathParams": [
+                        "tenantId",
+                        "userId"
+                    ],
+                    "queryParams": [
+                        "includeDisabled"
+                    ],
+                    "headers": [
+                        "X-Tenant-Token"
+                    ]
+                }
+            }
+        }
+    ],
+    "errors": [],
+    "serverDescription": "Multi Params"
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/apim/infra/domain_service/mcp_tool/oas-fixtures/expected/no-operation-id.expected.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/apim/infra/domain_service/mcp_tool/oas-fixtures/expected/no-operation-id.expected.json
@@ -1,0 +1,40 @@
+{
+    "result": [
+        {
+            "toolDefinition": {
+                "name": "get_alpha_beta",
+                "description": "Listing",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {},
+                    "required": []
+                }
+            },
+            "gatewayMapping": {
+                "http": {
+                    "method": "GET",
+                    "path": "/alpha/beta"
+                }
+            }
+        },
+        {
+            "toolDefinition": {
+                "name": "post_alpha_beta",
+                "description": "Creation",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {},
+                    "required": []
+                }
+            },
+            "gatewayMapping": {
+                "http": {
+                    "method": "POST",
+                    "path": "/alpha/beta"
+                }
+            }
+        }
+    ],
+    "errors": [],
+    "serverDescription": "Unnamed Ops"
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/apim/infra/domain_service/mcp_tool/oas-fixtures/expected/petstore.expected.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/apim/infra/domain_service/mcp_tool/oas-fixtures/expected/petstore.expected.json
@@ -1,0 +1,201 @@
+{
+    "result": [
+        {
+            "toolDefinition": {
+                "name": "listPets",
+                "description": "List all pets",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "limit": {
+                            "type": "integer",
+                            "format": "int32"
+                        }
+                    },
+                    "required": []
+                },
+                "outputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "bodySchema": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "required": [
+                                    "id",
+                                    "name"
+                                ],
+                                "properties": {
+                                    "id": {
+                                        "type": "integer",
+                                        "format": "int64"
+                                    },
+                                    "name": {
+                                        "type": "string"
+                                    },
+                                    "tag": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "required": []
+                }
+            },
+            "gatewayMapping": {
+                "http": {
+                    "method": "GET",
+                    "path": "/pets",
+                    "queryParams": [
+                        "limit"
+                    ]
+                }
+            }
+        },
+        {
+            "toolDefinition": {
+                "name": "createPet",
+                "description": "Create a pet",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "bodySchema": {
+                            "type": "object",
+                            "required": [
+                                "name"
+                            ],
+                            "properties": {
+                                "name": {
+                                    "type": "string"
+                                },
+                                "tag": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "required": []
+                },
+                "outputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "bodySchema": {
+                            "type": "object",
+                            "required": [
+                                "id",
+                                "name"
+                            ],
+                            "properties": {
+                                "id": {
+                                    "type": "integer",
+                                    "format": "int64"
+                                },
+                                "name": {
+                                    "type": "string"
+                                },
+                                "tag": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "required": []
+                }
+            },
+            "gatewayMapping": {
+                "http": {
+                    "method": "POST",
+                    "path": "/pets",
+                    "contentType": "application/json"
+                }
+            }
+        },
+        {
+            "toolDefinition": {
+                "name": "getPet",
+                "description": "Fetch a pet by id",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "petId": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "petId"
+                    ]
+                },
+                "outputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "bodySchema": {
+                            "type": "object",
+                            "required": [
+                                "id",
+                                "name"
+                            ],
+                            "properties": {
+                                "id": {
+                                    "type": "integer",
+                                    "format": "int64"
+                                },
+                                "name": {
+                                    "type": "string"
+                                },
+                                "tag": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "required": []
+                },
+                "annotations": {
+                    "readOnlyHint": true,
+                    "idempotentHint": true
+                }
+            },
+            "gatewayMapping": {
+                "http": {
+                    "method": "GET",
+                    "path": "/pets/:petId",
+                    "pathParams": [
+                        "petId"
+                    ]
+                }
+            }
+        },
+        {
+            "toolDefinition": {
+                "name": "deletePet",
+                "description": "Delete a pet",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "petId": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "petId"
+                    ]
+                },
+                "annotations": {
+                    "destructiveHint": true
+                }
+            },
+            "gatewayMapping": {
+                "http": {
+                    "method": "DELETE",
+                    "path": "/pets/:petId",
+                    "pathParams": [
+                        "petId"
+                    ]
+                }
+            }
+        }
+    ],
+    "errors": [],
+    "serverDescription": "Petstore\n\nA minimal petstore API used as parser fixture."
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/apim/infra/domain_service/mcp_tool/oas-fixtures/expected/swagger2-with-body.expected.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/apim/infra/domain_service/mcp_tool/oas-fixtures/expected/swagger2-with-body.expected.json
@@ -1,0 +1,39 @@
+{
+    "result": [
+        {
+            "toolDefinition": {
+                "name": "placeOrder",
+                "description": "Place a new order",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "bodySchema": {
+                            "type": "object",
+                            "required": [
+                                "sku"
+                            ],
+                            "properties": {
+                                "sku": {
+                                    "type": "string"
+                                },
+                                "quantity": {
+                                    "type": "integer"
+                                }
+                            }
+                        }
+                    },
+                    "required": []
+                }
+            },
+            "gatewayMapping": {
+                "http": {
+                    "method": "POST",
+                    "path": "/orders",
+                    "contentType": "application/json"
+                }
+            }
+        }
+    ],
+    "errors": [],
+    "serverDescription": "Legacy Orders"
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/apim/infra/domain_service/mcp_tool/oas-fixtures/invalid.txt
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/apim/infra/domain_service/mcp_tool/oas-fixtures/invalid.txt
@@ -1,0 +1,2 @@
+not-an-openapi-document
+just-some-text

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/apim/infra/domain_service/mcp_tool/oas-fixtures/multi-params.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/apim/infra/domain_service/mcp_tool/oas-fixtures/multi-params.yaml
@@ -1,0 +1,32 @@
+openapi: 3.0.3
+info:
+  title: Multi Params
+  version: '1.0'
+paths:
+  /tenants/{tenantId}/users/{userId}:
+    get:
+      operationId: getTenantUser
+      parameters:
+        - name: tenantId
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: userId
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: includeDisabled
+          in: query
+          required: false
+          schema:
+            type: boolean
+        - name: X-Tenant-Token
+          in: header
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: OK

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/apim/infra/domain_service/mcp_tool/oas-fixtures/no-operation-id.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/apim/infra/domain_service/mcp_tool/oas-fixtures/no-operation-id.yaml
@@ -1,0 +1,16 @@
+openapi: 3.0.3
+info:
+  title: Unnamed Ops
+  version: '1.0'
+paths:
+  /alpha/beta:
+    get:
+      summary: Listing
+      responses:
+        '200':
+          description: OK
+    post:
+      summary: Creation
+      responses:
+        '201':
+          description: Created

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/apim/infra/domain_service/mcp_tool/oas-fixtures/petstore.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/apim/infra/domain_service/mcp_tool/oas-fixtures/petstore.yaml
@@ -1,0 +1,89 @@
+openapi: 3.0.3
+info:
+  title: Petstore
+  description: A minimal petstore API used as parser fixture.
+  version: 1.0.0
+paths:
+  /pets:
+    get:
+      operationId: listPets
+      summary: List all pets
+      parameters:
+        - name: limit
+          in: query
+          required: false
+          schema:
+            type: integer
+            format: int32
+      responses:
+        '200':
+          description: A paged array of pets
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Pet'
+    post:
+      operationId: createPet
+      summary: Create a pet
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/NewPet'
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Pet'
+  /pets/{petId}:
+    parameters:
+      - name: petId
+        in: path
+        required: true
+        schema:
+          type: string
+    get:
+      operationId: getPet
+      summary: Fetch a pet by id
+      x-mcp-readOnlyHint: true
+      x-mcp-idempotentHint: true
+      responses:
+        '200':
+          description: The pet
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Pet'
+    delete:
+      operationId: deletePet
+      summary: Delete a pet
+      x-mcp-destructiveHint: true
+      responses:
+        '204':
+          description: Deleted
+components:
+  schemas:
+    Pet:
+      type: object
+      required: [id, name]
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+        tag:
+          type: string
+    NewPet:
+      type: object
+      required: [name]
+      properties:
+        name:
+          type: string
+        tag:
+          type: string

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/apim/infra/domain_service/mcp_tool/oas-fixtures/swagger2-with-body.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/io/gravitee/apim/infra/domain_service/mcp_tool/oas-fixtures/swagger2-with-body.yaml
@@ -1,0 +1,32 @@
+swagger: '2.0'
+info:
+  title: Legacy Orders
+  version: '1.0'
+basePath: /api
+paths:
+  /orders:
+    post:
+      operationId: placeOrder
+      summary: Place a new order
+      consumes:
+        - application/json
+      parameters:
+        - in: body
+          name: order
+          required: true
+          schema:
+            $ref: '#/definitions/Order'
+      responses:
+        '201':
+          description: Created
+          schema:
+            $ref: '#/definitions/Order'
+definitions:
+  Order:
+    type: object
+    required: [sku]
+    properties:
+      sku:
+        type: string
+      quantity:
+        type: integer


### PR DESCRIPTION
**Issue**
  
  https://gravitee.atlassian.net/browse/GMA-158

**Description**
  
Adds a Java port of the front-end `convertOpenApiToMcpTools` parser as a new `OpenApiToMcpToolsDomainService` in the management API service module. From an OpenAPI specification (YAML or JSON, OpenAPI 3.x or Swagger 2.0), the service produces a list of MCP tools whose shape matches byte-for-byte the `MCPTool` configuration consumed by the `gravitee-entrypoint-mcp` gateway plugin — paths use Express-style `:paramName` placeholders, methods are upper-cased, `x-mcp-*` extensions surface as MCP annotations. Any tool produced here can be persisted then handed to the gateway without further transformation.
  
The service is exposed as a Spring `@Service` bean and consumes nothing from outside `gravitee-api-management`.

**Why move it server-side**
  
  - Single source of truth for the OAS → MCP tool transform: the front today does it, the gateway will need it tomorrow (for the `reactor-mcp-proxy` path), and a `potentialToolCount` style enrichment of `/_search` would otherwise duplicate the logic.
  - Removes the runtime dependency on `@scalar/openapi-parser` + `js-yaml` for clients that should not need a browser/JS environment.
  - The Java implementation, when finished, becomes the reference; the TS code will be retired once the console switches to the backend endpoint.

**Design notes**

  - Domain models live in `io.gravitee.apim.core.mcp_tool.model` (records: `McpTool`, `McpToolDefinition`, `McpToolAnnotations`, `McpToolGatewayMapping`, `McpToolGatewayMappingHttp`, `OpenApiToMcpToolsResult`, `ParseError`). Interface in `core.mcp_tool.domain_service`, impl in `infra.domain_service.mcp_tool`. Pattern aligned with the existing `OpenApiDomainService` / `SwaggerOpenApiParser`.
  - Parsing uses the umbrella `io.swagger.parser.OpenAPIParser` (already in the BOM) with `setResolveFully(true)`, which transparently converts Swagger 2.0 to OpenAPI 3 and dereferences `$ref` chains.
  - JSON schemas (`inputSchema`, `outputSchema`) are produced as Jackson `JsonNode` so they can be embedded as-is in the gateway plugin's `MCPToolDefinition`, which also uses `JsonNode`.
  - `JsonInclude.NON_NULL` (inherited from `Json.mapper()`) makes empty `gatewayMapping` fields (`contentType`, `pathParams`, `queryParams`, `headers`) disappear from the serialised payload, matching the front-end output where these are absent when empty.

**Parity guarantee with the front end**

A parameterised snapshot test (`should_match_front_end_snapshot`) loads five fixtures captured manually from the APIM console (`empty-paths`, `multi-params`, `no-operation-id`, `petstore`, `swagger2-with-body`) and asserts a structural JSON equality (`JsonNode.equals`) against the Java parser output. Together they exercise empty specs, multiple parameter locations, snake_case fallback naming, refs resolution + `x-mcp-*` annotations + request/response body schemas, and Swagger-2 conversion.

**Intentional divergences with the TS**
(Java is the cleaner reference, documented in the test javadoc):

  1. *Swagger 2.0 body parameter in `required`* — the TS leaves the body param name (e.g. `"order"`) in `inputSchema.required` even though no matching property exists in `inputSchema.properties`. The Java parser delegates Swagger-2-to-OpenAPI-3 conversion to `swagger-parser`, which migrates the body cleanly, so `required` stays empty.
  2. *Duplicate tool names* — the TS emits the duplicate-named tool twice in `result` plus a `DUPLICATE_NAME` error. The Java parser appends a `_2`, `_3`, ... suffix to disambiguate while still emitting the error. The gateway requires unique tool names at runtime, so suffixing is the correct behaviour.

Both divergences are safe for the gateway plugin (which routes via `gatewayMapping`, not via `required` or duplicate names).

**Additional context**
  
  - Zero new Maven dependencies — `swagger-parser` 2.1.25 was already declared in the BOM and consumed by `OAIParser` / `OasProviderImpl`.
  - No REST endpoint added: the bean is meant to be wired in a follow-up PR from the AIM module (`GetApiMcpToolsUseCase`).
  - The TS code in `gravitee-apim-console-webui` stays in place during the transition and will be retired in a later PR.

**Test plan**

  - [x] `mvn -pl gravitee-apim-rest-api/gravitee-apim-rest-api-service test -Dtest=OpenApiToMcpToolsDomainServiceImplTest` — 26/26 pass.
  - [x] `mvn prettier:check` clean.
  - [x] License headers and import order verified by the module's existing checks.
  - [ ] Manual: stage a real OAS via the AIM wizard (when wired up), confirm the produced tools mirror what the console TS produces for the same spec.

