### PR TITLE
fix(gamma-apim): deploy banner, checklist toggles, and UX polish

### DIFF
--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/app/AppRoutes.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/app/AppRoutes.tsx
@@ -105,8 +105,6 @@ export function AppRoutes() {
                             <Route path="properties" element={<ApiPropertiesPage />} />
                             <Route path="resources" element={<ApiDetailPlaceholderPage title="Resources" />} />
                             <Route path="notifications" element={<ApiNotificationsPage />} />
-                            <Route path="api-score" element={<ApiDetailPlaceholderPage title="API Score" />} />
-                            <Route path="response-templates" element={<ApiDetailPlaceholderPage title="Response Templates" />} />
                             <Route path="entrypoints" element={<ApiEntrypointsPage />} />
                             <Route path="cors" element={<ApiCorsPage />} />
                             <Route path="endpoints">
@@ -131,7 +129,6 @@ export function AppRoutes() {
                                 <Route path=":subscriptionId" element={<ApiConsumerDetailPage />} />
                             </Route>
                             <Route path="broadcasts" element={<ApiBroadcastsPage />} />
-                            <Route path="authorization" element={<ApiDetailPlaceholderPage title="Authorization" />} />
                             <Route path="user-permissions" element={<UserPermissionsPage />} />
                             <Route path="alerts">
                                 <Route index element={<ApiAlertsPage />} />

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/api-products/components/list/ApiProductListView.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/api-products/components/list/ApiProductListView.tsx
@@ -67,7 +67,7 @@ export function ApiProductListView({
 
             {/* Search + pagination row */}
             <div className="flex items-center justify-between gap-4">
-                <div className="relative w-72 shrink-0">
+                <div className="relative flex-1 max-w-sm">
                     <SearchIcon
                         className="absolute left-3 top-1/2 -translate-y-1/2 size-4 text-muted-foreground pointer-events-none"
                         aria-hidden

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/api-products/pages/detail/ApiProductOverviewPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/api-products/pages/detail/ApiProductOverviewPage.tsx
@@ -15,7 +15,7 @@
  */
 import { Card, CardContent } from '@gravitee/graphene-core';
 import { BoxesIcon, PlugIcon, ShieldIcon, UserCogIcon } from '@gravitee/graphene-core/icons';
-import { useMemo } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import { useParams } from 'react-router-dom';
 
 import { OverviewChecklistCard, type OverviewChecklistItem } from '../../../../shared/components/OverviewChecklistCard';
@@ -29,6 +29,7 @@ export function ApiProductOverviewPage() {
 
     const apiCount = product?.apiIds?.length ?? 0;
     const memberCount = membersData?.pagination?.totalCount ?? 0;
+    const [manuallyDone, setManuallyDone] = useState<Set<string>>(new Set());
 
     const checklistItems = useMemo<OverviewChecklistItem[]>(
         () => [
@@ -39,7 +40,8 @@ export function ApiProductOverviewPage() {
                 to: '../apis',
                 icon: BoxesIcon,
                 actionLabel: 'Open APIs',
-                done: apiCount > 0,
+                done: apiCount > 0 || manuallyDone.has('add-apis'),
+                locked: apiCount > 0,
             },
             {
                 id: 'add-plans',
@@ -49,7 +51,8 @@ export function ApiProductOverviewPage() {
                 to: '../plans',
                 icon: ShieldIcon,
                 actionLabel: 'Open Plans',
-                done: false,
+                done: manuallyDone.has('add-plans'),
+                locked: false,
             },
             {
                 id: 'first-subscription',
@@ -59,7 +62,8 @@ export function ApiProductOverviewPage() {
                 to: '../consumers',
                 icon: PlugIcon,
                 actionLabel: 'Open Consumers',
-                done: false,
+                done: manuallyDone.has('first-subscription'),
+                locked: false,
             },
             {
                 id: 'team-access',
@@ -68,11 +72,22 @@ export function ApiProductOverviewPage() {
                 to: '../user-permissions',
                 icon: UserCogIcon,
                 actionLabel: 'Manage Access',
-                done: memberCount > 1,
+                done: memberCount > 1 || manuallyDone.has('team-access'),
+                locked: memberCount > 1,
             },
         ],
-        [apiCount, memberCount],
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+        [apiCount, memberCount, manuallyDone],
     );
+
+    const handleToggle = useCallback((id: string, newDone: boolean) => {
+        setManuallyDone(prev => {
+            const next = new Set(prev);
+            if (newDone) next.add(id);
+            else next.delete(id);
+            return next;
+        });
+    }, []);
 
     if (isLoading)
         return (
@@ -91,6 +106,7 @@ export function ApiProductOverviewPage() {
             <OverviewChecklistCard
                 description="Finish setting up your API product. Each row links to the right screen."
                 items={checklistItems}
+                onToggle={handleToggle}
             />
 
             <div className="space-y-3">

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/components/detail/ApiDetailLayout.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/components/detail/ApiDetailLayout.spec.tsx
@@ -59,18 +59,14 @@ jest.mock('../../utils/queryKeys', () => ({
 }));
 
 jest.mock('@gravitee/graphene-core', () => ({
-    Alert: ({ children, className }: { children?: ReactNode; className?: string }) => (
-        <div role="alert" className={className}>
-            {children}
-        </div>
-    ),
-    AlertDescription: ({ children }: { children?: ReactNode }) => <span>{children}</span>,
     Badge: ({ children }: { children?: ReactNode }) => <span>{children}</span>,
     Button: ({ children, onClick, disabled }: { children?: ReactNode; onClick?: () => void; disabled?: boolean }) => (
         <button type="button" onClick={onClick} disabled={disabled}>
             {children}
         </button>
     ),
+    Card: ({ children, className }: { children?: ReactNode; className?: string }) => <div className={className}>{children}</div>,
+    CardContent: ({ children, className }: { children?: ReactNode; className?: string }) => <div className={className}>{children}</div>,
     Skeleton: () => <div />,
 }));
 

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/components/detail/ApiDetailLayout.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/components/detail/ApiDetailLayout.tsx
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 import { useEnvironment, useHasPermission } from '@gravitee/gamma-modules-sdk';
-import { Alert, AlertDescription, Badge, Button, Skeleton } from '@gravitee/graphene-core';
-import { CircleCheckIcon, CircleStopIcon, CircleXIcon, TriangleAlertIcon } from '@gravitee/graphene-core/icons';
+import { Badge, Button, Card, CardContent, Skeleton } from '@gravitee/graphene-core';
+import { CircleCheckIcon, CircleStopIcon, CircleXIcon, MessageSquareWarningIcon, TriangleAlertIcon } from '@gravitee/graphene-core/icons';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useState } from 'react';
 import { Navigate, Outlet, useParams } from 'react-router-dom';
@@ -29,13 +29,25 @@ import { deployApi } from '../../services/apis';
 import type { ApiDetailDto } from '../../types';
 import { apiDetailKeys } from '../../utils/queryKeys';
 
-function StateIndicator({ state }: { state: ApiDetailDto['state'] }) {
+function StateIndicator({ state, deploymentState }: { state: ApiDetailDto['state']; deploymentState?: string }) {
+    if (state === 'STARTED' && deploymentState === 'NEED_REDEPLOY') {
+        return (
+            <Badge
+                className="gap-1 h-5 px-1.5 text-xs font-medium border-transparent"
+                style={{ backgroundColor: 'color-mix(in oklab, var(--color-warning) 12%, transparent)', color: 'var(--color-warning)' }}
+            >
+                <TriangleAlertIcon className="size-3" />
+                Out of sync
+            </Badge>
+        );
+    }
+
     switch (state) {
         case 'STARTED':
             return (
                 <Badge className="gap-1 h-5 px-1.5 text-xs font-medium bg-success/10 text-success border-transparent">
                     <CircleCheckIcon className="size-3" />
-                    Deployed
+                    Started
                 </Badge>
             );
         case 'STOPPED':
@@ -66,15 +78,20 @@ function ApiAvatar({ api }: { api: ApiDetailDto }) {
 
 function DeployBanner({ onDeploy, isPending }: { onDeploy: () => void; isPending: boolean }) {
     return (
-        <Alert className="rounded-none border-x-0 border-t-0 flex items-center justify-between gap-4">
-            <div className="flex items-center gap-2">
-                <TriangleAlertIcon className="size-4 text-warning shrink-0" />
-                <AlertDescription>This API has pending changes. Redeploy to apply them to the gateway.</AlertDescription>
-            </div>
-            <Button size="sm" onClick={onDeploy} disabled={isPending} className="shrink-0">
-                {isPending ? 'Deploying…' : 'Deploy API'}
-            </Button>
-        </Alert>
+        <div className="px-6 pt-4">
+            <Card>
+                <CardContent className="flex items-center justify-between gap-3 py-3">
+                    <div className="flex items-center gap-2">
+                        <MessageSquareWarningIcon className="size-4 text-warning shrink-0" />
+                        <p className="text-sm font-medium">Pending changes</p>
+                        <p className="text-sm text-muted-foreground">— This API is out of sync.</p>
+                    </div>
+                    <Button size="sm" onClick={onDeploy} disabled={isPending} className="shrink-0">
+                        {isPending ? 'Deploying…' : 'Deploy API'}
+                    </Button>
+                </CardContent>
+            </Card>
+        </div>
     );
 }
 
@@ -111,7 +128,7 @@ function ApiInfoHeader({ api, isLoading }: { api: ApiDetailDto | null; isLoading
                     >
                         {api.name}
                     </p>
-                    {api.state ? <StateIndicator state={api.state} /> : null}
+                    {api.state ? <StateIndicator state={api.state} deploymentState={api.deploymentState} /> : null}
                 </div>
             </div>
 

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/components/detail/ApiDetailSidebarNav.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/components/detail/ApiDetailSidebarNav.tsx
@@ -13,12 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { cn, Skeleton } from '@gravitee/graphene-core';
+import { cn, Skeleton, Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@gravitee/graphene-core';
 import {
     ActivityIcon,
     BellIcon,
     ChevronDownIcon,
     ChevronRightIcon,
+    FlaskConicalIcon,
     GlobeIcon,
     LayoutDashboardIcon,
     ListIcon,
@@ -55,6 +56,8 @@ export interface DetailNavItem {
     /** When false, matches any sub-path (prefix match). Defaults to true (exact match). */
     end?: boolean;
     children?: DetailNavChild[];
+    /** When true, renders as a non-navigable item with a lab icon and "Coming soon" tooltip. */
+    comingSoon?: boolean;
 }
 
 export interface DetailNavGroup {
@@ -73,8 +76,8 @@ export const API_PROXY_NAV_GROUPS: DetailNavGroup[] = [
             { path: 'properties', label: 'API Properties', icon: SettingsIcon },
             { path: 'resources', label: 'Resources', icon: ServerIcon },
             { path: 'notifications', label: 'Notifications', icon: BellIcon },
-            { path: 'api-score', label: 'API Score', icon: SparklesIcon },
-            { path: 'response-templates', label: 'Response Templates', icon: ScrollTextIcon },
+            { path: 'api-score', label: 'API Score', icon: SparklesIcon, comingSoon: true },
+            { path: 'response-templates', label: 'Response Templates', icon: ScrollTextIcon, comingSoon: true },
             { path: 'cors', label: 'CORS', icon: ShieldCheckIcon },
         ],
     },
@@ -110,7 +113,7 @@ export const API_PROXY_NAV_GROUPS: DetailNavGroup[] = [
     {
         label: 'Security',
         items: [
-            { path: 'authorization', label: 'Authorization', icon: LockIcon },
+            { path: 'authorization', label: 'Authorization', icon: LockIcon, comingSoon: true },
             { path: 'user-permissions', label: 'User Permissions', icon: UsersIcon },
         ],
     },
@@ -221,42 +224,63 @@ export function ApiDetailSidebarNav({ groups, basePath, permissionsReady = true 
     }
 
     return (
-        <div className="space-y-0.5 px-2 py-2">
-            {groups.map(group => (
-                <div key={group.label} className="pt-4 first:pt-0">
-                    <p className="mb-1 px-3 text-xs font-semibold uppercase tracking-wider text-muted-foreground">{group.label}</p>
-                    {group.items.map(item => {
-                        if (item.children && item.children.length > 0) {
+        <TooltipProvider delayDuration={300}>
+            <div className="space-y-0.5 px-2 py-2">
+                {groups.map(group => (
+                    <div key={group.label} className="pt-4 first:pt-0">
+                        <p className="mb-1 px-3 text-xs font-semibold uppercase tracking-wider text-muted-foreground">{group.label}</p>
+                        {group.items.map(item => {
+                            if (item.children && item.children.length > 0) {
+                                return (
+                                    <CollapsibleNavItem
+                                        key={item.path}
+                                        item={item as DetailNavItem & { children: DetailNavChild[] }}
+                                        basePath={basePath}
+                                    />
+                                );
+                            }
+                            const Icon = item.icon;
+                            if (item.comingSoon) {
+                                return (
+                                    <Tooltip key={item.path}>
+                                        <TooltipTrigger asChild>
+                                            <div
+                                                className="flex items-center gap-2.5 rounded-lg px-3 py-2 text-sm cursor-not-allowed select-none text-muted-foreground/50"
+                                                aria-disabled="true"
+                                            >
+                                                <Icon className="size-4 shrink-0" aria-hidden />
+                                                <span className="flex-1">{item.label}</span>
+                                                <FlaskConicalIcon className="size-3.5 shrink-0" aria-hidden />
+                                            </div>
+                                        </TooltipTrigger>
+                                        <TooltipContent side="right" className="text-xs">
+                                            Coming soon
+                                        </TooltipContent>
+                                    </Tooltip>
+                                );
+                            }
                             return (
-                                <CollapsibleNavItem
+                                <NavLink
+                                    end={item.end !== false}
                                     key={item.path}
-                                    item={item as DetailNavItem & { children: DetailNavChild[] }}
-                                    basePath={basePath}
-                                />
+                                    to={`${basePath}/${item.path}`}
+                                    className={({ isActive }) =>
+                                        cn(
+                                            'flex items-center gap-2.5 rounded-lg px-3 py-2 text-sm transition-colors',
+                                            isActive
+                                                ? 'bg-accent text-foreground font-medium'
+                                                : 'text-muted-foreground hover:bg-muted hover:text-foreground',
+                                        )
+                                    }
+                                >
+                                    <Icon className="size-4 shrink-0" aria-hidden />
+                                    {item.label}
+                                </NavLink>
                             );
-                        }
-                        const Icon = item.icon;
-                        return (
-                            <NavLink
-                                end={item.end !== false}
-                                key={item.path}
-                                to={`${basePath}/${item.path}`}
-                                className={({ isActive }) =>
-                                    cn(
-                                        'flex items-center gap-2.5 rounded-lg px-3 py-2 text-sm transition-colors',
-                                        isActive
-                                            ? 'bg-accent text-foreground font-medium'
-                                            : 'text-muted-foreground hover:bg-muted hover:text-foreground',
-                                    )
-                                }
-                            >
-                                <Icon className="size-4 shrink-0" aria-hidden />
-                                {item.label}
-                            </NavLink>
-                        );
-                    })}
-                </div>
-            ))}
-        </div>
+                        })}
+                    </div>
+                ))}
+            </div>
+        </TooltipProvider>
     );
 }

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/components/list/ApisListView.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/components/list/ApisListView.tsx
@@ -73,7 +73,7 @@ export function ApisListView({
 
             {/* Search + pagination row */}
             <div className="flex items-center justify-between gap-4">
-                <div className="relative w-72 shrink-0">
+                <div className="relative flex-1 max-w-sm">
                     <SearchIcon
                         className="absolute left-3 top-1/2 -translate-y-1/2 size-4 text-muted-foreground pointer-events-none"
                         aria-hidden

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/hooks/usePlans.ts
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/hooks/usePlans.ts
@@ -19,7 +19,7 @@ import { keepPreviousData, useMutation, useQuery, useQueryClient } from '@tansta
 import { createPlan, deletePlan, getPlan, listPlans, transitionPlan, updatePlan } from '../services/plans';
 import type { ManagedPlan, PlanContext, PlanFormValue, PlanStatus, PlanTransitionAction } from '../types/plan';
 import { planFormToPayload } from '../utils/planTransformers';
-import { apiPlanKeys } from '../utils/queryKeys';
+import { apiDetailKeys, apiPlanKeys } from '../utils/queryKeys';
 
 /** Paginated plan list filtered by statuses. */
 export function usePlanList(ctx: PlanContext, statuses: PlanStatus[], page: number, perPage = 10) {
@@ -85,8 +85,11 @@ export function usePlan(ctx: PlanContext, planId: string | undefined) {
     });
 }
 
-function invalidatePlans(qc: ReturnType<typeof useQueryClient>, ctx: PlanContext) {
+function invalidatePlans(qc: ReturnType<typeof useQueryClient>, ctx: PlanContext, envId: string) {
     qc.invalidateQueries({ queryKey: [apiPlanKeys.all[0], ctx.type, ctx.entityId] });
+    if (ctx.type === 'api') {
+        qc.invalidateQueries({ queryKey: apiDetailKeys.detail(envId, ctx.entityId) });
+    }
 }
 
 /** Create a new plan — mutate receives a PlanFormValue and transforms it internally. */
@@ -96,7 +99,7 @@ export function useCreatePlan(ctx: PlanContext) {
     const qc = useQueryClient();
     return useMutation({
         mutationFn: (form: PlanFormValue) => createPlan(envId, ctx, planFormToPayload(form, ctx)),
-        onSuccess: () => invalidatePlans(qc, ctx),
+        onSuccess: () => invalidatePlans(qc, ctx, envId),
     });
 }
 
@@ -110,7 +113,7 @@ export function useUpdatePlan(ctx: PlanContext) {
             updatePlan(envId, ctx, planId, planFormToPayload(form, ctx)),
         onSuccess: updated => {
             qc.setQueryData(apiPlanKeys.detail(envId, ctx, updated.id), updated);
-            invalidatePlans(qc, ctx);
+            invalidatePlans(qc, ctx, envId);
         },
     });
 }
@@ -124,7 +127,7 @@ export function usePlanTransition(ctx: PlanContext) {
         mutationFn: ({ planId, action }: { planId: string; action: PlanTransitionAction }) => transitionPlan(envId, ctx, planId, action),
         onSuccess: updated => {
             qc.setQueryData(apiPlanKeys.detail(envId, ctx, updated.id), updated);
-            invalidatePlans(qc, ctx);
+            invalidatePlans(qc, ctx, envId);
         },
     });
 }
@@ -140,7 +143,7 @@ export function useReorderPlan(ctx: PlanContext) {
             const { id: _id, status: _status, ...planFields } = fullPlan;
             return updatePlan(envId, ctx, planId, { ...planFields, order: newOrder });
         },
-        onSuccess: () => invalidatePlans(qc, ctx),
+        onSuccess: () => invalidatePlans(qc, ctx, envId),
     });
 }
 
@@ -151,6 +154,6 @@ export function useDeletePlan(ctx: PlanContext) {
     const qc = useQueryClient();
     return useMutation({
         mutationFn: (planId: string) => deletePlan(envId, ctx, planId),
-        onSuccess: () => invalidatePlans(qc, ctx),
+        onSuccess: () => invalidatePlans(qc, ctx, envId),
     });
 }

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/hooks/useSubscriptionActions.ts
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/hooks/useSubscriptionActions.ts
@@ -28,7 +28,13 @@ import {
     updateSubscriptionEndDate,
 } from '../services/subscriptions';
 import type { ApproveSubscriptionPayload, CreateSubscriptionPayload, SubscriptionContext } from '../types/subscription';
-import { apiSubscriptionKeys } from '../utils/queryKeys';
+import { apiDetailKeys, apiSubscriptionKeys } from '../utils/queryKeys';
+
+function invalidateApiDetail(qc: ReturnType<typeof useQueryClient>, ctx: SubscriptionContext, envId: string) {
+    if (ctx.type === 'api') {
+        qc.invalidateQueries({ queryKey: apiDetailKeys.detail(envId, ctx.entityId) });
+    }
+}
 
 export function useCreateSubscription(ctx: SubscriptionContext) {
     const envId = useEnv();
@@ -38,6 +44,7 @@ export function useCreateSubscription(ctx: SubscriptionContext) {
         mutationFn: (payload: CreateSubscriptionPayload) => createSubscription(envId, ctx, payload),
         onSuccess: () => {
             qc.invalidateQueries({ queryKey: [...apiSubscriptionKeys.all, ctx.type, ctx.entityId, 'list'] });
+            invalidateApiDetail(qc, ctx, envId);
         },
     });
 }
@@ -51,6 +58,7 @@ export function useTransferSubscription(ctx: SubscriptionContext, subscriptionId
         onSuccess: sub => {
             qc.setQueryData(apiSubscriptionKeys.detail(envId, ctx, subscriptionId), sub);
             qc.invalidateQueries({ queryKey: [...apiSubscriptionKeys.all, ctx.type, ctx.entityId, 'list'] });
+            invalidateApiDetail(qc, ctx, envId);
         },
     });
 }
@@ -64,6 +72,7 @@ export function usePauseSubscription(ctx: SubscriptionContext, subscriptionId: s
         onSuccess: sub => {
             qc.setQueryData(apiSubscriptionKeys.detail(envId, ctx, subscriptionId), sub);
             qc.invalidateQueries({ queryKey: [...apiSubscriptionKeys.all, ctx.type, ctx.entityId, 'list'] });
+            invalidateApiDetail(qc, ctx, envId);
         },
     });
 }
@@ -77,6 +86,7 @@ export function useResumeSubscription(ctx: SubscriptionContext, subscriptionId: 
         onSuccess: sub => {
             qc.setQueryData(apiSubscriptionKeys.detail(envId, ctx, subscriptionId), sub);
             qc.invalidateQueries({ queryKey: [...apiSubscriptionKeys.all, ctx.type, ctx.entityId, 'list'] });
+            invalidateApiDetail(qc, ctx, envId);
         },
     });
 }
@@ -90,6 +100,7 @@ export function useCloseSubscription(ctx: SubscriptionContext, subscriptionId: s
         onSuccess: sub => {
             qc.setQueryData(apiSubscriptionKeys.detail(envId, ctx, subscriptionId), sub);
             qc.invalidateQueries({ queryKey: [...apiSubscriptionKeys.all, ctx.type, ctx.entityId, 'list'] });
+            invalidateApiDetail(qc, ctx, envId);
         },
     });
 }
@@ -103,6 +114,7 @@ export function useApproveSubscription(ctx: SubscriptionContext, subscriptionId:
         onSuccess: sub => {
             qc.setQueryData(apiSubscriptionKeys.detail(envId, ctx, subscriptionId), sub);
             qc.invalidateQueries({ queryKey: [...apiSubscriptionKeys.all, ctx.type, ctx.entityId, 'list'] });
+            invalidateApiDetail(qc, ctx, envId);
         },
     });
 }
@@ -116,6 +128,7 @@ export function useRejectSubscription(ctx: SubscriptionContext, subscriptionId: 
         onSuccess: sub => {
             qc.setQueryData(apiSubscriptionKeys.detail(envId, ctx, subscriptionId), sub);
             qc.invalidateQueries({ queryKey: [...apiSubscriptionKeys.all, ctx.type, ctx.entityId, 'list'] });
+            invalidateApiDetail(qc, ctx, envId);
         },
     });
 }
@@ -129,6 +142,7 @@ export function useResumeFailedSubscription(ctx: SubscriptionContext, subscripti
         onSuccess: sub => {
             qc.setQueryData(apiSubscriptionKeys.detail(envId, ctx, subscriptionId), sub);
             qc.invalidateQueries({ queryKey: [...apiSubscriptionKeys.all, ctx.type, ctx.entityId, 'list'] });
+            invalidateApiDetail(qc, ctx, envId);
         },
     });
 }

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/detail/entrypoints/ApiEntrypointsPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/detail/entrypoints/ApiEntrypointsPage.tsx
@@ -253,13 +253,8 @@ export function ApiEntrypointsPage() {
                             Save changes
                         </Button>
                     )}
-                    {!isReadOnly && !virtualHostMode && (
-                        <Button
-                            variant={showConfig ? 'outline' : 'default'}
-                            size="sm"
-                            onClick={showConfig ? addContextPath : handleAddFirstContextPath}
-                            className="gap-1.5"
-                        >
+                    {!isReadOnly && !virtualHostMode && !showConfig && (
+                        <Button size="sm" onClick={handleAddFirstContextPath} className="gap-1.5">
                             <PlusIcon className="size-3.5" />
                             Add context path
                         </Button>

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/detail/overview/ApiOverviewChecklist.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/detail/overview/ApiOverviewChecklist.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import { ActivityIcon, GlobeIcon, LockIcon, NetworkIcon, UsersIcon, WorkflowIcon } from '@gravitee/graphene-core/icons';
-import { useMemo } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 
 import { OverviewChecklistCard, type OverviewChecklistItem } from '../../../../../shared/components/OverviewChecklistCard';
 import type { AlertTrigger, ApiDetailDto } from '../../../types';
@@ -24,10 +24,12 @@ function buildChecklistItems(
     api: ApiDetailDto | null,
     membersData: MembersResponse | undefined,
     alertsData: AlertTrigger[] | undefined,
+    manuallyDone: Set<string>,
 ): OverviewChecklistItem[] {
     const hasEndpointGroup = Boolean(api?.endpointGroups?.[0]?.endpoints?.length);
     const memberCount = membersData?.pagination?.totalCount ?? 0;
     const isPublished = api?.lifecycleState === 'PUBLISHED';
+    const hasAlerts = Boolean(alertsData?.length);
 
     return [
         {
@@ -37,7 +39,8 @@ function buildChecklistItems(
             to: '../endpoints/list',
             icon: NetworkIcon,
             actionLabel: 'Open Endpoints',
-            done: hasEndpointGroup,
+            done: hasEndpointGroup || manuallyDone.has('endpoint-security'),
+            locked: hasEndpointGroup,
         },
         {
             id: 'security-policies',
@@ -46,7 +49,8 @@ function buildChecklistItems(
             to: '../policy-studio',
             icon: WorkflowIcon,
             actionLabel: 'Open Policy Studio',
-            done: false,
+            done: manuallyDone.has('security-policies'),
+            locked: false,
         },
         {
             id: 'authorization',
@@ -64,7 +68,8 @@ function buildChecklistItems(
             to: '../alerts',
             icon: ActivityIcon,
             actionLabel: 'Open Alerts',
-            done: Boolean(alertsData?.length),
+            done: hasAlerts || manuallyDone.has('alerts'),
+            locked: hasAlerts,
         },
         {
             id: 'team-access',
@@ -73,7 +78,8 @@ function buildChecklistItems(
             to: '../user-permissions',
             icon: UsersIcon,
             actionLabel: 'Manage Access',
-            done: memberCount > 1,
+            done: memberCount > 1 || manuallyDone.has('team-access'),
+            locked: memberCount > 1,
         },
         {
             id: 'publish',
@@ -82,7 +88,8 @@ function buildChecklistItems(
             to: '../general',
             icon: GlobeIcon,
             actionLabel: 'Open General',
-            done: isPublished,
+            done: isPublished || manuallyDone.has('publish'),
+            locked: isPublished,
         },
     ];
 }
@@ -103,18 +110,29 @@ export function ApiOverviewChecklist({
     isLoadingAlerts,
 }: Readonly<ApiOverviewChecklistProps>) {
     const isReady = !isLoadingMembers && !isLoadingAlerts;
+    const [manuallyDone, setManuallyDone] = useState<Set<string>>(new Set());
 
     const items = useMemo(
-        () => (isReady ? buildChecklistItems(api, membersData, alertsData) : []),
-        [api, membersData, alertsData, isReady],
+        () => (isReady ? buildChecklistItems(api, membersData, alertsData, manuallyDone) : []),
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+        [api, membersData, alertsData, isReady, manuallyDone],
     );
+
+    const handleToggle = useCallback((id: string, newDone: boolean) => {
+        setManuallyDone(prev => {
+            const next = new Set(prev);
+            if (newDone) next.add(id);
+            else next.delete(id);
+            return next;
+        });
+    }, []);
 
     return (
         <OverviewChecklistCard
             description="Finish setting up your API proxy. Each row links to the right screen."
             items={items}
             isReady={isReady}
-            totalCountHint={4}
+            onToggle={handleToggle}
         />
     );
 }

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/detail/reporter-settings/ApiReporterSettingsPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/detail/reporter-settings/ApiReporterSettingsPage.tsx
@@ -123,7 +123,7 @@ export function ApiReporterSettingsPage() {
     const mutation = useMutation({
         mutationFn: (analytics: Analytics) => updateApiAnalytics(env!.id, apiId!, analytics),
         onSuccess: () => {
-            queryClient.invalidateQueries({ queryKey: apiDetailKeys.detail(env?.id ?? '', apiId ?? '') });
+            void queryClient.invalidateQueries({ queryKey: apiDetailKeys.detail(env?.id ?? '', apiId ?? '') });
             initializedForApiIdRef.current = undefined;
             setSaveError(null);
         },

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/detail/reporter-settings/SpanRedactionRules.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/pages/detail/reporter-settings/SpanRedactionRules.tsx
@@ -346,7 +346,7 @@ export function SpanRedactionRules({ rules, disabled, onChange }: SpanRedactionR
                     </TableHeader>
                     <TableBody>
                         {rules.map((rule, i) => (
-                            <TableRow key={rule.attributeNamePattern}>
+                            <TableRow key={i}>
                                 <TableCell>
                                     <Badge variant="secondary">{i + 1}</Badge>
                                 </TableCell>

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/types/api.ts
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/types/api.ts
@@ -209,6 +209,7 @@ export interface ApiDetailDto {
         backgroundUrl?: string;
     };
     properties?: Property[];
+
     services?: { dynamicProperty?: DynamicPropertyConfig };
     analytics?: Analytics;
     listeners?: HttpListener[];

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/shared/components/OverviewChecklistCard.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/shared/components/OverviewChecklistCard.spec.tsx
@@ -83,4 +83,64 @@ describe('OverviewChecklistCard', () => {
             expect(screen.queryByRole('link', { name: 'Open APIs' })).toBeNull();
         });
     });
+
+    describe('manual toggle', () => {
+        it('calls onToggle with newDone=true when an unchecked toggleable row is clicked', () => {
+            const onToggle = jest.fn();
+            wrap(<OverviewChecklistCard description="desc" items={[BASE_ITEM]} onToggle={onToggle} />);
+            fireEvent.click(screen.getByRole('checkbox', { name: 'Add APIs' }));
+            expect(onToggle).toHaveBeenCalledWith('item-1', true);
+        });
+
+        it('calls onToggle with newDone=false when a checked non-locked row is clicked', () => {
+            const onToggle = jest.fn();
+            wrap(<OverviewChecklistCard description="desc" items={[{ ...BASE_ITEM, done: true }]} onToggle={onToggle} />);
+            fireEvent.click(screen.getByRole('checkbox', { name: 'Add APIs' }));
+            expect(onToggle).toHaveBeenCalledWith('item-1', false);
+        });
+
+        it('does not call onToggle when a locked (auto-done) row is clicked', () => {
+            const onToggle = jest.fn();
+            wrap(<OverviewChecklistCard description="desc" items={[{ ...BASE_ITEM, done: true, locked: true }]} onToggle={onToggle} />);
+            expect(screen.queryByRole('checkbox', { name: 'Add APIs' })).toBeNull();
+        });
+
+        it('does not call onToggle when a comingSoon row is clicked', () => {
+            const onToggle = jest.fn();
+            wrap(
+                <OverviewChecklistCard
+                    description="desc"
+                    items={[{ ...BASE_ITEM, to: undefined, comingSoon: true }]}
+                    onToggle={onToggle}
+                />,
+            );
+            expect(screen.queryByRole('checkbox', { name: 'Add APIs' })).toBeNull();
+        });
+
+        it('does not render rows as checkboxes when onToggle is not provided', () => {
+            wrap(<OverviewChecklistCard description="desc" items={[BASE_ITEM]} />);
+            expect(screen.queryByRole('checkbox')).toBeNull();
+        });
+
+        it('calls onToggle via keyboard Enter on a toggleable row', () => {
+            const onToggle = jest.fn();
+            wrap(<OverviewChecklistCard description="desc" items={[BASE_ITEM]} onToggle={onToggle} />);
+            fireEvent.keyDown(screen.getByRole('checkbox', { name: 'Add APIs' }), { key: 'Enter' });
+            expect(onToggle).toHaveBeenCalledWith('item-1', true);
+        });
+
+        it('clicking the info tooltip button does not trigger the row toggle', () => {
+            const onToggle = jest.fn();
+            wrap(<OverviewChecklistCard description="desc" items={[BASE_ITEM]} onToggle={onToggle} />);
+            fireEvent.click(screen.getByRole('button', { name: 'Info: Add APIs' }));
+            expect(onToggle).not.toHaveBeenCalled();
+        });
+
+        it('clicking the action link does not trigger the row toggle', () => {
+            const onToggle = jest.fn();
+            wrap(<OverviewChecklistCard description="desc" items={[BASE_ITEM]} onToggle={onToggle} />);
+            fireEvent.click(screen.getByRole('link', { name: 'Open APIs' }));
+            expect(onToggle).not.toHaveBeenCalled();
+        });
+    });
 });

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/shared/components/OverviewChecklistCard.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/shared/components/OverviewChecklistCard.tsx
@@ -40,6 +40,8 @@ export interface OverviewChecklistItem {
     actionLabel: string;
     done: boolean;
     comingSoon?: boolean;
+    /** When true the done state is driven by a real API condition — the row cannot be unchecked manually. */
+    locked?: boolean;
 }
 
 interface OverviewChecklistCardProps {
@@ -49,14 +51,22 @@ interface OverviewChecklistCardProps {
     isReady?: boolean;
     /** Total item count to show while loading. Defaults to items.length. */
     totalCountHint?: number;
+    /** Called when user clicks a non-locked, non-comingSoon row. */
+    onToggle?: (id: string, newDone: boolean) => void;
 }
 
-export function OverviewChecklistCard({ description, items, isReady = true, totalCountHint }: Readonly<OverviewChecklistCardProps>) {
+export function OverviewChecklistCard({
+    description,
+    items,
+    isReady = true,
+    totalCountHint,
+    onToggle,
+}: Readonly<OverviewChecklistCardProps>) {
     const [open, setOpen] = useState(true);
 
     const completedCount = items.filter(i => i.done).length;
     const totalCount = totalCountHint ?? items.length;
-    const completionPct = totalCount > 0 ? Math.round((completedCount / totalCount) * 100) : 0;
+    const completionPct = totalCount > 0 ? Math.min(100, Math.round((completedCount / totalCount) * 100)) : 0;
 
     return (
         <Card>
@@ -97,12 +107,28 @@ export function OverviewChecklistCard({ description, items, isReady = true, tota
                             <TooltipProvider delayDuration={200}>
                                 {items.map(item => {
                                     const ItemIcon = item.icon;
+                                    const isToggleable = !item.locked && !item.comingSoon && Boolean(onToggle);
                                     return (
                                         <div
                                             key={item.id}
                                             className={`flex items-center gap-3 rounded-lg px-3 py-2.5 transition-colors${
-                                                item.done ? ' opacity-60' : item.comingSoon ? '' : ' hover:bg-accent/50'
-                                            }`}
+                                                item.done && item.locked ? ' opacity-60' : ''
+                                            }${isToggleable ? ' cursor-pointer hover:bg-accent/50' : ''}`}
+                                            onClick={isToggleable ? () => onToggle!(item.id, !item.done) : undefined}
+                                            role={isToggleable ? 'checkbox' : undefined}
+                                            aria-checked={isToggleable ? item.done : undefined}
+                                            aria-label={isToggleable ? item.label : undefined}
+                                            tabIndex={isToggleable ? 0 : undefined}
+                                            onKeyDown={
+                                                isToggleable
+                                                    ? e => {
+                                                          if (e.key === 'Enter' || e.key === ' ') {
+                                                              e.preventDefault();
+                                                              onToggle!(item.id, !item.done);
+                                                          }
+                                                      }
+                                                    : undefined
+                                            }
                                         >
                                             <div className="shrink-0">
                                                 {item.done ? (
@@ -129,6 +155,7 @@ export function OverviewChecklistCard({ description, items, isReady = true, tota
                                                         type="button"
                                                         className="text-muted-foreground/40 hover:text-muted-foreground transition-colors shrink-0"
                                                         aria-label={`Info: ${item.label}`}
+                                                        onClick={e => e.stopPropagation()}
                                                     >
                                                         <InfoIcon className="size-3.5" aria-hidden />
                                                     </button>
@@ -144,6 +171,7 @@ export function OverviewChecklistCard({ description, items, isReady = true, tota
                                                     to={item.to ?? '#'}
                                                     className="shrink-0 inline-flex items-center gap-1 rounded-md px-1.5 py-1 text-xs font-medium text-primary transition-colors"
                                                     aria-label={item.actionLabel}
+                                                    onClick={e => e.stopPropagation()}
                                                 >
                                                     {item.actionLabel}
                                                     <ArrowRightIcon className="size-4 shrink-0" aria-hidden />


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/GMA-XXXX

## Description

Deploy banner reliability
- usePlans: invalidate API detail query after every plan mutation (create,
  update, transition, reorder, delete) so the deploy banner appears
  immediately after plan changes without a manual refresh
- useSubscriptionActions: same fix for all subscription mutations (create,
  transfer, approve, reject, pause, resume, close, resumeFailed)

API sidebar state indicator
- Renamed "Deployed" badge to "Started" to match actual runtime state
- Added "Out of sync" warning badge when deploymentState = NEED_REDEPLOY
  and the API is running (started but has un-deployed changes)
- Deploy banner redesigned as a compact Card with MessageSquareWarningIcon
  instead of a full-width alert stripe

Checklist manual toggles
- OverviewChecklistCard: rows are now clickable (checkbox role, keyboard
  accessible) when onToggle is provided and the item is not auto-locked
- Locked items (done via real API condition) cannot be unchecked manually
- comingSoon items are never toggleable
- Progress ring capped at 100%; removed incorrect totalCountHint=4 that
  caused 5/4 = 125% when multiple items were checked
- Both API proxy and API Product overview checklists wired with manual
  toggle state and correct locked/unlocked classification

Coming soon nav items
- API Score, Response Templates, and Authorization are now non-navigable
  in the sidebar: rendered as disabled rows with FlaskConicalIcon and a
  "Coming soon" tooltip on hover
- Corresponding placeholder routes removed from AppRoutes (catch-all
  redirects to overview for any direct URL access)

Minor UX
- Entrypoints: removed duplicate "Add context path" button from page
  header; the card already has its own add button
- API Proxies and API Products list pages: search input now fills all
  available horizontal space (flex-1) instead of a fixed 288 px width

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

