### PR TITLE
chore(deps): bump gravitee-apim-repository-bridge 9.0.0-alpha.2 → 9.0.0-alpha.3 (APIM-14087)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -316,7 +316,7 @@
         <gravitee-resource-ai-vector-store-aws-s3.version>1.0.0</gravitee-resource-ai-vector-store-aws-s3.version>
         <gravitee-resource-ai-model-text-embedding.version>1.0.0</gravitee-resource-ai-model-text-embedding.version>
         <gravitee-policy-ai-semantic-caching.version>1.1.0</gravitee-policy-ai-semantic-caching.version>
-        <gravitee-apim-repository-bridge.version>9.0.0-alpha.2</gravitee-apim-repository-bridge.version>
+        <gravitee-apim-repository-bridge.version>9.0.0-alpha.3</gravitee-apim-repository-bridge.version>
         <gravitee-secretprovider-hc-vault.version>2.1.0</gravitee-secretprovider-hc-vault.version>
         <gravitee-secretprovider-aws.version>2.0.0</gravitee-secretprovider-aws.version>
         <gravitee-service-secrets.version>3.0.1</gravitee-service-secrets.version>


### PR DESCRIPTION
## Summary

Bumps `gravitee-apim-repository-bridge` from **9.0.0-alpha.2** → **9.0.0-alpha.3** on `master` (4.12 line).

## Why

9.0.0-alpha.3 ships the bridge-side `searchAfter` implementation ported to the alpha (vertx 5) line ([bridge PR #133](https://github.com/gravitee-io/gravitee-apim-repository-bridge/pull/133)) — the forward-port of the work first landed in bridge 8.2.0 on `main` ([bridge PR #132](https://github.com/gravitee-io/gravitee-apim-repository-bridge/pull/132)) and merged in APIM 4.11.x via [#16968](https://github.com/gravitee-io/gravitee-api-management/pull/16968).

APIM-14087 is already on master ([commit 8d90d3f3a2](https://github.com/gravitee-io/gravitee-api-management/commit/8d90d3f3a2)) — `SubscriptionRepository.searchAfter` is on the interface. Without this bump, gateways pinning bridge 9.0.0-alpha.2 + APIM 4.12+ would fail at Spring init with `AbstractMethodError`.

This is the master-line equivalent of the 4.11.x bump in [#17092](https://github.com/gravitee-io/gravitee-api-management/pull/17092) (`bridge 8.1.0 → 8.2.0`).

## Test plan

- [x] Local build of monorepo with the version bump compiles
- [ ] CI green on this PR
- [ ] Smoke verification on a bridge-mode deployment on master line (server: this APIM build, client: bridge 9.0.0-alpha.3 jar)

Fixes APIM-14087 (deployment side, master)