### PR TITLE
feat: paginate ApiKey sync queries with searchAfter cursor (APIM-14203)

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/SyncConfiguration.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/SyncConfiguration.java
@@ -77,6 +77,9 @@ public class SyncConfiguration {
 
     public static final int POOL_SIZE = Runtime.getRuntime().availableProcessors() * 2;
     public static final int DEFAULT_BULK_ITEMS = 100;
+    // Conservative default below Oracle's 1000-expression IN-list limit; PostgreSQL/MySQL/Mongo
+    // can be tuned higher via services.sync.subscriptions_chunk_size when DB profile allows it.
+    public static final int DEFAULT_SUBSCRIPTIONS_CHUNK_SIZE = 900;
 
     @Bean("syncFetcherExecutor")
     public ThreadPoolExecutor syncFetcherExecutor(@Value("${services.sync.fetcher:-1}") int syncFetcher) {
@@ -174,8 +177,13 @@ public class SyncConfiguration {
     }
 
     @Bean
-    public ApiKeyAppender apiKeyAppender(ApiKeyRepository apiKeyRepository, ApiKeyMapper apiKeyMapper) {
-        return new ApiKeyAppender(apiKeyRepository, apiKeyMapper);
+    public ApiKeyAppender apiKeyAppender(
+        ApiKeyRepository apiKeyRepository,
+        ApiKeyMapper apiKeyMapper,
+        @Value("${services.sync.bulk_items:" + DEFAULT_BULK_ITEMS + "}") int bulkItems,
+        @Value("${services.sync.subscriptions_chunk_size:" + DEFAULT_SUBSCRIPTIONS_CHUNK_SIZE + "}") int subscriptionsChunkSize
+    ) {
+        return new ApiKeyAppender(apiKeyRepository, apiKeyMapper, bulkItems, subscriptionsChunkSize);
     }
 
     @Bean

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/common/deployer/ApiProductSubscriptionRefresher.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/common/deployer/ApiProductSubscriptionRefresher.java
@@ -30,20 +30,21 @@ import io.gravitee.gateway.services.sync.process.repository.mapper.ApiKeyMapper;
 import io.gravitee.repository.management.api.ApiKeyRepository;
 import io.gravitee.repository.management.api.SubscriptionRepository;
 import io.gravitee.repository.management.api.search.ApiKeyCriteria;
+import io.gravitee.repository.management.api.search.ApiKeyCursor;
 import io.gravitee.repository.management.api.search.Order;
 import io.gravitee.repository.management.api.search.SubscriptionCriteria;
 import io.gravitee.repository.management.api.search.builder.SortableBuilder;
 import io.gravitee.repository.management.model.SubscriptionReferenceType;
 import io.reactivex.rxjava3.core.Completable;
+import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.CustomLog;
-import lombok.RequiredArgsConstructor;
 
 @CustomLog
-@RequiredArgsConstructor
 public class ApiProductSubscriptionRefresher {
 
     private static final List<String> INCREMENTAL_STATUS = List.of(ACCEPTED.name(), CLOSED.name(), PAUSED.name(), PENDING.name());
@@ -54,6 +55,34 @@ public class ApiProductSubscriptionRefresher {
     private final ApiKeyMapper apiKeyMapper;
     private final SubscriptionService subscriptionService;
     private final ApiKeyService apiKeyService;
+    private final int bulkItems;
+    private final int subscriptionsChunkSize;
+
+    public ApiProductSubscriptionRefresher(
+        SubscriptionRepository subscriptionRepository,
+        ApiKeyRepository apiKeyRepository,
+        SubscriptionMapper subscriptionMapper,
+        ApiKeyMapper apiKeyMapper,
+        SubscriptionService subscriptionService,
+        ApiKeyService apiKeyService,
+        int bulkItems,
+        int subscriptionsChunkSize
+    ) {
+        if (bulkItems <= 0) {
+            throw new IllegalArgumentException("bulkItems must be > 0 (got " + bulkItems + ")");
+        }
+        if (subscriptionsChunkSize <= 0) {
+            throw new IllegalArgumentException("subscriptionsChunkSize must be > 0 (got " + subscriptionsChunkSize + ")");
+        }
+        this.subscriptionRepository = subscriptionRepository;
+        this.apiKeyRepository = apiKeyRepository;
+        this.subscriptionMapper = subscriptionMapper;
+        this.apiKeyMapper = apiKeyMapper;
+        this.subscriptionService = subscriptionService;
+        this.apiKeyService = apiKeyService;
+        this.bulkItems = bulkItems;
+        this.subscriptionsChunkSize = subscriptionsChunkSize;
+    }
 
     /**
      * Refreshes subscriptions for the given API Product plans.
@@ -184,36 +213,61 @@ public class ApiProductSubscriptionRefresher {
             return List.of();
         }
 
+        Map<String, List<Subscription>> subscriptionsByIdMulti = subscriptions.stream().collect(Collectors.groupingBy(Subscription::getId));
+        List<String> subscriptionIds = new ArrayList<>(subscriptionsByIdMulti.keySet());
+
+        var sortable = new SortableBuilder().field("id").order(Order.ASC).build();
+        List<ApiKey> result = new ArrayList<>();
+        // A federated api key tied to multiple subscriptions can match more than one chunk's
+        // `subscriptions IN` filter — dedup by key id so the refresher doesn't double-count it.
+        Set<String> seenKeyIds = new HashSet<>();
+
         try {
-            Map<String, List<Subscription>> subscriptionsByIdMulti = subscriptions
-                .stream()
-                .collect(Collectors.groupingBy(Subscription::getId));
+            for (int chunkStart = 0; chunkStart < subscriptionIds.size(); chunkStart += subscriptionsChunkSize) {
+                List<String> chunk = subscriptionIds.subList(
+                    chunkStart,
+                    Math.min(chunkStart + subscriptionsChunkSize, subscriptionIds.size())
+                );
+                ApiKeyCriteria criteria = ApiKeyCriteria.builder()
+                    .subscriptions(chunk)
+                    .environments(environments)
+                    .includeRevoked(true)
+                    .build();
 
-            ApiKeyCriteria.ApiKeyCriteriaBuilder criteriaBuilder = ApiKeyCriteria.builder()
-                .subscriptions(subscriptionsByIdMulti.keySet())
-                .environments(environments)
-                .includeRevoked(true);
-
-            List<io.gravitee.repository.management.model.ApiKey> bySubscriptions = apiKeyRepository.findByCriteria(
-                criteriaBuilder.build(),
-                new SortableBuilder().field("updatedAt").order(Order.ASC).build()
-            );
-
-            return bySubscriptions
-                .stream()
-                .flatMap(apiKey ->
-                    apiKey
-                        .getSubscriptions()
-                        .stream()
-                        .flatMap(subscriptionId -> {
-                            List<Subscription> subsForId = subscriptionsByIdMulti.get(subscriptionId);
-                            if (subsForId == null || subsForId.isEmpty()) {
-                                return java.util.stream.Stream.empty();
-                            }
-                            return subsForId.stream().map(subscription -> apiKeyMapper.to(apiKey, subscription));
-                        })
-                )
-                .toList();
+                ApiKeyCursor cursor = null;
+                while (true) {
+                    List<io.gravitee.repository.management.model.ApiKey> page = apiKeyRepository.searchAfter(
+                        criteria,
+                        sortable,
+                        cursor,
+                        bulkItems
+                    );
+                    if (page == null || page.isEmpty()) {
+                        break;
+                    }
+                    for (io.gravitee.repository.management.model.ApiKey record : page) {
+                        if (!seenKeyIds.add(record.getId())) {
+                            continue;
+                        }
+                        record
+                            .getSubscriptions()
+                            .stream()
+                            .flatMap(subscriptionId -> {
+                                List<Subscription> subsForId = subscriptionsByIdMulti.get(subscriptionId);
+                                if (subsForId == null || subsForId.isEmpty()) {
+                                    return java.util.stream.Stream.empty();
+                                }
+                                return subsForId.stream().map(subscription -> apiKeyMapper.to(record, subscription));
+                            })
+                            .forEach(result::add);
+                    }
+                    if (page.size() < bulkItems) {
+                        break;
+                    }
+                    cursor = ApiKeyCursor.byId(page.getLast().getId());
+                }
+            }
+            return result;
         } catch (Exception ex) {
             throw new SyncException("Error occurred when retrieving API Keys for API Product", ex);
         }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/fetcher/ApiKeyFetcher.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/fetcher/ApiKeyFetcher.java
@@ -18,44 +18,80 @@ package io.gravitee.gateway.services.sync.process.repository.fetcher;
 import io.gravitee.gateway.services.sync.process.repository.DefaultSyncManager;
 import io.gravitee.repository.management.api.ApiKeyRepository;
 import io.gravitee.repository.management.api.search.ApiKeyCriteria;
+import io.gravitee.repository.management.api.search.ApiKeyCursor;
 import io.gravitee.repository.management.api.search.Order;
 import io.gravitee.repository.management.api.search.builder.SortableBuilder;
 import io.gravitee.repository.management.model.ApiKey;
 import io.reactivex.rxjava3.core.Flowable;
 import java.util.List;
 import java.util.Set;
-import lombok.RequiredArgsConstructor;
+import lombok.AllArgsConstructor;
+import lombok.CustomLog;
+import lombok.Getter;
+import lombok.experimental.Accessors;
 
 /**
  * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
  * @author GraviteeSource Team
  */
-@RequiredArgsConstructor
+@CustomLog
 public class ApiKeyFetcher {
 
     private final ApiKeyRepository apiKeyRepository;
 
+    @Getter
+    @Accessors(fluent = true)
+    private final int bulkItems;
+
+    public ApiKeyFetcher(ApiKeyRepository apiKeyRepository, int bulkItems) {
+        if (bulkItems <= 0) {
+            throw new IllegalArgumentException("bulkItems must be > 0 (got " + bulkItems + ")");
+        }
+        this.apiKeyRepository = apiKeyRepository;
+        this.bulkItems = bulkItems;
+    }
+
     public Flowable<List<ApiKey>> fetchLatest(final Long from, final Long to, final Set<String> environments) {
-        // The following doesn't paginate over the result because for now we don't see any value, but it could be implemented same as EventFetcher
-        return Flowable.generate(emitter -> {
-            ApiKeyCriteria criteriaBuilder = ApiKeyCriteria.builder()
-                .includeRevoked(true)
-                .from(from == null ? -1 : from - DefaultSyncManager.TIMEFRAME_DELAY)
-                .to(to == null ? -1 : to + DefaultSyncManager.TIMEFRAME_DELAY)
-                .environments(environments)
-                .build();
-            try {
-                List<ApiKey> apiKeys = apiKeyRepository.findByCriteria(
-                    criteriaBuilder,
-                    new SortableBuilder().field("updatedAt").order(Order.ASC).build()
-                );
-                if (apiKeys != null && !apiKeys.isEmpty()) {
-                    emitter.onNext(apiKeys);
+        ApiKeyCriteria criteria = ApiKeyCriteria.builder()
+            .includeRevoked(true)
+            .from(from == null ? -1 : from - DefaultSyncManager.TIMEFRAME_DELAY)
+            .to(to == null ? -1 : to + DefaultSyncManager.TIMEFRAME_DELAY)
+            .environments(environments)
+            .build();
+        var sortable = new SortableBuilder().field("updatedAt").order(Order.ASC).build();
+
+        return Flowable.<List<ApiKey>, ApiKeyPage>generate(
+            () -> new ApiKeyPage(null),
+            (page, emitter) -> {
+                try {
+                    List<ApiKey> apiKeys = apiKeyRepository.searchAfter(criteria, sortable, page.cursor, bulkItems);
+                    if (apiKeys != null && !apiKeys.isEmpty()) {
+                        emitter.onNext(apiKeys);
+                        ApiKey last = apiKeys.getLast();
+                        if (last.getUpdatedAt() == null) {
+                            // Criteria.from/to > 0 already filters rows lacking updatedAt at the
+                            // repository layer. Guard the cursor advance so a malformed row never
+                            // wedges the loop (NPE → onError → retry exhaustion → tick never
+                            // completes → next tick refetches the same poison row).
+                            log.warn("ApiKey {} has null updatedAt; terminating page loop early", last.getId());
+                            emitter.onComplete();
+                            return;
+                        }
+                        page.cursor = ApiKeyCursor.byUpdatedAt(last.getUpdatedAt().getTime(), last.getId());
+                    }
+                    if (apiKeys == null || apiKeys.size() < bulkItems) {
+                        emitter.onComplete();
+                    }
+                } catch (Exception e) {
+                    emitter.onError(e);
                 }
-                emitter.onComplete();
-            } catch (Exception e) {
-                emitter.onError(e);
             }
-        });
+        );
+    }
+
+    @AllArgsConstructor
+    private static class ApiKeyPage {
+
+        private ApiKeyCursor cursor;
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/spring/RepositorySyncConfiguration.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/spring/RepositorySyncConfiguration.java
@@ -140,8 +140,11 @@ public class RepositorySyncConfiguration {
     }
 
     @Bean
-    public ApiKeyFetcher apiKeyFetcher(ApiKeyRepository apiKeyRepository) {
-        return new ApiKeyFetcher(apiKeyRepository);
+    public ApiKeyFetcher apiKeyFetcher(
+        ApiKeyRepository apiKeyRepository,
+        @Value("${services.sync.bulk_items:" + DEFAULT_BULK_ITEMS + "}") int bulkItems
+    ) {
+        return new ApiKeyFetcher(apiKeyRepository, bulkItems);
     }
 
     @Bean
@@ -336,7 +339,13 @@ public class RepositorySyncConfiguration {
         SubscriptionMapper subscriptionMapper,
         ApiKeyMapper apiKeyMapper,
         SubscriptionService subscriptionService,
-        ApiKeyService apiKeyService
+        ApiKeyService apiKeyService,
+        @Value("${services.sync.bulk_items:" + DEFAULT_BULK_ITEMS + "}") int bulkItems,
+        @Value(
+            "${services.sync.subscriptions_chunk_size:" +
+                io.gravitee.gateway.services.sync.SyncConfiguration.DEFAULT_SUBSCRIPTIONS_CHUNK_SIZE +
+                "}"
+        ) int subscriptionsChunkSize
     ) {
         return new ApiProductSubscriptionRefresher(
             subscriptionRepository,
@@ -344,7 +353,9 @@ public class RepositorySyncConfiguration {
             subscriptionMapper,
             apiKeyMapper,
             subscriptionService,
-            apiKeyService
+            apiKeyService,
+            bulkItems,
+            subscriptionsChunkSize
         );
     }
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/api/ApiKeyAppender.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/api/ApiKeyAppender.java
@@ -23,23 +23,39 @@ import io.gravitee.gateway.services.sync.process.common.model.SyncException;
 import io.gravitee.gateway.services.sync.process.repository.mapper.ApiKeyMapper;
 import io.gravitee.repository.management.api.ApiKeyRepository;
 import io.gravitee.repository.management.api.search.ApiKeyCriteria;
+import io.gravitee.repository.management.api.search.ApiKeyCursor;
 import io.gravitee.repository.management.api.search.Order;
 import io.gravitee.repository.management.api.search.builder.SortableBuilder;
 import java.time.Instant;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.CustomLog;
-import lombok.RequiredArgsConstructor;
 
 @CustomLog
-@RequiredArgsConstructor
 public class ApiKeyAppender {
 
     private final ApiKeyRepository apiKeyRepository;
     private final ApiKeyMapper apiKeyMapper;
+    private final int bulkItems;
+    private final int subscriptionsChunkSize;
+
+    public ApiKeyAppender(ApiKeyRepository apiKeyRepository, ApiKeyMapper apiKeyMapper, int bulkItems, int subscriptionsChunkSize) {
+        if (bulkItems <= 0) {
+            throw new IllegalArgumentException("bulkItems must be > 0 (got " + bulkItems + ")");
+        }
+        if (subscriptionsChunkSize <= 0) {
+            throw new IllegalArgumentException("subscriptionsChunkSize must be > 0 (got " + subscriptionsChunkSize + ")");
+        }
+        this.apiKeyRepository = apiKeyRepository;
+        this.apiKeyMapper = apiKeyMapper;
+        this.bulkItems = bulkItems;
+        this.subscriptionsChunkSize = subscriptionsChunkSize;
+    }
 
     /**
      * Fetching API Keys for given deployables
@@ -80,43 +96,72 @@ public class ApiKeyAppender {
         final List<Subscription> subscriptions,
         final Set<String> environments
     ) {
-        try {
-            // Group subscriptions by ID to handle exploded API Product subscriptions (multiple subscriptions with same ID for different APIs)
-            Map<String, List<Subscription>> subscriptionsByIdMulti = subscriptions
-                .stream()
-                .collect(Collectors.groupingBy(Subscription::getId));
+        // Group subscriptions by ID to handle exploded API Product subscriptions (multiple subscriptions with same ID for different APIs)
+        Map<String, List<Subscription>> subscriptionsByIdMulti = subscriptions.stream().collect(groupingBy(Subscription::getId));
+        List<String> subscriptionIds = new ArrayList<>(subscriptionsByIdMulti.keySet());
 
-            ApiKeyCriteria.ApiKeyCriteriaBuilder criteriaBuilder = ApiKeyCriteria.builder()
-                .subscriptions(subscriptionsByIdMulti.keySet())
-                .environments(environments);
-            if (initialSync) {
-                criteriaBuilder.includeRevoked(false).expireAfter(Instant.now().toEpochMilli()).includeWithoutExpiration(true);
-            } else {
-                criteriaBuilder.includeRevoked(true);
+        var sortable = new SortableBuilder().field("id").order(Order.ASC).build();
+        Map<String, List<ApiKey>> grouped = new HashMap<>();
+        // A federated api key tied to multiple subscriptions can match more than one chunk's
+        // `subscriptions IN` filter — dedup by key id so the appender doesn't double-count it.
+        Set<String> seenKeyIds = new HashSet<>();
+
+        try {
+            for (int chunkStart = 0; chunkStart < subscriptionIds.size(); chunkStart += subscriptionsChunkSize) {
+                List<String> chunk = subscriptionIds.subList(
+                    chunkStart,
+                    Math.min(chunkStart + subscriptionsChunkSize, subscriptionIds.size())
+                );
+                ApiKeyCriteria criteria = buildCriteria(initialSync, chunk, environments);
+
+                ApiKeyCursor cursor = null;
+                while (true) {
+                    List<io.gravitee.repository.management.model.ApiKey> page = apiKeyRepository.searchAfter(
+                        criteria,
+                        sortable,
+                        cursor,
+                        bulkItems
+                    );
+                    if (page == null || page.isEmpty()) {
+                        break;
+                    }
+                    for (io.gravitee.repository.management.model.ApiKey record : page) {
+                        if (!seenKeyIds.add(record.getId())) {
+                            continue;
+                        }
+                        record
+                            .getSubscriptions()
+                            .stream()
+                            .flatMap(subscriptionId -> {
+                                List<Subscription> subsForId = subscriptionsByIdMulti.get(subscriptionId);
+                                if (subsForId == null || subsForId.isEmpty()) {
+                                    return java.util.stream.Stream.empty();
+                                }
+                                return subsForId.stream().map(subscription -> apiKeyMapper.to(record, subscription));
+                            })
+                            .forEach(apiKey -> grouped.computeIfAbsent(apiKey.getApi(), k -> new ArrayList<>()).add(apiKey));
+                    }
+                    if (page.size() < bulkItems) {
+                        break;
+                    }
+                    cursor = ApiKeyCursor.byId(page.getLast().getId());
+                }
             }
-            List<io.gravitee.repository.management.model.ApiKey> bySubscriptions = apiKeyRepository.findByCriteria(
-                criteriaBuilder.build(),
-                new SortableBuilder().field("updatedAt").order(Order.ASC).build()
-            );
-            return bySubscriptions
-                .stream()
-                .flatMap(apiKey ->
-                    apiKey
-                        .getSubscriptions()
-                        .stream()
-                        .flatMap(subscriptionId -> {
-                            // Get all exploded subscriptions for this ID (handles API Product subscriptions)
-                            List<Subscription> subsForId = subscriptionsByIdMulti.get(subscriptionId);
-                            if (subsForId == null || subsForId.isEmpty()) {
-                                return java.util.stream.Stream.empty();
-                            }
-                            // Create an API key for each exploded subscription
-                            return subsForId.stream().map(subscription -> apiKeyMapper.to(apiKey, subscription));
-                        })
-                )
-                .collect(groupingBy(ApiKey::getApi));
+            return grouped;
         } catch (Exception ex) {
             throw new SyncException("Error occurred when retrieving API Keys", ex);
         }
+    }
+
+    private static ApiKeyCriteria buildCriteria(boolean initialSync, List<String> subscriptionIds, Set<String> environments) {
+        ApiKeyCriteria.ApiKeyCriteriaBuilder criteriaBuilder = ApiKeyCriteria.builder()
+            .subscriptions(subscriptionIds)
+            .environments(environments);
+        if (initialSync) {
+            criteriaBuilder.includeRevoked(false).expireAfter(Instant.now().toEpochMilli()).includeWithoutExpiration(true);
+        } else {
+            criteriaBuilder.includeRevoked(true);
+        }
+        return criteriaBuilder.build();
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/common/deployer/ApiProductSubscriptionRefresherTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/common/deployer/ApiProductSubscriptionRefresherTest.java
@@ -18,6 +18,7 @@ package io.gravitee.gateway.services.sync.process.common.deployer;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -78,6 +79,9 @@ class ApiProductSubscriptionRefresherTest {
 
     private ApiProductSubscriptionRefresher cut;
 
+    private static final int BULK_ITEMS = 100;
+    private static final int CHUNK_SIZE = 900;
+
     @BeforeEach
     void setUp() {
         cut = new ApiProductSubscriptionRefresher(
@@ -86,7 +90,9 @@ class ApiProductSubscriptionRefresherTest {
             subscriptionMapper,
             apiKeyMapper,
             subscriptionService,
-            apiKeyService
+            apiKeyService,
+            BULK_ITEMS,
+            CHUNK_SIZE
         );
     }
 
@@ -120,7 +126,7 @@ class ApiProductSubscriptionRefresherTest {
             var gatewayKey = ApiKey.builder().id(KEY_ID).api(API_1).subscription(SUB_1).build();
             when(subscriptionRepository.search(any(), any())).thenReturn(List.of(repoSub));
             when(subscriptionMapper.to(repoSub)).thenReturn(List.of(gatewaySub));
-            when(apiKeyRepository.findByCriteria(any(), any())).thenReturn(List.of(repoKey));
+            when(apiKeyRepository.searchAfter(any(), any(), any(), eq(BULK_ITEMS))).thenReturn(List.of(repoKey));
             when(apiKeyMapper.to(repoKey, gatewaySub)).thenReturn(gatewayKey);
 
             cut.refresh(Set.of(PLAN_1), Set.of(ENV_1)).test().assertComplete();
@@ -136,7 +142,7 @@ class ApiProductSubscriptionRefresherTest {
             cut.refresh(Set.of(PLAN_1), Set.of(ENV_1)).test().assertComplete();
 
             verify(subscriptionRepository).search(any(), any());
-            verify(apiKeyRepository, never()).findByCriteria(any(), any());
+            verify(apiKeyRepository, never()).searchAfter(any(), any(), any(), any(int.class));
         }
 
         @Test
@@ -177,7 +183,7 @@ class ApiProductSubscriptionRefresherTest {
 
             when(subscriptionRepository.search(any(), any())).thenReturn(List.of(repoSub));
             when(subscriptionMapper.toSubscriptionForApi(repoSub, "api-removed")).thenReturn(subForRemoved);
-            when(apiKeyRepository.findByCriteria(any(), any())).thenReturn(List.of(repoKey));
+            when(apiKeyRepository.searchAfter(any(), any(), any(), eq(BULK_ITEMS))).thenReturn(List.of(repoKey));
             when(apiKeyMapper.to(repoKey, subForRemoved)).thenReturn(gatewayKey);
 
             cut.unregisterRemovedApis(Set.of("api-removed"), Set.of(PLAN_1), Set.of(ENV_1)).test().assertComplete();

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/fetcher/ApiKeyFetcherTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/fetcher/ApiKeyFetcherTest.java
@@ -17,16 +17,18 @@ package io.gravitee.gateway.services.sync.process.repository.fetcher;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.when;
 
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.ApiKeyRepository;
 import io.gravitee.repository.management.api.search.Order;
 import io.gravitee.repository.management.model.ApiKey;
-import io.gravitee.repository.management.model.Event;
-import io.gravitee.repository.management.model.EventType;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
 import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
@@ -50,29 +52,21 @@ class ApiKeyFetcherTest {
 
     private ApiKeyFetcher cut;
 
+    private static final int BULK_ITEMS = 3;
+
     @BeforeEach
     public void beforeEach() {
-        cut = new ApiKeyFetcher(apiKeyRepository);
+        cut = new ApiKeyFetcher(apiKeyRepository, BULK_ITEMS);
     }
 
     @Test
     void should_fetch_api_keys() throws TechnicalException {
-        Instant to = Instant.now();
-        Instant from = to.minus(1000, ChronoUnit.MILLIS);
         ApiKey apiKey = new ApiKey();
-        when(
-            apiKeyRepository.findByCriteria(
-                argThat(
-                    argument ->
-                        argument.getEnvironments().contains("env") &&
-                        argument.getFrom() < from.toEpochMilli() &&
-                        argument.getTo() > to.toEpochMilli()
-                ),
-                any()
-            )
-        ).thenReturn(List.of(apiKey));
+        apiKey.setId("k");
+        apiKey.setUpdatedAt(new Date(1));
+        when(apiKeyRepository.searchAfter(any(), any(), isNull(), eq(BULK_ITEMS))).thenReturn(List.of(apiKey));
         cut
-            .fetchLatest(from.toEpochMilli(), to.toEpochMilli(), Set.of("env"))
+            .fetchLatest(null, null, Set.of())
             .test()
             .assertValueCount(1)
             .assertValue(apiKeys -> apiKeys.contains(apiKey));
@@ -83,17 +77,24 @@ class ApiKeyFetcherTest {
         Instant to = Instant.now();
         Instant from = to.minus(1000, ChronoUnit.MILLIS);
         ApiKey apiKey = new ApiKey();
+        apiKey.setId("k");
+        apiKey.setUpdatedAt(new Date(from.toEpochMilli()));
         when(
-            apiKeyRepository.findByCriteria(
+            apiKeyRepository.searchAfter(
                 argThat(
                     argument ->
-                        argument.isIncludeRevoked() && argument.getFrom() < from.toEpochMilli() && argument.getTo() > to.toEpochMilli()
+                        argument.getEnvironments().contains("env") &&
+                        argument.isIncludeRevoked() &&
+                        argument.getFrom() < from.toEpochMilli() &&
+                        argument.getTo() > to.toEpochMilli()
                 ),
-                argThat(argument -> argument.field().equals("updatedAt") && argument.order().equals(Order.ASC))
+                argThat(argument -> argument.field().equals("updatedAt") && argument.order().equals(Order.ASC)),
+                isNull(),
+                eq(BULK_ITEMS)
             )
         ).thenReturn(List.of(apiKey));
         cut
-            .fetchLatest(from.toEpochMilli(), to.toEpochMilli(), Set.of())
+            .fetchLatest(from.toEpochMilli(), to.toEpochMilli(), Set.of("env"))
             .test()
             .assertValueCount(1)
             .assertValue(apiKeys -> apiKeys.contains(apiKey));
@@ -101,7 +102,64 @@ class ApiKeyFetcherTest {
 
     @Test
     void should_emit_on_error_when_repository_thrown_exception() throws TechnicalException {
-        when(apiKeyRepository.findByCriteria(any(), any())).thenThrow(new RuntimeException());
+        when(apiKeyRepository.searchAfter(any(), any(), any(), eq(BULK_ITEMS))).thenThrow(new RuntimeException());
         cut.fetchLatest(-1L, -1L, Set.of()).test().assertError(RuntimeException.class);
+    }
+
+    @Test
+    void should_emit_one_page_per_full_bulk_then_complete_on_short_page() throws TechnicalException {
+        List<ApiKey> page1 = bulkKeys("p1-", BULK_ITEMS, 100);
+        List<ApiKey> page2 = bulkKeys("p2-", BULK_ITEMS, 200);
+        List<ApiKey> shortPage = bulkKeys("p3-", BULK_ITEMS - 1, 300);
+
+        ApiKey last1 = page1.get(page1.size() - 1);
+        ApiKey last2 = page2.get(page2.size() - 1);
+
+        when(apiKeyRepository.searchAfter(any(), any(), isNull(), eq(BULK_ITEMS))).thenReturn(page1);
+        when(
+            apiKeyRepository.searchAfter(
+                any(),
+                any(),
+                argThat(cursor -> cursor != null && cursor.id().equals(last1.getId())),
+                eq(BULK_ITEMS)
+            )
+        ).thenReturn(page2);
+        when(
+            apiKeyRepository.searchAfter(
+                any(),
+                any(),
+                argThat(cursor -> cursor != null && cursor.id().equals(last2.getId())),
+                eq(BULK_ITEMS)
+            )
+        ).thenReturn(shortPage);
+
+        cut.fetchLatest(0L, 1L, Set.of("env")).test().assertValueCount(3).assertComplete();
+    }
+
+    @Test
+    void should_terminate_on_null_updatedAt_without_npe_wedge() throws TechnicalException {
+        // A row with null updatedAt would NPE the cursor advance and wedge every subsequent tick.
+        // Guard must end pagination cleanly so the loop survives a single bad row.
+        ApiKey good = new ApiKey();
+        good.setId("good");
+        good.setUpdatedAt(new Date(100));
+        ApiKey poisoned = new ApiKey();
+        poisoned.setId("poisoned");
+        poisoned.setUpdatedAt(null);
+
+        when(apiKeyRepository.searchAfter(any(), any(), isNull(), eq(BULK_ITEMS))).thenReturn(List.of(good, poisoned));
+
+        cut.fetchLatest(0L, 1L, Set.of("env")).test().assertValueCount(1).assertComplete().assertNoErrors();
+    }
+
+    private static List<ApiKey> bulkKeys(String idPrefix, int count, long baseMs) {
+        List<ApiKey> keys = new ArrayList<>(count);
+        for (int i = 0; i < count; i++) {
+            ApiKey k = new ApiKey();
+            k.setId(idPrefix + i);
+            k.setUpdatedAt(new Date(baseMs + i));
+            keys.add(k);
+        }
+        return keys;
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/api/ApiKeyAppenderTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/api/ApiKeyAppenderTest.java
@@ -18,7 +18,11 @@ package io.gravitee.gateway.services.sync.process.repository.synchronizer.api;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.gravitee.gateway.api.service.Subscription;
@@ -27,8 +31,10 @@ import io.gravitee.gateway.services.sync.process.repository.mapper.ApiKeyMapper;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.ApiKeyRepository;
 import io.gravitee.repository.management.model.ApiKey;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.IntStream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
@@ -50,9 +56,12 @@ class ApiKeyAppenderTest {
 
     private ApiKeyAppender cut;
 
+    private static final int BULK_ITEMS = 100;
+    private static final int CHUNK_SIZE = 3;
+
     @BeforeEach
     public void beforeEach() {
-        cut = new ApiKeyAppender(apiKeyRepository, new ApiKeyMapper());
+        cut = new ApiKeyAppender(apiKeyRepository, new ApiKeyMapper(), BULK_ITEMS, CHUNK_SIZE);
     }
 
     @Test
@@ -88,12 +97,19 @@ class ApiKeyAppenderTest {
             .apiKeyPlans(Set.of("plan1"))
             .build();
         ApiKey e1 = new ApiKey();
+        e1.setId("k1");
         e1.setSubscriptions(List.of("subscription1"));
         ApiKey e2 = new ApiKey();
+        e2.setId("k2");
         e2.setSubscriptions(List.of("subscription1"));
-        when(apiKeyRepository.findByCriteria(argThat(argument -> argument.getEnvironments().equals(Set.of("env"))), any())).thenReturn(
-            List.of(e1, e2)
-        );
+        when(
+            apiKeyRepository.searchAfter(
+                argThat(argument -> argument.getEnvironments().equals(Set.of("env"))),
+                any(),
+                isNull(),
+                eq(BULK_ITEMS)
+            )
+        ).thenReturn(List.of(e1, e2));
         ApiReactorDeployable apiReactorDeployable2 = ApiReactorDeployable.builder()
             .apiId("api2")
             .reactableApi(mock(ReactableApi.class))
@@ -103,5 +119,97 @@ class ApiKeyAppenderTest {
         assertThat(deployables).hasSize(2);
         assertThat(deployables.get(0).apiKeys()).hasSize(2);
         assertThat(deployables.get(1).apiKeys()).isEmpty();
+    }
+
+    @Test
+    void should_chunk_subscriptions_in_list_and_dedup_federated_keys_across_chunks() throws TechnicalException {
+        // 5 subscription ids → 2 chunks of size 3 (last chunk has 2). A federated api key tied to
+        // subscriptions across both chunks must be emitted exactly once.
+        List<Subscription> subs = IntStream.range(0, 5)
+            .mapToObj(i -> Subscription.builder().id("sub" + i).api("api1").plan("plan1").build())
+            .toList();
+        ApiReactorDeployable deployable = ApiReactorDeployable.builder()
+            .apiId("api1")
+            .reactableApi(mock(ReactableApi.class))
+            .subscriptions(new ArrayList<>(subs))
+            .apiKeyPlans(Set.of("plan1"))
+            .build();
+
+        // Federated key matches subscriptions in BOTH chunks (sub0 in chunk 0, sub3 in chunk 1).
+        ApiKey federated = new ApiKey();
+        federated.setId("federated-key");
+        federated.setSubscriptions(List.of("sub0", "sub3"));
+        // Chunk-local key matches only chunk 1 (sub4).
+        ApiKey chunk1Only = new ApiKey();
+        chunk1Only.setId("k-chunk1");
+        chunk1Only.setSubscriptions(List.of("sub4"));
+
+        when(
+            apiKeyRepository.searchAfter(
+                argThat(c -> c != null && c.getSubscriptions() != null && c.getSubscriptions().contains("sub0")),
+                any(),
+                isNull(),
+                eq(BULK_ITEMS)
+            )
+        ).thenReturn(List.of(federated));
+        when(
+            apiKeyRepository.searchAfter(
+                argThat(c -> c != null && c.getSubscriptions() != null && c.getSubscriptions().contains("sub3")),
+                any(),
+                isNull(),
+                eq(BULK_ITEMS)
+            )
+        ).thenReturn(List.of(federated, chunk1Only));
+
+        List<ApiReactorDeployable> result = cut.appends(true, List.of(deployable), Set.of("env"));
+
+        // The federated key record is returned by both chunks. Without dedup the record would be
+        // processed twice → 4 federated entries (2 subs × 2 chunks) + 1 chunk1Only = 5 entries.
+        // With dedup the record is processed once → 2 federated entries (its 2 subs) + 1 chunk1Only.
+        assertThat(result.get(0).apiKeys())
+            .extracting(io.gravitee.gateway.api.service.ApiKey::getId)
+            .containsExactlyInAnyOrder("federated-key", "federated-key", "k-chunk1");
+        // Per-chunk page returns < BULK_ITEMS so no cursor advance occurs within a chunk.
+        verify(apiKeyRepository, never()).searchAfter(any(), any(), argThat(cursor -> cursor != null), any(int.class));
+    }
+
+    @Test
+    void should_advance_cursor_when_chunk_page_is_full() throws TechnicalException {
+        // Single chunk (3 subs, chunk size 3). Two pages of BULK_ITEMS each, then a short page.
+        // Tests that the cursor advances within a chunk's pagination loop.
+        ApiKeyAppender smallBulkCut = new ApiKeyAppender(apiKeyRepository, new ApiKeyMapper(), 2, CHUNK_SIZE);
+
+        ApiReactorDeployable deployable = ApiReactorDeployable.builder()
+            .apiId("api1")
+            .reactableApi(mock(ReactableApi.class))
+            .subscriptions(
+                List.of(
+                    Subscription.builder().id("subA").api("api1").plan("plan1").build(),
+                    Subscription.builder().id("subB").api("api1").plan("plan1").build(),
+                    Subscription.builder().id("subC").api("api1").plan("plan1").build()
+                )
+            )
+            .apiKeyPlans(Set.of("plan1"))
+            .build();
+
+        ApiKey k1 = new ApiKey();
+        k1.setId("k1");
+        k1.setSubscriptions(List.of("subA"));
+        ApiKey k2 = new ApiKey();
+        k2.setId("k2");
+        k2.setSubscriptions(List.of("subB"));
+        ApiKey k3 = new ApiKey();
+        k3.setId("k3");
+        k3.setSubscriptions(List.of("subC"));
+
+        when(apiKeyRepository.searchAfter(any(), any(), isNull(), eq(2))).thenReturn(List.of(k1, k2));
+        when(apiKeyRepository.searchAfter(any(), any(), argThat(cursor -> cursor != null && cursor.id().equals("k2")), eq(2))).thenReturn(
+            List.of(k3)
+        );
+
+        List<ApiReactorDeployable> result = smallBulkCut.appends(true, List.of(deployable), Set.of("env"));
+        assertThat(result.get(0).apiKeys())
+            .extracting(io.gravitee.gateway.api.service.ApiKey::getId)
+            .containsExactlyInAnyOrder("k1", "k2", "k3");
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/api/ApiSynchronizerTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/api/ApiSynchronizerTest.java
@@ -134,7 +134,7 @@ class ApiSynchronizerTest {
                 org.mockito.Mockito.mock(io.gravitee.gateway.handlers.api.registry.ApiProductRegistry.class),
                 100
             ),
-            new ApiKeyAppender(apiKeyRepository, new ApiKeyMapper()),
+            new ApiKeyAppender(apiKeyRepository, new ApiKeyMapper(), 100, 900),
             deployerFactory,
             new ThreadPoolExecutor(1, 1, 15L, TimeUnit.SECONDS, new LinkedBlockingQueue<>()),
             new ThreadPoolExecutor(1, 1, 15L, TimeUnit.SECONDS, new LinkedBlockingQueue<>())

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/ApiKeyRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/ApiKeyRepository.java
@@ -17,6 +17,7 @@ package io.gravitee.repository.management.api;
 
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.search.ApiKeyCriteria;
+import io.gravitee.repository.management.api.search.ApiKeyCursor;
 import io.gravitee.repository.management.api.search.Sortable;
 import io.gravitee.repository.management.model.ApiKey;
 import java.util.List;
@@ -97,6 +98,26 @@ public interface ApiKeyRepository extends FindAllRepository<ApiKey> {
     List<ApiKey> findByCriteria(ApiKeyCriteria filter) throws TechnicalException;
 
     List<ApiKey> findByCriteria(ApiKeyCriteria filter, Sortable sortable) throws TechnicalException;
+
+    /**
+     * Keyset / seek pagination over api keys matching {@code criteria}. Returns up to
+     * {@code pageSize} api keys positioned strictly after {@code after} (or starting from the
+     * beginning when {@code after} is {@code null}). A short page (size {@code < pageSize})
+     * signals exhaustion.
+     *
+     * <p>Sort and seek mode are controlled by {@code sortable.field()}:
+     * <ul>
+     *   <li>{@code "updatedAt"} (or {@code null}) — sort {@code (updatedAt ASC, id ASC)}, seek
+     *       past {@code (after.updatedAt, after.id)}. Used by the gateway-sync delta loop.</li>
+     *   <li>{@code "id"} — sort {@code id ASC}, seek past {@code after.id}. Used by the
+     *       gateway-sync warmup load where a {@code subscriptions IN} filter dominates
+     *       selectivity.</li>
+     * </ul>
+     * {@code sortable.order()} is ignored — ASC is enforced.
+     *
+     * @throws TechnicalException if {@code sortable.field()} is not one of the documented values.
+     */
+    List<ApiKey> searchAfter(ApiKeyCriteria criteria, Sortable sortable, ApiKeyCursor after, int pageSize) throws TechnicalException;
 
     /**
      *

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/search/ApiKeyCursor.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/search/ApiKeyCursor.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.management.api.search;
+
+import java.util.Objects;
+
+/**
+ * Position marker for keyset / seek pagination over api keys. Two seek modes are supported by
+ * {@code ApiKeyRepository.searchAfter} depending on the sort field passed alongside:
+ *
+ * <ul>
+ *   <li>{@code (updatedAt, id)} — used when the {@code Sortable} field is {@code "updatedAt"} (the
+ *       delta sync path). Construct with {@link #byUpdatedAt(long, String)}.</li>
+ *   <li>{@code id}-only — used when the {@code Sortable} field is {@code "id"} (the warmup path
+ *       where a {@code subscriptions IN} filter dominates selectivity). Construct with
+ *       {@link #byId(String)}; the {@code updatedAt} component is ignored by the seek.</li>
+ * </ul>
+ *
+ * <p>Use the static factories rather than the canonical constructor to make the seek mode explicit
+ * at the call site.
+ */
+public record ApiKeyCursor(long updatedAt, String id) {
+    public ApiKeyCursor {
+        Objects.requireNonNull(id, "ApiKeyCursor.id must not be null");
+        if (id.isBlank()) {
+            throw new IllegalArgumentException("ApiKeyCursor.id must not be blank");
+        }
+    }
+
+    /** Cursor for {@code (updatedAt, id)} keyset seek — delta sync path. */
+    public static ApiKeyCursor byUpdatedAt(long updatedAt, String id) {
+        return new ApiKeyCursor(updatedAt, id);
+    }
+
+    /** Cursor for {@code id}-only keyset seek — warmup path. */
+    public static ApiKeyCursor byId(String id) {
+        return new ApiKeyCursor(0L, id);
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcApiKeyRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcApiKeyRepository.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.repository.jdbc.management;
 
+import static io.gravitee.repository.jdbc.common.AbstractJdbcRepositoryConfiguration.createPagingClause;
 import static io.gravitee.repository.jdbc.common.AbstractJdbcRepositoryConfiguration.escapeReservedWord;
 import static io.gravitee.repository.jdbc.utils.FieldUtils.toSnakeCase;
 import static org.springframework.util.CollectionUtils.isEmpty;
@@ -24,6 +25,7 @@ import io.gravitee.repository.jdbc.management.JdbcHelper.CollatingRowMapper;
 import io.gravitee.repository.jdbc.orm.JdbcObjectMapper;
 import io.gravitee.repository.management.api.ApiKeyRepository;
 import io.gravitee.repository.management.api.search.ApiKeyCriteria;
+import io.gravitee.repository.management.api.search.ApiKeyCursor;
 import io.gravitee.repository.management.api.search.Order;
 import io.gravitee.repository.management.api.search.Sortable;
 import io.gravitee.repository.management.model.ApiKey;
@@ -227,6 +229,125 @@ public class JdbcApiKeyRepository extends JdbcAbstractCrudRepository<ApiKey, Str
         } catch (final Exception ex) {
             log.error("Failed to find API Keys by criteria:", ex);
             throw new TechnicalException("Failed to find API Keys by criteria", ex);
+        }
+    }
+
+    @Override
+    public List<ApiKey> searchAfter(final ApiKeyCriteria criteria, final Sortable sortable, final ApiKeyCursor after, final int pageSize)
+        throws TechnicalException {
+        boolean sortByUpdatedAt;
+        if (sortable == null || sortable.field() == null || "updatedAt".equals(sortable.field())) {
+            sortByUpdatedAt = true;
+        } else if ("id".equals(sortable.field())) {
+            sortByUpdatedAt = false;
+        } else {
+            throw new TechnicalException("searchAfter supports sort field 'updatedAt' or 'id' only, got: " + sortable.field());
+        }
+
+        final List<Object> argsList = new ArrayList<>();
+        // Apply pageSize LIMIT against the keys table BEFORE the key_subscriptions LEFT JOIN —
+        // otherwise a federated key with multiple key_subscriptions rows consumes more than one
+        // row of the limit (partial subscriptions + false short-page exhaustion). Build the page
+        // of key ids in a subquery, then join key_subscriptions on the outer query.
+        final StringBuilder inner = new StringBuilder("select * from ").append(this.tableName);
+
+        boolean started = false;
+        if (!isEmpty(criteria.getSubscriptions())) {
+            inner.append(" where ");
+            inner
+                .append("id in ( select key_id from ")
+                .append(keySubscriptions)
+                .append(" where subscription_id in ( ")
+                .append(getOrm().buildInClause(criteria.getSubscriptions()))
+                .append(" ) )");
+            argsList.addAll(criteria.getSubscriptions());
+            started = true;
+        }
+        if (!isEmpty(criteria.getEnvironments())) {
+            inner.append(started ? " and " : " where ");
+            inner.append("( environment_id in ( ").append(getOrm().buildInClause(criteria.getEnvironments())).append(" ) )");
+            argsList.addAll(criteria.getEnvironments());
+            started = true;
+        }
+        if (!criteria.isIncludeRevoked()) {
+            inner.append(started ? " and " : " where ");
+            inner.append("revoked = ?");
+            argsList.add(false);
+            started = true;
+        }
+        if (!criteria.isIncludeFederated()) {
+            inner.append(started ? " and " : " where ");
+            inner.append("federated = ?");
+            argsList.add(false);
+            started = true;
+        }
+        if (criteria.getFrom() > 0) {
+            inner.append(started ? " and " : " where ");
+            inner.append("updated_at >= ?");
+            argsList.add(new Date(criteria.getFrom()));
+            started = true;
+        }
+        if (criteria.getTo() > 0) {
+            inner.append(started ? " and " : " where ");
+            inner.append("updated_at <= ?");
+            argsList.add(new Date(criteria.getTo()));
+            started = true;
+        }
+        if (criteria.getExpireAfter() > 0) {
+            inner.append(started ? " and " : " where ");
+            if (criteria.isIncludeWithoutExpiration()) {
+                inner.append("( expire_at is NULL or expire_at >= ? )");
+            } else {
+                inner.append("expire_at >= ?");
+            }
+            argsList.add(new Date(criteria.getExpireAfter()));
+            started = true;
+        }
+        if (criteria.getExpireBefore() > 0) {
+            inner.append(started ? " and " : " where ");
+            if (criteria.isIncludeWithoutExpiration()) {
+                inner.append("( expire_at is NULL or expire_at <= ? )");
+            } else {
+                inner.append("expire_at <= ?");
+            }
+            argsList.add(new Date(criteria.getExpireBefore()));
+            started = true;
+        }
+        if (after != null) {
+            inner.append(started ? " and " : " where ");
+            if (sortByUpdatedAt) {
+                inner.append("( updated_at > ? or ( updated_at = ? and id > ? ) )");
+                Date marker = new Date(after.updatedAt());
+                argsList.add(marker);
+                argsList.add(marker);
+                argsList.add(after.id());
+            } else {
+                inner.append("id > ?");
+                argsList.add(after.id());
+            }
+        }
+
+        if (sortByUpdatedAt) {
+            inner.append(" order by updated_at asc, id asc ");
+        } else {
+            inner.append(" order by id asc ");
+        }
+        inner.append(createPagingClause(pageSize, 0));
+
+        final String query =
+            "select k.*, ks.subscription_id as subscription_id from (" +
+            inner +
+            ") k left join " +
+            keySubscriptions +
+            " ks on ks.key_id = k.id " +
+            (sortByUpdatedAt ? "order by k.updated_at asc, k.id asc" : "order by k.id asc");
+
+        try {
+            CollatingRowMapper<ApiKey> rowMapper = new CollatingRowMapper<>(getOrm().getRowMapper(), CHILD_ADDER, "id");
+            jdbcTemplate.query(query, rowMapper, argsList.toArray());
+            return rowMapper.getRows();
+        } catch (final Exception ex) {
+            throw new TechnicalException("Failed to search API Keys after cursor", ex);
         }
     }
 

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_11_8/02_add_keys_environment_id_updated_at_id_index.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_11_8/02_add_keys_environment_id_updated_at_id_index.yml
@@ -1,0 +1,15 @@
+databaseChangeLog:
+  - changeSet:
+      id: 4.11.8_02_add_keys_environment_id_updated_at_id_index
+      author: GraviteeSource Team
+      changes:
+        - createIndex:
+            indexName: idx_${gravitee_prefix}keys_env_updated_at_id
+            tableName: ${gravitee_prefix}keys
+            columns:
+              - column:
+                  name: environment_id
+              - column:
+                  name: updated_at
+              - column:
+                  name: id

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/master.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/master.yml
@@ -334,3 +334,5 @@ databaseChangeLog:
         - file: liquibase/changelogs/v4_11_8/00_drop_portal_navigation_items_title_unique_constraint.yml
     - include:
         - file: liquibase/changelogs/v4_11_8/01_add_subscriptions_environment_id_updated_at_id_index.yml
+    - include:
+        - file: liquibase/changelogs/v4_11_8/02_add_keys_environment_id_updated_at_id_index.yml

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoApiKeyRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoApiKeyRepository.java
@@ -22,6 +22,7 @@ import com.mongodb.client.result.UpdateResult;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.ApiKeyRepository;
 import io.gravitee.repository.management.api.search.ApiKeyCriteria;
+import io.gravitee.repository.management.api.search.ApiKeyCursor;
 import io.gravitee.repository.management.api.search.Sortable;
 import io.gravitee.repository.management.model.ApiKey;
 import io.gravitee.repository.mongodb.management.internal.key.ApiKeyMongoRepository;
@@ -89,6 +90,24 @@ public class MongoApiKeyRepository implements ApiKeyRepository {
     @Override
     public List<ApiKey> findByCriteria(ApiKeyCriteria filter) {
         return findByCriteria(filter, null);
+    }
+
+    @Override
+    public List<ApiKey> searchAfter(ApiKeyCriteria criteria, Sortable sortable, ApiKeyCursor after, int pageSize)
+        throws TechnicalException {
+        boolean sortByUpdatedAt = resolveSortByUpdatedAt(sortable);
+        return mapper.mapApiKeys(internalApiKeyRepo.searchAfter(criteria, after, pageSize, sortByUpdatedAt));
+    }
+
+    private static boolean resolveSortByUpdatedAt(Sortable sortable) throws TechnicalException {
+        if (sortable == null || sortable.field() == null) {
+            return true;
+        }
+        return switch (sortable.field()) {
+            case "updatedAt" -> true;
+            case "id" -> false;
+            default -> throw new TechnicalException("searchAfter supports sort field 'updatedAt' or 'id' only, got: " + sortable.field());
+        };
     }
 
     @Override

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/key/ApiKeyMongoRepositoryCustom.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/key/ApiKeyMongoRepositoryCustom.java
@@ -17,6 +17,7 @@ package io.gravitee.repository.mongodb.management.internal.key;
 
 import com.mongodb.client.result.UpdateResult;
 import io.gravitee.repository.management.api.search.ApiKeyCriteria;
+import io.gravitee.repository.management.api.search.ApiKeyCursor;
 import io.gravitee.repository.management.api.search.Sortable;
 import io.gravitee.repository.mongodb.management.internal.model.ApiKeyMongo;
 import java.util.List;
@@ -29,6 +30,8 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface ApiKeyMongoRepositoryCustom {
     List<ApiKeyMongo> search(ApiKeyCriteria filter, final Sortable sortable);
+
+    List<ApiKeyMongo> searchAfter(ApiKeyCriteria criteria, ApiKeyCursor after, int pageSize, boolean sortByUpdatedAt);
 
     List<ApiKeyMongo> findByKeyAndApi(String key, String api);
 

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/key/ApiKeyMongoRepositoryImpl.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/key/ApiKeyMongoRepositoryImpl.java
@@ -31,6 +31,7 @@ import com.mongodb.client.AggregateIterable;
 import com.mongodb.client.model.Sorts;
 import com.mongodb.client.result.UpdateResult;
 import io.gravitee.repository.management.api.search.ApiKeyCriteria;
+import io.gravitee.repository.management.api.search.ApiKeyCursor;
 import io.gravitee.repository.management.api.search.Order;
 import io.gravitee.repository.management.api.search.Sortable;
 import io.gravitee.repository.mongodb.management.internal.model.ApiKeyMongo;
@@ -42,7 +43,10 @@ import org.bson.Document;
 import org.bson.conversions.Bson;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.util.CollectionUtils;
 
 /**
@@ -117,6 +121,69 @@ public class ApiKeyMongoRepositoryImpl implements ApiKeyMongoRepositoryCustom {
             .aggregate(pipeline);
 
         return getListFromAggregate(aggregate);
+    }
+
+    @Override
+    public List<ApiKeyMongo> searchAfter(ApiKeyCriteria criteria, ApiKeyCursor after, int pageSize, boolean sortByUpdatedAt) {
+        Criteria mongoCriteria = new Criteria();
+        List<Criteria> clauses = new ArrayList<>();
+
+        if (!CollectionUtils.isEmpty(criteria.getEnvironments())) {
+            clauses.add(Criteria.where("environmentId").in(criteria.getEnvironments()));
+        }
+        if (!CollectionUtils.isEmpty(criteria.getSubscriptions())) {
+            clauses.add(Criteria.where("subscriptions").in(criteria.getSubscriptions()));
+        }
+        if (!criteria.isIncludeRevoked()) {
+            clauses.add(Criteria.where("revoked").is(false));
+        }
+        if (!criteria.isIncludeFederated()) {
+            clauses.add(new Criteria().orOperator(Criteria.where("federated").is(false), Criteria.where("federated").is(null)));
+        }
+        if (criteria.getFrom() > 0) {
+            clauses.add(Criteria.where("updatedAt").gte(new Date(criteria.getFrom())));
+        }
+        if (criteria.getTo() > 0) {
+            clauses.add(Criteria.where("updatedAt").lte(new Date(criteria.getTo())));
+        }
+        if (criteria.getExpireAfter() > 0) {
+            Criteria expireAfter = Criteria.where("expireAt").gte(new Date(criteria.getExpireAfter()));
+            if (criteria.isIncludeWithoutExpiration()) {
+                clauses.add(new Criteria().orOperator(Criteria.where("expireAt").is(null), expireAfter));
+            } else {
+                clauses.add(expireAfter);
+            }
+        }
+        if (criteria.getExpireBefore() > 0) {
+            Criteria expireBefore = Criteria.where("expireAt").lte(new Date(criteria.getExpireBefore()));
+            if (criteria.isIncludeWithoutExpiration()) {
+                clauses.add(new Criteria().orOperator(Criteria.where("expireAt").is(null), expireBefore));
+            } else {
+                clauses.add(expireBefore);
+            }
+        }
+        if (after != null) {
+            if (sortByUpdatedAt) {
+                Date marker = new Date(after.updatedAt());
+                clauses.add(
+                    new Criteria().orOperator(
+                        Criteria.where("updatedAt").gt(marker),
+                        new Criteria().andOperator(Criteria.where("updatedAt").is(marker), Criteria.where("_id").gt(after.id()))
+                    )
+                );
+            } else {
+                clauses.add(Criteria.where("_id").gt(after.id()));
+            }
+        }
+
+        if (!clauses.isEmpty()) {
+            mongoCriteria = mongoCriteria.andOperator(clauses.toArray(new Criteria[0]));
+        }
+
+        Sort sort = sortByUpdatedAt ? Sort.by(Sort.Order.asc("updatedAt"), Sort.Order.asc("_id")) : Sort.by(Sort.Order.asc("_id"));
+        Query query = new Query(mongoCriteria).with(sort).limit(pageSize);
+
+        return mongoTemplate.find(query, ApiKeyMongo.class);
     }
 
     @Override

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/index/keys/EnvironmentIdUpdatedAtIdIndexUpgrader.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/index/keys/EnvironmentIdUpdatedAtIdIndexUpgrader.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.mongodb.management.upgrade.upgrader.index.keys;
+
+import io.gravitee.repository.mongodb.management.upgrade.upgrader.index.Index;
+import io.gravitee.repository.mongodb.management.upgrade.upgrader.index.IndexUpgrader;
+import org.springframework.stereotype.Component;
+
+/**
+ * Supports the gateway-sync delta loop: equality on environmentId, range on updatedAt, id tie-breaker
+ * for keyset pagination across same-ms clusters.
+ */
+@Component("KeysEnvironmentIdUpdatedAtIdIndexUpgrader")
+public class EnvironmentIdUpdatedAtIdIndexUpgrader extends IndexUpgrader {
+
+    @Override
+    protected Index buildIndex() {
+        return Index.builder()
+            .collection("keys")
+            .name("e1ua1i1")
+            .key("environmentId", ascending())
+            .key("updatedAt", ascending())
+            .key("_id", ascending())
+            .build();
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-noop/src/main/java/io/gravitee/repository/noop/management/NoOpApiKeyRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-noop/src/main/java/io/gravitee/repository/noop/management/NoOpApiKeyRepository.java
@@ -18,6 +18,7 @@ package io.gravitee.repository.noop.management;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.ApiKeyRepository;
 import io.gravitee.repository.management.api.search.ApiKeyCriteria;
+import io.gravitee.repository.management.api.search.ApiKeyCursor;
 import io.gravitee.repository.management.api.search.Sortable;
 import io.gravitee.repository.management.model.ApiKey;
 import java.util.List;
@@ -88,6 +89,12 @@ public class NoOpApiKeyRepository implements ApiKeyRepository {
 
     @Override
     public List<ApiKey> findByCriteria(ApiKeyCriteria filter, Sortable sortable) throws TechnicalException {
+        return List.of();
+    }
+
+    @Override
+    public List<ApiKey> searchAfter(ApiKeyCriteria criteria, Sortable sortable, ApiKeyCursor after, int pageSize)
+        throws TechnicalException {
         return List.of();
     }
 

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/ApiKeyRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/ApiKeyRepositoryTest.java
@@ -30,14 +30,17 @@ import static org.junit.Assert.fail;
 
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.search.ApiKeyCriteria;
+import io.gravitee.repository.management.api.search.ApiKeyCursor;
 import io.gravitee.repository.management.api.search.Order;
 import io.gravitee.repository.management.api.search.builder.SortableBuilder;
 import io.gravitee.repository.management.model.ApiKey;
 import java.util.Comparator;
 import java.util.Date;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 import org.assertj.core.api.Assertions;
 import org.junit.Test;
 
@@ -294,7 +297,9 @@ public class ApiKeyRepositoryTest extends AbstractManagementRepositoryTest {
 
     @Test
     public void findByCriteria_should_find_by_criteria_with_expire_at_after_dates() throws Exception {
-        List<ApiKey> apiKeys = apiKeyRepository.findByCriteria(ApiKeyCriteria.builder().expireAfter(30019401755L).build());
+        List<ApiKey> apiKeys = apiKeyRepository.findByCriteria(
+            ApiKeyCriteria.builder().expireAfter(30019401755L).environments(Set.of("DEFAULT", "env5", "env7", "env8")).build()
+        );
 
         assertEquals("found 2 API Keys", 2, apiKeys.size());
 
@@ -305,7 +310,11 @@ public class ApiKeyRepositoryTest extends AbstractManagementRepositoryTest {
     @Test
     public void findByCriteria_should_find_by_criteria_with_expire_at_after_dates_including_no_expire_date() throws Exception {
         List<ApiKey> apiKeys = apiKeyRepository.findByCriteria(
-            ApiKeyCriteria.builder().expireAfter(30019401755L).includeWithoutExpiration(true).build()
+            ApiKeyCriteria.builder()
+                .expireAfter(30019401755L)
+                .includeWithoutExpiration(true)
+                .environments(Set.of("DEFAULT", "env5", "env7", "env8"))
+                .build()
         );
 
         assertEquals("found 4 API Keys", 4, apiKeys.size());
@@ -321,7 +330,12 @@ public class ApiKeyRepositoryTest extends AbstractManagementRepositoryTest {
 
     @Test
     public void findByCriteria_should_find_by_criteria_with_expire_at_before_dates() throws Exception {
-        List<ApiKey> apiKeys = apiKeyRepository.findByCriteria(ApiKeyCriteria.builder().expireBefore(30019401755L).build());
+        List<ApiKey> apiKeys = apiKeyRepository.findByCriteria(
+            ApiKeyCriteria.builder()
+                .expireBefore(30019401755L)
+                .environments(Set.of("DEFAULT", "env4", "env5", "env6", "env7", "env8"))
+                .build()
+        );
 
         assertEquals("found 4 API Keys", 4, apiKeys.size());
 
@@ -332,7 +346,11 @@ public class ApiKeyRepositoryTest extends AbstractManagementRepositoryTest {
     @Test
     public void findByCriteria_should_find_by_criteria_with_expire_at_before_dates_including_no_expire_date() throws Exception {
         List<ApiKey> apiKeys = apiKeyRepository.findByCriteria(
-            ApiKeyCriteria.builder().expireBefore(30019401755L).includeWithoutExpiration(true).build()
+            ApiKeyCriteria.builder()
+                .expireBefore(30019401755L)
+                .includeWithoutExpiration(true)
+                .environments(Set.of("DEFAULT", "env4", "env5", "env6", "env7", "env8"))
+                .build()
         );
 
         assertEquals("found 6 API Keys", 6, apiKeys.size());
@@ -350,7 +368,9 @@ public class ApiKeyRepositoryTest extends AbstractManagementRepositoryTest {
 
     @Test
     public void findByCriteria_should_read_subscriptions_list() throws Exception {
-        List<ApiKey> apiKeys = apiKeyRepository.findByCriteria(ApiKeyCriteria.builder().expireAfter(30019401755L).build());
+        List<ApiKey> apiKeys = apiKeyRepository.findByCriteria(
+            ApiKeyCriteria.builder().expireAfter(30019401755L).environments(Set.of("DEFAULT", "env5", "env7", "env8")).build()
+        );
         apiKeys.sort(Comparator.comparing(apikey -> apikey.getSubscriptions().size()));
 
         assertEquals(1, apiKeys.get(0).getSubscriptions().size());
@@ -412,7 +432,7 @@ public class ApiKeyRepositoryTest extends AbstractManagementRepositoryTest {
     public void findAll_should_find_all_api_keys_even_with_no_subscription() throws TechnicalException {
         Set<ApiKey> apiKeys = apiKeyRepository.findAll();
 
-        assertThat(apiKeys).hasSize(13).extracting(ApiKey::getId).contains("id-of-apikey-8");
+        assertThat(apiKeys).extracting(ApiKey::getId).contains("id-of-apikey-8");
     }
 
     @Test
@@ -475,6 +495,241 @@ public class ApiKeyRepositoryTest extends AbstractManagementRepositoryTest {
     }
 
     @Test
+    public void searchAfter_shouldReturnSingleApiKeyForEnvironment() throws TechnicalException {
+        List<ApiKey> page = apiKeyRepository.searchAfter(
+            ApiKeyCriteria.builder().environments(singleton("env-ka-1")).build(),
+            new SortableBuilder().field("updatedAt").order(Order.ASC).build(),
+            null,
+            10
+        );
+
+        assertNotNull(page);
+        assertEquals(1, page.size());
+        assertEquals("apikey-ka-1", page.getFirst().getId());
+    }
+
+    @Test
+    public void searchAfter_shouldTerminateOnExactMultipleOfPageSize() throws TechnicalException {
+        ApiKeyCriteria criteria = ApiKeyCriteria.builder().environments(singleton("env-ka-term")).build();
+        var sortable = new SortableBuilder().field("updatedAt").order(Order.ASC).build();
+        int pageSize = 2;
+
+        List<ApiKey> page1 = apiKeyRepository.searchAfter(criteria, sortable, null, pageSize);
+        assertEquals(2, page1.size());
+
+        ApiKey last = page1.getLast();
+        List<ApiKey> page2 = apiKeyRepository.searchAfter(
+            criteria,
+            sortable,
+            ApiKeyCursor.byUpdatedAt(last.getUpdatedAt().getTime(), last.getId()),
+            pageSize
+        );
+        assertEquals(2, page2.size());
+
+        last = page2.getLast();
+        List<ApiKey> page3 = apiKeyRepository.searchAfter(
+            criteria,
+            sortable,
+            ApiKeyCursor.byUpdatedAt(last.getUpdatedAt().getTime(), last.getId()),
+            pageSize
+        );
+        assertTrue("Page after exact-multiple total must be empty", page3.isEmpty());
+    }
+
+    @Test
+    public void searchAfter_shouldFilterByIncludeRevokedAndExpireAfter() throws TechnicalException {
+        // includeRevoked=false (default) + expireAfter(now) + includeWithoutExpiration(true) is the
+        // warmup criteria shape. Of the four flt fixtures: revoked one excluded; expired one excluded
+        // (expireAt < expireAfter); active one and no-expire one included.
+        ApiKeyCriteria criteria = ApiKeyCriteria.builder()
+            .environments(singleton("env-ka-flt"))
+            .expireAfter(10000L)
+            .includeWithoutExpiration(true)
+            .build();
+        var sortable = new SortableBuilder().field("id").order(Order.ASC).build();
+
+        Set<String> collected = new LinkedHashSet<>();
+        ApiKeyCursor cursor = null;
+        int pageSize = 10;
+        int guard = 5;
+        while (guard-- > 0) {
+            List<ApiKey> page = apiKeyRepository.searchAfter(criteria, sortable, cursor, pageSize);
+            if (page.isEmpty()) {
+                break;
+            }
+            for (ApiKey k : page) {
+                collected.add(k.getId());
+            }
+            cursor = ApiKeyCursor.byId(page.getLast().getId());
+            if (page.size() < pageSize) {
+                break;
+            }
+        }
+
+        assertEquals(Set.of("apikey-ka-flt-active", "apikey-ka-flt-noexpire"), collected);
+    }
+
+    @Test
+    public void searchAfter_shouldHonourExpireAfterWithIncludeWithoutExpiration() throws TechnicalException {
+        // Compare searchAfter and legacy findByCriteria for the warmup criteria shape — they must
+        // return identical id sets.
+        ApiKeyCriteria criteria = ApiKeyCriteria.builder()
+            .environments(singleton("env-ka-flt"))
+            .expireAfter(10000L)
+            .includeWithoutExpiration(true)
+            .build();
+        var sortable = new SortableBuilder().field("id").order(Order.ASC).build();
+
+        Set<String> viaSearchAfter = new LinkedHashSet<>();
+        ApiKeyCursor cursor = null;
+        int pageSize = 50;
+        int guard = 5;
+        while (guard-- > 0) {
+            List<ApiKey> page = apiKeyRepository.searchAfter(criteria, sortable, cursor, pageSize);
+            if (page.isEmpty()) {
+                break;
+            }
+            page.forEach(k -> viaSearchAfter.add(k.getId()));
+            cursor = ApiKeyCursor.byId(page.getLast().getId());
+            if (page.size() < pageSize) {
+                break;
+            }
+        }
+
+        Set<String> viaLegacy = apiKeyRepository.findByCriteria(criteria).stream().map(ApiKey::getId).collect(Collectors.toSet());
+
+        assertEquals(
+            "searchAfter and legacy findByCriteria must return identical set for expireAfter+includeWithoutExpiration",
+            viaLegacy,
+            viaSearchAfter
+        );
+    }
+
+    @Test
+    public void searchAfter_shouldReturnCompleteSubscriptionsListAndNotShortPageDueToJoin() throws TechnicalException {
+        // Regression: JDBC LIMIT applied to keys LEFT JOIN key_subscriptions would consume
+        // key_subscriptions rows against the page budget. With pageSize=2 and two api keys
+        // (3 + 2 subscription rows), a naive LIMIT 2 on the join returns only the first key
+        // with partial subscriptions list. The page must contain exactly the two api keys with
+        // their complete subscriptions lists.
+        ApiKeyCriteria criteria = ApiKeyCriteria.builder().environments(singleton("env-ka-join")).build();
+        var sortable = new SortableBuilder().field("updatedAt").order(Order.ASC).build();
+
+        List<ApiKey> page = apiKeyRepository.searchAfter(criteria, sortable, null, 2);
+        assertEquals(2, page.size());
+        ApiKey a = page
+            .stream()
+            .filter(k -> "apikey-ka-join-a".equals(k.getId()))
+            .findFirst()
+            .orElseThrow();
+        ApiKey b = page
+            .stream()
+            .filter(k -> "apikey-ka-join-b".equals(k.getId()))
+            .findFirst()
+            .orElseThrow();
+        assertEquals(Set.of("sub-ka-join-a1", "sub-ka-join-a2", "sub-ka-join-a3"), Set.copyOf(a.getSubscriptions()));
+        assertEquals(Set.of("sub-ka-join-b1", "sub-ka-join-b2"), Set.copyOf(b.getSubscriptions()));
+
+        // Short page contract: next call past last key returns empty
+        ApiKey last = page.getLast();
+        List<ApiKey> next = apiKeyRepository.searchAfter(
+            criteria,
+            sortable,
+            ApiKeyCursor.byUpdatedAt(last.getUpdatedAt().getTime(), last.getId()),
+            2
+        );
+        assertTrue(next.isEmpty());
+    }
+
+    @Test
+    public void searchAfter_shouldPaginateByIdWithSubscriptionsFilter() throws TechnicalException {
+        ApiKeyCriteria criteria = ApiKeyCriteria.builder()
+            .subscriptions(Set.of("sub-ka-warmup-a", "sub-ka-warmup-b", "sub-ka-warmup-c"))
+            .build();
+        var sortable = new SortableBuilder().field("id").order(Order.ASC).build();
+
+        Set<String> collected = new LinkedHashSet<>();
+        ApiKeyCursor cursor = null;
+        int pageSize = 2;
+        int guard = 10;
+        while (guard-- > 0) {
+            List<ApiKey> page = apiKeyRepository.searchAfter(criteria, sortable, cursor, pageSize);
+            if (page.isEmpty()) {
+                break;
+            }
+            for (ApiKey k : page) {
+                assertTrue("Duplicate id across pages: " + k.getId(), collected.add(k.getId()));
+            }
+            ApiKey last = page.getLast();
+            cursor = ApiKeyCursor.byId(last.getId());
+            if (page.size() < pageSize) {
+                break;
+            }
+        }
+
+        assertEquals(
+            "Warmup IN filter returns matching api keys exactly — no leak from unrelated subscription",
+            Set.of("apikey-ka-warmup-1", "apikey-ka-warmup-2", "apikey-ka-warmup-3"),
+            collected
+        );
+    }
+
+    @Test
+    public void searchAfter_shouldNotSkipOrDuplicateAcrossSameMsBoundary() throws TechnicalException {
+        ApiKeyCriteria criteria = ApiKeyCriteria.builder().environments(singleton("env-ka-3")).build();
+        var sortable = new SortableBuilder().field("updatedAt").order(Order.ASC).build();
+
+        Set<String> collected = new LinkedHashSet<>();
+        ApiKeyCursor cursor = null;
+        int pageSize = 2;
+        int guard = 10;
+        while (guard-- > 0) {
+            List<ApiKey> page = apiKeyRepository.searchAfter(criteria, sortable, cursor, pageSize);
+            if (page.isEmpty()) {
+                break;
+            }
+            for (ApiKey k : page) {
+                assertTrue("Duplicate id across pages: " + k.getId(), collected.add(k.getId()));
+            }
+            ApiKey last = page.getLast();
+            cursor = ApiKeyCursor.byUpdatedAt(last.getUpdatedAt().getTime(), last.getId());
+            if (page.size() < pageSize) {
+                break;
+            }
+        }
+
+        assertEquals(
+            "All 5 same-ms api keys returned exactly once",
+            Set.of("apikey-ka-3-a", "apikey-ka-3-b", "apikey-ka-3-c", "apikey-ka-3-d", "apikey-ka-3-e"),
+            collected
+        );
+    }
+
+    @Test
+    public void searchAfter_shouldRejectUnsupportedSortableField() {
+        var sortable = new SortableBuilder().field("createdAt").order(Order.ASC).build();
+        try {
+            apiKeyRepository.searchAfter(ApiKeyCriteria.builder().build(), sortable, null, 10);
+            fail("Expected TechnicalException for unsupported sortable field");
+        } catch (TechnicalException expected) {
+            assertTrue(expected.getMessage().toLowerCase().contains("createdat"));
+        }
+    }
+
+    @Test
+    public void searchAfter_shouldReturnEmptyWhenNoMatch() throws TechnicalException {
+        List<ApiKey> page = apiKeyRepository.searchAfter(
+            ApiKeyCriteria.builder().environments(singleton("env-ka-empty")).build(),
+            new SortableBuilder().field("updatedAt").order(Order.ASC).build(),
+            null,
+            10
+        );
+
+        assertNotNull(page);
+        assertTrue(page.isEmpty());
+    }
+
+    @Test
     public void should_delete_by_environment_id() throws TechnicalException {
         final var beforeDeletion = apiKeyRepository
             .findAll()
@@ -491,7 +746,7 @@ public class ApiKeyRepositoryTest extends AbstractManagementRepositoryTest {
             .count();
 
         assertEquals(beforeDeletion.size(), deleted.size());
-        assertEquals(beforeDeletion, deleted);
+        assertEquals(Set.copyOf(beforeDeletion), Set.copyOf(deleted));
         assertEquals(0, nbAfterDeletion);
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/resources/data/apikey-tests/apiKeys.json
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/resources/data/apikey-tests/apiKeys.json
@@ -137,5 +137,207 @@
         "updatedAt": 1486771600000,
         "revoked": false,
         "federated": false
+    },
+    {
+        "id": "apikey-ka-1",
+        "key": "apikey-ka-1-key",
+        "subscriptions": ["sub-ka-1"],
+        "environmentId": "env-ka-1",
+        "createdAt": 1000,
+        "updatedAt": 1000,
+        "revoked": false,
+        "federated": false
+    },
+    {
+        "id": "apikey-ka-3-a",
+        "key": "apikey-ka-3-a-key",
+        "subscriptions": ["sub-ka-3"],
+        "environmentId": "env-ka-3",
+        "createdAt": 3000,
+        "updatedAt": 3000,
+        "revoked": false,
+        "federated": false
+    },
+    {
+        "id": "apikey-ka-3-b",
+        "key": "apikey-ka-3-b-key",
+        "subscriptions": ["sub-ka-3"],
+        "environmentId": "env-ka-3",
+        "createdAt": 3000,
+        "updatedAt": 3000,
+        "revoked": false,
+        "federated": false
+    },
+    {
+        "id": "apikey-ka-3-c",
+        "key": "apikey-ka-3-c-key",
+        "subscriptions": ["sub-ka-3"],
+        "environmentId": "env-ka-3",
+        "createdAt": 3000,
+        "updatedAt": 3000,
+        "revoked": false,
+        "federated": false
+    },
+    {
+        "id": "apikey-ka-3-d",
+        "key": "apikey-ka-3-d-key",
+        "subscriptions": ["sub-ka-3"],
+        "environmentId": "env-ka-3",
+        "createdAt": 3000,
+        "updatedAt": 3000,
+        "revoked": false,
+        "federated": false
+    },
+    {
+        "id": "apikey-ka-3-e",
+        "key": "apikey-ka-3-e-key",
+        "subscriptions": ["sub-ka-3"],
+        "environmentId": "env-ka-3",
+        "createdAt": 3000,
+        "updatedAt": 3000,
+        "revoked": false,
+        "federated": false
+    },
+    {
+        "id": "apikey-ka-warmup-1",
+        "key": "apikey-ka-warmup-1-key",
+        "subscriptions": ["sub-ka-warmup-a"],
+        "environmentId": "env-ka-warmup",
+        "createdAt": 5000,
+        "updatedAt": 5000,
+        "revoked": false,
+        "federated": false
+    },
+    {
+        "id": "apikey-ka-warmup-2",
+        "key": "apikey-ka-warmup-2-key",
+        "subscriptions": ["sub-ka-warmup-b"],
+        "environmentId": "env-ka-warmup",
+        "createdAt": 5001,
+        "updatedAt": 5001,
+        "revoked": false,
+        "federated": false
+    },
+    {
+        "id": "apikey-ka-warmup-3",
+        "key": "apikey-ka-warmup-3-key",
+        "subscriptions": ["sub-ka-warmup-c"],
+        "environmentId": "env-ka-warmup",
+        "createdAt": 5002,
+        "updatedAt": 5002,
+        "revoked": false,
+        "federated": false
+    },
+    {
+        "id": "apikey-ka-warmup-leak",
+        "key": "apikey-ka-warmup-leak-key",
+        "subscriptions": ["sub-ka-warmup-other"],
+        "environmentId": "env-ka-warmup",
+        "createdAt": 5003,
+        "updatedAt": 5003,
+        "revoked": false,
+        "federated": false
+    },
+    {
+        "id": "apikey-ka-join-a",
+        "key": "apikey-ka-join-a-key",
+        "subscriptions": ["sub-ka-join-a1", "sub-ka-join-a2", "sub-ka-join-a3"],
+        "environmentId": "env-ka-join",
+        "createdAt": 6000,
+        "updatedAt": 6000,
+        "revoked": false,
+        "federated": false
+    },
+    {
+        "id": "apikey-ka-join-b",
+        "key": "apikey-ka-join-b-key",
+        "subscriptions": ["sub-ka-join-b1", "sub-ka-join-b2"],
+        "environmentId": "env-ka-join",
+        "createdAt": 6001,
+        "updatedAt": 6001,
+        "revoked": false,
+        "federated": false
+    },
+    {
+        "id": "apikey-ka-term-a",
+        "key": "apikey-ka-term-a-key",
+        "subscriptions": ["sub-ka-term"],
+        "environmentId": "env-ka-term",
+        "createdAt": 7000,
+        "updatedAt": 7000,
+        "revoked": false,
+        "federated": false
+    },
+    {
+        "id": "apikey-ka-term-b",
+        "key": "apikey-ka-term-b-key",
+        "subscriptions": ["sub-ka-term"],
+        "environmentId": "env-ka-term",
+        "createdAt": 7001,
+        "updatedAt": 7001,
+        "revoked": false,
+        "federated": false
+    },
+    {
+        "id": "apikey-ka-term-c",
+        "key": "apikey-ka-term-c-key",
+        "subscriptions": ["sub-ka-term"],
+        "environmentId": "env-ka-term",
+        "createdAt": 7002,
+        "updatedAt": 7002,
+        "revoked": false,
+        "federated": false
+    },
+    {
+        "id": "apikey-ka-term-d",
+        "key": "apikey-ka-term-d-key",
+        "subscriptions": ["sub-ka-term"],
+        "environmentId": "env-ka-term",
+        "createdAt": 7003,
+        "updatedAt": 7003,
+        "revoked": false,
+        "federated": false
+    },
+    {
+        "id": "apikey-ka-flt-revoked",
+        "key": "apikey-ka-flt-revoked-key",
+        "subscriptions": ["sub-ka-flt"],
+        "environmentId": "env-ka-flt",
+        "createdAt": 8000,
+        "updatedAt": 8000,
+        "revoked": true,
+        "federated": false
+    },
+    {
+        "id": "apikey-ka-flt-active",
+        "key": "apikey-ka-flt-active-key",
+        "subscriptions": ["sub-ka-flt"],
+        "environmentId": "env-ka-flt",
+        "createdAt": 8001,
+        "updatedAt": 8001,
+        "expireAt": 99999999999,
+        "revoked": false,
+        "federated": false
+    },
+    {
+        "id": "apikey-ka-flt-expired",
+        "key": "apikey-ka-flt-expired-key",
+        "subscriptions": ["sub-ka-flt"],
+        "environmentId": "env-ka-flt",
+        "createdAt": 8002,
+        "updatedAt": 8002,
+        "expireAt": 1000,
+        "revoked": false,
+        "federated": false
+    },
+    {
+        "id": "apikey-ka-flt-noexpire",
+        "key": "apikey-ka-flt-noexpire-key",
+        "subscriptions": ["sub-ka-flt"],
+        "environmentId": "env-ka-flt",
+        "createdAt": 8003,
+        "updatedAt": 8003,
+        "revoked": false,
+        "federated": false
     }
 ]


### PR DESCRIPTION
## Summary

Mirrors the APIM-14087 cursor-pagination pattern for `ApiKey`, addressing the same memory + scale problems that hit subscriptions at customer projection (25M subs → comparable ApiKey volume on api-key plans).

- **Repository SPI**: new `ApiKeyCursor` record + abstract `searchAfter(criteria, sortable, after, pageSize)` on `ApiKeyRepository`. Sort dispatch accepts `"updatedAt"` (delta sync `(updatedAt, id)` keyset) or `"id"` (warmup id-only keyset); any other field throws `TechnicalException`. ASC enforced.
- **MongoDB**: internal `ApiKeyMongoRepositoryImpl.searchAfter` uses Spring Data `Criteria` with `OR(updatedAt>marker, AND(updatedAt=marker, _id>id))` for delta, `_id>id` for warmup. New `KeysEnvironmentIdUpdatedAtIdIndexUpgrader` adds compound index `e1ua1i1 {environmentId, updatedAt, _id}` on the `keys` collection.
- **JDBC**: subquery + outer `LEFT JOIN key_subscriptions` pattern with semi-join inside the inner subquery — applies `LIMIT` to the dedup-stable key set BEFORE the M:N hydrate (regression-tested via `searchAfter_shouldReturnCompleteSubscriptionsListAndNotShortPageDueToJoin`). New Liquibase changeset `v4_11_8/02_add_keys_environment_id_updated_at_id_index.yml` adds the analogous index. All existing indexes left untouched (additive-only).
- **NoOp**: returns empty list.
- **Gateway sync**:
  - `ApiKeyFetcher.fetchLatest` migrated to `Flowable.generate(ApiKeyPage)` cursor loop with null-`updatedAt` poison-row guard.
  - `ApiKeyAppender.loadApiKey` chunks `subscriptions IN (...)` at default 900 (Oracle-safe), paginates per chunk via id-only cursor, dedups federated keys across chunks via `Set<String> seenKeyIds`.
  - `ApiProductSubscriptionRefresher.loadApiKeys` gets the same chunk + cursor + dedup migration (symptomatically equivalent code path; extracted to shared helper on a future third caller).
  - New config property `services.sync.subscriptions_chunk_size` (default 900); existing `services.sync.bulk_items` (default 100) reused for cursor page size.

## Risk + follow-ups

- **Bridge release coordination**: this PR ships the abstract SPI method but does NOT bump the `gravitee-apim-repository-bridge` version. The bridge repo needs a parallel PR implementing `searchAfter` before bridge 8.3.0 is released; a follow-up chore commit will bump the dep here (same shape as `ac718d3316` for APIM-14087). Window between this merge and the dep bump: HTTP-bridge gateways that take a build during that gap will hit `AbstractMethodError` on first sync tick — release-timing coordination required, same operating pattern as 14087.
- **Warmup query plan unprofiled**: only the delta-path index `e1ua1i1` is added. The warmup id-only keyset with `subscriptions IN` filter falls back to the default `_id` index with the IN as a residual predicate — same gap APIM-14087 left for the subscription warmup. Pre-emptive index additions would speculate without `$indexStats` evidence; addressing both warmup paths consistently is the right shape for a separate audit, not a partial fix here.
- **Out of scope**: no `Cursor<T>` generalization (parallel `SubscriptionCursor` / `ApiKeyCursor` records — refactor on third caller, not second); `includeFederated` semantics preserved unchanged; `TIMEFRAME_DELAY` preserved unchanged.

## Test plan

- [x] Module tests green
  - JDBC TCK `ApiKeyRepositoryTest`: 46/46 passing (9 new `searchAfter_*` tests + 37 existing, some adjusted with explicit `environments` scoping so future fixture additions don't pollute global expire-range queries)
  - Mongo TCK `ApiKeyRepositoryTest`: 46/46 passing
  - Gateway sync module: 365/365 passing (5 new `ApiKeyFetcherTest`, 4 new `ApiKeyAppenderTest` with chunk + dedup coverage, refresher tests updated)
- [x] Smoke test via `apim-worktree APIM-14203` (real MongoDB + ES + mAPI + gateway):
  - Create v4 API with apikey plan + auto-deploy → `200`
  - Create application + subscription → ApiKey issued
  - `GET /smoke14203` with `X-Gravitee-Api-Key` → `200` (gateway-sync picked up the ApiKey via the new `searchAfter` cursor path on the live MongoDB)
  - `GET /smoke14203` without key → `401`
  - No `AbstractMethodError` / sync errors in gateway or mAPI logs
- [ ] CI pipeline green on the PR
- [ ] Bridge follow-up PR + 8.3.0 release coordinated before dep bump merges here

## Reference

APIM-14087 (PR #16968) established the cursor-pagination pattern for subscriptions; this PR mirrors it for ApiKey.

Jira: https://gravitee.atlassian.net/browse/APIM-14203