### PR TITLE
feat(repository): OTEL_LOGS scope + OtelLogRepository SPI with Elasticsearch impl

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/otel/log/api/OtelLogRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/otel/log/api/OtelLogRepository.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.otel.log.api;
+
+import io.gravitee.repository.common.query.QueryContext;
+import io.gravitee.repository.otel.log.model.OtelLogRecord;
+import io.gravitee.repository.otel.log.model.OtelLogSearchCriteria;
+import io.reactivex.rxjava3.core.Single;
+import java.util.List;
+
+/**
+ * Backend-agnostic port for reading OTel log records. Sits alongside
+ * {@link io.gravitee.repository.tracing.api.TracingRepository}. The OTel logs data model unifies two
+ * shapes that the SPI doesn't split:
+ * <ul>
+ *   <li>Span events — written by the OTel collector's ES {@code elasticsearch} exporter (in
+ *       {@code mapping.mode: otel}) as separate log documents in the logs data stream. Carry
+ *       {@code event.name} in their attributes. Only the ES-backed implementation returns them; in the
+ *       Tempo + Loki stack span events live inline on the spans and are returned by
+ *       {@code TracingRepository.getTrace}, so a Loki-backed implementation simply doesn't surface
+ *       any record carrying {@code event.name}.</li>
+ *   <li>Payload logs — gateway-captured request/response payloads written by
+ *       {@code gravitee-reporter-otel}. Both Elasticsearch and Loki implementations return these.</li>
+ * </ul>
+ * Consumers that need to partition span events vs payload logs do it on
+ * {@code attributes().containsKey("event.name")}.
+ *
+ * @author GraviteeSource Team
+ */
+public interface OtelLogRepository {
+    /**
+     * Fetch OTel log records matching the given criteria — span events and payload logs alike — in
+     * {@code @timestamp} ascending order so consumers can render them as a timeline without re-sorting.
+     * <p>
+     * Returns an empty list when no records match, when the resource filter excludes everything, or when
+     * the backing storage isn't reachable (e.g. the logs data stream doesn't exist because the operator
+     * didn't enable the logs pipeline). Never errors on "not found" — the gamma consumer is expected to
+     * still render the trace's spans even without any associated logs.
+     *
+     * @param queryContext caller's org/env tenant context, used to resolve the target index / data
+     *                     stream / Loki tenant. Mandatory: {@link QueryContext#orgId()} hard-partitions
+     *                     so a known trace id from another scope can't leak through.
+     * @param criteria     query shape — see {@link OtelLogSearchCriteria}. Every field is optional;
+     *                     callers are responsible for adding enough filters (trace id, resource scope,
+     *                     time range) that the response stays bounded and tenant-isolated.
+     */
+    Single<List<OtelLogRecord>> findLogs(QueryContext queryContext, OtelLogSearchCriteria criteria);
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/otel/log/model/OtelLogRecord.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/otel/log/model/OtelLogRecord.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.otel.log.model;
+
+import java.time.Instant;
+import java.util.Map;
+
+/**
+ * Single OTel log record, the unified data shape behind both span-event logs and gateway-captured payload
+ * logs. Both are stored as OTel {@code LogRecord} documents in the backend (the ES collector's logs data
+ * stream, or Loki) — the record carries no kind discriminator because the OTel attribute model already
+ * does it: span events carry {@code event.name} in {@link #attributes()} (per the OTel logs data model
+ * "Event" convention) and typically no {@link #body()}; payload logs ({@code gravitee-reporter-otel}) carry
+ * the captured payload in {@link #body()} and no {@code event.name}. Consumers that need the slice
+ * partition on {@code attributes().containsKey("event.name")}.
+ *
+ * @param traceId           parent trace id (32-character lowercase hex). Required.
+ * @param spanId            parent span id (16-character lowercase hex). Required for stitching — entries
+ *                          with a null {@code spanId} are dropped at the repository boundary.
+ * @param timestamp         record timestamp.
+ * @param severity          OTel severity text (e.g. {@code INFO}, {@code ERROR}). Often {@code null} for
+ *                          span events.
+ * @param body              record body. Used by payload logs to carry the captured request/response
+ *                          payload; usually {@code null} for span events.
+ * @param attributes        OTel record attributes, flattened to a string→string map (nested attribute
+ *                          keys dot-joined: {@code http.status_code}, {@code event.name}, …). For span
+ *                          events {@code event.name} is populated here.
+ * @param resourceAttributes producer's OTel resource attributes (e.g. {@code gravitee.module},
+ *                          {@code gravitee.env.id}), flattened the same way.
+ *
+ * @author GraviteeSource Team
+ */
+public record OtelLogRecord(
+    String traceId,
+    String spanId,
+    Instant timestamp,
+    String severity,
+    String body,
+    Map<String, String> attributes,
+    Map<String, String> resourceAttributes
+) {}

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/otel/log/model/OtelLogSearchCriteria.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/otel/log/model/OtelLogSearchCriteria.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.otel.log.model;
+
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Filter passed to {@link io.gravitee.repository.otel.log.api.OtelLogRepository#findLogs}. Mirrors
+ * {@link io.gravitee.repository.tracing.model.TraceSearchCriteria} so the two OTel SPIs share the same
+ * shape — the dimensions are the ones the OTel logs data model itself exposes.
+ * <ul>
+ *   <li>{@code traceId} — distinguished top-level field in the OTel logs data model (not an attribute);
+ *       optional so the SPI serves both "fetch all logs for trace X" and "browse logs for API Y over
+ *       time" use cases.</li>
+ *   <li>{@code attributeFilters} — per-record attribute filters ({@code LogRecord.attributes.*}). Use for
+ *       attributes set on the individual log event: {@code event.name} (span events),
+ *       {@code http.status_code} (payload logs), …</li>
+ *   <li>{@code resourceAttributeFilters} — resource-attribute filters ({@code Resource.attributes.*}).
+ *       Use for properties set once per producer process: service identity, environment, deployment
+ *       module, our {@code gravitee.api.id} / {@code gravitee.env.id} / {@code gravitee.module}.</li>
+ *   <li>{@code start} / {@code end} — half-open {@code @timestamp} window, both optional.</li>
+ *   <li>{@code limit} — hard cap on records returned. Defaulted to 5000 because a single
+ *       verbose-tracing trace can emit hundreds of span events plus request+response payloads per
+ *       acceptor; 5000 covers it without paging while still bounding worst case.</li>
+ * </ul>
+ * Separating record-vs-resource attributes avoids the impl having to guess (by prefix or hardcoded key
+ * list) where each entry belongs, and lines up with how OTel backends actually store attributes.
+ *
+ * @author GraviteeSource Team
+ */
+public record OtelLogSearchCriteria(
+    String traceId,
+    Map<String, String> attributeFilters,
+    Map<String, String> resourceAttributeFilters,
+    Instant start,
+    Instant end,
+    Integer limit
+) {
+    public OtelLogSearchCriteria {
+        if (limit == null || limit <= 0) {
+            limit = 5000;
+        }
+        if (attributeFilters == null) {
+            attributeFilters = new HashMap<>();
+        }
+        if (resourceAttributeFilters == null) {
+            resourceAttributeFilters = new HashMap<>();
+        }
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/README.adoc
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/README.adoc
@@ -97,3 +97,93 @@ service:
       processors: [batch]
       exporters: [elasticsearch]
 ----
+
+== OTel logs repository (`Scope.OTEL_LOGS`)
+
+This plugin also implements the APIM `OtelLogRepository` SPI — the read side for the OpenTelemetry logs data stream populated by two distinct producers:
+
+* **Span events**, written by the OTel Collector's `elasticsearch` exporter (in `mapping.mode: otel`) when it processes incoming OTel traces. The exporter forces `data_stream.type = logs` for events, so they land in the logs data stream rather than alongside the spans they belong to.
+* **Payload logs**, written by `gravitee-reporter-otel` (the gateway-side reporter that ships captured request/response payloads as OTLP log records).
+
+The SPI exposes a single `findLogs` method that returns both shapes uniformly — span events carry an `event.name` attribute (per the OTel logs data model convention), payload logs carry their captured payload in `body`. Consumers that need to partition span events vs payload logs do it on `record.attributes().containsKey("event.name")`.
+
+=== Configuration
+
+In `gravitee.yml`:
+
+[source,yaml]
+----
+otel-logs:
+  type: elasticsearch
+  elasticsearch:
+    # Logs data stream / index template. {orgId} and {envId} are substituted from the caller's QueryContext
+    # at query time, lowercased — same convention as the analytics / tracing scopes.
+    index: logs-apim.otel-{orgId}
+    endpoints:
+      - http://localhost:9200
+    # security, ssl, http.proxy, …: same shape as analytics / otel-traces; see RepositoryConfiguration for
+    # the full list of supported properties.
+----
+
+The `otel-logs.elasticsearch.*` block is **independent** from `analytics.elasticsearch.*` and `otel-traces.elasticsearch.*` — same per-scope pattern. No fallback: the OTel logs reader can target a different ES cluster from analytics / tracing, or be enabled in deployments that don't use ES for either.
+
+NOTE: For the Tempo + Loki stack (PR 4, future), span events live inline on the spans inside Tempo and are returned by `TracingRepository.getTrace` rather than by `OtelLogRepository.findLogs`. A Loki-backed `OtelLogRepository` returns only payload logs from Loki, with no `event.name` attribute on any record — consumers should still partition the same way.
+
+=== Org and env scoping
+
+Same two-level mapping as the tracing repository:
+
+* **Org → index name** (hard partition): `orgId` is substituted into the `otel-logs.elasticsearch.index` template.
+* **Soft scopes** (env, module, …): the caller passes `Map<String, String>` to `OtelLogSearchCriteria.resourceAttributeFilters()` (matched on `resource.attributes.<key>`) and/or `attributeFilters()` (matched on `attributes.<key>`). The producer must emit those keys as resource attributes on each log record (typically via `services.opentelemetry.extraAttributes` in the gateway / management API config); without them the resource filter rejects every record.
+
+The trace-detail use case calls with a `traceId` plus the env/module resource filters, but the SPI is intentionally generic so a future logs-explorer use case can browse logs by API id + time window with no `traceId` at all.
+
+=== Index templates, mappings & retention (ILM)
+
+Reader-only, same as tracing — the index template and mappings are authored by the producer:
+
+* **Self-managed OTel Collector**: the `elasticsearch` exporter (`mapping.mode: otel`) applies the logs template at startup, including the dynamic templates for `attributes.*`. The dedicated `logs_index` / `logs_dynamic_index` setting points at the data stream.
+* **`gravitee-reporter-otel`**: writes via OTLP/HTTP to the same OTel Collector pipeline; the exporter handles the template / mapping.
+* **Elastic Cloud managed OTLP**: ships with a sensible default `logs@lifecycle`; customize via Kibana or `_ilm/policy/...`.
+
+If queries return no data, check (in this order): (1) the data stream `logs-apim.otel-<orgId>` exists, (2) at least one of the two producers (collector for span events, gravitee-reporter-otel for payload logs) is actively writing, (3) the template's mapping mode is `otel` (not `ecs`), (4) ILM hasn't already deleted the documents.
+
+=== OTel Collector configuration snippet
+
+A minimal collector pipeline that handles both shapes — receives OTLP traces from the gateway tracing pipeline (the exporter extracts span events into the logs data stream automatically) and OTLP logs from `gravitee-reporter-otel`:
+
+[source,yaml]
+----
+receivers:
+  otlp:
+    protocols:
+      http:
+        endpoint: 0.0.0.0:4318
+      grpc:
+        endpoint: 0.0.0.0:4317
+
+exporters:
+  elasticsearch:
+    endpoints: ["http://elasticsearch:9200"]
+    mapping:
+      mode: otel
+    # Span events from the traces pipeline AND payload log records from the logs pipeline both land in this
+    # data stream. The repository discriminates them on attribute presence at read time.
+    logs_index: logs-apim.otel-<orgId>
+    traces_index: traces-apim.otel-<orgId>
+
+processors:
+  batch:
+    timeout: 1s
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [elasticsearch]
+    logs:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [elasticsearch]
+----

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/ElasticsearchRepositoryProvider.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/ElasticsearchRepositoryProvider.java
@@ -17,6 +17,7 @@ package io.gravitee.repository.elasticsearch;
 
 import io.gravitee.platform.repository.api.RepositoryProvider;
 import io.gravitee.platform.repository.api.Scope;
+import io.gravitee.repository.elasticsearch.otel.log.spring.OtelLogConfiguration;
 import io.gravitee.repository.elasticsearch.spring.ElasticsearchRepositoryConfiguration;
 import io.gravitee.repository.elasticsearch.tracing.spring.TracingConfiguration;
 import lombok.CustomLog;
@@ -35,19 +36,22 @@ public class ElasticsearchRepositoryProvider implements RepositoryProvider {
 
     @Override
     public Scope[] scopes() {
-        return new Scope[] { Scope.ANALYTICS, Scope.OTEL_TRACES };
+        return new Scope[] { Scope.ANALYTICS, Scope.OTEL_TRACES, Scope.OTEL_LOGS };
     }
 
     @Override
     public Class<?> configuration(Scope scope) {
         // Distinct configuration classes per scope are mandatory: the platform creates one application context per
-        // scope and promotes its singletons into the parent bean factory. Returning the same class for both scopes
+        // scope and promotes its singletons into the parent bean factory. Returning the same class for two scopes
         // double-registers every bean (e.g. analyticsRepository, client, …) and fails with a bean-name conflict.
         if (scope == Scope.ANALYTICS) {
             return ElasticsearchRepositoryConfiguration.class;
         }
         if (scope == Scope.OTEL_TRACES) {
             return TracingConfiguration.class;
+        }
+        if (scope == Scope.OTEL_LOGS) {
+            return OtelLogConfiguration.class;
         }
         log.debug("Skipping unhandled repository scope {}", scope);
         return null;

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/otel/log/ElasticsearchOtelLogRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/otel/log/ElasticsearchOtelLogRepository.java
@@ -1,0 +1,325 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.elasticsearch.otel.log;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.gravitee.elasticsearch.client.Client;
+import io.gravitee.elasticsearch.model.SearchHit;
+import io.gravitee.elasticsearch.model.SearchResponse;
+import io.gravitee.elasticsearch.utils.IndexNameUtils;
+import io.gravitee.repository.common.query.QueryContext;
+import io.gravitee.repository.otel.log.api.OtelLogRepository;
+import io.gravitee.repository.otel.log.model.OtelLogRecord;
+import io.gravitee.repository.otel.log.model.OtelLogSearchCriteria;
+import io.reactivex.rxjava3.core.Single;
+import java.time.Instant;
+import java.time.format.DateTimeParseException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Elasticsearch-backed {@link OtelLogRepository} reading log records written by the OpenTelemetry
+ * Collector's {@code elasticsearch} exporter in {@code mapping.mode: otel}.
+ * <p>
+ * Two distinct record shapes share the same logs data stream — span events written by the collector when
+ * an exporter forwards an OTel trace payload (the exporter writes the event's {@code event.name} into a
+ * top-level {@code event_name} field), and payload logs written by {@code gravitee-reporter-otel} when
+ * the gateway captures a request/response payload (no {@code event_name}). The repository returns both
+ * shapes uniformly: it doesn't discriminate them at query time, and on the read side it promotes the
+ * top-level {@code event_name} field back into the record's {@code attributes} map under the OTel-standard
+ * {@code event.name} key so consumers can partition without leaking ES-specific knowledge.
+ *
+ * @author GraviteeSource Team
+ */
+public class ElasticsearchOtelLogRepository implements OtelLogRepository {
+
+    /**
+     * OTel standard attribute key for an event's name (logs data model "Event" convention). The ES
+     * exporter writes it as a top-level {@code event_name} field for indexing convenience; the repository
+     * normalises back to the standard key so consumers stay backend-agnostic.
+     */
+    private static final String EVENT_NAME_ATTRIBUTE = "event.name";
+
+    private static final JsonNodeFactory JSON = JsonNodeFactory.instance;
+
+    private final String indexTemplate;
+    private final Client client;
+
+    public ElasticsearchOtelLogRepository(String indexTemplate, Client client) {
+        this.indexTemplate = indexTemplate;
+        this.client = client;
+    }
+
+    @Override
+    public Single<List<OtelLogRecord>> findLogs(QueryContext queryContext, OtelLogSearchCriteria criteria) {
+        String index = resolveIndex(indexTemplate, queryContext);
+        String body = buildSearchBody(criteria);
+        // Operators may run with traces but not payload logs configured (or vice-versa); a missing data
+        // stream raises an error from the client. Translate to empty list so the consumer can stitch the
+        // trace anyway.
+        return client.search(index, null, body).onErrorReturnItem(new SearchResponse()).map(ElasticsearchOtelLogRepository::parseResponse);
+    }
+
+    private String resolveIndex(String template, QueryContext queryContext) {
+        // Mirrors the analytics plugin's index-naming convention: IndexNameUtils.format substitutes
+        // {orgId} / {envId} with the lowercased values from QueryContext.placeholder(). ES data streams
+        // require lowercase names — the OTel collector writes to lowercase too, so a caller orgId of
+        // "DEFAULT" resolves to logs-apim.otel-default, not -DEFAULT.
+        return IndexNameUtils.format(template, queryContext.placeholder());
+    }
+
+    /**
+     * Composes a {@code _search} body that filters by every dimension the criteria carries, sorted by
+     * {@code @timestamp} ascending so consumers see entries in chronological order. No event_name
+     * discriminator — span events and payload logs are returned in the same response.
+     */
+    static String buildSearchBody(OtelLogSearchCriteria criteria) {
+        ObjectNode root = JSON.objectNode();
+        root.put("size", criteria.limit());
+
+        ArrayNode filter = JSON.arrayNode();
+
+        if (criteria.traceId() != null) {
+            ObjectNode traceIdTerm = JSON.objectNode();
+            ObjectNode traceIdInner = JSON.objectNode();
+            traceIdInner.put("trace_id", criteria.traceId());
+            traceIdTerm.set("term", traceIdInner);
+            filter.add(traceIdTerm);
+        }
+
+        if (criteria.start() != null || criteria.end() != null) {
+            filter.add(buildTimestampRangeFilter(criteria.start(), criteria.end()));
+        }
+
+        for (Map.Entry<String, String> entry : criteria.attributeFilters().entrySet()) {
+            // The OTel Collector ES exporter (mapping.mode: otel) writes most record attributes flat
+            // under attributes.<key>, but the standard event.name attribute is promoted to a top-level
+            // event_name field for indexing convenience — mirror that mapping on the query side so a
+            // caller filtering on event.name actually hits the indexed field. The response side already
+            // normalises event_name back into attributes["event.name"] for the API contract.
+            String field = EVENT_NAME_ATTRIBUTE.equals(entry.getKey()) ? "event_name" : "attributes." + entry.getKey();
+            filter.add(buildTermFilter(field, entry.getValue()));
+        }
+
+        for (Map.Entry<String, String> entry : criteria.resourceAttributeFilters().entrySet()) {
+            filter.add(buildTermFilter("resource.attributes." + entry.getKey(), entry.getValue()));
+        }
+
+        ObjectNode bool = JSON.objectNode();
+        bool.set("filter", filter);
+
+        ObjectNode query = JSON.objectNode();
+        query.set("bool", bool);
+        root.set("query", query);
+
+        ArrayNode sort = JSON.arrayNode();
+        ObjectNode sortField = JSON.objectNode();
+        ObjectNode order = JSON.objectNode();
+        order.put("order", "asc");
+        sortField.set("@timestamp", order);
+        sort.add(sortField);
+        root.set("sort", sort);
+
+        return root.toString();
+    }
+
+    private static ObjectNode buildTermFilter(String field, String value) {
+        ObjectNode termFilter = JSON.objectNode();
+        ObjectNode term = JSON.objectNode();
+        term.put(field, value);
+        termFilter.set("term", term);
+        return termFilter;
+    }
+
+    private static ObjectNode buildTimestampRangeFilter(Instant start, Instant end) {
+        // Half-open ISO 8601 range on @timestamp: gte = inclusive lower bound, lt = exclusive upper. ES
+        // accepts ISO with offset, and Instant.toString() is ISO-8601 UTC ("Z"), so no formatter needed.
+        ObjectNode rangeFilter = JSON.objectNode();
+        ObjectNode range = JSON.objectNode();
+        ObjectNode bounds = JSON.objectNode();
+        if (start != null) {
+            bounds.put("gte", start.toString());
+        }
+        if (end != null) {
+            bounds.put("lt", end.toString());
+        }
+        range.set("@timestamp", bounds);
+        rangeFilter.set("range", range);
+        return rangeFilter;
+    }
+
+    private static List<OtelLogRecord> parseResponse(SearchResponse response) {
+        if (
+            response == null ||
+            response.getSearchHits() == null ||
+            response.getSearchHits().getHits() == null ||
+            response.getSearchHits().getHits().isEmpty()
+        ) {
+            return List.of();
+        }
+        List<OtelLogRecord> records = new ArrayList<>(response.getSearchHits().getHits().size());
+        for (SearchHit hit : response.getSearchHits().getHits()) {
+            JsonNode source = hit.getSource();
+            if (source == null) {
+                continue;
+            }
+            String spanId = textOrNull(source.get("span_id"));
+            // Without a span_id the record can't be stitched onto any span — drop rather than
+            // synthesise an orphan that would confuse the consumer.
+            if (spanId == null) {
+                continue;
+            }
+            String traceId = textOrNull(source.get("trace_id"));
+            Instant timestamp = parseInstant(source.path("@timestamp"));
+            String severity = textOrNull(source.get("severity_text"));
+            String body = readBody(source);
+            Map<String, String> attributes = flattenStringMap(source.path("attributes"), "");
+            // Promote the ES-side top-level field back into the OTel-standard attribute key so consumers
+            // see a backend-agnostic record. Don't overwrite a same-named attribute that was already in
+            // the OTel attributes block — the exporter shouldn't double-write, but defensive doesn't hurt.
+            String eventName = textOrNull(source.get("event_name"));
+            if (eventName != null) {
+                attributes.putIfAbsent(EVENT_NAME_ATTRIBUTE, eventName);
+            }
+            Map<String, String> resourceAttributes = flattenStringMap(source.path("resource").path("attributes"), "");
+            records.add(new OtelLogRecord(traceId, spanId, timestamp, severity, body, attributes, resourceAttributes));
+        }
+        return records;
+    }
+
+    /**
+     * The OTel ES exporter writes the log {@code body} either as a top-level string or as a nested
+     * object {@code body.text} / {@code body.structured} depending on the OTel SDK / collector version.
+     * Try the common shapes; return {@code null} when none are populated.
+     */
+    private static String readBody(JsonNode source) {
+        JsonNode body = source.path("body");
+        if (body.isTextual()) {
+            return body.asText();
+        }
+        String text = textOrNull(body.path("text"));
+        if (text != null) {
+            return text;
+        }
+        // Structured bodies fall back to JSON serialization so consumers can inspect them.
+        JsonNode structured = body.path("structured");
+        if (!structured.isMissingNode() && !structured.isNull()) {
+            return structured.toString();
+        }
+        return null;
+    }
+
+    /**
+     * OTel-mode documents store {@code attributes} either as a JSON object (newer collector versions) or
+     * as an array of {@code {key, value}} pairs (older versions). This walks both into a flat key→string
+     * map; nested objects are dot-flattened (e.g. {@code http.status_code = "200"}).
+     */
+    private static Map<String, String> flattenStringMap(JsonNode node, String prefix) {
+        Map<String, String> result = new HashMap<>();
+        if (node == null || node.isMissingNode() || node.isNull()) {
+            return result;
+        }
+        if (node.isObject()) {
+            Iterator<Map.Entry<String, JsonNode>> it = node.fields();
+            while (it.hasNext()) {
+                Map.Entry<String, JsonNode> entry = it.next();
+                String key = prefix.isEmpty() ? entry.getKey() : prefix + "." + entry.getKey();
+                JsonNode value = entry.getValue();
+                if (value.isObject()) {
+                    result.putAll(flattenStringMap(value, key));
+                } else if (!value.isNull()) {
+                    result.put(key, value.asText());
+                }
+            }
+        } else if (node.isArray()) {
+            for (JsonNode element : node) {
+                JsonNode keyNode = element.get("key");
+                JsonNode valueNode = element.get("value");
+                if (keyNode == null || valueNode == null) {
+                    continue;
+                }
+                String key = prefix.isEmpty() ? keyNode.asText() : prefix + "." + keyNode.asText();
+                JsonNode unwrapped = unwrapOtlpValue(valueNode);
+                if (unwrapped != null && !unwrapped.isNull()) {
+                    result.put(key, unwrapped.asText());
+                }
+            }
+        }
+        return result;
+    }
+
+    private static JsonNode unwrapOtlpValue(JsonNode valueNode) {
+        if (valueNode.isObject()) {
+            for (String typedField : List.of("stringValue", "intValue", "doubleValue", "boolValue")) {
+                JsonNode typed = valueNode.get(typedField);
+                if (typed != null && !typed.isNull()) {
+                    return typed;
+                }
+            }
+            return null;
+        }
+        return valueNode;
+    }
+
+    private static String textOrNull(JsonNode node) {
+        if (node == null || node.isMissingNode() || node.isNull()) {
+            return null;
+        }
+        return node.asText();
+    }
+
+    /**
+     * The OTel collector's elasticsearch exporter (otel mapping mode) writes {@code @timestamp} as
+     * {@code "<epoch-millis>.<sub-ms-digits>"} (e.g. {@code "1778515640168.675208"}). Older collectors
+     * may emit plain integer epoch ms or ISO 8601; try ISO first, fall back to the decimal split.
+     */
+    private static Instant parseInstant(JsonNode node) {
+        String text = textOrNull(node);
+        if (text == null) {
+            return null;
+        }
+        try {
+            return Instant.parse(text);
+        } catch (DateTimeParseException e) {
+            return parseEpochMillisDecimalString(text);
+        }
+    }
+
+    private static Instant parseEpochMillisDecimalString(String text) {
+        try {
+            int dot = text.indexOf('.');
+            if (dot < 0) {
+                return Instant.ofEpochMilli(Long.parseLong(text));
+            }
+            long epochMillis = Long.parseLong(text.substring(0, dot));
+            String fractionalMs = text.substring(dot + 1);
+            // Sub-millisecond digits: pad / truncate to 6 chars and interpret as the nano-suffix below
+            // the millisecond boundary. "675208" → 675208 ns past the ms; "67" → 670000 ns;
+            // "67520823" → 675208 ns.
+            String padded = (fractionalMs + "000000").substring(0, 6);
+            long extraNanos = Long.parseLong(padded);
+            return Instant.ofEpochMilli(epochMillis).plusNanos(extraNanos);
+        } catch (NumberFormatException ignored) {
+            return null;
+        }
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/otel/log/spring/OtelLogConfiguration.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/otel/log/spring/OtelLogConfiguration.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.elasticsearch.otel.log.spring;
+
+import io.gravitee.elasticsearch.client.Client;
+import io.gravitee.platform.repository.api.Scope;
+import io.gravitee.repository.elasticsearch.client.ElasticsearchHttpClientFactory;
+import io.gravitee.repository.elasticsearch.otel.log.ElasticsearchOtelLogRepository;
+import io.gravitee.repository.elasticsearch.tracing.spring.TracingConfiguration;
+import io.gravitee.repository.otel.log.api.OtelLogRepository;
+import io.vertx.rxjava3.core.Vertx;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
+
+/**
+ * Spring configuration loaded for the {@code OTEL_LOGS} scope. Self-contained on purpose — same
+ * cross-scope bean-isolation pattern as {@link TracingConfiguration}: the platform's repository plugin
+ * handler creates one application context per scope and promotes its singletons into the parent bean
+ * factory, so each scope must expose distinctly-named beans to avoid collisions when an operator wires
+ * several scopes (analytics, otel-traces, otel-logs) through this plugin simultaneously.
+ * <p>
+ * Connection settings (endpoints, credentials, SSL, proxy) and the index template live under the
+ * dedicated {@code otel-logs.elasticsearch.*} property block — no fallback to
+ * {@code analytics.elasticsearch.*} or {@code otel-traces.elasticsearch.*}, so the OTel-log reader can
+ * target a different ES cluster (or be enabled in deployments that don't use ES for analytics or
+ * tracing). The actual property reads happen inside {@link ElasticsearchHttpClientFactory}, scoped by
+ * {@link Scope#OTEL_LOGS}.{@code getName()} — mirrors the per-scope factory pattern used by the Redis
+ * plugin for its rate-limit and distributed-sync scopes.
+ *
+ * @author GraviteeSource Team
+ */
+@Configuration
+public class OtelLogConfiguration {
+
+    @Bean
+    public Vertx otelLogVertxRx(io.vertx.core.Vertx vertx) {
+        return Vertx.newInstance(vertx);
+    }
+
+    @Bean
+    public Client otelLogClient(Environment environment) {
+        return new ElasticsearchHttpClientFactory(environment, Scope.OTEL_LOGS.getName()).createHttpClient();
+    }
+
+    @Bean
+    public OtelLogRepository otelLogRepository(
+        @Value("${otel-logs.elasticsearch.index:logs-apim.otel-{orgId}}") String indexTemplate,
+        Client otelLogClient
+    ) {
+        return new ElasticsearchOtelLogRepository(indexTemplate, otelLogClient);
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/ElasticsearchRepositoryProviderTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/ElasticsearchRepositoryProviderTest.java
@@ -34,8 +34,8 @@ public class ElasticsearchRepositoryProviderTest {
     }
 
     @Test
-    public void shouldReturnAnalyticsAndTracingScopes() {
-        assertThat(provider.scopes()).containsExactly(Scope.ANALYTICS, Scope.OTEL_TRACES);
+    public void shouldReturnAnalyticsTracingAndLogsScopes() {
+        assertThat(provider.scopes()).containsExactly(Scope.ANALYTICS, Scope.OTEL_TRACES, Scope.OTEL_LOGS);
     }
 
     @Test
@@ -43,6 +43,9 @@ public class ElasticsearchRepositoryProviderTest {
         assertThat(provider.configuration(Scope.ANALYTICS)).isEqualTo(ElasticsearchRepositoryConfiguration.class);
         assertThat(provider.configuration(Scope.OTEL_TRACES)).isEqualTo(
             io.gravitee.repository.elasticsearch.tracing.spring.TracingConfiguration.class
+        );
+        assertThat(provider.configuration(Scope.OTEL_LOGS)).isEqualTo(
+            io.gravitee.repository.elasticsearch.otel.log.spring.OtelLogConfiguration.class
         );
     }
 

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/otel/log/ElasticsearchOtelLogRepositoryIT.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/otel/log/ElasticsearchOtelLogRepositoryIT.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.elasticsearch.otel.log;
+
+import io.gravitee.repository.otel.log.OtelLogRepositoryTest;
+
+/**
+ * Runs the shared {@link OtelLogRepositoryTest} contract against the Elasticsearch implementation: the
+ * production {@link ElasticsearchOtelLogRepository} queries an Elasticsearch testcontainer fed by an OTel
+ * Collector container (configured for {@code mapping.mode: otel}). Fixtures are seeded by
+ * {@link ElasticsearchOtelLogTestRepositoryInitializer} over OTLP HTTP on both pipelines (traces — for
+ * span-event docs — and logs — for payload-log docs). {@code ElasticsearchOtelLogTest*} beans are picked
+ * up by {@code AbstractRepositoryTest}'s {@code .*TestRepository.*} component scan.
+ *
+ * @author GraviteeSource Team
+ */
+public class ElasticsearchOtelLogRepositoryIT extends OtelLogRepositoryTest {}

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/otel/log/ElasticsearchOtelLogRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/otel/log/ElasticsearchOtelLogRepositoryTest.java
@@ -1,0 +1,381 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.elasticsearch.otel.log;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.gravitee.elasticsearch.client.Client;
+import io.gravitee.elasticsearch.model.SearchHit;
+import io.gravitee.elasticsearch.model.SearchHits;
+import io.gravitee.elasticsearch.model.SearchResponse;
+import io.gravitee.repository.common.query.QueryContext;
+import io.gravitee.repository.otel.log.model.OtelLogRecord;
+import io.gravitee.repository.otel.log.model.OtelLogSearchCriteria;
+import io.reactivex.rxjava3.core.Single;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+
+class ElasticsearchOtelLogRepositoryTest {
+
+    private static final QueryContext QUERY_CONTEXT = new QueryContext("test-org", "test-env");
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private Client client;
+    private ElasticsearchOtelLogRepository repository;
+
+    @BeforeEach
+    void setUp() {
+        client = Mockito.mock(Client.class);
+        repository = new ElasticsearchOtelLogRepository("logs-apim.otel-{orgId}", client);
+    }
+
+    @Test
+    void findLogs_should_target_org_scoped_index_and_filter_by_trace_id_without_event_name_discriminator() throws Exception {
+        when(client.search(any(), any(), any())).thenReturn(Single.just(new SearchResponse()));
+
+        repository.findLogs(QUERY_CONTEXT, criteriaForTrace("a1b2c3d4")).blockingGet();
+
+        ArgumentCaptor<String> indexCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<String> bodyCaptor = ArgumentCaptor.forClass(String.class);
+        Mockito.verify(client).search(indexCaptor.capture(), eq(null), bodyCaptor.capture());
+
+        assertThat(indexCaptor.getValue()).isEqualTo("logs-apim.otel-test-org");
+
+        JsonNode body = MAPPER.readTree(bodyCaptor.getValue());
+        JsonNode filter = body.path("query").path("bool").path("filter");
+        boolean hasTraceId = false;
+        for (JsonNode clause : filter) {
+            if ("a1b2c3d4".equals(clause.path("term").path("trace_id").asText(null))) hasTraceId = true;
+            // No event_name existence filter — the SPI returns span events and payload logs together.
+            assertThat(clause.path("exists").path("field").asText(null)).isNotEqualTo("event_name");
+        }
+        assertThat(hasTraceId).isTrue();
+        assertThat(body.path("query").path("bool").path("must_not").isMissingNode()).isTrue();
+        // Sort by @timestamp ascending so consumers see entries in chronological order.
+        assertThat(body.path("sort").get(0).path("@timestamp").path("order").asText()).isEqualTo("asc");
+        // Default limit from the criteria's compact constructor.
+        assertThat(body.path("size").asInt()).isEqualTo(5000);
+    }
+
+    @Test
+    void findLogs_should_omit_trace_id_filter_when_criteria_has_none() throws Exception {
+        // Logs-explorer use case: filter by resource scope + time range only, no trace_id.
+        when(client.search(any(), any(), any())).thenReturn(Single.just(new SearchResponse()));
+
+        repository
+            .findLogs(QUERY_CONTEXT, new OtelLogSearchCriteria(null, Map.of(), Map.of("gravitee.api.id", "api-1"), null, null, null))
+            .blockingGet();
+
+        ArgumentCaptor<String> bodyCaptor = ArgumentCaptor.forClass(String.class);
+        Mockito.verify(client).search(any(), eq(null), bodyCaptor.capture());
+        JsonNode body = MAPPER.readTree(bodyCaptor.getValue());
+        for (JsonNode clause : body.path("query").path("bool").path("filter")) {
+            assertThat(clause.path("term").path("trace_id").isMissingNode()).isTrue();
+        }
+    }
+
+    @Test
+    void findLogs_should_propagate_resource_attribute_filters_as_resource_terms() throws Exception {
+        when(client.search(any(), any(), any())).thenReturn(Single.just(new SearchResponse()));
+
+        repository
+            .findLogs(
+                QUERY_CONTEXT,
+                new OtelLogSearchCriteria(
+                    "a1b2c3d4",
+                    Map.of(),
+                    Map.of("gravitee.env.id", "test-env", "gravitee.module", "apim"),
+                    null,
+                    null,
+                    null
+                )
+            )
+            .blockingGet();
+
+        ArgumentCaptor<String> bodyCaptor = ArgumentCaptor.forClass(String.class);
+        Mockito.verify(client).search(any(), eq(null), bodyCaptor.capture());
+        JsonNode body = MAPPER.readTree(bodyCaptor.getValue());
+        boolean hasEnv = false;
+        boolean hasModule = false;
+        for (JsonNode clause : body.path("query").path("bool").path("filter")) {
+            JsonNode term = clause.path("term");
+            if ("test-env".equals(term.path("resource.attributes.gravitee.env.id").asText(null))) hasEnv = true;
+            if ("apim".equals(term.path("resource.attributes.gravitee.module").asText(null))) hasModule = true;
+        }
+        assertThat(hasEnv).isTrue();
+        assertThat(hasModule).isTrue();
+    }
+
+    @Test
+    void findLogs_should_propagate_record_attribute_filters_under_attributes_prefix() throws Exception {
+        // Record attributes live under attributes.<key> (vs resource.attributes.<key> for resource scope),
+        // matching how the OTel ES exporter writes them.
+        when(client.search(any(), any(), any())).thenReturn(Single.just(new SearchResponse()));
+
+        repository
+            .findLogs(QUERY_CONTEXT, new OtelLogSearchCriteria("a1b2c3d4", Map.of("some.attribute", "value"), Map.of(), null, null, null))
+            .blockingGet();
+
+        ArgumentCaptor<String> bodyCaptor = ArgumentCaptor.forClass(String.class);
+        Mockito.verify(client).search(any(), eq(null), bodyCaptor.capture());
+        JsonNode body = MAPPER.readTree(bodyCaptor.getValue());
+        boolean hasAttribute = false;
+        for (JsonNode clause : body.path("query").path("bool").path("filter")) {
+            if ("value".equals(clause.path("term").path("attributes.some.attribute").asText(null))) hasAttribute = true;
+        }
+        assertThat(hasAttribute).isTrue();
+    }
+
+    @Test
+    void findLogs_should_map_event_name_attribute_filter_to_top_level_event_name_field() throws Exception {
+        // The OTel ES exporter promotes the standard event.name attribute to the top-level event_name
+        // field — query-side filters on event.name must hit that field, not attributes.event.name (which
+        // doesn't exist in the indexed document and would silently match nothing).
+        when(client.search(any(), any(), any())).thenReturn(Single.just(new SearchResponse()));
+
+        repository
+            .findLogs(QUERY_CONTEXT, new OtelLogSearchCriteria("a1b2c3d4", Map.of("event.name", "exception"), Map.of(), null, null, null))
+            .blockingGet();
+
+        ArgumentCaptor<String> bodyCaptor = ArgumentCaptor.forClass(String.class);
+        Mockito.verify(client).search(any(), eq(null), bodyCaptor.capture());
+        JsonNode body = MAPPER.readTree(bodyCaptor.getValue());
+        boolean hasEventName = false;
+        boolean usesAttributesPrefix = false;
+        for (JsonNode clause : body.path("query").path("bool").path("filter")) {
+            JsonNode term = clause.path("term");
+            if ("exception".equals(term.path("event_name").asText(null))) hasEventName = true;
+            if (term.has("attributes.event.name")) usesAttributesPrefix = true;
+        }
+        assertThat(hasEventName).isTrue();
+        assertThat(usesAttributesPrefix).isFalse();
+    }
+
+    @Test
+    void findLogs_should_emit_half_open_timestamp_range_when_bounds_set() throws Exception {
+        Instant start = Instant.parse("2026-04-30T10:00:00Z");
+        Instant end = Instant.parse("2026-04-30T11:00:00Z");
+        when(client.search(any(), any(), any())).thenReturn(Single.just(new SearchResponse()));
+
+        repository.findLogs(QUERY_CONTEXT, new OtelLogSearchCriteria("a1b2c3d4", Map.of(), Map.of(), start, end, null)).blockingGet();
+
+        ArgumentCaptor<String> bodyCaptor = ArgumentCaptor.forClass(String.class);
+        Mockito.verify(client).search(any(), eq(null), bodyCaptor.capture());
+        JsonNode body = MAPPER.readTree(bodyCaptor.getValue());
+        boolean hasRange = false;
+        for (JsonNode clause : body.path("query").path("bool").path("filter")) {
+            JsonNode range = clause.path("range").path("@timestamp");
+            if (!range.isMissingNode()) {
+                // gte = inclusive lower, lt = exclusive upper — half-open like every other time range in
+                // the analytics plugin, so back-to-back ranges don't double-count boundary records.
+                assertThat(range.path("gte").asText()).isEqualTo("2026-04-30T10:00:00Z");
+                assertThat(range.path("lt").asText()).isEqualTo("2026-04-30T11:00:00Z");
+                hasRange = true;
+            }
+        }
+        assertThat(hasRange).isTrue();
+    }
+
+    @Test
+    void findLogs_should_use_criteria_limit_as_search_size() throws Exception {
+        when(client.search(any(), any(), any())).thenReturn(Single.just(new SearchResponse()));
+
+        repository.findLogs(QUERY_CONTEXT, new OtelLogSearchCriteria("a1b2c3d4", Map.of(), Map.of(), null, null, 100)).blockingGet();
+
+        ArgumentCaptor<String> bodyCaptor = ArgumentCaptor.forClass(String.class);
+        Mockito.verify(client).search(any(), eq(null), bodyCaptor.capture());
+        JsonNode body = MAPPER.readTree(bodyCaptor.getValue());
+        assertThat(body.path("size").asInt()).isEqualTo(100);
+    }
+
+    @Test
+    void findLogs_should_promote_top_level_event_name_into_attributes_under_otel_key() {
+        // ES exporter writes event_name as a top-level field; the repository normalises it back to the
+        // OTel-standard `event.name` attribute so consumers don't carry ES-specific knowledge.
+        SearchResponse response = new SearchResponse();
+        SearchHits hits = new SearchHits();
+        hits.setHits(
+            List.of(
+                eventHit("a1b2c3d4", "11223344aabbccdd", "gravitee.policy.pre", "2026-04-30T10:00:00.100Z", "policy-id-1"),
+                eventHit("a1b2c3d4", "11223344aabbccdd", "gravitee.policy.post", "2026-04-30T10:00:00.200Z", "policy-id-1")
+            )
+        );
+        response.setSearchHits(hits);
+        when(client.search(any(), any(), any())).thenReturn(Single.just(response));
+
+        List<OtelLogRecord> records = repository.findLogs(QUERY_CONTEXT, criteriaForTrace("a1b2c3d4")).blockingGet();
+
+        assertThat(records)
+            .extracting(r -> r.attributes().get("event.name"))
+            .containsExactly("gravitee.policy.pre", "gravitee.policy.post");
+        assertThat(records.get(0).traceId()).isEqualTo("a1b2c3d4");
+        assertThat(records.get(0).spanId()).isEqualTo("11223344aabbccdd");
+        assertThat(records.get(0).attributes()).containsEntry("gravitee.policy.id", "policy-id-1");
+        assertThat(records.get(0).body()).isNull();
+    }
+
+    @Test
+    void findLogs_should_preserve_event_name_attribute_when_already_present_in_attributes_block() {
+        // Defensive: if a future collector writes event.name into the OTel attributes block instead of
+        // the top-level field, putIfAbsent must not clobber it with a null from `source.event_name`.
+        SearchResponse response = new SearchResponse();
+        SearchHits hits = new SearchHits();
+        Map<String, Object> source = new HashMap<>();
+        source.put("trace_id", "a1b2c3d4");
+        source.put("span_id", "11223344aabbccdd");
+        source.put("@timestamp", "2026-04-30T10:00:00.100Z");
+        source.put("attributes", Map.of("event.name", "exception"));
+        SearchHit hit = new SearchHit();
+        hit.setSource(MAPPER.valueToTree(source));
+        hits.setHits(List.of(hit));
+        response.setSearchHits(hits);
+        when(client.search(any(), any(), any())).thenReturn(Single.just(response));
+
+        List<OtelLogRecord> records = repository.findLogs(QUERY_CONTEXT, criteriaForTrace("a1b2c3d4")).blockingGet();
+
+        assertThat(records.get(0).attributes()).containsEntry("event.name", "exception");
+    }
+
+    @Test
+    void findLogs_should_map_body_as_top_level_string_for_payload_logs() {
+        SearchResponse response = new SearchResponse();
+        SearchHits hits = new SearchHits();
+        Map<String, Object> source = new HashMap<>();
+        source.put("trace_id", "a1b2c3d4");
+        source.put("span_id", "11223344aabbccdd");
+        source.put("@timestamp", "2026-04-30T10:00:00.100Z");
+        source.put("body", "{\"hello\":\"world\"}");
+        source.put("severity_text", "INFO");
+        SearchHit hit = new SearchHit();
+        hit.setSource(MAPPER.valueToTree(source));
+        hits.setHits(List.of(hit));
+        response.setSearchHits(hits);
+        when(client.search(any(), any(), any())).thenReturn(Single.just(response));
+
+        List<OtelLogRecord> records = repository.findLogs(QUERY_CONTEXT, criteriaForTrace("a1b2c3d4")).blockingGet();
+
+        assertThat(records).hasSize(1);
+        OtelLogRecord payload = records.get(0);
+        assertThat(payload.body()).isEqualTo("{\"hello\":\"world\"}");
+        assertThat(payload.severity()).isEqualTo("INFO");
+        // Payload logs have no event.name — that's the discriminator consumers use to slice them out.
+        assertThat(payload.attributes()).doesNotContainKey("event.name");
+    }
+
+    @Test
+    void findLogs_should_map_body_text_when_body_is_nested() {
+        // Some OTel SDK / collector versions write the body as a nested object with a typed `text`
+        // field rather than a top-level string. The reader must accept both shapes.
+        SearchResponse response = new SearchResponse();
+        SearchHits hits = new SearchHits();
+        Map<String, Object> source = new HashMap<>();
+        source.put("trace_id", "a1b2c3d4");
+        source.put("span_id", "11223344aabbccdd");
+        source.put("@timestamp", "2026-04-30T10:00:00.100Z");
+        source.put("body", Map.of("text", "nested-body"));
+        SearchHit hit = new SearchHit();
+        hit.setSource(MAPPER.valueToTree(source));
+        hits.setHits(List.of(hit));
+        response.setSearchHits(hits);
+        when(client.search(any(), any(), any())).thenReturn(Single.just(response));
+
+        List<OtelLogRecord> records = repository.findLogs(QUERY_CONTEXT, criteriaForTrace("a1b2c3d4")).blockingGet();
+
+        assertThat(records.get(0).body()).isEqualTo("nested-body");
+    }
+
+    @Test
+    void should_drop_records_with_missing_span_id() {
+        // A record without a span_id can't be stitched onto any span, so it's dropped at the boundary
+        // rather than synthesising an orphan that would confuse the consumer.
+        SearchResponse response = new SearchResponse();
+        SearchHits hits = new SearchHits();
+        SearchHit orphan = new SearchHit();
+        Map<String, Object> orphanSource = new HashMap<>();
+        orphanSource.put("trace_id", "a1b2c3d4");
+        orphanSource.put("event_name", "exception");
+        orphanSource.put("@timestamp", "2026-04-30T10:00:00.100Z");
+        orphan.setSource(MAPPER.valueToTree(orphanSource));
+        hits.setHits(
+            List.of(orphan, eventHit("a1b2c3d4", "11223344aabbccdd", "gravitee.policy.pre", "2026-04-30T10:00:00.200Z", "policy-id-1"))
+        );
+        response.setSearchHits(hits);
+        when(client.search(any(), any(), any())).thenReturn(Single.just(response));
+
+        List<OtelLogRecord> records = repository.findLogs(QUERY_CONTEXT, criteriaForTrace("a1b2c3d4")).blockingGet();
+
+        assertThat(records).hasSize(1);
+        assertThat(records.get(0).attributes()).containsEntry("event.name", "gravitee.policy.pre");
+    }
+
+    @Test
+    void should_return_empty_list_when_logs_data_stream_is_missing() {
+        // Operators may run the gateway tracing pipeline without a separate logs pipeline configured —
+        // the data stream doesn't exist and the search 404s. Repository degrades to empty list rather
+        // than failing so consumers (gamma use case) can still return the trace's spans.
+        when(client.search(any(), any(), any())).thenReturn(Single.error(new RuntimeException("logs index missing")));
+
+        List<OtelLogRecord> records = repository.findLogs(QUERY_CONTEXT, criteriaForTrace("a1b2c3d4")).blockingGet();
+
+        assertThat(records).isEmpty();
+    }
+
+    @Test
+    void should_parse_otel_epoch_millis_decimal_timestamp() {
+        // OTel ES exporter (otel mapping mode) writes @timestamp as "<epoch-ms>.<sub-ms-digits>" — a
+        // decimal-shaped string of epoch ms with sub-millisecond precision. parseInstant() must
+        // extract both parts to produce an accurate Instant.
+        SearchResponse response = new SearchResponse();
+        SearchHits hits = new SearchHits();
+        hits.setHits(List.of(eventHit("a1b2c3d4", "11223344aabbccdd", "exception", "1778515640168.675208", "policy-id-1")));
+        response.setSearchHits(hits);
+        when(client.search(any(), any(), any())).thenReturn(Single.just(response));
+
+        List<OtelLogRecord> records = repository.findLogs(QUERY_CONTEXT, criteriaForTrace("a1b2c3d4")).blockingGet();
+
+        assertThat(records.get(0).timestamp()).isEqualTo(Instant.ofEpochSecond(1778515640L, 168_675_208L));
+    }
+
+    private static OtelLogSearchCriteria criteriaForTrace(String traceId) {
+        return new OtelLogSearchCriteria(traceId, Map.of(), Map.of(), null, null, null);
+    }
+
+    private static SearchHit eventHit(String traceId, String spanId, String name, String timestamp, String policyId) {
+        Map<String, Object> source = new HashMap<>();
+        source.put("trace_id", traceId);
+        source.put("span_id", spanId);
+        source.put("event_name", name);
+        source.put("@timestamp", timestamp);
+        Map<String, Object> attributes = new HashMap<>();
+        attributes.put("gravitee.policy.id", policyId);
+        source.put("attributes", attributes);
+        SearchHit hit = new SearchHit();
+        hit.setSource(MAPPER.valueToTree(source));
+        return hit;
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/otel/log/ElasticsearchOtelLogRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/otel/log/ElasticsearchOtelLogRepositoryTest.java
@@ -361,6 +361,280 @@ class ElasticsearchOtelLogRepositoryTest {
         assertThat(records.get(0).timestamp()).isEqualTo(Instant.ofEpochSecond(1778515640L, 168_675_208L));
     }
 
+    @Test
+    void should_parse_iso_8601_timestamp() {
+        // Older OTel collector versions emit @timestamp as a plain ISO 8601 string — parseInstant tries
+        // ISO first and only falls back to the decimal-epoch-millis form on DateTimeParseException.
+        SearchResponse response = new SearchResponse();
+        SearchHits hits = new SearchHits();
+        hits.setHits(List.of(eventHit("a1b2c3d4", "11223344aabbccdd", "exception", "2026-04-30T10:00:00.100Z", "policy-id-1")));
+        response.setSearchHits(hits);
+        when(client.search(any(), any(), any())).thenReturn(Single.just(response));
+
+        List<OtelLogRecord> records = repository.findLogs(QUERY_CONTEXT, criteriaForTrace("a1b2c3d4")).blockingGet();
+
+        assertThat(records.get(0).timestamp()).isEqualTo(Instant.parse("2026-04-30T10:00:00.100Z"));
+    }
+
+    @Test
+    void should_parse_plain_epoch_millis_timestamp_without_sub_ms_digits() {
+        // Plain integer epoch-ms (no decimal point) — fallback path when an older exporter / SDK
+        // version emits the timestamp without sub-millisecond precision.
+        SearchResponse response = new SearchResponse();
+        SearchHits hits = new SearchHits();
+        hits.setHits(List.of(eventHit("a1b2c3d4", "11223344aabbccdd", "exception", "1778515640168", "policy-id-1")));
+        response.setSearchHits(hits);
+        when(client.search(any(), any(), any())).thenReturn(Single.just(response));
+
+        List<OtelLogRecord> records = repository.findLogs(QUERY_CONTEXT, criteriaForTrace("a1b2c3d4")).blockingGet();
+
+        assertThat(records.get(0).timestamp()).isEqualTo(Instant.ofEpochMilli(1778515640168L));
+    }
+
+    @Test
+    void should_return_null_timestamp_when_value_is_neither_iso_nor_numeric() {
+        // Malformed timestamp must not crash the read pipeline — degrade to null so the rest of the
+        // record still reaches the consumer (timestamp surfaces in the UI as "unknown").
+        SearchResponse response = new SearchResponse();
+        SearchHits hits = new SearchHits();
+        hits.setHits(List.of(eventHit("a1b2c3d4", "11223344aabbccdd", "exception", "not-a-timestamp", "policy-id-1")));
+        response.setSearchHits(hits);
+        when(client.search(any(), any(), any())).thenReturn(Single.just(response));
+
+        List<OtelLogRecord> records = repository.findLogs(QUERY_CONTEXT, criteriaForTrace("a1b2c3d4")).blockingGet();
+
+        assertThat(records).hasSize(1);
+        assertThat(records.get(0).timestamp()).isNull();
+    }
+
+    @Test
+    void should_resolve_envId_placeholder_in_index_template() {
+        // Logs-explorer use cases will template {envId} into a per-env data-stream name; verify the
+        // placeholder is substituted from QueryContext (lowercased — ES data streams require it).
+        ElasticsearchOtelLogRepository perEnvRepo = new ElasticsearchOtelLogRepository("logs-apim.otel-{orgId}-{envId}", client);
+        when(client.search(any(), any(), any())).thenReturn(Single.just(new SearchResponse()));
+
+        perEnvRepo.findLogs(QUERY_CONTEXT, criteriaForTrace("a1b2c3d4")).blockingGet();
+
+        ArgumentCaptor<String> indexCaptor = ArgumentCaptor.forClass(String.class);
+        Mockito.verify(client).search(indexCaptor.capture(), eq(null), any());
+        assertThat(indexCaptor.getValue()).isEqualTo("logs-apim.otel-test-org-test-env");
+    }
+
+    @Test
+    void should_fall_back_to_body_structured_when_top_level_string_and_body_text_are_absent() {
+        // Some collector versions emit a structured body — the reader serialises it to JSON so consumers
+        // can still inspect the payload without having to parse OTel's nested AnyValue shape themselves.
+        SearchResponse response = new SearchResponse();
+        SearchHits hits = new SearchHits();
+        Map<String, Object> source = new HashMap<>();
+        source.put("trace_id", "a1b2c3d4");
+        source.put("span_id", "11223344aabbccdd");
+        source.put("@timestamp", "2026-04-30T10:00:00.100Z");
+        source.put("body", Map.of("structured", Map.of("kind", "request", "ok", true)));
+        SearchHit hit = new SearchHit();
+        hit.setSource(MAPPER.valueToTree(source));
+        hits.setHits(List.of(hit));
+        response.setSearchHits(hits);
+        when(client.search(any(), any(), any())).thenReturn(Single.just(response));
+
+        List<OtelLogRecord> records = repository.findLogs(QUERY_CONTEXT, criteriaForTrace("a1b2c3d4")).blockingGet();
+
+        // Structured body is JSON-serialised; assert both expected fragments are present (key order isn't
+        // guaranteed across HashMap iteration).
+        assertThat(records.get(0).body()).contains("\"kind\":\"request\"").contains("\"ok\":true");
+    }
+
+    @Test
+    void should_flatten_nested_attribute_objects_into_dotted_keys() {
+        // Nested attribute objects get dot-flattened on the read side (e.g. http.request.method) so
+        // consumers see a flat key→string map rather than having to walk the JSON tree.
+        SearchResponse response = new SearchResponse();
+        SearchHits hits = new SearchHits();
+        Map<String, Object> source = new HashMap<>();
+        source.put("trace_id", "a1b2c3d4");
+        source.put("span_id", "11223344aabbccdd");
+        source.put("@timestamp", "2026-04-30T10:00:00.100Z");
+        Map<String, Object> http = new HashMap<>();
+        http.put("request", Map.of("method", "POST"));
+        http.put("status_code", 200);
+        source.put("attributes", Map.of("http", http));
+        SearchHit hit = new SearchHit();
+        hit.setSource(MAPPER.valueToTree(source));
+        hits.setHits(List.of(hit));
+        response.setSearchHits(hits);
+        when(client.search(any(), any(), any())).thenReturn(Single.just(response));
+
+        List<OtelLogRecord> records = repository.findLogs(QUERY_CONTEXT, criteriaForTrace("a1b2c3d4")).blockingGet();
+
+        assertThat(records.get(0).attributes()).containsEntry("http.request.method", "POST").containsEntry("http.status_code", "200");
+    }
+
+    @Test
+    void should_unwrap_otlp_typed_values_when_attributes_use_array_key_value_shape() {
+        // Older collector / SDK versions emit attributes as an OTLP-shaped array — each element is a
+        // {key, value} pair where the value is itself an object with one of stringValue / intValue /
+        // doubleValue / boolValue set. flattenStringMap walks the array and unwrapOtlpValue extracts
+        // the typed scalar so the consumer sees the same flat key→string contract as the object form.
+        SearchResponse response = new SearchResponse();
+        SearchHits hits = new SearchHits();
+        Map<String, Object> source = new HashMap<>();
+        source.put("trace_id", "a1b2c3d4");
+        source.put("span_id", "11223344aabbccdd");
+        source.put("@timestamp", "2026-04-30T10:00:00.100Z");
+        source.put(
+            "attributes",
+            List.of(
+                Map.of("key", "http.method", "value", Map.of("stringValue", "POST")),
+                Map.of("key", "http.status_code", "value", Map.of("intValue", 200)),
+                Map.of("key", "http.duration_ms", "value", Map.of("doubleValue", 12.5)),
+                Map.of("key", "http.cached", "value", Map.of("boolValue", true))
+            )
+        );
+        SearchHit hit = new SearchHit();
+        hit.setSource(MAPPER.valueToTree(source));
+        hits.setHits(List.of(hit));
+        response.setSearchHits(hits);
+        when(client.search(any(), any(), any())).thenReturn(Single.just(response));
+
+        List<OtelLogRecord> records = repository.findLogs(QUERY_CONTEXT, criteriaForTrace("a1b2c3d4")).blockingGet();
+
+        assertThat(records.get(0).attributes())
+            .containsEntry("http.method", "POST")
+            .containsEntry("http.status_code", "200")
+            .containsEntry("http.duration_ms", "12.5")
+            .containsEntry("http.cached", "true");
+    }
+
+    @Test
+    void should_skip_array_attribute_entries_missing_key_or_value() {
+        // Defensive: a malformed OTLP-shape entry (missing key or value field) is skipped rather than
+        // crashing the entire record.
+        SearchResponse response = new SearchResponse();
+        SearchHits hits = new SearchHits();
+        Map<String, Object> source = new HashMap<>();
+        source.put("trace_id", "a1b2c3d4");
+        source.put("span_id", "11223344aabbccdd");
+        source.put("@timestamp", "2026-04-30T10:00:00.100Z");
+        Map<String, Object> withoutValue = new HashMap<>();
+        withoutValue.put("key", "orphan");
+        source.put("attributes", List.of(withoutValue, Map.of("key", "http.method", "value", Map.of("stringValue", "POST"))));
+        SearchHit hit = new SearchHit();
+        hit.setSource(MAPPER.valueToTree(source));
+        hits.setHits(List.of(hit));
+        response.setSearchHits(hits);
+        when(client.search(any(), any(), any())).thenReturn(Single.just(response));
+
+        List<OtelLogRecord> records = repository.findLogs(QUERY_CONTEXT, criteriaForTrace("a1b2c3d4")).blockingGet();
+
+        assertThat(records.get(0).attributes()).hasSize(1).containsEntry("http.method", "POST");
+    }
+
+    @Test
+    void should_skip_array_attribute_when_otlp_value_has_no_typed_field() {
+        // Defensive: a value object with no recognised typed field (none of stringValue / intValue /
+        // doubleValue / boolValue) gets skipped — unwrapOtlpValue returns null and the entry is dropped.
+        SearchResponse response = new SearchResponse();
+        SearchHits hits = new SearchHits();
+        Map<String, Object> source = new HashMap<>();
+        source.put("trace_id", "a1b2c3d4");
+        source.put("span_id", "11223344aabbccdd");
+        source.put("@timestamp", "2026-04-30T10:00:00.100Z");
+        source.put(
+            "attributes",
+            List.of(
+                Map.of("key", "weird", "value", Map.of("arrayValue", List.of("a", "b"))),
+                Map.of("key", "http.method", "value", Map.of("stringValue", "POST"))
+            )
+        );
+        SearchHit hit = new SearchHit();
+        hit.setSource(MAPPER.valueToTree(source));
+        hits.setHits(List.of(hit));
+        response.setSearchHits(hits);
+        when(client.search(any(), any(), any())).thenReturn(Single.just(response));
+
+        List<OtelLogRecord> records = repository.findLogs(QUERY_CONTEXT, criteriaForTrace("a1b2c3d4")).blockingGet();
+
+        assertThat(records.get(0).attributes()).hasSize(1).containsEntry("http.method", "POST");
+    }
+
+    @Test
+    void should_unwrap_array_attribute_when_value_is_a_bare_scalar() {
+        // Defensive: if a (non-OTel-compliant) writer emits the value as a bare scalar instead of the
+        // typed-object wrapper, unwrapOtlpValue passes it through and the entry still lands in the map.
+        SearchResponse response = new SearchResponse();
+        SearchHits hits = new SearchHits();
+        Map<String, Object> source = new HashMap<>();
+        source.put("trace_id", "a1b2c3d4");
+        source.put("span_id", "11223344aabbccdd");
+        source.put("@timestamp", "2026-04-30T10:00:00.100Z");
+        source.put("attributes", List.of(Map.of("key", "raw", "value", "scalar-value")));
+        SearchHit hit = new SearchHit();
+        hit.setSource(MAPPER.valueToTree(source));
+        hits.setHits(List.of(hit));
+        response.setSearchHits(hits);
+        when(client.search(any(), any(), any())).thenReturn(Single.just(response));
+
+        List<OtelLogRecord> records = repository.findLogs(QUERY_CONTEXT, criteriaForTrace("a1b2c3d4")).blockingGet();
+
+        assertThat(records.get(0).attributes()).containsEntry("raw", "scalar-value");
+    }
+
+    @Test
+    void should_parse_resource_attributes_into_the_record() {
+        // Resource attributes (gravitee.module, gravitee.env.id, …) are part of every record returned
+        // by the OTel ES exporter — the reader must surface them so consumers can scope-filter without
+        // re-querying or relying on the resource filter that was sent.
+        SearchResponse response = new SearchResponse();
+        SearchHits hits = new SearchHits();
+        Map<String, Object> source = new HashMap<>();
+        source.put("trace_id", "a1b2c3d4");
+        source.put("span_id", "11223344aabbccdd");
+        source.put("@timestamp", "2026-04-30T10:00:00.100Z");
+        source.put(
+            "resource",
+            Map.of(
+                "attributes",
+                Map.of("gravitee", Map.of("module", "apim", "env", Map.of("id", "test-env"), "api", Map.of("id", "api-1")))
+            )
+        );
+        SearchHit hit = new SearchHit();
+        hit.setSource(MAPPER.valueToTree(source));
+        hits.setHits(List.of(hit));
+        response.setSearchHits(hits);
+        when(client.search(any(), any(), any())).thenReturn(Single.just(response));
+
+        List<OtelLogRecord> records = repository.findLogs(QUERY_CONTEXT, criteriaForTrace("a1b2c3d4")).blockingGet();
+
+        assertThat(records.get(0).resourceAttributes())
+            .containsEntry("gravitee.module", "apim")
+            .containsEntry("gravitee.env.id", "test-env")
+            .containsEntry("gravitee.api.id", "api-1");
+    }
+
+    @Test
+    void should_skip_hit_with_null_source() {
+        // SearchHit with no _source field — happens when ES returns just metadata (e.g. for stored_fields
+        // queries). Reader must skip rather than NPE.
+        SearchResponse response = new SearchResponse();
+        SearchHits hits = new SearchHits();
+        SearchHit nullSourceHit = new SearchHit();
+        nullSourceHit.setSource(null);
+        hits.setHits(
+            List.of(
+                nullSourceHit,
+                eventHit("a1b2c3d4", "11223344aabbccdd", "gravitee.policy.pre", "2026-04-30T10:00:00.100Z", "policy-id-1")
+            )
+        );
+        response.setSearchHits(hits);
+        when(client.search(any(), any(), any())).thenReturn(Single.just(response));
+
+        List<OtelLogRecord> records = repository.findLogs(QUERY_CONTEXT, criteriaForTrace("a1b2c3d4")).blockingGet();
+
+        assertThat(records).hasSize(1);
+        assertThat(records.get(0).attributes()).containsEntry("event.name", "gravitee.policy.pre");
+    }
+
     private static OtelLogSearchCriteria criteriaForTrace(String traceId) {
         return new OtelLogSearchCriteria(traceId, Map.of(), Map.of(), null, null, null);
     }

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/otel/log/ElasticsearchOtelLogTestRepositoryConfiguration.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/otel/log/ElasticsearchOtelLogTestRepositoryConfiguration.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.elasticsearch.otel.log;
+
+import io.gravitee.elasticsearch.client.Client;
+import io.gravitee.elasticsearch.client.http.HttpClient;
+import io.gravitee.elasticsearch.client.http.HttpClientConfiguration;
+import io.gravitee.elasticsearch.config.Endpoint;
+import io.gravitee.repository.otel.log.api.OtelLogRepository;
+import java.time.Duration;
+import java.util.List;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.Network;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.elasticsearch.ElasticsearchContainer;
+import org.testcontainers.utility.DockerImageName;
+import org.testcontainers.utility.MountableFile;
+
+/**
+ * Test wiring for {@link io.gravitee.repository.otel.log.OtelLogRepositoryTest} against Elasticsearch.
+ * <p>
+ * Stands up an Elasticsearch container plus an OTel Collector container on a shared docker network — the
+ * collector receives OTLP HTTP from {@link ElasticsearchOtelLogTestRepositoryInitializer} on both the
+ * traces pipeline (the elasticsearch exporter promotes span events into the logs data stream when
+ * {@code mapping.mode: otel} is set) and the logs pipeline (direct OTLP log records, modelling what
+ * {@code gravitee-reporter-otel} ships at runtime). The production
+ * {@link ElasticsearchOtelLogRepository} then queries ES through the same {@link HttpClient} pipeline
+ * used at runtime.
+ * <p>
+ * The configured {@code logs_index} ({@code logs-apim.otel-test-org}) matches what the contract test's
+ * {@code QueryContext("test-org", "test-env")} resolves through the {@code logs-apim.otel-{orgId}} template.
+ *
+ * @author GraviteeSource Team
+ */
+@Configuration
+public class ElasticsearchOtelLogTestRepositoryConfiguration {
+
+    static final String ES_NETWORK_ALIAS = "elasticsearch";
+    static final int OTEL_COLLECTOR_OTLP_HTTP_PORT = 4318;
+    private static final int ES_HTTP_PORT = 9200;
+    private static final String ES_IMAGE = "docker.elastic.co/elasticsearch/elasticsearch:8.17.2";
+    // The elasticsearch exporter exposes mapping.mode: otel from 0.116+. The snake_case OTel-native field
+    // layout it produces (trace_id, span_id, attributes.*, resource.attributes.*, event_name, body.*) is
+    // what ElasticsearchOtelLogRepository parses. Pin to a known-good recent build for reproducibility.
+    private static final String OTEL_COLLECTOR_IMAGE = "otel/opentelemetry-collector-contrib:0.145.0";
+
+    @Bean
+    public Network otelLogTestNetwork() {
+        return Network.newNetwork();
+    }
+
+    // No `Vertx` @Bean here on purpose. {@code AbstractRepositoryTest} component-scans every
+    // {@code *TestRepository*} config in the module, so this config and the tracing IT config load into the
+    // same Spring context. {@link io.gravitee.elasticsearch.client.http.HttpClient}'s
+    // {@code @Autowired Vertx vertx} would be ambiguous if both configs registered one. We rely on the
+    // single Vertx bean declared by the tracing IT config (or any other test that defines exactly one).
+
+    @Bean(destroyMethod = "stop")
+    public ElasticsearchContainer otelLogTestElasticsearchContainer(Network otelLogTestNetwork) {
+        ElasticsearchContainer container = new ElasticsearchContainer(DockerImageName.parse(ES_IMAGE))
+            .withEnv("xpack.security.enabled", "false")
+            .withEnv("ES_JAVA_OPTS", "-Xms512m -Xmx512m")
+            .withNetwork(otelLogTestNetwork)
+            .withNetworkAliases(ES_NETWORK_ALIAS);
+        container.setWaitStrategy(Wait.forLogMessage(".*started.*", 1).withStartupTimeout(Duration.ofSeconds(180)));
+        container.start();
+        return container;
+    }
+
+    @Bean(destroyMethod = "stop")
+    public GenericContainer<?> otelLogTestOtelCollectorContainer(
+        Network otelLogTestNetwork,
+        ElasticsearchContainer otelLogTestElasticsearchContainer
+    ) {
+        // Depending on otelLogTestElasticsearchContainer ensures Spring starts ES first; the collector
+        // retries during its own startup window if ES isn't yet accepting writes.
+        GenericContainer<?> collector = new GenericContainer<>(DockerImageName.parse(OTEL_COLLECTOR_IMAGE))
+            .withNetwork(otelLogTestNetwork)
+            .withExposedPorts(OTEL_COLLECTOR_OTLP_HTTP_PORT)
+            .withCopyFileToContainer(
+                MountableFile.forClasspathResource("otel-collector-otel-logs-config.yaml"),
+                "/etc/otelcol-contrib/config.yaml"
+            )
+            .waitingFor(Wait.forListeningPort().withStartupTimeout(Duration.ofSeconds(60)));
+        collector.start();
+        return collector;
+    }
+
+    @Bean(destroyMethod = "")
+    public Client otelLogTestElasticsearchClient(ElasticsearchContainer otelLogTestElasticsearchContainer) {
+        HttpClientConfiguration clientConfiguration = new HttpClientConfiguration();
+        clientConfiguration.setEndpoints(
+            List.of(
+                new Endpoint(
+                    "http://" +
+                        otelLogTestElasticsearchContainer.getHost() +
+                        ":" +
+                        otelLogTestElasticsearchContainer.getMappedPort(ES_HTTP_PORT)
+                )
+            )
+        );
+        clientConfiguration.setRequestTimeout(60_000L);
+        return new HttpClient(clientConfiguration);
+    }
+
+    @Bean
+    public OtelLogRepository otelLogRepository(Client otelLogTestElasticsearchClient) {
+        // Matches the collector's logs_index (otel-collector-otel-logs-config.yaml) once {orgId} is resolved
+        // against the contract test's QueryContext (Fixtures.ORG_ID = "test-org").
+        return new ElasticsearchOtelLogRepository("logs-apim.otel-{orgId}", otelLogTestElasticsearchClient);
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/otel/log/ElasticsearchOtelLogTestRepositoryInitializer.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/otel/log/ElasticsearchOtelLogTestRepositoryInitializer.java
@@ -1,0 +1,232 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.elasticsearch.otel.log;
+
+import static io.gravitee.repository.elasticsearch.otel.log.ElasticsearchOtelLogTestRepositoryConfiguration.OTEL_COLLECTOR_OTLP_HTTP_PORT;
+import static io.opentelemetry.api.common.AttributeKey.stringKey;
+import static org.awaitility.Awaitility.await;
+
+import io.gravitee.repository.common.query.QueryContext;
+import io.gravitee.repository.config.TestRepositoryInitializer;
+import io.gravitee.repository.otel.log.OtelLogRepositoryTest.Fixtures;
+import io.gravitee.repository.otel.log.api.OtelLogRepository;
+import io.gravitee.repository.otel.log.model.OtelLogRecord;
+import io.gravitee.repository.otel.log.model.OtelLogSearchCriteria;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.logs.Logger;
+import io.opentelemetry.api.logs.Severity;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.exporter.otlp.http.logs.OtlpHttpLogRecordExporter;
+import io.opentelemetry.exporter.otlp.http.trace.OtlpHttpSpanExporter;
+import io.opentelemetry.sdk.OpenTelemetrySdk;
+import io.opentelemetry.sdk.logs.SdkLoggerProvider;
+import io.opentelemetry.sdk.logs.export.SimpleLogRecordProcessor;
+import io.opentelemetry.sdk.resources.Resource;
+import io.opentelemetry.sdk.trace.IdGenerator;
+import io.opentelemetry.sdk.trace.SdkTracerProvider;
+import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.testcontainers.containers.GenericContainer;
+
+/**
+ * Pushes the {@link Fixtures} OTel log records into the collector via OTLP HTTP, then waits for them to
+ * become queryable through the production {@link ElasticsearchOtelLogRepository}. Two distinct producer
+ * paths are exercised so the contract test sees both shapes:
+ * <ul>
+ *   <li>OTLP traces with span events — the elasticsearch exporter (in {@code mapping.mode: otel})
+ *       extracts the span events into the logs data stream with {@code event_name} set, which the
+ *       production repository normalises to {@code attributes["event.name"]}.</li>
+ *   <li>OTLP log records — direct logs emitted by the seeder, modelling what
+ *       {@code gravitee-reporter-otel} ships at runtime when the gateway captures a request/response
+ *       payload. These land in the same data stream without {@code event_name}.</li>
+ * </ul>
+ * Seeding runs once across the suite — ES persists ingested records, so re-pushing on every test would
+ * inflate {@code findLogs} results.
+ *
+ * @author GraviteeSource Team
+ */
+public class ElasticsearchOtelLogTestRepositoryInitializer implements TestRepositoryInitializer {
+
+    private static final Duration QUERYABLE_POLL_TIMEOUT = Duration.ofSeconds(60);
+    private static final Duration QUERYABLE_POLL_INTERVAL = Duration.ofMillis(500);
+
+    /** Anchor instant for the seeded fixtures — events / log are spaced ~100ms apart from here. */
+    private static final Instant SEED_ANCHOR = Instant.parse("2026-04-30T10:00:00Z");
+
+    private final GenericContainer<?> otelCollectorContainer;
+    private final OtelLogRepository otelLogRepository;
+
+    private boolean seeded = false;
+
+    @Autowired
+    public ElasticsearchOtelLogTestRepositoryInitializer(
+        GenericContainer<?> otelLogTestOtelCollectorContainer,
+        OtelLogRepository otelLogRepository
+    ) {
+        this.otelCollectorContainer = otelLogTestOtelCollectorContainer;
+        this.otelLogRepository = otelLogRepository;
+    }
+
+    @Override
+    public void setUp() {
+        if (seeded) {
+            return;
+        }
+        String collectorHost = otelCollectorContainer.getHost() + ":" + otelCollectorContainer.getMappedPort(OTEL_COLLECTOR_OTLP_HTTP_PORT);
+        seedSpanEvents(collectorHost);
+        seedPayloadLog(collectorHost);
+        awaitLogsQueryable();
+        seeded = true;
+    }
+
+    @Override
+    public void tearDown() {
+        // ES storage is bound to the container lifecycle (managed by the Spring context), so per-test
+        // cleanup is unnecessary — the suite seeds once and tests share the read-only fixture set.
+    }
+
+    /**
+     * Emits a single OTLP trace whose span carries two events (pre + post). The collector's elasticsearch
+     * exporter promotes each event into a log document in the logs data stream with {@code event_name}
+     * set — matching what the production repository normalises back to {@code attributes["event.name"]}.
+     */
+    private void seedSpanEvents(String collectorHost) {
+        OtlpHttpSpanExporter exporter = OtlpHttpSpanExporter.builder().setEndpoint("http://" + collectorHost + "/v1/traces").build();
+        SdkTracerProvider tracerProvider = SdkTracerProvider.builder()
+            .setResource(Resource.create(Attributes.of(stringKey("service.name"), "otel-log-fixtures")))
+            .setIdGenerator(new FixtureIdGenerator())
+            .addSpanProcessor(SimpleSpanProcessor.create(exporter))
+            .build();
+
+        try (OpenTelemetrySdk sdk = OpenTelemetrySdk.builder().setTracerProvider(tracerProvider).build()) {
+            Tracer tracer = sdk.getTracer("elasticsearch-otel-log-test-fixtures");
+
+            long spanStartNanos = epochNanos(SEED_ANCHOR);
+            Span span = tracer.spanBuilder("seed-span").setStartTimestamp(spanStartNanos, TimeUnit.NANOSECONDS).startSpan();
+
+            // Pre event — carries the policy id attribute the contract test asserts on.
+            span.addEvent(
+                Fixtures.EVENT_PRE_NAME,
+                Attributes.of(stringKey("gravitee.policy.id"), Fixtures.EVENT_PRE_POLICY_ID),
+                spanStartNanos + Duration.ofMillis(100).toNanos(),
+                TimeUnit.NANOSECONDS
+            );
+            // Post event — no extra attributes; ordering by @timestamp is what matters.
+            span.addEvent(Fixtures.EVENT_POST_NAME, spanStartNanos + Duration.ofMillis(200).toNanos(), TimeUnit.NANOSECONDS);
+            span.end(spanStartNanos + Duration.ofMillis(300).toNanos(), TimeUnit.NANOSECONDS);
+
+            tracerProvider.forceFlush().join(10, TimeUnit.SECONDS);
+        }
+    }
+
+    /**
+     * Emits a single OTLP log record stamped with the fixture trace_id / span_id, modelling what
+     * {@code gravitee-reporter-otel} writes when the gateway captures a request/response payload. The
+     * record lands in the logs data stream without {@code event_name} — the contract test uses that
+     * absence to discriminate payload logs from span events.
+     */
+    private void seedPayloadLog(String collectorHost) {
+        OtlpHttpLogRecordExporter exporter = OtlpHttpLogRecordExporter.builder()
+            .setEndpoint("http://" + collectorHost + "/v1/logs")
+            .build();
+        SdkLoggerProvider loggerProvider = SdkLoggerProvider.builder()
+            .setResource(Resource.create(Attributes.of(stringKey("service.name"), "otel-log-fixtures")))
+            .addLogRecordProcessor(SimpleLogRecordProcessor.create(exporter))
+            .build();
+
+        try {
+            Logger logger = loggerProvider.get("elasticsearch-otel-log-test-fixtures");
+            // The OTel logs SDK ties trace/span ids to the active Context, not to LogRecordBuilder.setTraceId.
+            // Wrap a no-op span carrying the fixture ids and emit the log under that context so the exporter
+            // serialises trace_id / span_id correctly into the OTLP payload.
+            Context context = Context.current().with(
+                Span.wrap(FixtureIdGenerator.fixtureSpanContext(Fixtures.TRACE_OK_ID, Fixtures.TRACE_OK_SPAN_ID))
+            );
+            logger
+                .logRecordBuilder()
+                .setContext(context)
+                .setTimestamp(SEED_ANCHOR.plusMillis(400).getEpochSecond() * 1_000_000_000L + 400_000_000L, TimeUnit.NANOSECONDS)
+                .setSeverity(Severity.INFO)
+                .setSeverityText("INFO")
+                .setBody(Fixtures.PAYLOAD_BODY)
+                .emit();
+
+            loggerProvider.forceFlush().join(10, TimeUnit.SECONDS);
+        } finally {
+            loggerProvider.close();
+        }
+    }
+
+    private void awaitLogsQueryable() {
+        QueryContext queryContext = new QueryContext(Fixtures.ORG_ID, Fixtures.ENV_ID);
+        OtelLogSearchCriteria criteria = new OtelLogSearchCriteria(Fixtures.TRACE_OK_ID, Map.of(), Map.of(), null, null, null);
+
+        // Two span events + one payload log = 3 docs once both producer paths have flushed end-to-end.
+        await()
+            .atMost(QUERYABLE_POLL_TIMEOUT)
+            .pollInterval(QUERYABLE_POLL_INTERVAL)
+            .until(() -> {
+                List<OtelLogRecord> records = otelLogRepository.findLogs(queryContext, criteria).blockingGet();
+                return records.size() >= 3;
+            });
+    }
+
+    private static long epochNanos(Instant instant) {
+        return instant.getEpochSecond() * 1_000_000_000L + instant.getNano();
+    }
+
+    /**
+     * Hands the contract's fixture trace + span ids to the OTel SDK. Generates them once for the first
+     * span the tracer creates (which is the only span the IT seeds); subsequent ids fall back to random
+     * so a future test that opens another span here doesn't collide with the fixture.
+     */
+    private static final class FixtureIdGenerator implements IdGenerator {
+
+        private final java.util.concurrent.atomic.AtomicBoolean traceServed = new java.util.concurrent.atomic.AtomicBoolean();
+        private final java.util.concurrent.atomic.AtomicBoolean spanServed = new java.util.concurrent.atomic.AtomicBoolean();
+
+        @Override
+        public String generateTraceId() {
+            return traceServed.compareAndSet(false, true) ? Fixtures.TRACE_OK_ID : IdGenerator.random().generateTraceId();
+        }
+
+        @Override
+        public String generateSpanId() {
+            return spanServed.compareAndSet(false, true) ? Fixtures.TRACE_OK_SPAN_ID : IdGenerator.random().generateSpanId();
+        }
+
+        /**
+         * Builds a SpanContext carrying the fixture ids so the OTLP log exporter serialises trace_id /
+         * span_id correctly on the payload log record (OTel logs SDK reads them from the active context
+         * rather than from the LogRecordBuilder).
+         */
+        static io.opentelemetry.api.trace.SpanContext fixtureSpanContext(String traceId, String spanId) {
+            return io.opentelemetry.api.trace.SpanContext.create(
+                traceId,
+                spanId,
+                io.opentelemetry.api.trace.TraceFlags.getSampled(),
+                io.opentelemetry.api.trace.TraceState.getDefault()
+            );
+        }
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/otel/log/spring/OtelLogConfigurationTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/otel/log/spring/OtelLogConfigurationTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.elasticsearch.otel.log.spring;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import io.gravitee.elasticsearch.client.Client;
+import io.gravitee.repository.elasticsearch.otel.log.ElasticsearchOtelLogRepository;
+import io.gravitee.repository.otel.log.api.OtelLogRepository;
+import io.vertx.rxjava3.core.Vertx;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.env.MockEnvironment;
+
+class OtelLogConfigurationTest {
+
+    private final OtelLogConfiguration configuration = new OtelLogConfiguration();
+
+    @Test
+    void otelLogVertxRx_should_wrap_core_vertx_into_rxjava3_vertx() {
+        io.vertx.core.Vertx coreVertx = io.vertx.core.Vertx.vertx();
+        try {
+            Vertx wrapped = configuration.otelLogVertxRx(coreVertx);
+
+            assertThat(wrapped).isNotNull();
+            assertThat(wrapped.getDelegate()).isSameAs(coreVertx);
+        } finally {
+            coreVertx.close();
+        }
+    }
+
+    @Test
+    void otelLogClient_should_build_es_client_from_environment_with_otel_logs_prefix() {
+        // ElasticsearchHttpClientFactory reads <scope>.elasticsearch.* properties — with a bare Environment
+        // it falls back to all defaults (localhost:9200, no auth, no SSL) and still returns a usable client.
+        // We just verify wiring: the @Bean creates a non-null Client without any otel-logs.* property set.
+        MockEnvironment environment = new MockEnvironment();
+
+        Client client = configuration.otelLogClient(environment);
+
+        assertThat(client).isNotNull();
+    }
+
+    @Test
+    void otelLogRepository_should_construct_es_repository_with_index_template_and_client() {
+        Client client = mock(Client.class);
+
+        OtelLogRepository repository = configuration.otelLogRepository("logs-apim.otel-{orgId}", client);
+
+        assertThat(repository).isInstanceOf(ElasticsearchOtelLogRepository.class);
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/resources/otel-collector-otel-logs-config.yaml
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/resources/otel-collector-otel-logs-config.yaml
@@ -1,0 +1,51 @@
+# OTel Collector pipeline used by ElasticsearchOtelLogRepositoryIT.
+#
+# Two distinct producer paths feed the same logs data stream:
+#   * OTLP traces — the elasticsearch exporter (mapping.mode: otel) extracts span events into a logs data
+#     stream (it forces data_stream.type = logs for events regardless of pipeline). The fixture seeder
+#     emits a trace with two span events that surface here.
+#   * OTLP logs — direct log records emitted by the fixture seeder, modelling what gravitee-reporter-otel
+#     ships at runtime when the gateway captures a request/response payload.
+#
+# logs_index matches `logs-apim.otel-test-org` because the contract test's QueryContext resolves
+# otel-logs.elasticsearch.index ("logs-apim.otel-{orgId}") with orgId = Fixtures.ORG_ID = "test-org".
+
+receivers:
+  otlp:
+    protocols:
+      http:
+        endpoint: 0.0.0.0:4318
+
+exporters:
+  elasticsearch:
+    endpoints: ["http://elasticsearch:9200"]
+    mapping:
+      mode: otel
+    logs_index: logs-apim.otel-test-org
+    # We don't query the traces data stream from the OTel-logs IT, but we still need to route it somewhere
+    # — the exporter requires it to be set when traces flow through the pipeline.
+    traces_index: traces-apim.otel-test-org
+    # Tests need the exporter to flush each push from the OTel SDK immediately and surface errors instead of
+    # silently retrying — production deployments would want different defaults.
+    flush:
+      interval: 1s
+    retry:
+      enabled: false
+    sending_queue:
+      enabled: false
+    timeout: 30s
+
+processors:
+  batch:
+    timeout: 200ms
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [elasticsearch]
+    logs:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [elasticsearch]

--- a/gravitee-apim-repository/gravitee-apim-repository-noop/src/main/java/io/gravitee/repository/noop/NoOpOtelLogsRepositoryConfiguration.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-noop/src/main/java/io/gravitee/repository/noop/NoOpOtelLogsRepositoryConfiguration.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.noop;
+
+import io.gravitee.repository.noop.otel.log.NoOpOtelLogRepository;
+import io.gravitee.repository.otel.log.api.OtelLogRepository;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Loaded for the {@code OTEL_LOGS} scope when {@code repositories.otel-logs.type=none} — exposes a
+ * no-op {@link OtelLogRepository} bean so trace-detail consumers can call into the SPI uniformly and
+ * render spans without their events / payload logs when the operator hasn't wired a backend.
+ *
+ * @author GraviteeSource Team
+ */
+@Configuration
+public class NoOpOtelLogsRepositoryConfiguration {
+
+    @Bean
+    public OtelLogRepository otelLogRepository() {
+        return new NoOpOtelLogRepository();
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-noop/src/main/java/io/gravitee/repository/noop/NoOpOtelTracesRepositoryConfiguration.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-noop/src/main/java/io/gravitee/repository/noop/NoOpOtelTracesRepositoryConfiguration.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.noop;
+
+import io.gravitee.repository.noop.tracing.NoOpTracingRepository;
+import io.gravitee.repository.tracing.api.TracingRepository;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Loaded for the {@code OTEL_TRACES} scope when {@code repositories.otel-traces.type=none} — exposes
+ * a no-op {@link TracingRepository} bean so consumers (gamma APIM trace resource, future use cases)
+ * can rely on the SPI being present in the context without each implementing their own NoOp fallback.
+ *
+ * @author GraviteeSource Team
+ */
+@Configuration
+public class NoOpOtelTracesRepositoryConfiguration {
+
+    @Bean
+    public TracingRepository tracingRepository() {
+        return new NoOpTracingRepository();
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-noop/src/main/java/io/gravitee/repository/noop/NoOpRepositoryProvider.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-noop/src/main/java/io/gravitee/repository/noop/NoOpRepositoryProvider.java
@@ -33,7 +33,7 @@ public class NoOpRepositoryProvider implements RepositoryProvider {
 
     @Override
     public Scope[] scopes() {
-        return new Scope[] { Scope.ANALYTICS, Scope.MANAGEMENT, Scope.RATE_LIMIT };
+        return new Scope[] { Scope.ANALYTICS, Scope.MANAGEMENT, Scope.RATE_LIMIT, Scope.OTEL_TRACES, Scope.OTEL_LOGS };
     }
 
     @Override
@@ -44,6 +44,10 @@ public class NoOpRepositoryProvider implements RepositoryProvider {
             return NoOpManagementRepositoryConfiguration.class;
         } else if (scope == Scope.RATE_LIMIT) {
             return NoOpRateLimitRepositoryConfiguration.class;
+        } else if (scope == Scope.OTEL_TRACES) {
+            return NoOpOtelTracesRepositoryConfiguration.class;
+        } else if (scope == Scope.OTEL_LOGS) {
+            return NoOpOtelLogsRepositoryConfiguration.class;
         }
 
         log.debug("Skipping unhandled repository scope {}", scope);

--- a/gravitee-apim-repository/gravitee-apim-repository-noop/src/main/java/io/gravitee/repository/noop/otel/log/NoOpOtelLogRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-noop/src/main/java/io/gravitee/repository/noop/otel/log/NoOpOtelLogRepository.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.noop.otel.log;
+
+import io.gravitee.repository.common.query.QueryContext;
+import io.gravitee.repository.otel.log.api.OtelLogRepository;
+import io.gravitee.repository.otel.log.model.OtelLogRecord;
+import io.gravitee.repository.otel.log.model.OtelLogSearchCriteria;
+import io.reactivex.rxjava3.core.Single;
+import java.util.List;
+
+/**
+ * No-op {@link OtelLogRepository} for the {@code OTEL_LOGS} scope. Wired when an operator sets
+ * {@code repositories.otel-logs.type=none} — typical for deployments that haven't enabled span-event
+ * / payload-log retrieval yet, or that haven't shipped {@code gravitee-reporter-otel} on the gateway.
+ * Returns empty results so trace-detail consumers render spans without their events / payload logs
+ * rather than failing.
+ *
+ * @author GraviteeSource Team
+ */
+public class NoOpOtelLogRepository implements OtelLogRepository {
+
+    @Override
+    public Single<List<OtelLogRecord>> findLogs(QueryContext queryContext, OtelLogSearchCriteria criteria) {
+        return Single.just(List.of());
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-noop/src/main/java/io/gravitee/repository/noop/tracing/NoOpTracingRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-noop/src/main/java/io/gravitee/repository/noop/tracing/NoOpTracingRepository.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.noop.tracing;
+
+import io.gravitee.repository.common.query.QueryContext;
+import io.gravitee.repository.tracing.api.TracingRepository;
+import io.gravitee.repository.tracing.model.Trace;
+import io.gravitee.repository.tracing.model.TraceSearchCriteria;
+import io.reactivex.rxjava3.core.Maybe;
+import io.reactivex.rxjava3.core.Single;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * No-op {@link TracingRepository} for the {@code OTEL_TRACES} scope. Wired when an operator sets
+ * {@code repositories.otel-traces.type=none} — typical for deployments that haven't enabled the trace
+ * explorer yet, or that don't want to point tracing at a backend. Returns empty results so consumers
+ * (gamma APIM trace resource, future use cases) can rely on the SPI being present without each
+ * implementing their own NoOp fallback.
+ *
+ * @author GraviteeSource Team
+ */
+public class NoOpTracingRepository implements TracingRepository {
+
+    @Override
+    public Single<List<Trace>> searchTraces(QueryContext queryContext, TraceSearchCriteria criteria) {
+        return Single.just(List.of());
+    }
+
+    @Override
+    public Maybe<Trace> getTrace(QueryContext queryContext, String traceId, Map<String, String> resourceAttributeFilters) {
+        return Maybe.empty();
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-noop/src/test/java/io/gravitee/repository/noop/NoOpOtelLogsRepositoryConfigurationTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-noop/src/test/java/io/gravitee/repository/noop/NoOpOtelLogsRepositoryConfigurationTest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.noop;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.repository.noop.otel.log.NoOpOtelLogRepository;
+import io.gravitee.repository.otel.log.api.OtelLogRepository;
+import org.junit.Test;
+
+public class NoOpOtelLogsRepositoryConfigurationTest {
+
+    @Test
+    public void otelLogRepository_should_expose_no_op_instance() {
+        // Verifies the @Bean method wires the no-op impl so consumers can resolve the OtelLogRepository
+        // bean even when no OTel logs backend is configured (repositories.otel-logs.type=none path).
+        OtelLogRepository repository = new NoOpOtelLogsRepositoryConfiguration().otelLogRepository();
+
+        assertThat(repository).isInstanceOf(NoOpOtelLogRepository.class);
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-noop/src/test/java/io/gravitee/repository/noop/NoOpOtelTracesRepositoryConfigurationTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-noop/src/test/java/io/gravitee/repository/noop/NoOpOtelTracesRepositoryConfigurationTest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.noop;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.repository.noop.tracing.NoOpTracingRepository;
+import io.gravitee.repository.tracing.api.TracingRepository;
+import org.junit.Test;
+
+public class NoOpOtelTracesRepositoryConfigurationTest {
+
+    @Test
+    public void tracingRepository_should_expose_no_op_instance() {
+        // Verifies the @Bean method wires the no-op impl so consumers can resolve the TracingRepository
+        // bean even when no OTel traces backend is configured (repositories.otel-traces.type=none path).
+        TracingRepository repository = new NoOpOtelTracesRepositoryConfiguration().tracingRepository();
+
+        assertThat(repository).isInstanceOf(NoOpTracingRepository.class);
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-noop/src/test/java/io/gravitee/repository/noop/NoOpRepositoryProviderTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-noop/src/test/java/io/gravitee/repository/noop/NoOpRepositoryProviderTest.java
@@ -37,13 +37,19 @@ public class NoOpRepositoryProviderTest {
 
     @Test
     public void shouldReturnAnalyticsScope() {
-        assertArrayEquals(new Scope[] { Scope.ANALYTICS, Scope.MANAGEMENT, Scope.RATE_LIMIT }, provider.scopes());
+        assertArrayEquals(
+            new Scope[] { Scope.ANALYTICS, Scope.MANAGEMENT, Scope.RATE_LIMIT, Scope.OTEL_TRACES, Scope.OTEL_LOGS },
+            provider.scopes()
+        );
     }
 
     @Test
     public void shouldReturnNoOpConfigurationClass() {
-        Class<?> configClass = provider.configuration(Scope.ANALYTICS);
-        assertEquals(NoOpAnalyticsRepositoryConfiguration.class, configClass);
+        assertEquals(NoOpAnalyticsRepositoryConfiguration.class, provider.configuration(Scope.ANALYTICS));
+        assertEquals(NoOpManagementRepositoryConfiguration.class, provider.configuration(Scope.MANAGEMENT));
+        assertEquals(NoOpRateLimitRepositoryConfiguration.class, provider.configuration(Scope.RATE_LIMIT));
+        assertEquals(NoOpOtelTracesRepositoryConfiguration.class, provider.configuration(Scope.OTEL_TRACES));
+        assertEquals(NoOpOtelLogsRepositoryConfiguration.class, provider.configuration(Scope.OTEL_LOGS));
     }
 
     @Test

--- a/gravitee-apim-repository/gravitee-apim-repository-noop/src/test/java/io/gravitee/repository/noop/otel/log/NoOpOtelLogRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-noop/src/test/java/io/gravitee/repository/noop/otel/log/NoOpOtelLogRepositoryTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.noop.otel.log;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.repository.common.query.QueryContext;
+import io.gravitee.repository.otel.log.model.OtelLogRecord;
+import io.gravitee.repository.otel.log.model.OtelLogSearchCriteria;
+import java.util.List;
+import java.util.Map;
+import org.junit.Test;
+
+public class NoOpOtelLogRepositoryTest {
+
+    private final NoOpOtelLogRepository repository = new NoOpOtelLogRepository();
+
+    @Test
+    public void findLogs_should_return_empty_list() {
+        List<OtelLogRecord> records = repository
+            .findLogs(
+                new QueryContext("org#1", "env#1"),
+                new OtelLogSearchCriteria("a1b2c3d4", Map.of(), Map.of("gravitee.api.id", "api-1"), null, null, null)
+            )
+            .blockingGet();
+
+        assertThat(records).isEmpty();
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-noop/src/test/java/io/gravitee/repository/noop/tracing/NoOpTracingRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-noop/src/test/java/io/gravitee/repository/noop/tracing/NoOpTracingRepositoryTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.noop.tracing;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.repository.common.query.QueryContext;
+import io.gravitee.repository.tracing.model.Trace;
+import io.gravitee.repository.tracing.model.TraceSearchCriteria;
+import java.util.List;
+import java.util.Map;
+import org.junit.Test;
+
+public class NoOpTracingRepositoryTest {
+
+    private final NoOpTracingRepository repository = new NoOpTracingRepository();
+
+    @Test
+    public void searchTraces_should_return_empty_list() {
+        List<Trace> traces = repository
+            .searchTraces(
+                new QueryContext("org#1", "env#1"),
+                new TraceSearchCriteria(Map.of(), 100, null, null, Map.of("gravitee.api.id", "api-1"))
+            )
+            .blockingGet();
+
+        assertThat(traces).isEmpty();
+    }
+
+    @Test
+    public void getTrace_should_return_empty_maybe() {
+        Trace trace = repository.getTrace(new QueryContext("org#1", "env#1"), "a1b2c3d4", Map.of("gravitee.api.id", "api-1")).blockingGet();
+
+        assertThat(trace).isNull();
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/otel/log/OtelLogRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/otel/log/OtelLogRepositoryTest.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.otel.log;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.repository.common.query.QueryContext;
+import io.gravitee.repository.config.AbstractRepositoryTest;
+import io.gravitee.repository.otel.log.api.OtelLogRepository;
+import io.gravitee.repository.otel.log.model.OtelLogRecord;
+import io.gravitee.repository.otel.log.model.OtelLogSearchCriteria;
+import java.util.List;
+import java.util.Map;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * Shared contract for {@link OtelLogRepository} implementations. Log records aren't writable through the
+ * SPI, so this test doesn't drive a JSON-based create flow — implementations must seed the
+ * {@link Fixtures fixture} records into their backend from {@code TestRepositoryInitializer.setUp()}
+ * before each test.
+ * <p>
+ * The single query method is exercised against the seeded fixtures: one trace with two span-event docs
+ * ({@code event.name} populated, no body) and one payload-log doc (body populated, no {@code event.name}).
+ * Implementations whose backend doesn't store span events (Loki) should override the seed to skip them —
+ * the timestamp-ordering assertion would then short-circuit on the payload log only.
+ *
+ * @author GraviteeSource Team
+ */
+public abstract class OtelLogRepositoryTest extends AbstractRepositoryTest {
+
+    @Autowired
+    @SuppressWarnings("SpringJavaInjectionPointsAutowiringInspection")
+    protected OtelLogRepository otelLogRepository;
+
+    /** Fixed tenant context every assertion uses. */
+    protected static final QueryContext QUERY_CONTEXT = new QueryContext(Fixtures.ORG_ID, Fixtures.ENV_ID);
+
+    @Override
+    protected String getTestCasesPath() {
+        return null;
+    }
+
+    @Override
+    protected String getModelPackage() {
+        return null;
+    }
+
+    @Override
+    protected void createModel(Object object) {
+        // no-op: see class-level Javadoc
+    }
+
+    @Test
+    public void should_return_all_logs_for_known_trace_in_timestamp_ascending_order() {
+        List<OtelLogRecord> records = otelLogRepository
+            .findLogs(QUERY_CONTEXT, new OtelLogSearchCriteria(Fixtures.TRACE_OK_ID, Map.of(), Map.of(), null, null, null))
+            .blockingGet();
+
+        // Fixtures: 2 span events (with event.name attribute, no body) then 1 payload log (body populated,
+        // no event.name). Single query returns everything for the trace.
+        assertThat(records).hasSize(3);
+        assertThat(records).allMatch(r -> Fixtures.TRACE_OK_SPAN_ID.equals(r.spanId()));
+
+        OtelLogRecord first = records.get(0);
+        OtelLogRecord second = records.get(1);
+        OtelLogRecord third = records.get(2);
+
+        assertThat(first.attributes()).containsEntry("event.name", Fixtures.EVENT_PRE_NAME);
+        assertThat(first.attributes()).containsEntry("gravitee.policy.id", Fixtures.EVENT_PRE_POLICY_ID);
+        assertThat(first.body()).isNull();
+
+        assertThat(second.attributes()).containsEntry("event.name", Fixtures.EVENT_POST_NAME);
+        assertThat(second.body()).isNull();
+
+        // Payload log: body populated, no event.name attribute — the discriminator consumers use.
+        assertThat(third.body()).isEqualTo(Fixtures.PAYLOAD_BODY);
+        assertThat(third.attributes()).doesNotContainKey("event.name");
+    }
+
+    @Test
+    public void should_return_empty_list_when_trace_id_is_unknown() {
+        List<OtelLogRecord> records = otelLogRepository
+            .findLogs(QUERY_CONTEXT, new OtelLogSearchCriteria(Fixtures.UNKNOWN_TRACE_ID, Map.of(), Map.of(), null, null, null))
+            .blockingGet();
+
+        assertThat(records).isEmpty();
+    }
+
+    /**
+     * Fixture records the implementation's {@code TestRepositoryInitializer.setUp()} must seed in the
+     * backend before each test runs. Defined as a single source of truth so impl-side seeding and
+     * assertion expectations stay aligned.
+     */
+    public static final class Fixtures {
+
+        public static final String ORG_ID = "test-org";
+        public static final String ENV_ID = "test-env";
+
+        public static final String TRACE_OK_ID = "a1b2c3d4e5f60718293a4b5c6d7e8f01";
+        public static final String TRACE_OK_SPAN_ID = "11223344aabbccdd";
+
+        public static final String EVENT_PRE_NAME = "gravitee.policy.pre";
+        public static final String EVENT_PRE_POLICY_ID = "policy-rate-limit";
+
+        public static final String EVENT_POST_NAME = "gravitee.policy.post";
+
+        public static final String PAYLOAD_BODY = "{\"hello\":\"world\"}";
+
+        /** Valid-shape trace id (32-hex) that no fixture seeds — used by the not-found test. */
+        public static final String UNKNOWN_TRACE_ID = "deadbeef0000000000000000beefdead";
+
+        private Fixtures() {}
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-repository/src/main/java/io/gravitee/rest/api/repository/plugins/RestApiRepositoryScopeProvider.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-repository/src/main/java/io/gravitee/rest/api/repository/plugins/RestApiRepositoryScopeProvider.java
@@ -29,12 +29,13 @@ public class RestApiRepositoryScopeProvider implements RepositoryScopeProvider {
     }
 
     /**
-     * OTEL_TRACES is opt-in: the rest-api can query traces (e.g. via the gamma APIM tracing resource) but startup
-     * must not fail when no provider is wired. Declaring it as optional means the platform loads the matching
-     * {@code RepositoryProvider} when {@code otel-traces.type} is set and silently skips it otherwise.
+     * OTEL_TRACES / OTEL_LOGS are opt-in: the rest-api can query traces and span-event logs (e.g. via the gamma
+     * APIM tracing resource) but startup must not fail when no provider is wired. Declaring them as optional
+     * means the platform loads the matching {@code RepositoryProvider} when {@code otel-traces.type} /
+     * {@code otel-logs.type} is set and silently skips otherwise.
      */
     @Override
     public Scope[] getOptionalHandledScopes() {
-        return new Scope[] { Scope.OTEL_TRACES };
+        return new Scope[] { Scope.OTEL_TRACES, Scope.OTEL_LOGS };
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-repository/src/test/java/io/gravitee/rest/api/repository/plugins/RestApiRepositoryScopeProviderTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-repository/src/test/java/io/gravitee/rest/api/repository/plugins/RestApiRepositoryScopeProviderTest.java
@@ -32,7 +32,7 @@ public class RestApiRepositoryScopeProviderTest {
     }
 
     @Test
-    public void shouldReturnOtelTracesAsOptionalScope() {
-        Assert.assertArrayEquals(new Scope[] { Scope.OTEL_TRACES }, provider.getOptionalHandledScopes());
+    public void shouldReturnOtelTracesAndOtelLogsAsOptionalScopes() {
+        Assert.assertArrayEquals(new Scope[] { Scope.OTEL_TRACES, Scope.OTEL_LOGS }, provider.getOptionalHandledScopes());
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/src/main/resources/config/gravitee.yml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/src/main/resources/config/gravitee.yml
@@ -263,18 +263,62 @@ repositories:
 #            username: user
 #            password: secret
 
-# OTel traces repository — feeds the gamma APIM tracing resource. Disabled by default; set type to
-# "elasticsearch" to wire the ES-backed TracingRepository. Configuration is fully independent from
-# analytics (same per-scope pattern as ratelimit.redis / distributed-sync.redis). The ES cluster declared
-# here must be the one the OTel collector / Elastic Cloud OTLP endpoint writes traces to.
-#  otel-traces:
-#    type: elasticsearch # or "none" to disable
+# OTel traces repository — feeds the gamma APIM tracing resource. Defaults to "none" so a dev install
+# bootstraps without OTel infra; the NoOpTracingRepository returns empty results so any consumer code
+# stays bean-resolvable. Set type to "elasticsearch" and fill in the block below to wire the real
+# ES-backed TracingRepository. Configuration is fully independent from analytics (same per-scope
+# pattern as ratelimit.redis / distributed-sync.redis). When enabled, the ES cluster declared below
+# must be the one the OTel collector / Elastic Cloud OTLP endpoint writes traces to.
+  otel-traces:
+    type: none # or "elasticsearch" to enable the block below
 #    elasticsearch:
 #      # Index/data-stream template — {orgId} / {envId} placeholders are substituted (lowercased) from the
 #      # caller's QueryContext at query time, matching the analytics IndexNameUtils.format convention.
 #      # Should match the data-stream name the OTel collector elasticsearch exporter (mapping.mode: otel)
 #      # writes to.
 #      index: traces-apim.otel-{orgId}
+#      endpoints:
+#        - http://${ds.elastic.host}:${ds.elastic.port}
+#      security:
+#        username: user
+#        password: secret
+#      ssl:
+#        keystore:
+#          type: jks # jks, pkcs12 or pem
+#          path: ${gravitee.home}/security/keystore.jks
+#          password: secret
+#          # PEM only:
+#          # certs: [/path/to/cert1.pem, /path/to/cert2.pem]
+#          # keys:  [/path/to/key1.pem,  /path/to/key2.pem]
+#      http:
+#        timeout: 10000 # in milliseconds
+#        proxy:
+#          type: HTTP #HTTP, SOCK4, SOCK5
+#          http:
+#            host: localhost
+#            port: 3128
+#            username: user
+#            password: secret
+#          https:
+#            host: localhost
+#            port: 3128
+#            username: user
+#            password: secret
+
+# OTel logs repository — backs the gamma APIM tracing resource alongside `otel-traces`. Reads two distinct
+# document shapes from the same OTel logs data stream: span events (written by the OTel collector when it
+# processes traces) and gateway-captured payload logs (written by gravitee-reporter-otel). Defaults to
+# "none" so a dev install bootstraps without OTel infra; the NoOpOtelLogRepository returns empty results
+# so any consumer code stays bean-resolvable. Set type to "elasticsearch" and fill in the block below to
+# wire the real ES-backed OtelLogRepository. Same per-scope independence pattern as `analytics` /
+# `otel-traces` — no fallback across scopes.
+  otel-logs:
+    type: none # or "elasticsearch" to enable the block below
+#    elasticsearch:
+#      # Index/data-stream template — {orgId} / {envId} placeholders are substituted (lowercased) from the
+#      # caller's QueryContext at query time. Should match the data-stream name the OTel collector
+#      # elasticsearch exporter (mapping.mode: otel) writes to AND the one gravitee-reporter-otel ships to.
+#      index: logs-apim.otel-{orgId}
 #      endpoints:
 #        - http://${ds.elastic.host}:${ds.elastic.port}
 #      security:

--- a/helm/templates/api/api-configmap.yaml
+++ b/helm/templates/api/api-configmap.yaml
@@ -167,6 +167,43 @@ data:
         {{- end }}
       {{- end }}
 
+      {{- if ne .Values.api.otelLogs.type "none" }}
+      otel-logs:
+        type: {{ .Values.api.otelLogs.type }}
+        {{- if (eq .Values.api.otelLogs.type "elasticsearch") }}
+        elasticsearch:
+          {{- with .Values.api.otelLogs.elasticsearch.endpoints }}
+          endpoints:
+            {{ toYaml . | nindent 12 | trim -}}
+          {{- end }}
+          {{- if .Values.api.otelLogs.elasticsearch.http }}
+          http:
+            {{- if .Values.api.otelLogs.elasticsearch.http.timeout }}
+            timeout: {{ .Values.api.otelLogs.elasticsearch.http.timeout }}
+            {{- end }}
+          {{- end }}
+          {{- if .Values.api.otelLogs.elasticsearch.security }}
+          security:
+            username: {{ .Values.api.otelLogs.elasticsearch.security.username }}
+            password: {{ .Values.api.otelLogs.elasticsearch.security.password }}
+          {{- end }}
+          {{- if .Values.api.otelLogs.elasticsearch.ssl }}
+          ssl:
+            keystore:
+              type: {{ .Values.api.otelLogs.elasticsearch.ssl.keystore.type }}
+              {{- if or .Values.api.otelLogs.elasticsearch.ssl.keystore.path .Values.api.otelLogs.elasticsearch.ssl.keystore.password }}
+              path: {{ .Values.api.otelLogs.elasticsearch.ssl.keystore.path }}
+              password: {{ .Values.api.otelLogs.elasticsearch.ssl.keystore.password }}
+              {{- end }}
+              {{- if or .Values.api.otelLogs.elasticsearch.ssl.keystore.certs .Values.api.otelLogs.elasticsearch.ssl.keystore.keys }}
+              certs: {{ .Values.api.otelLogs.elasticsearch.ssl.keystore.certs }}
+              keys: {{ .Values.api.otelLogs.elasticsearch.ssl.keystore.keys }}
+              {{- end }}
+          {{- end }}
+          index: {{ .Values.api.otelLogs.elasticsearch.index }}
+        {{- end }}
+      {{- end }}
+
     # Secret Manager configuration
     {{- if .Values.secrets }}
     secrets:

--- a/helm/tests/api/configmap_otel_logs_test.yaml
+++ b/helm/tests/api/configmap_otel_logs_test.yaml
@@ -1,0 +1,116 @@
+suite: Test Management API configmap for the OTel logs repository scope
+templates:
+  - "api/api-configmap.yaml"
+tests:
+  - it: Default values render no otel-logs block (type "none")
+    template: api/api-configmap.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ConfigMap
+      - notMatchRegex:
+          path: data["gravitee.yml"]
+          pattern: "otel-logs:"
+
+  - it: Type elasticsearch renders the block with endpoints and index template
+    template: api/api-configmap.yaml
+    set:
+      api:
+        otelLogs:
+          type: elasticsearch
+          elasticsearch:
+            index: logs-apim.otel-{orgId}
+            endpoints:
+              - http://es.example.com:9200
+    asserts:
+      - matchRegex:
+          path: data["gravitee.yml"]
+          pattern: "otel-logs:\\s+type: elasticsearch"
+      - matchRegex:
+          path: data["gravitee.yml"]
+          pattern: "- http://es.example.com:9200"
+      - matchRegex:
+          path: data["gravitee.yml"]
+          pattern: "index: logs-apim.otel-\\{orgId\\}"
+
+  - it: Type elasticsearch renders the security block when set
+    template: api/api-configmap.yaml
+    set:
+      api:
+        otelLogs:
+          type: elasticsearch
+          elasticsearch:
+            index: logs-apim.otel-{orgId}
+            endpoints:
+              - http://es.example.com:9200
+            security:
+              username: elastic
+              password: changeme
+    asserts:
+      - matchRegex:
+          path: data["gravitee.yml"]
+          pattern: "username: elastic"
+      - matchRegex:
+          path: data["gravitee.yml"]
+          pattern: "password: changeme"
+
+  - it: Type elasticsearch renders the SSL keystore block when set
+    template: api/api-configmap.yaml
+    set:
+      api:
+        otelLogs:
+          type: elasticsearch
+          elasticsearch:
+            index: logs-apim.otel-{orgId}
+            endpoints:
+              - https://es.example.com:9200
+            ssl:
+              keystore:
+                type: jks
+                path: /path/to/keystore.jks
+                password: kspw
+    asserts:
+      - matchRegex:
+          path: data["gravitee.yml"]
+          pattern: "type: jks"
+      - matchRegex:
+          path: data["gravitee.yml"]
+          pattern: "path: /path/to/keystore.jks"
+      - matchRegex:
+          path: data["gravitee.yml"]
+          pattern: "password: kspw"
+
+  - it: Type elasticsearch renders the http timeout when set
+    template: api/api-configmap.yaml
+    set:
+      api:
+        otelLogs:
+          type: elasticsearch
+          elasticsearch:
+            index: logs-apim.otel-{orgId}
+            endpoints:
+              - http://es.example.com:9200
+            http:
+              timeout: 30000
+    asserts:
+      - matchRegex:
+          path: data["gravitee.yml"]
+          pattern: "timeout: 30000"
+
+  - it: Type other than elasticsearch (e.g. loki) still renders the type line but skips ES-specific config
+    template: api/api-configmap.yaml
+    set:
+      api:
+        otelLogs:
+          type: loki
+    asserts:
+      # The block-level guard is `ne … "none"`, so any non-"none" type renders `otel-logs.type: <value>`
+      # without forcing it through the ES branch. A Loki-backed impl would add its own block next to the
+      # elasticsearch one — this test pins that the structure is type-agnostic, not ES-only.
+      - matchRegex:
+          path: data["gravitee.yml"]
+          pattern: "otel-logs:\\s+type: loki"
+      - notMatchRegex:
+          path: data["gravitee.yml"]
+          pattern: "otel-logs:\\s+type: loki\\s+elasticsearch:"

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -1157,6 +1157,33 @@ api:
       # http:
       #   timeout: 10000
 
+  # OpenTelemetry logs reader (backs the gamma APIM tracing resource alongside otelTraces). Reads the same
+  # data stream the OTel collector writes span events to AND the one gravitee-reporter-otel writes captured
+  # request/response payloads to. Disabled by default; set type to "elasticsearch" to wire the ES-backed
+  # OtelLogRepository. Independent from `analytics.*` and `otelTraces.*` — no fallback across scopes.
+  otelLogs:
+    type: none # or elasticsearch
+    elasticsearch:
+      # Index/data-stream template — {orgId} / {envId} are substituted (lowercased) from the caller's
+      # QueryContext at query time. Should match the data-stream name the OTel collector elasticsearch
+      # exporter (mapping.mode: otel) writes to AND the one gravitee-reporter-otel ships to.
+      index: logs-apim.otel-{orgId}
+      endpoints:
+        - http://elasticsearch:9200
+      # security:
+      #   username: elastic
+      #   password: changeme
+      # ssl:
+      #   keystore:
+      #     type: jks            # jks, pkcs12 or pem
+      #     path: /path/to/keystore.jks
+      #     password: changeme
+      #     # PEM only:
+      #     # certs: [/path/to/cert1.pem, /path/to/cert2.pem]
+      #     # keys:  [/path/to/key1.pem,  /path/to/key2.pem]
+      # http:
+      #   timeout: 10000
+
   # External Authentication settings
   #  auth:
   #    external:


### PR DESCRIPTION
## Issue

N/A — internal SPI groundwork for the OTel trace explorer initiative.

## Description

Introduces a new scope-aware repository for OTel log records (span events + gateway-captured payload logs), backed by the OTel Collector's elasticsearch exporter logs data stream. Mirrors the existing \`TracingRepository\` shape so consumers can stitch payload logs onto trace spans server-side rather than reaching across two repositories at query time.

**SPI (in \`gravitee-apim-repository\`)** — commit \`114002fb43\`
- New \`OTEL_LOGS\` scope alongside \`OTEL_TRACES\`
- \`OtelLogRepository\` interface with \`findLogs(QueryContext, OtelLogSearchCriteria)\`
- \`OtelLogSearchCriteria\` aligned with \`TraceSearchCriteria\` (traceId pin + record/resource-attribute filters + time range)
- Elasticsearch impl using the existing OTel Collector elasticsearch exporter logs data stream layout (top-level \`trace_id\` / \`span_id\`, ECS aliases for ECS-shaped queries)

**No-op fallbacks (in \`gravitee-apim-repository-noop\`)** — commit \`e890bf6db4\`
- \`NoOpOtelLogRepository\` / \`NoOpTracingRepository\` returning empty \`Single\` / \`Maybe\` so a deployment can start without a real OTel backing store by setting \`repositories.otel-logs.type=none\` / \`repositories.otel-traces.type=none\`
- Per-scope Spring \`@Configuration\` registering the bean against the SPI marker
- \`NoOpRepositoryProvider\` advertises both new scopes

**Why no-op matters**: dependent code on the consumer side (gamma APIM trace explorer, span/log stitching) needs *some* implementation in the Spring context so HK2/Spring resolves the dependency. Without the no-op, every dev environment that doesn't have OTel collector wired up fails to bootstrap.

## Additional context

- Related work coming separately:
  - Reporter side (top-level \`trace_id\` / \`span_id\` placement + \`gravitee.*\`-namespaced attributes): https://github.com/gravitee-io/gravitee-reporter-otel/pull/11
  - Logger overload it depends on: https://github.com/gravitee-io/gravitee-node/pull/563 (merged, released as 9.0.0-alpha.13)
- Consumer side (gamma APIM trace explorer + use cases) is in-flight on the same local branch and will land as separate follow-up PRs once this SPI is in master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)