### PR TITLE
feat(gateway-tracing): module-aware createTracingContext overload

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/DefaultApiReactorFactory.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/DefaultApiReactorFactory.java
@@ -425,6 +425,17 @@ public class DefaultApiReactorFactory extends AbstractReactorFactory<Api> {
     }
 
     protected TracingContext createTracingContext(final Api api, final String apiType) {
+        return createTracingContext(api, apiType, MODULE);
+    }
+
+    /**
+     * Module-aware variant for subclasses that reactor on top of this factory and emit telemetry under
+     * a different {@code gravitee.module} value (e.g. {@code aim} for the LLM proxy reactor). Kept
+     * separate from the 2-arg overload so existing call sites stay untouched while subclasses opt into
+     * the override without having to duplicate the tracer / redaction wiring (the redaction mapper is
+     * package-private and shouldn't be reached out to from subclasses in other modules).
+     */
+    protected TracingContext createTracingContext(final Api api, final String apiType, final String module) {
         boolean tracingEnabled = isApiTracingEnabled(api);
         if (tracingEnabled) {
             Tracer tracer = openTelemetryFactory.createTracer(
@@ -433,7 +444,7 @@ public class DefaultApiReactorFactory extends AbstractReactorFactory<Api> {
                 "gravitee",
                 Version.RUNTIME_VERSION.MAJOR_VERSION,
                 instrumenterTracerFactories,
-                TracerResourceAttributes.of(MODULE, api.getId(), api.getName(), apiType, api.getOrganizationId(), api.getEnvironmentId()),
+                TracerResourceAttributes.of(module, api.getId(), api.getName(), apiType, api.getOrganizationId(), api.getEnvironmentId()),
                 TracingRedactionMapper.toRedactionConfig(api)
             );
             return new TracingContext(tracer, true, isApiTracingVerboseEnabled(api));


### PR DESCRIPTION
## Issue

N/A — unblocks subclass reactor factories (LLM proxy first) from setting their own \`gravitee.module\` OTel resource-attribute value.

## Description

Splits \`DefaultApiReactorFactory.createTracingContext\` into two overloads:

- The existing **2-arg** signature \`(Api, apiType)\` stays as-is and now delegates to the new variant with \`MODULE = \"apim\"\`. Every current call site keeps working unchanged — no breaking change.
- A new **3-arg** signature \`(Api, apiType, module)\` lets subclasses emit telemetry under a different \`gravitee.module\` resource-attribute value without having to duplicate the tracer / redaction-mapper wiring. \`TracingRedactionMapper\` is package-private and isn't reachable from subclass modules, so the previous \"just override the method\" approach didn't work for subclasses living outside \`io.gravitee.gateway.reactive.handlers.api.v4\`.

## Additional context

The concrete motivation is the LLM proxy reactor in \`gravitee-reactor-llm-proxy\`. Today its \`LLMProxyApiReactorFactory\` extends \`DefaultApiReactorFactory\` but ships its records under \`gravitee.module=apim\` because the constant is private and the override path can't reach \`TracingRedactionMapper\`. With this overload it can pass \`\"aim\"\` through and downstream consumers can scope-filter logs / traces by reactor.

Companion PR on the LLM proxy side: https://github.com/gravitee-io/gravitee-reactor-llm-proxy/pull/119 (will be opened right after this one; can't merge until this one ships and a new APIM alpha is released).

Tests: existing \`DefaultApiReactorFactoryTest\` \`Create\` + \`CreateTracingContext\` suites (20 cases) still pass — the delegation keeps the 2-arg behaviour identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)