### PR TITLE
fix(console): guard console settings fetch with org-settings-r

### DIFF
--- a/gravitee-apim-console-webui/src/management/settings/groups/groups.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/settings/groups/groups.component.spec.ts
@@ -45,13 +45,15 @@ describe('GroupsComponent', () => {
   let rootLoader: HarnessLoader;
   let httpTestingController: HttpTestingController;
 
-  const init = async () => {
+  const init = async (
+    permissions: string[] = ['environment-group-u', 'environment-group-d', 'environment-group-c', 'organization-settings-r'],
+  ) => {
     await TestBed.configureTestingModule({
       declarations: [],
       providers: [
         {
           provide: GioTestingPermissionProvider,
-          useValue: ['environment-group-u', 'environment-group-d', 'environment-group-c', 'environment-settings-r'],
+          useValue: permissions,
         },
       ],
       imports: [GroupsComponent, GioTestingModule, NoopAnimationsModule],
@@ -73,6 +75,17 @@ describe('GroupsComponent', () => {
 
   afterEach(() => {
     httpTestingController.verify();
+  });
+
+  describe('Settings (without organization-settings-r permission)', () => {
+    beforeEach(async () => {
+      await init(['environment-group-u', 'environment-group-d', 'environment-group-c']);
+    });
+
+    it('should not fetch console settings when user lacks organization-settings-r', async () => {
+      expectGetGroupsList(emptyPage);
+      httpTestingController.expectNone(`${CONSTANTS_TESTING.org.baseURL}/settings`);
+    });
   });
 
   describe('Settings', () => {

--- a/gravitee-apim-console-webui/src/management/settings/groups/groups.component.ts
+++ b/gravitee-apim-console-webui/src/management/settings/groups/groups.component.ts
@@ -180,7 +180,7 @@ export class GroupsComponent implements OnInit {
   }
 
   private initializeSettingsForm() {
-    const canReadSettings = this.permissionService.hasAnyMatching(['environment-settings-r']);
+    const canReadSettings = this.permissionService.hasAnyMatching(['organization-settings-r']);
 
     if (canReadSettings) {
       this.consoleSettingsService


### PR DESCRIPTION
Fixes [APIM-13836](https://gravitee.atlassian.net/browse/APIM-13836).

`GroupsComponent.initializeSettingsForm` guarded its call to `ConsoleSettingsService.get()` with `environment-settings-r`, but the endpoint hit (`GET /organizations/{orgId}/settings`) requires `organization-settings-r`. Users with env-level Group CRUD but no org-level settings perm passed the guard, the call 403ed, and the UI showed an "insufficient rights" pop-up.

## Changes
- `groups.component.ts`: guard switched to `organization-settings-r` to match the endpoint's actual permission requirement.
- `groups.component.spec.ts`: parameterized `init()` to accept a permissions list; added regression test asserting no `GET /settings` call when the org permission is absent.

## Test plan
- [x] `nx test console --testPathPatterns=groups.component.spec` — all pass (including the new regression test)
- [x] `nx format:check --libs-and-apps` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[APIM-13836]: https://gravitee.atlassian.net/browse/APIM-13836?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ