### PR TITLE
chore(deps): bump gravitee-node version 7.26.4

### DIFF
--- a/helm/tests/api/deployment_federation_test.yaml
+++ b/helm/tests/api/deployment_federation_test.yaml
@@ -37,7 +37,7 @@ tests:
             - command:
                 - sh
                 - -c
-                - mkdir -p /tmp/plugins && cd /tmp/plugins && ( rm  gravitee-node-cache-plugin-hazelcast-7.26.3.zip  2>/dev/null || true ) && wget https://download.gravitee.io/plugins/node-cache/gravitee-node-cache-plugin-hazelcast/gravitee-node-cache-plugin-hazelcast-7.26.3.zip && ( rm  gravitee-node-cluster-plugin-hazelcast-7.26.3.zip  2>/dev/null || true ) && wget https://download.gravitee.io/plugins/node-cluster/gravitee-node-cluster-plugin-hazelcast/gravitee-node-cluster-plugin-hazelcast-7.26.3.zip
+                - mkdir -p /tmp/plugins && cd /tmp/plugins && ( rm  gravitee-node-cache-plugin-hazelcast-7.26.4.zip  2>/dev/null || true ) && wget https://download.gravitee.io/plugins/node-cache/gravitee-node-cache-plugin-hazelcast/gravitee-node-cache-plugin-hazelcast-7.26.4.zip && ( rm  gravitee-node-cluster-plugin-hazelcast-7.26.4.zip  2>/dev/null || true ) && wget https://download.gravitee.io/plugins/node-cluster/gravitee-node-cluster-plugin-hazelcast/gravitee-node-cluster-plugin-hazelcast-7.26.4.zip
               env: [ ]
               image: alpine:latest
               imagePullPolicy: Always

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -473,8 +473,8 @@ cloud:
 
 cluster:
   plugins:
-    - https://download.gravitee.io/plugins/node-cache/gravitee-node-cache-plugin-hazelcast/gravitee-node-cache-plugin-hazelcast-7.26.3.zip
-    - https://download.gravitee.io/plugins/node-cluster/gravitee-node-cluster-plugin-hazelcast/gravitee-node-cluster-plugin-hazelcast-7.26.3.zip
+    - https://download.gravitee.io/plugins/node-cache/gravitee-node-cache-plugin-hazelcast/gravitee-node-cache-plugin-hazelcast-7.26.4.zip
+    - https://download.gravitee.io/plugins/node-cluster/gravitee-node-cluster-plugin-hazelcast/gravitee-node-cluster-plugin-hazelcast-7.26.4.zip
 
 api:
   enabled: true

--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
         <gravitee-integration-api.version>5.1.0</gravitee-integration-api.version>
         <gravitee-json-validation.version>2.2.0</gravitee-json-validation.version>
         <gravitee-kubernetes.version>3.7.1</gravitee-kubernetes.version>
-        <gravitee-node.version>7.26.3</gravitee-node.version>
+        <gravitee-node.version>7.26.4</gravitee-node.version>
         <gravitee-notifier-api.version>1.4.3</gravitee-notifier-api.version>
         <gravitee-platform-repository-api.version>1.4.0</gravitee-platform-repository-api.version>
         <gravitee-plugin.version>4.11.1</gravitee-plugin.version>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-13559

## Description

Bumps `gravitee-node` from `7.26.3` to `7.26.4` on `4.10.x` to pick up the [APIM-13559](https://gravitee.atlassian.net/browse/APIM-13559) fix — Vert.x Micrometer metrics now honour user-configured Prometheus labels (e.g. `http_path`) instead of being silently overwritten by the defaults.

## Changes

- `pom.xml`: `gravitee-node.version` → `7.26.4`
- `helm/values.yaml`: Hazelcast cache + cluster plugin URLs → `7.26.4`
- `helm/tests/api/deployment_federation_test.yaml`: expected plugin URLs → `7.26.4`

## Additional context

The first iteration of this PR bumped to `8.0.5`, which was [flagged on review](https://github.com/gravitee-io/gravitee-api-management/pull/17122#discussion_r3303998058) as an unexpected major-version jump for a maintenance branch. The fix was backported to the `7.26.x` line ([gravitee-node#566](https://github.com/gravitee-io/gravitee-node/pull/566)) and released as `7.26.4`, keeping `4.10.x` on its existing `7.26.x` minor line.

[APIM-13559]: https://gravitee.atlassian.net/browse/APIM-13559?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ