### PR TITLE
fix: scope unpublish warning to container items only (EXT-131)

### DIFF
--- a/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.ts
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.ts
@@ -615,15 +615,17 @@ export class PortalNavigationItemsComponent implements HasUnsavedChanges {
 
     const action = isPublished ? 'Unpublish' : 'Publish';
     const pastAction = `${action.toLowerCase()}ed`;
-    const warning = isPublished
-      ? `Unpublishing this ${typeLabel} will also unpublish all nested documentation and APIs. This action cannot be undone automatically. Do you want to proceed?`
-      : '';
+    const isContainer = navItem.type === 'FOLDER' || navItem.type === 'API';
+    const warning =
+      isPublished && isContainer
+        ? ` Unpublishing this ${typeLabel} will also unpublish all nested documentation and APIs. This action cannot be undone automatically. Do you want to proceed?`
+        : '';
 
-    const contentScope = navItem.type === 'FOLDER' || navItem.type === 'API' ? ' and its content ' : ' ';
+    const contentScope = isContainer ? ' and its content ' : ' ';
 
     return {
       title: `${action} "${navItem.title}" ${typeLabel}?`,
-      content: `This ${typeLabel}${contentScope}will be ${pastAction}. This change will be visible in the Developer Portal. ${warning}`,
+      content: `This ${typeLabel}${contentScope}will be ${pastAction}. This change will be visible in the Developer Portal.${warning}`,
       confirmButton: action,
     };
   }


### PR DESCRIPTION
Scope unpublish confirmation warning to container items (FOLDER/API) only — PAGE and LINK types no longer show the unnecessary nested content disclaimer.

Link to jira ticket: https://gravitee.atlassian.net/jira/software/c/projects/EXT/boards/994?selectedIssue=EXT-131&visitedUserSeg=true


<img width="1198" height="709" alt="image" src="https://github.com/user-attachments/assets/f568e794-50e2-4a2d-b08c-50dbfd972cee" />
