### PR TITLE
feat(portal): add application ownership transfer flow to portal

### DIFF
--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-members/application-tab-members.component.harness.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-members/application-tab-members.component.harness.ts
@@ -33,6 +33,9 @@ export class ApplicationTabMembersComponentHarness extends ComponentHarness {
   private readonly locateAddMembersButton = this.locatorForOptional(
     MatButtonHarness.with({ selector: '[data-testid="members-add-button"]' }),
   );
+  private readonly locateTransferOwnershipButton = this.locatorForOptional(
+    MatButtonHarness.with({ selector: '[data-testid="members-transfer-ownership-button"]' }),
+  );
 
   public async getLoader(): Promise<LoaderHarness | null> {
     return this.locateLoader();
@@ -60,6 +63,14 @@ export class ApplicationTabMembersComponentHarness extends ComponentHarness {
 
   public async clickAddMembersButton(): Promise<void> {
     return (await this.locateAddMembersButton())!.click();
+  }
+
+  public async getTransferOwnershipButton(): Promise<MatButtonHarness | null> {
+    return this.locateTransferOwnershipButton();
+  }
+
+  public async clickTransferOwnershipButton(): Promise<void> {
+    return (await this.locateTransferOwnershipButton())!.click();
   }
 
   public async getUserCells(): Promise<UserCellHarness[]> {

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-members/application-tab-members.component.html
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-members/application-tab-members.component.html
@@ -18,19 +18,33 @@
 @if (canRead()) {
   <div class="members__toolbar">
     <app-search-bar (searchTerm)="onSearchTermChange($event)" />
-    @if (canCreate()) {
-      <button
-        mat-flat-button
-        color="primary"
-        type="button"
-        data-testid="members-add-button"
-        (click)="openAddMembersDialog()"
-        i18n="@@applicationMembersAddButton"
-      >
-        <mat-icon aria-hidden="true">person_add</mat-icon>
-        Add Members
-      </button>
-    }
+    <div class="members__toolbar-actions">
+      @if (canTransferOwnership()) {
+        <button
+          mat-stroked-button
+          type="button"
+          data-testid="members-transfer-ownership-button"
+          (click)="openTransferOwnershipDialog()"
+          i18n="@@applicationMembersTransferOwnershipButton"
+        >
+          <mat-icon aria-hidden="true">swap_horiz</mat-icon>
+          Transfer Ownership
+        </button>
+      }
+      @if (canCreate()) {
+        <button
+          mat-flat-button
+          color="primary"
+          type="button"
+          data-testid="members-add-button"
+          (click)="openAddMembersDialog()"
+          i18n="@@applicationMembersAddButton"
+        >
+          <mat-icon aria-hidden="true">person_add</mat-icon>
+          Add Members
+        </button>
+      }
+    </div>
   </div>
   <h4 class="next-gen-h4 members__title" data-testid="members-section-title" i18n="@@applicationMembersTitle">
     Members ({{ totalElements() }})

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-members/application-tab-members.component.scss
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-members/application-tab-members.component.scss
@@ -24,9 +24,14 @@ app-search-bar {
   &__toolbar {
     display: flex;
     align-items: flex-start;
-    justify-content: space-between;
     gap: 16px;
     margin-bottom: 24px;
+  }
+
+  &__toolbar-actions {
+    display: flex;
+    gap: 8px;
+    margin-left: auto;
   }
 
   &__title {

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-members/application-tab-members.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-members/application-tab-members.component.spec.ts
@@ -28,7 +28,7 @@ import { ApplicationTabMembersComponent } from './application-tab-members.compon
 import { ApplicationTabMembersComponentHarness } from './application-tab-members.component.harness';
 import { ConfirmDialogComponent } from '../../../../components/confirm-dialog/confirm-dialog.component';
 import { ConfirmDialogHarness } from '../../../../components/confirm-dialog/confirm-dialog.harness';
-import { APPLICATION_PRIMARY_OWNER_ROLE_NAME, ApplicationRole } from '../../../../entities/application/application';
+import { APPLICATION_PRIMARY_OWNER_ROLE_NAME, Application, ApplicationRole } from '../../../../entities/application/application';
 import { MembersResponse } from '../../../../entities/member/member';
 import { fakeMember, fakeMembersResponse } from '../../../../entities/member/member.fixtures';
 import { fakeUserApplicationPermissions } from '../../../../entities/permission/permission.fixtures';
@@ -533,4 +533,97 @@ describe('ApplicationTabMembersComponent', () => {
       await fixture.whenStable();
     });
   });
+
+  describe('transfer ownership action', () => {
+    it('should not show transfer ownership button when user lacks MEMBER[U] permission', async () => {
+      fixture.componentRef.setInput('application', fakeApplication(CURRENT_USER_ID));
+      const harness = await flush(fakeMembersResponse([fakeMember()]));
+
+      expect(await harness.getTransferOwnershipButton()).toBeNull();
+    });
+
+    it('should not show transfer ownership button when current user is not the application owner', async () => {
+      fixture.componentRef.setInput('application', fakeApplication('other-owner-id'));
+      fixture.componentRef.setInput('userApplicationPermissions', fakeUserApplicationPermissions({ MEMBER: ['R', 'U'] }));
+      const harness = await flush(fakeMembersResponse([fakeMember()]));
+
+      expect(await harness.getTransferOwnershipButton()).toBeNull();
+    });
+
+    it('should show transfer ownership button for application owner with MEMBER[U] permission', async () => {
+      fixture.componentRef.setInput('application', fakeApplication(CURRENT_USER_ID));
+      fixture.componentRef.setInput('userApplicationPermissions', fakeUserApplicationPermissions({ MEMBER: ['R', 'U'] }));
+      const harness = await flush(fakeMembersResponse([fakeMember()]));
+
+      expect(await harness.getTransferOwnershipButton()).not.toBeNull();
+    });
+
+    it('should open transfer ownership dialog', async () => {
+      fixture.componentRef.setInput('application', fakeApplication(CURRENT_USER_ID));
+      fixture.componentRef.setInput('userApplicationPermissions', fakeUserApplicationPermissions({ MEMBER: ['R', 'U'] }));
+      const harness = await flush(
+        fakeMembersResponse([
+          fakeMember({ id: CURRENT_USER_ID, role: APPLICATION_PRIMARY_OWNER_ROLE_NAME, user: { id: CURRENT_USER_ID, _links: {} } }),
+          fakeMember({ id: 'member-2', user: { id: 'user-2', display_name: 'Bob Martin', _links: {} } }),
+        ]),
+      );
+
+      await harness.clickTransferOwnershipButton();
+      await fixture.whenStable();
+      fixture.detectChanges();
+
+      expect(TestBed.inject(MatDialog).openDialogs).toHaveLength(1);
+    });
+
+    it('should reload members list after transfer ownership dialog closes with success', async () => {
+      fixture.componentRef.setInput('application', fakeApplication(CURRENT_USER_ID));
+      fixture.componentRef.setInput('userApplicationPermissions', fakeUserApplicationPermissions({ MEMBER: ['R', 'U'] }));
+      const harness = await flush(fakeMembersResponse([fakeMember()]));
+
+      await harness.clickTransferOwnershipButton();
+      await fixture.whenStable();
+      fixture.detectChanges();
+
+      TestBed.inject(MatDialog).openDialogs[0].close(true);
+      fixture.detectChanges();
+      await fixture.whenStable();
+      fixture.detectChanges();
+
+      httpTestingController
+        .expectOne(r => r.url === `${TESTING_BASE_URL}/permissions` && r.params.get('applicationId') === applicationId)
+        .flush(fakeUserApplicationPermissions({ MEMBER: ['R'] }));
+      await fixture.whenStable();
+      fixture.detectChanges();
+
+      httpTestingController.expectOne(r => r.url.includes('members/_search')).flush(fakeMembersResponse([fakeMember({ id: 'member-2' })]));
+      await fixture.whenStable();
+
+      expect(await harness.getTransferOwnershipButton()).toBeNull();
+    });
+  });
 });
+
+function fakeApplication(ownerId: string): Application {
+  return {
+    id: 'app-1',
+    name: 'Application',
+    owner: {
+      id: ownerId,
+      first_name: 'Current',
+      last_name: 'Owner',
+      display_name: 'Current Owner',
+      email: 'owner@example.com',
+      editable_profile: false,
+      customFields: {
+        city: '',
+        job_position: '',
+      },
+      _links: {
+        avatar: '',
+        notifications: '',
+        self: '',
+      },
+    },
+    settings: {},
+  };
+}

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-members/application-tab-members.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-members/application-tab-members.component.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Component, computed, DestroyRef, inject, input, signal } from '@angular/core';
+import { Component, computed, DestroyRef, inject, input, linkedSignal, signal } from '@angular/core';
 import { rxResource, takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { MatButtonModule } from '@angular/material/button';
 import { MatDialog, MatDialogModule } from '@angular/material/dialog';
@@ -26,11 +26,12 @@ import { PaginatedTableComponent, TableAction, TableColumn } from '../../../../c
 import { TableCellDirective } from '../../../../components/paginated-table/table-cell.directive';
 import { SearchBarComponent } from '../../../../components/search-bar/search-bar.component';
 import { UserCellComponent, UserCellVM } from '../../../../components/user-cell/user-cell.component';
-import { APPLICATION_PRIMARY_OWNER_ROLE_NAME } from '../../../../entities/application/application';
+import { APPLICATION_PRIMARY_OWNER_ROLE_NAME, Application } from '../../../../entities/application/application';
 import { Member, MemberSearchFilters, MembersResponse } from '../../../../entities/member/member';
 import { UserApplicationPermissions } from '../../../../entities/permission/permission';
 import { CurrentUserService } from '../../../../services/current-user.service';
 import { MembershipService } from '../../../../services/membership.service';
+import { PermissionsService } from '../../../../services/permissions.service';
 import {
   ApplicationMemberEditDialogComponent,
   ApplicationMemberEditDialogData,
@@ -39,9 +40,15 @@ import {
   ApplicationMembersAddDialogComponent,
   ApplicationMembersAddDialogData,
 } from '../application-members-add-dialog/application-members-add-dialog.component';
+import {
+  ApplicationTransferOwnershipDialogComponent,
+  ApplicationTransferOwnershipDialogData,
+  ApplicationTransferOwnershipMemberOption,
+} from '../application-transfer-ownership-dialog/application-transfer-ownership-dialog.component';
 
 interface MemberTableRow {
   id: string;
+  reference?: string;
   user: UserCellVM;
   isCurrentUser: boolean;
   role: string;
@@ -76,24 +83,32 @@ export class ApplicationTabMembersComponent {
   private readonly currentUserService = inject(CurrentUserService);
   private readonly matDialog = inject(MatDialog);
   private readonly destroyRef = inject(DestroyRef);
+  private readonly permissionsService = inject(PermissionsService);
 
   readonly applicationId = input.required<string>();
+  readonly application = input<Application | undefined>(undefined);
   readonly userApplicationPermissions = input.required<UserApplicationPermissions>();
 
   readonly currentPage = signal(1);
   readonly pageSize = signal(10);
   readonly searchTerm = signal('');
   readonly error = signal<string | null>(null);
+  readonly effectiveUserApplicationPermissions = linkedSignal(() => this.userApplicationPermissions());
 
   readonly tableColumns: TableColumn[] = [
     { id: 'name', label: $localize`:@@memberColumnName:Name` },
     { id: 'role', label: $localize`:@@memberColumnRole:Role` },
   ];
 
-  readonly canRead = computed(() => this.userApplicationPermissions().MEMBER?.includes('R') ?? false);
-  readonly canCreate = computed(() => this.userApplicationPermissions().MEMBER?.includes('C') ?? false);
-  readonly canUpdate = computed(() => this.userApplicationPermissions().MEMBER?.includes('U') ?? false);
-  readonly canDelete = computed(() => this.userApplicationPermissions().MEMBER?.includes('D') ?? false);
+  readonly canRead = computed(() => this.effectiveUserApplicationPermissions().MEMBER?.includes('R') ?? false);
+  readonly canCreate = computed(() => this.effectiveUserApplicationPermissions().MEMBER?.includes('C') ?? false);
+  readonly canUpdate = computed(() => this.effectiveUserApplicationPermissions().MEMBER?.includes('U') ?? false);
+  readonly canDelete = computed(() => this.effectiveUserApplicationPermissions().MEMBER?.includes('D') ?? false);
+  readonly canTransferOwnership = computed(() => {
+    const currentUserId = this.currentUserService.user()?.id;
+    const ownerId = this.application()?.owner?.id;
+    return this.canUpdate() && !!currentUserId && currentUserId === ownerId;
+  });
 
   readonly actions = computed<TableAction<MemberTableRow>[]>(() => {
     const actions: TableAction<MemberTableRow>[] = [];
@@ -189,6 +204,33 @@ export class ApplicationTabMembersComponent {
       .subscribe();
   }
 
+  openTransferOwnershipDialog(): void {
+    this.error.set(null);
+    this.matDialog
+      .open<ApplicationTransferOwnershipDialogComponent, ApplicationTransferOwnershipDialogData, boolean>(
+        ApplicationTransferOwnershipDialogComponent,
+        {
+          data: {
+            applicationId: this.applicationId(),
+            currentOwnerId: this.application()?.owner?.id,
+            members: this.rows()
+              .filter(row => !!row.id)
+              .map(row => this.toTransferOwnershipMemberOption(row)),
+          },
+          disableClose: true,
+        },
+      )
+      .afterClosed()
+      .pipe(
+        filter((ownershipTransferred): ownershipTransferred is true => ownershipTransferred === true),
+        switchMap(() => this.permissionsService.getApplicationPermissions(this.applicationId())),
+        tap(permissions => this.effectiveUserApplicationPermissions.set(permissions)),
+        tap(() => this.membersResource.reload()),
+        takeUntilDestroyed(this.destroyRef),
+      )
+      .subscribe();
+  }
+
   private openEditMemberDialog(member: MemberTableRow): void {
     this.error.set(null);
     this.matDialog
@@ -239,6 +281,7 @@ export class ApplicationTabMembersComponent {
       (user?.first_name || user?.last_name ? `${user?.first_name ?? ''} ${user?.last_name ?? ''}`.trim() : (user?.id ?? ''));
     return {
       id: member.id ?? user?.id ?? '',
+      reference: user?.reference,
       user: {
         displayName,
         email: user?.email,
@@ -248,6 +291,17 @@ export class ApplicationTabMembersComponent {
       isCurrentUser: !!user?.id && user.id === this.currentUserService.user()?.id,
       role: member.role ?? '',
       isPrimaryOwner: member.role === APPLICATION_PRIMARY_OWNER_ROLE_NAME,
+    };
+  }
+
+  private toTransferOwnershipMemberOption(member: MemberTableRow): ApplicationTransferOwnershipMemberOption {
+    return {
+      id: member.id,
+      reference: member.reference,
+      displayName: member.user.displayName,
+      email: member.user.email,
+      avatarUrl: member.user.avatarUrl,
+      initials: member.user.initials,
     };
   }
 

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-transfer-ownership-dialog/application-transfer-ownership-dialog.component.harness.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-transfer-ownership-dialog/application-transfer-ownership-dialog.component.harness.ts
@@ -1,0 +1,149 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ComponentHarness } from '@angular/cdk/testing';
+import { MatAutocompleteHarness } from '@angular/material/autocomplete/testing';
+import { MatButtonHarness } from '@angular/material/button/testing';
+import { MatSelectHarness } from '@angular/material/select/testing';
+
+export class ApplicationTransferOwnershipDialogHarness extends ComponentHarness {
+  static readonly hostSelector = 'app-application-transfer-ownership-dialog';
+
+  private readonly locateApplicationMemberAutocomplete = this.locatorFor(
+    MatAutocompleteHarness.with({ selector: '[data-testid="transfer-ownership-application-member-input"]' }),
+  );
+  private readonly locateOtherUserAutocomplete = this.locatorFor(
+    MatAutocompleteHarness.with({ selector: '[data-testid="transfer-ownership-other-user-input"]' }),
+  );
+  private readonly locateRoleSelect = this.locatorFor(
+    MatSelectHarness.with({ selector: '[data-testid="transfer-ownership-role-select"]' }),
+  );
+  private readonly locateMethodButtons = this.locatorForAll(MatButtonHarness.with({ selector: 'app-button-toggle-option button' }));
+  private readonly locateCancelButton = this.locatorFor(
+    MatButtonHarness.with({ selector: '[data-testid="transfer-ownership-cancel-button"]' }),
+  );
+  private readonly locateSubmitButton = this.locatorFor(
+    MatButtonHarness.with({ selector: '[data-testid="transfer-ownership-submit-button"]' }),
+  );
+  private readonly locateSearchError = this.locatorForOptional('[data-testid="transfer-ownership-user-search-error"]');
+  private readonly locateSubmitError = this.locatorForOptional('[data-testid="transfer-ownership-submit-error"]');
+  private readonly locateRolesError = this.locatorForOptional('[data-testid="transfer-ownership-roles-error"]');
+
+  async getMethodOptionTexts(): Promise<string[]> {
+    return Promise.all((await this.locateMethodButtons()).map(button => button.getText()));
+  }
+
+  async selectMethod(text: string | RegExp): Promise<void> {
+    const buttons = await this.locateMethodButtons();
+    for (const button of buttons) {
+      const buttonText = await button.getText();
+      const matches = typeof text === 'string' ? buttonText.includes(text) : text.test(buttonText);
+      if (matches) {
+        await button.click();
+        return;
+      }
+    }
+    throw new Error(`Unable to find transfer method matching ${text.toString()}`);
+  }
+
+  async searchApplicationMember(query: string): Promise<void> {
+    const autocomplete = await this.locateApplicationMemberAutocomplete();
+    await autocomplete.enterText(query);
+  }
+
+  async getApplicationMemberOptionTexts(): Promise<string[]> {
+    const autocomplete = await this.openApplicationMemberAutocomplete();
+    return Promise.all((await autocomplete.getOptions()).map(option => option.getText()));
+  }
+
+  async selectApplicationMember(text: string | RegExp): Promise<void> {
+    const autocomplete = await this.openApplicationMemberAutocomplete();
+    return autocomplete.selectOption({ text });
+  }
+
+  async searchOtherUser(query: string): Promise<void> {
+    const autocomplete = await this.locateOtherUserAutocomplete();
+    await autocomplete.enterText(query);
+  }
+
+  async getOtherUserOptionTexts(): Promise<string[]> {
+    const autocomplete = await this.openOtherUserAutocomplete();
+    return Promise.all((await autocomplete.getOptions()).map(option => option.getText()));
+  }
+
+  async selectOtherUser(text: string | RegExp): Promise<void> {
+    const autocomplete = await this.openOtherUserAutocomplete();
+    return autocomplete.selectOption({ text });
+  }
+
+  async isOtherUserOptionDisabled(text: string | RegExp): Promise<boolean> {
+    const autocomplete = await this.openOtherUserAutocomplete();
+    const options = await autocomplete.getOptions({ text });
+    return options[0]?.isDisabled() ?? false;
+  }
+
+  async selectRole(role: string): Promise<void> {
+    const select = await this.locateRoleSelect();
+    await select.open();
+    return select.clickOptions({ text: role });
+  }
+
+  async getRoleOptionTexts(): Promise<string[]> {
+    const select = await this.locateRoleSelect();
+    await select.open();
+    return Promise.all((await select.getOptions()).map(option => option.getText()));
+  }
+
+  async isSubmitDisabled(): Promise<boolean> {
+    return (await this.locateSubmitButton()).isDisabled();
+  }
+
+  async clickSubmit(): Promise<void> {
+    return (await this.locateSubmitButton()).click();
+  }
+
+  async clickCancel(): Promise<void> {
+    return (await this.locateCancelButton()).click();
+  }
+
+  async getSearchErrorText(): Promise<string | null> {
+    const element = await this.locateSearchError();
+    return element ? element.text() : null;
+  }
+
+  async getSubmitErrorText(): Promise<string | null> {
+    const element = await this.locateSubmitError();
+    return element ? element.text() : null;
+  }
+
+  async getRolesErrorText(): Promise<string | null> {
+    const element = await this.locateRolesError();
+    return element ? element.text() : null;
+  }
+
+  private async openApplicationMemberAutocomplete(): Promise<MatAutocompleteHarness> {
+    const autocomplete = await this.locateApplicationMemberAutocomplete();
+    await autocomplete.blur();
+    await autocomplete.focus();
+    return autocomplete;
+  }
+
+  private async openOtherUserAutocomplete(): Promise<MatAutocompleteHarness> {
+    const autocomplete = await this.locateOtherUserAutocomplete();
+    await autocomplete.blur();
+    await autocomplete.focus();
+    return autocomplete;
+  }
+}

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-transfer-ownership-dialog/application-transfer-ownership-dialog.component.html
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-transfer-ownership-dialog/application-transfer-ownership-dialog.component.html
@@ -1,0 +1,204 @@
+<!--
+
+    Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<h2 mat-dialog-title i18n="@@transferApplicationOwnershipDialogTitle">Transfer Ownership</h2>
+
+<mat-dialog-content class="application-transfer-ownership-dialog">
+  <p class="application-transfer-ownership-dialog__description next-gen-body" i18n="@@transferApplicationOwnershipDialogDescription">
+    Transfer ownership and grant access to your Application to another user.
+  </p>
+
+  <section class="application-transfer-ownership-dialog__section">
+    <p class="application-transfer-ownership-dialog__hint next-gen-small" i18n="@@transferApplicationOwnershipMethodHint">
+      Select your preferred method for granting complete Application access.
+    </p>
+    <app-button-toggle-group [value]="transferMethod()" (valueChange)="onTransferMethodChange($event)">
+      <app-button-toggle-option
+        value="APPLICATION_MEMBER"
+        icon="groups"
+        label="Application member"
+        i18n-label="@@transferApplicationOwnershipApplicationMemberMethod"
+      />
+      <app-button-toggle-option
+        value="OTHER_USER"
+        icon="person_search"
+        label="Other user"
+        i18n-label="@@transferApplicationOwnershipOtherUserMethod"
+      />
+    </app-button-toggle-group>
+  </section>
+
+  <section class="application-transfer-ownership-dialog__section">
+    @if (isApplicationMemberMethod()) {
+      <mat-form-field appearance="outline" class="application-transfer-ownership-dialog__field">
+        <mat-label i18n="@@transferApplicationOwnershipMemberLabel">Select application member</mat-label>
+        <input
+          matInput
+          type="search"
+          [formControl]="applicationMemberControl"
+          [matAutocomplete]="applicationMemberAutocomplete"
+          (input)="clearTarget()"
+          data-testid="transfer-ownership-application-member-input"
+          aria-label="Select application member"
+          i18n-aria-label="@@transferApplicationOwnershipMemberAriaLabel"
+          placeholder="Name or email..."
+          i18n-placeholder="@@transferApplicationOwnershipMemberPlaceholder"
+        />
+        <mat-autocomplete #applicationMemberAutocomplete="matAutocomplete">
+          @for (option of applicationMemberOptions(); track option.id) {
+            <mat-option [value]="applicationMemberSearchQuery()" (onSelectionChange)="$event.isUserInput && onTargetSelected(option)">
+              <app-user-cell [user]="option.vm" />
+            </mat-option>
+          }
+          @if (noApplicationMembersFound()) {
+            <mat-option disabled data-testid="transfer-ownership-application-member-no-match">
+              <span i18n="@@transferApplicationOwnershipNoMembersFound">No application members found</span>
+            </mat-option>
+          }
+        </mat-autocomplete>
+      </mat-form-field>
+    } @else {
+      <mat-form-field appearance="outline" class="application-transfer-ownership-dialog__field">
+        <mat-label i18n="@@transferApplicationOwnershipOtherUserLabel">Search user</mat-label>
+        <input
+          matInput
+          type="search"
+          [formControl]="otherUserControl"
+          [matAutocomplete]="otherUserAutocomplete"
+          (input)="clearTarget()"
+          data-testid="transfer-ownership-other-user-input"
+          aria-label="Search user"
+          i18n-aria-label="@@transferApplicationOwnershipOtherUserAriaLabel"
+          placeholder="Name or email..."
+          i18n-placeholder="@@transferApplicationOwnershipOtherUserPlaceholder"
+        />
+        <mat-autocomplete #otherUserAutocomplete="matAutocomplete">
+          @if (usersResource.isLoading()) {
+            <mat-option disabled data-testid="transfer-ownership-user-search-loading">
+              <div class="application-transfer-ownership-dialog__option">
+                <mat-progress-spinner diameter="20" mode="indeterminate" />
+                <span class="next-gen-small" i18n="@@transferApplicationOwnershipUserSearchLoading">Searching users...</span>
+              </div>
+            </mat-option>
+          }
+          @for (option of otherUserOptions(); track option.id) {
+            <mat-option
+              [value]="otherUserSearchQuery()"
+              [disabled]="option.isDisabled"
+              (onSelectionChange)="$event.isUserInput && onTargetSelected(option)"
+            >
+              <div class="application-transfer-ownership-dialog__option">
+                <app-user-cell [user]="option.vm" />
+                @if (option.isAlreadyMember) {
+                  <span
+                    class="application-transfer-ownership-dialog__already-member next-gen-small"
+                    data-testid="transfer-ownership-user-already-member"
+                    i18n="@@transferApplicationOwnershipAlreadyMember"
+                  >
+                    Already member
+                  </span>
+                }
+              </div>
+            </mat-option>
+          }
+          @if (noUsersFound()) {
+            <mat-option disabled data-testid="transfer-ownership-user-search-no-match">
+              <span i18n="@@transferApplicationOwnershipNoUsersFound">No users found</span>
+            </mat-option>
+          }
+        </mat-autocomplete>
+        <mat-hint i18n="@@transferApplicationOwnershipOtherUserHint">Search by name or email.</mat-hint>
+      </mat-form-field>
+
+      @if (usersResource.error()) {
+        <p
+          class="application-transfer-ownership-dialog__error next-gen-small"
+          data-testid="transfer-ownership-user-search-error"
+          role="alert"
+          i18n
+        >
+          An error occurred while searching users. Please try again.
+        </p>
+      }
+    }
+  </section>
+
+  <section class="application-transfer-ownership-dialog__section">
+    @if (rolesResource.isLoading()) {
+      <div class="application-transfer-ownership-dialog__loading" aria-live="polite" data-testid="transfer-ownership-roles-loading">
+        <mat-progress-spinner diameter="20" mode="indeterminate" />
+        <span class="next-gen-small" i18n="@@transferApplicationOwnershipRolesLoading">Loading roles...</span>
+      </div>
+    } @else if (rolesResource.error()) {
+      <p
+        class="application-transfer-ownership-dialog__error next-gen-small"
+        role="alert"
+        data-testid="transfer-ownership-roles-error"
+        i18n="@@transferApplicationOwnershipRolesError"
+      >
+        An error occurred while loading application roles. Please try again.
+      </p>
+    } @else {
+      <mat-form-field appearance="outline" class="application-transfer-ownership-dialog__field">
+        <mat-label i18n="@@transferApplicationOwnershipCurrentOwnerRoleLabel">Current owner new role</mat-label>
+        <mat-select
+          [formControl]="roleControl"
+          data-testid="transfer-ownership-role-select"
+          aria-label="Current owner new role"
+          i18n-aria-label="@@transferApplicationOwnershipCurrentOwnerRoleAriaLabel"
+        >
+          @for (role of assignableRoles(); track role.name) {
+            <mat-option [value]="role.name">{{ role.name }}</mat-option>
+          }
+        </mat-select>
+        @if (roleControl.hasError('required') && roleControl.touched) {
+          <mat-error i18n="@@transferApplicationOwnershipRoleRequired">Application role is required.</mat-error>
+        }
+      </mat-form-field>
+    }
+  </section>
+
+  @if (submitError(); as error) {
+    <p class="application-transfer-ownership-dialog__error next-gen-small" data-testid="transfer-ownership-submit-error" role="alert">
+      {{ error }}
+    </p>
+  }
+</mat-dialog-content>
+
+<mat-dialog-actions align="end">
+  <button
+    mat-stroked-button
+    type="button"
+    [disabled]="isSubmitting()"
+    (click)="onCancel()"
+    data-testid="transfer-ownership-cancel-button"
+    i18n="@@transferApplicationOwnershipCancelButton"
+  >
+    Cancel
+  </button>
+  <button
+    mat-flat-button
+    color="primary"
+    type="button"
+    [disabled]="!canSubmit()"
+    (click)="onSubmit()"
+    data-testid="transfer-ownership-submit-button"
+    i18n="@@transferApplicationOwnershipSubmitButton"
+  >
+    Transfer
+  </button>
+</mat-dialog-actions>

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-transfer-ownership-dialog/application-transfer-ownership-dialog.component.scss
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-transfer-ownership-dialog/application-transfer-ownership-dialog.component.scss
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@use '../../../../scss/theme' as app-theme;
+
+.application-transfer-ownership-dialog {
+  display: flex;
+  width: 640px;
+  max-width: 100%;
+  flex-direction: column;
+  gap: 24px;
+  padding-top: app-theme.$form-field-container-vertical-padding;
+
+  &__section {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+  }
+
+  &__description,
+  &__hint {
+    margin: 0;
+    color: app-theme.$paragraph-color;
+  }
+
+  &__field {
+    width: 100%;
+  }
+
+  &__loading {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    color: app-theme.$paragraph-color;
+  }
+
+  &__error {
+    margin: 0;
+    color: app-theme.$error-main-color;
+  }
+
+  &__option {
+    display: flex;
+    width: 100%;
+    align-items: center;
+    justify-content: space-between;
+    gap: 16px;
+  }
+
+  &__already-member {
+    flex-shrink: 0;
+    color: app-theme.$paragraph-color;
+  }
+}

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-transfer-ownership-dialog/application-transfer-ownership-dialog.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-transfer-ownership-dialog/application-transfer-ownership-dialog.component.spec.ts
@@ -1,0 +1,275 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { provideHttpClient } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+
+import {
+  ApplicationTransferOwnershipDialogComponent,
+  ApplicationTransferOwnershipDialogData,
+} from './application-transfer-ownership-dialog.component';
+import { ApplicationTransferOwnershipDialogHarness } from './application-transfer-ownership-dialog.component.harness';
+import { APPLICATION_PRIMARY_OWNER_ROLE_NAME, ApplicationRole } from '../../../../entities/application/application';
+import { User, UsersResponse } from '../../../../entities/user/user';
+import { fakeUser, fakeUsersResponse } from '../../../../entities/user/user.fixtures';
+import { ConfigService } from '../../../../services/config.service';
+import { TESTING_BASE_URL } from '../../../../testing/app-testing.module';
+
+const APPLICATION_ID = 'app-1';
+const OWNER_ID = 'owner-1';
+const ROLES_URL = `${TESTING_BASE_URL}/configuration/applications/roles`;
+const TRANSFER_URL = `${TESTING_BASE_URL}/applications/${APPLICATION_ID}/members/_transfer_ownership`;
+const USERS_SEARCH_URL = `${TESTING_BASE_URL}/users/_search`;
+
+const DIALOG_DATA: ApplicationTransferOwnershipDialogData = {
+  applicationId: APPLICATION_ID,
+  currentOwnerId: OWNER_ID,
+  members: [
+    {
+      id: OWNER_ID,
+      displayName: 'Current Owner',
+      email: 'owner@example.com',
+      initials: 'CO',
+    },
+    {
+      id: 'member-1',
+      reference: 'member-reference',
+      displayName: 'Alice Smith',
+      email: 'alice@example.com',
+      initials: 'AS',
+    },
+  ],
+};
+
+const APPLICATION_ROLES: ApplicationRole[] = [
+  { id: APPLICATION_PRIMARY_OWNER_ROLE_NAME, name: APPLICATION_PRIMARY_OWNER_ROLE_NAME, default: false, system: true },
+  { id: 'SYSTEM_AUDITOR', name: 'SYSTEM_AUDITOR', default: false, system: true },
+  { id: 'EMPTY', name: '', default: false, system: false },
+  { id: 'OWNER', name: 'OWNER', default: false, system: false },
+  { id: 'USER', name: 'USER', default: true, system: false },
+];
+
+describe('ApplicationTransferOwnershipDialogComponent', () => {
+  let fixture: ComponentFixture<ApplicationTransferOwnershipDialogComponent>;
+  let harness: ApplicationTransferOwnershipDialogHarness;
+  let httpTestingController: HttpTestingController;
+  let dialogRef: { close: jest.Mock };
+
+  async function init(
+    data: ApplicationTransferOwnershipDialogData = DIALOG_DATA,
+    roles: ApplicationRole[] | null = APPLICATION_ROLES,
+    createHarness = true,
+  ): Promise<void> {
+    jest.useRealTimers();
+    dialogRef = { close: jest.fn() };
+
+    await TestBed.configureTestingModule({
+      imports: [ApplicationTransferOwnershipDialogComponent],
+      providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        provideNoopAnimations(),
+        { provide: ConfigService, useValue: { baseURL: TESTING_BASE_URL } },
+        { provide: MAT_DIALOG_DATA, useValue: data },
+        { provide: MatDialogRef, useValue: dialogRef },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ApplicationTransferOwnershipDialogComponent);
+    httpTestingController = TestBed.inject(HttpTestingController);
+
+    fixture.detectChanges();
+    if (roles) {
+      flushRoles(roles);
+      await fixture.whenStable();
+      fixture.detectChanges();
+    }
+    if (createHarness) {
+      harness = await TestbedHarnessEnvironment.harnessForFixture(fixture, ApplicationTransferOwnershipDialogHarness);
+    }
+  }
+
+  function flushRoles(roles: ApplicationRole[] = APPLICATION_ROLES): void {
+    const req = httpTestingController.expectOne(ROLES_URL);
+    expect(req.request.method).toBe('GET');
+    req.flush({ data: roles });
+  }
+
+  async function searchOtherUser(query: string, response: UsersResponse): Promise<void> {
+    await harness.selectMethod(/Other user/);
+    fixture.detectChanges();
+    await harness.searchOtherUser(query);
+    fixture.detectChanges();
+    await new Promise(resolve => setTimeout(resolve, 350));
+    fixture.detectChanges();
+
+    const req = httpTestingController.expectOne(req => req.url === USERS_SEARCH_URL);
+    expect(req.request.method).toBe('POST');
+    expect(req.request.params.get('page')).toBe('1');
+    expect(req.request.params.get('size')).toBe('20');
+    expect(req.request.body).toEqual({
+      filters: {
+        query,
+      },
+      includes: {
+        applicationMembership: APPLICATION_ID,
+      },
+    });
+    req.flush(response);
+    await fixture.whenStable();
+    fixture.detectChanges();
+  }
+
+  afterEach(() => {
+    httpTestingController.verify();
+  });
+
+  it('should show only user transfer methods', async () => {
+    await init();
+
+    const methodTexts = await harness.getMethodOptionTexts();
+    expect(methodTexts).toEqual([expect.stringContaining('Application member'), expect.stringContaining('Other user')]);
+    expect(methodTexts.some(text => text.includes('Primary owner group'))).toBe(false);
+  });
+
+  it('should offer only assignable roles for the current owner new role', async () => {
+    await init();
+
+    expect(await harness.getRoleOptionTexts()).toEqual(['OWNER', 'USER']);
+  });
+
+  it('should keep transfer disabled until target and role are selected', async () => {
+    await init();
+
+    await harness.searchApplicationMember('Alice');
+    await harness.selectApplicationMember(/Alice Smith/);
+    fixture.detectChanges();
+
+    expect(await harness.isSubmitDisabled()).toBe(true);
+
+    await harness.selectRole('OWNER');
+
+    expect(await harness.isSubmitDisabled()).toBe(false);
+  });
+
+  it('should transfer ownership to an application member', async () => {
+    await init();
+
+    await harness.searchApplicationMember('Alice');
+    expect(await harness.getApplicationMemberOptionTexts()).toEqual([expect.stringContaining('Alice Smith')]);
+    await harness.selectApplicationMember(/Alice Smith/);
+    await harness.selectRole('OWNER');
+    await harness.clickSubmit();
+    fixture.detectChanges();
+
+    const req = httpTestingController.expectOne(TRANSFER_URL);
+    expect(req.request.method).toBe('POST');
+    expect(req.request.body).toEqual({
+      new_primary_owner_id: 'member-1',
+      new_primary_owner_reference: 'member-reference',
+      primary_owner_newrole: 'OWNER',
+    });
+    req.flush(null, { status: 204, statusText: 'No Content' });
+    await fixture.whenStable();
+
+    expect(dialogRef.close).toHaveBeenCalledWith(true);
+  });
+
+  it('should transfer ownership to another registered user', async () => {
+    const user = fakeUser({ id: 'user-2', reference: 'user-reference', display_name: 'Bob Martin', email: 'bob@example.com' });
+    await init();
+
+    await searchOtherUser('Bob', usersResponse([user]));
+    expect(await harness.getOtherUserOptionTexts()).toEqual([expect.stringContaining('Bob Martin')]);
+    await harness.selectOtherUser(/Bob Martin/);
+    await harness.selectRole('USER');
+    await harness.clickSubmit();
+    fixture.detectChanges();
+
+    const req = httpTestingController.expectOne(TRANSFER_URL);
+    expect(req.request.method).toBe('POST');
+    expect(req.request.body).toEqual({
+      new_primary_owner_id: 'user-2',
+      new_primary_owner_reference: 'user-reference',
+      primary_owner_newrole: 'USER',
+    });
+    req.flush(null, { status: 204, statusText: 'No Content' });
+    await fixture.whenStable();
+
+    expect(dialogRef.close).toHaveBeenCalledWith(true);
+  });
+
+  it('should annotate already assigned users without blocking transfer in other user search', async () => {
+    const user = fakeUser({ id: 'user-1', display_name: 'Ada Lovelace' });
+    await init();
+
+    await searchOtherUser('Ada', usersResponse([user], { 'user-1': true }));
+
+    expect(await harness.getOtherUserOptionTexts()).toEqual([expect.stringContaining('Already member')]);
+    expect(await harness.isOtherUserOptionDisabled(/Ada Lovelace/)).toBe(false);
+  });
+
+  it('should keep dialog open and show inline error when transfer fails', async () => {
+    await init();
+
+    await harness.searchApplicationMember('Alice');
+    await harness.selectApplicationMember(/Alice Smith/);
+    await harness.selectRole('OWNER');
+    await harness.clickSubmit();
+    fixture.detectChanges();
+
+    httpTestingController.expectOne(TRANSFER_URL).flush({ message: 'Server error' }, { status: 500, statusText: 'Error' });
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    expect(dialogRef.close).not.toHaveBeenCalled();
+    expect(await harness.getSubmitErrorText()).toContain('An error occurred while transferring ownership');
+    expect(await harness.isSubmitDisabled()).toBe(false);
+  });
+
+  it('should close dialog without transfer when cancelled', async () => {
+    await init();
+
+    await harness.clickCancel();
+
+    expect(dialogRef.close).toHaveBeenCalledWith(false);
+    httpTestingController.expectNone(TRANSFER_URL);
+  });
+
+  it('should show recoverable roles loading error', async () => {
+    await init(DIALOG_DATA, null, false);
+
+    httpTestingController.expectOne(ROLES_URL).flush({ message: 'Server error' }, { status: 500, statusText: 'Error' });
+    await fixture.whenStable();
+    fixture.detectChanges();
+    harness = await TestbedHarnessEnvironment.harnessForFixture(fixture, ApplicationTransferOwnershipDialogHarness);
+
+    expect(await harness.getRolesErrorText()).toContain('An error occurred while loading application roles');
+  });
+});
+
+function usersResponse(users: User[], applicationMembership: Record<string, boolean> = {}): UsersResponse {
+  return fakeUsersResponse({
+    data: users,
+    metadata: {
+      data: { total: users.length },
+      applicationMembership,
+    },
+  });
+}

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-transfer-ownership-dialog/application-transfer-ownership-dialog.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-transfer-ownership-dialog/application-transfer-ownership-dialog.component.ts
@@ -1,0 +1,332 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Component, DestroyRef, computed, inject, signal } from '@angular/core';
+import { rxResource, takeUntilDestroyed, toSignal } from '@angular/core/rxjs-interop';
+import { FormControl, ReactiveFormsModule, Validators } from '@angular/forms';
+import { MatAutocompleteModule } from '@angular/material/autocomplete';
+import { MatButtonModule } from '@angular/material/button';
+import { MAT_DIALOG_DATA, MatDialogModule, MatDialogRef } from '@angular/material/dialog';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatIconModule } from '@angular/material/icon';
+import { MatInputModule } from '@angular/material/input';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+import { MatSelectModule } from '@angular/material/select';
+import { debounceTime, distinctUntilChanged, of, startWith } from 'rxjs';
+
+import { ButtonToggleGroupComponent } from '../../../../components/button-toggle-group/button-toggle-group.component';
+import { ButtonToggleOptionComponent } from '../../../../components/button-toggle-group/button-toggle-option.component';
+import { UserCellComponent, UserCellVM } from '../../../../components/user-cell/user-cell.component';
+import { isAssignableApplicationRole } from '../../../../entities/application/application';
+import { User, UsersResponse } from '../../../../entities/user/user';
+import { ApplicationService } from '../../../../services/application.service';
+import { MembershipService } from '../../../../services/membership.service';
+import { UsersService } from '../../../../services/users.service';
+
+const APPLICATION_MEMBER_METHOD = 'APPLICATION_MEMBER';
+const OTHER_USER_METHOD = 'OTHER_USER';
+
+type TransferOwnershipMethod = typeof APPLICATION_MEMBER_METHOD | typeof OTHER_USER_METHOD;
+
+export interface ApplicationTransferOwnershipMemberOption {
+  id: string;
+  reference?: string;
+  displayName: string;
+  email?: string;
+  avatarUrl?: string;
+  initials: string;
+}
+
+export interface ApplicationTransferOwnershipDialogData {
+  applicationId: string;
+  currentOwnerId?: string;
+  members: ApplicationTransferOwnershipMemberOption[];
+}
+
+interface TransferOwnershipTarget extends ApplicationTransferOwnershipMemberOption {
+  vm: UserCellVM;
+  isAlreadyMember: boolean;
+  isDisabled: boolean;
+}
+
+@Component({
+  selector: 'app-application-transfer-ownership-dialog',
+  standalone: true,
+  imports: [
+    ButtonToggleGroupComponent,
+    ButtonToggleOptionComponent,
+    MatAutocompleteModule,
+    MatButtonModule,
+    MatDialogModule,
+    MatFormFieldModule,
+    MatIconModule,
+    MatInputModule,
+    MatProgressSpinnerModule,
+    MatSelectModule,
+    ReactiveFormsModule,
+    UserCellComponent,
+  ],
+  templateUrl: './application-transfer-ownership-dialog.component.html',
+  styleUrl: './application-transfer-ownership-dialog.component.scss',
+})
+export class ApplicationTransferOwnershipDialogComponent {
+  private readonly applicationService = inject(ApplicationService);
+  private readonly destroyRef = inject(DestroyRef);
+  private readonly dialogRef = inject(MatDialogRef<ApplicationTransferOwnershipDialogComponent, boolean>);
+  private readonly membershipService = inject(MembershipService);
+  private readonly usersService = inject(UsersService);
+  private readonly data: ApplicationTransferOwnershipDialogData = inject(MAT_DIALOG_DATA);
+
+  readonly transferMethod = signal<TransferOwnershipMethod>(APPLICATION_MEMBER_METHOD);
+  readonly applicationMemberControl = new FormControl('', { nonNullable: true });
+  readonly otherUserControl = new FormControl('', { nonNullable: true });
+  readonly roleControl = new FormControl('', { nonNullable: true, validators: [Validators.required] });
+  readonly submitError = signal<string | null>(null);
+  readonly isSubmitting = signal(false);
+  readonly selectedTarget = signal<TransferOwnershipTarget | null>(null);
+
+  private readonly applicationMemberSearchValue = toSignal(
+    this.applicationMemberControl.valueChanges.pipe(startWith(this.applicationMemberControl.value)),
+    {
+      initialValue: this.applicationMemberControl.value,
+    },
+  );
+
+  private readonly otherUserSearchValue = toSignal(
+    this.otherUserControl.valueChanges.pipe(debounceTime(300), distinctUntilChanged(), startWith(this.otherUserControl.value)),
+    {
+      initialValue: this.otherUserControl.value,
+    },
+  );
+
+  private readonly selectedRole = toSignal(this.roleControl.valueChanges.pipe(startWith(this.roleControl.value)), {
+    initialValue: this.roleControl.value,
+  });
+
+  readonly isApplicationMemberMethod = computed(() => this.transferMethod() === APPLICATION_MEMBER_METHOD);
+  readonly isOtherUserMethod = computed(() => this.transferMethod() === OTHER_USER_METHOD);
+  readonly applicationMemberSearchQuery = computed(() => this.applicationMemberSearchValue().trim());
+  readonly otherUserSearchQuery = computed(() => this.otherUserSearchValue().trim());
+  readonly otherUserSearchRequest = computed(() => (this.isOtherUserMethod() ? this.otherUserSearchQuery() : ''));
+
+  protected readonly rolesResource = rxResource({
+    stream: () => this.applicationService.getApplicationRoles(),
+  });
+
+  protected readonly usersResource = rxResource<UsersResponse | undefined, string>({
+    params: this.otherUserSearchRequest,
+    stream: ({ params }) =>
+      params.length > 0 ? this.usersService.searchUsersForApplicationMembership(this.data.applicationId, params) : of(undefined),
+  });
+
+  readonly assignableRoles = computed(() => (this.rolesResource.value() ?? []).filter(isAssignableApplicationRole));
+
+  readonly applicationMemberOptions = computed<TransferOwnershipTarget[]>(() => {
+    const query = this.applicationMemberSearchQuery().toLowerCase();
+    return this.data.members
+      .filter(member => member.id !== this.data.currentOwnerId)
+      .map(member => this.toMemberTarget(member))
+      .filter(target => this.targetMatchesQuery(target, query));
+  });
+
+  readonly otherUserOptions = computed<TransferOwnershipTarget[]>(() => {
+    if (this.usersResource.error()) {
+      return [];
+    }
+
+    const response = this.usersResource.value();
+    const membership = response?.metadata?.applicationMembership ?? {};
+    return (response?.data ?? []).map(user => {
+      const id = user.id ?? '';
+      const isAlreadyMember = !!id && membership[id] === true;
+      return {
+        ...this.toUserTarget(user, id),
+        isAlreadyMember,
+        isDisabled: !id || id === this.data.currentOwnerId,
+      };
+    });
+  });
+
+  readonly noApplicationMembersFound = computed(
+    () => this.applicationMemberSearchQuery() !== '' && this.applicationMemberOptions().length === 0,
+  );
+
+  readonly noUsersFound = computed(
+    () =>
+      this.otherUserSearchQuery() !== '' &&
+      !this.usersResource.isLoading() &&
+      !this.usersResource.error() &&
+      this.otherUserOptions().length === 0,
+  );
+
+  readonly canSubmit = computed(() => {
+    const role = this.selectedRole();
+    return (
+      !this.isSubmitting() &&
+      !!this.selectedTarget() &&
+      !!role &&
+      !this.rolesResource.isLoading() &&
+      !this.rolesResource.error() &&
+      this.assignableRoles().some(assignableRole => assignableRole.name === role)
+    );
+  });
+
+  onTransferMethodChange(method: string): void {
+    if (!this.isTransferOwnershipMethod(method) || method === this.transferMethod()) {
+      return;
+    }
+
+    this.transferMethod.set(method);
+    this.clearTarget();
+    this.applicationMemberControl.setValue('');
+    this.otherUserControl.setValue('');
+    this.submitError.set(null);
+  }
+
+  clearTarget(): void {
+    this.selectedTarget.set(null);
+  }
+
+  onTargetSelected(target: TransferOwnershipTarget): void {
+    if (target.isDisabled) {
+      return;
+    }
+
+    this.submitError.set(null);
+    this.selectedTarget.set(target);
+    const control = this.isApplicationMemberMethod() ? this.applicationMemberControl : this.otherUserControl;
+    control.setValue(target.displayName, { emitEvent: false });
+  }
+
+  onCancel(): void {
+    this.dialogRef.close(false);
+  }
+
+  onSubmit(): void {
+    this.roleControl.markAsTouched();
+    const target = this.selectedTarget();
+    const role = this.roleControl.value;
+
+    if (!target || !this.canSubmit()) {
+      return;
+    }
+
+    this.isSubmitting.set(true);
+    this.submitError.set(null);
+    this.setControlsDisabled(true);
+
+    this.membershipService
+      .transferApplicationOwnership(this.data.applicationId, {
+        new_primary_owner_id: target.id,
+        new_primary_owner_reference: target.reference,
+        primary_owner_newrole: role,
+      })
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: () => {
+          this.isSubmitting.set(false);
+          this.dialogRef.close(true);
+        },
+        error: () => {
+          this.isSubmitting.set(false);
+          this.setControlsDisabled(false);
+          this.submitError.set(
+            $localize`:@@transferApplicationOwnershipSubmitError:An error occurred while transferring ownership. Please try again.`,
+          );
+        },
+      });
+  }
+
+  private setControlsDisabled(disabled: boolean): void {
+    const options = { emitEvent: false };
+    if (disabled) {
+      this.applicationMemberControl.disable(options);
+      this.otherUserControl.disable(options);
+      this.roleControl.disable(options);
+      return;
+    }
+
+    this.applicationMemberControl.enable(options);
+    this.otherUserControl.enable(options);
+    this.roleControl.enable(options);
+  }
+
+  private toMemberTarget(member: ApplicationTransferOwnershipMemberOption): TransferOwnershipTarget {
+    return {
+      ...member,
+      vm: {
+        displayName: member.displayName,
+        email: member.email,
+        avatarUrl: member.avatarUrl,
+        initials: member.initials,
+      },
+      isAlreadyMember: true,
+      isDisabled: false,
+    };
+  }
+
+  private toUserTarget(user: User, id: string): TransferOwnershipTarget {
+    const vm = this.toUserCell(user);
+    return {
+      id,
+      reference: user.reference,
+      displayName: vm.displayName,
+      email: vm.email,
+      avatarUrl: vm.avatarUrl,
+      initials: vm.initials,
+      vm,
+      isAlreadyMember: false,
+      isDisabled: false,
+    };
+  }
+
+  private toUserCell(user: User): UserCellVM {
+    const displayName =
+      user.display_name ??
+      (user.first_name || user.last_name ? `${user.first_name ?? ''} ${user.last_name ?? ''}`.trim() : (user.id ?? ''));
+
+    return {
+      displayName,
+      email: user.email,
+      avatarUrl: user._links?.avatar,
+      initials: this.getInitialsFromDisplayName(displayName),
+    };
+  }
+
+  private targetMatchesQuery(target: TransferOwnershipTarget, query: string): boolean {
+    if (query === '') {
+      return true;
+    }
+
+    return [target.displayName, target.email, target.id].some(value => value?.toLowerCase().includes(query));
+  }
+
+  private getInitialsFromDisplayName(displayName: string): string {
+    const parts = displayName
+      .trim()
+      .split(/\s+/)
+      .filter(part => part.length > 0);
+
+    return parts
+      .slice(0, 2)
+      .map(part => part[0])
+      .join('')
+      .toUpperCase();
+  }
+
+  private isTransferOwnershipMethod(method: string): method is TransferOwnershipMethod {
+    return method === APPLICATION_MEMBER_METHOD || method === OTHER_USER_METHOD;
+  }
+}

--- a/gravitee-apim-portal-webui-next/src/entities/member/member.ts
+++ b/gravitee-apim-portal-webui-next/src/entities/member/member.ts
@@ -29,6 +29,12 @@ export interface MemberInput {
   role: string;
 }
 
+export interface TransferOwnershipInput {
+  new_primary_owner_id: string;
+  new_primary_owner_reference?: string;
+  primary_owner_newrole: string;
+}
+
 export interface MembersResponse {
   data?: Member[];
   metadata?: {

--- a/gravitee-apim-portal-webui-next/src/services/membership.service.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/services/membership.service.spec.ts
@@ -120,4 +120,20 @@ describe('MembershipService', () => {
     expect(req.request.body).toEqual({ role: 'OWNER' });
     req.flush(member);
   });
+
+  it('should transfer application ownership', done => {
+    const input = {
+      new_primary_owner_id: 'user-1',
+      new_primary_owner_reference: 'user-reference',
+      primary_owner_newrole: 'OWNER',
+    };
+
+    service.transferApplicationOwnership(applicationId, input).subscribe(() => done());
+
+    const req = httpTestingController.expectOne(
+      r => r.url === `${TESTING_BASE_URL}/applications/${applicationId}/members/_transfer_ownership` && r.method === 'POST',
+    );
+    expect(req.request.body).toEqual(input);
+    req.flush(null, { status: 204, statusText: 'No Content' });
+  });
 });

--- a/gravitee-apim-portal-webui-next/src/services/membership.service.ts
+++ b/gravitee-apim-portal-webui-next/src/services/membership.service.ts
@@ -18,7 +18,7 @@ import { inject, Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
 
 import { ConfigService } from './config.service';
-import { Member, MemberInput, MemberSearchFilters, MembersResponse } from '../entities/member/member';
+import { Member, MemberInput, MemberSearchFilters, MembersResponse, TransferOwnershipInput } from '../entities/member/member';
 
 @Injectable({
   providedIn: 'root',
@@ -45,5 +45,9 @@ export class MembershipService {
 
   updateApplicationMember(applicationId: string, memberId: string, memberInput: MemberInput): Observable<Member> {
     return this.http.put<Member>(`${this.configService.baseURL}/applications/${applicationId}/members/${memberId}`, memberInput);
+  }
+
+  transferApplicationOwnership(applicationId: string, input: TransferOwnershipInput): Observable<void> {
+    return this.http.post<void>(`${this.configService.baseURL}/applications/${applicationId}/members/_transfer_ownership`, input);
   }
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-14199

## Changes

- Added Transfer Ownership action on the application members tab.
- Added a dedicated transfer dialog for: existing application members, other registered users
- wired the flow to POST /applications/{applicationId}/members/_transfer_ownership.
- Refreshes members and application permissions after successful transfer.
- Added service, component, and harness-based tests.



https://github.com/user-attachments/assets/85d47240-2b02-4433-80cb-dc271a0803ac


