### PR TITLE
feat(service): implement AcceptInvitationDomainServiceImpl

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/membership/domain_service/MembershipDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/membership/domain_service/MembershipDomainService.java
@@ -40,4 +40,6 @@ public interface MembershipDomainService {
         String externalReference,
         String roleName
     );
+
+    void addGroupMemberships(ExecutionContext executionContext, String groupId, String userId, String apiRole, String applicationRole);
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/invitation/AcceptInvitationDomainServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/invitation/AcceptInvitationDomainServiceImpl.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.infra.domain_service.invitation;
+
+import io.gravitee.apim.core.invitation.domain_service.AcceptInvitationDomainService;
+import io.gravitee.apim.core.invitation.model.ApplicationInvitation;
+import io.gravitee.apim.core.invitation.model.GroupInvitation;
+import io.gravitee.apim.core.invitation.model.Invitation;
+import io.gravitee.apim.core.member.model.MembershipReferenceType;
+import io.gravitee.apim.core.membership.domain_service.MembershipDomainService;
+import io.gravitee.rest.api.service.common.ExecutionContext;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AcceptInvitationDomainServiceImpl implements AcceptInvitationDomainService {
+
+    private final MembershipDomainService membershipDomainService;
+
+    @Override
+    public void addMember(ExecutionContext executionContext, Invitation invitation, String userId) {
+        switch (invitation) {
+            case GroupInvitation g -> membershipDomainService.addGroupMemberships(
+                executionContext,
+                g.referenceId(),
+                userId,
+                g.apiRole(),
+                g.applicationRole()
+            );
+            case ApplicationInvitation a -> membershipDomainService.createNewMembership(
+                executionContext,
+                MembershipReferenceType.APPLICATION,
+                a.applicationId(),
+                userId,
+                null,
+                a.roleName()
+            );
+        }
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/membership/MembershipDomainServiceLegacyWrapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/membership/MembershipDomainServiceLegacyWrapper.java
@@ -99,6 +99,43 @@ public class MembershipDomainServiceLegacyWrapper implements MembershipDomainSer
         );
     }
 
+    @Override
+    public void addGroupMemberships(
+        ExecutionContext executionContext,
+        String groupId,
+        String userId,
+        String apiRole,
+        String applicationRole
+    ) {
+        addRoleToMemberOnGroupReference(executionContext, groupId, userId, RoleScope.API, apiRole);
+        addRoleToMemberOnGroupReference(executionContext, groupId, userId, RoleScope.APPLICATION, applicationRole);
+        addRoleToMemberOnGroupReference(executionContext, groupId, userId, RoleScope.GROUP);
+    }
+
+    private void addRoleToMemberOnGroupReference(
+        ExecutionContext executionContext,
+        String groupId,
+        String userId,
+        RoleScope roleScope,
+        String roleName
+    ) {
+        legacyService.addRoleToMemberOnReference(
+            executionContext,
+            new MembershipService.MembershipReference(MembershipReferenceType.GROUP, groupId),
+            new MembershipService.MembershipMember(userId, null, MembershipMemberType.USER),
+            new MembershipService.MembershipRole(roleScope, roleName)
+        );
+    }
+
+    private void addRoleToMemberOnGroupReference(ExecutionContext executionContext, String groupId, String userId, RoleScope roleScope) {
+        roleService
+            .findDefaultRoleByScopes(executionContext.getOrganizationId(), roleScope)
+            .stream()
+            .findFirst()
+            .map(RoleEntity::getName)
+            .ifPresent(roleName -> addRoleToMemberOnGroupReference(executionContext, groupId, userId, roleScope, roleName));
+    }
+
     private void validateTransferOwnership(TransferOwnership transferOwnership) {
         if ("PRIMARY_OWNER".equals(transferOwnership.getCurrentPrimaryOwnerNewRole())) {
             throw new TransferOwnershipNotAllowedException(transferOwnership.getCurrentPrimaryOwnerNewRole());

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/fixtures/core/model/GroupInvitationFixtures.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/fixtures/core/model/GroupInvitationFixtures.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package fixtures.core.model;
+
+import io.gravitee.apim.core.invitation.model.GroupInvitation;
+import io.gravitee.apim.core.invitation.model.InvitationId;
+
+public class GroupInvitationFixtures {
+
+    private GroupInvitationFixtures() {}
+
+    public static GroupInvitation aGroupInvitation(String id, String groupId, String email) {
+        return new GroupInvitation(InvitationId.of(id), groupId, "GROUP", email, "API_USER", "APP_USER");
+    }
+
+    public static GroupInvitation aGroupInvitation(String id, String groupId, String email, String apiRole, String applicationRole) {
+        return new GroupInvitation(InvitationId.of(id), groupId, "GROUP", email, apiRole, applicationRole);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/MembershipDomainServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/MembershipDomainServiceInMemory.java
@@ -114,4 +114,31 @@ public class MembershipDomainServiceInMemory extends AbstractServiceInMemory<Mem
         storage.add(newMembership);
         return newMembership;
     }
+
+    @Override
+    public void addGroupMemberships(
+        ExecutionContext executionContext,
+        String groupId,
+        String userId,
+        String apiRole,
+        String applicationRole
+    ) {
+        addGroupMembershipForScope(groupId, userId, RoleScope.API, apiRole);
+        addGroupMembershipForScope(groupId, userId, RoleScope.APPLICATION, applicationRole);
+    }
+
+    private void addGroupMembershipForScope(String groupId, String userId, RoleScope scope, String roleName) {
+        if (roleName == null) {
+            return;
+        }
+        storage.add(
+            MemberEntity.builder()
+                .referenceType(MembershipReferenceType.GROUP)
+                .referenceId(groupId)
+                .roles(List.of(RoleEntity.builder().scope(scope).name(roleName).build()))
+                .type(MembershipMemberType.USER)
+                .id(userId)
+                .build()
+        );
+    }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/invitation/AcceptInvitationDomainServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/invitation/AcceptInvitationDomainServiceImplTest.java
@@ -60,6 +60,13 @@ class AcceptInvitationDomainServiceImplTest {
 
         cut.addMember(EXECUTION_CONTEXT, invitation, USER_ID);
 
-        verify(membershipDomainService).createNewMembership(EXECUTION_CONTEXT, MembershipReferenceType.APPLICATION, "app-1", USER_ID, null, "USER");
+        verify(membershipDomainService).createNewMembership(
+            EXECUTION_CONTEXT,
+            MembershipReferenceType.APPLICATION,
+            "app-1",
+            USER_ID,
+            null,
+            "USER"
+        );
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/invitation/AcceptInvitationDomainServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/invitation/AcceptInvitationDomainServiceImplTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.infra.domain_service.invitation;
+
+import static fixtures.core.model.ApplicationInvitationFixtures.anApplicationInvitation;
+import static fixtures.core.model.GroupInvitationFixtures.aGroupInvitation;
+import static org.mockito.Mockito.verify;
+
+import io.gravitee.apim.core.member.model.MembershipReferenceType;
+import io.gravitee.apim.core.membership.domain_service.MembershipDomainService;
+import io.gravitee.rest.api.service.common.ExecutionContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class AcceptInvitationDomainServiceImplTest {
+
+    private static final ExecutionContext EXECUTION_CONTEXT = new ExecutionContext("org-id", "env-id");
+    private static final String USER_ID = "user-id";
+    private static final String INVITATION_ID = "00000000-0000-0000-0000-000000000001";
+
+    @Mock
+    MembershipDomainService membershipDomainService;
+
+    AcceptInvitationDomainServiceImpl cut;
+
+    @BeforeEach
+    void setUp() {
+        cut = new AcceptInvitationDomainServiceImpl(membershipDomainService);
+    }
+
+    @Test
+    void should_add_member_for_group_invitation() {
+        var invitation = aGroupInvitation(INVITATION_ID, "group-1", "alice@example.com", "API_USER", "APP_USER");
+
+        cut.addMember(EXECUTION_CONTEXT, invitation, USER_ID);
+
+        verify(membershipDomainService).addGroupMemberships(EXECUTION_CONTEXT, "group-1", USER_ID, "API_USER", "APP_USER");
+    }
+
+    @Test
+    void should_add_member_for_application_invitation() {
+        var invitation = anApplicationInvitation(INVITATION_ID, "app-1", "alice@example.com", "USER");
+
+        cut.addMember(EXECUTION_CONTEXT, invitation, USER_ID);
+
+        verify(membershipDomainService).createNewMembership(EXECUTION_CONTEXT, MembershipReferenceType.APPLICATION, "app-1", USER_ID, null, "USER");
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/membership/MembershipDomainServiceLegacyWrapperTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/membership/MembershipDomainServiceLegacyWrapperTest.java
@@ -1,0 +1,217 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.infra.domain_service.membership;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.apim.core.member.model.MembershipReferenceType;
+import io.gravitee.apim.core.membership.model.TransferOwnership;
+import io.gravitee.rest.api.model.MemberEntity;
+import io.gravitee.rest.api.model.MembershipMemberType;
+import io.gravitee.rest.api.model.RoleEntity;
+import io.gravitee.rest.api.model.permissions.RoleScope;
+import io.gravitee.rest.api.service.MembershipService;
+import io.gravitee.rest.api.service.RoleService;
+import io.gravitee.rest.api.service.common.ExecutionContext;
+import io.gravitee.rest.api.service.common.GraviteeContext;
+import io.gravitee.rest.api.service.exceptions.InvalidDataException;
+import io.gravitee.rest.api.service.exceptions.TransferOwnershipNotAllowedException;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@ExtendWith(MockitoExtension.class)
+class MembershipDomainServiceLegacyWrapperTest {
+
+    private static final ExecutionContext EXECUTION_CONTEXT = new ExecutionContext("org-id", "env-id");
+    private static final String GROUP_ID = "group-id";
+    private static final String USER_ID = "user-id";
+
+    @Mock
+    MembershipService membershipService;
+
+    @Mock
+    RoleService roleService;
+
+    MembershipDomainServiceLegacyWrapper cut;
+
+    @BeforeEach
+    void setUp() {
+        cut = new MembershipDomainServiceLegacyWrapper(membershipService, roleService);
+    }
+
+    @Nested
+    class GetUserMemberPermissions {
+
+        @Test
+        void should_delegate_to_legacy_service() {
+            when(
+                membershipService.getUserMemberPermissions(
+                    EXECUTION_CONTEXT,
+                    io.gravitee.rest.api.model.MembershipReferenceType.API,
+                    "api-id",
+                    USER_ID
+                )
+            ).thenReturn(null);
+
+            cut.getUserMemberPermissions(EXECUTION_CONTEXT, io.gravitee.rest.api.model.MembershipReferenceType.API, "api-id", USER_ID);
+
+            verify(membershipService).getUserMemberPermissions(
+                EXECUTION_CONTEXT,
+                io.gravitee.rest.api.model.MembershipReferenceType.API,
+                "api-id",
+                USER_ID
+            );
+        }
+    }
+
+    @Nested
+    class CreateNewMembership {
+
+        @Test
+        void should_delegate_to_legacy_service_with_mapped_reference_type() {
+            var memberEntity = new MemberEntity();
+            when(
+                membershipService.createNewMembership(
+                    EXECUTION_CONTEXT,
+                    io.gravitee.rest.api.model.MembershipReferenceType.APPLICATION,
+                    "app-id",
+                    USER_ID,
+                    null,
+                    "USER"
+                )
+            ).thenReturn(memberEntity);
+
+            var result = cut.createNewMembership(EXECUTION_CONTEXT, MembershipReferenceType.APPLICATION, "app-id", USER_ID, null, "USER");
+
+            assertThat(result).isSameAs(memberEntity);
+        }
+    }
+
+    @Nested
+    class AddGroupMemberships {
+
+        @Test
+        void should_add_api_application_and_group_roles() {
+            var defaultGroupRole = RoleEntity.builder().name("MEMBER").build();
+            when(roleService.findDefaultRoleByScopes("org-id", RoleScope.GROUP)).thenReturn(List.of(defaultGroupRole));
+
+            cut.addGroupMemberships(EXECUTION_CONTEXT, GROUP_ID, USER_ID, "API_USER", "APP_USER");
+
+            verify(membershipService).addRoleToMemberOnReference(
+                EXECUTION_CONTEXT,
+                new MembershipService.MembershipReference(io.gravitee.rest.api.model.MembershipReferenceType.GROUP, GROUP_ID),
+                new MembershipService.MembershipMember(USER_ID, null, MembershipMemberType.USER),
+                new MembershipService.MembershipRole(RoleScope.API, "API_USER")
+            );
+            verify(membershipService).addRoleToMemberOnReference(
+                EXECUTION_CONTEXT,
+                new MembershipService.MembershipReference(io.gravitee.rest.api.model.MembershipReferenceType.GROUP, GROUP_ID),
+                new MembershipService.MembershipMember(USER_ID, null, MembershipMemberType.USER),
+                new MembershipService.MembershipRole(RoleScope.APPLICATION, "APP_USER")
+            );
+            verify(membershipService).addRoleToMemberOnReference(
+                EXECUTION_CONTEXT,
+                new MembershipService.MembershipReference(io.gravitee.rest.api.model.MembershipReferenceType.GROUP, GROUP_ID),
+                new MembershipService.MembershipMember(USER_ID, null, MembershipMemberType.USER),
+                new MembershipService.MembershipRole(RoleScope.GROUP, "MEMBER")
+            );
+        }
+
+        @Test
+        void should_skip_group_role_when_no_default_role_exists() {
+            when(roleService.findDefaultRoleByScopes("org-id", RoleScope.GROUP)).thenReturn(List.of());
+
+            cut.addGroupMemberships(EXECUTION_CONTEXT, GROUP_ID, USER_ID, "API_USER", "APP_USER");
+
+            verify(membershipService).addRoleToMemberOnReference(
+                EXECUTION_CONTEXT,
+                new MembershipService.MembershipReference(io.gravitee.rest.api.model.MembershipReferenceType.GROUP, GROUP_ID),
+                new MembershipService.MembershipMember(USER_ID, null, MembershipMemberType.USER),
+                new MembershipService.MembershipRole(RoleScope.API, "API_USER")
+            );
+            verify(membershipService).addRoleToMemberOnReference(
+                EXECUTION_CONTEXT,
+                new MembershipService.MembershipReference(io.gravitee.rest.api.model.MembershipReferenceType.GROUP, GROUP_ID),
+                new MembershipService.MembershipMember(USER_ID, null, MembershipMemberType.USER),
+                new MembershipService.MembershipRole(RoleScope.APPLICATION, "APP_USER")
+            );
+            verifyNoMoreInteractions(membershipService);
+        }
+    }
+
+    @Nested
+    class TransferOwnership_Tests {
+
+        @BeforeEach
+        void setUpGraviteeContext() {
+            GraviteeContext.setCurrentOrganization(EXECUTION_CONTEXT.getOrganizationId());
+            GraviteeContext.setCurrentEnvironment(EXECUTION_CONTEXT.getEnvironmentId());
+        }
+
+        @AfterEach
+        void cleanGraviteeContext() {
+            GraviteeContext.cleanContext();
+        }
+
+        @Test
+        void should_transfer_ownership() {
+            var transfer = TransferOwnership.builder().newPrimaryOwnerId(USER_ID).currentPrimaryOwnerNewRole("USER").build();
+            var newRole = RoleEntity.builder().name("USER").build();
+            when(roleService.findByScopeAndName(RoleScope.API, "USER", "org-id")).thenReturn(Optional.of(newRole));
+
+            cut.transferOwnership(transfer, RoleScope.API, "api-id");
+
+            verify(membershipService).transferOwnership(
+                EXECUTION_CONTEXT,
+                io.gravitee.rest.api.model.MembershipReferenceType.API,
+                RoleScope.API,
+                "api-id",
+                new MembershipService.MembershipMember(USER_ID, null, MembershipMemberType.USER),
+                List.of(newRole)
+            );
+        }
+
+        @Test
+        void should_throw_when_new_role_is_primary_owner() {
+            var transfer = TransferOwnership.builder().newPrimaryOwnerId(USER_ID).currentPrimaryOwnerNewRole("PRIMARY_OWNER").build();
+
+            assertThatThrownBy(() -> cut.transferOwnership(transfer, RoleScope.API, "api-id")).isInstanceOf(
+                TransferOwnershipNotAllowedException.class
+            );
+        }
+
+        @Test
+        void should_throw_when_neither_owner_id_nor_user_ref_is_provided() {
+            var transfer = TransferOwnership.builder().currentPrimaryOwnerNewRole("USER").build();
+
+            assertThatThrownBy(() -> cut.transferOwnership(transfer, RoleScope.API, "api-id")).isInstanceOf(InvalidDataException.class);
+        }
+    }
+}


### PR DESCRIPTION
## Issue
https://gravitee.atlassian.net/browse/APIM-14130

## Description
- Replaced `ApplicationInvitationAdapter` with a generic `InvitationAdapter` (MapStruct) supporting both `GroupInvitation` and `ApplicationInvitation` via a `default toEntity` dispatch on `InvitationReferenceType`
- Implemented `InvitationCrudService.findByEmail` and `delete` in `InvitationCrudServiceImpl` using `InvitationRepository.findAll()` + stream filter / `InvitationRepository.delete`
- Extended `MembershipDomainService` with `addGroupMemberships` and implemented it in `MembershipDomainServiceLegacyWrapper` — mirrors the three-scope (API, APPLICATION, GROUP) logic from the legacy `InvitationServiceImpl.addMember` without calling the legacy service directly
- Implemented `AcceptInvitationDomainServiceImpl` dispatching on sealed `Invitation` subtypes: `GroupInvitation` → `addGroupMemberships`, `ApplicationInvitation` → `createNewMembership`
- Added `InvitationCrudServiceImplTest` (findByEmail + delete), `AcceptInvitationDomainServiceImplTest`, `GroupInvitationFixtures`, `InvitationFixtures`, and updated `MembershipDomainServiceInMemory`
