### PR TITLE
chore(deps): bump gravitee-apim-repository-bridge 8.1.0 → 8.2.0 (APIM-14087)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -314,7 +314,7 @@
         <gravitee-resource-ai-vector-store-aws-s3.version>1.0.0</gravitee-resource-ai-vector-store-aws-s3.version>
         <gravitee-resource-ai-model-text-embedding.version>1.0.0</gravitee-resource-ai-model-text-embedding.version>
         <gravitee-policy-ai-semantic-caching.version>1.1.0</gravitee-policy-ai-semantic-caching.version>
-        <gravitee-apim-repository-bridge.version>8.1.0</gravitee-apim-repository-bridge.version>
+        <gravitee-apim-repository-bridge.version>8.2.0</gravitee-apim-repository-bridge.version>
         <gravitee-secretprovider-hc-vault.version>2.1.0</gravitee-secretprovider-hc-vault.version>
         <gravitee-secretprovider-aws.version>2.0.0</gravitee-secretprovider-aws.version>
         <gravitee-service-secrets.version>3.0.1</gravitee-service-secrets.version>


### PR DESCRIPTION
## Summary

Bumps `gravitee-apim-repository-bridge` from **8.1.0** → **8.2.0**.

## Why

8.2.0 ships the bridge-side `searchAfter` implementation ([bridge PR #132](https://github.com/gravitee-io/gravitee-apim-repository-bridge/pull/132)) that pairs with the gateway-sync keyset pagination work in APIM-14087 (merged via [#16968](https://github.com/gravitee-io/gravitee-api-management/pull/16968), commit `39a9346931`).

Without this bump, gateways configured with `management.type: http` would fail at Spring init with `AbstractMethodError` — `SubscriptionRepository.searchAfter` is on the interface but the 8.1.0 bridge client doesn't implement it.

## Compatibility

- **Required** for HTTP-bridge gateways on 4.11.x once any tick triggers `searchAfter` (which is now the default subscription sync path).
- 8.2.0 also covers two unrelated upstream additions (`PlanRepository.findByCrossIds`, `SubscriptionRepository.searchUnordered`) — they're stubbed in the bridge as `notImplementedException()`; gateway code doesn't call them.

## Test plan

- [x] Local build of monorepo with the version bump compiles
- [ ] CI green on this PR
- [ ] Smoke verification on a bridge-mode deployment (server: this APIM build, client: bridge 8.2.0 jar)

Fixes APIM-14087 (deployment side)