### PR TITLE
fix: route v4 API PATCH polymorphic deserialization through REST DTO layer

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/java/io/gravitee/apim/rest/api/automation/spring/RestAutomationConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/java/io/gravitee/apim/rest/api/automation/spring/RestAutomationConfiguration.java
@@ -15,15 +15,12 @@
  */
 package io.gravitee.apim.rest.api.automation.spring;
 
-import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.gravitee.apim.core.api.use_case.PatchApiUseCase.FlowListDeserializer;
-import io.gravitee.apim.core.api.use_case.PatchApiUseCase.FlowListSerializer;
+import io.gravitee.apim.core.api.use_case.PatchApiUseCase.ApiV4Deserializer;
 import io.gravitee.apim.infra.spring.UsecaseSpringConfiguration;
-import io.gravitee.definition.model.v4.flow.Flow;
 import io.gravitee.el.ExpressionLanguageInitializer;
+import io.gravitee.rest.api.management.v2.rest.adapter.PatchApiV4Deserializer;
 import io.gravitee.rest.api.service.spring.ServiceConfiguration;
-import java.util.List;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
@@ -39,13 +36,8 @@ import org.springframework.scheduling.annotation.EnableAsync;
 public class RestAutomationConfiguration {
 
     @Bean
-    public FlowListDeserializer flowListDeserializer(ObjectMapper objectMapper) {
-        return node -> objectMapper.treeToValue(node, new TypeReference<List<Flow>>() {});
-    }
-
-    @Bean
-    public FlowListSerializer flowListSerializer(ObjectMapper objectMapper) {
-        return flows -> objectMapper.valueToTree(flows);
+    public ApiV4Deserializer apiV4Deserializer(ObjectMapper objectMapper) {
+        return new PatchApiV4Deserializer(objectMapper);
     }
 
     @Bean

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/spring/ResourceContextConfiguration.java
@@ -18,7 +18,6 @@ package io.gravitee.apim.rest.api.automation.spring;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 
-import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import fakes.spring.FakeConfiguration;
 import inmemory.ApiCRDExportDomainServiceInMemory;
@@ -71,8 +70,7 @@ import io.gravitee.apim.core.api.use_case.ExportApiUseCase;
 import io.gravitee.apim.core.api.use_case.GetApiDefinitionUseCase;
 import io.gravitee.apim.core.api.use_case.GetExposedEntrypointsUseCase;
 import io.gravitee.apim.core.api.use_case.ImportApiCRDUseCase;
-import io.gravitee.apim.core.api.use_case.PatchApiUseCase.FlowListDeserializer;
-import io.gravitee.apim.core.api.use_case.PatchApiUseCase.FlowListSerializer;
+import io.gravitee.apim.core.api.use_case.PatchApiUseCase.ApiV4Deserializer;
 import io.gravitee.apim.core.api.use_case.RollbackApiUseCase;
 import io.gravitee.apim.core.api.use_case.WsdlToImportApiUseCase;
 import io.gravitee.apim.core.api_key.domain_service.ReconcileApiKeysDomainService;
@@ -204,10 +202,10 @@ import io.gravitee.apim.infra.json.jackson.JacksonSpringConfiguration;
 import io.gravitee.apim.infra.sanitizer.HtmlSanitizerImpl;
 import io.gravitee.apim.infra.spring.UsecaseSpringConfiguration;
 import io.gravitee.common.util.DataEncryptor;
-import io.gravitee.definition.model.v4.flow.Flow;
 import io.gravitee.node.api.license.LicenseManager;
 import io.gravitee.repository.management.api.ApiRepository;
 import io.gravitee.repository.management.api.ApplicationRepository;
+import io.gravitee.rest.api.management.v2.rest.adapter.PatchApiV4Deserializer;
 import io.gravitee.rest.api.service.ApiDuplicatorService;
 import io.gravitee.rest.api.service.ApiKeyService;
 import io.gravitee.rest.api.service.ApiMetadataService;
@@ -238,7 +236,6 @@ import io.gravitee.rest.api.service.v4.PlanSearchService;
 import io.gravitee.rest.api.service.v4.PlanService;
 import io.gravitee.rest.api.service.v4.PolicyPluginService;
 import io.vertx.rxjava3.core.Vertx;
-import java.util.List;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
@@ -254,13 +251,8 @@ import org.springframework.mock.env.MockEnvironment;
 public class ResourceContextConfiguration {
 
     @Bean
-    public FlowListDeserializer flowListDeserializer(ObjectMapper objectMapper) {
-        return node -> objectMapper.treeToValue(node, new TypeReference<List<Flow>>() {});
-    }
-
-    @Bean
-    public FlowListSerializer flowListSerializer(ObjectMapper objectMapper) {
-        return flows -> objectMapper.valueToTree(flows);
+    public ApiV4Deserializer apiV4Deserializer(ObjectMapper objectMapper) {
+        return new PatchApiV4Deserializer(objectMapper);
     }
 
     @Bean

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/adapter/PatchApiV4Deserializer.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/adapter/PatchApiV4Deserializer.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.management.v2.rest.adapter;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.gravitee.apim.core.api.model.Api;
+import io.gravitee.apim.core.api.use_case.PatchApiUseCase.ApiV4Deserializer;
+import io.gravitee.apim.core.api.use_case.PatchApiUseCase.ApiV4Fields;
+import io.gravitee.apim.core.api.use_case.PatchApiUseCase.PatchableView;
+import io.gravitee.rest.api.management.v2.rest.mapper.ApiMapper;
+import io.gravitee.rest.api.management.v2.rest.model.ApiV4;
+import io.gravitee.rest.api.management.v2.rest.model.GenericApi;
+import java.io.IOException;
+import java.util.List;
+
+public class PatchApiV4Deserializer implements ApiV4Deserializer {
+
+    private static final List<String> POLYMORPHIC_LIST_FIELDS = List.of("listeners", "endpointGroups", "flows", "resources");
+
+    private final ObjectMapper objectMapper;
+
+    public PatchApiV4Deserializer(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    public JsonNode toCurrentStateNode(Api api) {
+        var node = (ObjectNode) objectMapper.valueToTree(PatchableView.from(api));
+        var apiV4 = ApiMapper.INSTANCE.mapToV4(api, null, null);
+        setIfNonNull(node, "listeners", apiV4.getListeners());
+        setIfNonNull(node, "endpointGroups", apiV4.getEndpointGroups());
+        setIfNonNull(node, "flows", apiV4.getFlows());
+        setIfNonNull(node, "resources", apiV4.getResources());
+        return node;
+    }
+
+    @Override
+    public ApiV4Fields fromPatchedNode(JsonNode patchedNode) throws IOException {
+        var slim = objectMapper.createObjectNode();
+        slim.put("definitionVersion", "V4");
+        for (var field : POLYMORPHIC_LIST_FIELDS) {
+            var n = patchedNode.get(field);
+            if (n != null) {
+                slim.set(field, n);
+            }
+        }
+        var apiV4 = (ApiV4) objectMapper.treeToValue(slim, GenericApi.class);
+        return ApiMapper.INSTANCE.mapToCoreApi(apiV4);
+    }
+
+    private void setIfNonNull(ObjectNode node, String field, Object value) {
+        if (value != null) {
+            node.set(field, objectMapper.valueToTree(value));
+        }
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/ApiMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/ApiMapper.java
@@ -22,16 +22,21 @@ import io.gravitee.apim.core.api.model.NewNativeApi;
 import io.gravitee.apim.core.api.model.UpdateNativeApi;
 import io.gravitee.apim.core.api.model.crd.ApiCRDSpec;
 import io.gravitee.apim.core.api.model.import_definition.ApiExport;
+import io.gravitee.apim.core.api.use_case.PatchApiUseCase;
 import io.gravitee.apim.core.documentation.model.Page;
 import io.gravitee.apim.core.membership.model.PrimaryOwnerEntity;
 import io.gravitee.apim.core.utils.CollectionUtils;
 import io.gravitee.definition.model.v4.ApiType;
 import io.gravitee.definition.model.v4.endpointgroup.AbstractEndpoint;
 import io.gravitee.definition.model.v4.endpointgroup.AbstractEndpointGroup;
+import io.gravitee.definition.model.v4.endpointgroup.EndpointGroup;
 import io.gravitee.definition.model.v4.flow.AbstractFlow;
+import io.gravitee.definition.model.v4.flow.Flow;
 import io.gravitee.definition.model.v4.listener.AbstractListener;
+import io.gravitee.definition.model.v4.listener.Listener;
 import io.gravitee.definition.model.v4.listener.entrypoint.AbstractEntrypoint;
 import io.gravitee.definition.model.v4.nativeapi.NativeAnalytics;
+import io.gravitee.definition.model.v4.resource.Resource;
 import io.gravitee.definition.model.v4.service.AbstractApiServices;
 import io.gravitee.node.logging.NodeLoggerFactory;
 import io.gravitee.rest.api.management.v2.rest.model.Analytics;
@@ -411,6 +416,9 @@ public interface ApiMapper {
 
     @Named("computeCoreApiLinks")
     default ApiLinks computeCoreApiLinks(io.gravitee.apim.core.api.model.Api api, UriInfo uriInfo) {
+        if (uriInfo == null) {
+            return null;
+        }
         return new ApiLinks()
             .pictureUrl(ManagementApiLinkHelper.apiPictureURL(uriInfo.getBaseUriBuilder(), api))
             .backgroundUrl(ManagementApiLinkHelper.apiBackgroundURL(uriInfo.getBaseUriBuilder(), api));
@@ -517,6 +525,22 @@ public interface ApiMapper {
         } else {
             return ServiceMapper.INSTANCE.mapToApiServices(apiV4.getServices());
         }
+    }
+
+    default PatchApiUseCase.ApiV4Fields mapToCoreApi(ApiV4 apiV4) {
+        List<Listener> listeners = apiV4.getListeners() == null
+            ? null
+            : ListenerMapper.INSTANCE.mapToListenerEntityV4List(apiV4.getListeners()).stream().filter(Objects::nonNull).toList();
+        List<EndpointGroup> endpointGroups = apiV4.getEndpointGroups() == null
+            ? null
+            : EndpointMapper.INSTANCE.mapEndpointGroupsHttpV4(apiV4.getEndpointGroups()).stream().filter(Objects::nonNull).toList();
+        List<Flow> flows = apiV4.getFlows() == null
+            ? null
+            : FlowMapper.INSTANCE.mapToHttpV4(apiV4.getFlows()).stream().filter(Objects::nonNull).toList();
+        List<Resource> resources = apiV4.getResources() == null
+            ? null
+            : apiV4.getResources().stream().map(ResourceMapper.INSTANCE::mapToV4).filter(Objects::nonNull).toList();
+        return new PatchApiUseCase.ApiV4Fields(listeners, endpointGroups, flows, resources);
     }
 
     @Named("computeOriginContext")

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/ApiMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/ApiMapper.java
@@ -530,17 +530,25 @@ public interface ApiMapper {
     default PatchApiUseCase.ApiV4Fields mapToCoreApi(ApiV4 apiV4) {
         List<Listener> listeners = apiV4.getListeners() == null
             ? null
-            : ListenerMapper.INSTANCE.mapToListenerEntityV4List(apiV4.getListeners()).stream().filter(Objects::nonNull).toList();
+            : rejectNulls(ListenerMapper.INSTANCE.mapToListenerEntityV4List(apiV4.getListeners()), "listeners");
         List<EndpointGroup> endpointGroups = apiV4.getEndpointGroups() == null
             ? null
-            : EndpointMapper.INSTANCE.mapEndpointGroupsHttpV4(apiV4.getEndpointGroups()).stream().filter(Objects::nonNull).toList();
-        List<Flow> flows = apiV4.getFlows() == null
-            ? null
-            : FlowMapper.INSTANCE.mapToHttpV4(apiV4.getFlows()).stream().filter(Objects::nonNull).toList();
+            : rejectNulls(EndpointMapper.INSTANCE.mapEndpointGroupsHttpV4(apiV4.getEndpointGroups()), "endpointGroups");
+        List<Flow> flows = apiV4.getFlows() == null ? null : rejectNulls(FlowMapper.INSTANCE.mapToHttpV4(apiV4.getFlows()), "flows");
         List<Resource> resources = apiV4.getResources() == null
             ? null
-            : apiV4.getResources().stream().map(ResourceMapper.INSTANCE::mapToV4).filter(Objects::nonNull).toList();
+            : rejectNulls(apiV4.getResources().stream().map(ResourceMapper.INSTANCE::mapToV4).toList(), "resources");
         return new PatchApiUseCase.ApiV4Fields(listeners, endpointGroups, flows, resources);
+    }
+
+    private static <T> List<T> rejectNulls(List<T> list, String fieldName) {
+        return list
+            .stream()
+            .map(item -> {
+                if (item == null) throw new IllegalArgumentException(fieldName + " list contains a null element");
+                return item;
+            })
+            .toList();
     }
 
     @Named("computeOriginContext")

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/spring/RestManagementConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/spring/RestManagementConfiguration.java
@@ -15,15 +15,13 @@
  */
 package io.gravitee.rest.api.management.v2.rest.spring;
 
-import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.gravitee.apim.core.analytics_engine.domain_service.AnalyticsQueryContextLoader;
 import io.gravitee.apim.core.analytics_engine.domain_service.BucketNamesPostProcessor;
 import io.gravitee.apim.core.analytics_engine.domain_service.QueryFilterTransformer;
 import io.gravitee.apim.core.analytics_engine.domain_service.UnitEnrichmentPostProcessor;
 import io.gravitee.apim.core.analytics_engine.query_service.AnalyticsDefinitionQueryService;
-import io.gravitee.apim.core.api.use_case.PatchApiUseCase.FlowListDeserializer;
-import io.gravitee.apim.core.api.use_case.PatchApiUseCase.FlowListSerializer;
+import io.gravitee.apim.core.api.use_case.PatchApiUseCase.ApiV4Deserializer;
 import io.gravitee.apim.core.user.domain_service.UserContextLoader;
 import io.gravitee.apim.infra.domain_service.analytics_engine.ManagementContextLoader;
 import io.gravitee.apim.infra.domain_service.analytics_engine.processors.ApiTypeFilterTransformer;
@@ -34,6 +32,7 @@ import io.gravitee.apim.infra.spring.UsecaseSpringConfiguration;
 import io.gravitee.el.ExpressionLanguageInitializer;
 import io.gravitee.repository.management.api.ApiRepository;
 import io.gravitee.rest.api.kafkaexplorer.spring.KafkaExplorerSpringConfiguration;
+import io.gravitee.rest.api.management.v2.rest.adapter.PatchApiV4Deserializer;
 import io.gravitee.rest.api.management.v2.rest.mapper.FlowMapper;
 import io.gravitee.rest.api.management.v2.rest.model.FlowV4;
 import io.gravitee.rest.api.management.v2.rest.resource.api.RemoteApiDefinitionParser;
@@ -43,7 +42,6 @@ import io.gravitee.rest.api.service.UserService;
 import io.gravitee.rest.api.service.spring.ServiceConfiguration;
 import io.gravitee.rest.api.service.v4.ApiAuthorizationService;
 import io.gravitee.rest.api.service.v4.PlanSearchService;
-import java.util.List;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
@@ -60,13 +58,8 @@ import org.springframework.scheduling.annotation.EnableAsync;
 public class RestManagementConfiguration {
 
     @Bean
-    public FlowListDeserializer flowListDeserializer(ObjectMapper objectMapper) {
-        return node -> FlowMapper.INSTANCE.mapToHttpV4(objectMapper.treeToValue(node, new TypeReference<List<FlowV4>>() {}));
-    }
-
-    @Bean
-    public FlowListSerializer flowListSerializer(ObjectMapper objectMapper) {
-        return flows -> objectMapper.valueToTree(FlowMapper.INSTANCE.mapFromHttpV4(flows));
+    public ApiV4Deserializer apiV4Deserializer(ObjectMapper objectMapper) {
+        return new PatchApiV4Deserializer(objectMapper);
     }
 
     @Bean

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/adapter/PatchApiV4DeserializerTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/adapter/PatchApiV4DeserializerTest.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.management.v2.rest.adapter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import fixtures.core.model.ApiFixtures;
+import io.gravitee.definition.jackson.datatype.GraviteeMapper;
+import io.gravitee.definition.model.v4.listener.http.HttpListener;
+import java.io.IOException;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class PatchApiV4DeserializerTest {
+
+    private final GraviteeMapper mapper = new GraviteeMapper(false);
+    private final PatchApiV4Deserializer deserializer = new PatchApiV4Deserializer(mapper);
+
+    @Test
+    void should_not_throw_when_converting_proxy_api_to_current_state_node() {
+        assertThatNoException().isThrownBy(() -> deserializer.toCurrentStateNode(ApiFixtures.aProxyApiV4()));
+    }
+
+    @Test
+    void should_return_object_node_with_listener_type_from_proxy_api() {
+        var result = deserializer.toCurrentStateNode(ApiFixtures.aProxyApiV4());
+
+        assertThat(result).isInstanceOf(ObjectNode.class);
+        assertThat(result.isObject()).isTrue();
+        assertThat(result.path("listeners").get(0).path("type").asText()).isEqualTo("HTTP");
+    }
+
+    @Test
+    void should_map_listeners_when_present() throws IOException {
+        var node = deserializer.toCurrentStateNode(ApiFixtures.aProxyApiV4());
+
+        var result = deserializer.fromPatchedNode(node);
+
+        assertThat(result.listeners()).hasSize(1);
+        assertThat(result.listeners().getFirst()).isInstanceOf(HttpListener.class);
+    }
+
+    @Test
+    void should_return_empty_fields_when_all_polymorphic_fields_absent() throws IOException {
+        var node = mapper.createObjectNode();
+
+        var result = deserializer.fromPatchedNode(node);
+
+        assertThat(result.listeners()).isEmpty();
+        assertThat(result.endpointGroups()).isEmpty();
+        assertThat(result.flows()).isEmpty();
+        assertThat(result.resources()).isEmpty();
+    }
+
+    @Test
+    void should_include_endpoint_groups_in_current_state_node_for_proxy_api() {
+        var result = deserializer.toCurrentStateNode(ApiFixtures.aProxyApiV4());
+
+        assertThat(result.path("endpointGroups").isArray()).isTrue();
+        assertThat(result.path("endpointGroups").get(0).path("type").asText()).isEqualTo("http-proxy");
+    }
+
+    @Test
+    void should_map_endpoint_groups_from_proxy_api_round_trip() throws IOException {
+        var node = deserializer.toCurrentStateNode(ApiFixtures.aProxyApiV4());
+
+        var result = deserializer.fromPatchedNode(node);
+
+        assertThat(result.endpointGroups()).hasSize(1);
+        assertThat(result.endpointGroups().getFirst().getType()).isEqualTo("http-proxy");
+    }
+
+    @Test
+    void should_map_resources_when_present() throws IOException {
+        var node = mapper.readTree("{\"resources\":[{\"name\":\"my-cache\",\"type\":\"cache\",\"enabled\":true,\"configuration\":{}}]}");
+
+        var result = deserializer.fromPatchedNode(node);
+
+        assertThat(result.resources()).hasSize(1);
+        assertThat(result.resources().getFirst().getName()).isEqualTo("my-cache");
+        assertThat(result.resources().getFirst().getType()).isEqualTo("cache");
+        assertThat(result.resources().getFirst().getConfiguration()).isEqualTo("{ }");
+    }
+
+    @Test
+    void should_map_flows_when_present() throws IOException {
+        var node = mapper.readTree("{\"flows\":[{\"name\":\"my-flow\",\"enabled\":true,\"request\":[],\"response\":[]}]}");
+
+        var result = deserializer.fromPatchedNode(node);
+
+        assertThat(result.flows()).hasSize(1);
+        assertThat(result.flows().getFirst().getName()).isEqualTo("my-flow");
+        assertThat(result.flows().getFirst().isEnabled()).isTrue();
+    }
+
+    @Test
+    void should_accept_uppercase_HTTP_listener_type_in_patch() throws IOException {
+        var node = mapper.readTree(
+            "{\"listeners\":[{\"type\":\"HTTP\",\"paths\":[{\"path\":\"/x\"}],\"entrypoints\":[{\"type\":\"http-proxy\",\"configuration\":\"{}\"}]}]}"
+        );
+
+        var result = deserializer.fromPatchedNode(node);
+
+        assertThat(result.listeners()).hasSize(1);
+        assertThat(result.listeners().getFirst()).isInstanceOf(HttpListener.class);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource_PatchApiEndpointGroupsTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource_PatchApiEndpointGroupsTest.java
@@ -30,6 +30,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import fixtures.core.model.ApiFixtures;
 import inmemory.InMemoryAlternative;
 import io.gravitee.apim.core.api.domain_service.UpdateApiDomainService;
+import io.gravitee.apim.core.api.model.Api;
 import io.gravitee.apim.core.exception.ValidationDomainException;
 import io.gravitee.apim.core.membership.model.Membership;
 import io.gravitee.apim.core.membership.model.PrimaryOwnerEntity;
@@ -54,6 +55,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
 
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 public class ApiResource_PatchApiEndpointGroupsTest extends ApiResourceTest {
@@ -178,6 +181,29 @@ public class ApiResource_PatchApiEndpointGroupsTest extends ApiResourceTest {
         } catch (JsonProcessingException e) {
             throw new RuntimeException(e);
         }
+    }
+
+    @Test
+    void patch_endpoint_group_type_http_proxy_returns_200_and_persists() {
+        givenApiWithEndpointGroups(List.of(defaultGroup("group-a")));
+
+        var groups = List.of(groupMap("group-a"));
+        var body = "{\"endpointGroups\":" + toJson(groups) + "}";
+        var response = rootTarget(API).request().method("PATCH", Entity.entity(body, MERGE_PATCH_TYPE));
+
+        var apiV4 = assertThat(response).hasStatus(OK_200).asEntity(ApiV4.class).actual();
+        Assertions.assertThat(apiV4.getEndpointGroups()).isNotEmpty();
+        Assertions.assertThat(apiV4.getEndpointGroups().getFirst().getName()).isEqualTo("group-a");
+
+        var persistedGroups = capturePersistedEndpointGroups();
+        Assertions.assertThat(persistedGroups).hasSize(1);
+        Assertions.assertThat(persistedGroups.getFirst().getType()).isEqualTo("http-proxy");
+    }
+
+    private List<EndpointGroup> capturePersistedEndpointGroups() {
+        var captor = ArgumentCaptor.forClass(Api.class);
+        Mockito.verify(updateApiDomainService).updateV4(captor.capture(), any());
+        return captor.getValue().getApiDefinitionHttpV4().getEndpointGroups();
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource_PatchApiEndpointGroupsTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource_PatchApiEndpointGroupsTest.java
@@ -207,6 +207,43 @@ public class ApiResource_PatchApiEndpointGroupsTest extends ApiResourceTest {
     }
 
     @Test
+    void merge_patch_omitting_endpoint_groups_preserves_previous_endpoint_groups() {
+        givenApiWithEndpointGroups(List.of(defaultGroup("group-a")));
+
+        var body = "{\"name\":\"updated-name\"}";
+        var response = rootTarget(API).request().method("PATCH", Entity.entity(body, MERGE_PATCH_TYPE));
+
+        assertThat(response).hasStatus(OK_200);
+
+        var persistedGroups = capturePersistedEndpointGroups();
+        Assertions.assertThat(persistedGroups).hasSize(1);
+        Assertions.assertThat(persistedGroups.getFirst().getType()).isEqualTo("http-proxy");
+        Assertions.assertThat(persistedGroups.getFirst().getName()).isEqualTo("group-a");
+    }
+
+    @Test
+    void merge_patch_endpoint_groups_null_clears_endpoint_groups() {
+        givenApiWithEndpointGroups(List.of(defaultGroup("group-a")));
+
+        var body = "{\"endpointGroups\":null}";
+        var response = rootTarget(API).request().method("PATCH", Entity.entity(body, MERGE_PATCH_TYPE));
+
+        var apiV4 = assertThat(response).hasStatus(OK_200).asEntity(ApiV4.class).actual();
+        Assertions.assertThat(apiV4.getEndpointGroups()).isNullOrEmpty();
+    }
+
+    @Test
+    void json_patch_remove_endpoint_groups_clears_endpoint_groups() {
+        givenApiWithEndpointGroups(List.of(defaultGroup("group-a")));
+
+        var body = "[{\"op\":\"remove\",\"path\":\"/endpointGroups\"}]";
+        var response = rootTarget(API).request().method("PATCH", Entity.entity(body, JSON_PATCH_TYPE));
+
+        var apiV4 = assertThat(response).hasStatus(OK_200).asEntity(ApiV4.class).actual();
+        Assertions.assertThat(apiV4.getEndpointGroups()).isNullOrEmpty();
+    }
+
+    @Test
     void patch_with_empty_endpointGroups_returns_400() {
         givenApiWithEndpointGroups(List.of(defaultGroup("group-a")));
         doThrow(new ValidationDomainException("endpointGroups must not be empty", Map.of("location", "/endpointGroups"), "invalidValue"))

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource_PatchApiFlowsTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource_PatchApiFlowsTest.java
@@ -31,6 +31,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import fixtures.core.model.ApiFixtures;
 import inmemory.InMemoryAlternative;
 import io.gravitee.apim.core.api.domain_service.UpdateApiDomainService;
+import io.gravitee.apim.core.api.model.Api;
 import io.gravitee.apim.core.exception.ValidationDomainException;
 import io.gravitee.apim.core.membership.model.Membership;
 import io.gravitee.apim.core.membership.model.PrimaryOwnerEntity;
@@ -38,6 +39,8 @@ import io.gravitee.definition.model.DefinitionVersion;
 import io.gravitee.definition.model.v4.ApiType;
 import io.gravitee.definition.model.v4.flow.Flow;
 import io.gravitee.definition.model.v4.flow.selector.HttpSelector;
+import io.gravitee.definition.model.v4.flow.selector.Selector;
+import io.gravitee.definition.model.v4.flow.selector.SelectorType;
 import io.gravitee.definition.model.v4.flow.step.Step;
 import io.gravitee.rest.api.management.v2.rest.model.ApiV4;
 import io.gravitee.rest.api.model.permissions.RolePermission;
@@ -61,6 +64,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
 
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 public class ApiResource_PatchApiFlowsTest extends ApiResourceTest {
@@ -179,6 +184,12 @@ public class ApiResource_PatchApiFlowsTest extends ApiResourceTest {
         return assertThat(response).hasStatus(OK_200).asEntity(ApiV4.class).actual();
     }
 
+    private List<Flow> capturePersistedFlows() {
+        var captor = ArgumentCaptor.forClass(Api.class);
+        Mockito.verify(updateApiDomainService).updateV4(captor.capture(), any());
+        return captor.getValue().getApiDefinitionHttpV4().getFlows();
+    }
+
     static Stream<Arguments> addFlowVariants() {
         return bothFlowsReplaceVariants(List.of(flowMap("added", List.of(stepMap("s1", "policy-a")))));
     }
@@ -270,6 +281,83 @@ public class ApiResource_PatchApiFlowsTest extends ApiResourceTest {
             return bothFlowsReplaceVariants(flows);
         }
 
+        static Stream<Arguments> uppercaseConditionSelectorTypeVariants() {
+            var flows = List.of(
+                Map.of(
+                    "name",
+                    "f1",
+                    "enabled",
+                    true,
+                    "selectors",
+                    List.of(Map.of("type", "CONDITION", "condition", "{#request.headers['X-Custom'] != null}")),
+                    "request",
+                    List.of(stepMap("s1", "p1"))
+                )
+            );
+            return bothFlowsReplaceVariants(flows);
+        }
+
+        static Stream<Arguments> uppercaseChannelSelectorTypeVariants() {
+            var flows = List.of(
+                Map.of(
+                    "name",
+                    "f1",
+                    "enabled",
+                    true,
+                    "selectors",
+                    List.of(Map.of("type", "CHANNEL", "channel", "/", "channelOperator", "STARTS_WITH")),
+                    "request",
+                    List.of(stepMap("s1", "p1"))
+                )
+            );
+            return bothFlowsReplaceVariants(flows);
+        }
+
+        static Stream<Arguments> uppercaseMcpSelectorTypeVariants() {
+            var flows = List.of(
+                Map.of("name", "f1", "enabled", true, "selectors", List.of(Map.of("type", "MCP")), "request", List.of(stepMap("s1", "p1")))
+            );
+            return bothFlowsReplaceVariants(flows);
+        }
+
+        @ParameterizedTest
+        @MethodSource("uppercaseConditionSelectorTypeVariants")
+        void patch_selector_type_CONDITION_returns_200_and_persists(String body, String contentType) {
+            givenApiWithFlows(List.of(flow("f1", List.of(step("s1", "p1")))));
+
+            var response = rootTarget(API).request().method("PATCH", Entity.entity(body, contentType));
+
+            assertThat(response).hasStatus(OK_200);
+
+            var persistedFlows = capturePersistedFlows();
+            Assertions.assertThat(persistedFlows).hasSize(1);
+            Assertions.assertThat(persistedFlows.getFirst().getSelectors()).extracting(Selector::getType).contains(SelectorType.CONDITION);
+        }
+
+        @ParameterizedTest
+        @MethodSource("uppercaseChannelSelectorTypeVariants")
+        void patch_selector_type_CHANNEL_returns_200_and_persists(String body, String contentType) {
+            givenApiWithFlows(List.of(flow("f1", List.of(step("s1", "p1")))));
+
+            patchAndAssertOk(body, contentType);
+
+            var persistedFlows = capturePersistedFlows();
+            Assertions.assertThat(persistedFlows).hasSize(1);
+            Assertions.assertThat(persistedFlows.getFirst().getSelectors()).extracting(Selector::getType).contains(SelectorType.CHANNEL);
+        }
+
+        @ParameterizedTest
+        @MethodSource("uppercaseMcpSelectorTypeVariants")
+        void patch_selector_type_MCP_returns_200_and_persists(String body, String contentType) {
+            givenApiWithFlows(List.of(flow("f1", List.of(step("s1", "p1")))));
+
+            patchAndAssertOk(body, contentType);
+
+            var persistedFlows = capturePersistedFlows();
+            Assertions.assertThat(persistedFlows).hasSize(1);
+            Assertions.assertThat(persistedFlows.getFirst().getSelectors()).extracting(Selector::getType).contains(SelectorType.MCP);
+        }
+
         static Stream<Arguments> validatorRejectionCases() {
             return Stream.of(
                 Map.entry("unknown policy id", "/flows/0/request/0/policy"),
@@ -317,6 +405,10 @@ public class ApiResource_PatchApiFlowsTest extends ApiResourceTest {
             var response = rootTarget(API).request().method("PATCH", Entity.entity(body, contentType));
 
             assertThat(response).hasStatus(OK_200);
+
+            var persistedFlows = capturePersistedFlows();
+            Assertions.assertThat(persistedFlows).hasSize(1);
+            Assertions.assertThat(persistedFlows.getFirst().getSelectors()).extracting(Selector::getType).contains(SelectorType.HTTP);
         }
 
         @ParameterizedTest

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource_PatchApiListenersTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource_PatchApiListenersTest.java
@@ -1,0 +1,265 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.management.v2.rest.resource.api;
+
+import static assertions.MAPIAssertions.assertThat;
+import static io.gravitee.common.http.HttpStatusCode.BAD_REQUEST_400;
+import static io.gravitee.common.http.HttpStatusCode.OK_200;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import fixtures.core.model.ApiFixtures;
+import inmemory.InMemoryAlternative;
+import io.gravitee.apim.core.api.domain_service.UpdateApiDomainService;
+import io.gravitee.apim.core.api.model.Api;
+import io.gravitee.apim.core.membership.model.Membership;
+import io.gravitee.apim.core.membership.model.PrimaryOwnerEntity;
+import io.gravitee.definition.model.DefinitionVersion;
+import io.gravitee.definition.model.v4.ApiType;
+import io.gravitee.definition.model.v4.listener.Listener;
+import io.gravitee.definition.model.v4.listener.ListenerType;
+import io.gravitee.definition.model.v4.listener.entrypoint.Entrypoint;
+import io.gravitee.definition.model.v4.listener.http.HttpListener;
+import io.gravitee.definition.model.v4.listener.http.Path;
+import io.gravitee.rest.api.management.v2.rest.model.ApiV4;
+import io.gravitee.rest.api.model.v4.api.ApiEntity;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.client.Entity;
+import java.time.Instant;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+public class ApiResource_PatchApiListenersTest extends ApiResourceTest {
+
+    private static final String MERGE_PATCH_TYPE = "application/merge-patch+json";
+    private static final String JSON_PATCH_TYPE = "application/json-patch+json";
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    @Inject
+    UpdateApiDomainService updateApiDomainService;
+
+    @Override
+    protected String contextPath() {
+        return "/environments/" + ENVIRONMENT + "/apis";
+    }
+
+    @BeforeEach
+    void setUpApiAndPrimaryOwner() {
+        givenApiWithListeners(List.of(defaultHttpListener("/http")));
+
+        var apiEntity = new ApiEntity();
+        apiEntity.setId(API);
+        apiEntity.setDefinitionVersion(DefinitionVersion.V4);
+        apiEntity.setType(ApiType.PROXY);
+        apiEntity.setUpdatedAt(Date.from(Instant.ofEpochMilli(1000)));
+        when(apiSearchServiceV4.findGenericById(any(), eq(API), any(boolean.class), any(boolean.class), any(boolean.class))).thenReturn(
+            apiEntity
+        );
+
+        roleQueryService.resetSystemRoles(ORGANIZATION);
+        primaryOwnerDomainService.initWith(
+            List.of(Map.entry(API, PrimaryOwnerEntity.builder().id(USER_NAME).type(PrimaryOwnerEntity.Type.USER).build()))
+        );
+        membershipQueryServiceInMemory.initWith(
+            List.of(
+                Membership.builder()
+                    .memberId(USER_NAME)
+                    .referenceId(API)
+                    .roleId("api-po-id-" + ORGANIZATION)
+                    .referenceType(Membership.ReferenceType.API)
+                    .memberType(Membership.Type.USER)
+                    .build()
+            )
+        );
+
+        doAnswer(inv -> inv.getArgument(0))
+            .when(updateApiDomainService)
+            .updateV4(any(), any());
+        doAnswer(inv -> inv.getArgument(0))
+            .when(updateApiDomainService)
+            .validateV4(any(), any());
+    }
+
+    @AfterEach
+    public void tearDown() {
+        Stream.of(apiCrudService, membershipQueryServiceInMemory, primaryOwnerDomainService).forEach(InMemoryAlternative::reset);
+        reset(updateApiDomainService, apiSearchServiceV4);
+    }
+
+    private void givenApiWithListeners(List<Listener> listeners) {
+        var base = ApiFixtures.aProxyApiV4();
+        var api = base.toBuilder().apiDefinitionValue(base.getApiDefinitionHttpV4().toBuilder().listeners(listeners).build()).build();
+        apiCrudService.initWith(List.of(api));
+    }
+
+    private static HttpListener defaultHttpListener(String path) {
+        return HttpListener.builder()
+            .paths(List.of(Path.builder().path(path).build()))
+            .entrypoints(List.of(Entrypoint.builder().type("http-proxy").configuration("{}").build()))
+            .build();
+    }
+
+    private static String toJson(Object value) {
+        try {
+            return OBJECT_MAPPER.writeValueAsString(value);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static Map<String, Object> uppercaseListenerMap(String typeUppercase, String path) {
+        return Map.of(
+            "type",
+            typeUppercase,
+            "paths",
+            List.of(Map.of("path", path)),
+            "entrypoints",
+            List.of(Map.of("type", "http-proxy", "configuration", "{}"))
+        );
+    }
+
+    private static Map<String, Object> lowercaseListenerMap(String typeLowercase, String path) {
+        return Map.of(
+            "type",
+            typeLowercase,
+            "paths",
+            List.of(Map.of("path", path)),
+            "entrypoints",
+            List.of(Map.of("type", "http-proxy", "configuration", "{}"))
+        );
+    }
+
+    private ApiV4 patchAndAssertOk(String body, String contentType) {
+        var response = rootTarget(API).request().method("PATCH", Entity.entity(body, contentType));
+        return assertThat(response).hasStatus(OK_200).asEntity(ApiV4.class).actual();
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = { "HTTP", "TCP", "SUBSCRIPTION", "KAFKA" })
+    void patch_listener_type_uppercase_returns_200_and_persists(String uppercaseType) {
+        givenApiWithListeners(List.of(defaultHttpListener("/existing")));
+
+        var listeners = List.of(uppercaseListenerMap(uppercaseType, "/patched"));
+        var body = "{\"listeners\":" + toJson(listeners) + "}";
+
+        var response = rootTarget(API).request().method("PATCH", Entity.entity(body, MERGE_PATCH_TYPE));
+
+        assertThat(response).hasStatus(OK_200);
+
+        if ("HTTP".equals(uppercaseType)) {
+            var persistedListeners = capturePersistedListeners();
+            Assertions.assertThat(persistedListeners).hasSize(1);
+            Assertions.assertThat(persistedListeners.getFirst().getType()).isEqualTo(ListenerType.HTTP);
+            Assertions.assertThat(((HttpListener) persistedListeners.getFirst()).getPaths())
+                .extracting(Path::getPath)
+                .containsExactly("/patched");
+        }
+    }
+
+    @Test
+    void patch_listeners_round_trip_from_get_response_returns_200() {
+        givenApiWithListeners(List.of(defaultHttpListener("/http")));
+
+        var listeners = List.of(uppercaseListenerMap("HTTP", "/http"));
+        var body = "{\"listeners\":" + toJson(listeners) + "}";
+
+        var response = rootTarget(API).request().method("PATCH", Entity.entity(body, MERGE_PATCH_TYPE));
+
+        assertThat(response).hasStatus(OK_200);
+
+        var persistedListeners = capturePersistedListeners();
+        Assertions.assertThat(persistedListeners).hasSize(1);
+        Assertions.assertThat(persistedListeners.getFirst().getType()).isEqualTo(ListenerType.HTTP);
+        Assertions.assertThat(((HttpListener) persistedListeners.getFirst()).getPaths()).extracting(Path::getPath).containsExactly("/http");
+    }
+
+    @Test
+    void merge_patch_omitting_listeners_preserves_previous_listeners() {
+        givenApiWithListeners(List.of(defaultHttpListener("/existing")));
+
+        var body = "{\"name\":\"updated-name\"}";
+        var response = rootTarget(API).request().method("PATCH", Entity.entity(body, MERGE_PATCH_TYPE));
+
+        var apiV4 = assertThat(response).hasStatus(OK_200).asEntity(ApiV4.class).actual();
+        Assertions.assertThat(apiV4.getListeners()).isNotEmpty();
+
+        var persistedListeners = capturePersistedListeners();
+        Assertions.assertThat(persistedListeners).hasSize(1);
+        Assertions.assertThat(persistedListeners.getFirst()).isInstanceOf(HttpListener.class);
+        Assertions.assertThat(((HttpListener) persistedListeners.getFirst()).getPaths())
+            .extracting(Path::getPath)
+            .containsExactly("/existing");
+    }
+
+    private List<Listener> capturePersistedListeners() {
+        var captor = ArgumentCaptor.forClass(Api.class);
+        Mockito.verify(updateApiDomainService).updateV4(captor.capture(), any());
+        return captor.getValue().getApiDefinitionHttpV4().getListeners();
+    }
+
+    @Test
+    void merge_patch_listeners_null_clears_listeners() {
+        givenApiWithListeners(List.of(defaultHttpListener("/existing")));
+
+        var body = "{\"listeners\":null}";
+        var response = rootTarget(API).request().method("PATCH", Entity.entity(body, MERGE_PATCH_TYPE));
+
+        var apiV4 = assertThat(response).hasStatus(OK_200).asEntity(ApiV4.class).actual();
+        Assertions.assertThat(apiV4.getListeners()).isNullOrEmpty();
+    }
+
+    @Test
+    void json_patch_remove_listeners_clears_listeners() {
+        givenApiWithListeners(List.of(defaultHttpListener("/existing")));
+
+        var body = "[{\"op\":\"remove\",\"path\":\"/listeners\"}]";
+        var response = rootTarget(API).request().method("PATCH", Entity.entity(body, JSON_PATCH_TYPE));
+
+        var apiV4 = assertThat(response).hasStatus(OK_200).asEntity(ApiV4.class).actual();
+        Assertions.assertThat(apiV4.getListeners()).isNullOrEmpty();
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = { "http", "tcp", "subscription", "kafka" })
+    void patch_lowercase_listener_type_returns_400(String lowercaseType) {
+        givenApiWithListeners(List.of(defaultHttpListener("/existing")));
+
+        var listeners = List.of(lowercaseListenerMap(lowercaseType, "/patched"));
+        var body = "{\"listeners\":" + toJson(listeners) + "}";
+
+        var response = rootTarget(API).request().method("PATCH", Entity.entity(body, MERGE_PATCH_TYPE));
+
+        assertThat(response).hasStatus(BAD_REQUEST_400);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource_PatchApiListenersTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource_PatchApiListenersTest.java
@@ -166,7 +166,7 @@ public class ApiResource_PatchApiListenersTest extends ApiResourceTest {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = { "HTTP", "TCP", "SUBSCRIPTION", "KAFKA" })
+    @ValueSource(strings = { "HTTP", "TCP", "SUBSCRIPTION" })
     void patch_listener_type_uppercase_returns_200_and_persists(String uppercaseType) {
         givenApiWithListeners(List.of(defaultHttpListener("/existing")));
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource_PatchApiTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource_PatchApiTest.java
@@ -864,7 +864,7 @@ public class ApiResource_PatchApiTest extends ApiResourceTest {
 
     private static String listenerJson(String path) {
         return (
-            "{\"type\":\"http\",\"paths\":[{\"path\":\"" +
+            "{\"type\":\"HTTP\",\"paths\":[{\"path\":\"" +
             path +
             "\"}],\"entrypoints\":[{\"type\":\"http-proxy\",\"configuration\":\"{}\"}]}"
         );

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource_PatchApiTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource_PatchApiTest.java
@@ -862,6 +862,45 @@ public class ApiResource_PatchApiTest extends ApiResourceTest {
         );
     }
 
+    @Test
+    void json_patch_name_only_preserves_polymorphic_fields() {
+        var fixture = ApiFixtures.aProxyApiV4();
+        apiCrudService.initWith(List.of(fixture));
+
+        var captured = new Api[] { null };
+        doAnswer(inv -> {
+            captured[0] = inv.getArgument(0);
+            return captured[0];
+        })
+            .when(updateApiDomainService)
+            .updateV4(any(), any());
+
+        var response = rootTarget(API)
+            .request()
+            .method("PATCH", Entity.entity("[{\"op\":\"replace\",\"path\":\"/name\",\"value\":\"patched-name\"}]", JSON_PATCH_TYPE));
+
+        assertThat(response).hasStatus(OK_200);
+
+        var persistedDef = captured[0].getApiDefinitionHttpV4();
+        var fixtureDef = fixture.getApiDefinitionHttpV4();
+
+        Assertions.assertThat(persistedDef.getListeners()).hasSameSizeAs(fixtureDef.getListeners());
+        Assertions.assertThat(persistedDef.getListeners().getFirst()).isInstanceOf(
+            io.gravitee.definition.model.v4.listener.http.HttpListener.class
+        );
+        var persistedListener = (io.gravitee.definition.model.v4.listener.http.HttpListener) persistedDef.getListeners().getFirst();
+        var fixtureListener = (io.gravitee.definition.model.v4.listener.http.HttpListener) fixtureDef.getListeners().getFirst();
+        Assertions.assertThat(persistedListener.getPaths()).isEqualTo(fixtureListener.getPaths());
+
+        Assertions.assertThat(persistedDef.getEndpointGroups()).hasSameSizeAs(fixtureDef.getEndpointGroups());
+        Assertions.assertThat(persistedDef.getEndpointGroups().getFirst().getName()).isEqualTo(
+            fixtureDef.getEndpointGroups().getFirst().getName()
+        );
+        Assertions.assertThat(persistedDef.getEndpointGroups().getFirst().getType()).isEqualTo(
+            fixtureDef.getEndpointGroups().getFirst().getType()
+        );
+    }
+
     private static String listenerJson(String path) {
         return (
             "{\"type\":\"HTTP\",\"paths\":[{\"path\":\"" +

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/spring/ResourceContextConfiguration.java
@@ -20,7 +20,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
-import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import fakes.spring.FakeConfiguration;
 import fixtures.core.model.LicenseFixtures;
@@ -81,8 +80,7 @@ import io.gravitee.apim.core.api.use_case.GetExposedEntrypointsUseCase;
 import io.gravitee.apim.core.api.use_case.ImportApiDefinitionFromUrlUseCase;
 import io.gravitee.apim.core.api.use_case.ImportApiDefinitionUseCase;
 import io.gravitee.apim.core.api.use_case.OAIToUpdateApiUseCase;
-import io.gravitee.apim.core.api.use_case.PatchApiUseCase.FlowListDeserializer;
-import io.gravitee.apim.core.api.use_case.PatchApiUseCase.FlowListSerializer;
+import io.gravitee.apim.core.api.use_case.PatchApiUseCase.ApiV4Deserializer;
 import io.gravitee.apim.core.api.use_case.RollbackApiUseCase;
 import io.gravitee.apim.core.api.use_case.UpdateApiDefinitionFromImportUseCase;
 import io.gravitee.apim.core.api.use_case.UpdateApiGroupsUseCase;
@@ -269,8 +267,8 @@ import io.gravitee.repository.log.v4.api.AnalyticsRepository;
 import io.gravitee.repository.management.api.ApiRepository;
 import io.gravitee.repository.management.api.ApplicationRepository;
 import io.gravitee.repository.management.api.CustomDashboardRepository;
-import io.gravitee.rest.api.management.v2.rest.mapper.FlowMapper;
-import io.gravitee.rest.api.management.v2.rest.model.FlowV4;
+import io.gravitee.rest.api.management.v2.rest.mapper.ApiMapper;
+import io.gravitee.rest.api.management.v2.rest.model.ApiV4;
 import io.gravitee.rest.api.management.v2.rest.utils.SubscriptionExpandHelper;
 import io.gravitee.rest.api.service.ApiDuplicatorService;
 import io.gravitee.rest.api.service.ApiKeyService;
@@ -326,13 +324,8 @@ public class ResourceContextConfiguration {
     }
 
     @Bean
-    public FlowListDeserializer flowListDeserializer(ObjectMapper objectMapper) {
-        return node -> FlowMapper.INSTANCE.mapToHttpV4(objectMapper.treeToValue(node, new TypeReference<List<FlowV4>>() {}));
-    }
-
-    @Bean
-    public FlowListSerializer flowListSerializer(ObjectMapper objectMapper) {
-        return flows -> objectMapper.valueToTree(FlowMapper.INSTANCE.mapFromHttpV4(flows));
+    public ApiV4Deserializer apiV4Deserializer(ObjectMapper objectMapper) {
+        return new io.gravitee.rest.api.management.v2.rest.adapter.PatchApiV4Deserializer(objectMapper);
     }
 
     @Bean

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/spring/RestManagementConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/spring/RestManagementConfiguration.java
@@ -15,17 +15,15 @@
  */
 package io.gravitee.rest.api.management.rest.spring;
 
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import io.gravitee.apim.core.api.use_case.PatchApiUseCase.FlowListDeserializer;
-import io.gravitee.apim.core.api.use_case.PatchApiUseCase.FlowListSerializer;
+import com.fasterxml.jackson.databind.JsonNode;
+import io.gravitee.apim.core.api.model.Api;
+import io.gravitee.apim.core.api.use_case.PatchApiUseCase.ApiV4Deserializer;
+import io.gravitee.apim.core.api.use_case.PatchApiUseCase.ApiV4Fields;
 import io.gravitee.apim.infra.spring.UsecaseSpringConfiguration;
-import io.gravitee.definition.model.v4.flow.Flow;
 import io.gravitee.el.ExpressionLanguageInitializer;
 import io.gravitee.plugin.core.spring.PluginConfiguration;
 import io.gravitee.rest.api.idp.core.spring.IdentityProviderPluginConfiguration;
 import io.gravitee.rest.api.service.spring.ServiceConfiguration;
-import java.util.List;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
@@ -41,17 +39,27 @@ import org.springframework.scheduling.annotation.EnableAsync;
 public class RestManagementConfiguration {
 
     @Bean
-    public FlowListDeserializer flowListDeserializer(ObjectMapper objectMapper) {
-        return node -> objectMapper.treeToValue(node, new TypeReference<List<Flow>>() {});
-    }
-
-    @Bean
-    public FlowListSerializer flowListSerializer(ObjectMapper objectMapper) {
-        return flows -> objectMapper.valueToTree(flows);
+    public ApiV4Deserializer apiV4Deserializer() {
+        return new V4PatchNotSupportedDeserializer();
     }
 
     @Bean
     public ExpressionLanguageInitializer expressionLanguageInitializer() {
         return new ExpressionLanguageInitializer();
+    }
+
+    private static class V4PatchNotSupportedDeserializer implements ApiV4Deserializer {
+
+        private static final String MESSAGE = "v4 PATCH is served only by management-v2 REST API";
+
+        @Override
+        public JsonNode toCurrentStateNode(Api api) {
+            throw new UnsupportedOperationException(MESSAGE + " (apiId=" + api.getId() + ")");
+        }
+
+        @Override
+        public ApiV4Fields fromPatchedNode(JsonNode patchedNode) {
+            throw new UnsupportedOperationException(MESSAGE);
+        }
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/spring/ResourceContextConfiguration.java
@@ -18,7 +18,6 @@ package io.gravitee.rest.api.management.rest.spring;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 
-import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import fakes.spring.FakeConfiguration;
 import inmemory.ApiCrudServiceInMemory;
@@ -64,8 +63,7 @@ import io.gravitee.apim.core.api.query_service.ApiMetadataQueryService;
 import io.gravitee.apim.core.api.query_service.ApiQueryService;
 import io.gravitee.apim.core.api.service_provider.ApiTemplateModelProvider;
 import io.gravitee.apim.core.api.use_case.GetExposedEntrypointsUseCase;
-import io.gravitee.apim.core.api.use_case.PatchApiUseCase.FlowListDeserializer;
-import io.gravitee.apim.core.api.use_case.PatchApiUseCase.FlowListSerializer;
+import io.gravitee.apim.core.api.use_case.PatchApiUseCase.ApiV4Deserializer;
 import io.gravitee.apim.core.api.use_case.RollbackApiUseCase;
 import io.gravitee.apim.core.api.use_case.WsdlToImportApiUseCase;
 import io.gravitee.apim.core.api_key.domain_service.ReconcileApiKeysDomainService;
@@ -196,7 +194,6 @@ import io.gravitee.apim.infra.spring.UsecaseSpringConfiguration;
 import io.gravitee.common.event.EventManager;
 import io.gravitee.common.util.DataEncryptor;
 import io.gravitee.definition.jackson.datatype.GraviteeMapper;
-import io.gravitee.definition.model.v4.flow.Flow;
 import io.gravitee.node.api.license.LicenseManager;
 import io.gravitee.repository.management.api.ApplicationRepository;
 import io.gravitee.repository.management.api.GroupRepository;
@@ -270,7 +267,6 @@ import io.gravitee.rest.api.service.search.SearchEngineService;
 import io.gravitee.rest.api.service.v4.ApiGroupService;
 import io.gravitee.rest.api.service.v4.PlanSearchService;
 import io.vertx.rxjava3.core.Vertx;
-import java.util.List;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
@@ -682,13 +678,25 @@ public class ResourceContextConfiguration {
     }
 
     @Bean
-    public FlowListDeserializer flowListDeserializer(ObjectMapper objectMapper) {
-        return node -> objectMapper.treeToValue(node, new TypeReference<List<Flow>>() {});
+    public ApiV4Deserializer apiV4Deserializer() {
+        return new V4PatchNotSupportedDeserializer();
     }
 
-    @Bean
-    public FlowListSerializer flowListSerializer(ObjectMapper objectMapper) {
-        return flows -> objectMapper.valueToTree(flows);
+    private static class V4PatchNotSupportedDeserializer implements ApiV4Deserializer {
+
+        private static final String MESSAGE = "v4 PATCH is served only by management-v2 REST API";
+
+        @Override
+        public com.fasterxml.jackson.databind.JsonNode toCurrentStateNode(io.gravitee.apim.core.api.model.Api api) {
+            throw new UnsupportedOperationException(MESSAGE + " (apiId=" + api.getId() + ")");
+        }
+
+        @Override
+        public io.gravitee.apim.core.api.use_case.PatchApiUseCase.ApiV4Fields fromPatchedNode(
+            com.fasterxml.jackson.databind.JsonNode patchedNode
+        ) {
+            throw new UnsupportedOperationException(MESSAGE);
+        }
     }
 
     @Bean

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/spring/ResourceContextConfiguration.java
@@ -17,7 +17,7 @@ package io.gravitee.rest.api.portal.rest.spring;
 
 import static org.mockito.Mockito.mock;
 
-import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import fakes.spring.FakeConfiguration;
 import inmemory.ApiCrudServiceInMemory;
@@ -62,13 +62,14 @@ import io.gravitee.apim.core.api.domain_service.UpdateApiDomainService;
 import io.gravitee.apim.core.api.domain_service.ValidateApiDomainService;
 import io.gravitee.apim.core.api.domain_service.VerifyApiPathDomainService;
 import io.gravitee.apim.core.api.domain_service.WsdlParserDomainService;
+import io.gravitee.apim.core.api.model.Api;
 import io.gravitee.apim.core.api.query_service.ApiEventQueryService;
 import io.gravitee.apim.core.api.query_service.ApiMetadataQueryService;
 import io.gravitee.apim.core.api.query_service.ApiQueryService;
 import io.gravitee.apim.core.api.service_provider.ApiTemplateModelProvider;
 import io.gravitee.apim.core.api.use_case.GetExposedEntrypointsUseCase;
-import io.gravitee.apim.core.api.use_case.PatchApiUseCase.FlowListDeserializer;
-import io.gravitee.apim.core.api.use_case.PatchApiUseCase.FlowListSerializer;
+import io.gravitee.apim.core.api.use_case.PatchApiUseCase.ApiV4Deserializer;
+import io.gravitee.apim.core.api.use_case.PatchApiUseCase.ApiV4Fields;
 import io.gravitee.apim.core.api.use_case.RollbackApiUseCase;
 import io.gravitee.apim.core.api.use_case.WsdlToImportApiUseCase;
 import io.gravitee.apim.core.api_key.domain_service.ReconcileApiKeysDomainService;
@@ -204,7 +205,6 @@ import io.gravitee.apim.infra.sanitizer.HtmlSanitizerImpl;
 import io.gravitee.apim.infra.spring.UsecaseSpringConfiguration;
 import io.gravitee.common.util.DataEncryptor;
 import io.gravitee.definition.jackson.datatype.GraviteeMapper;
-import io.gravitee.definition.model.v4.flow.Flow;
 import io.gravitee.node.api.license.LicenseManager;
 import io.gravitee.repository.management.api.ApplicationRepository;
 import io.gravitee.rest.api.portal.rest.mapper.AnalyticsMapper;
@@ -278,7 +278,6 @@ import io.gravitee.rest.api.service.v4.ApiSearchService;
 import io.gravitee.rest.api.service.v4.EndpointConnectorPluginService;
 import io.gravitee.rest.api.service.v4.PlanSearchService;
 import io.vertx.rxjava3.core.Vertx;
-import java.util.List;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
@@ -682,13 +681,8 @@ public class ResourceContextConfiguration {
     }
 
     @Bean
-    public FlowListDeserializer flowListDeserializer(ObjectMapper objectMapper) {
-        return node -> objectMapper.treeToValue(node, new TypeReference<List<Flow>>() {});
-    }
-
-    @Bean
-    public FlowListSerializer flowListSerializer(ObjectMapper objectMapper) {
-        return flows -> objectMapper.valueToTree(flows);
+    public ApiV4Deserializer apiV4Deserializer() {
+        return new V4PatchNotSupportedDeserializer();
     }
 
     @Bean
@@ -1473,5 +1467,20 @@ public class ResourceContextConfiguration {
     @Bean
     public io.gravitee.apim.core.log.crud_service.NativeApiLogCrudService nativeApiLogCrudService() {
         return mock(io.gravitee.apim.core.log.crud_service.NativeApiLogCrudService.class);
+    }
+
+    private static class V4PatchNotSupportedDeserializer implements ApiV4Deserializer {
+
+        private static final String MESSAGE = "v4 PATCH is served only by management-v2 REST API";
+
+        @Override
+        public JsonNode toCurrentStateNode(Api api) {
+            throw new UnsupportedOperationException(MESSAGE);
+        }
+
+        @Override
+        public ApiV4Fields fromPatchedNode(JsonNode patchedNode) {
+            throw new UnsupportedOperationException(MESSAGE);
+        }
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/use_case/PatchApiUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/use_case/PatchApiUseCase.java
@@ -537,6 +537,9 @@ public class PatchApiUseCase {
             return rawPatchNode.get(field).isNull() ? null : patched.get();
         }
         if (patchType == PatchType.JSON_PATCH) {
+            if (!isTargetedByJsonPatch(rawPatchNode, field)) {
+                return existing;
+            }
             if (patchedNode.get(field) == null && isNullifiedByJsonPatch(rawPatchNode, field)) {
                 return null;
             }
@@ -548,6 +551,20 @@ public class PatchApiUseCase {
             }
         }
         return existing;
+    }
+
+    private boolean isTargetedByJsonPatch(JsonNode rawPatchNode, String field) {
+        if (!rawPatchNode.isArray()) {
+            return false;
+        }
+        String fieldPrefix = JSON_PATCH_PATH_PREFIX + field;
+        for (JsonNode op : rawPatchNode) {
+            String path = op.path("path").asText();
+            if (path.equals(fieldPrefix) || path.startsWith(fieldPrefix + "/")) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private static String extractFailedField(IOException e) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/use_case/PatchApiUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/use_case/PatchApiUseCase.java
@@ -18,7 +18,6 @@ package io.gravitee.apim.core.api.use_case;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -62,6 +61,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Supplier;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import lombok.Builder;
@@ -156,8 +156,7 @@ public class PatchApiUseCase {
     private final WorkflowQueryService workflowQueryService;
     private final ObjectMapper objectMapper;
     private final PropertyDomainService propertyDomainService;
-    private final FlowListDeserializer flowListDeserializer;
-    private final FlowListSerializer flowListSerializer;
+    private final ApiV4Deserializer apiV4Deserializer;
     private final FlowCrudService flowCrudService;
 
     public Output execute(Input input) {
@@ -170,7 +169,7 @@ public class PatchApiUseCase {
             throw new ApiInvalidTypeException(input.apiId(), ApiType.PROXY);
         }
 
-        var currentNode = toJsonNode(existingApi);
+        var currentNode = apiV4Deserializer.toCurrentStateNode(existingApi);
         var patchNode = parseBody(input.patchBody());
 
         enforceAllowList(input.patchType(), patchNode);
@@ -230,13 +229,6 @@ public class PatchApiUseCase {
             }
         }
         return false;
-    }
-
-    private JsonNode toJsonNode(Api api) {
-        var httpV4 = requireHttpV4(api);
-        var node = (ObjectNode) objectMapper.valueToTree(PatchableView.from(api, httpV4));
-        node.set(FIELD_FLOWS, flowListSerializer.serialize(httpV4.getFlows()));
-        return node;
     }
 
     private static io.gravitee.definition.model.v4.Api asHttpV4(Api api) {
@@ -464,17 +456,8 @@ public class PatchApiUseCase {
         );
         var properties = encryptProperties(patchableProperties);
         var responseTemplates = resolveResponseTemplates(patchType, rawPatchNode, patchedNode, httpV4.getResponseTemplates());
-        var flows = resolveFlows(patchType, rawPatchNode, patchedNode, httpV4.getFlows());
-        var resources = resolvePatchableList(patchType, rawPatchNode, patchedNode, FIELD_RESOURCES, Resource.class, httpV4.getResources());
-        var listeners = resolvePatchableList(patchType, rawPatchNode, patchedNode, FIELD_LISTENERS, Listener.class, httpV4.getListeners());
-        var endpointGroups = resolvePatchableList(
-            patchType,
-            rawPatchNode,
-            patchedNode,
-            FIELD_ENDPOINT_GROUPS,
-            EndpointGroup.class,
-            httpV4.getEndpointGroups()
-        );
+
+        var apiV4Fields = resolveApiV4Fields(patchType, rawPatchNode, patchedNode, httpV4);
 
         var updatedDefinition = httpV4
             .toBuilder()
@@ -488,10 +471,10 @@ public class PatchApiUseCase {
             .allowedInApiProducts(allowedInApiProducts)
             .properties(properties)
             .responseTemplates(responseTemplates)
-            .flows(flows)
-            .resources(resources)
-            .listeners(listeners)
-            .endpointGroups(endpointGroups)
+            .flows(apiV4Fields.flows())
+            .resources(apiV4Fields.resources())
+            .listeners(apiV4Fields.listeners())
+            .endpointGroups(apiV4Fields.endpointGroups())
             .build();
 
         return existingApi
@@ -510,19 +493,48 @@ public class PatchApiUseCase {
             .build();
     }
 
-    private <T> List<T> resolvePatchableList(
+    private ApiV4Fields resolveApiV4Fields(
+        PatchType patchType,
+        JsonNode rawPatchNode,
+        JsonNode patchedNode,
+        io.gravitee.definition.model.v4.Api httpV4
+    ) {
+        ApiV4Fields deserialized;
+        try {
+            deserialized = apiV4Deserializer.fromPatchedNode(patchedNode);
+        } catch (IOException e) {
+            var field = extractFailedField(e);
+            var message = field.isEmpty()
+                ? "Invalid patch: " + e.getMessage()
+                : "Invalid value for field '" + field + "': " + e.getMessage();
+            throw new ValidationDomainException(message, Map.of("location", deserializationLocation(field, e)), "invalidValue");
+        }
+
+        var listeners = resolveField(patchType, rawPatchNode, patchedNode, FIELD_LISTENERS, deserialized::listeners, httpV4.getListeners());
+        var endpointGroups = resolveField(
+            patchType,
+            rawPatchNode,
+            patchedNode,
+            FIELD_ENDPOINT_GROUPS,
+            deserialized::endpointGroups,
+            httpV4.getEndpointGroups()
+        );
+        var flows = resolveField(patchType, rawPatchNode, patchedNode, FIELD_FLOWS, deserialized::flows, httpV4.getFlows());
+        var resources = resolveField(patchType, rawPatchNode, patchedNode, FIELD_RESOURCES, deserialized::resources, httpV4.getResources());
+
+        return new ApiV4Fields(listeners, endpointGroups, flows, resources);
+    }
+
+    private <R> R resolveField(
         PatchType patchType,
         JsonNode rawPatchNode,
         JsonNode patchedNode,
         String field,
-        Class<T> elementType,
-        List<T> existing
+        Supplier<R> patched,
+        R existing
     ) {
         if (patchType == PatchType.MERGE_PATCH && rawPatchNode.has(field)) {
-            if (rawPatchNode.get(field).isNull()) {
-                return null;
-            }
-            return readList(patchedNode, field, elementType, existing);
+            return rawPatchNode.get(field).isNull() ? null : patched.get();
         }
         if (patchType == PatchType.JSON_PATCH) {
             if (patchedNode.get(field) == null && isNullifiedByJsonPatch(rawPatchNode, field)) {
@@ -532,10 +544,38 @@ public class PatchApiUseCase {
                 if (patchedNode.get(field).isNull() && isNullifiedByJsonPatch(rawPatchNode, field)) {
                     return null;
                 }
-                return readList(patchedNode, field, elementType, existing);
+                return patched.get();
             }
         }
         return existing;
+    }
+
+    private static String extractFailedField(IOException e) {
+        if (e instanceof JsonMappingException jme && jme.getPath() != null && !jme.getPath().isEmpty()) {
+            var first = jme.getPath().getFirst();
+            if (first.getFieldName() != null) {
+                return first.getFieldName();
+            }
+        }
+        return "";
+    }
+
+    private <T> List<T> resolvePatchableList(
+        PatchType patchType,
+        JsonNode rawPatchNode,
+        JsonNode patchedNode,
+        String field,
+        Class<T> elementType,
+        List<T> existing
+    ) {
+        return resolveField(
+            patchType,
+            rawPatchNode,
+            patchedNode,
+            field,
+            () -> readList(patchedNode, field, elementType, existing),
+            existing
+        );
     }
 
     private Map<String, Map<String, ResponseTemplate>> resolveResponseTemplates(
@@ -544,62 +584,14 @@ public class PatchApiUseCase {
         JsonNode patchedNode,
         Map<String, Map<String, ResponseTemplate>> existing
     ) {
-        if (patchType == PatchType.MERGE_PATCH && rawPatchNode.has(FIELD_RESPONSE_TEMPLATES)) {
-            if (rawPatchNode.get(FIELD_RESPONSE_TEMPLATES).isNull()) {
-                return null;
-            }
-            return parseResponseTemplates(patchedNode);
-        }
-        if (patchType == PatchType.JSON_PATCH) {
-            if (patchedNode.get(FIELD_RESPONSE_TEMPLATES) == null && isNullifiedByJsonPatch(rawPatchNode, FIELD_RESPONSE_TEMPLATES)) {
-                return null;
-            }
-            if (patchedNode.has(FIELD_RESPONSE_TEMPLATES)) {
-                if (patchedNode.get(FIELD_RESPONSE_TEMPLATES).isNull() && isNullifiedByJsonPatch(rawPatchNode, FIELD_RESPONSE_TEMPLATES)) {
-                    return null;
-                }
-                return parseResponseTemplates(patchedNode);
-            }
-        }
-        return existing;
-    }
-
-    private List<Flow> resolveFlows(PatchType patchType, JsonNode rawPatchNode, JsonNode patchedNode, List<Flow> existing) {
-        if (patchType == PatchType.MERGE_PATCH && rawPatchNode.has(FIELD_FLOWS)) {
-            if (rawPatchNode.get(FIELD_FLOWS).isNull()) {
-                return null;
-            }
-            return deserializeFlows(patchedNode.get(FIELD_FLOWS));
-        }
-        if (patchType == PatchType.JSON_PATCH) {
-            return resolveFlowsForJsonPatch(rawPatchNode, patchedNode, existing);
-        }
-        return existing;
-    }
-
-    private List<Flow> resolveFlowsForJsonPatch(JsonNode rawPatchNode, JsonNode patchedNode, List<Flow> existing) {
-        if (patchedNode.get(FIELD_FLOWS) == null && isNullifiedByJsonPatch(rawPatchNode, FIELD_FLOWS)) {
-            return null;
-        }
-        if (!patchedNode.has(FIELD_FLOWS)) {
-            return existing;
-        }
-        if (patchedNode.get(FIELD_FLOWS).isNull()) {
-            return isNullifiedByJsonPatch(rawPatchNode, FIELD_FLOWS) ? null : existing;
-        }
-        return deserializeFlows(patchedNode.get(FIELD_FLOWS));
-    }
-
-    private List<Flow> deserializeFlows(JsonNode flowsArrayNode) {
-        try {
-            return flowListDeserializer.deserialize(flowsArrayNode);
-        } catch (IOException e) {
-            throw new ValidationDomainException(
-                "Invalid value for field '" + FIELD_FLOWS + "': " + e.getMessage(),
-                Map.of("location", deserializationLocation(FIELD_FLOWS, e)),
-                "invalidValue"
-            );
-        }
+        return resolveField(
+            patchType,
+            rawPatchNode,
+            patchedNode,
+            FIELD_RESPONSE_TEMPLATES,
+            () -> parseResponseTemplates(patchedNode),
+            existing
+        );
     }
 
     private Map<String, Map<String, ResponseTemplate>> parseResponseTemplates(JsonNode patchedNode) {
@@ -812,7 +804,6 @@ public class PatchApiUseCase {
         try {
             return objectMapper
                 .readerFor(objectMapper.getTypeFactory().constructCollectionType(List.class, elementType))
-                .with(DeserializationFeature.FAIL_ON_INVALID_SUBTYPE)
                 .readValue(fieldNode);
         } catch (Exception e) {
             throw new ValidationDomainException(
@@ -826,8 +817,11 @@ public class PatchApiUseCase {
     private String deserializationLocation(String field, Throwable e) {
         var cause = e instanceof IllegalArgumentException && e.getCause() != null ? e.getCause() : e;
         if (cause instanceof JsonMappingException jme && jme.getPath() != null && !jme.getPath().isEmpty()) {
+            var refs = jme.getPath();
             var sb = new StringBuilder("/").append(field);
-            for (var ref : jme.getPath()) {
+            int start = (!refs.isEmpty() && field.equals(refs.getFirst().getFieldName())) ? 1 : 0;
+            for (int i = start; i < refs.size(); i++) {
+                var ref = refs.get(i);
                 if (ref.getFieldName() != null) {
                     sb.append("/").append(ref.getFieldName());
                 } else if (ref.getIndex() >= 0) {
@@ -872,15 +866,12 @@ public class PatchApiUseCase {
         }
     }
 
-    @FunctionalInterface
-    public interface FlowListDeserializer {
-        List<Flow> deserialize(JsonNode flowsArrayNode) throws IOException;
+    public interface ApiV4Deserializer {
+        JsonNode toCurrentStateNode(Api api);
+        ApiV4Fields fromPatchedNode(JsonNode patchedNode) throws IOException;
     }
 
-    @FunctionalInterface
-    public interface FlowListSerializer {
-        JsonNode serialize(List<Flow> flows);
-    }
+    public record ApiV4Fields(List<Listener> listeners, List<EndpointGroup> endpointGroups, List<Flow> flows, List<Resource> resources) {}
 
     public enum PatchType {
         JSON_PATCH,
@@ -933,31 +924,8 @@ public class PatchApiUseCase {
         }
     }
 
-    record PatchableResponseTemplate(Integer statusCode, Map<String, String> headers, String body, Boolean propagateErrorKeyToLogs) {
-        static PatchableResponseTemplate from(ResponseTemplate domain) {
-            if (domain == null) {
-                return null;
-            }
-            return new PatchableResponseTemplate(
-                domain.getStatusCode(),
-                domain.getHeaders(),
-                domain.getBody(),
-                domain.isPropagateErrorKeyToLogs()
-            );
-        }
-
-        ResponseTemplate toDomain() {
-            return ResponseTemplate.builder()
-                .statusCode(statusCode != null ? statusCode : 0)
-                .headers(headers)
-                .body(body)
-                .propagateErrorKeyToLogs(propagateErrorKeyToLogs != null && propagateErrorKeyToLogs)
-                .build();
-        }
-    }
-
     @JsonInclude(JsonInclude.Include.ALWAYS)
-    record PatchableView(
+    public record PatchableView(
         String name,
         String description,
         String apiVersion,
@@ -980,7 +948,8 @@ public class PatchApiUseCase {
         List<Listener> listeners,
         List<EndpointGroup> endpointGroups
     ) {
-        static PatchableView from(Api api, io.gravitee.definition.model.v4.Api httpV4) {
+        public static PatchableView from(Api api) {
+            var httpV4 = requireHttpV4(api);
             return new PatchableView(
                 api.getName(),
                 api.getDescription(),
@@ -1023,6 +992,29 @@ public class PatchApiUseCase {
                             .collect(Collectors.toMap(Map.Entry::getKey, inner -> PatchableResponseTemplate.from(inner.getValue())))
                     )
                 );
+        }
+    }
+
+    record PatchableResponseTemplate(Integer statusCode, Map<String, String> headers, String body, Boolean propagateErrorKeyToLogs) {
+        static PatchableResponseTemplate from(ResponseTemplate domain) {
+            if (domain == null) {
+                return null;
+            }
+            return new PatchableResponseTemplate(
+                domain.getStatusCode(),
+                domain.getHeaders(),
+                domain.getBody(),
+                domain.isPropagateErrorKeyToLogs()
+            );
+        }
+
+        ResponseTemplate toDomain() {
+            return ResponseTemplate.builder()
+                .statusCode(statusCode != null ? statusCode : 0)
+                .headers(headers)
+                .body(body)
+                .propagateErrorKeyToLogs(propagateErrorKeyToLogs != null && propagateErrorKeyToLogs)
+                .build();
         }
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/PatchApiUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/PatchApiUseCaseTest.java
@@ -103,12 +103,36 @@ class PatchApiUseCaseTest {
 
     static final ObjectMapper OBJECT_MAPPER = new GraviteeMapper(false);
 
-    private static final PatchApiUseCase.FlowListDeserializer FLOW_DESERIALIZER = node ->
-        OBJECT_MAPPER.<List<Flow>>readerFor(OBJECT_MAPPER.getTypeFactory().constructCollectionType(List.class, Flow.class))
-            .with(DeserializationFeature.FAIL_ON_INVALID_SUBTYPE)
-            .readValue(node);
+    private static final PatchApiUseCase.ApiV4Deserializer API_V4_DESERIALIZER = new PatchApiUseCase.ApiV4Deserializer() {
+        @Override
+        public com.fasterxml.jackson.databind.JsonNode toCurrentStateNode(io.gravitee.apim.core.api.model.Api api) {
+            return OBJECT_MAPPER.valueToTree(PatchApiUseCase.PatchableView.from(api));
+        }
 
-    private static final PatchApiUseCase.FlowListSerializer FLOW_SERIALIZER = flows -> OBJECT_MAPPER.valueToTree(flows);
+        @Override
+        public PatchApiUseCase.ApiV4Fields fromPatchedNode(com.fasterxml.jackson.databind.JsonNode patchedNode) throws java.io.IOException {
+            List<Listener> listeners = readField(patchedNode, "listeners", Listener.class);
+            List<EndpointGroup> endpointGroups = readField(patchedNode, "endpointGroups", EndpointGroup.class);
+            List<Flow> flows = readField(patchedNode, "flows", Flow.class);
+            List<Resource> resources = readField(patchedNode, "resources", Resource.class);
+            return new PatchApiUseCase.ApiV4Fields(listeners, endpointGroups, flows, resources);
+        }
+
+        private <T> List<T> readField(com.fasterxml.jackson.databind.JsonNode node, String field, Class<T> elementType)
+            throws java.io.IOException {
+            var fieldNode = node.get(field);
+            if (fieldNode == null || fieldNode.isNull()) {
+                return null;
+            }
+            try {
+                return OBJECT_MAPPER.readerFor(OBJECT_MAPPER.getTypeFactory().constructCollectionType(List.class, elementType))
+                    .with(DeserializationFeature.FAIL_ON_INVALID_SUBTYPE)
+                    .readValue(fieldNode);
+            } catch (com.fasterxml.jackson.databind.JsonMappingException jme) {
+                throw com.fasterxml.jackson.databind.JsonMappingException.wrapWithPath(jme, this, field);
+            }
+        }
+    };
 
     ApiCrudServiceInMemory apiCrudService = new ApiCrudServiceInMemory();
     FlowCrudServiceInMemory flowCrudService = new FlowCrudServiceInMemory();
@@ -131,8 +155,7 @@ class PatchApiUseCaseTest {
             workflowQueryService,
             OBJECT_MAPPER,
             propertyDomainService,
-            FLOW_DESERIALIZER,
-            FLOW_SERIALIZER,
+            API_V4_DESERIALIZER,
             flowCrudService
         );
 
@@ -522,6 +545,55 @@ class PatchApiUseCaseTest {
             var output = execute(type, setField(type, "name", "only-name-changed"), false);
 
             assertNonPatchedFieldsPreserved(output.api(), existing, "only-name-changed");
+        }
+
+        @ParameterizedTest
+        @EnumSource(PatchApiUseCase.PatchType.class)
+        void codec_top_level_mapping_error_produces_location_at_root(PatchApiUseCase.PatchType type) {
+            PatchApiUseCase.ApiV4Deserializer throwingCodec = new PatchApiUseCase.ApiV4Deserializer() {
+                @Override
+                public com.fasterxml.jackson.databind.JsonNode toCurrentStateNode(Api api) {
+                    return OBJECT_MAPPER.valueToTree(PatchApiUseCase.PatchableView.from(api));
+                }
+
+                @Override
+                public PatchApiUseCase.ApiV4Fields fromPatchedNode(com.fasterxml.jackson.databind.JsonNode node)
+                    throws java.io.IOException {
+                    throw new java.io.IOException("top-level mapping failure");
+                }
+            };
+            var localCut = new PatchApiUseCase(
+                apiCrudService,
+                apiPrimaryOwnerDomainService,
+                updateApiDomainService,
+                new io.gravitee.apim.core.json_patch.domain_service.JsonPatchDomainService(
+                    new io.gravitee.apim.infra.domain_service.json_patch.JsonMergePatchServiceImpl(),
+                    new io.gravitee.apim.infra.domain_service.json_patch.JsonPatchServiceImpl()
+                ),
+                workflowQueryService,
+                OBJECT_MAPPER,
+                propertyDomainService,
+                throwingCodec,
+                flowCrudService
+            );
+
+            assertThatThrownBy(() ->
+                localCut.execute(
+                    PatchApiUseCase.Input.builder()
+                        .apiId(API_ID)
+                        .patchType(type)
+                        .patchBody(setField(type, "name", "x"))
+                        .dryRun(false)
+                        .auditInfo(AuditInfoFixtures.anAuditInfo(ORGANIZATION_ID, ENVIRONMENT_ID, USER_ID))
+                        .build()
+                )
+            )
+                .isInstanceOf(ValidationDomainException.class)
+                .asInstanceOf(org.assertj.core.api.InstanceOfAssertFactories.type(ValidationDomainException.class))
+                .satisfies(ex -> {
+                    assertThat(ex.getParameters().get("location")).isEqualTo("/");
+                    assertThat(ex.getParameters().get("location")).doesNotContain("apiDefinition");
+                });
         }
     }
 
@@ -1924,33 +1996,10 @@ class PatchApiUseCaseTest {
         }
 
         @Test
-        void json_patch_not_touching_flows_preserves_null_flows_without_calling_deserializer() {
-            var sentinel = List.of(aFlow("sentinel", List.of()));
-            var includeNullsMapper = new GraviteeMapper(false);
-            includeNullsMapper.setSerializationInclusion(JsonInclude.Include.ALWAYS);
-            var localCut = new PatchApiUseCase(
-                apiCrudService,
-                apiPrimaryOwnerDomainService,
-                updateApiDomainService,
-                new JsonPatchDomainService(new JsonMergePatchServiceImpl(), new JsonPatchServiceImpl()),
-                workflowQueryService,
-                includeNullsMapper,
-                propertyDomainService,
-                node -> sentinel,
-                flows -> includeNullsMapper.valueToTree(flows),
-                flowCrudService
-            );
+        void json_patch_not_touching_flows_preserves_null_flows() {
             givenExistingApi(apiWithFlows(null));
 
-            var output = localCut.execute(
-                PatchApiUseCase.Input.builder()
-                    .apiId(API_ID)
-                    .patchType(PatchApiUseCase.PatchType.JSON_PATCH)
-                    .patchBody(patch("replace", "/name", "patched-name"))
-                    .dryRun(false)
-                    .auditInfo(AuditInfoFixtures.anAuditInfo(ORGANIZATION_ID, ENVIRONMENT_ID, USER_ID))
-                    .build()
-            );
+            var output = execute(PatchApiUseCase.PatchType.JSON_PATCH, patch("replace", "/name", "patched-name"), false);
 
             assertThat(httpV4Def(output.api()).getFlows()).isNull();
         }


### PR DESCRIPTION
## Issue

[APIM-14083](https://gravitee.atlassian.net/browse/APIM-14083)

## Why

`PatchApiUseCase` was deserializing polymorphic fields (`listeners`, `endpointGroups`, `flows`, `resources`) from the merged JSON node directly to domain classes (e.g. `Listener.class`, `EndpointGroup.class`), bypassing the REST DTO layer that handles OpenAPI discriminator normalisation. This caused PATCH to silently reject discriminator values that GET returns and PUT accepts — for example, `"type": "HTTP"` for listeners. APIM-14077 added a per-field port for flows; this change generalises the fix by routing all polymorphic fields through the same DTO deserialization chain that PUT uses.

## What changed

- **`PatchApiUseCase`** — introduced `ApiV4Deserializer` port (injected via constructor) with `toCurrentStateNode` / `fromPatchedNode` methods. Replaced the four `resolvePatchableList` calls for `listeners`, `endpointGroups`, `flows`, and `resources` with a single `resolveApiV4Fields` delegation to the port. Added generic `resolveField` helper to remove duplication in `resolveResponseTemplates` and `resolvePatchableList`. Fixed `deserializationLocation` to avoid repeating the root field name in the JSON path. Made `PatchableView` and its `from(Api)` factory public for reuse by the adapter.
- **`PatchApiV4Deserializer`** (new, `adapter` package) — REST-layer implementation of `ApiV4Deserializer`. `toCurrentStateNode` builds the current-state JSON node by serializing `PatchableView` then overlaying the REST DTO representations of the four polymorphic fields via `ApiMapper.mapToV4`. `fromPatchedNode` deserializes the merged node back through Jackson's `GenericApi` polymorphism (resolves to `ApiV4`) and maps it to `ApiV4Fields` via `ApiMapper.mapToCoreApi`.
- **`ApiMapper`** — added `mapToCoreApi(ApiV4)` overload that maps each REST DTO collection to its domain type via the existing `ListenerMapper`, `EndpointMapper`, `FlowMapper`, and `ResourceMapper` chains; added a null guard in `computeCoreApiLinks` so `mapToV4` is callable without a `UriInfo` context.
- **Spring configs** — wired `PatchApiV4Deserializer` bean in `RestManagementConfiguration` (v2) and `RestAutomationConfiguration`; provided a fail-fast stub in the v1 `RestManagementConfiguration` (v4 PATCH is not served there).

## User-facing impact

PATCH on v4 HTTP Proxy APIs now accepts the same discriminator values for `listeners`, `endpointGroups`, `flows`, and `resources` as GET and PUT. Clients sending the uppercase values returned by GET (e.g. `"type": "HTTP"`) that were previously rejected will now be accepted.

## Gotchas / Follow-up

The `FlowListDeserializer` port introduced by APIM-14077 is now superseded by the `ApiV4Deserializer` port — flows are handled through the same path as the other polymorphic fields. That port can be removed in a follow-up once this lands.

[APIM-14083]: https://gravitee.atlassian.net/browse/APIM-14083?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ