### PR TITLE
feat(gamma-platform-ui): applications-> overview, notifications, user permissions

### DIFF
--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/config/applicationDetailNavigation.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/config/applicationDetailNavigation.spec.ts
@@ -63,14 +63,14 @@ describe('applicationDetailNavigation permissions', () => {
         expect(getFirstAccessibleApplicationDetailPath(APPLICATION_NAV_GROUPS, hasDefinitionRead)).toBe('overview');
     });
 
-    it('returns first accessible implemented path (skips overview placeholder)', () => {
+    it('returns first accessible implemented path', () => {
         expect(
             getFirstAccessibleImplementedApplicationDetailPath(
                 APPLICATION_NAV_GROUPS,
                 APPLICATION_IMPLEMENTED_DETAIL_PATHS,
                 hasDefinitionRead,
             ),
-        ).toBe('general');
+        ).toBe('overview');
         expect(
             getFirstAccessibleImplementedApplicationDetailPath(APPLICATION_NAV_GROUPS, APPLICATION_IMPLEMENTED_DETAIL_PATHS, hasMemberRead),
         ).toBe('user-permissions');
@@ -88,7 +88,7 @@ describe('applicationDetailNavigation permissions', () => {
     });
 
     it('resolveApplicationDetailLandingPath prefers implemented tabs then any permitted tab', () => {
-        expect(resolveApplicationDetailLandingPath(hasDefinitionRead)).toBe('general');
+        expect(resolveApplicationDetailLandingPath(hasDefinitionRead)).toBe('overview');
         expect(resolveApplicationDetailLandingPath(hasMemberRead)).toBe('user-permissions');
         expect(resolveApplicationDetailLandingPath(hasNotificationRead)).toBe('notifications');
         expect(resolveApplicationDetailLandingPath(() => false)).toBeNull();

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/config/applicationDetailNavigation.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/config/applicationDetailNavigation.spec.ts
@@ -38,7 +38,6 @@ describe('normalizeCrudMapRecord (application permissions)', () => {
 describe('applicationDetailNavigation permissions', () => {
     const hasDefinitionRead = (permissions: string[]) => permissions.includes('application-definition-r');
     const hasMemberRead = (permissions: string[]) => permissions.includes('application-member-r');
-    const hasNotificationRead = (permissions: string[]) => permissions.includes('application-notification-r');
 
     it('maps general tab to application-definition-r', () => {
         expect(getApplicationDetailTabPermissions('general')).toEqual(['application-definition-r']);
@@ -46,10 +45,6 @@ describe('applicationDetailNavigation permissions', () => {
 
     it('maps subscriptions tab to application-subscription-r', () => {
         expect(getApplicationDetailTabPermissions('subscriptions')).toEqual(['application-subscription-r']);
-    });
-
-    it('maps notification settings tab to console notification permissions', () => {
-        expect(getApplicationDetailTabPermissions('notifications')).toEqual(['application-notification-r', 'application-alert-r']);
     });
 
     it('filters nav groups by permission', () => {
@@ -74,13 +69,6 @@ describe('applicationDetailNavigation permissions', () => {
         expect(
             getFirstAccessibleImplementedApplicationDetailPath(APPLICATION_NAV_GROUPS, APPLICATION_IMPLEMENTED_DETAIL_PATHS, hasMemberRead),
         ).toBe('user-permissions');
-        expect(
-            getFirstAccessibleImplementedApplicationDetailPath(
-                APPLICATION_NAV_GROUPS,
-                APPLICATION_IMPLEMENTED_DETAIL_PATHS,
-                hasNotificationRead,
-            ),
-        ).toBe('notifications');
     });
 
     it('returns null when user has no tab permissions', () => {
@@ -90,7 +78,6 @@ describe('applicationDetailNavigation permissions', () => {
     it('resolveApplicationDetailLandingPath prefers implemented tabs then any permitted tab', () => {
         expect(resolveApplicationDetailLandingPath(hasDefinitionRead)).toBe('overview');
         expect(resolveApplicationDetailLandingPath(hasMemberRead)).toBe('user-permissions');
-        expect(resolveApplicationDetailLandingPath(hasNotificationRead)).toBe('notifications');
         expect(resolveApplicationDetailLandingPath(() => false)).toBeNull();
     });
 });

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/config/applicationDetailNavigation.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/config/applicationDetailNavigation.spec.ts
@@ -38,6 +38,7 @@ describe('normalizeCrudMapRecord (application permissions)', () => {
 describe('applicationDetailNavigation permissions', () => {
     const hasDefinitionRead = (permissions: string[]) => permissions.includes('application-definition-r');
     const hasMemberRead = (permissions: string[]) => permissions.includes('application-member-r');
+    const hasNotificationRead = (permissions: string[]) => permissions.includes('application-notification-r');
 
     it('maps general tab to application-definition-r', () => {
         expect(getApplicationDetailTabPermissions('general')).toEqual(['application-definition-r']);
@@ -45,6 +46,10 @@ describe('applicationDetailNavigation permissions', () => {
 
     it('maps subscriptions tab to application-subscription-r', () => {
         expect(getApplicationDetailTabPermissions('subscriptions')).toEqual(['application-subscription-r']);
+    });
+
+    it('maps notification settings tab to console notification permissions', () => {
+        expect(getApplicationDetailTabPermissions('notifications')).toEqual(['application-notification-r', 'application-alert-r']);
     });
 
     it('filters nav groups by permission', () => {
@@ -69,6 +74,13 @@ describe('applicationDetailNavigation permissions', () => {
         expect(
             getFirstAccessibleImplementedApplicationDetailPath(APPLICATION_NAV_GROUPS, APPLICATION_IMPLEMENTED_DETAIL_PATHS, hasMemberRead),
         ).toBe('user-permissions');
+        expect(
+            getFirstAccessibleImplementedApplicationDetailPath(
+                APPLICATION_NAV_GROUPS,
+                APPLICATION_IMPLEMENTED_DETAIL_PATHS,
+                hasNotificationRead,
+            ),
+        ).toBe('notifications');
     });
 
     it('returns null when user has no tab permissions', () => {
@@ -78,6 +90,7 @@ describe('applicationDetailNavigation permissions', () => {
     it('resolveApplicationDetailLandingPath prefers implemented tabs then any permitted tab', () => {
         expect(resolveApplicationDetailLandingPath(hasDefinitionRead)).toBe('general');
         expect(resolveApplicationDetailLandingPath(hasMemberRead)).toBe('user-permissions');
+        expect(resolveApplicationDetailLandingPath(hasNotificationRead)).toBe('notifications');
         expect(resolveApplicationDetailLandingPath(() => false)).toBeNull();
     });
 });

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/config/applicationDetailNavigation.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/config/applicationDetailNavigation.spec.ts
@@ -68,7 +68,7 @@ describe('applicationDetailNavigation permissions', () => {
         ).toBe('general');
         expect(
             getFirstAccessibleImplementedApplicationDetailPath(APPLICATION_NAV_GROUPS, APPLICATION_IMPLEMENTED_DETAIL_PATHS, hasMemberRead),
-        ).toBeNull();
+        ).toBe('user-permissions');
     });
 
     it('returns null when user has no tab permissions', () => {

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/config/applicationDetailNavigation.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/config/applicationDetailNavigation.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { LayoutDashboardIcon, PlugIcon, ShieldCheckIcon, SlidersHorizontalIcon } from '@gravitee/graphene-core/icons';
+import { BellIcon, LayoutDashboardIcon, PlugIcon, ShieldCheckIcon, SlidersHorizontalIcon } from '@gravitee/graphene-core/icons';
 import type { ComponentType } from 'react';
 
 import { APPLICATION_IMPLEMENTED_DETAIL_PATHS } from './applicationDetailPages';
@@ -47,6 +47,17 @@ export const APPLICATION_NAV_GROUPS: ApplicationDetailNavGroup[] = [
     {
         label: 'Subscriptions',
         items: [{ path: 'subscriptions', label: 'Subscriptions', icon: PlugIcon, permissions: ['application-subscription-r'] }],
+    },
+    {
+        label: 'Settings',
+        items: [
+            {
+                path: 'notifications',
+                label: 'Notification settings',
+                icon: BellIcon,
+                permissions: ['application-notification-r', 'application-alert-r'],
+            },
+        ],
     },
 ];
 

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/config/applicationDetailNavigation.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/config/applicationDetailNavigation.ts
@@ -92,7 +92,7 @@ export function getFirstAccessibleApplicationDetailPath(
     return null;
 }
 
-/** First permission-visible tab that has a real page (skips placeholder-only routes such as overview). */
+/** First permission-visible tab that has a real page (skips placeholder-only routes). */
 export function getFirstAccessibleImplementedApplicationDetailPath(
     groups: ApplicationDetailNavGroup[],
     implementedPaths: Set<string>,

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/config/applicationDetailPages.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/config/applicationDetailPages.tsx
@@ -17,6 +17,7 @@ import type { ComponentType } from 'react';
 
 import { ApplicationDetailPlaceholderPage } from '../features/applications/components/detail';
 import { ApplicationDetailGeneralPage } from '../pages/ApplicationDetailGeneralPage';
+import { ApplicationDetailOverviewPage } from '../pages/ApplicationDetailOverviewPage';
 import { ApplicationDetailSubscriptionsPage } from '../pages/ApplicationDetailSubscriptionsPage';
 import { ApplicationNotificationSettingsPage } from '../pages/ApplicationNotificationSettingsPage';
 import { ApplicationUserPermissionsPage } from '../pages/ApplicationUserPermissionsPage';
@@ -25,6 +26,7 @@ import { ApplicationUserPermissionsPage } from '../pages/ApplicationUserPermissi
 export const APPLICATION_DETAIL_PAGES = {
     general: ApplicationDetailGeneralPage,
     notifications: ApplicationNotificationSettingsPage,
+    overview: ApplicationDetailOverviewPage,
     'user-permissions': ApplicationUserPermissionsPage,
     subscriptions: ApplicationDetailSubscriptionsPage,
 } as const satisfies Record<string, ComponentType>;

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/config/applicationDetailPages.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/config/applicationDetailPages.tsx
@@ -18,11 +18,13 @@ import type { ComponentType } from 'react';
 import { ApplicationDetailPlaceholderPage } from '../features/applications/components/detail';
 import { ApplicationDetailGeneralPage } from '../pages/ApplicationDetailGeneralPage';
 import { ApplicationDetailSubscriptionsPage } from '../pages/ApplicationDetailSubscriptionsPage';
+import { ApplicationNotificationSettingsPage } from '../pages/ApplicationNotificationSettingsPage';
 import { ApplicationUserPermissionsPage } from '../pages/ApplicationUserPermissionsPage';
 
 /** Tab paths with a dedicated page implementation (keys drive routing and landing redirect). */
 export const APPLICATION_DETAIL_PAGES = {
     general: ApplicationDetailGeneralPage,
+    notifications: ApplicationNotificationSettingsPage,
     'user-permissions': ApplicationUserPermissionsPage,
     subscriptions: ApplicationDetailSubscriptionsPage,
 } as const satisfies Record<string, ComponentType>;

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/config/applicationDetailPages.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/config/applicationDetailPages.tsx
@@ -18,10 +18,12 @@ import type { ComponentType } from 'react';
 import { ApplicationDetailPlaceholderPage } from '../features/applications/components/detail';
 import { ApplicationDetailGeneralPage } from '../pages/ApplicationDetailGeneralPage';
 import { ApplicationDetailSubscriptionsPage } from '../pages/ApplicationDetailSubscriptionsPage';
+import { ApplicationUserPermissionsPage } from '../pages/ApplicationUserPermissionsPage';
 
 /** Tab paths with a dedicated page implementation (keys drive routing and landing redirect). */
 export const APPLICATION_DETAIL_PAGES = {
     general: ApplicationDetailGeneralPage,
+    'user-permissions': ApplicationUserPermissionsPage,
     subscriptions: ApplicationDetailSubscriptionsPage,
 } as const satisfies Record<string, ComponentType>;
 

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/list/ApplicationListTable.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/list/ApplicationListTable.tsx
@@ -81,7 +81,7 @@ function ApplicationActionsMenu({ applicationId, onNavigate }: { applicationId: 
                     <MoreHorizontalIcon className="size-4" aria-hidden />
                 </Button>
             </DropdownMenuTrigger>
-            <DropdownMenuContent align="end" className="w-auto min-w-[12rem]" onClick={event => event.stopPropagation()}>
+            <DropdownMenuContent align="end" className="w-auto" style={{ minWidth: '12rem' }} onClick={event => event.stopPropagation()}>
                 <DropdownMenuItem className="gap-2" onSelect={navigateTo(`${applicationId}/general`)}>
                     <ExternalLinkIcon className="size-4" aria-hidden />
                     View Details

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/metadata/ApplicationMetadataSection.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/metadata/ApplicationMetadataSection.tsx
@@ -1,0 +1,237 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+    Alert,
+    AlertDescription,
+    Button,
+    Card,
+    CardContent,
+    CardDescription,
+    CardHeader,
+    CardTitle,
+    Input,
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from '@gravitee/graphene-core';
+import { PlusIcon } from '@gravitee/graphene-core/icons';
+import { type FormEvent, useMemo, useState } from 'react';
+
+import { DeleteMetadataDialog } from './DeleteMetadataDialog';
+import { EditMetadataDialog } from './EditMetadataDialog';
+import { METADATA_FORMATS } from './metadataConstants';
+import { deriveMetadataKey } from './metadataHelpers';
+import { MetadataTable } from './MetadataTable';
+import { MetadataValueField } from './MetadataValueField';
+import type {
+    ApplicationMetadata,
+    ApplicationMetadataFormat,
+    NewApplicationMetadata,
+    UpdateApplicationMetadata,
+} from '../../types/applicationNotification';
+import { RequiredLabel } from '../notification-settings/RequiredLabel';
+
+export function ApplicationMetadataSection({
+    metadata,
+    isLoading,
+    isError,
+    canCreate,
+    canUpdate,
+    canDelete,
+    isCreating,
+    isUpdating,
+    isDeleting,
+    mutationErrorMessage,
+    onCreate,
+    onUpdate,
+    onDelete,
+}: Readonly<{
+    metadata: ApplicationMetadata[];
+    isLoading: boolean;
+    isError: boolean;
+    canCreate: boolean;
+    canUpdate: boolean;
+    canDelete: boolean;
+    isCreating: boolean;
+    isUpdating: boolean;
+    isDeleting: boolean;
+    mutationErrorMessage: string | null;
+    onCreate: (payload: NewApplicationMetadata) => Promise<void>;
+    onUpdate: (payload: UpdateApplicationMetadata) => Promise<void>;
+    onDelete: (metadataKey: string) => Promise<void>;
+}>) {
+    const [metadataName, setMetadataName] = useState('');
+    const [metadataFormat, setMetadataFormat] = useState<ApplicationMetadataFormat>('STRING');
+    const [metadataValue, setMetadataValue] = useState('');
+    const [metadataToEdit, setMetadataToEdit] = useState<ApplicationMetadata | null>(null);
+    const [metadataToDelete, setMetadataToDelete] = useState<ApplicationMetadata | null>(null);
+
+    const metadataKey = useMemo(() => deriveMetadataKey(metadataName), [metadataName]);
+    const canSubmitMetadata =
+        canCreate && metadataKey.length > 0 && metadataName.trim().length > 0 && metadataFormat.length > 0 && metadataValue.length > 0;
+
+    async function handleAddMetadata(event: FormEvent<HTMLFormElement>) {
+        event.preventDefault();
+        if (!canSubmitMetadata) {
+            return;
+        }
+        try {
+            await onCreate({ name: metadataName.trim(), format: metadataFormat, value: metadataValue });
+            setMetadataName('');
+            setMetadataFormat('STRING');
+            setMetadataValue('');
+        } catch {
+            // Error surfaced via mutationErrorMessage from the page
+        }
+    }
+
+    async function handleDeleteMetadataConfirm() {
+        if (!metadataToDelete) {
+            return;
+        }
+        try {
+            await onDelete(metadataToDelete.key);
+            setMetadataToDelete(null);
+        } catch {
+            // Error surfaced via mutationErrorMessage from the page
+        }
+    }
+
+    async function handleUpdateMetadata(updatedMetadata: UpdateApplicationMetadata) {
+        try {
+            await onUpdate(updatedMetadata);
+            setMetadataToEdit(null);
+        } catch {
+            // Error surfaced via mutationErrorMessage from the page
+        }
+    }
+
+    return (
+        <>
+            <Card>
+                <CardHeader>
+                    <CardTitle className="text-base">Metadata</CardTitle>
+                    <CardDescription>Custom metadata available in notification templates (classic console pattern).</CardDescription>
+                </CardHeader>
+                <CardContent className="space-y-6">
+                    {isError ? (
+                        <Alert variant="destructive">
+                            <AlertDescription>Failed to load metadata. Please refresh the page.</AlertDescription>
+                        </Alert>
+                    ) : null}
+                    {mutationErrorMessage ? (
+                        <Alert variant="destructive">
+                            <AlertDescription>{mutationErrorMessage}</AlertDescription>
+                        </Alert>
+                    ) : null}
+
+                    {canCreate ? (
+                        <form className="space-y-3" onSubmit={handleAddMetadata}>
+                            <div className="grid gap-3 md:grid-cols-4">
+                                <div className="space-y-2">
+                                    <RequiredLabel htmlFor="metadata-key">Key</RequiredLabel>
+                                    <Input
+                                        id="metadata-key"
+                                        value={metadataKey}
+                                        placeholder="department"
+                                        readOnly
+                                        required
+                                        aria-required="true"
+                                        className="bg-muted/40"
+                                    />
+                                </div>
+                                <div className="space-y-2">
+                                    <RequiredLabel htmlFor="metadata-name">Name</RequiredLabel>
+                                    <Input
+                                        id="metadata-name"
+                                        value={metadataName}
+                                        onChange={event => setMetadataName(event.target.value)}
+                                        placeholder="Department"
+                                        disabled={isCreating}
+                                        required
+                                        aria-required="true"
+                                    />
+                                </div>
+                                <div className="space-y-2">
+                                    <RequiredLabel htmlFor="metadata-format">Format</RequiredLabel>
+                                    <Select
+                                        value={metadataFormat}
+                                        onValueChange={value => {
+                                            const nextFormat = value as ApplicationMetadataFormat;
+                                            setMetadataFormat(nextFormat);
+                                            setMetadataValue(nextFormat === 'BOOLEAN' ? 'false' : '');
+                                        }}
+                                        disabled={isCreating}
+                                        required
+                                    >
+                                        <SelectTrigger id="metadata-format" className="w-full" aria-required="true">
+                                            <SelectValue placeholder="Select a format" />
+                                        </SelectTrigger>
+                                        <SelectContent>
+                                            {METADATA_FORMATS.map(format => (
+                                                <SelectItem key={format} value={format}>
+                                                    {format.toLowerCase()}
+                                                </SelectItem>
+                                            ))}
+                                        </SelectContent>
+                                    </Select>
+                                </div>
+                                <div className="space-y-2">
+                                    <RequiredLabel htmlFor="metadata-value">Value</RequiredLabel>
+                                    <MetadataValueField
+                                        id="metadata-value"
+                                        format={metadataFormat}
+                                        value={metadataValue}
+                                        disabled={isCreating}
+                                        onChange={setMetadataValue}
+                                    />
+                                </div>
+                            </div>
+                            <Button type="submit" size="sm" disabled={!canSubmitMetadata || isCreating}>
+                                <PlusIcon className="size-4" aria-hidden />
+                                {isCreating ? 'Adding…' : 'Add metadata'}
+                            </Button>
+                        </form>
+                    ) : null}
+
+                    <MetadataTable
+                        metadata={metadata}
+                        isLoading={isLoading}
+                        canUpdate={canUpdate}
+                        canDelete={canDelete}
+                        isMutating={isUpdating || isDeleting}
+                        onEdit={setMetadataToEdit}
+                        onDelete={setMetadataToDelete}
+                    />
+                </CardContent>
+            </Card>
+            <DeleteMetadataDialog
+                metadata={metadataToDelete}
+                isDeleting={isDeleting}
+                onCancel={() => setMetadataToDelete(null)}
+                onConfirm={handleDeleteMetadataConfirm}
+            />
+            <EditMetadataDialog
+                metadata={metadataToEdit}
+                isSaving={isUpdating}
+                onCancel={() => setMetadataToEdit(null)}
+                onSave={handleUpdateMetadata}
+            />
+        </>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/metadata/DeleteMetadataDialog.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/metadata/DeleteMetadataDialog.tsx
@@ -1,0 +1,49 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Button, Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@gravitee/graphene-core';
+
+import type { ApplicationMetadata } from '../../types/applicationNotification';
+
+export function DeleteMetadataDialog({
+    metadata,
+    isDeleting,
+    onCancel,
+    onConfirm,
+}: Readonly<{
+    metadata: ApplicationMetadata | null;
+    isDeleting: boolean;
+    onCancel: () => void;
+    onConfirm: () => void;
+}>) {
+    return (
+        <Dialog open={metadata !== null} onOpenChange={open => !open && onCancel()}>
+            <DialogContent className="max-w-sm">
+                <DialogHeader>
+                    <DialogTitle>Delete Application metadata</DialogTitle>
+                    <DialogDescription>{`Are you sure you want to delete Application metadata '${metadata?.name}'?`}</DialogDescription>
+                </DialogHeader>
+                <DialogFooter className="border-t px-6 py-4 gap-2">
+                    <Button type="button" variant="outline" onClick={onCancel} disabled={isDeleting}>
+                        Cancel
+                    </Button>
+                    <Button type="button" variant="destructive" onClick={onConfirm} disabled={isDeleting || metadata === null}>
+                        {isDeleting ? 'Deleting…' : 'Delete'}
+                    </Button>
+                </DialogFooter>
+            </DialogContent>
+        </Dialog>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/metadata/EditMetadataDialog.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/metadata/EditMetadataDialog.spec.tsx
@@ -1,0 +1,48 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import { EditMetadataDialog } from './EditMetadataDialog';
+import type { ApplicationMetadata } from '../../types/applicationNotification';
+
+const metadata: ApplicationMetadata = {
+    key: 'threshold',
+    name: 'Threshold',
+    format: 'NUMERIC',
+    value: '1',
+};
+
+describe('EditMetadataDialog', () => {
+    it('keeps Save enabled for a "0" value', () => {
+        render(<EditMetadataDialog metadata={metadata} isSaving={false} onCancel={jest.fn()} onSave={jest.fn()} />);
+
+        const saveButton = screen.getByRole('button', { name: 'Save' }) as HTMLButtonElement;
+        expect(saveButton.disabled).toBe(true);
+
+        fireEvent.change(screen.getByLabelText(/Value/i), { target: { value: '0' } });
+
+        expect(saveButton.disabled).toBe(false);
+    });
+
+    it('keeps Save disabled for blank values', () => {
+        render(<EditMetadataDialog metadata={metadata} isSaving={false} onCancel={jest.fn()} onSave={jest.fn()} />);
+
+        const saveButton = screen.getByRole('button', { name: 'Save' }) as HTMLButtonElement;
+        fireEvent.change(screen.getByLabelText(/Value/i), { target: { value: '   ' } });
+
+        expect(saveButton.disabled).toBe(true);
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/metadata/EditMetadataDialog.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/metadata/EditMetadataDialog.tsx
@@ -1,0 +1,138 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+    Button,
+    Dialog,
+    DialogContent,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+    Input,
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from '@gravitee/graphene-core';
+import { type FormEvent, useEffect, useState } from 'react';
+
+import { METADATA_FORMATS } from './metadataConstants';
+import { metadataFormat, metadataValue } from './metadataHelpers';
+import { MetadataValueField } from './MetadataValueField';
+import type { ApplicationMetadata, UpdateApplicationMetadata } from '../../types/applicationNotification';
+import { RequiredLabel } from '../notification-settings/RequiredLabel';
+
+export function EditMetadataDialog({
+    metadata,
+    isSaving,
+    onCancel,
+    onSave,
+}: Readonly<{
+    metadata: ApplicationMetadata | null;
+    isSaving: boolean;
+    onCancel: () => void;
+    onSave: (metadata: UpdateApplicationMetadata) => void;
+}>) {
+    const [name, setName] = useState('');
+    const [value, setValue] = useState('');
+
+    useEffect(() => {
+        setName(metadata?.name ?? '');
+        setValue(metadataValue(metadata));
+    }, [metadata]);
+
+    const format = metadataFormat(metadata);
+    const initialName = metadata?.name ?? '';
+    const initialValue = metadataValue(metadata);
+    const hasChange = name !== initialName || value !== initialValue;
+    const canSave = Boolean(metadata && name.trim().length > 0 && value.trim().length > 0 && hasChange);
+
+    function handleSubmit(event: FormEvent<HTMLFormElement>) {
+        event.preventDefault();
+        if (!metadata || !canSave) {
+            return;
+        }
+        onSave({
+            key: metadata.key,
+            name: name.trim(),
+            format,
+            value,
+            defaultValue: metadata.defaultValue,
+        });
+    }
+
+    return (
+        <Dialog open={metadata !== null} onOpenChange={open => !open && onCancel()}>
+            <DialogContent className="max-w-2xl">
+                <DialogHeader>
+                    <DialogTitle>Update Application metadata</DialogTitle>
+                </DialogHeader>
+                <form className="space-y-4" onSubmit={handleSubmit}>
+                    <div className="grid gap-3 md:grid-cols-2">
+                        <div className="space-y-2">
+                            <RequiredLabel htmlFor="edit-metadata-key">Key</RequiredLabel>
+                            <Input id="edit-metadata-key" value={metadata?.key ?? ''} disabled required aria-required="true" />
+                        </div>
+                        <div className="space-y-2">
+                            <RequiredLabel htmlFor="edit-metadata-name">Name</RequiredLabel>
+                            <Input
+                                id="edit-metadata-name"
+                                value={name}
+                                onChange={event => setName(event.target.value)}
+                                disabled={isSaving}
+                                required
+                                aria-required="true"
+                            />
+                        </div>
+                        <div className="space-y-2">
+                            <RequiredLabel htmlFor="edit-metadata-format">Format</RequiredLabel>
+                            <Select value={format} disabled required>
+                                <SelectTrigger id="edit-metadata-format" className="w-full" aria-required="true">
+                                    <SelectValue />
+                                </SelectTrigger>
+                                <SelectContent>
+                                    {METADATA_FORMATS.map(item => (
+                                        <SelectItem key={item} value={item}>
+                                            {item.toLowerCase()}
+                                        </SelectItem>
+                                    ))}
+                                </SelectContent>
+                            </Select>
+                        </div>
+                        <div className="space-y-2">
+                            <RequiredLabel htmlFor="edit-metadata-value">Value</RequiredLabel>
+                            <MetadataValueField
+                                id="edit-metadata-value"
+                                format={format}
+                                value={value}
+                                disabled={isSaving}
+                                onChange={setValue}
+                            />
+                        </div>
+                    </div>
+                    <DialogFooter className="border-t px-6 py-4 gap-2">
+                        <Button type="button" variant="outline" onClick={onCancel} disabled={isSaving}>
+                            Cancel
+                        </Button>
+                        <Button type="submit" disabled={!canSave || isSaving}>
+                            {isSaving ? 'Saving…' : 'Save'}
+                        </Button>
+                    </DialogFooter>
+                </form>
+            </DialogContent>
+        </Dialog>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/metadata/MetadataTable.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/metadata/MetadataTable.tsx
@@ -1,0 +1,171 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+    Button,
+    DataTablePagination,
+    Skeleton,
+    Table,
+    TableBody,
+    TableCell,
+    TableHead,
+    TableHeader,
+    TableRow,
+} from '@gravitee/graphene-core';
+import { PencilIcon, Trash2Icon } from '@gravitee/graphene-core/icons';
+import { useEffect, useMemo, useState } from 'react';
+
+import { DEFAULT_METADATA_PAGE_SIZE, METADATA_PAGE_SIZE_OPTIONS } from './metadataConstants';
+import type { ApplicationMetadata } from '../../types/applicationNotification';
+
+export function MetadataTable({
+    metadata,
+    isLoading,
+    canUpdate,
+    canDelete,
+    isMutating,
+    onEdit,
+    onDelete,
+}: {
+    readonly metadata: ApplicationMetadata[];
+    readonly isLoading: boolean;
+    readonly canUpdate: boolean;
+    readonly canDelete: boolean;
+    readonly isMutating: boolean;
+    readonly onEdit: (metadata: ApplicationMetadata) => void;
+    readonly onDelete: (metadata: ApplicationMetadata) => void;
+}) {
+    const [page, setPage] = useState(1);
+    const [pageSize, setPageSize] = useState(DEFAULT_METADATA_PAGE_SIZE);
+    const totalCount = metadata.length;
+    const totalPages = Math.max(1, Math.ceil(totalCount / pageSize));
+    const paginatedMetadata = useMemo(() => {
+        const start = (page - 1) * pageSize;
+        return metadata.slice(start, start + pageSize);
+    }, [metadata, page, pageSize]);
+
+    useEffect(() => {
+        if (page > totalPages) {
+            setPage(totalPages);
+        }
+    }, [page, totalPages]);
+
+    function handlePageSizeChange(size: number) {
+        setPageSize(size);
+        setPage(1);
+    }
+
+    const hasActions = canUpdate || canDelete;
+
+    if (isLoading) {
+        return (
+            <div className="space-y-2">
+                {Array.from({ length: pageSize }).map((_, index) => (
+                    <Skeleton key={index} className="h-10 rounded-lg" />
+                ))}
+            </div>
+        );
+    }
+
+    return (
+        <div className="space-y-4">
+            <div className="flex justify-end">
+                <DataTablePagination
+                    page={page}
+                    pageSize={pageSize}
+                    totalCount={totalCount}
+                    pageSizeOptions={METADATA_PAGE_SIZE_OPTIONS}
+                    onPageChange={setPage}
+                    onPageSizeChange={handlePageSizeChange}
+                />
+            </div>
+            <Table aria-label="Application metadata">
+                <TableHeader>
+                    <TableRow>
+                        <TableHead>Key</TableHead>
+                        <TableHead>Name</TableHead>
+                        <TableHead>Format</TableHead>
+                        <TableHead>Value</TableHead>
+                        {hasActions ? <TableHead className="w-24 text-right" aria-label="Actions" /> : null}
+                    </TableRow>
+                </TableHeader>
+                <TableBody>
+                    {metadata.length === 0 ? (
+                        <TableRow>
+                            <TableCell colSpan={hasActions ? 5 : 4} className="h-16 text-center text-sm text-muted-foreground">
+                                No metadata configured.
+                            </TableCell>
+                        </TableRow>
+                    ) : (
+                        paginatedMetadata.map(item => {
+                            const value = item.value ?? item.defaultValue ?? '—';
+                            const isDeletable = item.value !== undefined;
+                            return (
+                                <TableRow key={item.key}>
+                                    <TableCell className="font-medium">{item.key}</TableCell>
+                                    <TableCell>{item.name}</TableCell>
+                                    <TableCell className="text-sm text-muted-foreground">{item.format ?? 'STRING'}</TableCell>
+                                    <TableCell>{value}</TableCell>
+                                    {hasActions ? (
+                                        <TableCell className="text-right">
+                                            <div className="flex justify-end gap-1">
+                                                {canUpdate ? (
+                                                    <Button
+                                                        type="button"
+                                                        variant="ghost"
+                                                        size="icon"
+                                                        className="size-8"
+                                                        aria-label={`Edit ${item.name} metadata`}
+                                                        disabled={isMutating}
+                                                        onClick={() => onEdit(item)}
+                                                    >
+                                                        <PencilIcon className="size-4" aria-hidden />
+                                                    </Button>
+                                                ) : null}
+                                                {canDelete && isDeletable ? (
+                                                    <Button
+                                                        type="button"
+                                                        variant="ghost"
+                                                        size="icon"
+                                                        className="size-8 text-destructive hover:text-destructive"
+                                                        aria-label={`Delete ${item.name} metadata`}
+                                                        disabled={isMutating}
+                                                        onClick={() => onDelete(item)}
+                                                    >
+                                                        <Trash2Icon className="size-4" aria-hidden />
+                                                    </Button>
+                                                ) : null}
+                                            </div>
+                                        </TableCell>
+                                    ) : null}
+                                </TableRow>
+                            );
+                        })
+                    )}
+                </TableBody>
+            </Table>
+            <div className="flex justify-end">
+                <DataTablePagination
+                    page={page}
+                    pageSize={pageSize}
+                    totalCount={totalCount}
+                    pageSizeOptions={METADATA_PAGE_SIZE_OPTIONS}
+                    onPageChange={setPage}
+                    onPageSizeChange={handlePageSizeChange}
+                />
+            </div>
+        </div>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/metadata/MetadataValueField.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/metadata/MetadataValueField.tsx
@@ -1,0 +1,70 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Input, Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@gravitee/graphene-core';
+
+import type { ApplicationMetadataFormat } from '../../types/applicationNotification';
+import { MAIL_PATTERN, URL_PATTERN } from '../../utils/metadataValidators';
+
+export function MetadataValueField({
+    id,
+    format,
+    value,
+    disabled,
+    onChange,
+}: Readonly<{
+    id: string;
+    format: ApplicationMetadataFormat;
+    value: string;
+    disabled: boolean;
+    onChange: (value: string) => void;
+}>) {
+    if (format === 'BOOLEAN') {
+        return (
+            <Select value={value} onValueChange={onChange} disabled={disabled} required>
+                <SelectTrigger id={id} className="w-full" aria-required="true">
+                    <SelectValue placeholder="Select a value" />
+                </SelectTrigger>
+                <SelectContent>
+                    <SelectItem value="true">true</SelectItem>
+                    <SelectItem value="false">false</SelectItem>
+                </SelectContent>
+            </Select>
+        );
+    }
+
+    const commonProps = {
+        id,
+        value,
+        onChange: (event: React.ChangeEvent<HTMLInputElement>) => onChange(event.target.value),
+        disabled,
+        required: true,
+        'aria-required': true,
+    };
+
+    if (format === 'NUMERIC') {
+        return <Input {...commonProps} type="number" placeholder="123000.92" />;
+    }
+    if (format === 'DATE') {
+        return <Input {...commonProps} type="date" />;
+    }
+    if (format === 'MAIL') {
+        return <Input {...commonProps} type="email" pattern={MAIL_PATTERN.source} placeholder="john@doe.com" />;
+    }
+    if (format === 'URL') {
+        return <Input {...commonProps} type="url" pattern={URL_PATTERN.source} placeholder="https://gravitee.io" />;
+    }
+    return <Input {...commonProps} type="text" placeholder="Operations" />;
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/metadata/metadataConstants.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/metadata/metadataConstants.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import type { ApplicationMetadataFormat } from '../../types/applicationNotification';
+
+export const METADATA_FORMATS: ApplicationMetadataFormat[] = ['STRING', 'NUMERIC', 'BOOLEAN', 'DATE', 'MAIL', 'URL'];
+export const METADATA_PAGE_SIZE_OPTIONS = [10, 25, 50, 100];
+export const DEFAULT_METADATA_PAGE_SIZE = 10;

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/metadata/metadataHelpers.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/metadata/metadataHelpers.spec.ts
@@ -1,0 +1,50 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { deriveMetadataKey, metadataFormat, metadataValue } from './metadataHelpers';
+import type { ApplicationMetadata } from '../../types/applicationNotification';
+
+describe('metadataHelpers', () => {
+    describe('deriveMetadataKey', () => {
+        it('slugifies display names', () => {
+            expect(deriveMetadataKey('  My Custom Key  ')).toBe('my-custom-key');
+            expect(deriveMetadataKey('API_URL')).toBe('api-url');
+        });
+    });
+
+    describe('metadataFormat', () => {
+        it('defaults to STRING when metadata is null', () => {
+            expect(metadataFormat(null)).toBe('STRING');
+        });
+
+        it('returns metadata format when set', () => {
+            expect(metadataFormat({ format: 'MAIL' } as ApplicationMetadata)).toBe('MAIL');
+        });
+    });
+
+    describe('metadataValue', () => {
+        it('returns empty string for null metadata', () => {
+            expect(metadataValue(null)).toBe('');
+        });
+
+        it('prefers value over defaultValue', () => {
+            expect(metadataValue({ value: 'live', defaultValue: 'default' } as ApplicationMetadata)).toBe('live');
+        });
+
+        it('truncates DATE values to yyyy-mm-dd', () => {
+            expect(metadataValue({ format: 'DATE', value: '2024-06-15T10:00:00Z' } as ApplicationMetadata)).toBe('2024-06-15');
+        });
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/metadata/metadataHelpers.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/metadata/metadataHelpers.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import type { ApplicationMetadata, ApplicationMetadataFormat } from '../../types/applicationNotification';
+
+export function deriveMetadataKey(name: string): string {
+    return name
+        .trim()
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, '-')
+        .replace(/^-|-$/g, '');
+}
+
+export function metadataFormat(metadata: ApplicationMetadata | null): ApplicationMetadataFormat {
+    return metadata?.format ?? 'STRING';
+}
+
+export function metadataValue(metadata: ApplicationMetadata | null): string {
+    if (!metadata) {
+        return '';
+    }
+    const value = metadata.value ?? metadata.defaultValue ?? '';
+    if (metadataFormat(metadata) === 'DATE') {
+        return value.slice(0, 10);
+    }
+    return String(value);
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/notification-settings/RequiredLabel.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/notification-settings/RequiredLabel.tsx
@@ -1,0 +1,25 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Label } from '@gravitee/graphene-core';
+
+export function RequiredLabel({ htmlFor, children }: Readonly<{ htmlFor: string; children: string }>) {
+    return (
+        <Label htmlFor={htmlFor}>
+            {children}
+            <span className="text-destructive"> *</span>
+        </Label>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/notifications/DeleteNotificationDialog.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/notifications/DeleteNotificationDialog.spec.tsx
@@ -1,0 +1,44 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { render, screen } from '@testing-library/react';
+
+import { DeleteNotificationDialog } from './DeleteNotificationDialog';
+import type { ApplicationNotificationRow } from '../../types/applicationNotification';
+
+const row: ApplicationNotificationRow = {
+    key: 'n1',
+    name: 'Subscription alerts',
+    subscribedEvents: 2,
+    notifierName: 'Email',
+    notification: { id: 'n1', name: 'Subscription alerts', config_type: 'DEFAULT' },
+    isReadonly: false,
+};
+
+describe('DeleteNotificationDialog', () => {
+    it('shows the notification name in the confirmation message', () => {
+        render(<DeleteNotificationDialog row={row} isDeleting={false} onCancel={jest.fn()} onConfirm={jest.fn()} />);
+
+        expect(screen.getByText(/Subscription alerts/)).not.toBeNull();
+        expect(screen.getByRole('button', { name: 'Delete' })).not.toBeNull();
+    });
+
+    it('shows deleting label while the mutation is in progress', () => {
+        render(<DeleteNotificationDialog row={row} isDeleting onCancel={jest.fn()} onConfirm={jest.fn()} />);
+
+        expect(screen.getByRole('button', { name: 'Deleting…' })).not.toBeNull();
+        expect(screen.queryByRole('button', { name: 'Delete' })).toBeNull();
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/notifications/DeleteNotificationDialog.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/notifications/DeleteNotificationDialog.tsx
@@ -1,0 +1,49 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Button, Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@gravitee/graphene-core';
+
+import type { ApplicationNotificationRow } from '../../types/applicationNotification';
+
+export function DeleteNotificationDialog({
+    row,
+    isDeleting,
+    onCancel,
+    onConfirm,
+}: Readonly<{
+    row: ApplicationNotificationRow | null;
+    isDeleting: boolean;
+    onCancel: () => void;
+    onConfirm: () => void;
+}>) {
+    return (
+        <Dialog open={row !== null} onOpenChange={open => !open && onCancel()}>
+            <DialogContent className="max-w-sm">
+                <DialogHeader>
+                    <DialogTitle>Delete notification</DialogTitle>
+                    <DialogDescription>{`Are you sure you want to delete the notification '${row?.name}'?`}</DialogDescription>
+                </DialogHeader>
+                <DialogFooter className="border-t px-6 py-4 gap-2">
+                    <Button type="button" variant="outline" onClick={onCancel} disabled={isDeleting}>
+                        Cancel
+                    </Button>
+                    <Button type="button" variant="destructive" onClick={onConfirm} disabled={isDeleting || row === null}>
+                        {isDeleting ? 'Deleting…' : 'Delete'}
+                    </Button>
+                </DialogFooter>
+            </DialogContent>
+        </Dialog>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/notifications/EditNotificationDialog.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/notifications/EditNotificationDialog.tsx
@@ -1,0 +1,166 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+    Button,
+    Dialog,
+    DialogContent,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+    Input,
+    Label,
+    Skeleton,
+    Switch,
+} from '@gravitee/graphene-core';
+import { type FormEvent, useMemo, useState } from 'react';
+
+import { NotificationHookCategorySection } from './NotificationHookCategorySection';
+import type {
+    ApplicationNotificationHookCategory,
+    ApplicationNotificationRow,
+    UpdateApplicationNotification,
+} from '../../types/applicationNotification';
+
+export function EditNotificationDialog({
+    row,
+    hookCategories,
+    isLoadingHooks,
+    isSaving,
+    onCancel,
+    onSave,
+}: Readonly<{
+    row: ApplicationNotificationRow | null;
+    hookCategories: ApplicationNotificationHookCategory[];
+    isLoadingHooks: boolean;
+    isSaving: boolean;
+    onCancel: () => void;
+    onSave: (notification: UpdateApplicationNotification) => void;
+}>) {
+    const notification = row?.notification ?? null;
+    const notifier = row?.notifier;
+    const groupHookIds = useMemo(() => new Set(notification?.groupHooks ?? []), [notification?.groupHooks]);
+    const [selectedHooks, setSelectedHooks] = useState<Set<string>>(new Set());
+    const [config, setConfig] = useState('');
+    const [useSystemProxy, setUseSystemProxy] = useState(false);
+
+    // Reset form when a different notification is edited (setState-during-render pattern).
+    const [prevNotification, setPrevNotification] = useState(notification);
+    if (prevNotification !== notification) {
+        setPrevNotification(notification);
+        setSelectedHooks(new Set([...(notification?.hooks ?? []), ...(notification?.groupHooks ?? [])]));
+        setConfig(notification?.config ?? '');
+        setUseSystemProxy(Boolean(notification?.useSystemProxy));
+    }
+
+    function toggleHook(hookId: string) {
+        setSelectedHooks(prev => {
+            const next = new Set(prev);
+            if (next.has(hookId)) {
+                next.delete(hookId);
+            } else {
+                next.add(hookId);
+            }
+            return next;
+        });
+    }
+
+    function handleSubmit(event: FormEvent<HTMLFormElement>) {
+        event.preventDefault();
+        if (!notification || row?.isReadonly) {
+            return;
+        }
+        onSave({
+            ...notification,
+            config,
+            useSystemProxy,
+            hooks: [...selectedHooks].filter(hookId => !groupHookIds.has(hookId)),
+        });
+    }
+
+    const needsNotifierConfig = notifier?.type === 'EMAIL' || notifier?.type === 'WEBHOOK';
+    const configLabel = notifier?.type === 'EMAIL' ? 'Email list' : 'Webhook';
+    const configHelp =
+        notifier?.type === 'EMAIL'
+            ? "Use space, ',' or ';' to separate emails. EL supported."
+            : 'URL (Gravitee will POST datas to this url)';
+    const disabled = isSaving || Boolean(row?.isReadonly);
+
+    return (
+        <Dialog open={row !== null} onOpenChange={open => !open && onCancel()}>
+            <DialogContent style={{ width: 'min(72rem, 98vw)', maxWidth: '98vw' }}>
+                <DialogHeader>
+                    <DialogTitle>Edit Console Notification</DialogTitle>
+                </DialogHeader>
+                <form className="space-y-5" onSubmit={handleSubmit}>
+                    <div className="grid gap-4 lg:grid-cols-3">
+                        {needsNotifierConfig ? (
+                            <div className="space-y-2 lg:col-span-2">
+                                <Label htmlFor="notification-config">{configLabel}</Label>
+                                <Input
+                                    id="notification-config"
+                                    value={config}
+                                    onChange={event => setConfig(event.target.value)}
+                                    disabled={disabled}
+                                />
+                                <p className="text-xs text-muted-foreground">{configHelp}</p>
+                            </div>
+                        ) : null}
+                        {notifier?.type === 'WEBHOOK' ? (
+                            <div className="flex items-center justify-between gap-4 self-end rounded-lg border px-3 py-2">
+                                <Label htmlFor="notification-system-proxy">Use system proxy</Label>
+                                <Switch
+                                    id="notification-system-proxy"
+                                    checked={useSystemProxy}
+                                    onCheckedChange={setUseSystemProxy}
+                                    disabled={disabled}
+                                />
+                            </div>
+                        ) : null}
+                    </div>
+                    <div className="space-y-4">
+                        <h3 className="text-sm font-semibold">Event subscribed</h3>
+                        {isLoadingHooks ? (
+                            <div className="space-y-2">
+                                {Array.from({ length: 3 }).map((_, index) => (
+                                    <Skeleton key={index} className="h-16 rounded-lg" />
+                                ))}
+                            </div>
+                        ) : (
+                            hookCategories.map(category => (
+                                <NotificationHookCategorySection
+                                    key={category.name}
+                                    category={category}
+                                    selectedHooks={selectedHooks}
+                                    groupHookIds={groupHookIds}
+                                    disabled={disabled}
+                                    onToggle={toggleHook}
+                                />
+                            ))
+                        )}
+                    </div>
+                    <DialogFooter className="border-t px-6 py-4 gap-2">
+                        <Button type="button" variant="outline" onClick={onCancel} disabled={isSaving}>
+                            Cancel
+                        </Button>
+                        <Button type="submit" disabled={disabled || isLoadingHooks || !notification}>
+                            {isSaving ? 'Saving…' : 'Save'}
+                        </Button>
+                    </DialogFooter>
+                </form>
+            </DialogContent>
+        </Dialog>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/notifications/NotificationHookCategorySection.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/notifications/NotificationHookCategorySection.tsx
@@ -1,0 +1,58 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Checkbox } from '@gravitee/graphene-core';
+
+import type { ApplicationNotificationHookCategory } from '../../types/applicationNotification';
+
+export function NotificationHookCategorySection({
+    category,
+    selectedHooks,
+    groupHookIds,
+    disabled,
+    onToggle,
+}: Readonly<{
+    category: ApplicationNotificationHookCategory;
+    selectedHooks: Set<string>;
+    groupHookIds: Set<string>;
+    disabled: boolean;
+    onToggle: (hookId: string) => void;
+}>) {
+    return (
+        <div className="space-y-2">
+            <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">{category.name}</p>
+            <div className="grid gap-2 sm:grid-cols-2 xl:grid-cols-4">
+                {category.hooks.map(hook => {
+                    const isGroupHook = groupHookIds.has(hook.id);
+                    const isDisabled = disabled || isGroupHook;
+                    return (
+                        <label key={hook.id} className="flex items-start gap-2 rounded-md p-2">
+                            <Checkbox
+                                checked={selectedHooks.has(hook.id)}
+                                onCheckedChange={checked => checked !== 'indeterminate' && !isDisabled && onToggle(hook.id)}
+                                disabled={isDisabled}
+                                className="mt-0.5 shrink-0"
+                            />
+                            <span className="min-w-0">
+                                <span className="block text-sm font-medium leading-snug">{hook.label}</span>
+                                {hook.description ? <span className="block text-xs text-muted-foreground">{hook.description}</span> : null}
+                            </span>
+                        </label>
+                    );
+                })}
+            </div>
+        </div>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/notifications/NotificationsSection.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/notifications/NotificationsSection.tsx
@@ -1,0 +1,223 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+    Alert,
+    AlertDescription,
+    Button,
+    Card,
+    CardContent,
+    CardDescription,
+    CardHeader,
+    CardTitle,
+    Input,
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+    Skeleton,
+    Table,
+    TableBody,
+    TableCell,
+    TableHead,
+    TableHeader,
+    TableRow,
+} from '@gravitee/graphene-core';
+import { PencilIcon, PlusIcon, Trash2Icon } from '@gravitee/graphene-core/icons';
+import { type FormEvent, useEffect, useMemo, useState } from 'react';
+
+import { notificationNotifierOptions } from './notificationHelpers';
+import type { ApplicationNotificationRow, ApplicationNotifier } from '../../types/applicationNotification';
+import { RequiredLabel } from '../notification-settings/RequiredLabel';
+
+export function NotificationsSection({
+    rows,
+    notifiers,
+    isLoading,
+    isError,
+    canCreate,
+    canUpdate,
+    canDelete,
+    isCreating,
+    onAdd,
+    onEdit,
+    onDelete,
+}: {
+    readonly rows: ApplicationNotificationRow[];
+    readonly notifiers: ApplicationNotifier[];
+    readonly isLoading: boolean;
+    readonly isError: boolean;
+    readonly canCreate: boolean;
+    readonly canUpdate: boolean;
+    readonly canDelete: boolean;
+    readonly isCreating: boolean;
+    readonly onAdd: (name: string, notifierId: string) => Promise<boolean>;
+    readonly onEdit: (row: ApplicationNotificationRow) => void;
+    readonly onDelete: (row: ApplicationNotificationRow) => void;
+}) {
+    const notifierOptions = useMemo(() => notificationNotifierOptions(notifiers), [notifiers]);
+    const [name, setName] = useState('');
+    const [notifierId, setNotifierId] = useState('');
+
+    useEffect(() => {
+        if (!notifierId && notifierOptions[0]) {
+            setNotifierId(notifierOptions[0].id);
+        }
+    }, [notifierId, notifierOptions]);
+
+    const canSubmit = Boolean(canCreate && name.trim() && notifierId);
+
+    async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+        event.preventDefault();
+        if (!canSubmit) {
+            return;
+        }
+        const created = await onAdd(name.trim(), notifierId);
+        if (created) {
+            setName('');
+            setNotifierId(notifierOptions[0]?.id ?? '');
+        }
+    }
+
+    return (
+        <Card>
+            <CardHeader>
+                <CardTitle className="text-base">Notifications</CardTitle>
+                <CardDescription>Events that trigger notifiers for this application.</CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-6">
+                {canCreate ? (
+                    <form className="space-y-3" onSubmit={handleSubmit}>
+                        <div className="grid gap-3 md:grid-cols-2">
+                            <div className="space-y-2">
+                                <RequiredLabel htmlFor="notification-name">Name</RequiredLabel>
+                                <Input
+                                    id="notification-name"
+                                    value={name}
+                                    onChange={event => setName(event.target.value)}
+                                    placeholder="Notification name"
+                                    disabled={isCreating}
+                                    required
+                                    aria-required="true"
+                                />
+                            </div>
+                            <div className="space-y-2">
+                                <RequiredLabel htmlFor="notification-notifier">Notifier</RequiredLabel>
+                                <Select
+                                    value={notifierId}
+                                    onValueChange={setNotifierId}
+                                    disabled={isCreating || notifierOptions.length === 0}
+                                >
+                                    <SelectTrigger id="notification-notifier" className="w-full" aria-required="true">
+                                        <SelectValue placeholder="Select a notifier" />
+                                    </SelectTrigger>
+                                    <SelectContent>
+                                        {notifierOptions.map(option => (
+                                            <SelectItem key={option.id} value={option.id}>
+                                                {option.label}
+                                            </SelectItem>
+                                        ))}
+                                    </SelectContent>
+                                </Select>
+                            </div>
+                        </div>
+                        <Button type="submit" size="sm" disabled={!canSubmit || isCreating}>
+                            <PlusIcon className="size-4" aria-hidden />
+                            {isCreating ? 'Adding…' : 'Add notification'}
+                        </Button>
+                    </form>
+                ) : null}
+                {isError ? (
+                    <Alert variant="destructive">
+                        <AlertDescription>Failed to load notification settings. Please refresh the page.</AlertDescription>
+                    </Alert>
+                ) : isLoading ? (
+                    <div className="space-y-2">
+                        {Array.from({ length: 3 }).map((_, index) => (
+                            <Skeleton key={index} className="h-10 rounded-lg" />
+                        ))}
+                    </div>
+                ) : (
+                    <Table aria-label="Application notification settings">
+                        <TableHeader>
+                            <TableRow>
+                                <TableHead>Name</TableHead>
+                                <TableHead>Events subscribed</TableHead>
+                                <TableHead>Notifier</TableHead>
+                                <TableHead className="w-16 text-right">Actions</TableHead>
+                            </TableRow>
+                        </TableHeader>
+                        <TableBody>
+                            {rows.length === 0 ? (
+                                <TableRow>
+                                    <TableCell colSpan={4} className="h-16 text-center text-sm text-muted-foreground">
+                                        No notifications configured.
+                                    </TableCell>
+                                </TableRow>
+                            ) : (
+                                rows.map(row => (
+                                    <TableRow key={row.key}>
+                                        <TableCell className="font-medium">{row.name}</TableCell>
+                                        <TableCell>
+                                            <span className="inline-flex rounded-md bg-muted px-2 py-1 text-xs text-muted-foreground">
+                                                {row.subscribedEvents} events
+                                            </span>
+                                        </TableCell>
+                                        <TableCell>
+                                            <span className="inline-flex rounded-md bg-muted px-2 py-1 text-xs text-muted-foreground">
+                                                {row.notifierName}
+                                            </span>
+                                        </TableCell>
+                                        <TableCell className="text-right">
+                                            <div className="flex justify-end gap-1">
+                                                {canUpdate ? (
+                                                    <Button
+                                                        type="button"
+                                                        variant="ghost"
+                                                        size="icon"
+                                                        className="size-8"
+                                                        aria-label={`Edit ${row.name} notification`}
+                                                        disabled={row.isReadonly}
+                                                        onClick={() => onEdit(row)}
+                                                    >
+                                                        <PencilIcon className="size-4" aria-hidden />
+                                                    </Button>
+                                                ) : null}
+                                                {canDelete && row.notification.config_type !== 'PORTAL' && Boolean(row.notification.id) ? (
+                                                    <Button
+                                                        type="button"
+                                                        variant="ghost"
+                                                        size="icon"
+                                                        className="size-8 text-destructive hover:text-destructive"
+                                                        aria-label={`Delete ${row.name} notification`}
+                                                        disabled={row.isReadonly}
+                                                        onClick={() => onDelete(row)}
+                                                    >
+                                                        <Trash2Icon className="size-4" aria-hidden />
+                                                    </Button>
+                                                ) : null}
+                                            </div>
+                                        </TableCell>
+                                    </TableRow>
+                                ))
+                            )}
+                        </TableBody>
+                    </Table>
+                )}
+            </CardContent>
+        </Card>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/notifications/notificationHelpers.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/notifications/notificationHelpers.spec.ts
@@ -1,0 +1,115 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+    groupHooksByCategory,
+    mapApplicationNotificationsToRows,
+    notificationNotifierOptions,
+    notifierTypeLabel,
+    resolveNotifierName,
+} from './notificationHelpers';
+import type {
+    ApplicationNotificationHook,
+    ApplicationNotificationSettings,
+    ApplicationNotifier,
+} from '../../types/applicationNotification';
+
+describe('notificationHelpers', () => {
+    describe('notifierTypeLabel', () => {
+        it('labels built-in notifier types', () => {
+            expect(notifierTypeLabel({ id: 'e1', type: 'EMAIL' })).toBe('Default Email Notifier');
+            expect(notifierTypeLabel({ id: 'w1', type: 'WEBHOOK' })).toBe('Default Webhook Notifier');
+        });
+
+        it('falls back to name or id', () => {
+            expect(notifierTypeLabel({ id: 'custom', type: 'SLACK', name: 'Slack' })).toBe('Slack');
+            expect(notifierTypeLabel({ id: 'custom', type: 'SLACK' })).toBe('custom');
+        });
+    });
+
+    describe('notificationNotifierOptions', () => {
+        it('keeps all notifiers with ids (including custom types)', () => {
+            const notifiers: ApplicationNotifier[] = [
+                { id: 'e1', type: 'EMAIL' },
+                { id: 'w1', type: 'WEBHOOK' },
+                { id: 's1', type: 'SLACK', name: 'Slack' },
+                { type: 'EMAIL' },
+            ];
+            expect(notificationNotifierOptions(notifiers).map(option => option.id)).toEqual(['e1', 'w1', 's1']);
+        });
+    });
+
+    describe('resolveNotifierName', () => {
+        it('uses notifier name when available', () => {
+            const notification = { notifier: 'n1', config_type: 'DEFAULT' } as ApplicationNotificationSettings;
+            const notifiers: ApplicationNotifier[] = [{ id: 'n1', type: 'EMAIL', name: 'Team inbox' }];
+            expect(resolveNotifierName(notification, notifiers)).toBe('Team inbox');
+        });
+
+        it('returns Console for PORTAL config', () => {
+            expect(resolveNotifierName({ config_type: 'PORTAL' } as ApplicationNotificationSettings, [])).toBe('Console');
+        });
+    });
+
+    describe('groupHooksByCategory', () => {
+        it('groups hooks by category name', () => {
+            const hooks: ApplicationNotificationHook[] = [
+                { id: 'h1', category: 'Subscription', label: 'Accepted', description: '', scope: 'APPLICATION' },
+                { id: 'h2', category: 'Subscription', label: 'Closed', description: '', scope: 'APPLICATION' },
+                { id: 'h3', category: 'API Key', label: 'Expired', description: '', scope: 'APPLICATION' },
+            ];
+            const grouped = groupHooksByCategory(hooks);
+            expect(grouped).toHaveLength(2);
+            expect(grouped.find(category => category.name === 'Subscription')?.hooks).toHaveLength(2);
+        });
+    });
+
+    describe('mapApplicationNotificationsToRows', () => {
+        it('maps notification settings to table rows', () => {
+            const notifications: ApplicationNotificationSettings[] = [
+                {
+                    id: 'n1',
+                    name: 'Sub events',
+                    config_type: 'DEFAULT',
+                    notifier: 'e1',
+                    hooks: ['SUBSCRIPTION_NEW'],
+                    origin: 'MANAGEMENT',
+                },
+            ];
+            const notifiers: ApplicationNotifier[] = [{ id: 'e1', type: 'EMAIL', name: 'Email' }];
+
+            const rows = mapApplicationNotificationsToRows(notifications, notifiers);
+
+            expect(rows).toEqual([
+                expect.objectContaining({
+                    key: 'n1',
+                    name: 'Sub events',
+                    subscribedEvents: 1,
+                    notifierName: 'Email',
+                    isReadonly: false,
+                }),
+            ]);
+        });
+
+        it('marks non-management origin as readonly', () => {
+            const rows = mapApplicationNotificationsToRows(
+                [{ id: 'n1', name: 'Portal', config_type: 'PORTAL', origin: 'PORTAL' } as ApplicationNotificationSettings],
+                [],
+            );
+            expect(rows[0].isReadonly).toBe(true);
+            expect(rows[0].notifierName).toBe('Console');
+        });
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/notifications/notificationHelpers.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/notifications/notificationHelpers.ts
@@ -1,0 +1,78 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import type {
+    ApplicationNotificationHook,
+    ApplicationNotificationHookCategory,
+    ApplicationNotificationRow,
+    ApplicationNotificationSettings,
+    ApplicationNotifier,
+} from '../../types/applicationNotification';
+
+export interface NotificationNotifierOption {
+    readonly id: string;
+    readonly label: string;
+    readonly notifier: ApplicationNotifier;
+}
+
+export function notifierTypeLabel(notifier: ApplicationNotifier): string {
+    if (notifier.type === 'EMAIL') {
+        return 'Default Email Notifier';
+    }
+    if (notifier.type === 'WEBHOOK') {
+        return 'Default Webhook Notifier';
+    }
+    return notifier.name ?? notifier.id ?? 'Notifier';
+}
+
+export function notificationNotifierOptions(notifiers: ApplicationNotifier[]): NotificationNotifierOption[] {
+    return notifiers
+        .filter((notifier): notifier is ApplicationNotifier & { id: string } => Boolean(notifier.id))
+        .map(notifier => ({ id: notifier.id, label: notifierTypeLabel(notifier), notifier }));
+}
+
+export function resolveNotifierName(notification: ApplicationNotificationSettings, notifiers: ApplicationNotifier[]): string {
+    const notifier = notifiers.find(item => item.id === notification.notifier);
+    if (notifier?.name) {
+        return notifier.name;
+    }
+    if (notification.config_type === 'PORTAL') {
+        return 'Console';
+    }
+    return notification.notifier ?? '—';
+}
+
+export function groupHooksByCategory(hooks: ApplicationNotificationHook[]): ApplicationNotificationHookCategory[] {
+    const groups = new Map<string, ApplicationNotificationHook[]>();
+    for (const hook of hooks) {
+        groups.set(hook.category, [...(groups.get(hook.category) ?? []), hook]);
+    }
+    return [...groups.entries()].map(([name, groupedHooks]) => ({ name, hooks: groupedHooks }));
+}
+
+export function mapApplicationNotificationsToRows(
+    notifications: ApplicationNotificationSettings[],
+    notifiers: ApplicationNotifier[],
+): ApplicationNotificationRow[] {
+    return notifications.map(notification => ({
+        key: notification.id ?? notification.config_type,
+        name: notification.name,
+        subscribedEvents: (notification.hooks ?? []).length + (notification.groupHooks ?? []).length,
+        notifierName: resolveNotifierName(notification, notifiers),
+        notification,
+        notifier: notifiers.find(item => item.id === notification.notifier),
+        isReadonly: Boolean(notification.origin && notification.origin !== 'MANAGEMENT'),
+    }));
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/overview/ApplicationOverviewChecklist.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/overview/ApplicationOverviewChecklist.tsx
@@ -19,19 +19,7 @@ import { useMemo } from 'react';
 import { OverviewChecklistCard, type OverviewChecklistItem } from './OverviewChecklistCard';
 import type { ApplicationOverviewData } from '../../hooks/useApplicationOverviewData';
 import type { ApplicationListItem } from '../../types/application';
-
-function hasReviewedGeneralSettings(application: ApplicationListItem | null): boolean {
-    if (!application) return false;
-
-    return Boolean(
-        application.description?.trim() ||
-            application.domain?.trim() ||
-            application.settings?.app?.client_id?.trim() ||
-            application.settings?.oauth?.client_id?.trim() ||
-            application.settings?.oauth?.redirect_uris?.length ||
-            application.updated_at > application.created_at,
-    );
-}
+import { hasReviewedGeneralSettings } from '../../utils/applicationOverviewHelpers';
 
 interface ApplicationOverviewChecklistProps {
     readonly application: ApplicationListItem | null;

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/overview/ApplicationOverviewChecklist.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/overview/ApplicationOverviewChecklist.tsx
@@ -1,0 +1,94 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { BellIcon, PlugIcon, SlidersHorizontalIcon, UsersIcon } from '@gravitee/graphene-core/icons';
+import { useMemo } from 'react';
+
+import { OverviewChecklistCard, type OverviewChecklistItem } from './OverviewChecklistCard';
+import type { ApplicationOverviewData } from '../../hooks/useApplicationOverviewData';
+import type { ApplicationListItem } from '../../types/application';
+
+function hasReviewedGeneralSettings(application: ApplicationListItem | null): boolean {
+    if (!application) return false;
+
+    return Boolean(
+        application.description?.trim() ||
+            application.domain?.trim() ||
+            application.settings?.app?.client_id?.trim() ||
+            application.settings?.oauth?.client_id?.trim() ||
+            application.settings?.oauth?.redirect_uris?.length ||
+            application.updated_at > application.created_at,
+    );
+}
+
+interface ApplicationOverviewChecklistProps {
+    readonly application: ApplicationListItem | null;
+    readonly overviewData: ApplicationOverviewData;
+}
+
+export function ApplicationOverviewChecklist({ application, overviewData }: Readonly<ApplicationOverviewChecklistProps>) {
+    const isReady = !overviewData.isLoadingMembers && !overviewData.isLoadingNotifications && !overviewData.isLoadingSubscriptions;
+
+    const items = useMemo<OverviewChecklistItem[]>(
+        () => [
+            {
+                actionLabel: 'Open General',
+                done: hasReviewedGeneralSettings(application),
+                icon: SlidersHorizontalIcon,
+                id: 'general-settings',
+                label: 'Review general settings',
+                to: '../general',
+                tooltip: 'Review the application profile, security type, OAuth client details, and lifecycle settings.',
+            },
+            {
+                actionLabel: 'Open Subscriptions',
+                done: overviewData.subscriptionCount > 0,
+                icon: PlugIcon,
+                id: 'subscriptions',
+                label: 'Subscribe to an API plan',
+                to: '../subscriptions',
+                tooltip: 'Create a subscription so this application can consume an API or API product plan.',
+            },
+            {
+                actionLabel: 'Manage Access',
+                done: overviewData.memberCount > 1,
+                icon: UsersIcon,
+                id: 'team-access',
+                label: 'Invite teammates and assign roles',
+                to: '../user-permissions',
+                tooltip: 'Collaborate on this application by adding members, groups, and application-scoped roles.',
+            },
+            {
+                actionLabel: 'Open Notifications',
+                done: overviewData.notificationCount > 0,
+                icon: BellIcon,
+                id: 'notifications',
+                label: 'Configure notification settings',
+                to: '../notifications',
+                tooltip: 'Subscribe this application to notifications for subscription, API key, and lifecycle events.',
+            },
+        ],
+        [application, overviewData.memberCount, overviewData.notificationCount, overviewData.subscriptionCount],
+    );
+
+    return (
+        <OverviewChecklistCard
+            description="Finish setting up your application. Each row links to the right screen."
+            isReady={isReady}
+            items={items}
+            totalCountHint={4}
+        />
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/overview/ApplicationOverviewSnapshot.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/overview/ApplicationOverviewSnapshot.tsx
@@ -1,0 +1,92 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Button, Card, CardContent, Skeleton } from '@gravitee/graphene-core';
+import { ArrowRightIcon, CircleCheckIcon, ClockIcon, PlugIcon } from '@gravitee/graphene-core/icons';
+import type { ComponentType } from 'react';
+import { Link } from 'react-router-dom';
+
+import type { ApplicationOverviewData } from '../../hooks/useApplicationOverviewData';
+
+interface SnapshotMetricCardProps {
+    readonly helper: string;
+    readonly icon: ComponentType<{ className?: string }>;
+    readonly iconClassName: string;
+    readonly isLoading: boolean;
+    readonly label: string;
+    readonly value: number;
+}
+
+function SnapshotMetricCard({ helper, icon: Icon, iconClassName, isLoading, label, value }: SnapshotMetricCardProps) {
+    return (
+        <Card className="flex-1">
+            <CardContent className="pt-6">
+                <div className="flex items-start justify-between gap-4">
+                    <div>
+                        <p className="mb-2 text-sm text-muted-foreground">{label}</p>
+                        {isLoading ? <Skeleton className="h-8 w-12" /> : <p className="text-2xl font-semibold tracking-tight">{value}</p>}
+                        <p className="mt-2 text-xs text-muted-foreground">{helper}</p>
+                    </div>
+                    <Icon className={iconClassName} aria-hidden />
+                </div>
+            </CardContent>
+        </Card>
+    );
+}
+
+export function ApplicationOverviewSnapshot({ overviewData }: Readonly<{ overviewData: ApplicationOverviewData }>) {
+    return (
+        <section className="space-y-3" aria-labelledby="application-overview-snapshot-title">
+            <div className="flex items-center justify-between gap-4">
+                <h2 id="application-overview-snapshot-title" className="text-sm font-medium text-muted-foreground">
+                    Application snapshot
+                </h2>
+                <Button asChild variant="link" size="sm" className="h-auto px-0 text-primary">
+                    <Link to="../subscriptions">
+                        More details
+                        <ArrowRightIcon className="size-4" aria-hidden />
+                    </Link>
+                </Button>
+            </div>
+
+            <div className="flex gap-4">
+                <SnapshotMetricCard
+                    helper="Total API subscriptions"
+                    icon={PlugIcon}
+                    iconClassName="size-4 text-muted-foreground"
+                    isLoading={overviewData.isLoadingSubscriptions}
+                    label="Subscriptions"
+                    value={overviewData.subscriptionCount}
+                />
+                <SnapshotMetricCard
+                    helper="Consuming APIs"
+                    icon={CircleCheckIcon}
+                    iconClassName="size-4 text-success"
+                    isLoading={overviewData.isLoadingActiveSubscriptions}
+                    label="Active"
+                    value={overviewData.activeSubscriptionCount}
+                />
+                <SnapshotMetricCard
+                    helper="Awaiting approval"
+                    icon={ClockIcon}
+                    iconClassName="size-4 text-warning"
+                    isLoading={overviewData.isLoadingPendingSubscriptions}
+                    label="Pending"
+                    value={overviewData.pendingSubscriptionCount}
+                />
+            </div>
+        </section>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/overview/CircularProgress.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/overview/CircularProgress.tsx
@@ -1,0 +1,54 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const RADIUS = 42;
+const CIRCUMFERENCE = 2 * Math.PI * RADIUS;
+
+export function CircularProgress({ pct }: Readonly<{ pct: number }>) {
+    const boundedPct = Math.min(100, Math.max(0, pct));
+    const offset = CIRCUMFERENCE * (1 - boundedPct / 100);
+
+    return (
+        <div className="relative h-24 w-24" aria-label={`${boundedPct}% complete`} role="img">
+            <svg viewBox="0 0 100 100" aria-hidden className="h-24 w-24 -rotate-90 text-primary">
+                <circle
+                    cx="50"
+                    cy="50"
+                    r={RADIUS}
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="8"
+                    className="text-muted-foreground opacity-20"
+                />
+                <circle
+                    cx="50"
+                    cy="50"
+                    r={RADIUS}
+                    fill="none"
+                    stroke="currentColor"
+                    strokeDasharray={CIRCUMFERENCE}
+                    strokeDashoffset={offset}
+                    strokeLinecap="round"
+                    strokeWidth="8"
+                    className="transition-all duration-500 ease-out"
+                />
+            </svg>
+            <div className="absolute inset-0 flex flex-col items-center justify-center">
+                <span className="text-xl font-bold">{boundedPct}%</span>
+            </div>
+        </div>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/overview/OverviewChecklistCard.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/overview/OverviewChecklistCard.tsx
@@ -1,0 +1,158 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+    Button,
+    Card,
+    CardContent,
+    CardDescription,
+    CardHeader,
+    CardTitle,
+    Tooltip,
+    TooltipContent,
+    TooltipProvider,
+    TooltipTrigger,
+    cn,
+} from '@gravitee/graphene-core';
+import { ArrowRightIcon, ChevronDownIcon, ChevronUpIcon, CircleCheckIcon, InfoIcon } from '@gravitee/graphene-core/icons';
+import { type ComponentType, useState } from 'react';
+import { Link } from 'react-router-dom';
+
+import { CircularProgress } from './CircularProgress';
+
+export interface OverviewChecklistItem {
+    readonly actionLabel: string;
+    readonly done: boolean;
+    readonly icon: ComponentType<{ className?: string }>;
+    readonly id: string;
+    readonly label: string;
+    readonly to: string;
+    readonly tooltip: string;
+}
+
+interface OverviewChecklistCardProps {
+    readonly description: string;
+    readonly isReady?: boolean;
+    readonly items: OverviewChecklistItem[];
+    readonly totalCountHint?: number;
+}
+
+export function OverviewChecklistCard({ description, isReady = true, items, totalCountHint }: Readonly<OverviewChecklistCardProps>) {
+    const [open, setOpen] = useState(true);
+    const completedCount = items.filter(item => item.done).length;
+    const totalCount = totalCountHint ?? items.length;
+    const completionPct = totalCount > 0 ? Math.round((completedCount / totalCount) * 100) : 0;
+
+    return (
+        <Card>
+            <CardHeader className="pb-0">
+                <div className="flex items-center justify-between gap-4">
+                    <div className="flex items-center gap-3">
+                        <div className="flex size-9 items-center justify-center rounded-lg bg-primary/10">
+                            <CircleCheckIcon className="size-4 text-primary" aria-hidden />
+                        </div>
+                        <div>
+                            <CardTitle className="text-base">Checklist</CardTitle>
+                            <CardDescription className="mt-0.5">{description}</CardDescription>
+                        </div>
+                    </div>
+                    <div className="flex items-center gap-3">
+                        <span className="text-sm font-semibold text-muted-foreground">
+                            {isReady ? completedCount : '…'}/{totalCount}
+                        </span>
+                        <Button
+                            type="button"
+                            variant="ghost"
+                            size="icon"
+                            className="size-8 text-muted-foreground"
+                            onClick={() => setOpen(current => !current)}
+                            aria-label={open ? 'Collapse checklist' : 'Expand checklist'}
+                        >
+                            {open ? <ChevronUpIcon className="size-5" aria-hidden /> : <ChevronDownIcon className="size-5" aria-hidden />}
+                        </Button>
+                    </div>
+                </div>
+            </CardHeader>
+
+            {open ? (
+                <CardContent className="pt-4">
+                    <div className="flex flex-row gap-8">
+                        <div className="min-w-0 flex-1 space-y-1">
+                            <TooltipProvider delayDuration={200}>
+                                {items.map(item => {
+                                    const ItemIcon = item.icon;
+
+                                    return (
+                                        <div
+                                            key={item.id}
+                                            className={cn('flex items-center gap-3 rounded-lg px-3 py-2.5 transition-colors', {
+                                                'hover:bg-accent/50': !item.done,
+                                                'opacity-60': item.done,
+                                            })}
+                                        >
+                                            <div className="shrink-0">
+                                                {item.done ? (
+                                                    <CircleCheckIcon className="size-4 text-success" aria-hidden />
+                                                ) : (
+                                                    <div className="size-4 rounded border-2 border-muted-foreground/30" aria-hidden />
+                                                )}
+                                            </div>
+                                            <ItemIcon className="size-4 shrink-0 text-muted-foreground" aria-hidden />
+                                            <span
+                                                className={cn('min-w-0 flex-1 text-sm', {
+                                                    'line-through text-muted-foreground': item.done,
+                                                    'text-foreground': !item.done,
+                                                })}
+                                            >
+                                                {item.label}
+                                            </span>
+                                            <Tooltip>
+                                                <TooltipTrigger asChild>
+                                                    <Button
+                                                        type="button"
+                                                        variant="ghost"
+                                                        size="icon"
+                                                        className="size-7 shrink-0 text-muted-foreground/60"
+                                                        aria-label={`Info: ${item.label}`}
+                                                    >
+                                                        <InfoIcon className="size-3.5" aria-hidden />
+                                                    </Button>
+                                                </TooltipTrigger>
+                                                <TooltipContent side="top" className="max-w-xs text-xs">
+                                                    {item.tooltip}
+                                                </TooltipContent>
+                                            </Tooltip>
+                                            <Button asChild variant="link" size="sm" className="h-auto shrink-0 px-1.5 py-1 text-primary">
+                                                <Link to={item.to} aria-label={item.actionLabel}>
+                                                    {item.actionLabel}
+                                                    <ArrowRightIcon className="size-4 shrink-0" aria-hidden />
+                                                </Link>
+                                            </Button>
+                                        </div>
+                                    );
+                                })}
+                            </TooltipProvider>
+                        </div>
+
+                        <div className="flex shrink-0 flex-col items-center justify-center gap-2 border-l pl-8 pr-2">
+                            <CircularProgress pct={completionPct} />
+                            <span className="text-center text-xs text-muted-foreground">Completion</span>
+                        </div>
+                    </div>
+                </CardContent>
+            ) : null}
+        </Card>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/user-permissions/AddMembersDialog.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/user-permissions/AddMembersDialog.tsx
@@ -1,0 +1,210 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+    Button,
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+    Input,
+    Label,
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+    Skeleton,
+} from '@gravitee/graphene-core';
+import { PlusIcon, SearchIcon, XIcon } from '@gravitee/graphene-core/icons';
+import { useQuery } from '@tanstack/react-query';
+import { useDeferredValue, useMemo, useState } from 'react';
+
+import { MemberAvatar } from './MemberAvatar';
+import { isSameUser } from './memberHelpers';
+import { searchUsers } from '../../services/applicationMembers';
+import type { ApplicationUiMember, SearchableUser } from '../../types/applicationMembers.types';
+
+export function AddMembersDialog({
+    open,
+    roles,
+    existingMembers,
+    onClose,
+    onAdd,
+    isAdding,
+}: Readonly<{
+    open: boolean;
+    roles: string[];
+    existingMembers: ApplicationUiMember[];
+    onClose: () => void;
+    onAdd: (users: SearchableUser[], roleName: string) => void;
+    isAdding: boolean;
+}>) {
+    const [search, setSearch] = useState('');
+    const [selectedUsers, setSelectedUsers] = useState<SearchableUser[]>([]);
+    const [selectedRoleOverride, setSelectedRoleOverride] = useState<string | null>(null);
+    const selectedRole = selectedRoleOverride ?? roles[0] ?? '';
+
+    // Reset dialog state each time it opens (setState-during-render pattern).
+    const [prevOpen, setPrevOpen] = useState(open);
+    if (prevOpen !== open) {
+        setPrevOpen(open);
+        setSearch('');
+        setSelectedUsers([]);
+        setSelectedRoleOverride(null);
+    }
+
+    const deferredQuery = useDeferredValue(search);
+    const { data: results, isFetching } = useQuery({
+        queryKey: ['user-search', deferredQuery],
+        queryFn: () => searchUsers(deferredQuery),
+        enabled: deferredQuery.trim().length >= 2,
+        staleTime: 30_000,
+    });
+
+    const filteredResults = useMemo(
+        () =>
+            (results ?? []).filter(
+                result =>
+                    !selectedUsers.some(u => isSameUser(u, result)) &&
+                    !existingMembers.some(
+                        m => (result.id !== null && result.id !== undefined && m.id === result.id) || m.id === result.reference,
+                    ),
+            ),
+        [results, selectedUsers, existingMembers],
+    );
+
+    const canSubmit = selectedUsers.length > 0 && !!selectedRole;
+
+    function handleSelectUser(user: SearchableUser) {
+        setSelectedUsers(prev => (prev.some(u => isSameUser(u, user)) ? prev : [...prev, user]));
+        setSearch('');
+    }
+
+    function handleClose() {
+        setSearch('');
+        setSelectedUsers([]);
+        setSelectedRoleOverride(null);
+        onClose();
+    }
+
+    const addLabel = selectedUsers.length > 1 ? `Add ${selectedUsers.length} members` : 'Add member';
+
+    return (
+        <Dialog open={open} onOpenChange={isOpen => !isOpen && handleClose()}>
+            <DialogContent className="max-w-[480px]">
+                <DialogHeader>
+                    <DialogTitle>Add Members</DialogTitle>
+                    <DialogDescription>Search for users by name or email and add them to this application.</DialogDescription>
+                </DialogHeader>
+
+                <div className="space-y-6">
+                    <div className="space-y-1">
+                        <div className="relative">
+                            <SearchIcon className="absolute left-3 top-1/2 -translate-y-1/2 size-4 text-muted-foreground pointer-events-none" />
+                            <Input
+                                className="pl-10"
+                                placeholder="Search a user by name or email…"
+                                value={search}
+                                onChange={e => setSearch(e.target.value)}
+                            />
+                        </div>
+                        {search.trim().length >= 2 && (
+                            <div className="rounded-lg border shadow-md bg-background overflow-y-auto" style={{ maxHeight: '12rem' }}>
+                                {isFetching || search !== deferredQuery ? (
+                                    <div className="p-3 space-y-2">
+                                        <Skeleton className="h-10 rounded" />
+                                        <Skeleton className="h-10 rounded" />
+                                    </div>
+                                ) : filteredResults.length === 0 ? (
+                                    <p className="px-3 py-4 text-sm text-center text-muted-foreground">No users found.</p>
+                                ) : (
+                                    filteredResults.map(user => (
+                                        <button
+                                            key={user.reference}
+                                            type="button"
+                                            onClick={() => handleSelectUser(user)}
+                                            className="w-full flex items-center gap-3 px-3 py-2.5 text-left text-sm transition-colors hover:bg-muted/50"
+                                        >
+                                            <MemberAvatar name={user.displayName} />
+                                            <div className="min-w-0">
+                                                <p className="font-medium truncate">{user.displayName}</p>
+                                                {user.email ? <p className="text-xs text-muted-foreground truncate">{user.email}</p> : null}
+                                            </div>
+                                        </button>
+                                    ))
+                                )}
+                            </div>
+                        )}
+                    </div>
+
+                    {selectedUsers.length > 0 && (
+                        <div className="space-y-2">
+                            <p className="text-sm text-muted-foreground">
+                                {selectedUsers.length} {selectedUsers.length === 1 ? 'user' : 'users'} selected
+                            </p>
+                            <div className="flex flex-wrap gap-2">
+                                {selectedUsers.map(u => (
+                                    <span
+                                        key={u.id ?? u.reference}
+                                        className="inline-flex items-center gap-1.5 rounded-md border px-2.5 py-1 text-sm font-medium bg-muted/40"
+                                    >
+                                        {u.displayName}
+                                        <button
+                                            type="button"
+                                            onClick={() => setSelectedUsers(prev => prev.filter(x => !isSameUser(x, u)))}
+                                            className="rounded-sm opacity-60 hover:opacity-100 transition-opacity"
+                                            aria-label={`Remove ${u.displayName}`}
+                                        >
+                                            <XIcon className="size-3" />
+                                        </button>
+                                    </span>
+                                ))}
+                            </div>
+                        </div>
+                    )}
+
+                    <div className="space-y-2">
+                        <Label className="text-sm font-medium">Role for new members</Label>
+                        <Select value={selectedRole} onValueChange={setSelectedRoleOverride}>
+                            <SelectTrigger className="w-full">
+                                <SelectValue placeholder="Select a role…" />
+                            </SelectTrigger>
+                            <SelectContent>
+                                {roles.map(role => (
+                                    <SelectItem key={role} value={role}>
+                                        {role}
+                                    </SelectItem>
+                                ))}
+                            </SelectContent>
+                        </Select>
+                    </div>
+                </div>
+
+                <DialogFooter className="border-t px-6 py-4 gap-2">
+                    <Button type="button" variant="outline" onClick={handleClose} disabled={isAdding}>
+                        Cancel
+                    </Button>
+                    <Button type="button" onClick={() => onAdd(selectedUsers, selectedRole)} disabled={!canSubmit || isAdding}>
+                        <PlusIcon className="size-4" />
+                        {addLabel}
+                    </Button>
+                </DialogFooter>
+            </DialogContent>
+        </Dialog>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/user-permissions/AddMembersDialog.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/user-permissions/AddMembersDialog.tsx
@@ -38,6 +38,7 @@ import { MemberAvatar } from './MemberAvatar';
 import { isSameUser } from './memberHelpers';
 import { searchUsers } from '../../services/applicationMembers';
 import type { ApplicationUiMember, SearchableUser } from '../../types/applicationMembers.types';
+import { applicationMemberKeys } from '../../utils/queryKeys';
 
 export function AddMembersDialog({
     open,
@@ -70,7 +71,7 @@ export function AddMembersDialog({
 
     const deferredQuery = useDeferredValue(search);
     const { data: results, isFetching } = useQuery({
-        queryKey: ['user-search', deferredQuery],
+        queryKey: applicationMemberKeys.userSearch(deferredQuery),
         queryFn: () => searchUsers(deferredQuery),
         enabled: deferredQuery.trim().length >= 2,
         staleTime: 30_000,
@@ -106,7 +107,7 @@ export function AddMembersDialog({
 
     return (
         <Dialog open={open} onOpenChange={isOpen => !isOpen && handleClose()}>
-            <DialogContent className="max-w-[480px]">
+            <DialogContent style={{ maxWidth: '30rem' }}>
                 <DialogHeader>
                     <DialogTitle>Add Members</DialogTitle>
                     <DialogDescription>Search for users by name or email and add them to this application.</DialogDescription>
@@ -117,10 +118,10 @@ export function AddMembersDialog({
                         <div className="relative">
                             <SearchIcon className="absolute left-3 top-1/2 -translate-y-1/2 size-4 text-muted-foreground pointer-events-none" />
                             <Input
-                                className="pl-10"
                                 placeholder="Search a user by name or email…"
                                 value={search}
                                 onChange={e => setSearch(e.target.value)}
+                                style={{ paddingLeft: '2.5rem' }}
                             />
                         </div>
                         {search.trim().length >= 2 && (

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/user-permissions/DirectMembersTable.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/user-permissions/DirectMembersTable.tsx
@@ -77,7 +77,7 @@ export function DirectMembersTable({
                 <TableHeader>
                     <TableRow>
                         <TableHead>Name</TableHead>
-                        <TableHead className="w-[32%]">Role</TableHead>
+                        <TableHead style={{ width: '32%' }}>Role</TableHead>
                         <TableHead />
                     </TableRow>
                 </TableHeader>
@@ -95,7 +95,7 @@ export function DirectMembersTable({
                                     </div>
                                 </TableCell>
 
-                                <TableCell className="w-[32%]">
+                                <TableCell style={{ width: '32%' }}>
                                     <RoleBadge roleName={currentRole} isPO={isPO} />
                                 </TableCell>
 
@@ -113,7 +113,7 @@ export function DirectMembersTable({
                                                     <MoreHorizontalIcon className="size-4" />
                                                 </Button>
                                             </DropdownMenuTrigger>
-                                            <DropdownMenuContent align="end" className="w-auto min-w-[12rem]">
+                                            <DropdownMenuContent align="end" className="w-auto" style={{ minWidth: '12rem' }}>
                                                 {canEditRole ? (
                                                     <DropdownMenuItem onSelect={() => onEditRole(member)}>
                                                         <PencilIcon className="size-4" />

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/user-permissions/DirectMembersTable.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/user-permissions/DirectMembersTable.tsx
@@ -1,0 +1,145 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+    Badge,
+    Button,
+    DropdownMenu,
+    DropdownMenuContent,
+    DropdownMenuItem,
+    DropdownMenuSeparator,
+    DropdownMenuTrigger,
+    Table,
+    TableBody,
+    TableCell,
+    TableHead,
+    TableHeader,
+    TableRow,
+} from '@gravitee/graphene-core';
+import { MoreHorizontalIcon, PencilIcon, ShieldCheckIcon, Trash2Icon } from '@gravitee/graphene-core/icons';
+
+import { MemberAvatar } from './MemberAvatar';
+import { formatRoleLabel, getApplicationRole, isMemberPrimaryOwner } from './memberHelpers';
+import type { ApplicationUiMember } from '../../types/applicationMembers.types';
+
+function RoleBadge({ roleName, isPO }: Readonly<{ roleName: string; isPO: boolean }>) {
+    if (isPO) {
+        return (
+            <Badge className="gap-1 bg-primary/10 text-primary border-transparent font-normal">
+                <ShieldCheckIcon className="size-3" aria-hidden="true" />
+                Primary Owner
+            </Badge>
+        );
+    }
+    return (
+        <Badge variant="secondary" className="font-normal">
+            {roleName ? formatRoleLabel(roleName) : '—'}
+        </Badge>
+    );
+}
+
+export function DirectMembersTable({
+    members,
+    onEditRole,
+    onRemove,
+    isRemoving,
+    getRoleName,
+    canManageMembers = true,
+    canEditRole = true,
+    canRemoveMember = true,
+}: Readonly<{
+    members: ApplicationUiMember[];
+    onEditRole: (member: ApplicationUiMember) => void;
+    onRemove: (member: ApplicationUiMember) => void;
+    isRemoving: boolean;
+    getRoleName?: (member: ApplicationUiMember) => string;
+    canManageMembers?: boolean;
+    canEditRole?: boolean;
+    canRemoveMember?: boolean;
+}>) {
+    const showActionsMenu = canManageMembers && (canEditRole || canRemoveMember);
+
+    return (
+        <div className="rounded-lg border overflow-hidden">
+            <Table className="table-fixed w-full">
+                <TableHeader>
+                    <TableRow>
+                        <TableHead>Name</TableHead>
+                        <TableHead className="w-[32%]">Role</TableHead>
+                        <TableHead />
+                    </TableRow>
+                </TableHeader>
+                <TableBody>
+                    {members.map(member => {
+                        const isPO = isMemberPrimaryOwner(member);
+                        const currentRole = getRoleName ? getRoleName(member) : getApplicationRole(member);
+
+                        return (
+                            <TableRow key={member.id}>
+                                <TableCell>
+                                    <div className="flex items-center gap-3">
+                                        <MemberAvatar name={member.displayName ?? ''} />
+                                        <span className="text-sm font-medium">{member.displayName}</span>
+                                    </div>
+                                </TableCell>
+
+                                <TableCell className="w-[32%]">
+                                    <RoleBadge roleName={currentRole} isPO={isPO} />
+                                </TableCell>
+
+                                <TableCell className="text-right">
+                                    {showActionsMenu && !isPO ? (
+                                        <DropdownMenu>
+                                            <DropdownMenuTrigger asChild>
+                                                <Button
+                                                    type="button"
+                                                    variant="ghost"
+                                                    size="icon"
+                                                    className="size-8"
+                                                    aria-label={`Actions for ${member.displayName}`}
+                                                >
+                                                    <MoreHorizontalIcon className="size-4" />
+                                                </Button>
+                                            </DropdownMenuTrigger>
+                                            <DropdownMenuContent align="end" className="w-auto min-w-[12rem]">
+                                                {canEditRole ? (
+                                                    <DropdownMenuItem onSelect={() => onEditRole(member)}>
+                                                        <PencilIcon className="size-4" />
+                                                        Edit role
+                                                    </DropdownMenuItem>
+                                                ) : null}
+                                                {canEditRole && canRemoveMember ? <DropdownMenuSeparator /> : null}
+                                                {canRemoveMember ? (
+                                                    <DropdownMenuItem
+                                                        onSelect={() => onRemove(member)}
+                                                        disabled={isRemoving}
+                                                        className="text-destructive focus:text-destructive"
+                                                    >
+                                                        <Trash2Icon className="size-4" />
+                                                        Remove member
+                                                    </DropdownMenuItem>
+                                                ) : null}
+                                            </DropdownMenuContent>
+                                        </DropdownMenu>
+                                    ) : null}
+                                </TableCell>
+                            </TableRow>
+                        );
+                    })}
+                </TableBody>
+            </Table>
+        </div>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/user-permissions/EditRoleDialog.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/user-permissions/EditRoleDialog.tsx
@@ -1,0 +1,107 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+    Button,
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+    Label,
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from '@gravitee/graphene-core';
+import { useEffect, useState } from 'react';
+
+import { MemberAvatar } from './MemberAvatar';
+import { formatRoleLabel, getApplicationRole } from './memberHelpers';
+import type { ApplicationUiMember } from '../../types/applicationMembers.types';
+
+export function EditRoleDialog({
+    member,
+    roles,
+    onClose,
+    onSave,
+    isSaving,
+}: Readonly<{
+    member: ApplicationUiMember | null;
+    roles: string[];
+    onClose: () => void;
+    onSave: (roleName: string) => void;
+    isSaving: boolean;
+}>) {
+    const [role, setRole] = useState('');
+
+    useEffect(() => {
+        setRole(member ? getApplicationRole(member) : '');
+    }, [member]);
+
+    const handleOpenChange = (open: boolean) => {
+        if (!open) onClose();
+    };
+
+    return (
+        <Dialog open={member !== null} onOpenChange={handleOpenChange}>
+            <DialogContent className="max-w-sm">
+                <DialogHeader>
+                    <DialogTitle>Edit Role</DialogTitle>
+                    <DialogDescription>Change the role for {member?.displayName}.</DialogDescription>
+                </DialogHeader>
+
+                {member ? (
+                    <div className="space-y-4 py-2">
+                        <div className="flex items-center gap-3">
+                            <MemberAvatar name={member.displayName} />
+                            <div className="min-w-0">
+                                <p className="text-sm font-medium">{member.displayName}</p>
+                                {member.email ? <p className="text-xs text-muted-foreground truncate">{member.email}</p> : null}
+                            </div>
+                        </div>
+
+                        <div className="space-y-2">
+                            <Label className="text-sm font-medium">Role</Label>
+                            <Select value={role} onValueChange={setRole}>
+                                <SelectTrigger className="w-full">
+                                    <SelectValue placeholder="Select a role…" />
+                                </SelectTrigger>
+                                <SelectContent>
+                                    {roles.map(roleName => (
+                                        <SelectItem key={roleName} value={roleName}>
+                                            {formatRoleLabel(roleName)}
+                                        </SelectItem>
+                                    ))}
+                                </SelectContent>
+                            </Select>
+                        </div>
+                    </div>
+                ) : null}
+
+                <DialogFooter className="border-t px-6 py-4 gap-2">
+                    <Button type="button" variant="outline" onClick={onClose} disabled={isSaving}>
+                        Cancel
+                    </Button>
+                    <Button type="button" onClick={() => onSave(role)} disabled={isSaving || !role || !member}>
+                        Save
+                    </Button>
+                </DialogFooter>
+            </DialogContent>
+        </Dialog>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/user-permissions/GroupMembersSection.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/user-permissions/GroupMembersSection.tsx
@@ -1,0 +1,104 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+    Badge,
+    Card,
+    CardContent,
+    CardDescription,
+    CardHeader,
+    CardTitle,
+    Skeleton,
+    Table,
+    TableBody,
+    TableCell,
+    TableHead,
+    TableHeader,
+    TableRow,
+} from '@gravitee/graphene-core';
+import { UsersIcon } from '@gravitee/graphene-core/icons';
+
+import { MemberAvatar } from './MemberAvatar';
+import { getGroupMemberRole } from './memberHelpers';
+import type { GroupMember } from '../../types/applicationMembers.types';
+
+export function GroupMembersSection({
+    groupName,
+    members,
+    isLoading = false,
+}: Readonly<{ groupName: string; members: GroupMember[]; isLoading?: boolean }>) {
+    const count = members.length;
+    return (
+        <Card className="overflow-hidden">
+            <CardHeader className="pb-3">
+                <div className="flex items-center gap-3">
+                    <UsersIcon className="size-4 shrink-0 text-muted-foreground" aria-hidden="true" />
+                    <CardTitle className="text-sm">{groupName}</CardTitle>
+                    <Badge variant="secondary" className="text-xs tabular-nums">
+                        {count} inherited {count === 1 ? 'member' : 'members'}
+                    </Badge>
+                </div>
+                <CardDescription className="text-xs">
+                    Members inherited from this group. Permissions are managed at the group level.
+                </CardDescription>
+            </CardHeader>
+            <CardContent>
+                <div className="rounded-lg border overflow-hidden">
+                    <Table className="table-fixed w-full">
+                        <TableHeader>
+                            <TableRow>
+                                <TableHead>Name</TableHead>
+                                <TableHead className="w-[32%]">Role</TableHead>
+                            </TableRow>
+                        </TableHeader>
+                        <TableBody>
+                            {isLoading ? (
+                                Array.from({ length: 2 }).map((_, i) => (
+                                    <TableRow key={`skeleton-${i}`}>
+                                        <TableCell colSpan={2}>
+                                            <Skeleton className="h-10 w-full rounded" />
+                                        </TableCell>
+                                    </TableRow>
+                                ))
+                            ) : members.length === 0 ? (
+                                <TableRow>
+                                    <TableCell colSpan={2} className="text-sm text-muted-foreground">
+                                        No members in this group.
+                                    </TableCell>
+                                </TableRow>
+                            ) : (
+                                members.map(m => (
+                                    <TableRow key={m.id}>
+                                        <TableCell>
+                                            <div className="flex items-center gap-3">
+                                                <MemberAvatar name={m.displayName ?? ''} />
+                                                <span className="text-sm font-medium">{m.displayName}</span>
+                                            </div>
+                                        </TableCell>
+                                        <TableCell className="w-[32%]">
+                                            <Badge variant="secondary" className="font-normal">
+                                                {getGroupMemberRole(m)}
+                                            </Badge>
+                                        </TableCell>
+                                    </TableRow>
+                                ))
+                            )}
+                        </TableBody>
+                    </Table>
+                </div>
+            </CardContent>
+        </Card>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/user-permissions/GroupMembersSection.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/user-permissions/GroupMembersSection.tsx
@@ -60,7 +60,7 @@ export function GroupMembersSection({
                         <TableHeader>
                             <TableRow>
                                 <TableHead>Name</TableHead>
-                                <TableHead className="w-[32%]">Role</TableHead>
+                                <TableHead style={{ width: '32%' }}>Role</TableHead>
                             </TableRow>
                         </TableHeader>
                         <TableBody>
@@ -87,7 +87,7 @@ export function GroupMembersSection({
                                                 <span className="text-sm font-medium">{m.displayName}</span>
                                             </div>
                                         </TableCell>
-                                        <TableCell className="w-[32%]">
+                                        <TableCell style={{ width: '32%' }}>
                                             <Badge variant="secondary" className="font-normal">
                                                 {getGroupMemberRole(m)}
                                             </Badge>

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/user-permissions/ManageGroupsDialog.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/user-permissions/ManageGroupsDialog.tsx
@@ -84,13 +84,18 @@ export function ManageGroupsDialog({
             <DialogContent className="max-w-md">
                 <DialogHeader>
                     <DialogTitle>Manage groups</DialogTitle>
-                    <DialogDescription>Select the groups that should have access to this API.</DialogDescription>
+                    <DialogDescription>Select the groups that should have access to this application.</DialogDescription>
                 </DialogHeader>
 
                 <div className="space-y-4">
                     <div className="relative">
                         <SearchIcon className="absolute left-3 top-1/2 -translate-y-1/2 size-4 text-muted-foreground pointer-events-none" />
-                        <Input className="pl-10" placeholder="Search groups…" value={search} onChange={e => setSearch(e.target.value)} />
+                        <Input
+                            placeholder="Search groups…"
+                            value={search}
+                            onChange={e => setSearch(e.target.value)}
+                            style={{ paddingLeft: '2.5rem' }}
+                        />
                     </div>
 
                     <div className="overflow-y-auto rounded-md" style={{ maxHeight: '18rem' }}>

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/user-permissions/ManageGroupsDialog.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/user-permissions/ManageGroupsDialog.tsx
@@ -1,0 +1,146 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+    Badge,
+    Button,
+    Checkbox,
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+    Input,
+} from '@gravitee/graphene-core';
+import { SearchIcon } from '@gravitee/graphene-core/icons';
+import { useCallback, useMemo, useState } from 'react';
+
+import type { EnvironmentGroup } from '../../types/applicationMembers.types';
+
+export function ManageGroupsDialog({
+    open,
+    allGroups,
+    currentGroupIds,
+    onClose,
+    onSave,
+    isSaving,
+}: Readonly<{
+    open: boolean;
+    allGroups: EnvironmentGroup[];
+    currentGroupIds: string[];
+    onClose: () => void;
+    onSave: (groupIds: string[]) => void;
+    isSaving: boolean;
+}>) {
+    const [selected, setSelected] = useState<Set<string>>(() => new Set(currentGroupIds));
+    const [search, setSearch] = useState('');
+
+    // Reset selection and search each time the dialog opens (setState-during-render pattern).
+    const [prevOpen, setPrevOpen] = useState(open);
+    if (prevOpen !== open) {
+        setPrevOpen(open);
+        if (open) {
+            setSelected(new Set(currentGroupIds));
+            setSearch('');
+        }
+    }
+
+    const handleOpen = useCallback(
+        (isOpen: boolean) => {
+            if (!isOpen) onClose();
+        },
+        [onClose],
+    );
+
+    const filtered = useMemo(() => {
+        const query = search.trim().toLowerCase();
+        return query ? allGroups.filter(g => g.name.toLowerCase().includes(query)) : allGroups;
+    }, [allGroups, search]);
+
+    function toggle(id: string) {
+        setSelected(prev => {
+            const next = new Set(prev);
+            if (next.has(id)) next.delete(id);
+            else next.add(id);
+            return next;
+        });
+    }
+
+    return (
+        <Dialog open={open} onOpenChange={handleOpen}>
+            <DialogContent className="max-w-md">
+                <DialogHeader>
+                    <DialogTitle>Manage groups</DialogTitle>
+                    <DialogDescription>Select the groups that should have access to this API.</DialogDescription>
+                </DialogHeader>
+
+                <div className="space-y-4">
+                    <div className="relative">
+                        <SearchIcon className="absolute left-3 top-1/2 -translate-y-1/2 size-4 text-muted-foreground pointer-events-none" />
+                        <Input className="pl-10" placeholder="Search groups…" value={search} onChange={e => setSearch(e.target.value)} />
+                    </div>
+
+                    <div className="overflow-y-auto rounded-md" style={{ maxHeight: '18rem' }}>
+                        {filtered.length === 0 ? (
+                            <p className="p-3 text-sm text-muted-foreground">
+                                {search.trim() ? 'No groups match your search.' : 'No groups found in this environment.'}
+                            </p>
+                        ) : (
+                            <div className="space-y-1">
+                                {filtered.map(group => {
+                                    const isAssociated = currentGroupIds.includes(group.id);
+                                    const isChecked = selected.has(group.id);
+                                    return (
+                                        <label
+                                            key={group.id}
+                                            htmlFor={`group-${group.id}`}
+                                            className="flex items-center gap-3 rounded-lg px-3 py-2 hover:bg-muted/50 cursor-pointer"
+                                        >
+                                            <Checkbox
+                                                id={`group-${group.id}`}
+                                                checked={isChecked}
+                                                onCheckedChange={() => toggle(group.id)}
+                                            />
+                                            <span className="flex-1 text-sm select-none">{group.name}</span>
+                                            {isAssociated ? (
+                                                <Badge variant="secondary" className="text-xs">
+                                                    Associated
+                                                </Badge>
+                                            ) : null}
+                                        </label>
+                                    );
+                                })}
+                            </div>
+                        )}
+                    </div>
+
+                    <p className="text-xs text-muted-foreground">
+                        {selected.size} group{selected.size !== 1 ? 's' : ''} selected
+                    </p>
+                </div>
+
+                <DialogFooter className="border-t px-6 py-4 gap-2">
+                    <Button type="button" variant="outline" onClick={() => handleOpen(false)} disabled={isSaving}>
+                        Cancel
+                    </Button>
+                    <Button type="button" onClick={() => onSave([...selected])} disabled={isSaving}>
+                        Save
+                    </Button>
+                </DialogFooter>
+            </DialogContent>
+        </Dialog>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/user-permissions/MemberAvatar.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/user-permissions/MemberAvatar.tsx
@@ -1,0 +1,29 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export function MemberAvatar({ name }: Readonly<{ name: string }>) {
+    const initials = name
+        .split(' ')
+        .map(part => part[0] ?? '')
+        .join('')
+        .toUpperCase()
+        .slice(0, 2);
+    return (
+        <div className="size-8 rounded-full bg-primary/10 flex items-center justify-center shrink-0">
+            <span className="text-xs font-semibold text-primary">{initials || '?'}</span>
+        </div>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/user-permissions/RemoveMemberDialog.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/user-permissions/RemoveMemberDialog.tsx
@@ -1,0 +1,47 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Button, Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@gravitee/graphene-core';
+
+import type { ApplicationUiMember } from '../../types/applicationMembers.types';
+
+export function RemoveMemberDialog({
+    member,
+    isRemoving,
+    onConfirm,
+    onCancel,
+}: Readonly<{ member: ApplicationUiMember | null; isRemoving: boolean; onConfirm: () => void; onCancel: () => void }>) {
+    return (
+        <Dialog open={member !== null} onOpenChange={open => !open && onCancel()}>
+            <DialogContent className="max-w-sm">
+                <DialogHeader>
+                    <DialogTitle>Remove application member</DialogTitle>
+                    <DialogDescription>
+                        Are you sure you want to remove <span className="font-semibold text-foreground">{member?.displayName}</span> from
+                        this application? They will lose all direct access immediately.
+                    </DialogDescription>
+                </DialogHeader>
+                <DialogFooter className="border-t px-6 py-4 gap-2">
+                    <Button type="button" variant="outline" onClick={onCancel} disabled={isRemoving}>
+                        Cancel
+                    </Button>
+                    <Button type="button" variant="destructive" onClick={onConfirm} disabled={isRemoving}>
+                        Remove
+                    </Button>
+                </DialogFooter>
+            </DialogContent>
+        </Dialog>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/user-permissions/TransferOwnershipDialog.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/user-permissions/TransferOwnershipDialog.tsx
@@ -1,0 +1,274 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+    Button,
+    cn,
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+    Input,
+    Label,
+    ScrollArea,
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+    Skeleton,
+} from '@gravitee/graphene-core';
+import { SearchIcon, TriangleAlertIcon, XIcon } from '@gravitee/graphene-core/icons';
+import { useQuery } from '@tanstack/react-query';
+import { useDeferredValue, useMemo, useState } from 'react';
+
+import { MemberAvatar } from './MemberAvatar';
+import { isMemberPrimaryOwner } from './memberHelpers';
+import { searchUsers } from '../../services/applicationMembers';
+import type { ApplicationTransferOwnershipPayload, ApplicationUiMember, SearchableUser } from '../../types/applicationMembers.types';
+
+export function TransferOwnershipDialog({
+    open,
+    members,
+    roles,
+    onClose,
+    onTransfer,
+    isTransferring,
+}: Readonly<{
+    open: boolean;
+    members: ApplicationUiMember[];
+    roles: string[];
+    onClose: () => void;
+    onTransfer: (payload: ApplicationTransferOwnershipPayload) => void;
+    isTransferring: boolean;
+}>) {
+    const [tab, setTab] = useState<'member' | 'user'>('member');
+    const [selectedMemberId, setSelectedMemberId] = useState('');
+    const [selectedRoleOverride, setSelectedRoleOverride] = useState<string | null>(null);
+    const selectedRole = selectedRoleOverride ?? roles[0] ?? '';
+    const [userSearch, setUserSearch] = useState('');
+    const [selectedUser, setSelectedUser] = useState<SearchableUser | null>(null);
+
+    const [prevOpen, setPrevOpen] = useState(open);
+    if (prevOpen !== open) {
+        setPrevOpen(open);
+        if (open) {
+            setTab('member');
+            setSelectedMemberId('');
+            setSelectedRoleOverride(null);
+            setUserSearch('');
+            setSelectedUser(null);
+        }
+    }
+
+    const deferredQuery = useDeferredValue(userSearch);
+    const { data: searchResults, isFetching: isSearching } = useQuery({
+        queryKey: ['user-search-transfer', deferredQuery],
+        queryFn: () => searchUsers(deferredQuery),
+        enabled: tab === 'user' && deferredQuery.trim().length >= 2,
+        staleTime: 30_000,
+    });
+
+    const nonOwnerMembers = useMemo(() => members.filter(m => !isMemberPrimaryOwner(m)), [members]);
+    const canSubmit = selectedRole && (tab === 'member' ? !!selectedMemberId : !!selectedUser);
+
+    function handleSubmit() {
+        if (!canSubmit) return;
+        if (tab === 'member') {
+            onTransfer({ id: selectedMemberId, role: selectedRole });
+        } else if (selectedUser) {
+            onTransfer({
+                id: selectedUser.id ?? undefined,
+                reference: selectedUser.reference,
+                role: selectedRole,
+            });
+        }
+    }
+
+    function handleClose() {
+        setTab('member');
+        setSelectedMemberId('');
+        setSelectedRoleOverride(null);
+        setUserSearch('');
+        setSelectedUser(null);
+        onClose();
+    }
+
+    return (
+        <Dialog open={open} onOpenChange={isOpen => !isOpen && handleClose()}>
+            <DialogContent className="overflow-visible" style={{ width: 'min(90vw, 38rem)', maxWidth: 'min(90vw, 38rem)' }}>
+                <DialogHeader>
+                    <DialogTitle>Transfer ownership</DialogTitle>
+                    <DialogDescription>Transfer primary ownership of this application to another user.</DialogDescription>
+                </DialogHeader>
+
+                <div className="space-y-8">
+                    <div className="flex rounded-lg border overflow-hidden">
+                        <button
+                            type="button"
+                            onClick={() => {
+                                setTab('member');
+                                setSelectedUser(null);
+                                setUserSearch('');
+                            }}
+                            className={cn(
+                                'flex-1 px-4 py-2.5 text-sm font-semibold transition-colors',
+                                tab === 'member' ? 'bg-primary text-primary-foreground' : 'text-muted-foreground',
+                            )}
+                        >
+                            Application member
+                        </button>
+                        <button
+                            type="button"
+                            onClick={() => {
+                                setTab('user');
+                                setSelectedMemberId('');
+                            }}
+                            className={cn(
+                                'flex-1 px-4 py-2.5 text-sm font-semibold transition-colors border-l',
+                                tab === 'user' ? 'bg-primary text-primary-foreground' : 'text-muted-foreground',
+                            )}
+                        >
+                            Other user
+                        </button>
+                    </div>
+
+                    {tab === 'member' ? (
+                        <div className="space-y-2">
+                            <Label className="text-sm font-medium">Select application member</Label>
+                            <Select value={selectedMemberId} onValueChange={setSelectedMemberId}>
+                                <SelectTrigger className="w-full">
+                                    <SelectValue placeholder="Choose a member…" />
+                                </SelectTrigger>
+                                <SelectContent>
+                                    {nonOwnerMembers.map(m => (
+                                        <SelectItem key={m.id} value={m.id}>
+                                            {m.displayName}
+                                        </SelectItem>
+                                    ))}
+                                </SelectContent>
+                            </Select>
+                        </div>
+                    ) : (
+                        <div className="space-y-2">
+                            <Label className="text-sm font-medium">Search by name or email</Label>
+                            {selectedUser ? (
+                                <div className="flex items-center gap-3 rounded-lg border px-3 py-2.5">
+                                    <MemberAvatar name={selectedUser.displayName} />
+                                    <div className="flex-1 min-w-0">
+                                        <p className="text-sm font-medium truncate">{selectedUser.displayName}</p>
+                                        {selectedUser.email ? (
+                                            <p className="text-xs text-muted-foreground truncate">{selectedUser.email}</p>
+                                        ) : null}
+                                    </div>
+                                    <button
+                                        type="button"
+                                        onClick={() => setSelectedUser(null)}
+                                        className="rounded-sm opacity-60 hover:opacity-100 transition-opacity shrink-0"
+                                        aria-label={`Remove ${selectedUser.displayName}`}
+                                    >
+                                        <XIcon className="size-4" />
+                                    </button>
+                                </div>
+                            ) : (
+                                <div className="relative">
+                                    <SearchIcon className="absolute left-3 top-1/2 -translate-y-1/2 size-4 text-muted-foreground pointer-events-none" />
+                                    <Input
+                                        className="pl-10"
+                                        placeholder="Type at least 2 characters…"
+                                        value={userSearch}
+                                        onChange={e => setUserSearch(e.target.value)}
+                                    />
+                                    {userSearch.trim().length >= 2 && (
+                                        <div className="absolute z-50 w-full top-full mt-1 rounded-lg border shadow-md overflow-hidden bg-background">
+                                            {isSearching || userSearch !== deferredQuery ? (
+                                                <div className="p-3 space-y-2">
+                                                    <Skeleton className="h-10 rounded" />
+                                                    <Skeleton className="h-10 rounded" />
+                                                </div>
+                                            ) : (searchResults ?? []).length === 0 ? (
+                                                <p className="px-3 py-4 text-sm text-center text-muted-foreground">No users found.</p>
+                                            ) : (
+                                                <ScrollArea className="max-h-48">
+                                                    {(searchResults ?? []).map(u => (
+                                                        <button
+                                                            key={u.reference}
+                                                            type="button"
+                                                            onClick={() => {
+                                                                setSelectedUser(u);
+                                                                setUserSearch('');
+                                                            }}
+                                                            className="w-full flex items-center gap-3 px-3 py-2.5 text-left text-sm transition-colors hover:bg-muted/50"
+                                                        >
+                                                            <MemberAvatar name={u.displayName} />
+                                                            <div className="min-w-0">
+                                                                <p className="font-medium truncate">{u.displayName}</p>
+                                                                {u.email ? (
+                                                                    <p className="text-xs text-muted-foreground truncate">{u.email}</p>
+                                                                ) : null}
+                                                            </div>
+                                                        </button>
+                                                    ))}
+                                                </ScrollArea>
+                                            )}
+                                        </div>
+                                    )}
+                                </div>
+                            )}
+                        </div>
+                    )}
+
+                    <div className="space-y-2">
+                        <Label className="text-sm font-medium">New role for current Primary Owner</Label>
+                        <Select value={selectedRole} onValueChange={setSelectedRoleOverride}>
+                            <SelectTrigger className="w-full">
+                                <SelectValue placeholder="Select a role…" />
+                            </SelectTrigger>
+                            <SelectContent>
+                                {roles.map(role => (
+                                    <SelectItem key={role} value={role}>
+                                        {role}
+                                    </SelectItem>
+                                ))}
+                            </SelectContent>
+                        </Select>
+                    </div>
+
+                    <div className="flex items-start gap-2 rounded-lg border border-destructive/30 bg-destructive/10 p-3">
+                        <TriangleAlertIcon className="size-4 shrink-0 mt-0.5 text-destructive" />
+                        <div className="text-sm leading-snug text-destructive">
+                            <p className="font-semibold">This action is irreversible</p>
+                            <p className="mt-1">
+                                The current Primary Owner will be reassigned to the{' '}
+                                <span className="font-semibold">{selectedRole || '—'}</span> role.
+                            </p>
+                        </div>
+                    </div>
+                </div>
+
+                <DialogFooter className="border-t px-6 py-4 gap-2">
+                    <Button type="button" variant="outline" onClick={handleClose} disabled={isTransferring}>
+                        Cancel
+                    </Button>
+                    <Button type="button" onClick={handleSubmit} disabled={!canSubmit || isTransferring}>
+                        Transfer
+                    </Button>
+                </DialogFooter>
+            </DialogContent>
+        </Dialog>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/user-permissions/TransferOwnershipDialog.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/user-permissions/TransferOwnershipDialog.tsx
@@ -40,6 +40,7 @@ import { MemberAvatar } from './MemberAvatar';
 import { isMemberPrimaryOwner } from './memberHelpers';
 import { searchUsers } from '../../services/applicationMembers';
 import type { ApplicationTransferOwnershipPayload, ApplicationUiMember, SearchableUser } from '../../types/applicationMembers.types';
+import { applicationMemberKeys } from '../../utils/queryKeys';
 
 export function TransferOwnershipDialog({
     open,
@@ -77,7 +78,7 @@ export function TransferOwnershipDialog({
 
     const deferredQuery = useDeferredValue(userSearch);
     const { data: searchResults, isFetching: isSearching } = useQuery({
-        queryKey: ['user-search-transfer', deferredQuery],
+        queryKey: applicationMemberKeys.userSearchTransfer(deferredQuery),
         queryFn: () => searchUsers(deferredQuery),
         enabled: tab === 'user' && deferredQuery.trim().length >= 2,
         staleTime: 30_000,
@@ -188,10 +189,10 @@ export function TransferOwnershipDialog({
                                 <div className="relative">
                                     <SearchIcon className="absolute left-3 top-1/2 -translate-y-1/2 size-4 text-muted-foreground pointer-events-none" />
                                     <Input
-                                        className="pl-10"
                                         placeholder="Type at least 2 characters…"
                                         value={userSearch}
                                         onChange={e => setUserSearch(e.target.value)}
+                                        style={{ paddingLeft: '2.5rem' }}
                                     />
                                     {userSearch.trim().length >= 2 && (
                                         <div className="absolute z-50 w-full top-full mt-1 rounded-lg border shadow-md overflow-hidden bg-background">

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/user-permissions/memberHelpers.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/user-permissions/memberHelpers.spec.ts
@@ -1,0 +1,133 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+    formatAddMembersResultMessage,
+    formatRoleLabel,
+    getApplicationRole,
+    getGroupMemberRole,
+    isMemberPrimaryOwner,
+    isSameUser,
+} from './memberHelpers';
+import type { ApplicationUiMember } from '../../types/applicationMembers.types';
+
+describe('memberHelpers', () => {
+    describe('formatRoleLabel', () => {
+        it('formats underscore-separated roles', () => {
+            expect(formatRoleLabel('PRIMARY_OWNER')).toBe('Primary Owner');
+            expect(formatRoleLabel('USER')).toBe('User');
+        });
+    });
+
+    describe('getApplicationRole', () => {
+        it('prefers APPLICATION scope role', () => {
+            const member: ApplicationUiMember = {
+                id: 'u1',
+                displayName: 'User',
+                roles: [
+                    { name: 'USER', scope: 'GROUP' },
+                    { name: 'OWNER', scope: 'APPLICATION' },
+                ],
+            };
+            expect(getApplicationRole(member)).toBe('OWNER');
+        });
+
+        it('falls back to first role when APPLICATION scope is missing', () => {
+            const member: ApplicationUiMember = {
+                id: 'u1',
+                displayName: 'User',
+                roles: [{ name: 'USER', scope: 'GROUP' }],
+            };
+            expect(getApplicationRole(member)).toBe('USER');
+        });
+    });
+
+    describe('isMemberPrimaryOwner', () => {
+        it('returns true when member has PRIMARY_OWNER role', () => {
+            expect(
+                isMemberPrimaryOwner({
+                    id: 'u1',
+                    displayName: 'Owner',
+                    roles: [{ name: 'PRIMARY_OWNER', scope: 'APPLICATION' }],
+                }),
+            ).toBe(true);
+        });
+
+        it('returns false for other roles', () => {
+            expect(
+                isMemberPrimaryOwner({
+                    id: 'u1',
+                    displayName: 'User',
+                    roles: [{ name: 'USER', scope: 'APPLICATION' }],
+                }),
+            ).toBe(false);
+        });
+    });
+
+    describe('isSameUser', () => {
+        it('matches by id when both ids are set', () => {
+            expect(isSameUser({ id: 'a', reference: 'ref-a' }, { id: 'a', reference: 'ref-b' })).toBe(true);
+            expect(isSameUser({ id: 'a', reference: 'ref-a' }, { id: 'b', reference: 'ref-a' })).toBe(false);
+        });
+
+        it('falls back to reference when ids are missing', () => {
+            expect(isSameUser({ id: null, reference: 'ref-1' }, { id: undefined, reference: 'ref-1' })).toBe(true);
+        });
+    });
+
+    describe('formatAddMembersResultMessage', () => {
+        const alice = { reference: 'ref-a', displayName: 'Alice' };
+        const bob = { reference: 'ref-b', displayName: 'Bob' };
+
+        it('describes partial success with failed member names', () => {
+            expect(
+                formatAddMembersResultMessage(5, 2, [
+                    { user: alice, reason: 'Conflict' },
+                    { user: bob, reason: 'Forbidden' },
+                ]),
+            ).toBe('Added 2 of 5 members. Failed to add: Alice (Conflict), Bob (Forbidden).');
+        });
+
+        it('describes total failure for multiple members', () => {
+            expect(
+                formatAddMembersResultMessage(2, 0, [
+                    { user: alice, reason: 'Conflict' },
+                    { user: bob, reason: 'Forbidden' },
+                ]),
+            ).toBe('Failed to add 2 members: Alice (Conflict), Bob (Forbidden).');
+        });
+
+        it('describes single-member failure with API reason', () => {
+            expect(formatAddMembersResultMessage(1, 0, [{ user: alice, reason: 'Member already exists' }])).toBe(
+                'Failed to add member: Member already exists',
+            );
+        });
+    });
+
+    describe('getGroupMemberRole', () => {
+        it('prefers GROUP scope role', () => {
+            expect(getGroupMemberRole({ roles: { GROUP: 'OWNER', APPLICATION: 'USER' } })).toBe('OWNER');
+        });
+
+        it('falls back to APPLICATION then first value', () => {
+            expect(getGroupMemberRole({ roles: { APPLICATION: 'USER' } })).toBe('USER');
+            expect(getGroupMemberRole({ roles: { OTHER: 'ADMIN' } })).toBe('ADMIN');
+        });
+
+        it('returns em dash when roles are empty', () => {
+            expect(getGroupMemberRole({ roles: {} })).toBe('—');
+        });
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/user-permissions/memberHelpers.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/user-permissions/memberHelpers.ts
@@ -41,3 +41,33 @@ export function isSameUser(userA: SearchableUser, userB: SearchableUser): boolea
 export function getGroupMemberRole(member: { roles: Record<string, string> }): string {
     return member.roles.GROUP ?? member.roles.APPLICATION ?? Object.values(member.roles)[0] ?? '—';
 }
+
+function addMemberUserLabel(user: SearchableUser): string {
+    return user.displayName || user.email || user.reference;
+}
+
+/** User-facing message when one or more bulk member adds fail (including partial success). */
+export function formatAddMembersResultMessage(
+    total: number,
+    succeededCount: number,
+    failed: ReadonlyArray<{ user: SearchableUser; reason: string }>,
+): string {
+    const failedDescriptions = failed.map(({ user, reason }) => {
+        const label = addMemberUserLabel(user);
+        return reason ? `${label} (${reason})` : label;
+    });
+    const failedList = failedDescriptions.join(', ');
+
+    if (succeededCount === 0) {
+        if (total === 1) {
+            const only = failed[0];
+            if (!only) {
+                return 'Failed to add member.';
+            }
+            return only.reason ? `Failed to add member: ${only.reason}` : `Failed to add ${addMemberUserLabel(only.user)}.`;
+        }
+        return `Failed to add ${total} members: ${failedList}.`;
+    }
+
+    return `Added ${succeededCount} of ${total} members. Failed to add: ${failedList}.`;
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/user-permissions/memberHelpers.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/user-permissions/memberHelpers.ts
@@ -1,0 +1,43 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import type { ApplicationUiMember, SearchableUser } from '../../types/applicationMembers.types';
+
+const APPLICATION_SCOPE = 'APPLICATION';
+
+export function formatRoleLabel(role: string): string {
+    return role
+        .split('_')
+        .map(part => part.charAt(0) + part.slice(1).toLowerCase())
+        .join(' ');
+}
+
+export function getApplicationRole(member: ApplicationUiMember): string {
+    return member.roles?.find(role => role.scope === APPLICATION_SCOPE)?.name ?? member.roles?.[0]?.name ?? '';
+}
+
+export function isMemberPrimaryOwner(member: ApplicationUiMember): boolean {
+    return member.roles?.some(role => role.name === 'PRIMARY_OWNER') ?? false;
+}
+
+export function isSameUser(userA: SearchableUser, userB: SearchableUser): boolean {
+    if (userA.id !== null && userA.id !== undefined && userB.id !== null && userB.id !== undefined) return userA.id === userB.id;
+    return userA.reference === userB.reference;
+}
+
+/** Group members carry roles keyed by scope (typically GROUP). */
+export function getGroupMemberRole(member: { roles: Record<string, string> }): string {
+    return member.roles.GROUP ?? member.roles.APPLICATION ?? Object.values(member.roles)[0] ?? '—';
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/hooks/useApplicationGroupMembers.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/hooks/useApplicationGroupMembers.ts
@@ -1,0 +1,59 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useEnvironment } from '@gravitee/gamma-modules-sdk';
+import { useQueries } from '@tanstack/react-query';
+import { useMemo } from 'react';
+
+import { getGroupMembers } from '../services/applicationMembers';
+import type { EnvironmentGroup, GroupMember } from '../types/applicationMembers.types';
+import { applicationMemberKeys } from '../utils/queryKeys';
+
+export interface ApplicationGroupMembersView {
+    group: EnvironmentGroup;
+    members: GroupMember[];
+    isLoading: boolean;
+    isError: boolean;
+}
+
+export function useApplicationGroupMembers(applicationId: string | undefined, groups: EnvironmentGroup[]) {
+    const env = useEnvironment();
+
+    const results = useQueries({
+        queries: groups.map(g => ({
+            queryKey: applicationMemberKeys.groupMembers(env?.id ?? '', applicationId ?? '', g.id),
+            queryFn: () => getGroupMembers(env!.id, g.id),
+            enabled: Boolean(env && applicationId && g.id),
+            staleTime: 30_000,
+        })),
+    });
+
+    const isLoading = groups.length > 0 && results.some(r => r.isLoading);
+    const groupIds = groups.map(g => g.id).join(',');
+
+    const views = useMemo<ApplicationGroupMembersView[]>(
+        () =>
+            groups.map((group, index) => ({
+                group,
+                members: results[index]?.data ?? [],
+                isLoading: results[index]?.isLoading ?? false,
+                isError: results[index]?.isError ?? false,
+            })),
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+        [results, groupIds],
+    );
+
+    return { views, isLoading };
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/hooks/useApplicationMemberPermissions.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/hooks/useApplicationMemberPermissions.spec.tsx
@@ -1,0 +1,69 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useHasPermission } from '@gravitee/gamma-modules-sdk';
+import { renderHook } from '@testing-library/react';
+
+import { useApplicationMemberPermissions } from './useApplicationMemberPermissions';
+import { useApplicationDetailContext } from '../context/ApplicationDetailContext';
+
+jest.mock('@gravitee/gamma-modules-sdk', () => ({
+    useHasPermission: jest.fn(),
+}));
+
+jest.mock('../context/ApplicationDetailContext', () => ({
+    useApplicationDetailContext: jest.fn(),
+}));
+
+const mockUseHasPermission = jest.mocked(useHasPermission);
+const mockUseApplicationDetailContext = jest.mocked(useApplicationDetailContext);
+
+describe('useApplicationMemberPermissions', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockUseApplicationDetailContext.mockReturnValue({
+            permissionsReady: true,
+        } as ReturnType<typeof useApplicationDetailContext>);
+    });
+
+    it('gates CRUD flags until permissions are ready', () => {
+        mockUseApplicationDetailContext.mockReturnValue({
+            permissionsReady: false,
+        } as ReturnType<typeof useApplicationDetailContext>);
+        mockUseHasPermission.mockReturnValue(true);
+
+        const { result } = renderHook(() => useApplicationMemberPermissions());
+
+        expect(result.current.permissionsReady).toBe(false);
+        expect(result.current.canCreate).toBe(false);
+        expect(result.current.canUpdate).toBe(false);
+        expect(result.current.canDelete).toBe(false);
+    });
+
+    it('exposes member permissions when ready', () => {
+        mockUseHasPermission.mockImplementation(({ anyOf }) => anyOf?.includes('application-member-c') ?? false);
+
+        const { result, rerender } = renderHook(() => useApplicationMemberPermissions());
+
+        expect(result.current.canCreate).toBe(true);
+        expect(result.current.canUpdate).toBe(false);
+        expect(result.current.canDelete).toBe(false);
+
+        mockUseHasPermission.mockImplementation(({ anyOf }) => anyOf?.includes('application-member-d') ?? false);
+        rerender();
+
+        expect(result.current.canDelete).toBe(true);
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/hooks/useApplicationMemberPermissions.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/hooks/useApplicationMemberPermissions.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useHasPermission } from '@gravitee/gamma-modules-sdk';
+
+export function useApplicationMemberPermissions() {
+    const canCreate = useHasPermission({ anyOf: ['application-member-c'] });
+    const canUpdate = useHasPermission({ anyOf: ['application-member-u'] });
+    const canDelete = useHasPermission({ anyOf: ['application-member-d'] });
+
+    return { canCreate, canUpdate, canDelete };
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/hooks/useApplicationMemberPermissions.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/hooks/useApplicationMemberPermissions.ts
@@ -15,10 +15,19 @@
  */
 import { useHasPermission } from '@gravitee/gamma-modules-sdk';
 
+import { useApplicationDetailContext } from '../context/ApplicationDetailContext';
+
 export function useApplicationMemberPermissions() {
+    const { permissionsReady } = useApplicationDetailContext();
+
     const canCreate = useHasPermission({ anyOf: ['application-member-c'] });
     const canUpdate = useHasPermission({ anyOf: ['application-member-u'] });
     const canDelete = useHasPermission({ anyOf: ['application-member-d'] });
 
-    return { canCreate, canUpdate, canDelete };
+    return {
+        permissionsReady,
+        canCreate: permissionsReady && canCreate,
+        canUpdate: permissionsReady && canUpdate,
+        canDelete: permissionsReady && canDelete,
+    };
 }

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/hooks/useApplicationMembers.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/hooks/useApplicationMembers.ts
@@ -1,0 +1,65 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useEnvironment } from '@gravitee/gamma-modules-sdk';
+import { useQuery } from '@tanstack/react-query';
+
+import {
+    listApplicationMembers,
+    listApplicationRoles,
+    listEnvironmentGroups,
+    searchEnvironmentGroupsByIds,
+} from '../services/applicationMembers';
+import type { EnvironmentGroup } from '../types/applicationMembers.types';
+import { applicationMemberKeys } from '../utils/queryKeys';
+
+export function useApplicationMembers(applicationId: string | undefined) {
+    const env = useEnvironment();
+    return useQuery({
+        queryKey: applicationMemberKeys.list(env?.id ?? '', applicationId ?? ''),
+        queryFn: () => listApplicationMembers(env!.id, applicationId!),
+        enabled: Boolean(env && applicationId),
+        staleTime: 30_000,
+    });
+}
+
+export function useApplicationRoles() {
+    return useQuery({
+        queryKey: applicationMemberKeys.roles(),
+        queryFn: () => listApplicationRoles(),
+        staleTime: 60_000,
+    });
+}
+
+export function useEnvironmentGroups() {
+    const env = useEnvironment();
+    return useQuery({
+        queryKey: applicationMemberKeys.groups(env?.id ?? ''),
+        queryFn: () => listEnvironmentGroups(env!.id),
+        enabled: Boolean(env),
+        staleTime: 60_000,
+    });
+}
+
+export function useApplicationAssociatedGroups(groupIds: string[]) {
+    const env = useEnvironment();
+    const groupIdsKey = groupIds.join(',');
+    return useQuery<EnvironmentGroup[]>({
+        queryKey: applicationMemberKeys.associatedGroups(env?.id ?? '', groupIdsKey),
+        queryFn: () => searchEnvironmentGroupsByIds(env!.id, groupIds),
+        enabled: Boolean(env) && groupIds.length > 0,
+        staleTime: 60_000,
+    });
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/hooks/useApplicationNotificationPermissions.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/hooks/useApplicationNotificationPermissions.spec.tsx
@@ -1,0 +1,71 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useHasPermission } from '@gravitee/gamma-modules-sdk';
+import { renderHook } from '@testing-library/react';
+
+import { useApplicationNotificationPermissions } from './useApplicationNotificationPermissions';
+import { useApplicationDetailContext } from '../context/ApplicationDetailContext';
+
+jest.mock('@gravitee/gamma-modules-sdk', () => ({
+    useHasPermission: jest.fn(),
+}));
+
+jest.mock('../context/ApplicationDetailContext', () => ({
+    useApplicationDetailContext: jest.fn(),
+}));
+
+const mockUseHasPermission = jest.mocked(useHasPermission);
+const mockUseApplicationDetailContext = jest.mocked(useApplicationDetailContext);
+
+describe('useApplicationNotificationPermissions', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockUseApplicationDetailContext.mockReturnValue({
+            permissionsReady: true,
+        } as ReturnType<typeof useApplicationDetailContext>);
+        mockUseHasPermission.mockReturnValue(false);
+    });
+
+    it('gates notification and metadata flags until permissions are ready', () => {
+        mockUseApplicationDetailContext.mockReturnValue({
+            permissionsReady: false,
+        } as ReturnType<typeof useApplicationDetailContext>);
+        mockUseHasPermission.mockReturnValue(true);
+
+        const { result } = renderHook(() => useApplicationNotificationPermissions());
+
+        expect(result.current.canCreateNotification).toBe(false);
+        expect(result.current.canDeleteMetadata).toBe(false);
+    });
+
+    it('maps notification and metadata permissions independently', () => {
+        mockUseHasPermission.mockImplementation(({ anyOf }) => {
+            if (anyOf?.includes('application-notification-d')) {
+                return true;
+            }
+            if (anyOf?.includes('application-metadata-u')) {
+                return true;
+            }
+            return false;
+        });
+
+        const { result } = renderHook(() => useApplicationNotificationPermissions());
+
+        expect(result.current.canDeleteNotification).toBe(true);
+        expect(result.current.canUpdateMetadata).toBe(true);
+        expect(result.current.canCreateNotification).toBe(false);
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/hooks/useApplicationNotificationPermissions.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/hooks/useApplicationNotificationPermissions.ts
@@ -22,6 +22,7 @@ export function useApplicationNotificationPermissions() {
 
     const canCreateNotification = useHasPermission({ anyOf: ['application-notification-c'] });
     const canUpdateNotification = useHasPermission({ anyOf: ['application-notification-u'] });
+    const canDeleteNotification = useHasPermission({ anyOf: ['application-notification-d'] });
     const canCreateMetadata = useHasPermission({ anyOf: ['application-metadata-c'] });
     const canUpdateMetadata = useHasPermission({ anyOf: ['application-metadata-u'] });
     const canDeleteMetadata = useHasPermission({ anyOf: ['application-metadata-d'] });
@@ -30,6 +31,7 @@ export function useApplicationNotificationPermissions() {
         permissionsReady,
         canCreateNotification: permissionsReady && canCreateNotification,
         canUpdateNotification: permissionsReady && canUpdateNotification,
+        canDeleteNotification: permissionsReady && canDeleteNotification,
         canCreateMetadata: permissionsReady && canCreateMetadata,
         canUpdateMetadata: permissionsReady && canUpdateMetadata,
         canDeleteMetadata: permissionsReady && canDeleteMetadata,

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/hooks/useApplicationNotificationPermissions.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/hooks/useApplicationNotificationPermissions.ts
@@ -1,0 +1,37 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useHasPermission } from '@gravitee/gamma-modules-sdk';
+
+import { useApplicationDetailContext } from '../context/ApplicationDetailContext';
+
+export function useApplicationNotificationPermissions() {
+    const { permissionsReady } = useApplicationDetailContext();
+
+    const canCreateNotification = useHasPermission({ anyOf: ['application-notification-c'] });
+    const canUpdateNotification = useHasPermission({ anyOf: ['application-notification-u'] });
+    const canCreateMetadata = useHasPermission({ anyOf: ['application-metadata-c'] });
+    const canUpdateMetadata = useHasPermission({ anyOf: ['application-metadata-u'] });
+    const canDeleteMetadata = useHasPermission({ anyOf: ['application-metadata-d'] });
+
+    return {
+        permissionsReady,
+        canCreateNotification: permissionsReady && canCreateNotification,
+        canUpdateNotification: permissionsReady && canUpdateNotification,
+        canCreateMetadata: permissionsReady && canCreateMetadata,
+        canUpdateMetadata: permissionsReady && canUpdateMetadata,
+        canDeleteMetadata: permissionsReady && canDeleteMetadata,
+    };
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/hooks/useApplicationNotifications.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/hooks/useApplicationNotifications.ts
@@ -17,10 +17,12 @@ import { useEnvironment } from '@gravitee/gamma-modules-sdk';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useMemo } from 'react';
 
+import { groupHooksByCategory, mapApplicationNotificationsToRows } from '../components/notifications/notificationHelpers';
 import {
     createApplicationNotification,
     createApplicationMetadata,
     deleteApplicationMetadata,
+    deleteApplicationNotification,
     listApplicationMetadata,
     listApplicationNotificationHooks,
     listApplicationNotifications,
@@ -29,36 +31,13 @@ import {
     updateApplicationMetadata,
 } from '../services/applicationNotifications';
 import type {
-    ApplicationNotificationHook,
-    ApplicationNotificationHookCategory,
     ApplicationNotificationRow,
-    ApplicationNotificationSettings,
-    ApplicationNotifier,
     CreateApplicationNotification,
     NewApplicationMetadata,
     UpdateApplicationNotification,
     UpdateApplicationMetadata,
 } from '../types/applicationNotification';
 import { applicationNotificationKeys } from '../utils/queryKeys';
-
-function resolveNotifierName(notification: ApplicationNotificationSettings, notifiers: ApplicationNotifier[]): string {
-    const notifier = notifiers.find(item => item.id === notification.notifier);
-    if (notifier?.name) {
-        return notifier.name;
-    }
-    if (notification.config_type === 'PORTAL') {
-        return 'Console';
-    }
-    return notification.notifier ?? '—';
-}
-
-function groupHooksByCategory(hooks: ApplicationNotificationHook[]): ApplicationNotificationHookCategory[] {
-    const groups = new Map<string, ApplicationNotificationHook[]>();
-    for (const hook of hooks) {
-        groups.set(hook.category, [...(groups.get(hook.category) ?? []), hook]);
-    }
-    return [...groups.entries()].map(([name, groupedHooks]) => ({ name, hooks: groupedHooks }));
-}
 
 export function useApplicationNotifications(applicationId: string | undefined) {
     const env = useEnvironment();
@@ -86,20 +65,10 @@ export function useApplicationNotifications(applicationId: string | undefined) {
         staleTime: 5 * 60_000,
     });
 
-    const rows = useMemo<ApplicationNotificationRow[]>(() => {
-        const notifications = notificationsQuery.data ?? [];
-        const notifiers = notifiersQuery.data ?? [];
-
-        return notifications.map(notification => ({
-            key: notification.id ?? notification.config_type,
-            name: notification.name,
-            subscribedEvents: (notification.hooks ?? []).length + (notification.groupHooks ?? []).length,
-            notifierName: resolveNotifierName(notification, notifiers),
-            notification,
-            notifier: notifiers.find(item => item.id === notification.notifier),
-            isReadonly: Boolean(notification.origin && notification.origin !== 'MANAGEMENT'),
-        }));
-    }, [notificationsQuery.data, notifiersQuery.data]);
+    const rows = useMemo<ApplicationNotificationRow[]>(
+        () => mapApplicationNotificationsToRows(notificationsQuery.data ?? [], notifiersQuery.data ?? []),
+        [notificationsQuery.data, notifiersQuery.data],
+    );
 
     const hookCategories = useMemo(() => groupHooksByCategory(hooksQuery.data ?? []), [hooksQuery.data]);
 
@@ -133,6 +102,19 @@ export function useUpdateApplicationNotification(applicationId: string | undefin
 
     return useMutation({
         mutationFn: (notification: UpdateApplicationNotification) => updateApplicationNotification(envId, applicationId!, notification),
+        onSuccess: () => {
+            void queryClient.invalidateQueries({ queryKey: applicationNotificationKeys.list(envId, applicationId ?? '') });
+        },
+    });
+}
+
+export function useDeleteApplicationNotification(applicationId: string | undefined) {
+    const env = useEnvironment();
+    const queryClient = useQueryClient();
+    const envId = env?.id ?? '';
+
+    return useMutation({
+        mutationFn: (notificationId: string) => deleteApplicationNotification(envId, applicationId!, notificationId),
         onSuccess: () => {
             void queryClient.invalidateQueries({ queryKey: applicationNotificationKeys.list(envId, applicationId ?? '') });
         },

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/hooks/useApplicationNotifications.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/hooks/useApplicationNotifications.ts
@@ -1,0 +1,191 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useEnvironment } from '@gravitee/gamma-modules-sdk';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useMemo } from 'react';
+
+import {
+    createApplicationNotification,
+    createApplicationMetadata,
+    deleteApplicationMetadata,
+    listApplicationMetadata,
+    listApplicationNotificationHooks,
+    listApplicationNotifications,
+    listApplicationNotifiers,
+    updateApplicationNotification,
+    updateApplicationMetadata,
+} from '../services/applicationNotifications';
+import type {
+    ApplicationNotificationHook,
+    ApplicationNotificationHookCategory,
+    ApplicationNotificationRow,
+    ApplicationNotificationSettings,
+    ApplicationNotifier,
+    CreateApplicationNotification,
+    NewApplicationMetadata,
+    UpdateApplicationNotification,
+    UpdateApplicationMetadata,
+} from '../types/applicationNotification';
+import { applicationNotificationKeys } from '../utils/queryKeys';
+
+function resolveNotifierName(notification: ApplicationNotificationSettings, notifiers: ApplicationNotifier[]): string {
+    const notifier = notifiers.find(item => item.id === notification.notifier);
+    if (notifier?.name) {
+        return notifier.name;
+    }
+    if (notification.config_type === 'PORTAL') {
+        return 'Console';
+    }
+    return notification.notifier ?? '—';
+}
+
+function groupHooksByCategory(hooks: ApplicationNotificationHook[]): ApplicationNotificationHookCategory[] {
+    const groups = new Map<string, ApplicationNotificationHook[]>();
+    for (const hook of hooks) {
+        groups.set(hook.category, [...(groups.get(hook.category) ?? []), hook]);
+    }
+    return [...groups.entries()].map(([name, groupedHooks]) => ({ name, hooks: groupedHooks }));
+}
+
+export function useApplicationNotifications(applicationId: string | undefined) {
+    const env = useEnvironment();
+    const envId = env?.id ?? '';
+    const enabled = Boolean(env && applicationId);
+
+    const notificationsQuery = useQuery({
+        queryKey: applicationNotificationKeys.list(envId, applicationId ?? ''),
+        queryFn: () => listApplicationNotifications(envId, applicationId!),
+        enabled,
+        staleTime: 30_000,
+    });
+
+    const notifiersQuery = useQuery({
+        queryKey: applicationNotificationKeys.notifiers(envId, applicationId ?? ''),
+        queryFn: () => listApplicationNotifiers(envId, applicationId!),
+        enabled,
+        staleTime: 60_000,
+    });
+
+    const hooksQuery = useQuery({
+        queryKey: applicationNotificationKeys.hooks(envId),
+        queryFn: () => listApplicationNotificationHooks(envId),
+        enabled,
+        staleTime: 5 * 60_000,
+    });
+
+    const rows = useMemo<ApplicationNotificationRow[]>(() => {
+        const notifications = notificationsQuery.data ?? [];
+        const notifiers = notifiersQuery.data ?? [];
+
+        return notifications.map(notification => ({
+            key: notification.id ?? notification.config_type,
+            name: notification.name,
+            subscribedEvents: (notification.hooks ?? []).length + (notification.groupHooks ?? []).length,
+            notifierName: resolveNotifierName(notification, notifiers),
+            notification,
+            notifier: notifiers.find(item => item.id === notification.notifier),
+            isReadonly: Boolean(notification.origin && notification.origin !== 'MANAGEMENT'),
+        }));
+    }, [notificationsQuery.data, notifiersQuery.data]);
+
+    const hookCategories = useMemo(() => groupHooksByCategory(hooksQuery.data ?? []), [hooksQuery.data]);
+
+    return {
+        rows,
+        notifiers: notifiersQuery.data ?? [],
+        hookCategories,
+        isLoading: notificationsQuery.isLoading || notifiersQuery.isLoading,
+        isLoadingHooks: hooksQuery.isLoading,
+        isError: notificationsQuery.isError || notifiersQuery.isError || hooksQuery.isError,
+    };
+}
+
+export function useCreateApplicationNotification(applicationId: string | undefined) {
+    const env = useEnvironment();
+    const queryClient = useQueryClient();
+    const envId = env?.id ?? '';
+
+    return useMutation({
+        mutationFn: (notification: CreateApplicationNotification) => createApplicationNotification(envId, applicationId!, notification),
+        onSuccess: () => {
+            void queryClient.invalidateQueries({ queryKey: applicationNotificationKeys.list(envId, applicationId ?? '') });
+        },
+    });
+}
+
+export function useUpdateApplicationNotification(applicationId: string | undefined) {
+    const env = useEnvironment();
+    const queryClient = useQueryClient();
+    const envId = env?.id ?? '';
+
+    return useMutation({
+        mutationFn: (notification: UpdateApplicationNotification) => updateApplicationNotification(envId, applicationId!, notification),
+        onSuccess: () => {
+            void queryClient.invalidateQueries({ queryKey: applicationNotificationKeys.list(envId, applicationId ?? '') });
+        },
+    });
+}
+
+export function useApplicationMetadata(applicationId: string | undefined) {
+    const env = useEnvironment();
+    const envId = env?.id ?? '';
+
+    return useQuery({
+        queryKey: applicationNotificationKeys.metadata(envId, applicationId ?? ''),
+        queryFn: () => listApplicationMetadata(envId, applicationId!),
+        enabled: Boolean(env && applicationId),
+        staleTime: 30_000,
+    });
+}
+
+export function useCreateApplicationMetadata(applicationId: string | undefined) {
+    const env = useEnvironment();
+    const queryClient = useQueryClient();
+    const envId = env?.id ?? '';
+
+    return useMutation({
+        mutationFn: (metadata: NewApplicationMetadata) => createApplicationMetadata(envId, applicationId!, metadata),
+        onSuccess: () => {
+            void queryClient.invalidateQueries({ queryKey: applicationNotificationKeys.metadata(envId, applicationId ?? '') });
+        },
+    });
+}
+
+export function useDeleteApplicationMetadata(applicationId: string | undefined) {
+    const env = useEnvironment();
+    const queryClient = useQueryClient();
+    const envId = env?.id ?? '';
+
+    return useMutation({
+        mutationFn: (metadataKey: string) => deleteApplicationMetadata(envId, applicationId!, metadataKey),
+        onSuccess: () => {
+            void queryClient.invalidateQueries({ queryKey: applicationNotificationKeys.metadata(envId, applicationId ?? '') });
+        },
+    });
+}
+
+export function useUpdateApplicationMetadata(applicationId: string | undefined) {
+    const env = useEnvironment();
+    const queryClient = useQueryClient();
+    const envId = env?.id ?? '';
+
+    return useMutation({
+        mutationFn: (metadata: UpdateApplicationMetadata) => updateApplicationMetadata(envId, applicationId!, metadata),
+        onSuccess: () => {
+            void queryClient.invalidateQueries({ queryKey: applicationNotificationKeys.metadata(envId, applicationId ?? '') });
+        },
+    });
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/hooks/useApplicationOverviewData.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/hooks/useApplicationOverviewData.ts
@@ -16,14 +16,11 @@
 import { useEnvironment } from '@gravitee/gamma-modules-sdk';
 import { useQuery } from '@tanstack/react-query';
 
-import { listApplicationMembers } from '../services/applicationMembers';
+import { useApplicationMembers } from './useApplicationMembers';
+import { useApplicationSubscriptionCount } from './useApplicationSubscriptions';
 import { listApplicationNotifications } from '../services/applicationNotifications';
-import { listApplicationSubscriptions } from '../services/applicationSubscriptions';
 import type { ApplicationSubscriptionsFilters } from '../types/applicationSubscription';
-import { applicationMemberKeys, applicationNotificationKeys, applicationSubscriptionKeys } from '../utils/queryKeys';
-
-const OVERVIEW_COUNT_PAGE = 1;
-const OVERVIEW_COUNT_SIZE = 1;
+import { applicationNotificationKeys } from '../utils/queryKeys';
 
 const ACTIVE_SUBSCRIPTIONS_FILTER: ApplicationSubscriptionsFilters = { status: ['ACCEPTED'] };
 const PENDING_SUBSCRIPTIONS_FILTER: ApplicationSubscriptionsFilters = { status: ['PENDING'] };
@@ -42,22 +39,15 @@ export interface ApplicationOverviewData {
     readonly subscriptionCount: number;
 }
 
-function getSubscriptionCount(response: Awaited<ReturnType<typeof listApplicationSubscriptions>> | undefined): number {
-    return response?.page?.total_elements ?? 0;
-}
-
 export function useApplicationOverviewData(applicationId: string | undefined): ApplicationOverviewData {
     const env = useEnvironment();
     const envId = env?.id ?? '';
     const enabled = Boolean(env && applicationId);
 
-    const membersQuery = useQuery({
-        queryKey: applicationMemberKeys.list(envId, applicationId ?? ''),
-        queryFn: () => listApplicationMembers(envId, applicationId!),
-        enabled,
-        staleTime: 30_000,
-    });
+    // Shares React Query cache with Application user permissions (same list key).
+    const membersQuery = useApplicationMembers(applicationId);
 
+    // Shares cache with Notification settings (same list key).
     const notificationsQuery = useQuery({
         queryKey: applicationNotificationKeys.list(envId, applicationId ?? ''),
         queryFn: () => listApplicationNotifications(envId, applicationId!),
@@ -65,57 +55,27 @@ export function useApplicationOverviewData(applicationId: string | undefined): A
         staleTime: 30_000,
     });
 
-    const subscriptionsQuery = useQuery({
-        queryKey: applicationSubscriptionKeys.list(envId, applicationId ?? '', undefined, OVERVIEW_COUNT_PAGE, OVERVIEW_COUNT_SIZE),
-        queryFn: () => listApplicationSubscriptions(envId, applicationId!, undefined, OVERVIEW_COUNT_PAGE, OVERVIEW_COUNT_SIZE),
-        enabled,
-        staleTime: 30_000,
-    });
-
-    const activeSubscriptionsQuery = useQuery({
-        queryKey: applicationSubscriptionKeys.list(
-            envId,
-            applicationId ?? '',
-            ACTIVE_SUBSCRIPTIONS_FILTER,
-            OVERVIEW_COUNT_PAGE,
-            OVERVIEW_COUNT_SIZE,
-        ),
-        queryFn: () =>
-            listApplicationSubscriptions(envId, applicationId!, ACTIVE_SUBSCRIPTIONS_FILTER, OVERVIEW_COUNT_PAGE, OVERVIEW_COUNT_SIZE),
-        enabled,
-        staleTime: 30_000,
-    });
-
-    const pendingSubscriptionsQuery = useQuery({
-        queryKey: applicationSubscriptionKeys.list(
-            envId,
-            applicationId ?? '',
-            PENDING_SUBSCRIPTIONS_FILTER,
-            OVERVIEW_COUNT_PAGE,
-            OVERVIEW_COUNT_SIZE,
-        ),
-        queryFn: () =>
-            listApplicationSubscriptions(envId, applicationId!, PENDING_SUBSCRIPTIONS_FILTER, OVERVIEW_COUNT_PAGE, OVERVIEW_COUNT_SIZE),
-        enabled,
-        staleTime: 30_000,
-    });
+    // Count keys are shared with the subscriptions list (primed on list fetch with matching filters).
+    const subscriptionsCountQuery = useApplicationSubscriptionCount(applicationId, undefined);
+    const activeSubscriptionsCountQuery = useApplicationSubscriptionCount(applicationId, ACTIVE_SUBSCRIPTIONS_FILTER);
+    const pendingSubscriptionsCountQuery = useApplicationSubscriptionCount(applicationId, PENDING_SUBSCRIPTIONS_FILTER);
 
     return {
-        activeSubscriptionCount: getSubscriptionCount(activeSubscriptionsQuery.data),
+        activeSubscriptionCount: activeSubscriptionsCountQuery.data ?? 0,
         isError:
             membersQuery.isError ||
             notificationsQuery.isError ||
-            subscriptionsQuery.isError ||
-            activeSubscriptionsQuery.isError ||
-            pendingSubscriptionsQuery.isError,
-        isLoadingActiveSubscriptions: activeSubscriptionsQuery.isLoading,
+            subscriptionsCountQuery.isError ||
+            activeSubscriptionsCountQuery.isError ||
+            pendingSubscriptionsCountQuery.isError,
+        isLoadingActiveSubscriptions: activeSubscriptionsCountQuery.isLoading,
         isLoadingMembers: membersQuery.isLoading,
         isLoadingNotifications: notificationsQuery.isLoading,
-        isLoadingPendingSubscriptions: pendingSubscriptionsQuery.isLoading,
-        isLoadingSubscriptions: subscriptionsQuery.isLoading,
+        isLoadingPendingSubscriptions: pendingSubscriptionsCountQuery.isLoading,
+        isLoadingSubscriptions: subscriptionsCountQuery.isLoading,
         memberCount: membersQuery.data?.length ?? 0,
         notificationCount: notificationsQuery.data?.length ?? 0,
-        pendingSubscriptionCount: getSubscriptionCount(pendingSubscriptionsQuery.data),
-        subscriptionCount: getSubscriptionCount(subscriptionsQuery.data),
+        pendingSubscriptionCount: pendingSubscriptionsCountQuery.data ?? 0,
+        subscriptionCount: subscriptionsCountQuery.data ?? 0,
     };
 }

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/hooks/useApplicationOverviewData.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/hooks/useApplicationOverviewData.ts
@@ -1,0 +1,121 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useEnvironment } from '@gravitee/gamma-modules-sdk';
+import { useQuery } from '@tanstack/react-query';
+
+import { listApplicationMembers } from '../services/applicationMembers';
+import { listApplicationNotifications } from '../services/applicationNotifications';
+import { listApplicationSubscriptions } from '../services/applicationSubscriptions';
+import type { ApplicationSubscriptionsFilters } from '../types/applicationSubscription';
+import { applicationMemberKeys, applicationNotificationKeys, applicationSubscriptionKeys } from '../utils/queryKeys';
+
+const OVERVIEW_COUNT_PAGE = 1;
+const OVERVIEW_COUNT_SIZE = 1;
+
+const ACTIVE_SUBSCRIPTIONS_FILTER: ApplicationSubscriptionsFilters = { status: ['ACCEPTED'] };
+const PENDING_SUBSCRIPTIONS_FILTER: ApplicationSubscriptionsFilters = { status: ['PENDING'] };
+
+export interface ApplicationOverviewData {
+    readonly activeSubscriptionCount: number;
+    readonly isError: boolean;
+    readonly isLoadingActiveSubscriptions: boolean;
+    readonly isLoadingMembers: boolean;
+    readonly isLoadingNotifications: boolean;
+    readonly isLoadingPendingSubscriptions: boolean;
+    readonly isLoadingSubscriptions: boolean;
+    readonly memberCount: number;
+    readonly notificationCount: number;
+    readonly pendingSubscriptionCount: number;
+    readonly subscriptionCount: number;
+}
+
+function getSubscriptionCount(response: Awaited<ReturnType<typeof listApplicationSubscriptions>> | undefined): number {
+    return response?.page?.total_elements ?? 0;
+}
+
+export function useApplicationOverviewData(applicationId: string | undefined): ApplicationOverviewData {
+    const env = useEnvironment();
+    const envId = env?.id ?? '';
+    const enabled = Boolean(env && applicationId);
+
+    const membersQuery = useQuery({
+        queryKey: applicationMemberKeys.list(envId, applicationId ?? ''),
+        queryFn: () => listApplicationMembers(envId, applicationId!),
+        enabled,
+        staleTime: 30_000,
+    });
+
+    const notificationsQuery = useQuery({
+        queryKey: applicationNotificationKeys.list(envId, applicationId ?? ''),
+        queryFn: () => listApplicationNotifications(envId, applicationId!),
+        enabled,
+        staleTime: 30_000,
+    });
+
+    const subscriptionsQuery = useQuery({
+        queryKey: applicationSubscriptionKeys.list(envId, applicationId ?? '', undefined, OVERVIEW_COUNT_PAGE, OVERVIEW_COUNT_SIZE),
+        queryFn: () => listApplicationSubscriptions(envId, applicationId!, undefined, OVERVIEW_COUNT_PAGE, OVERVIEW_COUNT_SIZE),
+        enabled,
+        staleTime: 30_000,
+    });
+
+    const activeSubscriptionsQuery = useQuery({
+        queryKey: applicationSubscriptionKeys.list(
+            envId,
+            applicationId ?? '',
+            ACTIVE_SUBSCRIPTIONS_FILTER,
+            OVERVIEW_COUNT_PAGE,
+            OVERVIEW_COUNT_SIZE,
+        ),
+        queryFn: () =>
+            listApplicationSubscriptions(envId, applicationId!, ACTIVE_SUBSCRIPTIONS_FILTER, OVERVIEW_COUNT_PAGE, OVERVIEW_COUNT_SIZE),
+        enabled,
+        staleTime: 30_000,
+    });
+
+    const pendingSubscriptionsQuery = useQuery({
+        queryKey: applicationSubscriptionKeys.list(
+            envId,
+            applicationId ?? '',
+            PENDING_SUBSCRIPTIONS_FILTER,
+            OVERVIEW_COUNT_PAGE,
+            OVERVIEW_COUNT_SIZE,
+        ),
+        queryFn: () =>
+            listApplicationSubscriptions(envId, applicationId!, PENDING_SUBSCRIPTIONS_FILTER, OVERVIEW_COUNT_PAGE, OVERVIEW_COUNT_SIZE),
+        enabled,
+        staleTime: 30_000,
+    });
+
+    return {
+        activeSubscriptionCount: getSubscriptionCount(activeSubscriptionsQuery.data),
+        isError:
+            membersQuery.isError ||
+            notificationsQuery.isError ||
+            subscriptionsQuery.isError ||
+            activeSubscriptionsQuery.isError ||
+            pendingSubscriptionsQuery.isError,
+        isLoadingActiveSubscriptions: activeSubscriptionsQuery.isLoading,
+        isLoadingMembers: membersQuery.isLoading,
+        isLoadingNotifications: notificationsQuery.isLoading,
+        isLoadingPendingSubscriptions: pendingSubscriptionsQuery.isLoading,
+        isLoadingSubscriptions: subscriptionsQuery.isLoading,
+        memberCount: membersQuery.data?.length ?? 0,
+        notificationCount: notificationsQuery.data?.length ?? 0,
+        pendingSubscriptionCount: getSubscriptionCount(pendingSubscriptionsQuery.data),
+        subscriptionCount: getSubscriptionCount(subscriptionsQuery.data),
+    };
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/hooks/useApplicationSubscriptionApiKeys.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/hooks/useApplicationSubscriptionApiKeys.ts
@@ -48,6 +48,7 @@ export function useApplicationSubscriptionApiKeys(applicationId: string | undefi
             return mapApiKeysToRows(entities);
         },
         enabled: Boolean(enabled && envId && applicationId && subscriptionId),
+        staleTime: 30_000,
     });
 }
 

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/hooks/useApplicationSubscriptions.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/hooks/useApplicationSubscriptions.ts
@@ -14,13 +14,37 @@
  * limitations under the License.
  */
 import { useEnvironment } from '@gravitee/gamma-modules-sdk';
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 
 import { listApplicationSubscriptions, listSubscribedApis } from '../services/applicationSubscriptions';
 import type { ApiKeyMode } from '../types/application';
 import type { ApplicationSubscriptionsFilters } from '../types/applicationSubscription';
 import { mapSubscriptionsPageToRows } from '../utils/applicationSubscriptionMapper';
 import { applicationSubscriptionKeys } from '../utils/queryKeys';
+
+export const SUBSCRIPTION_COUNT_PAGE = 1;
+export const SUBSCRIPTION_COUNT_SIZE = 1;
+
+/** Paginated total for a filter set; reuses cache primed by {@link useApplicationSubscriptions}. */
+export function useApplicationSubscriptionCount(applicationId: string | undefined, filters: ApplicationSubscriptionsFilters | undefined) {
+    const env = useEnvironment();
+
+    return useQuery({
+        queryKey: applicationSubscriptionKeys.count(env?.id ?? '', applicationId ?? '', filters),
+        queryFn: async () => {
+            const response = await listApplicationSubscriptions(
+                env!.id,
+                applicationId!,
+                filters,
+                SUBSCRIPTION_COUNT_PAGE,
+                SUBSCRIPTION_COUNT_SIZE,
+            );
+            return response.page?.total_elements ?? 0;
+        },
+        enabled: Boolean(env && applicationId),
+        staleTime: 30_000,
+    });
+}
 
 export function useApplicationSubscriptions(
     applicationId: string | undefined,
@@ -30,17 +54,23 @@ export function useApplicationSubscriptions(
     apiKeyMode: ApiKeyMode | undefined,
 ) {
     const env = useEnvironment();
+    const queryClient = useQueryClient();
 
     return useQuery({
         queryKey: applicationSubscriptionKeys.list(env?.id ?? '', applicationId ?? '', filters, page, size),
         queryFn: async () => {
             const response = await listApplicationSubscriptions(env!.id, applicationId!, filters, page, size);
+            const totalCount = response.page?.total_elements ?? 0;
+            if (env?.id && applicationId) {
+                queryClient.setQueryData(applicationSubscriptionKeys.count(env.id, applicationId, filters), totalCount);
+            }
             return {
                 rows: mapSubscriptionsPageToRows(response, apiKeyMode),
-                totalCount: response.page?.total_elements ?? 0,
+                totalCount,
             };
         },
         enabled: Boolean(env && applicationId),
+        staleTime: 30_000,
     });
 }
 

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/services/applicationDetail.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/services/applicationDetail.ts
@@ -53,9 +53,9 @@ export async function updateApplication(
         name: payload.name,
         description: payload.description,
         domain: payload.domain,
-        groups: application.groups,
+        groups: payload.groups ?? application.groups,
         settings: payload.settings,
-        disable_membership_notifications: application.disable_membership_notifications,
+        disable_membership_notifications: payload.disable_membership_notifications ?? application.disable_membership_notifications,
         api_key_mode: application.api_key_mode,
     };
     if (payload.picture !== undefined) {

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/services/applicationMembers.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/services/applicationMembers.ts
@@ -42,8 +42,8 @@ export async function addApplicationMember(
     environmentId: string,
     applicationId: string,
     payload: { id: string; role: string },
-): Promise<ApplicationUiMember> {
-    const created = await apimFetchJsonV1Env<ApplicationMemberEntity | undefined>(
+): Promise<void> {
+    await apimFetchJsonV1Env<ApplicationMemberEntity | undefined>(
         environmentId,
         `/applications/${encodeURIComponent(applicationId)}/members`,
         {
@@ -52,7 +52,6 @@ export async function addApplicationMember(
             body: JSON.stringify(payload),
         },
     );
-    return mapApplicationMemberToUiMember(created ?? { id: payload.id, displayName: payload.id, role: payload.role });
 }
 
 export async function updateApplicationMember(

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/services/applicationMembers.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/services/applicationMembers.ts
@@ -1,0 +1,169 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { updateApplication, type UpdateApplicationPayload } from './applicationDetail';
+import { apimFetchJsonOrg, apimFetchJsonV1Env, apimFetchJsonV2 } from '../../../shared/api/apimClient';
+import type { ApplicationListItem } from '../types/application';
+import type {
+    ApplicationMemberEntity,
+    ApplicationRole,
+    ApplicationTransferOwnershipPayload,
+    ApplicationUiMember,
+    EnvironmentGroup,
+    GroupMember,
+    GroupsPagedResponse,
+    SearchableUser,
+} from '../types/applicationMembers.types';
+import { mapApplicationMemberToUiMember } from '../utils/applicationMemberMapper';
+
+const JSON_HEADERS = { 'Content-Type': 'application/json' };
+
+export async function listApplicationMembers(environmentId: string, applicationId: string): Promise<ApplicationUiMember[]> {
+    const members = await apimFetchJsonV1Env<ApplicationMemberEntity[]>(
+        environmentId,
+        `/applications/${encodeURIComponent(applicationId)}/members`,
+    );
+    return members.map(mapApplicationMemberToUiMember);
+}
+
+export async function addApplicationMember(
+    environmentId: string,
+    applicationId: string,
+    payload: { id: string; role: string },
+): Promise<ApplicationUiMember> {
+    const created = await apimFetchJsonV1Env<ApplicationMemberEntity | undefined>(
+        environmentId,
+        `/applications/${encodeURIComponent(applicationId)}/members`,
+        {
+            method: 'POST',
+            headers: JSON_HEADERS,
+            body: JSON.stringify(payload),
+        },
+    );
+    return mapApplicationMemberToUiMember(created ?? { id: payload.id, displayName: payload.id, role: payload.role });
+}
+
+export async function updateApplicationMember(
+    environmentId: string,
+    applicationId: string,
+    member: ApplicationMemberEntity,
+): Promise<ApplicationUiMember> {
+    const updated = await apimFetchJsonV1Env<ApplicationMemberEntity | undefined>(
+        environmentId,
+        `/applications/${encodeURIComponent(applicationId)}/members`,
+        {
+            method: 'POST',
+            headers: JSON_HEADERS,
+            body: JSON.stringify(member),
+        },
+    );
+    return mapApplicationMemberToUiMember(updated ?? member);
+}
+
+export async function deleteApplicationMember(environmentId: string, applicationId: string, userId: string): Promise<void> {
+    await apimFetchJsonV1Env<void>(
+        environmentId,
+        `/applications/${encodeURIComponent(applicationId)}/members?user=${encodeURIComponent(userId)}`,
+        { method: 'DELETE' },
+    );
+}
+
+export async function transferApplicationOwnership(
+    environmentId: string,
+    applicationId: string,
+    payload: ApplicationTransferOwnershipPayload,
+): Promise<ApplicationTransferOwnershipPayload> {
+    return apimFetchJsonV1Env<ApplicationTransferOwnershipPayload>(
+        environmentId,
+        `/applications/${encodeURIComponent(applicationId)}/members/transfer_ownership`,
+        {
+            method: 'POST',
+            headers: JSON_HEADERS,
+            body: JSON.stringify(payload),
+        },
+    );
+}
+
+export async function listApplicationRoles(): Promise<ApplicationRole[]> {
+    return apimFetchJsonOrg<ApplicationRole[]>('/configuration/rolescopes/APPLICATION/roles');
+}
+
+export async function listEnvironmentGroups(environmentId: string): Promise<GroupsPagedResponse> {
+    return apimFetchJsonV2<GroupsPagedResponse>(environmentId, '/groups?page=1&perPage=9999');
+}
+
+/** Resolves groups linked to an application by id (console GroupV2Service.listById). */
+export async function searchEnvironmentGroupsByIds(environmentId: string, ids: string[]): Promise<EnvironmentGroup[]> {
+    if (ids.length === 0) {
+        return [];
+    }
+    const response = await apimFetchJsonV2<GroupsPagedResponse>(environmentId, `/groups/_search?page=1&perPage=${ids.length}`, {
+        method: 'POST',
+        headers: JSON_HEADERS,
+        body: JSON.stringify({ ids }),
+    });
+    return response.data ?? [];
+}
+
+export async function getGroupMembers(environmentId: string, groupId: string): Promise<GroupMember[]> {
+    const response = await apimFetchJsonV2<{
+        data?: Array<{ id?: string; displayName?: string; roles?: Array<{ name?: string; scope?: string }> }>;
+    }>(environmentId, `/groups/${encodeURIComponent(groupId)}/members?page=1&perPage=100`);
+    return (response.data ?? []).map(m => ({
+        id: m.id ?? '',
+        displayName: m.displayName ?? '',
+        roles: Object.fromEntries((m.roles ?? []).map(r => [r.scope ?? '', r.name ?? ''])),
+    }));
+}
+
+export async function searchUsers(query: string): Promise<SearchableUser[]> {
+    return apimFetchJsonOrg<SearchableUser[]>(`/search/users?q=${encodeURIComponent(query)}`);
+}
+
+export async function updateApplicationGroups(
+    environmentId: string,
+    application: ApplicationListItem,
+    groupIds: string[],
+): Promise<ApplicationListItem> {
+    return updateApplication(environmentId, application, buildApplicationUpdatePayload(application, { groups: groupIds }));
+}
+
+export async function updateApplicationMembershipNotifications(
+    environmentId: string,
+    application: ApplicationListItem,
+    disableMembershipNotifications: boolean,
+): Promise<ApplicationListItem> {
+    return updateApplication(
+        environmentId,
+        application,
+        buildApplicationUpdatePayload(application, { disable_membership_notifications: disableMembershipNotifications }),
+    );
+}
+
+function buildApplicationUpdatePayload(
+    application: ApplicationListItem,
+    overrides: Partial<UpdateApplicationPayload>,
+): UpdateApplicationPayload {
+    return {
+        name: application.name,
+        description: application.description ?? '',
+        domain: application.domain,
+        groups: application.groups,
+        settings: application.settings,
+        disable_membership_notifications: application.disable_membership_notifications,
+        api_key_mode: application.api_key_mode,
+        ...overrides,
+    };
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/services/applicationNotifications.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/services/applicationNotifications.spec.ts
@@ -1,0 +1,79 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { deleteApplicationMetadata, deleteApplicationNotification, updateApplicationNotification } from './applicationNotifications';
+import { apimFetchJsonV1Env } from '../../../shared/api/apimClient';
+
+jest.mock('../../../shared/api/apimClient', () => ({
+    apimFetchJsonV1Env: jest.fn(),
+}));
+
+const mockApimFetchJsonV1Env = jest.mocked(apimFetchJsonV1Env);
+
+describe('applicationNotifications service', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockApimFetchJsonV1Env.mockResolvedValue(undefined);
+    });
+
+    describe('deleteApplicationNotification', () => {
+        it('calls DELETE on the notification settings resource', async () => {
+            await deleteApplicationNotification('DEFAULT', 'app/1', 'notif id');
+
+            expect(mockApimFetchJsonV1Env).toHaveBeenCalledWith('DEFAULT', '/applications/app%2F1/notificationsettings/notif%20id', {
+                method: 'DELETE',
+            });
+        });
+    });
+
+    describe('updateApplicationNotification', () => {
+        it('uses root path for PORTAL notifications', async () => {
+            await updateApplicationNotification('DEFAULT', 'app-1', {
+                config_type: 'PORTAL',
+                name: 'Portal',
+            });
+
+            expect(mockApimFetchJsonV1Env).toHaveBeenCalledWith(
+                'DEFAULT',
+                '/applications/app-1/notificationsettings/',
+                expect.objectContaining({ method: 'PUT' }),
+            );
+        });
+
+        it('includes notification id for non-PORTAL updates', async () => {
+            await updateApplicationNotification('DEFAULT', 'app-1', {
+                id: 'n-1',
+                config_type: 'DEFAULT',
+                name: 'Email alerts',
+            });
+
+            expect(mockApimFetchJsonV1Env).toHaveBeenCalledWith(
+                'DEFAULT',
+                '/applications/app-1/notificationsettings/n-1',
+                expect.objectContaining({ method: 'PUT' }),
+            );
+        });
+    });
+
+    describe('deleteApplicationMetadata', () => {
+        it('calls DELETE on the metadata key resource', async () => {
+            await deleteApplicationMetadata('DEFAULT', 'app-1', 'my-key');
+
+            expect(mockApimFetchJsonV1Env).toHaveBeenCalledWith('DEFAULT', '/applications/app-1/metadata/my-key', {
+                method: 'DELETE',
+            });
+        });
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/services/applicationNotifications.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/services/applicationNotifications.ts
@@ -1,0 +1,112 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { apimFetchJsonV1Env } from '../../../shared/api/apimClient';
+import type {
+    ApplicationMetadata,
+    ApplicationNotificationHook,
+    ApplicationNotificationSettings,
+    ApplicationNotifier,
+    CreateApplicationNotification,
+    NewApplicationMetadata,
+    UpdateApplicationNotification,
+    UpdateApplicationMetadata,
+} from '../types/applicationNotification';
+
+const JSON_HEADERS = { 'Content-Type': 'application/json' };
+
+const applicationPath = (applicationId: string) => `/applications/${encodeURIComponent(applicationId)}`;
+
+export async function listApplicationNotifications(
+    environmentId: string,
+    applicationId: string,
+): Promise<ApplicationNotificationSettings[]> {
+    return apimFetchJsonV1Env<ApplicationNotificationSettings[]>(environmentId, `${applicationPath(applicationId)}/notificationsettings`);
+}
+
+export async function listApplicationNotifiers(environmentId: string, applicationId: string): Promise<ApplicationNotifier[]> {
+    return apimFetchJsonV1Env<ApplicationNotifier[]>(environmentId, `${applicationPath(applicationId)}/notifiers`);
+}
+
+export async function listApplicationNotificationHooks(environmentId: string): Promise<ApplicationNotificationHook[]> {
+    return apimFetchJsonV1Env<ApplicationNotificationHook[]>(environmentId, '/applications/hooks');
+}
+
+export async function createApplicationNotification(
+    environmentId: string,
+    applicationId: string,
+    notification: CreateApplicationNotification,
+): Promise<ApplicationNotificationSettings> {
+    return apimFetchJsonV1Env<ApplicationNotificationSettings>(environmentId, `${applicationPath(applicationId)}/notificationsettings`, {
+        method: 'POST',
+        headers: JSON_HEADERS,
+        body: JSON.stringify(notification),
+    });
+}
+
+export async function updateApplicationNotification(
+    environmentId: string,
+    applicationId: string,
+    notification: UpdateApplicationNotification,
+): Promise<ApplicationNotificationSettings> {
+    const suffix = notification.config_type === 'PORTAL' ? '/' : `/${encodeURIComponent(notification.id ?? '')}`;
+    return apimFetchJsonV1Env<ApplicationNotificationSettings>(
+        environmentId,
+        `${applicationPath(applicationId)}/notificationsettings${suffix}`,
+        {
+            method: 'PUT',
+            headers: JSON_HEADERS,
+            body: JSON.stringify(notification),
+        },
+    );
+}
+
+export async function listApplicationMetadata(environmentId: string, applicationId: string): Promise<ApplicationMetadata[]> {
+    return apimFetchJsonV1Env<ApplicationMetadata[]>(environmentId, `${applicationPath(applicationId)}/metadata/`);
+}
+
+export async function createApplicationMetadata(
+    environmentId: string,
+    applicationId: string,
+    metadata: NewApplicationMetadata,
+): Promise<ApplicationMetadata> {
+    return apimFetchJsonV1Env<ApplicationMetadata>(environmentId, `${applicationPath(applicationId)}/metadata/`, {
+        method: 'POST',
+        headers: JSON_HEADERS,
+        body: JSON.stringify(metadata),
+    });
+}
+
+export async function updateApplicationMetadata(
+    environmentId: string,
+    applicationId: string,
+    metadata: UpdateApplicationMetadata,
+): Promise<ApplicationMetadata> {
+    return apimFetchJsonV1Env<ApplicationMetadata>(
+        environmentId,
+        `${applicationPath(applicationId)}/metadata/${encodeURIComponent(metadata.key)}`,
+        {
+            method: 'PUT',
+            headers: JSON_HEADERS,
+            body: JSON.stringify(metadata),
+        },
+    );
+}
+
+export async function deleteApplicationMetadata(environmentId: string, applicationId: string, metadataKey: string): Promise<void> {
+    await apimFetchJsonV1Env<void>(environmentId, `${applicationPath(applicationId)}/metadata/${encodeURIComponent(metadataKey)}`, {
+        method: 'DELETE',
+    });
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/services/applicationNotifications.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/services/applicationNotifications.ts
@@ -73,6 +73,16 @@ export async function updateApplicationNotification(
     );
 }
 
+export async function deleteApplicationNotification(environmentId: string, applicationId: string, notificationId: string): Promise<void> {
+    await apimFetchJsonV1Env<void>(
+        environmentId,
+        `${applicationPath(applicationId)}/notificationsettings/${encodeURIComponent(notificationId)}`,
+        {
+            method: 'DELETE',
+        },
+    );
+}
+
 export async function listApplicationMetadata(environmentId: string, applicationId: string): Promise<ApplicationMetadata[]> {
     return apimFetchJsonV1Env<ApplicationMetadata[]>(environmentId, `${applicationPath(applicationId)}/metadata/`);
 }

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/types/applicationMembers.types.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/types/applicationMembers.types.ts
@@ -1,0 +1,72 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/** v1 Management API member (GET/POST /applications/{id}/members). */
+export interface ApplicationMemberEntity {
+    id: string;
+    displayName?: string;
+    role: string;
+}
+
+export interface MemberRole {
+    name: string;
+    scope: string;
+}
+
+/** UI member shape aligned with API user-permissions tables. */
+export interface ApplicationUiMember {
+    id: string;
+    displayName: string;
+    email?: string;
+    roles: MemberRole[];
+}
+
+export interface ApplicationRole {
+    name: string;
+    scope: string;
+    system?: boolean;
+    default?: boolean;
+}
+
+export interface EnvironmentGroup {
+    id: string;
+    name: string;
+}
+
+export interface GroupsPagedResponse {
+    data: EnvironmentGroup[];
+}
+
+export interface GroupMember {
+    id: string;
+    displayName: string;
+    roles: Record<string, string>;
+}
+
+export type GroupMembersMap = Record<string, GroupMember[]>;
+
+export interface SearchableUser {
+    id?: string | null;
+    reference: string;
+    displayName: string;
+    email?: string;
+}
+
+export interface ApplicationTransferOwnershipPayload {
+    id?: string;
+    reference?: string;
+    role?: string;
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/types/applicationNotification.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/types/applicationNotification.ts
@@ -1,0 +1,94 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export type ApplicationMetadataFormat = 'STRING' | 'NUMERIC' | 'BOOLEAN' | 'DATE' | 'MAIL' | 'URL';
+
+export interface ApplicationMetadata {
+    readonly key: string;
+    readonly name: string;
+    readonly format?: ApplicationMetadataFormat;
+    readonly value?: string;
+    readonly defaultValue?: string;
+}
+
+export interface NewApplicationMetadata {
+    readonly name: string;
+    readonly format: ApplicationMetadataFormat;
+    readonly value: string;
+}
+
+export interface UpdateApplicationMetadata {
+    readonly key: string;
+    readonly name: string;
+    readonly format: ApplicationMetadataFormat;
+    readonly value: string;
+    readonly defaultValue?: string;
+}
+
+export interface ApplicationNotifier {
+    readonly id?: string;
+    readonly type?: string;
+    readonly name?: string;
+}
+
+export interface ApplicationNotificationHook {
+    readonly id: string;
+    readonly label: string;
+    readonly description: string;
+    readonly scope: string;
+    readonly category: string;
+}
+
+export interface ApplicationNotificationSettings {
+    readonly id?: string;
+    readonly name: string;
+    readonly referenceType: string;
+    readonly referenceId: string;
+    readonly notifier?: string;
+    readonly hooks?: string[];
+    readonly groupHooks?: string[];
+    readonly useSystemProxy?: boolean;
+    readonly config_type: string;
+    readonly config?: string;
+    readonly groups?: string[];
+    readonly origin?: string;
+}
+
+export interface CreateApplicationNotification {
+    readonly name: string;
+    readonly notifier: string;
+    readonly referenceType: 'APPLICATION';
+    readonly referenceId: string;
+    readonly config_type: 'GENERIC';
+    readonly hooks: string[];
+}
+
+export type UpdateApplicationNotification = ApplicationNotificationSettings;
+
+export interface ApplicationNotificationRow {
+    readonly key: string;
+    readonly name: string;
+    readonly subscribedEvents: number;
+    readonly notifierName: string;
+    readonly notification: ApplicationNotificationSettings;
+    readonly notifier: ApplicationNotifier | undefined;
+    readonly isReadonly: boolean;
+}
+
+export interface ApplicationNotificationHookCategory {
+    readonly name: string;
+    readonly hooks: ApplicationNotificationHook[];
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/utils/applicationMemberMapper.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/utils/applicationMemberMapper.spec.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { mapApplicationMemberToUiMember, toApplicationMemberEntity } from './applicationMemberMapper';
+
+describe('applicationMemberMapper', () => {
+    it('maps API member to UI member with APPLICATION scope', () => {
+        expect(mapApplicationMemberToUiMember({ id: 'u1', displayName: 'Alice', role: 'USER' })).toEqual({
+            id: 'u1',
+            displayName: 'Alice',
+            roles: [{ name: 'USER', scope: 'APPLICATION' }],
+        });
+    });
+
+    it('uses id as displayName when displayName is missing', () => {
+        expect(mapApplicationMemberToUiMember({ id: 'u1', role: 'USER' }).displayName).toBe('u1');
+    });
+
+    it('maps UI member back to API entity', () => {
+        expect(
+            toApplicationMemberEntity({ id: 'u1', displayName: 'Alice', roles: [{ name: 'OWNER', scope: 'APPLICATION' }] }, 'OWNER'),
+        ).toEqual({ id: 'u1', displayName: 'Alice', role: 'OWNER' });
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/utils/applicationMemberMapper.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/utils/applicationMemberMapper.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import type { ApplicationMemberEntity, ApplicationUiMember } from '../types/applicationMembers.types';
+
+const APPLICATION_SCOPE = 'APPLICATION';
+
+export function mapApplicationMemberToUiMember(member: ApplicationMemberEntity): ApplicationUiMember {
+    return {
+        id: member.id,
+        displayName: member.displayName ?? member.id,
+        roles: [{ name: member.role, scope: APPLICATION_SCOPE }],
+    };
+}
+
+export function toApplicationMemberEntity(member: ApplicationUiMember, role: string): ApplicationMemberEntity {
+    return {
+        id: member.id,
+        displayName: member.displayName,
+        role,
+    };
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/utils/applicationOverviewHelpers.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/utils/applicationOverviewHelpers.spec.ts
@@ -1,0 +1,64 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { getSubscriptionCountFromPage, hasReviewedGeneralSettings } from './applicationOverviewHelpers';
+import type { ApplicationListItem } from '../types/application';
+
+function baseApplication(overrides: Partial<ApplicationListItem> = {}): ApplicationListItem {
+    return {
+        id: 'app-1',
+        name: 'Demo',
+        created_at: 1_000,
+        updated_at: 1_000,
+        ...overrides,
+    } as ApplicationListItem;
+}
+
+describe('applicationOverviewHelpers', () => {
+    describe('hasReviewedGeneralSettings', () => {
+        it('returns false for null application', () => {
+            expect(hasReviewedGeneralSettings(null)).toBe(false);
+        });
+
+        it('returns true when profile fields are set', () => {
+            expect(hasReviewedGeneralSettings(baseApplication({ description: 'About this app' }))).toBe(true);
+            expect(hasReviewedGeneralSettings(baseApplication({ domain: 'example.com' }))).toBe(true);
+            expect(
+                hasReviewedGeneralSettings(
+                    baseApplication({ settings: { oauth: { client_id: 'client', redirect_uris: ['https://cb'] } } }),
+                ),
+            ).toBe(true);
+        });
+
+        it('returns true when updated after creation', () => {
+            expect(hasReviewedGeneralSettings(baseApplication({ created_at: 1_000, updated_at: 2_000 }))).toBe(true);
+        });
+
+        it('returns false for untouched default application', () => {
+            expect(hasReviewedGeneralSettings(baseApplication())).toBe(false);
+        });
+    });
+
+    describe('getSubscriptionCountFromPage', () => {
+        it('reads total_elements from paginated response', () => {
+            expect(getSubscriptionCountFromPage({ page: { total_elements: 12 } })).toBe(12);
+        });
+
+        it('returns zero when response or page is missing', () => {
+            expect(getSubscriptionCountFromPage(undefined)).toBe(0);
+            expect(getSubscriptionCountFromPage({})).toBe(0);
+        });
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/utils/applicationOverviewHelpers.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/utils/applicationOverviewHelpers.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import type { ApplicationListItem } from '../types/application';
+
+export function hasReviewedGeneralSettings(application: ApplicationListItem | null): boolean {
+    if (!application) {
+        return false;
+    }
+
+    return Boolean(
+        application.description?.trim() ||
+            application.domain?.trim() ||
+            application.settings?.app?.client_id?.trim() ||
+            application.settings?.oauth?.client_id?.trim() ||
+            application.settings?.oauth?.redirect_uris?.length ||
+            application.updated_at > application.created_at,
+    );
+}
+
+export function getSubscriptionCountFromPage(response: { page?: { total_elements?: number } } | undefined): number {
+    return response?.page?.total_elements ?? 0;
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/utils/applicationSubscriptionListSearchParams.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/utils/applicationSubscriptionListSearchParams.spec.ts
@@ -52,9 +52,20 @@ describe('applicationSubscriptionListSearchParams', () => {
             statusFilters: ['ACCEPTED', 'PAUSED', 'PENDING', 'RESUMED'],
             apiKeyInput: '',
         });
-        expect(built.get('status')).toBe('ACCEPTED,PAUSED,PENDING,RESUMED');
+        expect(built.get('status')).toBeNull();
         expect(built.get('page')).toBeNull();
         expect(built.get('size')).toBeNull();
+    });
+
+    it('omits default status filters regardless of order', () => {
+        const built = buildApplicationSubscriptionListSearchParams({
+            page: 1,
+            pageSize: 10,
+            apiFilters: [],
+            statusFilters: ['RESUMED', 'PENDING', 'PAUSED', 'ACCEPTED'],
+            apiKeyInput: '',
+        });
+        expect(built.get('status')).toBeNull();
     });
 
     it('serializes non-default filters', () => {
@@ -70,5 +81,16 @@ describe('applicationSubscriptionListSearchParams', () => {
         expect(built.get('apis')).toBe('a1');
         expect(built.get('status')).toBe('CLOSED');
         expect(built.get('apiKey')).toBe('k1');
+    });
+
+    it('sorts status filters when serializing', () => {
+        const built = buildApplicationSubscriptionListSearchParams({
+            page: 1,
+            pageSize: 10,
+            apiFilters: [],
+            statusFilters: ['PENDING', 'ACCEPTED'],
+            apiKeyInput: '',
+        });
+        expect(built.get('status')).toBe('ACCEPTED,PENDING');
     });
 });

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/utils/applicationSubscriptionListSearchParams.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/utils/applicationSubscriptionListSearchParams.ts
@@ -38,6 +38,14 @@ function parseStatusFilters(raw: string | null): SubscriptionStatus[] {
     return values.length > 0 ? values : [...DEFAULT_SUBSCRIPTION_FILTER_STATUSES];
 }
 
+function isDefaultStatusFilters(statusFilters: SubscriptionStatus[]): boolean {
+    if (statusFilters.length !== DEFAULT_SUBSCRIPTION_FILTER_STATUSES.length) {
+        return false;
+    }
+    const defaults = new Set(DEFAULT_SUBSCRIPTION_FILTER_STATUSES);
+    return statusFilters.every(status => defaults.has(status));
+}
+
 /** Reads subscription list filters from the URL (console: page, size, status, apis, apiKey). */
 export function parseApplicationSubscriptionListSearchParams(params: URLSearchParams): ApplicationSubscriptionListUrlState {
     return {
@@ -56,7 +64,10 @@ export function buildApplicationSubscriptionListSearchParams(state: ApplicationS
     if (state.page > 1) next.set('page', String(state.page));
     if (state.pageSize !== DEFAULT_PAGE_SIZE) next.set('size', String(state.pageSize));
     if (state.apiFilters.length > 0) next.set('apis', state.apiFilters.join(','));
-    if (state.statusFilters.length > 0) next.set('status', state.statusFilters.join(','));
+    const sortedStatusFilters = [...state.statusFilters].sort();
+    if (!isDefaultStatusFilters(sortedStatusFilters)) {
+        next.set('status', sortedStatusFilters.join(','));
+    }
     if (state.apiKeyInput.trim()) next.set('apiKey', state.apiKeyInput.trim());
 
     return next;

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/utils/metadataValidators.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/utils/metadataValidators.spec.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { MAIL_PATTERN, URL_PATTERN } from './metadataValidators';
+
+describe('metadataValidators', () => {
+    describe('MAIL_PATTERN', () => {
+        it('accepts valid emails and expression placeholders', () => {
+            expect(MAIL_PATTERN.test('user@example.com')).toBe(true);
+            expect(MAIL_PATTERN.test('${metadata.email}')).toBe(true);
+        });
+
+        it('rejects invalid emails', () => {
+            expect(MAIL_PATTERN.test('not-an-email')).toBe(false);
+            expect(MAIL_PATTERN.test('@missing-local.com')).toBe(false);
+        });
+    });
+
+    describe('URL_PATTERN', () => {
+        it('accepts URLs and expression placeholders', () => {
+            expect(URL_PATTERN.test('https://api.example.com/path')).toBe(true);
+            expect(URL_PATTERN.test('${metadata.callbackUrl}')).toBe(true);
+        });
+
+        it('rejects invalid URLs', () => {
+            expect(URL_PATTERN.test('not a url')).toBe(false);
+        });
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/utils/metadataValidators.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/utils/metadataValidators.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/** Aligned with classic console `shared/utils/simple-validator.ts`. */
+export const MAIL_PATTERN =
+    /^((\${.+})|(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,})))$/;
+
+export const URL_PATTERN = /^((\$\{.+\})|(https?:\/\/)?([\da-z.-]+)\.([a-z.]{2,6})\b([-a-zA-Z0-9()@:%_+.~#?&//=]*))$/;

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/utils/queryKeys.spec.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/utils/queryKeys.spec.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { applicationMemberKeys, applicationNotificationKeys } from './queryKeys';
+
+describe('application query keys', () => {
+    describe('applicationMemberKeys', () => {
+        it('builds stable list and user search keys', () => {
+            expect(applicationMemberKeys.list('env', 'app')).toEqual(['application-members', 'list', 'env', 'app']);
+            expect(applicationMemberKeys.userSearch('alice')).toEqual(['application-members', 'user-search', 'alice']);
+            expect(applicationMemberKeys.userSearchTransfer('bob')).toEqual(['application-members', 'user-search-transfer', 'bob']);
+        });
+    });
+
+    describe('applicationNotificationKeys', () => {
+        it('builds list, notifiers, hooks, and metadata keys', () => {
+            expect(applicationNotificationKeys.list('env', 'app')).toEqual(['application-notifications', 'list', 'env', 'app']);
+            expect(applicationNotificationKeys.notifiers('env', 'app')).toEqual(['application-notifications', 'notifiers', 'env', 'app']);
+            expect(applicationNotificationKeys.hooks('env')).toEqual(['application-notifications', 'hooks', 'env']);
+            expect(applicationNotificationKeys.metadata('env', 'app')).toEqual(['application-notifications', 'metadata', 'env', 'app']);
+        });
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/utils/queryKeys.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/utils/queryKeys.ts
@@ -62,6 +62,14 @@ export const applicationMemberKeys = {
         [...applicationMemberKeys.all, 'associated-groups', envId, groupIdsKey] as const,
 } as const;
 
+export const applicationNotificationKeys = {
+    all: ['application-notifications'] as const,
+    list: (envId: string, applicationId: string) => [...applicationNotificationKeys.all, 'list', envId, applicationId] as const,
+    notifiers: (envId: string, applicationId: string) => [...applicationNotificationKeys.all, 'notifiers', envId, applicationId] as const,
+    hooks: (envId: string) => [...applicationNotificationKeys.all, 'hooks', envId] as const,
+    metadata: (envId: string, applicationId: string) => [...applicationNotificationKeys.all, 'metadata', envId, applicationId] as const,
+} as const;
+
 export const applicationSubscriptionKeys = {
     all: ['application-subscriptions'] as const,
     list: (envId: string, applicationId: string, filters: ApplicationSubscriptionsFilters | undefined, page: number, size: number) =>

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/utils/queryKeys.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/utils/queryKeys.ts
@@ -51,6 +51,17 @@ export const applicationListKeys = {
     groups: (envId: string) => [...applicationListKeys.all, 'groups', envId] as const,
 } as const;
 
+export const applicationMemberKeys = {
+    all: ['application-members'] as const,
+    list: (envId: string, applicationId: string) => [...applicationMemberKeys.all, 'list', envId, applicationId] as const,
+    roles: () => [...applicationMemberKeys.all, 'roles'] as const,
+    groups: (envId: string) => [...applicationMemberKeys.all, 'env-groups', envId] as const,
+    groupMembers: (envId: string, applicationId: string, groupId: string) =>
+        [...applicationMemberKeys.all, 'group-members', envId, applicationId, groupId] as const,
+    associatedGroups: (envId: string, groupIdsKey: string) =>
+        [...applicationMemberKeys.all, 'associated-groups', envId, groupIdsKey] as const,
+} as const;
+
 export const applicationSubscriptionKeys = {
     all: ['application-subscriptions'] as const,
     list: (envId: string, applicationId: string, filters: ApplicationSubscriptionsFilters | undefined, page: number, size: number) =>

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/utils/queryKeys.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/utils/queryKeys.ts
@@ -60,6 +60,8 @@ export const applicationMemberKeys = {
         [...applicationMemberKeys.all, 'group-members', envId, applicationId, groupId] as const,
     associatedGroups: (envId: string, groupIdsKey: string) =>
         [...applicationMemberKeys.all, 'associated-groups', envId, groupIdsKey] as const,
+    userSearch: (query: string) => [...applicationMemberKeys.all, 'user-search', query] as const,
+    userSearchTransfer: (query: string) => [...applicationMemberKeys.all, 'user-search-transfer', query] as const,
 } as const;
 
 export const applicationNotificationKeys = {
@@ -70,21 +72,17 @@ export const applicationNotificationKeys = {
     metadata: (envId: string, applicationId: string) => [...applicationNotificationKeys.all, 'metadata', envId, applicationId] as const,
 } as const;
 
+function subscriptionFiltersKeyParts(filters: ApplicationSubscriptionsFilters | undefined) {
+    return [filters?.apiKey ?? '', sorted(filters?.apis), sorted(filters?.status), sorted(filters?.securityTypes)] as const;
+}
+
 export const applicationSubscriptionKeys = {
     all: ['application-subscriptions'] as const,
+    /** Total count for a filter set; shared by overview metrics and primed when the list query runs. */
+    count: (envId: string, applicationId: string, filters: ApplicationSubscriptionsFilters | undefined) =>
+        [...applicationSubscriptionKeys.all, 'count', envId, applicationId, ...subscriptionFiltersKeyParts(filters)] as const,
     list: (envId: string, applicationId: string, filters: ApplicationSubscriptionsFilters | undefined, page: number, size: number) =>
-        [
-            ...applicationSubscriptionKeys.all,
-            'list',
-            envId,
-            applicationId,
-            filters?.apiKey ?? '',
-            sorted(filters?.apis),
-            sorted(filters?.status),
-            sorted(filters?.securityTypes),
-            page,
-            size,
-        ] as const,
+        [...applicationSubscriptionKeys.all, 'list', envId, applicationId, ...subscriptionFiltersKeyParts(filters), page, size] as const,
     subscribedApis: (envId: string, applicationId: string) =>
         [...applicationSubscriptionKeys.all, 'subscribed-apis', envId, applicationId] as const,
     referenceSearch: (envId: string, query: string, includeApiProducts: boolean) =>

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/ApplicationDetailOverviewPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/ApplicationDetailOverviewPage.tsx
@@ -1,0 +1,61 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Alert, AlertDescription, Skeleton } from '@gravitee/graphene-core';
+import { useParams } from 'react-router-dom';
+
+import { ApplicationOverviewChecklist } from '../features/applications/components/overview/ApplicationOverviewChecklist';
+import { ApplicationOverviewSnapshot } from '../features/applications/components/overview/ApplicationOverviewSnapshot';
+import { useApplicationDetailContext } from '../features/applications/context/ApplicationDetailContext';
+import { useApplicationOverviewData } from '../features/applications/hooks/useApplicationOverviewData';
+
+export function ApplicationDetailOverviewPage() {
+    const { applicationId } = useParams<{ applicationId: string }>();
+    const { application, isLoading } = useApplicationDetailContext();
+    const overviewData = useApplicationOverviewData(applicationId);
+
+    if (isLoading) {
+        return (
+            <div className="space-y-6">
+                <Skeleton className="h-10 w-64" />
+                <Skeleton className="h-72 w-full" />
+                <Skeleton className="h-32 w-full" />
+            </div>
+        );
+    }
+
+    if (!application) {
+        return <p className="text-sm text-muted-foreground">Application not found or you may not have access.</p>;
+    }
+
+    return (
+        <div className="space-y-6">
+            <div className="space-y-1">
+                <h1 className="text-2xl font-semibold tracking-tight">Overview</h1>
+                <p className="text-sm text-muted-foreground">Setup progress and snapshot for {application.name}.</p>
+            </div>
+
+            {overviewData.isError ? (
+                <Alert variant="destructive">
+                    <AlertDescription>Some overview data could not be loaded. Please refresh and try again.</AlertDescription>
+                </Alert>
+            ) : null}
+
+            <ApplicationOverviewChecklist application={application} overviewData={overviewData} />
+
+            <ApplicationOverviewSnapshot overviewData={overviewData} />
+        </div>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/ApplicationNotificationSettingsPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/ApplicationNotificationSettingsPage.tsx
@@ -13,43 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import {
-    Alert,
-    AlertDescription,
-    Button,
-    Card,
-    CardContent,
-    CardDescription,
-    CardHeader,
-    CardTitle,
-    Checkbox,
-    DataTablePagination,
-    Dialog,
-    DialogContent,
-    DialogDescription,
-    DialogFooter,
-    DialogHeader,
-    DialogTitle,
-    Input,
-    Label,
-    Select,
-    SelectContent,
-    SelectItem,
-    SelectTrigger,
-    SelectValue,
-    Skeleton,
-    Switch,
-    Table,
-    TableBody,
-    TableCell,
-    TableHead,
-    TableHeader,
-    TableRow,
-} from '@gravitee/graphene-core';
-import { PencilIcon, PlusIcon, Trash2Icon } from '@gravitee/graphene-core/icons';
-import { type FormEvent, useEffect, useMemo, useState } from 'react';
+import { Alert, AlertDescription } from '@gravitee/graphene-core';
+import { useState } from 'react';
 import { useParams } from 'react-router-dom';
 
+import { ApplicationMetadataSection } from '../features/applications/components/metadata/ApplicationMetadataSection';
+import { DeleteNotificationDialog } from '../features/applications/components/notifications/DeleteNotificationDialog';
+import { EditNotificationDialog } from '../features/applications/components/notifications/EditNotificationDialog';
+import { notifierTypeLabel } from '../features/applications/components/notifications/notificationHelpers';
+import { NotificationsSection } from '../features/applications/components/notifications/NotificationsSection';
 import { useApplicationDetailContext } from '../features/applications/context/ApplicationDetailContext';
 import { useApplicationNotificationPermissions } from '../features/applications/hooks/useApplicationNotificationPermissions';
 import {
@@ -58,738 +30,21 @@ import {
     useApplicationNotifications,
     useCreateApplicationMetadata,
     useDeleteApplicationMetadata,
+    useDeleteApplicationNotification,
     useUpdateApplicationNotification,
     useUpdateApplicationMetadata,
 } from '../features/applications/hooks/useApplicationNotifications';
 import type {
-    ApplicationMetadata,
-    ApplicationMetadataFormat,
-    ApplicationNotificationHookCategory,
     ApplicationNotificationRow,
-    ApplicationNotifier,
+    NewApplicationMetadata,
     UpdateApplicationNotification,
     UpdateApplicationMetadata,
 } from '../features/applications/types/applicationNotification';
 
-const METADATA_FORMATS: ApplicationMetadataFormat[] = ['STRING', 'NUMERIC', 'BOOLEAN', 'DATE', 'MAIL', 'URL'];
-const METADATA_PAGE_SIZE_OPTIONS = [10, 25, 50, 100];
-const DEFAULT_METADATA_PAGE_SIZE = 10;
-const MAIL_PATTERN =
-    /^((\${.+})|(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,})))$/;
-const URL_PATTERN = /^((\$\{.+\})|(https?:\/\/)?([\da-z.-]+)\.([a-z.]{2,6})\b([-a-zA-Z0-9()@:%_+.~#?&//=]*))$/;
-
-interface NotificationNotifierOption {
-    readonly id: string;
-    readonly label: string;
-    readonly notifier: ApplicationNotifier;
-}
-
-function deriveMetadataKey(name: string): string {
-    return name
-        .trim()
-        .toLowerCase()
-        .replace(/[^a-z0-9]+/g, '-')
-        .replace(/^-|-$/g, '');
-}
-
-function notifierTypeLabel(notifier: ApplicationNotifier): string {
-    if (notifier.type === 'EMAIL') {
-        return 'Default Email Notifier';
-    }
-    if (notifier.type === 'WEBHOOK') {
-        return 'Default Webhook Notifier';
-    }
-    return notifier.name ?? notifier.id ?? 'Notifier';
-}
-
-function notificationNotifierOptions(notifiers: ApplicationNotifier[]): NotificationNotifierOption[] {
-    return notifiers
-        .filter((notifier): notifier is ApplicationNotifier & { id: string } =>
-            Boolean(notifier.id && (notifier.type === 'EMAIL' || notifier.type === 'WEBHOOK')),
-        )
-        .map(notifier => ({ id: notifier.id, label: notifierTypeLabel(notifier), notifier }));
-}
-
-function RequiredLabel({ htmlFor, children }: Readonly<{ htmlFor: string; children: string }>) {
-    return (
-        <Label htmlFor={htmlFor}>
-            {children}
-            <span className="text-destructive"> *</span>
-        </Label>
-    );
-}
-
-function MetadataValueField({
-    id,
-    format,
-    value,
-    disabled,
-    onChange,
-}: Readonly<{
-    id: string;
-    format: ApplicationMetadataFormat;
-    value: string;
-    disabled: boolean;
-    onChange: (value: string) => void;
-}>) {
-    if (format === 'BOOLEAN') {
-        return (
-            <Select value={value} onValueChange={onChange} disabled={disabled} required>
-                <SelectTrigger id={id} className="w-full" aria-required="true">
-                    <SelectValue placeholder="Select a value" />
-                </SelectTrigger>
-                <SelectContent>
-                    <SelectItem value="true">true</SelectItem>
-                    <SelectItem value="false">false</SelectItem>
-                </SelectContent>
-            </Select>
-        );
-    }
-
-    const commonProps = {
-        id,
-        value,
-        onChange: (event: React.ChangeEvent<HTMLInputElement>) => onChange(event.target.value),
-        disabled,
-        required: true,
-        'aria-required': true,
-    };
-
-    if (format === 'NUMERIC') {
-        return <Input {...commonProps} type="number" placeholder="123000.92" />;
-    }
-    if (format === 'DATE') {
-        return <Input {...commonProps} type="date" />;
-    }
-    if (format === 'MAIL') {
-        return <Input {...commonProps} type="email" pattern={MAIL_PATTERN.source} placeholder="john@doe.com" />;
-    }
-    if (format === 'URL') {
-        return <Input {...commonProps} type="url" pattern={URL_PATTERN.source} placeholder="https://gravitee.io" />;
-    }
-    return <Input {...commonProps} type="text" placeholder="Operations" />;
-}
-
-function NotificationsSection({
-    rows,
-    notifiers,
-    isLoading,
-    isError,
-    canCreate,
-    canUpdate,
-    isCreating,
-    onAdd,
-    onEdit,
-}: {
-    readonly rows: ApplicationNotificationRow[];
-    readonly notifiers: ApplicationNotifier[];
-    readonly isLoading: boolean;
-    readonly isError: boolean;
-    readonly canCreate: boolean;
-    readonly canUpdate: boolean;
-    readonly isCreating: boolean;
-    readonly onAdd: (name: string, notifierId: string) => Promise<boolean>;
-    readonly onEdit: (row: ApplicationNotificationRow) => void;
-}) {
-    const notifierOptions = useMemo(() => notificationNotifierOptions(notifiers), [notifiers]);
-    const [name, setName] = useState('');
-    const [notifierId, setNotifierId] = useState('');
-
-    useEffect(() => {
-        if (!notifierId && notifierOptions[0]) {
-            setNotifierId(notifierOptions[0].id);
-        }
-    }, [notifierId, notifierOptions]);
-
-    const canSubmit = Boolean(canCreate && name.trim() && notifierId);
-
-    async function handleSubmit(event: FormEvent<HTMLFormElement>) {
-        event.preventDefault();
-        if (!canSubmit) {
-            return;
-        }
-        const created = await onAdd(name.trim(), notifierId);
-        if (created) {
-            setName('');
-            setNotifierId(notifierOptions[0]?.id ?? '');
-        }
-    }
-
-    return (
-        <Card>
-            <CardHeader>
-                <CardTitle className="text-base">Notifications</CardTitle>
-                <CardDescription>Events that trigger notifiers for this application.</CardDescription>
-            </CardHeader>
-            <CardContent className="space-y-6">
-                {canCreate ? (
-                    <form className="space-y-3" onSubmit={handleSubmit}>
-                        <div className="grid gap-3 md:grid-cols-2">
-                            <div className="space-y-2">
-                                <RequiredLabel htmlFor="notification-name">Name</RequiredLabel>
-                                <Input
-                                    id="notification-name"
-                                    value={name}
-                                    onChange={event => setName(event.target.value)}
-                                    placeholder="Notification name"
-                                    disabled={isCreating}
-                                    required
-                                    aria-required="true"
-                                />
-                            </div>
-                            <div className="space-y-2">
-                                <RequiredLabel htmlFor="notification-notifier">Notifier</RequiredLabel>
-                                <Select
-                                    value={notifierId}
-                                    onValueChange={setNotifierId}
-                                    disabled={isCreating || notifierOptions.length === 0}
-                                >
-                                    <SelectTrigger id="notification-notifier" className="w-full" aria-required="true">
-                                        <SelectValue placeholder="Select a notifier" />
-                                    </SelectTrigger>
-                                    <SelectContent>
-                                        {notifierOptions.map(option => (
-                                            <SelectItem key={option.id} value={option.id}>
-                                                {option.label}
-                                            </SelectItem>
-                                        ))}
-                                    </SelectContent>
-                                </Select>
-                            </div>
-                        </div>
-                        <Button type="submit" size="sm" disabled={!canSubmit || isCreating}>
-                            <PlusIcon className="size-4" aria-hidden />
-                            {isCreating ? 'Adding…' : 'Add notification'}
-                        </Button>
-                    </form>
-                ) : null}
-                {isError ? (
-                    <Alert variant="destructive">
-                        <AlertDescription>Failed to load notification settings. Please refresh the page.</AlertDescription>
-                    </Alert>
-                ) : isLoading ? (
-                    <div className="space-y-2">
-                        {Array.from({ length: 3 }).map((_, index) => (
-                            <Skeleton key={index} className="h-10 rounded-lg" />
-                        ))}
-                    </div>
-                ) : (
-                    <Table aria-label="Application notification settings">
-                        <TableHeader>
-                            <TableRow>
-                                <TableHead>Name</TableHead>
-                                <TableHead>Events subscribed</TableHead>
-                                <TableHead>Notifier</TableHead>
-                                <TableHead className="w-16 text-right">Actions</TableHead>
-                            </TableRow>
-                        </TableHeader>
-                        <TableBody>
-                            {rows.length === 0 ? (
-                                <TableRow>
-                                    <TableCell colSpan={4} className="h-16 text-center text-sm text-muted-foreground">
-                                        No notifications configured.
-                                    </TableCell>
-                                </TableRow>
-                            ) : (
-                                rows.map(row => (
-                                    <TableRow key={row.key}>
-                                        <TableCell className="font-medium">{row.name}</TableCell>
-                                        <TableCell>
-                                            <span className="inline-flex rounded-md bg-muted px-2 py-1 text-xs text-muted-foreground">
-                                                {row.subscribedEvents} events
-                                            </span>
-                                        </TableCell>
-                                        <TableCell>
-                                            <span className="inline-flex rounded-md bg-muted px-2 py-1 text-xs text-muted-foreground">
-                                                {row.notifierName}
-                                            </span>
-                                        </TableCell>
-                                        <TableCell className="text-right">
-                                            {canUpdate ? (
-                                                <Button
-                                                    type="button"
-                                                    variant="ghost"
-                                                    size="icon"
-                                                    className="size-8"
-                                                    aria-label={`Edit ${row.name} notification`}
-                                                    disabled={row.isReadonly}
-                                                    onClick={() => onEdit(row)}
-                                                >
-                                                    <PencilIcon className="size-4" aria-hidden />
-                                                </Button>
-                                            ) : null}
-                                        </TableCell>
-                                    </TableRow>
-                                ))
-                            )}
-                        </TableBody>
-                    </Table>
-                )}
-            </CardContent>
-        </Card>
-    );
-}
-
-function NotificationHookCategorySection({
-    category,
-    selectedHooks,
-    groupHookIds,
-    disabled,
-    onToggle,
-}: Readonly<{
-    category: ApplicationNotificationHookCategory;
-    selectedHooks: Set<string>;
-    groupHookIds: Set<string>;
-    disabled: boolean;
-    onToggle: (hookId: string) => void;
-}>) {
-    return (
-        <div className="space-y-2">
-            <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">{category.name}</p>
-            <div className="grid gap-2 sm:grid-cols-2 xl:grid-cols-4">
-                {category.hooks.map(hook => {
-                    const isGroupHook = groupHookIds.has(hook.id);
-                    const isDisabled = disabled || isGroupHook;
-                    return (
-                        <label key={hook.id} className="flex items-start gap-2 rounded-md p-2">
-                            <Checkbox
-                                checked={selectedHooks.has(hook.id)}
-                                onCheckedChange={checked => checked !== 'indeterminate' && !isDisabled && onToggle(hook.id)}
-                                disabled={isDisabled}
-                                className="mt-0.5 shrink-0"
-                            />
-                            <span className="min-w-0">
-                                <span className="block text-sm font-medium leading-snug">{hook.label}</span>
-                                {hook.description ? <span className="block text-xs text-muted-foreground">{hook.description}</span> : null}
-                            </span>
-                        </label>
-                    );
-                })}
-            </div>
-        </div>
-    );
-}
-
-function EditNotificationDialog({
-    row,
-    hookCategories,
-    isLoadingHooks,
-    isSaving,
-    onCancel,
-    onSave,
-}: Readonly<{
-    row: ApplicationNotificationRow | null;
-    hookCategories: ApplicationNotificationHookCategory[];
-    isLoadingHooks: boolean;
-    isSaving: boolean;
-    onCancel: () => void;
-    onSave: (notification: UpdateApplicationNotification) => void;
-}>) {
-    const notification = row?.notification ?? null;
-    const notifier = row?.notifier;
-    const groupHookIds = useMemo(() => new Set(notification?.groupHooks ?? []), [notification?.groupHooks]);
-    const [selectedHooks, setSelectedHooks] = useState<Set<string>>(new Set());
-    const [config, setConfig] = useState('');
-    const [useSystemProxy, setUseSystemProxy] = useState(false);
-
-    useEffect(() => {
-        setSelectedHooks(new Set([...(notification?.hooks ?? []), ...(notification?.groupHooks ?? [])]));
-        setConfig(notification?.config ?? '');
-        setUseSystemProxy(Boolean(notification?.useSystemProxy));
-    }, [notification]);
-
-    function toggleHook(hookId: string) {
-        setSelectedHooks(prev => {
-            const next = new Set(prev);
-            if (next.has(hookId)) {
-                next.delete(hookId);
-            } else {
-                next.add(hookId);
-            }
-            return next;
-        });
-    }
-
-    function handleSubmit(event: FormEvent<HTMLFormElement>) {
-        event.preventDefault();
-        if (!notification || row?.isReadonly) {
-            return;
-        }
-        onSave({
-            ...notification,
-            config,
-            useSystemProxy,
-            hooks: [...selectedHooks].filter(hookId => !groupHookIds.has(hookId)),
-        });
-    }
-
-    const needsNotifierConfig = notifier?.type === 'EMAIL' || notifier?.type === 'WEBHOOK';
-    const configLabel = notifier?.type === 'EMAIL' ? 'Email list' : 'Webhook';
-    const configHelp =
-        notifier?.type === 'EMAIL'
-            ? "Use space, ',' or ';' to separate emails. EL supported."
-            : 'URL (Gravitee will POST datas to this url)';
-    const disabled = isSaving || Boolean(row?.isReadonly);
-
-    return (
-        <Dialog open={row !== null} onOpenChange={open => !open && onCancel()}>
-            <DialogContent style={{ width: 'min(72rem, 98vw)', maxWidth: '98vw' }}>
-                <DialogHeader>
-                    <DialogTitle>Edit Console Notification</DialogTitle>
-                </DialogHeader>
-                <form className="space-y-5" onSubmit={handleSubmit}>
-                    <div className="grid gap-4 lg:grid-cols-3">
-                        {needsNotifierConfig ? (
-                            <div className="space-y-2 lg:col-span-2">
-                                <Label htmlFor="notification-config">{configLabel}</Label>
-                                <Input
-                                    id="notification-config"
-                                    value={config}
-                                    onChange={event => setConfig(event.target.value)}
-                                    disabled={disabled}
-                                />
-                                <p className="text-xs text-muted-foreground">{configHelp}</p>
-                            </div>
-                        ) : null}
-                        {notifier?.type === 'WEBHOOK' ? (
-                            <div className="flex items-center justify-between gap-4 self-end rounded-lg border px-3 py-2">
-                                <Label htmlFor="notification-system-proxy">Use system proxy</Label>
-                                <Switch
-                                    id="notification-system-proxy"
-                                    checked={useSystemProxy}
-                                    onCheckedChange={setUseSystemProxy}
-                                    disabled={disabled}
-                                />
-                            </div>
-                        ) : null}
-                    </div>
-                    <div className="space-y-4">
-                        <h3 className="text-sm font-semibold">Event subscribed</h3>
-                        {isLoadingHooks ? (
-                            <div className="space-y-2">
-                                {Array.from({ length: 3 }).map((_, index) => (
-                                    <Skeleton key={index} className="h-16 rounded-lg" />
-                                ))}
-                            </div>
-                        ) : (
-                            hookCategories.map(category => (
-                                <NotificationHookCategorySection
-                                    key={category.name}
-                                    category={category}
-                                    selectedHooks={selectedHooks}
-                                    groupHookIds={groupHookIds}
-                                    disabled={disabled}
-                                    onToggle={toggleHook}
-                                />
-                            ))
-                        )}
-                    </div>
-                    <DialogFooter className="border-t px-6 py-4 gap-2">
-                        <Button type="button" variant="outline" onClick={onCancel} disabled={isSaving}>
-                            Cancel
-                        </Button>
-                        <Button type="submit" disabled={disabled || isLoadingHooks || !notification}>
-                            {isSaving ? 'Saving…' : 'Save'}
-                        </Button>
-                    </DialogFooter>
-                </form>
-            </DialogContent>
-        </Dialog>
-    );
-}
-
-function MetadataTable({
-    metadata,
-    isLoading,
-    canUpdate,
-    canDelete,
-    isMutating,
-    onEdit,
-    onDelete,
-}: {
-    readonly metadata: ApplicationMetadata[];
-    readonly isLoading: boolean;
-    readonly canUpdate: boolean;
-    readonly canDelete: boolean;
-    readonly isMutating: boolean;
-    readonly onEdit: (metadata: ApplicationMetadata) => void;
-    readonly onDelete: (metadata: ApplicationMetadata) => void;
-}) {
-    const [page, setPage] = useState(1);
-    const [pageSize, setPageSize] = useState(DEFAULT_METADATA_PAGE_SIZE);
-    const totalCount = metadata.length;
-    const totalPages = Math.max(1, Math.ceil(totalCount / pageSize));
-    const paginatedMetadata = useMemo(() => {
-        const start = (page - 1) * pageSize;
-        return metadata.slice(start, start + pageSize);
-    }, [metadata, page, pageSize]);
-
-    useEffect(() => {
-        if (page > totalPages) {
-            setPage(totalPages);
-        }
-    }, [page, totalPages]);
-
-    function handlePageSizeChange(size: number) {
-        setPageSize(size);
-        setPage(1);
-    }
-
-    const hasActions = canUpdate || canDelete;
-
-    if (isLoading) {
-        return (
-            <div className="space-y-2">
-                {Array.from({ length: pageSize }).map((_, index) => (
-                    <Skeleton key={index} className="h-10 rounded-lg" />
-                ))}
-            </div>
-        );
-    }
-
-    return (
-        <div className="space-y-4">
-            <div className="flex justify-end">
-                <DataTablePagination
-                    page={page}
-                    pageSize={pageSize}
-                    totalCount={totalCount}
-                    pageSizeOptions={METADATA_PAGE_SIZE_OPTIONS}
-                    onPageChange={setPage}
-                    onPageSizeChange={handlePageSizeChange}
-                />
-            </div>
-            <Table aria-label="Application metadata">
-                <TableHeader>
-                    <TableRow>
-                        <TableHead>Key</TableHead>
-                        <TableHead>Name</TableHead>
-                        <TableHead>Format</TableHead>
-                        <TableHead>Value</TableHead>
-                        {hasActions ? <TableHead className="w-24 text-right" aria-label="Actions" /> : null}
-                    </TableRow>
-                </TableHeader>
-                <TableBody>
-                    {metadata.length === 0 ? (
-                        <TableRow>
-                            <TableCell colSpan={hasActions ? 5 : 4} className="h-16 text-center text-sm text-muted-foreground">
-                                No metadata configured.
-                            </TableCell>
-                        </TableRow>
-                    ) : (
-                        paginatedMetadata.map(item => {
-                            const value = item.value ?? item.defaultValue ?? '—';
-                            const isDeletable = item.value !== undefined;
-                            return (
-                                <TableRow key={item.key}>
-                                    <TableCell className="font-medium">{item.key}</TableCell>
-                                    <TableCell>{item.name}</TableCell>
-                                    <TableCell className="text-sm text-muted-foreground">{item.format ?? 'STRING'}</TableCell>
-                                    <TableCell>{value}</TableCell>
-                                    {hasActions ? (
-                                        <TableCell className="text-right">
-                                            <div className="flex justify-end gap-1">
-                                                {canUpdate ? (
-                                                    <Button
-                                                        type="button"
-                                                        variant="ghost"
-                                                        size="icon"
-                                                        className="size-8"
-                                                        aria-label={`Edit ${item.name} metadata`}
-                                                        disabled={isMutating}
-                                                        onClick={() => onEdit(item)}
-                                                    >
-                                                        <PencilIcon className="size-4" aria-hidden />
-                                                    </Button>
-                                                ) : null}
-                                                {canDelete && isDeletable ? (
-                                                    <Button
-                                                        type="button"
-                                                        variant="ghost"
-                                                        size="icon"
-                                                        className="size-8 text-destructive hover:text-destructive"
-                                                        aria-label={`Delete ${item.name} metadata`}
-                                                        disabled={isMutating}
-                                                        onClick={() => onDelete(item)}
-                                                    >
-                                                        <Trash2Icon className="size-4" aria-hidden />
-                                                    </Button>
-                                                ) : null}
-                                            </div>
-                                        </TableCell>
-                                    ) : null}
-                                </TableRow>
-                            );
-                        })
-                    )}
-                </TableBody>
-            </Table>
-            <div className="flex justify-end">
-                <DataTablePagination
-                    page={page}
-                    pageSize={pageSize}
-                    totalCount={totalCount}
-                    pageSizeOptions={METADATA_PAGE_SIZE_OPTIONS}
-                    onPageChange={setPage}
-                    onPageSizeChange={handlePageSizeChange}
-                />
-            </div>
-        </div>
-    );
-}
-
-function DeleteMetadataDialog({
-    metadata,
-    isDeleting,
-    onCancel,
-    onConfirm,
-}: Readonly<{
-    metadata: ApplicationMetadata | null;
-    isDeleting: boolean;
-    onCancel: () => void;
-    onConfirm: () => void;
-}>) {
-    return (
-        <Dialog open={metadata !== null} onOpenChange={open => !open && onCancel()}>
-            <DialogContent className="max-w-sm">
-                <DialogHeader>
-                    <DialogTitle>Delete Application metadata</DialogTitle>
-                    <DialogDescription>{`Are you sure you want to delete Application metadata '${metadata?.name}'?`}</DialogDescription>
-                </DialogHeader>
-                <DialogFooter className="border-t px-6 py-4 gap-2">
-                    <Button type="button" variant="outline" onClick={onCancel} disabled={isDeleting}>
-                        Cancel
-                    </Button>
-                    <Button type="button" variant="destructive" onClick={onConfirm} disabled={isDeleting || metadata === null}>
-                        {isDeleting ? 'Deleting…' : 'Delete'}
-                    </Button>
-                </DialogFooter>
-            </DialogContent>
-        </Dialog>
-    );
-}
-
-function metadataFormat(metadata: ApplicationMetadata | null): ApplicationMetadataFormat {
-    return metadata?.format ?? 'STRING';
-}
-
-function metadataValue(metadata: ApplicationMetadata | null): string {
-    if (!metadata) {
-        return '';
-    }
-    const value = metadata.value ?? metadata.defaultValue ?? '';
-    if (metadataFormat(metadata) === 'DATE') {
-        return value.slice(0, 10);
-    }
-    return String(value);
-}
-
-function EditMetadataDialog({
-    metadata,
-    isSaving,
-    onCancel,
-    onSave,
-}: Readonly<{
-    metadata: ApplicationMetadata | null;
-    isSaving: boolean;
-    onCancel: () => void;
-    onSave: (metadata: UpdateApplicationMetadata) => void;
-}>) {
-    const [name, setName] = useState('');
-    const [value, setValue] = useState('');
-
-    useEffect(() => {
-        setName(metadata?.name ?? '');
-        setValue(metadataValue(metadata));
-    }, [metadata]);
-
-    const format = metadataFormat(metadata);
-    const initialName = metadata?.name ?? '';
-    const initialValue = metadataValue(metadata);
-    const hasChange = name !== initialName || value !== initialValue;
-    const canSave = Boolean(metadata && name.trim() && value && hasChange);
-
-    function handleSubmit(event: FormEvent<HTMLFormElement>) {
-        event.preventDefault();
-        if (!metadata || !canSave) {
-            return;
-        }
-        onSave({
-            key: metadata.key,
-            name: name.trim(),
-            format,
-            value,
-            defaultValue: metadata.defaultValue,
-        });
-    }
-
-    return (
-        <Dialog open={metadata !== null} onOpenChange={open => !open && onCancel()}>
-            <DialogContent className="max-w-2xl">
-                <DialogHeader>
-                    <DialogTitle>Update Application metadata</DialogTitle>
-                </DialogHeader>
-                <form className="space-y-4" onSubmit={handleSubmit}>
-                    <div className="grid gap-3 md:grid-cols-2">
-                        <div className="space-y-2">
-                            <RequiredLabel htmlFor="edit-metadata-key">Key</RequiredLabel>
-                            <Input id="edit-metadata-key" value={metadata?.key ?? ''} disabled required aria-required="true" />
-                        </div>
-                        <div className="space-y-2">
-                            <RequiredLabel htmlFor="edit-metadata-name">Name</RequiredLabel>
-                            <Input
-                                id="edit-metadata-name"
-                                value={name}
-                                onChange={event => setName(event.target.value)}
-                                disabled={isSaving}
-                                required
-                                aria-required="true"
-                            />
-                        </div>
-                        <div className="space-y-2">
-                            <RequiredLabel htmlFor="edit-metadata-format">Format</RequiredLabel>
-                            <Select value={format} disabled required>
-                                <SelectTrigger id="edit-metadata-format" className="w-full" aria-required="true">
-                                    <SelectValue />
-                                </SelectTrigger>
-                                <SelectContent>
-                                    {METADATA_FORMATS.map(item => (
-                                        <SelectItem key={item} value={item}>
-                                            {item.toLowerCase()}
-                                        </SelectItem>
-                                    ))}
-                                </SelectContent>
-                            </Select>
-                        </div>
-                        <div className="space-y-2">
-                            <RequiredLabel htmlFor="edit-metadata-value">Value</RequiredLabel>
-                            <MetadataValueField
-                                id="edit-metadata-value"
-                                format={format}
-                                value={value}
-                                disabled={isSaving}
-                                onChange={setValue}
-                            />
-                        </div>
-                    </div>
-                    <DialogFooter className="border-t px-6 py-4 gap-2">
-                        <Button type="button" variant="outline" onClick={onCancel} disabled={isSaving}>
-                            Cancel
-                        </Button>
-                        <Button type="submit" disabled={!canSave || isSaving}>
-                            {isSaving ? 'Saving…' : 'Save'}
-                        </Button>
-                    </DialogFooter>
-                </form>
-            </DialogContent>
-        </Dialog>
-    );
-}
-
 export function ApplicationNotificationSettingsPage() {
     const { applicationId } = useParams<{ applicationId: string }>();
     const { application } = useApplicationDetailContext();
-    const { canCreateNotification, canUpdateNotification, canCreateMetadata, canUpdateMetadata, canDeleteMetadata } =
+    const { canCreateNotification, canUpdateNotification, canDeleteNotification, canCreateMetadata, canUpdateMetadata, canDeleteMetadata } =
         useApplicationNotificationPermissions();
 
     const {
@@ -803,43 +58,22 @@ export function ApplicationNotificationSettingsPage() {
     const { data: metadata = [], isLoading: metadataLoading, isError: metadataError } = useApplicationMetadata(applicationId);
     const createNotificationMutation = useCreateApplicationNotification(applicationId);
     const updateNotificationMutation = useUpdateApplicationNotification(applicationId);
+    const deleteNotificationMutation = useDeleteApplicationNotification(applicationId);
     const createMetadataMutation = useCreateApplicationMetadata(applicationId);
     const updateMetadataMutation = useUpdateApplicationMetadata(applicationId);
     const deleteMetadataMutation = useDeleteApplicationMetadata(applicationId);
 
+    const [notificationSaveError, setNotificationSaveError] = useState<string | null>(null);
     const [notificationToEdit, setNotificationToEdit] = useState<ApplicationNotificationRow | null>(null);
-    const [metadataName, setMetadataName] = useState('');
-    const [metadataFormat, setMetadataFormat] = useState<ApplicationMetadataFormat>('STRING');
-    const [metadataValue, setMetadataValue] = useState('');
-    const [metadataToEdit, setMetadataToEdit] = useState<ApplicationMetadata | null>(null);
-    const [metadataToDelete, setMetadataToDelete] = useState<ApplicationMetadata | null>(null);
+    const [notificationToDelete, setNotificationToDelete] = useState<ApplicationNotificationRow | null>(null);
 
-    const metadataKey = useMemo(() => deriveMetadataKey(metadataName), [metadataName]);
     const isReadOnly = application?.origin === 'KUBERNETES';
     const canAddNotification = canCreateNotification && !isReadOnly;
     const canEditNotification = canUpdateNotification && !isReadOnly;
+    const canRemoveNotification = canDeleteNotification && !isReadOnly;
     const canAddMetadata = canCreateMetadata && !isReadOnly;
     const canEditMetadata = canUpdateMetadata && !isReadOnly;
     const canRemoveMetadata = canDeleteMetadata && !isReadOnly;
-    const canSubmitMetadata =
-        canAddMetadata && metadataKey.length > 0 && metadataName.trim().length > 0 && metadataFormat.length > 0 && metadataValue.length > 0;
-
-    function handleAddMetadata(event: FormEvent<HTMLFormElement>) {
-        event.preventDefault();
-        if (!canSubmitMetadata) {
-            return;
-        }
-        createMetadataMutation.mutate(
-            { name: metadataName.trim(), format: metadataFormat, value: metadataValue },
-            {
-                onSuccess: () => {
-                    setMetadataName('');
-                    setMetadataFormat('STRING');
-                    setMetadataValue('');
-                },
-            },
-        );
-    }
 
     async function handleAddNotification(name: string, notifierId: string): Promise<boolean> {
         if (!applicationId) {
@@ -855,6 +89,7 @@ export function ApplicationNotificationSettingsPage() {
                 hooks: [],
             });
             const notifier = notifiers.find(item => item.id === created.notifier);
+            setNotificationSaveError(null);
             setNotificationToEdit({
                 key: created.id ?? created.config_type,
                 name: created.name,
@@ -865,39 +100,59 @@ export function ApplicationNotificationSettingsPage() {
                 isReadonly: Boolean(created.origin && created.origin !== 'MANAGEMENT'),
             });
             return true;
-        } catch {
+        } catch (err: unknown) {
+            setNotificationSaveError(err instanceof Error ? err.message : 'Failed to create notification.');
             return false;
         }
     }
 
     function handleUpdateNotification(notification: UpdateApplicationNotification) {
         updateNotificationMutation.mutate(notification, {
-            onSuccess: () => setNotificationToEdit(null),
+            onSuccess: () => {
+                setNotificationSaveError(null);
+                setNotificationToEdit(null);
+            },
+            onError: (err: unknown) => {
+                setNotificationSaveError(err instanceof Error ? err.message : 'Failed to save notification.');
+            },
         });
     }
 
-    function handleDeleteMetadataConfirm() {
-        if (!metadataToDelete) {
+    function handleDeleteNotificationConfirm() {
+        const notificationId = notificationToDelete?.notification?.id;
+        if (!notificationId) {
             return;
         }
-        deleteMetadataMutation.mutate(metadataToDelete.key, {
-            onSuccess: () => setMetadataToDelete(null),
+        deleteNotificationMutation.mutate(notificationId, {
+            onSuccess: () => {
+                setNotificationSaveError(null);
+                setNotificationToDelete(null);
+            },
+            onError: (err: unknown) => {
+                setNotificationSaveError(err instanceof Error ? err.message : 'Failed to delete notification.');
+            },
         });
     }
 
-    function handleUpdateMetadata(updatedMetadata: UpdateApplicationMetadata) {
-        updateMetadataMutation.mutate(updatedMetadata, {
-            onSuccess: () => setMetadataToEdit(null),
-        });
+    async function handleCreateMetadata(payload: NewApplicationMetadata) {
+        await createMetadataMutation.mutateAsync(payload);
     }
 
-    const mutationError =
-        createNotificationMutation.error ??
-        updateNotificationMutation.error ??
-        createMetadataMutation.error ??
-        updateMetadataMutation.error ??
-        deleteMetadataMutation.error;
-    const mutationErrorMessage = mutationError instanceof Error ? mutationError.message : mutationError ? String(mutationError) : null;
+    async function handleUpdateMetadata(payload: UpdateApplicationMetadata) {
+        await updateMetadataMutation.mutateAsync(payload);
+    }
+
+    async function handleDeleteMetadata(metadataKey: string) {
+        await deleteMetadataMutation.mutateAsync(metadataKey);
+    }
+
+    const metadataMutationError = createMetadataMutation.error ?? updateMetadataMutation.error ?? deleteMetadataMutation.error;
+    const metadataMutationErrorMessage =
+        metadataMutationError instanceof Error
+            ? metadataMutationError.message
+            : metadataMutationError
+              ? String(metadataMutationError)
+              : null;
 
     return (
         <div className="space-y-6 p-6">
@@ -906,6 +161,12 @@ export function ApplicationNotificationSettingsPage() {
                 <p className="text-sm text-muted-foreground">Hooks and metadata used in notification templates.</p>
             </div>
 
+            {notificationSaveError ? (
+                <Alert variant="destructive">
+                    <AlertDescription>{notificationSaveError}</AlertDescription>
+                </Alert>
+            ) : null}
+
             <NotificationsSection
                 rows={rows}
                 notifiers={notifiers}
@@ -913,127 +174,54 @@ export function ApplicationNotificationSettingsPage() {
                 isError={notificationsError}
                 canCreate={canAddNotification}
                 canUpdate={canEditNotification}
+                canDelete={canRemoveNotification}
                 isCreating={createNotificationMutation.isPending}
                 onAdd={handleAddNotification}
-                onEdit={setNotificationToEdit}
+                onEdit={row => {
+                    setNotificationSaveError(null);
+                    setNotificationToEdit(row);
+                }}
+                onDelete={row => {
+                    setNotificationSaveError(null);
+                    setNotificationToDelete(row);
+                }}
             />
 
-            <Card>
-                <CardHeader>
-                    <CardTitle className="text-base">Metadata</CardTitle>
-                    <CardDescription>Custom metadata available in notification templates (classic console pattern).</CardDescription>
-                </CardHeader>
-                <CardContent className="space-y-6">
-                    {metadataError ? (
-                        <Alert variant="destructive">
-                            <AlertDescription>Failed to load metadata. Please refresh the page.</AlertDescription>
-                        </Alert>
-                    ) : null}
-                    {mutationErrorMessage ? (
-                        <Alert variant="destructive">
-                            <AlertDescription>{mutationErrorMessage}</AlertDescription>
-                        </Alert>
-                    ) : null}
-
-                    {canAddMetadata ? (
-                        <form className="space-y-3" onSubmit={handleAddMetadata}>
-                            <div className="grid gap-3 md:grid-cols-4">
-                                <div className="space-y-2">
-                                    <RequiredLabel htmlFor="metadata-key">Key</RequiredLabel>
-                                    <Input
-                                        id="metadata-key"
-                                        value={metadataKey}
-                                        placeholder="department"
-                                        readOnly
-                                        required
-                                        aria-required="true"
-                                        className="bg-muted/40"
-                                    />
-                                </div>
-                                <div className="space-y-2">
-                                    <RequiredLabel htmlFor="metadata-name">Name</RequiredLabel>
-                                    <Input
-                                        id="metadata-name"
-                                        value={metadataName}
-                                        onChange={event => setMetadataName(event.target.value)}
-                                        placeholder="Department"
-                                        disabled={createMetadataMutation.isPending}
-                                        required
-                                        aria-required="true"
-                                    />
-                                </div>
-                                <div className="space-y-2">
-                                    <RequiredLabel htmlFor="metadata-format">Format</RequiredLabel>
-                                    <Select
-                                        value={metadataFormat}
-                                        onValueChange={value => {
-                                            const nextFormat = value as ApplicationMetadataFormat;
-                                            setMetadataFormat(nextFormat);
-                                            setMetadataValue(nextFormat === 'BOOLEAN' ? 'false' : '');
-                                        }}
-                                        disabled={createMetadataMutation.isPending}
-                                        required
-                                    >
-                                        <SelectTrigger id="metadata-format" className="w-full" aria-required="true">
-                                            <SelectValue placeholder="Select a format" />
-                                        </SelectTrigger>
-                                        <SelectContent>
-                                            {METADATA_FORMATS.map(format => (
-                                                <SelectItem key={format} value={format}>
-                                                    {format.toLowerCase()}
-                                                </SelectItem>
-                                            ))}
-                                        </SelectContent>
-                                    </Select>
-                                </div>
-                                <div className="space-y-2">
-                                    <RequiredLabel htmlFor="metadata-value">Value</RequiredLabel>
-                                    <MetadataValueField
-                                        id="metadata-value"
-                                        format={metadataFormat}
-                                        value={metadataValue}
-                                        disabled={createMetadataMutation.isPending}
-                                        onChange={setMetadataValue}
-                                    />
-                                </div>
-                            </div>
-                            <Button type="submit" size="sm" disabled={!canSubmitMetadata || createMetadataMutation.isPending}>
-                                <PlusIcon className="size-4" aria-hidden />
-                                {createMetadataMutation.isPending ? 'Adding…' : 'Add metadata'}
-                            </Button>
-                        </form>
-                    ) : null}
-
-                    <MetadataTable
-                        metadata={metadata}
-                        isLoading={metadataLoading}
-                        canUpdate={canEditMetadata}
-                        canDelete={canRemoveMetadata}
-                        isMutating={updateMetadataMutation.isPending || deleteMetadataMutation.isPending}
-                        onEdit={setMetadataToEdit}
-                        onDelete={setMetadataToDelete}
-                    />
-                </CardContent>
-            </Card>
-            <DeleteMetadataDialog
-                metadata={metadataToDelete}
+            <ApplicationMetadataSection
+                metadata={metadata}
+                isLoading={metadataLoading}
+                isError={metadataError}
+                canCreate={canAddMetadata}
+                canUpdate={canEditMetadata}
+                canDelete={canRemoveMetadata}
+                isCreating={createMetadataMutation.isPending}
+                isUpdating={updateMetadataMutation.isPending}
                 isDeleting={deleteMetadataMutation.isPending}
-                onCancel={() => setMetadataToDelete(null)}
-                onConfirm={handleDeleteMetadataConfirm}
+                mutationErrorMessage={metadataMutationErrorMessage}
+                onCreate={handleCreateMetadata}
+                onUpdate={handleUpdateMetadata}
+                onDelete={handleDeleteMetadata}
             />
-            <EditMetadataDialog
-                metadata={metadataToEdit}
-                isSaving={updateMetadataMutation.isPending}
-                onCancel={() => setMetadataToEdit(null)}
-                onSave={handleUpdateMetadata}
-            />
+
             <EditNotificationDialog
                 row={notificationToEdit}
                 hookCategories={hookCategories}
                 isLoadingHooks={isLoadingHooks}
                 isSaving={updateNotificationMutation.isPending}
-                onCancel={() => setNotificationToEdit(null)}
+                onCancel={() => {
+                    setNotificationSaveError(null);
+                    setNotificationToEdit(null);
+                }}
                 onSave={handleUpdateNotification}
+            />
+            <DeleteNotificationDialog
+                row={notificationToDelete}
+                isDeleting={deleteNotificationMutation.isPending}
+                onCancel={() => {
+                    setNotificationSaveError(null);
+                    setNotificationToDelete(null);
+                }}
+                onConfirm={handleDeleteNotificationConfirm}
             />
         </div>
     );

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/ApplicationNotificationSettingsPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/ApplicationNotificationSettingsPage.tsx
@@ -1,0 +1,1040 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+    Alert,
+    AlertDescription,
+    Button,
+    Card,
+    CardContent,
+    CardDescription,
+    CardHeader,
+    CardTitle,
+    Checkbox,
+    DataTablePagination,
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+    Input,
+    Label,
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+    Skeleton,
+    Switch,
+    Table,
+    TableBody,
+    TableCell,
+    TableHead,
+    TableHeader,
+    TableRow,
+} from '@gravitee/graphene-core';
+import { PencilIcon, PlusIcon, Trash2Icon } from '@gravitee/graphene-core/icons';
+import { type FormEvent, useEffect, useMemo, useState } from 'react';
+import { useParams } from 'react-router-dom';
+
+import { useApplicationDetailContext } from '../features/applications/context/ApplicationDetailContext';
+import { useApplicationNotificationPermissions } from '../features/applications/hooks/useApplicationNotificationPermissions';
+import {
+    useCreateApplicationNotification,
+    useApplicationMetadata,
+    useApplicationNotifications,
+    useCreateApplicationMetadata,
+    useDeleteApplicationMetadata,
+    useUpdateApplicationNotification,
+    useUpdateApplicationMetadata,
+} from '../features/applications/hooks/useApplicationNotifications';
+import type {
+    ApplicationMetadata,
+    ApplicationMetadataFormat,
+    ApplicationNotificationHookCategory,
+    ApplicationNotificationRow,
+    ApplicationNotifier,
+    UpdateApplicationNotification,
+    UpdateApplicationMetadata,
+} from '../features/applications/types/applicationNotification';
+
+const METADATA_FORMATS: ApplicationMetadataFormat[] = ['STRING', 'NUMERIC', 'BOOLEAN', 'DATE', 'MAIL', 'URL'];
+const METADATA_PAGE_SIZE_OPTIONS = [10, 25, 50, 100];
+const DEFAULT_METADATA_PAGE_SIZE = 10;
+const MAIL_PATTERN =
+    /^((\${.+})|(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,})))$/;
+const URL_PATTERN = /^((\$\{.+\})|(https?:\/\/)?([\da-z.-]+)\.([a-z.]{2,6})\b([-a-zA-Z0-9()@:%_+.~#?&//=]*))$/;
+
+interface NotificationNotifierOption {
+    readonly id: string;
+    readonly label: string;
+    readonly notifier: ApplicationNotifier;
+}
+
+function deriveMetadataKey(name: string): string {
+    return name
+        .trim()
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, '-')
+        .replace(/^-|-$/g, '');
+}
+
+function notifierTypeLabel(notifier: ApplicationNotifier): string {
+    if (notifier.type === 'EMAIL') {
+        return 'Default Email Notifier';
+    }
+    if (notifier.type === 'WEBHOOK') {
+        return 'Default Webhook Notifier';
+    }
+    return notifier.name ?? notifier.id ?? 'Notifier';
+}
+
+function notificationNotifierOptions(notifiers: ApplicationNotifier[]): NotificationNotifierOption[] {
+    return notifiers
+        .filter((notifier): notifier is ApplicationNotifier & { id: string } =>
+            Boolean(notifier.id && (notifier.type === 'EMAIL' || notifier.type === 'WEBHOOK')),
+        )
+        .map(notifier => ({ id: notifier.id, label: notifierTypeLabel(notifier), notifier }));
+}
+
+function RequiredLabel({ htmlFor, children }: Readonly<{ htmlFor: string; children: string }>) {
+    return (
+        <Label htmlFor={htmlFor}>
+            {children}
+            <span className="text-destructive"> *</span>
+        </Label>
+    );
+}
+
+function MetadataValueField({
+    id,
+    format,
+    value,
+    disabled,
+    onChange,
+}: Readonly<{
+    id: string;
+    format: ApplicationMetadataFormat;
+    value: string;
+    disabled: boolean;
+    onChange: (value: string) => void;
+}>) {
+    if (format === 'BOOLEAN') {
+        return (
+            <Select value={value} onValueChange={onChange} disabled={disabled} required>
+                <SelectTrigger id={id} className="w-full" aria-required="true">
+                    <SelectValue placeholder="Select a value" />
+                </SelectTrigger>
+                <SelectContent>
+                    <SelectItem value="true">true</SelectItem>
+                    <SelectItem value="false">false</SelectItem>
+                </SelectContent>
+            </Select>
+        );
+    }
+
+    const commonProps = {
+        id,
+        value,
+        onChange: (event: React.ChangeEvent<HTMLInputElement>) => onChange(event.target.value),
+        disabled,
+        required: true,
+        'aria-required': true,
+    };
+
+    if (format === 'NUMERIC') {
+        return <Input {...commonProps} type="number" placeholder="123000.92" />;
+    }
+    if (format === 'DATE') {
+        return <Input {...commonProps} type="date" />;
+    }
+    if (format === 'MAIL') {
+        return <Input {...commonProps} type="email" pattern={MAIL_PATTERN.source} placeholder="john@doe.com" />;
+    }
+    if (format === 'URL') {
+        return <Input {...commonProps} type="url" pattern={URL_PATTERN.source} placeholder="https://gravitee.io" />;
+    }
+    return <Input {...commonProps} type="text" placeholder="Operations" />;
+}
+
+function NotificationsSection({
+    rows,
+    notifiers,
+    isLoading,
+    isError,
+    canCreate,
+    canUpdate,
+    isCreating,
+    onAdd,
+    onEdit,
+}: {
+    readonly rows: ApplicationNotificationRow[];
+    readonly notifiers: ApplicationNotifier[];
+    readonly isLoading: boolean;
+    readonly isError: boolean;
+    readonly canCreate: boolean;
+    readonly canUpdate: boolean;
+    readonly isCreating: boolean;
+    readonly onAdd: (name: string, notifierId: string) => Promise<boolean>;
+    readonly onEdit: (row: ApplicationNotificationRow) => void;
+}) {
+    const notifierOptions = useMemo(() => notificationNotifierOptions(notifiers), [notifiers]);
+    const [name, setName] = useState('');
+    const [notifierId, setNotifierId] = useState('');
+
+    useEffect(() => {
+        if (!notifierId && notifierOptions[0]) {
+            setNotifierId(notifierOptions[0].id);
+        }
+    }, [notifierId, notifierOptions]);
+
+    const canSubmit = Boolean(canCreate && name.trim() && notifierId);
+
+    async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+        event.preventDefault();
+        if (!canSubmit) {
+            return;
+        }
+        const created = await onAdd(name.trim(), notifierId);
+        if (created) {
+            setName('');
+            setNotifierId(notifierOptions[0]?.id ?? '');
+        }
+    }
+
+    return (
+        <Card>
+            <CardHeader>
+                <CardTitle className="text-base">Notifications</CardTitle>
+                <CardDescription>Events that trigger notifiers for this application.</CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-6">
+                {canCreate ? (
+                    <form className="space-y-3" onSubmit={handleSubmit}>
+                        <div className="grid gap-3 md:grid-cols-2">
+                            <div className="space-y-2">
+                                <RequiredLabel htmlFor="notification-name">Name</RequiredLabel>
+                                <Input
+                                    id="notification-name"
+                                    value={name}
+                                    onChange={event => setName(event.target.value)}
+                                    placeholder="Notification name"
+                                    disabled={isCreating}
+                                    required
+                                    aria-required="true"
+                                />
+                            </div>
+                            <div className="space-y-2">
+                                <RequiredLabel htmlFor="notification-notifier">Notifier</RequiredLabel>
+                                <Select
+                                    value={notifierId}
+                                    onValueChange={setNotifierId}
+                                    disabled={isCreating || notifierOptions.length === 0}
+                                >
+                                    <SelectTrigger id="notification-notifier" className="w-full" aria-required="true">
+                                        <SelectValue placeholder="Select a notifier" />
+                                    </SelectTrigger>
+                                    <SelectContent>
+                                        {notifierOptions.map(option => (
+                                            <SelectItem key={option.id} value={option.id}>
+                                                {option.label}
+                                            </SelectItem>
+                                        ))}
+                                    </SelectContent>
+                                </Select>
+                            </div>
+                        </div>
+                        <Button type="submit" size="sm" disabled={!canSubmit || isCreating}>
+                            <PlusIcon className="size-4" aria-hidden />
+                            {isCreating ? 'Adding…' : 'Add notification'}
+                        </Button>
+                    </form>
+                ) : null}
+                {isError ? (
+                    <Alert variant="destructive">
+                        <AlertDescription>Failed to load notification settings. Please refresh the page.</AlertDescription>
+                    </Alert>
+                ) : isLoading ? (
+                    <div className="space-y-2">
+                        {Array.from({ length: 3 }).map((_, index) => (
+                            <Skeleton key={index} className="h-10 rounded-lg" />
+                        ))}
+                    </div>
+                ) : (
+                    <Table aria-label="Application notification settings">
+                        <TableHeader>
+                            <TableRow>
+                                <TableHead>Name</TableHead>
+                                <TableHead>Events subscribed</TableHead>
+                                <TableHead>Notifier</TableHead>
+                                <TableHead className="w-16 text-right">Actions</TableHead>
+                            </TableRow>
+                        </TableHeader>
+                        <TableBody>
+                            {rows.length === 0 ? (
+                                <TableRow>
+                                    <TableCell colSpan={4} className="h-16 text-center text-sm text-muted-foreground">
+                                        No notifications configured.
+                                    </TableCell>
+                                </TableRow>
+                            ) : (
+                                rows.map(row => (
+                                    <TableRow key={row.key}>
+                                        <TableCell className="font-medium">{row.name}</TableCell>
+                                        <TableCell>
+                                            <span className="inline-flex rounded-md bg-muted px-2 py-1 text-xs text-muted-foreground">
+                                                {row.subscribedEvents} events
+                                            </span>
+                                        </TableCell>
+                                        <TableCell>
+                                            <span className="inline-flex rounded-md bg-muted px-2 py-1 text-xs text-muted-foreground">
+                                                {row.notifierName}
+                                            </span>
+                                        </TableCell>
+                                        <TableCell className="text-right">
+                                            {canUpdate ? (
+                                                <Button
+                                                    type="button"
+                                                    variant="ghost"
+                                                    size="icon"
+                                                    className="size-8"
+                                                    aria-label={`Edit ${row.name} notification`}
+                                                    disabled={row.isReadonly}
+                                                    onClick={() => onEdit(row)}
+                                                >
+                                                    <PencilIcon className="size-4" aria-hidden />
+                                                </Button>
+                                            ) : null}
+                                        </TableCell>
+                                    </TableRow>
+                                ))
+                            )}
+                        </TableBody>
+                    </Table>
+                )}
+            </CardContent>
+        </Card>
+    );
+}
+
+function NotificationHookCategorySection({
+    category,
+    selectedHooks,
+    groupHookIds,
+    disabled,
+    onToggle,
+}: Readonly<{
+    category: ApplicationNotificationHookCategory;
+    selectedHooks: Set<string>;
+    groupHookIds: Set<string>;
+    disabled: boolean;
+    onToggle: (hookId: string) => void;
+}>) {
+    return (
+        <div className="space-y-2">
+            <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">{category.name}</p>
+            <div className="grid gap-2 sm:grid-cols-2 xl:grid-cols-4">
+                {category.hooks.map(hook => {
+                    const isGroupHook = groupHookIds.has(hook.id);
+                    const isDisabled = disabled || isGroupHook;
+                    return (
+                        <label key={hook.id} className="flex items-start gap-2 rounded-md p-2">
+                            <Checkbox
+                                checked={selectedHooks.has(hook.id)}
+                                onCheckedChange={checked => checked !== 'indeterminate' && !isDisabled && onToggle(hook.id)}
+                                disabled={isDisabled}
+                                className="mt-0.5 shrink-0"
+                            />
+                            <span className="min-w-0">
+                                <span className="block text-sm font-medium leading-snug">{hook.label}</span>
+                                {hook.description ? <span className="block text-xs text-muted-foreground">{hook.description}</span> : null}
+                            </span>
+                        </label>
+                    );
+                })}
+            </div>
+        </div>
+    );
+}
+
+function EditNotificationDialog({
+    row,
+    hookCategories,
+    isLoadingHooks,
+    isSaving,
+    onCancel,
+    onSave,
+}: Readonly<{
+    row: ApplicationNotificationRow | null;
+    hookCategories: ApplicationNotificationHookCategory[];
+    isLoadingHooks: boolean;
+    isSaving: boolean;
+    onCancel: () => void;
+    onSave: (notification: UpdateApplicationNotification) => void;
+}>) {
+    const notification = row?.notification ?? null;
+    const notifier = row?.notifier;
+    const groupHookIds = useMemo(() => new Set(notification?.groupHooks ?? []), [notification?.groupHooks]);
+    const [selectedHooks, setSelectedHooks] = useState<Set<string>>(new Set());
+    const [config, setConfig] = useState('');
+    const [useSystemProxy, setUseSystemProxy] = useState(false);
+
+    useEffect(() => {
+        setSelectedHooks(new Set([...(notification?.hooks ?? []), ...(notification?.groupHooks ?? [])]));
+        setConfig(notification?.config ?? '');
+        setUseSystemProxy(Boolean(notification?.useSystemProxy));
+    }, [notification]);
+
+    function toggleHook(hookId: string) {
+        setSelectedHooks(prev => {
+            const next = new Set(prev);
+            if (next.has(hookId)) {
+                next.delete(hookId);
+            } else {
+                next.add(hookId);
+            }
+            return next;
+        });
+    }
+
+    function handleSubmit(event: FormEvent<HTMLFormElement>) {
+        event.preventDefault();
+        if (!notification || row?.isReadonly) {
+            return;
+        }
+        onSave({
+            ...notification,
+            config,
+            useSystemProxy,
+            hooks: [...selectedHooks].filter(hookId => !groupHookIds.has(hookId)),
+        });
+    }
+
+    const needsNotifierConfig = notifier?.type === 'EMAIL' || notifier?.type === 'WEBHOOK';
+    const configLabel = notifier?.type === 'EMAIL' ? 'Email list' : 'Webhook';
+    const configHelp =
+        notifier?.type === 'EMAIL'
+            ? "Use space, ',' or ';' to separate emails. EL supported."
+            : 'URL (Gravitee will POST datas to this url)';
+    const disabled = isSaving || Boolean(row?.isReadonly);
+
+    return (
+        <Dialog open={row !== null} onOpenChange={open => !open && onCancel()}>
+            <DialogContent style={{ width: 'min(72rem, 98vw)', maxWidth: '98vw' }}>
+                <DialogHeader>
+                    <DialogTitle>Edit Console Notification</DialogTitle>
+                </DialogHeader>
+                <form className="space-y-5" onSubmit={handleSubmit}>
+                    <div className="grid gap-4 lg:grid-cols-3">
+                        {needsNotifierConfig ? (
+                            <div className="space-y-2 lg:col-span-2">
+                                <Label htmlFor="notification-config">{configLabel}</Label>
+                                <Input
+                                    id="notification-config"
+                                    value={config}
+                                    onChange={event => setConfig(event.target.value)}
+                                    disabled={disabled}
+                                />
+                                <p className="text-xs text-muted-foreground">{configHelp}</p>
+                            </div>
+                        ) : null}
+                        {notifier?.type === 'WEBHOOK' ? (
+                            <div className="flex items-center justify-between gap-4 self-end rounded-lg border px-3 py-2">
+                                <Label htmlFor="notification-system-proxy">Use system proxy</Label>
+                                <Switch
+                                    id="notification-system-proxy"
+                                    checked={useSystemProxy}
+                                    onCheckedChange={setUseSystemProxy}
+                                    disabled={disabled}
+                                />
+                            </div>
+                        ) : null}
+                    </div>
+                    <div className="space-y-4">
+                        <h3 className="text-sm font-semibold">Event subscribed</h3>
+                        {isLoadingHooks ? (
+                            <div className="space-y-2">
+                                {Array.from({ length: 3 }).map((_, index) => (
+                                    <Skeleton key={index} className="h-16 rounded-lg" />
+                                ))}
+                            </div>
+                        ) : (
+                            hookCategories.map(category => (
+                                <NotificationHookCategorySection
+                                    key={category.name}
+                                    category={category}
+                                    selectedHooks={selectedHooks}
+                                    groupHookIds={groupHookIds}
+                                    disabled={disabled}
+                                    onToggle={toggleHook}
+                                />
+                            ))
+                        )}
+                    </div>
+                    <DialogFooter className="border-t px-6 py-4 gap-2">
+                        <Button type="button" variant="outline" onClick={onCancel} disabled={isSaving}>
+                            Cancel
+                        </Button>
+                        <Button type="submit" disabled={disabled || isLoadingHooks || !notification}>
+                            {isSaving ? 'Saving…' : 'Save'}
+                        </Button>
+                    </DialogFooter>
+                </form>
+            </DialogContent>
+        </Dialog>
+    );
+}
+
+function MetadataTable({
+    metadata,
+    isLoading,
+    canUpdate,
+    canDelete,
+    isMutating,
+    onEdit,
+    onDelete,
+}: {
+    readonly metadata: ApplicationMetadata[];
+    readonly isLoading: boolean;
+    readonly canUpdate: boolean;
+    readonly canDelete: boolean;
+    readonly isMutating: boolean;
+    readonly onEdit: (metadata: ApplicationMetadata) => void;
+    readonly onDelete: (metadata: ApplicationMetadata) => void;
+}) {
+    const [page, setPage] = useState(1);
+    const [pageSize, setPageSize] = useState(DEFAULT_METADATA_PAGE_SIZE);
+    const totalCount = metadata.length;
+    const totalPages = Math.max(1, Math.ceil(totalCount / pageSize));
+    const paginatedMetadata = useMemo(() => {
+        const start = (page - 1) * pageSize;
+        return metadata.slice(start, start + pageSize);
+    }, [metadata, page, pageSize]);
+
+    useEffect(() => {
+        if (page > totalPages) {
+            setPage(totalPages);
+        }
+    }, [page, totalPages]);
+
+    function handlePageSizeChange(size: number) {
+        setPageSize(size);
+        setPage(1);
+    }
+
+    const hasActions = canUpdate || canDelete;
+
+    if (isLoading) {
+        return (
+            <div className="space-y-2">
+                {Array.from({ length: pageSize }).map((_, index) => (
+                    <Skeleton key={index} className="h-10 rounded-lg" />
+                ))}
+            </div>
+        );
+    }
+
+    return (
+        <div className="space-y-4">
+            <div className="flex justify-end">
+                <DataTablePagination
+                    page={page}
+                    pageSize={pageSize}
+                    totalCount={totalCount}
+                    pageSizeOptions={METADATA_PAGE_SIZE_OPTIONS}
+                    onPageChange={setPage}
+                    onPageSizeChange={handlePageSizeChange}
+                />
+            </div>
+            <Table aria-label="Application metadata">
+                <TableHeader>
+                    <TableRow>
+                        <TableHead>Key</TableHead>
+                        <TableHead>Name</TableHead>
+                        <TableHead>Format</TableHead>
+                        <TableHead>Value</TableHead>
+                        {hasActions ? <TableHead className="w-24 text-right" aria-label="Actions" /> : null}
+                    </TableRow>
+                </TableHeader>
+                <TableBody>
+                    {metadata.length === 0 ? (
+                        <TableRow>
+                            <TableCell colSpan={hasActions ? 5 : 4} className="h-16 text-center text-sm text-muted-foreground">
+                                No metadata configured.
+                            </TableCell>
+                        </TableRow>
+                    ) : (
+                        paginatedMetadata.map(item => {
+                            const value = item.value ?? item.defaultValue ?? '—';
+                            const isDeletable = item.value !== undefined;
+                            return (
+                                <TableRow key={item.key}>
+                                    <TableCell className="font-medium">{item.key}</TableCell>
+                                    <TableCell>{item.name}</TableCell>
+                                    <TableCell className="text-sm text-muted-foreground">{item.format ?? 'STRING'}</TableCell>
+                                    <TableCell>{value}</TableCell>
+                                    {hasActions ? (
+                                        <TableCell className="text-right">
+                                            <div className="flex justify-end gap-1">
+                                                {canUpdate ? (
+                                                    <Button
+                                                        type="button"
+                                                        variant="ghost"
+                                                        size="icon"
+                                                        className="size-8"
+                                                        aria-label={`Edit ${item.name} metadata`}
+                                                        disabled={isMutating}
+                                                        onClick={() => onEdit(item)}
+                                                    >
+                                                        <PencilIcon className="size-4" aria-hidden />
+                                                    </Button>
+                                                ) : null}
+                                                {canDelete && isDeletable ? (
+                                                    <Button
+                                                        type="button"
+                                                        variant="ghost"
+                                                        size="icon"
+                                                        className="size-8 text-destructive hover:text-destructive"
+                                                        aria-label={`Delete ${item.name} metadata`}
+                                                        disabled={isMutating}
+                                                        onClick={() => onDelete(item)}
+                                                    >
+                                                        <Trash2Icon className="size-4" aria-hidden />
+                                                    </Button>
+                                                ) : null}
+                                            </div>
+                                        </TableCell>
+                                    ) : null}
+                                </TableRow>
+                            );
+                        })
+                    )}
+                </TableBody>
+            </Table>
+            <div className="flex justify-end">
+                <DataTablePagination
+                    page={page}
+                    pageSize={pageSize}
+                    totalCount={totalCount}
+                    pageSizeOptions={METADATA_PAGE_SIZE_OPTIONS}
+                    onPageChange={setPage}
+                    onPageSizeChange={handlePageSizeChange}
+                />
+            </div>
+        </div>
+    );
+}
+
+function DeleteMetadataDialog({
+    metadata,
+    isDeleting,
+    onCancel,
+    onConfirm,
+}: Readonly<{
+    metadata: ApplicationMetadata | null;
+    isDeleting: boolean;
+    onCancel: () => void;
+    onConfirm: () => void;
+}>) {
+    return (
+        <Dialog open={metadata !== null} onOpenChange={open => !open && onCancel()}>
+            <DialogContent className="max-w-sm">
+                <DialogHeader>
+                    <DialogTitle>Delete Application metadata</DialogTitle>
+                    <DialogDescription>{`Are you sure you want to delete Application metadata '${metadata?.name}'?`}</DialogDescription>
+                </DialogHeader>
+                <DialogFooter className="border-t px-6 py-4 gap-2">
+                    <Button type="button" variant="outline" onClick={onCancel} disabled={isDeleting}>
+                        Cancel
+                    </Button>
+                    <Button type="button" variant="destructive" onClick={onConfirm} disabled={isDeleting || metadata === null}>
+                        {isDeleting ? 'Deleting…' : 'Delete'}
+                    </Button>
+                </DialogFooter>
+            </DialogContent>
+        </Dialog>
+    );
+}
+
+function metadataFormat(metadata: ApplicationMetadata | null): ApplicationMetadataFormat {
+    return metadata?.format ?? 'STRING';
+}
+
+function metadataValue(metadata: ApplicationMetadata | null): string {
+    if (!metadata) {
+        return '';
+    }
+    const value = metadata.value ?? metadata.defaultValue ?? '';
+    if (metadataFormat(metadata) === 'DATE') {
+        return value.slice(0, 10);
+    }
+    return String(value);
+}
+
+function EditMetadataDialog({
+    metadata,
+    isSaving,
+    onCancel,
+    onSave,
+}: Readonly<{
+    metadata: ApplicationMetadata | null;
+    isSaving: boolean;
+    onCancel: () => void;
+    onSave: (metadata: UpdateApplicationMetadata) => void;
+}>) {
+    const [name, setName] = useState('');
+    const [value, setValue] = useState('');
+
+    useEffect(() => {
+        setName(metadata?.name ?? '');
+        setValue(metadataValue(metadata));
+    }, [metadata]);
+
+    const format = metadataFormat(metadata);
+    const initialName = metadata?.name ?? '';
+    const initialValue = metadataValue(metadata);
+    const hasChange = name !== initialName || value !== initialValue;
+    const canSave = Boolean(metadata && name.trim() && value && hasChange);
+
+    function handleSubmit(event: FormEvent<HTMLFormElement>) {
+        event.preventDefault();
+        if (!metadata || !canSave) {
+            return;
+        }
+        onSave({
+            key: metadata.key,
+            name: name.trim(),
+            format,
+            value,
+            defaultValue: metadata.defaultValue,
+        });
+    }
+
+    return (
+        <Dialog open={metadata !== null} onOpenChange={open => !open && onCancel()}>
+            <DialogContent className="max-w-2xl">
+                <DialogHeader>
+                    <DialogTitle>Update Application metadata</DialogTitle>
+                </DialogHeader>
+                <form className="space-y-4" onSubmit={handleSubmit}>
+                    <div className="grid gap-3 md:grid-cols-2">
+                        <div className="space-y-2">
+                            <RequiredLabel htmlFor="edit-metadata-key">Key</RequiredLabel>
+                            <Input id="edit-metadata-key" value={metadata?.key ?? ''} disabled required aria-required="true" />
+                        </div>
+                        <div className="space-y-2">
+                            <RequiredLabel htmlFor="edit-metadata-name">Name</RequiredLabel>
+                            <Input
+                                id="edit-metadata-name"
+                                value={name}
+                                onChange={event => setName(event.target.value)}
+                                disabled={isSaving}
+                                required
+                                aria-required="true"
+                            />
+                        </div>
+                        <div className="space-y-2">
+                            <RequiredLabel htmlFor="edit-metadata-format">Format</RequiredLabel>
+                            <Select value={format} disabled required>
+                                <SelectTrigger id="edit-metadata-format" className="w-full" aria-required="true">
+                                    <SelectValue />
+                                </SelectTrigger>
+                                <SelectContent>
+                                    {METADATA_FORMATS.map(item => (
+                                        <SelectItem key={item} value={item}>
+                                            {item.toLowerCase()}
+                                        </SelectItem>
+                                    ))}
+                                </SelectContent>
+                            </Select>
+                        </div>
+                        <div className="space-y-2">
+                            <RequiredLabel htmlFor="edit-metadata-value">Value</RequiredLabel>
+                            <MetadataValueField
+                                id="edit-metadata-value"
+                                format={format}
+                                value={value}
+                                disabled={isSaving}
+                                onChange={setValue}
+                            />
+                        </div>
+                    </div>
+                    <DialogFooter className="border-t px-6 py-4 gap-2">
+                        <Button type="button" variant="outline" onClick={onCancel} disabled={isSaving}>
+                            Cancel
+                        </Button>
+                        <Button type="submit" disabled={!canSave || isSaving}>
+                            {isSaving ? 'Saving…' : 'Save'}
+                        </Button>
+                    </DialogFooter>
+                </form>
+            </DialogContent>
+        </Dialog>
+    );
+}
+
+export function ApplicationNotificationSettingsPage() {
+    const { applicationId } = useParams<{ applicationId: string }>();
+    const { application } = useApplicationDetailContext();
+    const { canCreateNotification, canUpdateNotification, canCreateMetadata, canUpdateMetadata, canDeleteMetadata } =
+        useApplicationNotificationPermissions();
+
+    const {
+        rows,
+        notifiers,
+        hookCategories,
+        isLoading: notificationsLoading,
+        isLoadingHooks,
+        isError: notificationsError,
+    } = useApplicationNotifications(applicationId);
+    const { data: metadata = [], isLoading: metadataLoading, isError: metadataError } = useApplicationMetadata(applicationId);
+    const createNotificationMutation = useCreateApplicationNotification(applicationId);
+    const updateNotificationMutation = useUpdateApplicationNotification(applicationId);
+    const createMetadataMutation = useCreateApplicationMetadata(applicationId);
+    const updateMetadataMutation = useUpdateApplicationMetadata(applicationId);
+    const deleteMetadataMutation = useDeleteApplicationMetadata(applicationId);
+
+    const [notificationToEdit, setNotificationToEdit] = useState<ApplicationNotificationRow | null>(null);
+    const [metadataName, setMetadataName] = useState('');
+    const [metadataFormat, setMetadataFormat] = useState<ApplicationMetadataFormat>('STRING');
+    const [metadataValue, setMetadataValue] = useState('');
+    const [metadataToEdit, setMetadataToEdit] = useState<ApplicationMetadata | null>(null);
+    const [metadataToDelete, setMetadataToDelete] = useState<ApplicationMetadata | null>(null);
+
+    const metadataKey = useMemo(() => deriveMetadataKey(metadataName), [metadataName]);
+    const isReadOnly = application?.origin === 'KUBERNETES';
+    const canAddNotification = canCreateNotification && !isReadOnly;
+    const canEditNotification = canUpdateNotification && !isReadOnly;
+    const canAddMetadata = canCreateMetadata && !isReadOnly;
+    const canEditMetadata = canUpdateMetadata && !isReadOnly;
+    const canRemoveMetadata = canDeleteMetadata && !isReadOnly;
+    const canSubmitMetadata =
+        canAddMetadata && metadataKey.length > 0 && metadataName.trim().length > 0 && metadataFormat.length > 0 && metadataValue.length > 0;
+
+    function handleAddMetadata(event: FormEvent<HTMLFormElement>) {
+        event.preventDefault();
+        if (!canSubmitMetadata) {
+            return;
+        }
+        createMetadataMutation.mutate(
+            { name: metadataName.trim(), format: metadataFormat, value: metadataValue },
+            {
+                onSuccess: () => {
+                    setMetadataName('');
+                    setMetadataFormat('STRING');
+                    setMetadataValue('');
+                },
+            },
+        );
+    }
+
+    async function handleAddNotification(name: string, notifierId: string): Promise<boolean> {
+        if (!applicationId) {
+            return false;
+        }
+        try {
+            const created = await createNotificationMutation.mutateAsync({
+                name,
+                notifier: notifierId,
+                referenceType: 'APPLICATION',
+                referenceId: applicationId,
+                config_type: 'GENERIC',
+                hooks: [],
+            });
+            const notifier = notifiers.find(item => item.id === created.notifier);
+            setNotificationToEdit({
+                key: created.id ?? created.config_type,
+                name: created.name,
+                subscribedEvents: (created.hooks ?? []).length + (created.groupHooks ?? []).length,
+                notifierName: notifier ? notifierTypeLabel(notifier) : (created.notifier ?? '—'),
+                notification: created,
+                notifier,
+                isReadonly: Boolean(created.origin && created.origin !== 'MANAGEMENT'),
+            });
+            return true;
+        } catch {
+            return false;
+        }
+    }
+
+    function handleUpdateNotification(notification: UpdateApplicationNotification) {
+        updateNotificationMutation.mutate(notification, {
+            onSuccess: () => setNotificationToEdit(null),
+        });
+    }
+
+    function handleDeleteMetadataConfirm() {
+        if (!metadataToDelete) {
+            return;
+        }
+        deleteMetadataMutation.mutate(metadataToDelete.key, {
+            onSuccess: () => setMetadataToDelete(null),
+        });
+    }
+
+    function handleUpdateMetadata(updatedMetadata: UpdateApplicationMetadata) {
+        updateMetadataMutation.mutate(updatedMetadata, {
+            onSuccess: () => setMetadataToEdit(null),
+        });
+    }
+
+    const mutationError =
+        createNotificationMutation.error ??
+        updateNotificationMutation.error ??
+        createMetadataMutation.error ??
+        updateMetadataMutation.error ??
+        deleteMetadataMutation.error;
+    const mutationErrorMessage = mutationError instanceof Error ? mutationError.message : mutationError ? String(mutationError) : null;
+
+    return (
+        <div className="space-y-6 p-6">
+            <div className="space-y-1">
+                <h1 className="text-2xl font-semibold tracking-tight">Notification settings</h1>
+                <p className="text-sm text-muted-foreground">Hooks and metadata used in notification templates.</p>
+            </div>
+
+            <NotificationsSection
+                rows={rows}
+                notifiers={notifiers}
+                isLoading={notificationsLoading}
+                isError={notificationsError}
+                canCreate={canAddNotification}
+                canUpdate={canEditNotification}
+                isCreating={createNotificationMutation.isPending}
+                onAdd={handleAddNotification}
+                onEdit={setNotificationToEdit}
+            />
+
+            <Card>
+                <CardHeader>
+                    <CardTitle className="text-base">Metadata</CardTitle>
+                    <CardDescription>Custom metadata available in notification templates (classic console pattern).</CardDescription>
+                </CardHeader>
+                <CardContent className="space-y-6">
+                    {metadataError ? (
+                        <Alert variant="destructive">
+                            <AlertDescription>Failed to load metadata. Please refresh the page.</AlertDescription>
+                        </Alert>
+                    ) : null}
+                    {mutationErrorMessage ? (
+                        <Alert variant="destructive">
+                            <AlertDescription>{mutationErrorMessage}</AlertDescription>
+                        </Alert>
+                    ) : null}
+
+                    {canAddMetadata ? (
+                        <form className="space-y-3" onSubmit={handleAddMetadata}>
+                            <div className="grid gap-3 md:grid-cols-4">
+                                <div className="space-y-2">
+                                    <RequiredLabel htmlFor="metadata-key">Key</RequiredLabel>
+                                    <Input
+                                        id="metadata-key"
+                                        value={metadataKey}
+                                        placeholder="department"
+                                        readOnly
+                                        required
+                                        aria-required="true"
+                                        className="bg-muted/40"
+                                    />
+                                </div>
+                                <div className="space-y-2">
+                                    <RequiredLabel htmlFor="metadata-name">Name</RequiredLabel>
+                                    <Input
+                                        id="metadata-name"
+                                        value={metadataName}
+                                        onChange={event => setMetadataName(event.target.value)}
+                                        placeholder="Department"
+                                        disabled={createMetadataMutation.isPending}
+                                        required
+                                        aria-required="true"
+                                    />
+                                </div>
+                                <div className="space-y-2">
+                                    <RequiredLabel htmlFor="metadata-format">Format</RequiredLabel>
+                                    <Select
+                                        value={metadataFormat}
+                                        onValueChange={value => {
+                                            const nextFormat = value as ApplicationMetadataFormat;
+                                            setMetadataFormat(nextFormat);
+                                            setMetadataValue(nextFormat === 'BOOLEAN' ? 'false' : '');
+                                        }}
+                                        disabled={createMetadataMutation.isPending}
+                                        required
+                                    >
+                                        <SelectTrigger id="metadata-format" className="w-full" aria-required="true">
+                                            <SelectValue placeholder="Select a format" />
+                                        </SelectTrigger>
+                                        <SelectContent>
+                                            {METADATA_FORMATS.map(format => (
+                                                <SelectItem key={format} value={format}>
+                                                    {format.toLowerCase()}
+                                                </SelectItem>
+                                            ))}
+                                        </SelectContent>
+                                    </Select>
+                                </div>
+                                <div className="space-y-2">
+                                    <RequiredLabel htmlFor="metadata-value">Value</RequiredLabel>
+                                    <MetadataValueField
+                                        id="metadata-value"
+                                        format={metadataFormat}
+                                        value={metadataValue}
+                                        disabled={createMetadataMutation.isPending}
+                                        onChange={setMetadataValue}
+                                    />
+                                </div>
+                            </div>
+                            <Button type="submit" size="sm" disabled={!canSubmitMetadata || createMetadataMutation.isPending}>
+                                <PlusIcon className="size-4" aria-hidden />
+                                {createMetadataMutation.isPending ? 'Adding…' : 'Add metadata'}
+                            </Button>
+                        </form>
+                    ) : null}
+
+                    <MetadataTable
+                        metadata={metadata}
+                        isLoading={metadataLoading}
+                        canUpdate={canEditMetadata}
+                        canDelete={canRemoveMetadata}
+                        isMutating={updateMetadataMutation.isPending || deleteMetadataMutation.isPending}
+                        onEdit={setMetadataToEdit}
+                        onDelete={setMetadataToDelete}
+                    />
+                </CardContent>
+            </Card>
+            <DeleteMetadataDialog
+                metadata={metadataToDelete}
+                isDeleting={deleteMetadataMutation.isPending}
+                onCancel={() => setMetadataToDelete(null)}
+                onConfirm={handleDeleteMetadataConfirm}
+            />
+            <EditMetadataDialog
+                metadata={metadataToEdit}
+                isSaving={updateMetadataMutation.isPending}
+                onCancel={() => setMetadataToEdit(null)}
+                onSave={handleUpdateMetadata}
+            />
+            <EditNotificationDialog
+                row={notificationToEdit}
+                hookCategories={hookCategories}
+                isLoadingHooks={isLoadingHooks}
+                isSaving={updateNotificationMutation.isPending}
+                onCancel={() => setNotificationToEdit(null)}
+                onSave={handleUpdateNotification}
+            />
+        </div>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/ApplicationUserPermissionsPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/ApplicationUserPermissionsPage.tsx
@@ -1,0 +1,416 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useEnvironment } from '@gravitee/gamma-modules-sdk';
+import {
+    Alert,
+    AlertDescription,
+    Badge,
+    Button,
+    Card,
+    CardContent,
+    CardDescription,
+    CardHeader,
+    CardTitle,
+    Empty,
+    EmptyContent,
+    EmptyDescription,
+    EmptyHeader,
+    EmptyTitle,
+    Skeleton,
+    Switch,
+} from '@gravitee/graphene-core';
+import { PlusIcon, UserCogIcon, UsersIcon } from '@gravitee/graphene-core/icons';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useCallback, useMemo, useState } from 'react';
+import { useParams } from 'react-router-dom';
+
+import { AddMembersDialog } from '../features/applications/components/user-permissions/AddMembersDialog';
+import { DirectMembersTable } from '../features/applications/components/user-permissions/DirectMembersTable';
+import { EditRoleDialog } from '../features/applications/components/user-permissions/EditRoleDialog';
+import { GroupMembersSection } from '../features/applications/components/user-permissions/GroupMembersSection';
+import { ManageGroupsDialog } from '../features/applications/components/user-permissions/ManageGroupsDialog';
+import { getApplicationRole } from '../features/applications/components/user-permissions/memberHelpers';
+import { RemoveMemberDialog } from '../features/applications/components/user-permissions/RemoveMemberDialog';
+import { TransferOwnershipDialog } from '../features/applications/components/user-permissions/TransferOwnershipDialog';
+import { useApplicationDetailContext } from '../features/applications/context/ApplicationDetailContext';
+import { useApplicationGroupMembers } from '../features/applications/hooks/useApplicationGroupMembers';
+import { useApplicationMemberPermissions } from '../features/applications/hooks/useApplicationMemberPermissions';
+import {
+    useApplicationAssociatedGroups,
+    useApplicationMembers,
+    useApplicationRoles,
+    useEnvironmentGroups,
+} from '../features/applications/hooks/useApplicationMembers';
+import {
+    addApplicationMember,
+    deleteApplicationMember,
+    transferApplicationOwnership,
+    updateApplicationGroups,
+    updateApplicationMembershipNotifications,
+    updateApplicationMember,
+} from '../features/applications/services/applicationMembers';
+import type {
+    ApplicationTransferOwnershipPayload,
+    ApplicationUiMember,
+    SearchableUser,
+} from '../features/applications/types/applicationMembers.types';
+import { toApplicationMemberEntity } from '../features/applications/utils/applicationMemberMapper';
+import { applicationDetailKeys, applicationMemberKeys } from '../features/applications/utils/queryKeys';
+
+export function ApplicationUserPermissionsPage() {
+    const { applicationId } = useParams<{ applicationId: string }>();
+    const env = useEnvironment();
+    const queryClient = useQueryClient();
+    const { application } = useApplicationDetailContext();
+    const { canCreate, canUpdate, canDelete } = useApplicationMemberPermissions();
+
+    const isReadOnly = application?.origin === 'KUBERNETES';
+
+    const [memberToEdit, setMemberToEdit] = useState<ApplicationUiMember | null>(null);
+    const [memberToRemove, setMemberToRemove] = useState<ApplicationUiMember | null>(null);
+    const [addMembersOpen, setAddMembersOpen] = useState(false);
+    const [transferOpen, setTransferOpen] = useState(false);
+    const [manageGroupsOpen, setManageGroupsOpen] = useState(false);
+
+    const { data: members = [], isLoading: membersLoading, isError: membersError } = useApplicationMembers(applicationId);
+    const { data: rolesData } = useApplicationRoles();
+    const { data: groupsData } = useEnvironmentGroups();
+
+    const roleNames = useMemo(() => (rolesData ?? []).filter(r => r.name !== 'PRIMARY_OWNER').map(r => r.name), [rolesData]);
+    const allGroups = useMemo(() => groupsData?.data ?? [], [groupsData]);
+    const currentGroupIds = useMemo(() => application?.groups ?? [], [application]);
+    const { data: associatedGroups = [], isLoading: associatedGroupsLoading } = useApplicationAssociatedGroups(currentGroupIds);
+
+    const currentGroups = useMemo(() => {
+        if (associatedGroups.length > 0) {
+            return associatedGroups;
+        }
+        const fromCatalog = allGroups.filter(g => currentGroupIds.includes(g.id));
+        if (fromCatalog.length > 0) {
+            return fromCatalog;
+        }
+        return currentGroupIds.map(id => ({ id, name: id }));
+    }, [associatedGroups, allGroups, currentGroupIds]);
+
+    const { views: groupMemberViews, isLoading: groupMembersLoading } = useApplicationGroupMembers(applicationId, currentGroups);
+
+    const addMutation = useMutation({
+        mutationFn: async ({ users, roleName }: { users: SearchableUser[]; roleName: string }) => {
+            const results = await Promise.allSettled(
+                users.map(user =>
+                    addApplicationMember(env!.id, applicationId!, {
+                        id: user.id ?? user.reference,
+                        role: roleName,
+                    }),
+                ),
+            );
+            const failure = results.find((result): result is PromiseRejectedResult => result.status === 'rejected');
+            if (failure) {
+                throw failure.reason instanceof Error ? failure.reason : new Error(String(failure.reason));
+            }
+        },
+        onSuccess: async () => {
+            if (env?.id && applicationId) {
+                await queryClient.invalidateQueries({
+                    queryKey: applicationMemberKeys.list(env.id, applicationId),
+                });
+                await queryClient.refetchQueries({
+                    queryKey: applicationMemberKeys.list(env.id, applicationId),
+                });
+            }
+        },
+    });
+
+    const updateMutation = useMutation({
+        mutationFn: ({ member, roleName }: { member: ApplicationUiMember; roleName: string }) =>
+            updateApplicationMember(env!.id, applicationId!, toApplicationMemberEntity(member, roleName)),
+        onSuccess: async () => {
+            if (env?.id && applicationId) {
+                await queryClient.invalidateQueries({
+                    queryKey: applicationMemberKeys.list(env.id, applicationId),
+                });
+                await queryClient.refetchQueries({
+                    queryKey: applicationMemberKeys.list(env.id, applicationId),
+                });
+            }
+            setMemberToEdit(null);
+        },
+    });
+
+    const deleteMutation = useMutation({
+        mutationFn: (memberId: string) => deleteApplicationMember(env!.id, applicationId!, memberId),
+        onSuccess: () => {
+            void queryClient.invalidateQueries({ queryKey: applicationMemberKeys.list(env!.id, applicationId!) });
+            setMemberToRemove(null);
+        },
+    });
+
+    const transferMutation = useMutation({
+        mutationFn: (payload: ApplicationTransferOwnershipPayload) => transferApplicationOwnership(env!.id, applicationId!, payload),
+        onSuccess: () => {
+            void queryClient.invalidateQueries({ queryKey: applicationMemberKeys.list(env!.id, applicationId!) });
+            void queryClient.invalidateQueries({ queryKey: applicationDetailKeys.detail(env!.id, applicationId!) });
+            setTransferOpen(false);
+        },
+    });
+
+    const groupsMutation = useMutation({
+        mutationFn: (groupIds: string[]) => {
+            if (!application) throw new Error('Application is not loaded');
+            return updateApplicationGroups(env!.id, application, groupIds);
+        },
+        onSuccess: () => {
+            void queryClient.invalidateQueries({ queryKey: applicationDetailKeys.detail(env!.id, applicationId!) });
+            void queryClient.invalidateQueries({ queryKey: applicationMemberKeys.all });
+            setManageGroupsOpen(false);
+        },
+    });
+
+    const notificationMutation = useMutation({
+        mutationFn: (disable: boolean) => {
+            if (!application) throw new Error('Application is not loaded');
+            return updateApplicationMembershipNotifications(env!.id, application, disable);
+        },
+        onSuccess: () => {
+            void queryClient.invalidateQueries({ queryKey: applicationDetailKeys.detail(env!.id, applicationId!) });
+        },
+    });
+
+    const handleEditRole = useCallback(
+        (member: ApplicationUiMember) => {
+            if (!canUpdate || isReadOnly) return;
+            setMemberToEdit(member);
+        },
+        [canUpdate, isReadOnly],
+    );
+    const handleSaveEditRole = useCallback(
+        (roleName: string) => {
+            if (!memberToEdit || !canUpdate || isReadOnly) return;
+            updateMutation.mutate({ member: memberToEdit, roleName });
+        },
+        [canUpdate, isReadOnly, memberToEdit, updateMutation],
+    );
+    const handleCloseEditRole = useCallback(() => setMemberToEdit(null), []);
+    const handleRemoveRequest = useCallback(
+        (member: ApplicationUiMember) => {
+            if (!canDelete || isReadOnly) return;
+            setMemberToRemove(member);
+        },
+        [canDelete, isReadOnly],
+    );
+    const handleRemoveConfirm = useCallback(() => {
+        if (memberToRemove) deleteMutation.mutate(memberToRemove.id);
+    }, [memberToRemove, deleteMutation]);
+    const handleRemoveCancel = useCallback(() => setMemberToRemove(null), []);
+
+    const handleAddMembers = useCallback(
+        async (users: SearchableUser[], roleName: string) => {
+            try {
+                await addMutation.mutateAsync({ users, roleName });
+                setAddMembersOpen(false);
+            } catch {
+                // Error is surfaced via mutationErrorMessage
+            }
+        },
+        [addMutation],
+    );
+
+    const notificationsEnabled = !(application?.disable_membership_notifications ?? false);
+    const handleNotificationToggle = useCallback((checked: boolean) => notificationMutation.mutate(!checked), [notificationMutation]);
+
+    const actionsDisabled = isReadOnly || !canUpdate;
+
+    const mutationError =
+        addMutation.error ??
+        updateMutation.error ??
+        deleteMutation.error ??
+        transferMutation.error ??
+        groupsMutation.error ??
+        notificationMutation.error;
+
+    const mutationErrorMessage = mutationError instanceof Error ? mutationError.message : mutationError ? String(mutationError) : null;
+
+    return (
+        <div className="space-y-6 p-6">
+            {mutationErrorMessage ? (
+                <Alert variant="destructive">
+                    <AlertDescription>{mutationErrorMessage}</AlertDescription>
+                </Alert>
+            ) : null}
+            <div className="space-y-1">
+                <h1 className="text-2xl font-semibold tracking-tight">User Permissions</h1>
+                <p className="text-sm text-muted-foreground">Manage who can access and administer this application in the console.</p>
+            </div>
+
+            <Card className="px-4 py-3">
+                <div className="flex items-center justify-between gap-4">
+                    <div className="flex items-center gap-2">
+                        <Switch
+                            checked={notificationsEnabled}
+                            onCheckedChange={handleNotificationToggle}
+                            disabled={actionsDisabled || notificationMutation.isPending || !application}
+                            aria-label="Toggle membership notifications"
+                        />
+                        <span className="text-sm">Notify members when they are added to the application</span>
+                    </div>
+                    <div className="flex items-center gap-2">
+                        <Button type="button" variant="outline" size="sm" onClick={() => setTransferOpen(true)} disabled={actionsDisabled}>
+                            <UserCogIcon className="size-4" aria-hidden="true" />
+                            Transfer ownership
+                        </Button>
+                        <Button
+                            type="button"
+                            variant="outline"
+                            size="sm"
+                            onClick={() => setManageGroupsOpen(true)}
+                            disabled={actionsDisabled}
+                        >
+                            <UsersIcon className="size-4" aria-hidden="true" />
+                            Manage groups
+                        </Button>
+                        <Button type="button" size="sm" onClick={() => setAddMembersOpen(true)} disabled={isReadOnly || !canCreate}>
+                            <PlusIcon className="size-4" aria-hidden="true" />
+                            Add members
+                        </Button>
+                    </div>
+                </div>
+            </Card>
+
+            <Card>
+                <CardHeader className="pb-3">
+                    <div className="flex items-center gap-2">
+                        <CardTitle className="text-base">Direct Members</CardTitle>
+                        {!membersLoading ? (
+                            <Badge variant="secondary" className="text-xs tabular-nums">
+                                {members.length}
+                            </Badge>
+                        ) : null}
+                    </div>
+                    <CardDescription className="text-sm">
+                        Users with direct access to this application. You can change their roles or remove them.
+                    </CardDescription>
+                </CardHeader>
+                <CardContent className="space-y-3">
+                    {membersLoading ? (
+                        <div className="space-y-2">
+                            {Array.from({ length: 3 }).map((_, i) => (
+                                <Skeleton key={i} className="h-12 rounded-lg" />
+                            ))}
+                        </div>
+                    ) : membersError ? (
+                        <Alert variant="destructive">
+                            <AlertDescription>Failed to load application members. Please try again.</AlertDescription>
+                        </Alert>
+                    ) : members.length === 0 ? (
+                        <Empty>
+                            <EmptyHeader>
+                                <EmptyTitle>No direct members</EmptyTitle>
+                                <EmptyDescription>Add members to grant direct access to this application.</EmptyDescription>
+                            </EmptyHeader>
+                            <EmptyContent />
+                        </Empty>
+                    ) : (
+                        <DirectMembersTable
+                            members={members}
+                            onEditRole={handleEditRole}
+                            onRemove={handleRemoveRequest}
+                            isRemoving={deleteMutation.isPending}
+                            getRoleName={getApplicationRole}
+                            canManageMembers={!isReadOnly && (canUpdate || canDelete)}
+                            canEditRole={canUpdate}
+                            canRemoveMember={canDelete}
+                        />
+                    )}
+                </CardContent>
+            </Card>
+
+            {currentGroupIds.length > 0 ? (
+                <Card>
+                    <CardHeader className="pb-3">
+                        <CardTitle className="text-base">Group Inherited Members</CardTitle>
+                        <CardDescription className="text-sm">
+                            These members have access through their group membership. Their roles are managed at the group level.
+                        </CardDescription>
+                    </CardHeader>
+                    <CardContent className="space-y-3">
+                        {associatedGroupsLoading ? (
+                            <div className="space-y-2">
+                                {Array.from({ length: Math.min(currentGroupIds.length, 2) }).map((_, i) => (
+                                    <Skeleton key={`group-skeleton-${i}`} className="h-24 rounded-lg" />
+                                ))}
+                            </div>
+                        ) : (
+                            <div className="space-y-4">
+                                {groupMemberViews.map(({ group, members, isLoading: groupLoading, isError }) => (
+                                    <div key={group.id} className="space-y-2">
+                                        {isError ? (
+                                            <Alert variant="destructive">
+                                                <AlertDescription>Failed to load members for group {group.name}.</AlertDescription>
+                                            </Alert>
+                                        ) : null}
+                                        <GroupMembersSection
+                                            groupName={group.name}
+                                            members={members}
+                                            isLoading={groupLoading || (groupMembersLoading && members.length === 0)}
+                                        />
+                                    </div>
+                                ))}
+                            </div>
+                        )}
+                    </CardContent>
+                </Card>
+            ) : null}
+
+            <EditRoleDialog
+                member={memberToEdit}
+                roles={roleNames}
+                onClose={handleCloseEditRole}
+                onSave={handleSaveEditRole}
+                isSaving={updateMutation.isPending}
+            />
+            <RemoveMemberDialog
+                member={memberToRemove}
+                isRemoving={deleteMutation.isPending}
+                onConfirm={handleRemoveConfirm}
+                onCancel={handleRemoveCancel}
+            />
+            <AddMembersDialog
+                open={addMembersOpen}
+                roles={roleNames}
+                existingMembers={members}
+                onClose={() => setAddMembersOpen(false)}
+                onAdd={(users, roleName) => void handleAddMembers(users, roleName)}
+                isAdding={addMutation.isPending}
+            />
+            <TransferOwnershipDialog
+                open={transferOpen}
+                members={members}
+                roles={roleNames}
+                onClose={() => setTransferOpen(false)}
+                onTransfer={payload => transferMutation.mutate(payload)}
+                isTransferring={transferMutation.isPending}
+            />
+            <ManageGroupsDialog
+                open={manageGroupsOpen}
+                allGroups={allGroups}
+                currentGroupIds={currentGroupIds}
+                onClose={() => setManageGroupsOpen(false)}
+                onSave={groupIds => groupsMutation.mutate(groupIds)}
+                isSaving={groupsMutation.isPending}
+            />
+        </div>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/ApplicationUserPermissionsPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/pages/ApplicationUserPermissionsPage.tsx
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { useEnvironment } from '@gravitee/gamma-modules-sdk';
+import { useEnvironment, useHasPermission } from '@gravitee/gamma-modules-sdk';
 import {
     Alert,
     AlertDescription,
@@ -42,7 +42,7 @@ import { DirectMembersTable } from '../features/applications/components/user-per
 import { EditRoleDialog } from '../features/applications/components/user-permissions/EditRoleDialog';
 import { GroupMembersSection } from '../features/applications/components/user-permissions/GroupMembersSection';
 import { ManageGroupsDialog } from '../features/applications/components/user-permissions/ManageGroupsDialog';
-import { getApplicationRole } from '../features/applications/components/user-permissions/memberHelpers';
+import { formatAddMembersResultMessage, getApplicationRole } from '../features/applications/components/user-permissions/memberHelpers';
 import { RemoveMemberDialog } from '../features/applications/components/user-permissions/RemoveMemberDialog';
 import { TransferOwnershipDialog } from '../features/applications/components/user-permissions/TransferOwnershipDialog';
 import { useApplicationDetailContext } from '../features/applications/context/ApplicationDetailContext';
@@ -70,12 +70,24 @@ import type {
 import { toApplicationMemberEntity } from '../features/applications/utils/applicationMemberMapper';
 import { applicationDetailKeys, applicationMemberKeys } from '../features/applications/utils/queryKeys';
 
+class AddMembersMutationError extends Error {
+    public readonly succeededCount: number;
+
+    constructor(message: string, succeededCount: number) {
+        super(message);
+        this.name = 'AddMembersMutationError';
+        this.succeededCount = succeededCount;
+    }
+}
+
 export function ApplicationUserPermissionsPage() {
     const { applicationId } = useParams<{ applicationId: string }>();
     const env = useEnvironment();
     const queryClient = useQueryClient();
-    const { application } = useApplicationDetailContext();
+    const { application, permissionsReady } = useApplicationDetailContext();
     const { canCreate, canUpdate, canDelete } = useApplicationMemberPermissions();
+    const canUpdateDefinitionPermission = useHasPermission({ anyOf: ['application-definition-u'] });
+    const canUpdateDefinition = permissionsReady && canUpdateDefinitionPermission;
 
     const isReadOnly = application?.origin === 'KUBERNETES';
 
@@ -117,17 +129,34 @@ export function ApplicationUserPermissionsPage() {
                     }),
                 ),
             );
-            const failure = results.find((result): result is PromiseRejectedResult => result.status === 'rejected');
-            if (failure) {
-                throw failure.reason instanceof Error ? failure.reason : new Error(String(failure.reason));
+
+            let succeededCount = 0;
+            const failed: { user: SearchableUser; reason: string }[] = [];
+
+            results.forEach((result, index) => {
+                if (result.status === 'fulfilled') {
+                    succeededCount += 1;
+                } else {
+                    const reason = result.reason instanceof Error ? result.reason.message : String(result.reason);
+                    failed.push({ user: users[index]!, reason });
+                }
+            });
+
+            if (failed.length > 0) {
+                throw new AddMembersMutationError(formatAddMembersResultMessage(users.length, succeededCount, failed), succeededCount);
             }
         },
-        onSuccess: async () => {
+        onSuccess: () => {
             if (env?.id && applicationId) {
-                await queryClient.invalidateQueries({
+                void queryClient.invalidateQueries({
                     queryKey: applicationMemberKeys.list(env.id, applicationId),
                 });
-                await queryClient.refetchQueries({
+            }
+        },
+        onError: error => {
+            if (error instanceof AddMembersMutationError && error.succeededCount > 0 && env?.id && applicationId) {
+                // Partial success: refresh the list even though the mutation is considered failed.
+                void queryClient.invalidateQueries({
                     queryKey: applicationMemberKeys.list(env.id, applicationId),
                 });
             }
@@ -137,12 +166,9 @@ export function ApplicationUserPermissionsPage() {
     const updateMutation = useMutation({
         mutationFn: ({ member, roleName }: { member: ApplicationUiMember; roleName: string }) =>
             updateApplicationMember(env!.id, applicationId!, toApplicationMemberEntity(member, roleName)),
-        onSuccess: async () => {
+        onSuccess: () => {
             if (env?.id && applicationId) {
-                await queryClient.invalidateQueries({
-                    queryKey: applicationMemberKeys.list(env.id, applicationId),
-                });
-                await queryClient.refetchQueries({
+                void queryClient.invalidateQueries({
                     queryKey: applicationMemberKeys.list(env.id, applicationId),
                 });
             }
@@ -153,7 +179,9 @@ export function ApplicationUserPermissionsPage() {
     const deleteMutation = useMutation({
         mutationFn: (memberId: string) => deleteApplicationMember(env!.id, applicationId!, memberId),
         onSuccess: () => {
-            void queryClient.invalidateQueries({ queryKey: applicationMemberKeys.list(env!.id, applicationId!) });
+            if (env?.id && applicationId) {
+                void queryClient.invalidateQueries({ queryKey: applicationMemberKeys.list(env.id, applicationId) });
+            }
             setMemberToRemove(null);
         },
     });
@@ -161,8 +189,10 @@ export function ApplicationUserPermissionsPage() {
     const transferMutation = useMutation({
         mutationFn: (payload: ApplicationTransferOwnershipPayload) => transferApplicationOwnership(env!.id, applicationId!, payload),
         onSuccess: () => {
-            void queryClient.invalidateQueries({ queryKey: applicationMemberKeys.list(env!.id, applicationId!) });
-            void queryClient.invalidateQueries({ queryKey: applicationDetailKeys.detail(env!.id, applicationId!) });
+            if (env?.id && applicationId) {
+                void queryClient.invalidateQueries({ queryKey: applicationMemberKeys.list(env.id, applicationId) });
+                void queryClient.invalidateQueries({ queryKey: applicationDetailKeys.detail(env.id, applicationId) });
+            }
             setTransferOpen(false);
         },
     });
@@ -173,7 +203,9 @@ export function ApplicationUserPermissionsPage() {
             return updateApplicationGroups(env!.id, application, groupIds);
         },
         onSuccess: () => {
-            void queryClient.invalidateQueries({ queryKey: applicationDetailKeys.detail(env!.id, applicationId!) });
+            if (env?.id && applicationId) {
+                void queryClient.invalidateQueries({ queryKey: applicationDetailKeys.detail(env.id, applicationId) });
+            }
             void queryClient.invalidateQueries({ queryKey: applicationMemberKeys.all });
             setManageGroupsOpen(false);
         },
@@ -185,7 +217,9 @@ export function ApplicationUserPermissionsPage() {
             return updateApplicationMembershipNotifications(env!.id, application, disable);
         },
         onSuccess: () => {
-            void queryClient.invalidateQueries({ queryKey: applicationDetailKeys.detail(env!.id, applicationId!) });
+            if (env?.id && applicationId) {
+                void queryClient.invalidateQueries({ queryKey: applicationDetailKeys.detail(env.id, applicationId) });
+            }
         },
     });
 
@@ -231,7 +265,8 @@ export function ApplicationUserPermissionsPage() {
     const notificationsEnabled = !(application?.disable_membership_notifications ?? false);
     const handleNotificationToggle = useCallback((checked: boolean) => notificationMutation.mutate(!checked), [notificationMutation]);
 
-    const actionsDisabled = isReadOnly || !canUpdate;
+    const memberActionsDisabled = isReadOnly || !canUpdate;
+    const definitionActionsDisabled = isReadOnly || !canUpdateDefinition;
 
     const mutationError =
         addMutation.error ??
@@ -261,13 +296,19 @@ export function ApplicationUserPermissionsPage() {
                         <Switch
                             checked={notificationsEnabled}
                             onCheckedChange={handleNotificationToggle}
-                            disabled={actionsDisabled || notificationMutation.isPending || !application}
+                            disabled={definitionActionsDisabled || notificationMutation.isPending || !application}
                             aria-label="Toggle membership notifications"
                         />
                         <span className="text-sm">Notify members when they are added to the application</span>
                     </div>
                     <div className="flex items-center gap-2">
-                        <Button type="button" variant="outline" size="sm" onClick={() => setTransferOpen(true)} disabled={actionsDisabled}>
+                        <Button
+                            type="button"
+                            variant="outline"
+                            size="sm"
+                            onClick={() => setTransferOpen(true)}
+                            disabled={memberActionsDisabled}
+                        >
                             <UserCogIcon className="size-4" aria-hidden="true" />
                             Transfer ownership
                         </Button>
@@ -276,7 +317,7 @@ export function ApplicationUserPermissionsPage() {
                             variant="outline"
                             size="sm"
                             onClick={() => setManageGroupsOpen(true)}
-                            disabled={actionsDisabled}
+                            disabled={definitionActionsDisabled}
                         >
                             <UsersIcon className="size-4" aria-hidden="true" />
                             Manage groups


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-XXX

## Description

## Summary
Adds the missing Gamma Platform application detail pages for Overview, User Permissions, and Notification Settings.
## What changed
- Added an application Overview page with setup checklist, subscription snapshot, and links into the relevant application sections.
- Added User Permissions management, including direct members, role updates, member removal, ownership transfer, group association management, inherited group members, and membership notification toggle.
- Added Notification Settings management for application notifications, hook subscriptions, notifiers, and application metadata CRUD.
- Registered the new pages in application detail routing/navigation with permission-aware tab visibility and landing behavior.
- Updated navigation permission tests for the newly implemented tabs.
## Test plan
- [ ] Run Gamma Platform UI tests, including `applicationDetailNavigation.spec.ts`.
- [ ] Verify Overview loads setup progress and subscription counts for an application.
- [ ] Verify user permission flows: add member, edit role, remove member, transfer ownership, manage groups, and toggle membership notifications.
- [ ] Verify notification flows: create/edit notification settings, update subscribed events, and create/update/delete metadata.
- [ ] Verify read-only Kubernetes applications disable mutating actions.


## Additional context

Proof video: 

https://github.com/user-attachments/assets/edfa2598-ce23-4341-a391-32d9db517ab9



