### PR TITLE
perf(rest-api): collapse apiKey pre-expiration scheduler fan-out (APIM-14132)

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/ApiKeyRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/ApiKeyRepository.java
@@ -99,6 +99,13 @@ public interface ApiKeyRepository extends FindAllRepository<ApiKey> {
     List<ApiKey> findByCriteria(ApiKeyCriteria filter, Sortable sortable) throws TechnicalException;
 
     /**
+     * Same as {@link #findByCriteria(ApiKeyCriteria)} but without the implicit {@code updatedAt} sort.
+     * Use when the caller doesn't need a stable order — allows the planner to pick an ESR-friendly index
+     * (e.g. {@code {revoked:1, expireAt:1}}) instead of being constrained by an unwanted sort field.
+     */
+    List<ApiKey> findByCriteriaUnordered(ApiKeyCriteria filter) throws TechnicalException;
+
+    /**
      *
      * @param id apikey ID
      * @param subscriptionId subscription ID to add to this shared apikey

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcApiKeyRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcApiKeyRepository.java
@@ -144,74 +144,8 @@ public class JdbcApiKeyRepository extends JdbcAbstractCrudRepository<ApiKey, Str
         log.debug("JdbcApiKeyRepository.findByCriteria({})", criteria);
         try {
             List<Object> args = new ArrayList<>();
+            StringBuilder query = buildCriteriaQuery(criteria, args);
 
-            StringBuilder query = new StringBuilder(getOrm().getSelectAllSql())
-                .append(" k left join ")
-                .append(keySubscriptions)
-                .append(" ks on ks.key_id = k.id");
-
-            boolean first = true;
-
-            if (!isEmpty(criteria.getSubscriptions())) {
-                first = addClause(first, query);
-                query
-                    .append("k.id in ( select key_id from ")
-                    .append(keySubscriptions)
-                    .append(" where subscription_id in ( ")
-                    .append(getOrm().buildInClause(criteria.getSubscriptions()))
-                    .append(" ) )");
-                args.addAll(criteria.getSubscriptions());
-            }
-
-            if (!isEmpty(criteria.getEnvironments())) {
-                first = addClause(first, query);
-                query.append(" ( k.environment_id in ( ").append(getOrm().buildInClause(criteria.getEnvironments())).append(" ) )");
-                args.addAll(criteria.getEnvironments());
-            }
-
-            if (!criteria.isIncludeRevoked()) {
-                first = addClause(first, query);
-                query.append(" ( k.revoked = ? ) ");
-                args.add(false);
-            }
-
-            if (!criteria.isIncludeFederated()) {
-                first = addClause(first, query);
-                query.append(" ( k.federated = ? ) ");
-                args.add(false);
-            }
-
-            if (criteria.getFrom() > 0) {
-                first = addClause(first, query);
-                query.append(" ( k.updated_at >= ? ) ");
-                args.add(new Date(criteria.getFrom()));
-            }
-
-            if (criteria.getTo() > 0) {
-                first = addClause(first, query);
-                query.append(" ( k.updated_at <= ? ) ");
-                args.add(new Date(criteria.getTo()));
-            }
-
-            if (criteria.getExpireAfter() > 0) {
-                first = addClause(first, query);
-                if (criteria.isIncludeWithoutExpiration()) {
-                    query.append(" ( k.expire_at is NULL or k.expire_at >= ? ) ");
-                } else {
-                    query.append("( k.expire_at >= ? )");
-                }
-                args.add(new Date(criteria.getExpireAfter()));
-            }
-
-            if (criteria.getExpireBefore() > 0) {
-                addClause(first, query);
-                if (criteria.isIncludeWithoutExpiration()) {
-                    query.append(" ( k.expire_at is NULL or k.expire_at <= ? ) ");
-                } else {
-                    query.append("( k.expire_at <= ? )");
-                }
-                args.add(new Date(criteria.getExpireBefore()));
-            }
             if (sortable != null && sortable.field() != null && sortable.field().length() > 0) {
                 query.append(" order by k.");
                 query.append(toSnakeCase(sortable.field()));
@@ -220,14 +154,101 @@ public class JdbcApiKeyRepository extends JdbcAbstractCrudRepository<ApiKey, Str
                 query.append(" order by k.updated_at desc ");
             }
 
-            CollatingRowMapper<ApiKey> rowMapper = new CollatingRowMapper<>(getOrm().getRowMapper(), CHILD_ADDER, "id");
-            jdbcTemplate.query(query.toString(), rowMapper, args.toArray());
-
-            return rowMapper.getRows();
+            return runCriteriaQuery(query, args);
         } catch (final Exception ex) {
             log.error("Failed to find API Keys by criteria:", ex);
             throw new TechnicalException("Failed to find API Keys by criteria", ex);
         }
+    }
+
+    @Override
+    public List<ApiKey> findByCriteriaUnordered(final ApiKeyCriteria criteria) throws TechnicalException {
+        log.debug("JdbcApiKeyRepository.findByCriteriaUnordered({})", criteria);
+        try {
+            List<Object> args = new ArrayList<>();
+            StringBuilder query = buildCriteriaQuery(criteria, args);
+            return runCriteriaQuery(query, args);
+        } catch (final Exception ex) {
+            log.error("Failed to find API Keys by criteria (unordered):", ex);
+            throw new TechnicalException("Failed to find API Keys by criteria", ex);
+        }
+    }
+
+    private StringBuilder buildCriteriaQuery(final ApiKeyCriteria criteria, final List<Object> args) {
+        StringBuilder query = new StringBuilder(getOrm().getSelectAllSql())
+            .append(" k left join ")
+            .append(keySubscriptions)
+            .append(" ks on ks.key_id = k.id");
+
+        boolean first = true;
+
+        if (!isEmpty(criteria.getSubscriptions())) {
+            first = addClause(first, query);
+            query
+                .append("k.id in ( select key_id from ")
+                .append(keySubscriptions)
+                .append(" where subscription_id in ( ")
+                .append(getOrm().buildInClause(criteria.getSubscriptions()))
+                .append(" ) )");
+            args.addAll(criteria.getSubscriptions());
+        }
+
+        if (!isEmpty(criteria.getEnvironments())) {
+            first = addClause(first, query);
+            query.append(" ( k.environment_id in ( ").append(getOrm().buildInClause(criteria.getEnvironments())).append(" ) )");
+            args.addAll(criteria.getEnvironments());
+        }
+
+        if (!criteria.isIncludeRevoked()) {
+            first = addClause(first, query);
+            query.append(" ( k.revoked = ? ) ");
+            args.add(false);
+        }
+
+        if (!criteria.isIncludeFederated()) {
+            first = addClause(first, query);
+            query.append(" ( k.federated = ? ) ");
+            args.add(false);
+        }
+
+        if (criteria.getFrom() > 0) {
+            first = addClause(first, query);
+            query.append(" ( k.updated_at >= ? ) ");
+            args.add(new Date(criteria.getFrom()));
+        }
+
+        if (criteria.getTo() > 0) {
+            first = addClause(first, query);
+            query.append(" ( k.updated_at <= ? ) ");
+            args.add(new Date(criteria.getTo()));
+        }
+
+        if (criteria.getExpireAfter() > 0) {
+            first = addClause(first, query);
+            if (criteria.isIncludeWithoutExpiration()) {
+                query.append(" ( k.expire_at is NULL or k.expire_at >= ? ) ");
+            } else {
+                query.append("( k.expire_at >= ? )");
+            }
+            args.add(new Date(criteria.getExpireAfter()));
+        }
+
+        if (criteria.getExpireBefore() > 0) {
+            addClause(first, query);
+            if (criteria.isIncludeWithoutExpiration()) {
+                query.append(" ( k.expire_at is NULL or k.expire_at <= ? ) ");
+            } else {
+                query.append("( k.expire_at <= ? )");
+            }
+            args.add(new Date(criteria.getExpireBefore()));
+        }
+        return query;
+    }
+
+    private List<ApiKey> runCriteriaQuery(final StringBuilder query, final List<Object> args) {
+        CollatingRowMapper<ApiKey> rowMapper = new CollatingRowMapper<>(getOrm().getRowMapper(), CHILD_ADDER, "id");
+        jdbcTemplate.query(query.toString(), rowMapper, args.toArray());
+        return rowMapper.getRows();
     }
 
     @Override

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoApiKeyRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoApiKeyRepository.java
@@ -92,6 +92,11 @@ public class MongoApiKeyRepository implements ApiKeyRepository {
     }
 
     @Override
+    public List<ApiKey> findByCriteriaUnordered(ApiKeyCriteria filter) {
+        return mapper.mapApiKeys(internalApiKeyRepo.searchUnordered(filter));
+    }
+
+    @Override
     public Optional<ApiKey> addSubscription(String id, String subscriptionId) throws TechnicalException {
         UpdateResult result = internalApiKeyRepo.addSubscription(id, subscriptionId);
         if (result.getMatchedCount() == 0) {

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/key/ApiKeyMongoRepositoryCustom.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/key/ApiKeyMongoRepositoryCustom.java
@@ -30,6 +30,13 @@ import org.springframework.stereotype.Repository;
 public interface ApiKeyMongoRepositoryCustom {
     List<ApiKeyMongo> search(ApiKeyCriteria filter, final Sortable sortable);
 
+    /**
+     * Same predicate pipeline as {@link #search(ApiKeyCriteria, Sortable)} but emits no {@code $sort}
+     * stage. Lets the planner pick an ESR-friendly index for range-only call shapes
+     * (e.g. {@code {revoked:1, expireAt:1}}).
+     */
+    List<ApiKeyMongo> searchUnordered(ApiKeyCriteria filter);
+
     List<ApiKeyMongo> findByKeyAndApi(String key, String api);
 
     List<ApiKeyMongo> findByKeyAndReferenceIdAndReferenceType(String key, String referenceId, String referenceType);

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/key/ApiKeyMongoRepositoryImpl.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/key/ApiKeyMongoRepositoryImpl.java
@@ -59,6 +59,27 @@ public class ApiKeyMongoRepositoryImpl implements ApiKeyMongoRepositoryCustom {
 
     @Override
     public List<ApiKeyMongo> search(ApiKeyCriteria filter, final Sortable sortable) {
+        List<Bson> pipeline = buildFilterPipeline(filter);
+
+        if (sortable != null) {
+            if (sortable.order().equals(Order.ASC)) {
+                pipeline.add(sort(Sorts.ascending(FieldUtils.toCamelCase(sortable.field()))));
+            } else {
+                pipeline.add(sort(Sorts.descending(FieldUtils.toCamelCase(sortable.field()))));
+            }
+        } else {
+            pipeline.add(sort(Sorts.descending("updatedAt")));
+        }
+
+        return runAggregate(pipeline);
+    }
+
+    @Override
+    public List<ApiKeyMongo> searchUnordered(ApiKeyCriteria filter) {
+        return runAggregate(buildFilterPipeline(filter));
+    }
+
+    private List<Bson> buildFilterPipeline(ApiKeyCriteria filter) {
         List<Bson> pipeline = new ArrayList<>();
 
         if (!filter.isIncludeRevoked()) {
@@ -102,16 +123,10 @@ public class ApiKeyMongoRepositoryImpl implements ApiKeyMongoRepositoryCustom {
             pipeline.add(match(in("environmentId", filter.getEnvironments())));
         }
 
-        if (sortable != null) {
-            if (sortable.order().equals(Order.ASC)) {
-                pipeline.add(sort(Sorts.ascending(FieldUtils.toCamelCase(sortable.field()))));
-            } else {
-                pipeline.add(sort(Sorts.descending(FieldUtils.toCamelCase(sortable.field()))));
-            }
-        } else {
-            pipeline.add(sort(Sorts.descending("updatedAt")));
-        }
+        return pipeline;
+    }
 
+    private List<ApiKeyMongo> runAggregate(List<Bson> pipeline) {
         AggregateIterable<Document> aggregate = mongoTemplate
             .getCollection(mongoTemplate.getCollectionName(ApiKeyMongo.class))
             .aggregate(pipeline);

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/index/keys/RevokedExpireAtIndexUpgrader.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/index/keys/RevokedExpireAtIndexUpgrader.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.mongodb.management.upgrade.upgrader.index.keys;
+
+import io.gravitee.repository.mongodb.management.upgrade.upgrader.index.Index;
+import io.gravitee.repository.mongodb.management.upgrade.upgrader.index.IndexUpgrader;
+import org.springframework.stereotype.Component;
+
+/**
+ * Compound index {@code {revoked:1, expireAt:1}} on the {@code keys} collection.
+ *
+ * <p>Serves the cron-driven pre-expiration scheduler query, which matches keys by {@code revoked=false}
+ * (equality) and constrains {@code expireAt} to a window unioned across the configured notification
+ * days (typically 30–90 days out).</p>
+ *
+ * <p>Field ordering follows MongoDB's Equality-Sort-Range (ESR) rule: equality on revoked first, range
+ * on expireAt second. Inserting any field between would force a residual filter on expireAt and
+ * regress to a scan. Name {@code r1ea1} encodes the index shape: revoked asc, expireAt asc.</p>
+ *
+ * <p>See APIM-14132 for the original ESR violation this index resolves.</p>
+ */
+@Component("RevokedExpireAtIndexUpgrader")
+public class RevokedExpireAtIndexUpgrader extends IndexUpgrader {
+
+    @Override
+    protected Index buildIndex() {
+        return Index.builder()
+            .collection("keys")
+            .name("r1ea1")
+            .key("revoked", ascending())
+            .key("expireAt", ascending())
+            .build();
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/create-index.js
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/resources/scripts/create-index.js
@@ -59,6 +59,7 @@ db.getCollection(`${prefix}keys`).createIndex({ plan: 1, revoked: 1, updatedAt: 
 db.getCollection(`${prefix}keys`).createIndex({ key: 1 }, { name: "k1" });
 db.getCollection(`${prefix}keys`).createIndex({ key: 1, api: 1 }, { name: "k1a1" });
 db.getCollection(`${prefix}keys`).createIndex({ subscriptions: 1 }, { name: "s1" });
+db.getCollection(`${prefix}keys`).createIndex({ revoked: 1, expireAt: 1 }, { name: "r1ea1" });
 db.getCollection(`${prefix}keys`).reIndex();
 
 // "pages" collection

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/test/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/index/keys/RevokedExpireAtIndexUpgraderTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/test/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/index/keys/RevokedExpireAtIndexUpgraderTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.mongodb.management.upgrade.upgrader.index.keys;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.repository.mongodb.management.upgrade.upgrader.index.Index;
+import org.bson.Document;
+import org.junit.jupiter.api.Test;
+
+class RevokedExpireAtIndexUpgraderTest {
+
+    @Test
+    void buildIndex_definesCompoundIndexOnKeysWithExpectedNameAndKeys() {
+        Index index = new RevokedExpireAtIndexUpgrader().buildIndex();
+
+        assertThat(index.getCollection()).isEqualTo("keys");
+        assertThat(index.options().getName()).isEqualTo("r1ea1");
+
+        Document keys = index.toIndexDefinition().getIndexKeys();
+        assertThat(keys).hasSize(2);
+        assertThat(keys.get("revoked")).isEqualTo(1);
+        assertThat(keys.get("expireAt")).isEqualTo(1);
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-noop/src/main/java/io/gravitee/repository/noop/management/NoOpApiKeyRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-noop/src/main/java/io/gravitee/repository/noop/management/NoOpApiKeyRepository.java
@@ -92,6 +92,11 @@ public class NoOpApiKeyRepository implements ApiKeyRepository {
     }
 
     @Override
+    public List<ApiKey> findByCriteriaUnordered(ApiKeyCriteria filter) throws TechnicalException {
+        return List.of();
+    }
+
+    @Override
     public Optional<ApiKey> addSubscription(String id, String subscriptionId) throws TechnicalException {
         return Optional.empty();
     }

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/ApiKeyRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/ApiKeyRepositoryTest.java
@@ -293,6 +293,35 @@ public class ApiKeyRepositoryTest extends AbstractManagementRepositoryTest {
     }
 
     @Test
+    public void findByCriteriaUnordered_should_return_same_set_as_findByCriteria() throws Exception {
+        ApiKeyCriteria criteria = ApiKeyCriteria.builder().expireAfter(1439022010000L).expireBefore(1439022020000L).build();
+
+        List<ApiKey> sorted = apiKeyRepository.findByCriteria(criteria);
+        List<ApiKey> unordered = apiKeyRepository.findByCriteriaUnordered(criteria);
+
+        assertNotNull(unordered);
+        assertEquals(sorted.size(), unordered.size());
+        Set<String> sortedIds = sorted.stream().map(ApiKey::getId).collect(java.util.stream.Collectors.toSet());
+        Set<String> unorderedIds = unordered.stream().map(ApiKey::getId).collect(java.util.stream.Collectors.toSet());
+        assertEquals(sortedIds, unorderedIds);
+    }
+
+    @Test
+    public void findByCriteriaUnordered_should_exclude_revoked_key_in_window() throws Exception {
+        // id-of-apikey-1 is revoked AND has expireAt=1439022010883 (inside the window). It must not surface.
+        ApiKeyCriteria criteria = ApiKeyCriteria.builder()
+            .includeRevoked(false)
+            .expireAfter(1439022010000L)
+            .expireBefore(1439022020000L)
+            .build();
+
+        List<ApiKey> result = apiKeyRepository.findByCriteriaUnordered(criteria);
+
+        Set<String> ids = result.stream().map(ApiKey::getId).collect(java.util.stream.Collectors.toSet());
+        assertTrue("revoked key id-of-apikey-1 must be excluded, got: " + ids, !ids.contains("id-of-apikey-1"));
+    }
+
+    @Test
     public void findByCriteria_should_find_by_criteria_with_expire_at_after_dates() throws Exception {
         List<ApiKey> apiKeys = apiKeyRepository.findByCriteria(ApiKeyCriteria.builder().expireAfter(30019401755L).build());
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_key/model/ExpiringApiKey.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_key/model/ExpiringApiKey.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.api_key.model;
+
+import java.time.ZonedDateTime;
+import java.util.List;
+
+/**
+ * Minimal projection of an API key used by the pre-expiration notification scheduler.
+ * Carries only the fields needed for window bucketing, idempotency and notification dispatch.
+ */
+public record ExpiringApiKey(
+    String id,
+    String key,
+    ZonedDateTime expireAt,
+    Integer daysToExpirationOnLastNotification,
+    String applicationId,
+    List<ExpiringApiKeySubscription> subscriptions
+) {}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_key/model/ExpiringApiKeySubscription.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_key/model/ExpiringApiKeySubscription.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.api_key.model;
+
+/**
+ * Per-subscription projection carried by {@link ExpiringApiKey}. One per subscription bound to the
+ * expiring key; the scheduler resolves API/Plan/User by these ids when dispatching notifications.
+ */
+public record ExpiringApiKeySubscription(String id, String apiId, String planId, String subscribedBy) {}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_key/query_service/ApiKeyQueryService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_key/query_service/ApiKeyQueryService.java
@@ -16,6 +16,9 @@
 package io.gravitee.apim.core.api_key.query_service;
 
 import io.gravitee.apim.core.api_key.model.ApiKeyEntity;
+import io.gravitee.apim.core.api_key.model.ExpiringApiKey;
+import java.time.Instant;
+import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;
 
@@ -25,4 +28,12 @@ public interface ApiKeyQueryService {
     Optional<ApiKeyEntity> findByKeyAndApiId(String key, String apiId);
     Stream<ApiKeyEntity> findBySubscription(String subscriptionId);
     Optional<ApiKeyEntity> findByKeyAndReferenceIdAndReferenceType(String key, String referenceId, String referenceType);
+
+    /**
+     * Returns API keys whose {@code expireAt} falls inside any of the per-bucket windows
+     * {@code [now + d*24h, now + d*24h + windowMs)} for each {@code d} in {@code daysBuckets}.
+     * Runs as a single repository query over the outer-union range; callers perform bucket-inference
+     * in memory. Non-revoked keys only. Federated keys included.
+     */
+    List<ExpiringApiKey> findExpiringApiKeys(Instant now, List<Integer> daysBuckets, long windowMs);
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/query_service/api_key/ApiKeyQueryServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/query_service/api_key/ApiKeyQueryServiceImpl.java
@@ -16,24 +16,43 @@
 package io.gravitee.apim.infra.query_service.api_key;
 
 import io.gravitee.apim.core.api_key.model.ApiKeyEntity;
+import io.gravitee.apim.core.api_key.model.ExpiringApiKey;
+import io.gravitee.apim.core.api_key.model.ExpiringApiKeySubscription;
 import io.gravitee.apim.core.api_key.query_service.ApiKeyQueryService;
 import io.gravitee.apim.infra.adapter.ApiKeyAdapter;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.ApiKeyRepository;
+import io.gravitee.repository.management.api.SubscriptionRepository;
+import io.gravitee.repository.management.api.search.ApiKeyCriteria;
+import io.gravitee.repository.management.model.ApiKey;
+import io.gravitee.repository.management.model.Subscription;
 import io.gravitee.repository.management.model.SubscriptionReferenceType;
 import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import lombok.CustomLog;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Component;
 
 @Component
+@CustomLog
 public class ApiKeyQueryServiceImpl implements ApiKeyQueryService {
 
     private final ApiKeyRepository apiKeyRepository;
+    private final SubscriptionRepository subscriptionRepository;
 
-    public ApiKeyQueryServiceImpl(@Lazy ApiKeyRepository apiKeyRepository) {
+    public ApiKeyQueryServiceImpl(@Lazy ApiKeyRepository apiKeyRepository, @Lazy SubscriptionRepository subscriptionRepository) {
         this.apiKeyRepository = apiKeyRepository;
+        this.subscriptionRepository = subscriptionRepository;
     }
 
     @Override
@@ -76,6 +95,83 @@ public class ApiKeyQueryServiceImpl implements ApiKeyQueryService {
                 e
             );
         }
+    }
+
+    @Override
+    public List<ExpiringApiKey> findExpiringApiKeys(Instant now, List<Integer> daysBuckets, long windowMs) {
+        if (daysBuckets == null || daysBuckets.isEmpty()) {
+            return List.of();
+        }
+        // Outer envelope of all per-bucket windows: one repository call covers every bucket. Per-bucket
+        // assignment then happens client-side. Trades a wider DB filter for N→1 round-trips.
+        long oneDayMs = Duration.ofDays(1).toMillis();
+        long min = daysBuckets.stream().min(Comparator.naturalOrder()).get();
+        long max = daysBuckets.stream().max(Comparator.naturalOrder()).get();
+        long nowMs = now.toEpochMilli();
+        long expireAfter = nowMs + min * oneDayMs;
+        long expireBefore = nowMs + max * oneDayMs + windowMs;
+
+        ApiKeyCriteria criteria = ApiKeyCriteria.builder()
+            .includeRevoked(false)
+            .includeFederated(true)
+            .expireAfter(expireAfter)
+            .expireBefore(expireBefore)
+            .build();
+
+        List<ApiKey> apiKeys;
+        try {
+            apiKeys = apiKeyRepository.findByCriteriaUnordered(criteria);
+        } catch (TechnicalException e) {
+            throw new TechnicalManagementException("An error occurs while querying expiring API keys", e);
+        }
+        if (apiKeys.isEmpty()) {
+            return List.of();
+        }
+        Set<String> subscriptionIds = apiKeys
+            .stream()
+            .flatMap(k -> k.getSubscriptions() == null ? Stream.<String>empty() : k.getSubscriptions().stream())
+            .collect(Collectors.toSet());
+        Map<String, Subscription> subscriptionsById;
+        try {
+            subscriptionsById = subscriptionIds.isEmpty()
+                ? Map.of()
+                : subscriptionRepository.findByIdIn(subscriptionIds).stream().collect(Collectors.toMap(Subscription::getId, s -> s));
+        } catch (TechnicalException e) {
+            throw new TechnicalManagementException("An error occurs while resolving subscriptions for expiring API keys", e);
+        }
+        return apiKeys
+            .stream()
+            .map(k -> toExpiring(k, subscriptionsById))
+            .toList();
+    }
+
+    private static ExpiringApiKey toExpiring(ApiKey apiKey, Map<String, Subscription> subscriptionsById) {
+        ZonedDateTime expireAt = apiKey.getExpireAt() == null ? null : apiKey.getExpireAt().toInstant().atZone(ZoneOffset.UTC);
+        List<ExpiringApiKeySubscription> subs = apiKey.getSubscriptions() == null
+            ? List.of()
+            : apiKey
+                .getSubscriptions()
+                .stream()
+                .map(subId -> {
+                    Subscription s = subscriptionsById.get(subId);
+                    if (s == null) {
+                        // Data skew (subscription deleted between key write and our query). Surfacing here
+                        // gives ops a trail; the key still flows through with whatever subs remain.
+                        log.warn("API key {} references unknown subscription {} — skipping that projection", apiKey.getId(), subId);
+                    }
+                    return s;
+                })
+                .filter(java.util.Objects::nonNull)
+                .map(s -> new ExpiringApiKeySubscription(s.getId(), s.getApi(), s.getPlan(), s.getSubscribedBy()))
+                .toList();
+        return new ExpiringApiKey(
+            apiKey.getId(),
+            apiKey.getKey(),
+            expireAt,
+            apiKey.getDaysToExpirationOnLastNotification(),
+            apiKey.getApplication(),
+            subs
+        );
     }
 
     @Override

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/ApiKeyQueryServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/ApiKeyQueryServiceInMemory.java
@@ -16,9 +16,11 @@
 package inmemory;
 
 import io.gravitee.apim.core.api_key.model.ApiKeyEntity;
+import io.gravitee.apim.core.api_key.model.ExpiringApiKey;
 import io.gravitee.apim.core.api_key.query_service.ApiKeyQueryService;
 import io.gravitee.apim.core.subscription.model.SubscriptionReferenceType;
 import io.gravitee.rest.api.service.exceptions.SubscriptionNotFoundException;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -104,6 +106,11 @@ public class ApiKeyQueryServiceInMemory implements ApiKeyQueryService, InMemoryA
     @Override
     public Stream<ApiKeyEntity> findBySubscription(String subscriptionId) {
         return storage.stream().filter(apiKey -> apiKey.getSubscriptions().contains(subscriptionId));
+    }
+
+    @Override
+    public List<ExpiringApiKey> findExpiringApiKeys(Instant now, List<Integer> daysBuckets, long windowMs) {
+        return List.of();
     }
 
     @Override

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/query_service/api_key/ApiKeyQueryServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/query_service/api_key/ApiKeyQueryServiceImplTest.java
@@ -17,16 +17,23 @@ package io.gravitee.apim.infra.query_service.api_key;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import io.gravitee.apim.core.api_key.model.ApiKeyEntity;
+import io.gravitee.apim.core.api_key.model.ExpiringApiKey;
+import io.gravitee.apim.core.api_key.model.ExpiringApiKeySubscription;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.ApiKeyRepository;
+import io.gravitee.repository.management.api.SubscriptionRepository;
+import io.gravitee.repository.management.api.search.ApiKeyCriteria;
 import io.gravitee.repository.management.model.ApiKey;
+import io.gravitee.repository.management.model.Subscription;
 import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
 import java.time.Instant;
 import java.time.ZoneId;
+import java.util.Collection;
 import java.util.Date;
 import java.util.List;
 import java.util.Optional;
@@ -34,18 +41,22 @@ import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
 
 public class ApiKeyQueryServiceImplTest {
 
     ApiKeyRepository apiKeyRepository;
+    SubscriptionRepository subscriptionRepository;
 
     ApiKeyQueryServiceImpl service;
 
     @BeforeEach
     void setUp() {
         apiKeyRepository = mock(ApiKeyRepository.class);
+        subscriptionRepository = mock(SubscriptionRepository.class);
 
-        service = new ApiKeyQueryServiceImpl(apiKeyRepository);
+        service = new ApiKeyQueryServiceImpl(apiKeyRepository, subscriptionRepository);
     }
 
     @Nested
@@ -351,6 +362,107 @@ public class ApiKeyQueryServiceImplTest {
             assertThat(throwable)
                 .isInstanceOf(TechnicalManagementException.class)
                 .hasMessage("An error occurs while trying to find API keys by subscription id: " + subscriptionId);
+        }
+    }
+
+    @Nested
+    class FindExpiringApiKeys {
+
+        @Test
+        void should_return_empty_list_without_hitting_repo_when_days_buckets_is_empty() throws TechnicalException {
+            var result = service.findExpiringApiKeys(Instant.ofEpochMilli(1_700_000_000_000L), List.of(), 60_000L);
+
+            assertThat(result).isEmpty();
+            Mockito.verifyNoInteractions(apiKeyRepository);
+            Mockito.verifyNoInteractions(subscriptionRepository);
+        }
+
+        @Test
+        void should_emit_one_unordered_query_with_union_window_and_correct_flags() throws TechnicalException {
+            var now = Instant.ofEpochMilli(1_700_000_000_000L);
+            long oneDay = 24L * 60L * 60L * 1000L;
+            long windowMs = 60L * 60L * 1000L;
+            when(apiKeyRepository.findByCriteriaUnordered(any(ApiKeyCriteria.class))).thenReturn(List.of());
+
+            service.findExpiringApiKeys(now, List.of(30, 45, 90), windowMs);
+
+            ArgumentCaptor<ApiKeyCriteria> captor = ArgumentCaptor.forClass(ApiKeyCriteria.class);
+            Mockito.verify(apiKeyRepository, Mockito.times(1)).findByCriteriaUnordered(captor.capture());
+            ApiKeyCriteria criteria = captor.getValue();
+            assertThat(criteria.isIncludeRevoked()).isFalse();
+            assertThat(criteria.isIncludeFederated()).isTrue();
+            assertThat(criteria.isIncludeWithoutExpiration()).isFalse();
+            assertThat(criteria.getExpireAfter()).isEqualTo(now.toEpochMilli() + 30 * oneDay);
+            assertThat(criteria.getExpireBefore()).isEqualTo(now.toEpochMilli() + 90 * oneDay + windowMs);
+        }
+
+        @Test
+        void should_skip_orphaned_subscription_references() throws TechnicalException {
+            var now = Instant.ofEpochMilli(1_700_000_000_000L);
+            ApiKey repoKey = ApiKey.builder()
+                .id("key-id")
+                .key("the-key-value")
+                .application("app-id")
+                .subscriptions(List.of("sub-found", "sub-missing"))
+                .expireAt(new Date(now.toEpochMilli() + 30L * 24 * 60 * 60 * 1000))
+                .build();
+            when(apiKeyRepository.findByCriteriaUnordered(any(ApiKeyCriteria.class))).thenReturn(List.of(repoKey));
+            // sub-missing is intentionally not returned — simulates deletion between key write and our query
+            Subscription subFound = Subscription.builder().id("sub-found").api("api-x").plan("plan-x").subscribedBy("user-x").build();
+            when(subscriptionRepository.findByIdIn(any())).thenReturn(List.of(subFound));
+
+            List<ExpiringApiKey> result = service.findExpiringApiKeys(now, List.of(30), 60_000L);
+
+            assertThat(result).hasSize(1);
+            assertThat(result.get(0).subscriptions()).containsExactly(
+                new ExpiringApiKeySubscription("sub-found", "api-x", "plan-x", "user-x")
+            );
+        }
+
+        @Test
+        void should_map_api_keys_with_inline_subscription_projections_resolved_in_one_batch() throws TechnicalException {
+            var now = Instant.ofEpochMilli(1_700_000_000_000L);
+            Date expireDate = new Date(now.toEpochMilli() + 30L * 24 * 60 * 60 * 1000);
+            ApiKey repoKey = ApiKey.builder()
+                .id("key-id")
+                .key("the-key-value")
+                .application("app-id")
+                .subscriptions(List.of("sub-a", "sub-b"))
+                .expireAt(expireDate)
+                .daysToExpirationOnLastNotification(45)
+                .build();
+            when(apiKeyRepository.findByCriteriaUnordered(any(ApiKeyCriteria.class))).thenReturn(List.of(repoKey));
+
+            Subscription subA = Subscription.builder().id("sub-a").api("api-a").plan("plan-a").subscribedBy("user-a").build();
+            Subscription subB = Subscription.builder().id("sub-b").api("api-b").plan("plan-b").subscribedBy("user-b").build();
+            when(subscriptionRepository.findByIdIn(any())).thenReturn(List.of(subA, subB));
+
+            List<ExpiringApiKey> result = service.findExpiringApiKeys(now, List.of(30), 60_000L);
+
+            assertThat(result).hasSize(1);
+            ExpiringApiKey mapped = result.get(0);
+            assertThat(mapped.id()).isEqualTo("key-id");
+            assertThat(mapped.key()).isEqualTo("the-key-value");
+            assertThat(mapped.applicationId()).isEqualTo("app-id");
+            assertThat(mapped.daysToExpirationOnLastNotification()).isEqualTo(45);
+            assertThat(mapped.expireAt().toInstant()).isEqualTo(expireDate.toInstant());
+            assertThat(mapped.subscriptions()).containsExactlyInAnyOrder(
+                new ExpiringApiKeySubscription("sub-a", "api-a", "plan-a", "user-a"),
+                new ExpiringApiKeySubscription("sub-b", "api-b", "plan-b", "user-b")
+            );
+
+            ArgumentCaptor<Collection<String>> idsCaptor = ArgumentCaptor.forClass(Collection.class);
+            Mockito.verify(subscriptionRepository, Mockito.times(1)).findByIdIn(idsCaptor.capture());
+            assertThat(idsCaptor.getValue()).containsExactlyInAnyOrder("sub-a", "sub-b");
+        }
+
+        @Test
+        void should_throw_technical_management_exception_when_repo_fails() throws TechnicalException {
+            when(apiKeyRepository.findByCriteriaUnordered(any(ApiKeyCriteria.class))).thenThrow(TechnicalException.class);
+
+            Throwable thrown = catchThrowable(() -> service.findExpiringApiKeys(Instant.now(), List.of(30), 60_000L));
+
+            assertThat(thrown).isInstanceOf(TechnicalManagementException.class);
         }
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-subscription-pre-expiration-notif/src/main/java/io/gravitee/rest/api/services/subscriptionpreexpirationnotif/ScheduledSubscriptionPreExpirationNotificationService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-subscription-pre-expiration-notif/src/main/java/io/gravitee/rest/api/services/subscriptionpreexpirationnotif/ScheduledSubscriptionPreExpirationNotificationService.java
@@ -16,13 +16,14 @@
 package io.gravitee.rest.api.services.subscriptionpreexpirationnotif;
 
 import com.google.common.annotations.VisibleForTesting;
+import io.gravitee.apim.core.api_key.model.ExpiringApiKey;
+import io.gravitee.apim.core.api_key.query_service.ApiKeyQueryService;
 import io.gravitee.apim.core.subscription.model.ExpiringSubscription;
 import io.gravitee.apim.core.subscription.query_service.SubscriptionQueryService;
 import io.gravitee.common.service.AbstractService;
 import io.gravitee.rest.api.model.ApiKeyEntity;
 import io.gravitee.rest.api.model.ApplicationEntity;
 import io.gravitee.rest.api.model.SubscriptionStatus;
-import io.gravitee.rest.api.model.key.ApiKeyQuery;
 import io.gravitee.rest.api.model.v4.api.GenericApiEntity;
 import io.gravitee.rest.api.model.v4.plan.GenericPlanEntity;
 import io.gravitee.rest.api.service.ApiKeyService;
@@ -39,7 +40,6 @@ import io.gravitee.rest.api.service.v4.PlanSearchService;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.ZonedDateTime;
-import java.util.Collection;
 import java.util.Comparator;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
@@ -70,6 +70,9 @@ public class ScheduledSubscriptionPreExpirationNotificationService extends Abstr
 
     @Autowired
     private ApiKeyService apiKeyService;
+
+    @Autowired
+    private ApiKeyQueryService apiKeyQueryService;
 
     @Autowired
     private ApplicationService applicationService;
@@ -124,6 +127,7 @@ public class ScheduledSubscriptionPreExpirationNotificationService extends Abstr
 
         Instant now = Instant.now();
         Map<Integer, List<ExpiringSubscription>> subscriptionsByBucket = bucketExpiringSubscriptions(now);
+        Map<Integer, List<ExpiringApiKey>> apiKeysByBucket = bucketExpiringApiKeys(now);
 
         // Iterate buckets in descending day order. Within a single tick this only affects ordering of side-effects,
         // since windows are disjoint (1h cron slot vs day-granularity offsets). Across ticks it keeps the
@@ -131,7 +135,7 @@ public class ScheduledSubscriptionPreExpirationNotificationService extends Abstr
         // will not overwrite a previous notification with a smaller-than-current value.
         subscriptionsByBucket.forEach((daysToExpiration, subs) -> {
             Set<String> notifiedSubscriptionIds = notifySubscriptionsExpirations(daysToExpiration, subs);
-            notifyApiKeysExpirations(now, daysToExpiration, notifiedSubscriptionIds);
+            notifyApiKeysExpirations(daysToExpiration, apiKeysByBucket.getOrDefault(daysToExpiration, List.of()), notifiedSubscriptionIds);
         });
 
         log.debug("Subscription Pre Expiration Notification #{} ended at {}", counter.get(), Instant.now().toString());
@@ -166,42 +170,41 @@ public class ScheduledSubscriptionPreExpirationNotificationService extends Abstr
         return buckets;
     }
 
-    private void notifyApiKeysExpirations(Instant now, Integer daysToExpiration, Set<String> notifiedSubscriptionIds) {
-        Collection<ApiKeyEntity> apiKeyExpirationsToNotify = findApiKeyExpirationsToNotify(now, daysToExpiration);
-        apiKeyExpirationsToNotify
+    private void notifyApiKeysExpirations(Integer daysToExpiration, List<ExpiringApiKey> apiKeys, Set<String> notifiedSubscriptionIds) {
+        apiKeys
             .stream()
             // Remove the ones for which an email has already been sent (could happen in case of restart or concurrent processing with multiple instance of APIM)
             .filter(
                 apiKey ->
-                    apiKey.getDaysToExpirationOnLastNotification() == null ||
-                    apiKey.getDaysToExpirationOnLastNotification() > daysToExpiration
+                    apiKey.daysToExpirationOnLastNotification() == null || apiKey.daysToExpirationOnLastNotification() > daysToExpiration
             )
             .forEach(apiKey -> notifyApiKeyExpiration(daysToExpiration, apiKey, notifiedSubscriptionIds));
     }
 
-    private void notifyApiKeyExpiration(Integer daysToExpiration, ApiKeyEntity apiKey, Set<String> notifiedSubscriptionIds) {
-        ApplicationEntity application = apiKey.getApplication();
+    private void notifyApiKeyExpiration(Integer daysToExpiration, ExpiringApiKey apiKey, Set<String> notifiedSubscriptionIds) {
+        ApplicationEntity application = applicationService.findById(GraviteeContext.getExecutionContext(), apiKey.applicationId());
+        ApiKeyEntity emailParam = ApiKeyEntity.builder().id(apiKey.id()).key(apiKey.key()).build();
 
         apiKey
-            .getSubscriptions()
+            .subscriptions()
             .stream()
-            .filter(subscription -> !notifiedSubscriptionIds.contains(subscription.getId()))
+            .filter(subscription -> !notifiedSubscriptionIds.contains(subscription.id()))
             .forEach(subscription -> {
                 GenericApiEntity api = apiSearchService.findGenericById(
                     GraviteeContext.getExecutionContext(),
-                    subscription.getApi(),
+                    subscription.apiId(),
                     false,
                     false,
                     false
                 );
-                GenericPlanEntity plan = planSearchService.findById(GraviteeContext.getExecutionContext(), subscription.getPlan());
+                GenericPlanEntity plan = planSearchService.findById(GraviteeContext.getExecutionContext(), subscription.planId());
 
-                findEmailsToNotify(subscription.getSubscribedBy(), application).forEach(email ->
-                    this.sendEmail(email, daysToExpiration, api, plan, application, apiKey)
+                findEmailsToNotify(subscription.subscribedBy(), application).forEach(email ->
+                    this.sendEmail(email, daysToExpiration, api, plan, application, emailParam)
                 );
             });
 
-        apiKeyService.updateDaysToExpirationOnLastNotification(GraviteeContext.getExecutionContext(), apiKey, daysToExpiration);
+        apiKeyService.updateDaysToExpirationOnLastNotification(GraviteeContext.getExecutionContext(), emailParam, daysToExpiration);
     }
 
     private Set<String> notifySubscriptionsExpirations(Integer daysToExpiration, List<ExpiringSubscription> subscriptions) {
@@ -256,16 +259,27 @@ public class ScheduledSubscriptionPreExpirationNotificationService extends Abstr
     }
 
     @VisibleForTesting
-    Collection<ApiKeyEntity> findApiKeyExpirationsToNotify(Instant now, Integer daysToExpiration) {
-        long expirationStartingTime = now.plus(Duration.ofDays((long) daysToExpiration)).getEpochSecond() * 1000;
-
-        ApiKeyQuery query = new ApiKeyQuery();
-        query.setIncludeRevoked(false);
-        query.setIncludeFederated(true);
-        query.setExpireAfter(expirationStartingTime);
-        query.setExpireBefore(expirationStartingTime + cronPeriodInMs);
-
-        return apiKeyService.search(GraviteeContext.getExecutionContext(), query);
+    Map<Integer, List<ExpiringApiKey>> bucketExpiringApiKeys(Instant now) {
+        List<ExpiringApiKey> expiring = apiKeyQueryService.findExpiringApiKeys(now, notificationDays, cronPeriodInMs);
+        Map<Integer, List<ExpiringApiKey>> buckets = new LinkedHashMap<>();
+        long oneDayMs = Duration.ofDays(1).toMillis();
+        for (Integer d : notificationDays) {
+            long lo = now.toEpochMilli() + d * oneDayMs;
+            long hi = lo + cronPeriodInMs;
+            List<ExpiringApiKey> inBucket = expiring
+                .stream()
+                .filter(k -> {
+                    ZonedDateTime expire = k.expireAt();
+                    if (expire == null) {
+                        return false;
+                    }
+                    long expireMs = expire.toInstant().toEpochMilli();
+                    return expireMs >= lo && expireMs < hi;
+                })
+                .toList();
+            buckets.put(d, inBucket);
+        }
+        return buckets;
     }
 
     @VisibleForTesting

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-subscription-pre-expiration-notif/src/test/java/io/gravitee/rest/api/services/subscriptionpreexpirationnotif/ScheduledSubscriptionPreExpirationNotificationServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-services/gravitee-apim-rest-api-services-subscription-pre-expiration-notif/src/test/java/io/gravitee/rest/api/services/subscriptionpreexpirationnotif/ScheduledSubscriptionPreExpirationNotificationServiceTest.java
@@ -22,6 +22,9 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.*;
 
+import io.gravitee.apim.core.api_key.model.ExpiringApiKey;
+import io.gravitee.apim.core.api_key.model.ExpiringApiKeySubscription;
+import io.gravitee.apim.core.api_key.query_service.ApiKeyQueryService;
 import io.gravitee.apim.core.subscription.model.ExpiringSubscription;
 import io.gravitee.apim.core.subscription.query_service.SubscriptionQueryService;
 import io.gravitee.rest.api.model.*;
@@ -62,6 +65,9 @@ class ScheduledSubscriptionPreExpirationNotificationServiceTest {
     ApiKeyService apiKeyService;
 
     @Mock
+    ApiKeyQueryService apiKeyQueryService;
+
+    @Mock
     EmailService emailService;
 
     @Mock
@@ -79,6 +85,214 @@ class ScheduledSubscriptionPreExpirationNotificationServiceTest {
         List<Integer> cleanedNotificationDays = service.getCleanedNotificationDays(inputNotificationDays);
 
         assertThat(cleanedNotificationDays).isEqualTo(Arrays.asList(150, 75, 45, 30, 10));
+    }
+
+    @Test
+    void shouldBucketWithSingleDaySchedule() throws Exception {
+        // Guards the min==max math in the union window from silently breaking.
+        setNotificationDays(List.of(30));
+
+        Instant now = Instant.ofEpochMilli(1_700_000_000_000L);
+        long oneDay = 24L * 60L * 60L * 1000L;
+        ZonedDateTime expire30 = Instant.ofEpochMilli(now.toEpochMilli() + 30 * oneDay + 5 * 60_000L).atZone(ZoneOffset.UTC);
+        ExpiringApiKey key30 = new ExpiringApiKey("k30", null, expire30, null, null, List.of());
+
+        when(apiKeyQueryService.findExpiringApiKeys(eq(now), eq(List.of(30)), anyLong())).thenReturn(List.of(key30));
+
+        Map<Integer, List<ExpiringApiKey>> buckets = service.bucketExpiringApiKeys(now);
+
+        assertThat(buckets).containsOnlyKeys(30);
+        assertThat(buckets.get(30)).extracting(ExpiringApiKey::id).containsExactly("k30");
+    }
+
+    @Test
+    void shouldDropApiKeyWithNullExpireAt() throws Exception {
+        // Defensive branch in bucketExpiringApiKeys — the slim record's expireAt is nullable.
+        setNotificationDays(List.of(30));
+
+        Instant now = Instant.ofEpochMilli(1_700_000_000_000L);
+        ExpiringApiKey nullExpire = new ExpiringApiKey("k-null", null, null, null, null, List.of());
+
+        when(apiKeyQueryService.findExpiringApiKeys(eq(now), anyList(), anyLong())).thenReturn(List.of(nullExpire));
+
+        Map<Integer, List<ExpiringApiKey>> buckets = service.bucketExpiringApiKeys(now);
+
+        assertThat(buckets.get(30)).isEmpty();
+    }
+
+    @Test
+    void shouldBucketApiKeysByLargestMatchingDay() throws Exception {
+        setNotificationDays(List.of(90, 45, 30));
+
+        Instant now = Instant.ofEpochMilli(1_700_000_000_000L);
+        long oneDay = 24L * 60L * 60L * 1000L;
+        ZonedDateTime expire30 = Instant.ofEpochMilli(now.toEpochMilli() + 30 * oneDay + 5 * 60_000L).atZone(ZoneOffset.UTC);
+        ZonedDateTime expire45 = Instant.ofEpochMilli(now.toEpochMilli() + 45 * oneDay + 5 * 60_000L).atZone(ZoneOffset.UTC);
+        ZonedDateTime expire90 = Instant.ofEpochMilli(now.toEpochMilli() + 90 * oneDay + 5 * 60_000L).atZone(ZoneOffset.UTC);
+
+        ExpiringApiKey key30 = new ExpiringApiKey("k30", null, expire30, null, null, List.of());
+        ExpiringApiKey key45 = new ExpiringApiKey("k45", null, expire45, null, null, List.of());
+        ExpiringApiKey key90 = new ExpiringApiKey("k90", null, expire90, null, null, List.of());
+
+        when(apiKeyQueryService.findExpiringApiKeys(eq(now), anyList(), anyLong())).thenReturn(List.of(key30, key45, key90));
+
+        Map<Integer, List<ExpiringApiKey>> buckets = service.bucketExpiringApiKeys(now);
+
+        assertThat(buckets.get(30)).extracting(ExpiringApiKey::id).containsExactly("k30");
+        assertThat(buckets.get(45)).extracting(ExpiringApiKey::id).containsExactly("k45");
+        assertThat(buckets.get(90)).extracting(ExpiringApiKey::id).containsExactly("k90");
+    }
+
+    @Test
+    void shouldPassActualApiKeyValueToEmailNotification() throws Exception {
+        setNotificationDays(List.of(30));
+
+        ZonedDateTime expire30 = ZonedDateTime.now().plusDays(30).plusMinutes(5);
+        ExpiringApiKey key = new ExpiringApiKey(
+            "key-id",
+            "actual-key-value",
+            expire30,
+            null,
+            "app1",
+            List.of(new ExpiringApiKeySubscription("sub1", "api1", "plan1", "user1"))
+        );
+
+        when(subscriptionQueryService.findExpiringSubscriptions(any(Instant.class), anyList(), anyLong(), anyList())).thenReturn(List.of());
+        when(apiKeyQueryService.findExpiringApiKeys(any(Instant.class), anyList(), anyLong())).thenReturn(List.of(key));
+
+        UserEntity subscriber = mock(UserEntity.class);
+        when(subscriber.getEmail()).thenReturn("subscriber@example.com");
+        when(userService.findById(eq(GraviteeContext.getExecutionContext()), eq("user1"))).thenReturn(subscriber);
+        ApplicationEntity app = mock(ApplicationEntity.class);
+        PrimaryOwnerEntity po = mock(PrimaryOwnerEntity.class);
+        when(app.getPrimaryOwner()).thenReturn(po);
+        when(applicationService.findById(any(), eq("app1"))).thenReturn(app);
+
+        service.run();
+
+        verify(emailService).sendAsyncEmailNotification(
+            any(),
+            argThat(notification -> {
+                Object apiKeyParam = notification.getParams().get("apiKey");
+                return apiKeyParam instanceof ApiKeyEntity ake && "actual-key-value".equals(ake.getKey());
+            })
+        );
+    }
+
+    @Test
+    void shouldSkipApiKeySubscriptionAlreadyNotifiedThroughSubscriptionPath() throws Exception {
+        setNotificationDays(List.of(30));
+
+        ZonedDateTime expire30 = ZonedDateTime.now().plusDays(30).plusMinutes(5);
+        ExpiringSubscription expiringSub = new ExpiringSubscription(
+            "sub-already",
+            "api-already",
+            "plan-x",
+            "app1",
+            "user1",
+            expire30,
+            null
+        );
+        ExpiringApiKey key = new ExpiringApiKey(
+            "key1",
+            null,
+            expire30,
+            null,
+            "app1",
+            List.of(
+                new ExpiringApiKeySubscription("sub-already", "api-already", "plan-x", "user1"),
+                new ExpiringApiKeySubscription("sub-fresh", "api-fresh", "plan-y", "user1")
+            )
+        );
+
+        when(subscriptionQueryService.findExpiringSubscriptions(any(Instant.class), anyList(), anyLong(), anyList())).thenReturn(
+            List.of(expiringSub)
+        );
+        when(apiKeyQueryService.findExpiringApiKeys(any(Instant.class), anyList(), anyLong())).thenReturn(List.of(key));
+
+        when(userService.findById(eq(GraviteeContext.getExecutionContext()), eq("user1"))).thenReturn(mock(UserEntity.class));
+        ApplicationEntity app = mock(ApplicationEntity.class);
+        when(app.getPrimaryOwner()).thenReturn(mock(PrimaryOwnerEntity.class));
+        when(applicationService.findById(any(), eq("app1"))).thenReturn(app);
+
+        service.run();
+
+        verify(apiSearchService).findGenericById(any(), eq("api-fresh"), eq(false), eq(false), eq(false));
+        verify(apiSearchService, never()).findGenericById(any(), eq("api-already"), anyBoolean(), anyBoolean(), anyBoolean());
+    }
+
+    @Test
+    void shouldSkipApiKeyAlreadyNotifiedForCurrentOrSmallerDay() throws Exception {
+        setNotificationDays(List.of(30));
+
+        ZonedDateTime expire30 = ZonedDateTime.now().plusDays(30).plusMinutes(5);
+
+        ExpiringApiKey alreadyNotifiedAtSameDay = new ExpiringApiKey("already-30", null, expire30, 30, null, List.of());
+        ExpiringApiKey alreadyNotifiedAtSmallerDay = new ExpiringApiKey("already-15", null, expire30, 15, null, List.of());
+        ExpiringApiKey neverNotified = new ExpiringApiKey("fresh", null, expire30, null, null, List.of());
+        ExpiringApiKey notifiedAtLargerDay = new ExpiringApiKey("earlier-notification", null, expire30, 45, null, List.of());
+
+        when(subscriptionQueryService.findExpiringSubscriptions(any(Instant.class), anyList(), anyLong(), anyList())).thenReturn(List.of());
+        when(apiKeyQueryService.findExpiringApiKeys(any(Instant.class), anyList(), anyLong())).thenReturn(
+            List.of(alreadyNotifiedAtSameDay, alreadyNotifiedAtSmallerDay, neverNotified, notifiedAtLargerDay)
+        );
+
+        service.run();
+
+        verify(apiKeyService).updateDaysToExpirationOnLastNotification(any(), argThat(k -> k != null && "fresh".equals(k.getId())), eq(30));
+        verify(apiKeyService).updateDaysToExpirationOnLastNotification(
+            any(),
+            argThat(k -> k != null && "earlier-notification".equals(k.getId())),
+            eq(30)
+        );
+        verify(apiKeyService, never()).updateDaysToExpirationOnLastNotification(
+            any(),
+            argThat(k -> k != null && "already-30".equals(k.getId())),
+            any()
+        );
+        verify(apiKeyService, never()).updateDaysToExpirationOnLastNotification(
+            any(),
+            argThat(k -> k != null && "already-15".equals(k.getId())),
+            any()
+        );
+    }
+
+    @Test
+    void apiKeyBucketingIsInclusiveAtLowerBoundExclusiveAtUpperBound() throws Exception {
+        setNotificationDays(List.of(30));
+
+        Instant now = Instant.ofEpochMilli(1_700_000_000_000L);
+        long oneDay = 24L * 60L * 60L * 1000L;
+        long oneHour = 60L * 60L * 1000L;
+        ZonedDateTime atLo = Instant.ofEpochMilli(now.toEpochMilli() + 30 * oneDay).atZone(ZoneOffset.UTC);
+        ZonedDateTime justInsideHi = Instant.ofEpochMilli(now.toEpochMilli() + 30 * oneDay + oneHour - 1).atZone(ZoneOffset.UTC);
+        ZonedDateTime atHi = Instant.ofEpochMilli(now.toEpochMilli() + 30 * oneDay + oneHour).atZone(ZoneOffset.UTC);
+        ZonedDateTime justBeforeLo = Instant.ofEpochMilli(now.toEpochMilli() + 30 * oneDay - 1).atZone(ZoneOffset.UTC);
+
+        ExpiringApiKey keyAtLo = new ExpiringApiKey("at-lo", null, atLo, null, null, List.of());
+        ExpiringApiKey keyJustInsideHi = new ExpiringApiKey("just-inside-hi", null, justInsideHi, null, null, List.of());
+        ExpiringApiKey keyAtHi = new ExpiringApiKey("at-hi", null, atHi, null, null, List.of());
+        ExpiringApiKey keyJustBeforeLo = new ExpiringApiKey("just-before-lo", null, justBeforeLo, null, null, List.of());
+
+        when(apiKeyQueryService.findExpiringApiKeys(eq(now), anyList(), anyLong())).thenReturn(
+            List.of(keyAtLo, keyJustInsideHi, keyAtHi, keyJustBeforeLo)
+        );
+
+        Map<Integer, List<ExpiringApiKey>> buckets = service.bucketExpiringApiKeys(now);
+
+        assertThat(buckets.get(30)).extracting(ExpiringApiKey::id).containsExactly("at-lo", "just-inside-hi");
+    }
+
+    @Test
+    void shouldQueryExpiringApiKeysOnceRegardlessOfScheduleLength() throws Exception {
+        setNotificationDays(List.of(90, 45, 30));
+        when(subscriptionQueryService.findExpiringSubscriptions(any(Instant.class), anyList(), anyLong(), anyList())).thenReturn(List.of());
+        when(apiKeyQueryService.findExpiringApiKeys(any(Instant.class), anyList(), anyLong())).thenReturn(List.of());
+
+        service.run();
+
+        verify(apiKeyQueryService, times(1)).findExpiringApiKeys(any(Instant.class), eq(List.of(90, 45, 30)), anyLong());
+        verify(apiKeyService, never()).search(any(), any());
     }
 
     @Test
@@ -225,35 +439,5 @@ class ScheduledSubscriptionPreExpirationNotificationServiceTest {
             .build();
 
         verify(emailService, times(1)).sendAsyncEmailNotification(eq(GraviteeContext.getExecutionContext()), eq(emailNotification));
-    }
-
-    @Test
-    void shouldFindApiKeyExpirationsToNotify() {
-        Instant now = Instant.ofEpochMilli(1469022010000L);
-        Integer daysBeforeNotification = 10;
-
-        ApiKeyEntity apiKey = mock(ApiKeyEntity.class);
-
-        when(apiKeyService.search(eq(GraviteeContext.getExecutionContext()), any(ApiKeyQuery.class))).thenReturn(
-            Collections.singletonList(apiKey)
-        );
-
-        Collection<ApiKeyEntity> apiKeysToNotify = service.findApiKeyExpirationsToNotify(now, daysBeforeNotification);
-
-        assertThat(apiKeysToNotify).isEqualTo(Collections.singletonList(apiKey));
-
-        verify(apiKeyService, times(1)).search(
-            eq(GraviteeContext.getExecutionContext()),
-            argThat(
-                apiKeyQuery ->
-                    !apiKeyQuery.isIncludeRevoked() &&
-                    // 1469886010000 -> now + 10 days
-                    apiKeyQuery.getExpireAfter() ==
-                    1469886010000L &&
-                    // 1469889610000 -> now + 10 days + 1h (cron period)
-                    apiKeyQuery.getExpireBefore() ==
-                    1469889610000L
-            )
-        );
     }
 }


### PR DESCRIPTION
## Summary

Mirror of APIM-14086, for the **ApiKey side** of the hourly pre-expiration scheduler.

The cron loop iterated `notification-schedule` values (default `90,45,30`) and issued one `apiKeyService.search` per value — 3 redundant repository calls per tick — with a default `Sorts.descending("updatedAt")` that forced Mongo onto a non-ESR index.

After this PR:
- **One repository call per cron tick** regardless of `notification-schedule` length.
- **ESR-correct compound index `{revoked:1, expireAt:1}` (`r1ea1`)** on the `keys` collection — picked by the planner for the new union-window query.
- The notification side-effects (per-bucket dedupe, idempotency filter on `daysToExpirationOnLastNotification`, email plumbing) are preserved.

Fixes [APIM-14132](https://gravitee.atlassian.net/browse/APIM-14132).

## Design

| Layer | Change |
| --- | --- |
| Repository (api / mongo / jdbc / noop) | New `findByCriteriaUnordered(ApiKeyCriteria)` — no implicit `updatedAt` sort. |
| Mongo index upgrader | `RevokedExpireAtIndexUpgrader` adds `r1ea1` `{revoked:1, expireAt:1}`. Existing `r1ua-1ea1` kept (additive only). `create-index.js` updated for fresh installs. |
| Core query service | `ApiKeyQueryService.findExpiringApiKeys(now, daysBuckets, windowMs)` — single repo call over the outer-union range `[now+min(d)*24h, now+max(d)*24h + windowMs)`, batched subscription resolution via `findByIdIn`. |
| Domain | Slim records `ExpiringApiKey(id, key, expireAt, daysToExpirationOnLastNotification, applicationId, subscriptions)` + `ExpiringApiKeySubscription(id, apiId, planId, subscribedBy)`. |
| Scheduler | New `bucketExpiringApiKeys(now)` — partitions in memory by `expireAt`. `run()` lifts the apiKey query out of the per-bucket loop. `notifyApiKeyExpiration` takes the slim record; per-bucket `notifiedSubscriptionIds` dedupe + idempotency filter preserved. |

Mirrors the approach used in APIM-14086 for the subscription side.

## Implicit-order callers — surveyed

Survey confirmed there is no implicit-order dependency to worry about:

| Caller | Path | Sortable |
| --- | --- | --- |
| `ScheduledSubscriptionPreExpirationNotificationService` (this scheduler) | `apiKeyService.search` (no Sortable) | replaced by this PR |
| `ApiKeyFetcher` | `apiKeyRepository.findByCriteria(c, Sortable)` | explicit `updatedAt ASC` |
| `ApiKeyAppender` | `apiKeyRepository.findByCriteria(c, Sortable)` | explicit `updatedAt ASC` |
| `ApiProductSubscriptionRefresher` | `apiKeyRepository.findByCriteria(c, Sortable)` | explicit `updatedAt ASC` |

The new `findByCriteriaUnordered` is an opt-in path used only by the new query service method.

## Test plan

- [x] Repository integration tests (Testcontainers) — `findByCriteriaUnordered` returns the same set as `findByCriteria` (Mongo 38/38, JDBC 38/38).
- [x] `RevokedExpireAtIndexUpgraderTest` — verifies `{revoked:1, expireAt:1}` named `r1ea1`.
- [x] `ApiKeyQueryServiceImplTest.FindExpiringApiKeys` — empty days → no repo call; correct criteria emitted (`includeRevoked=false`, `includeFederated=true`, expire window); batched subscription resolution; `TechnicalException` → `TechnicalManagementException`.
- [x] `ScheduledSubscriptionPreExpirationNotificationServiceTest` — new tests for: single query per tick, no fallback to legacy `apiKeyService.search`, bucketing by largest matching day, window inclusivity (lo inclusive / hi exclusive), `daysToExpirationOnLastNotification` idempotency filter, `notifiedSubscriptionIds` dedupe with subscription path, `apiKey.key` propagated to email notification.
- [x] Manual smoke on apim-worktree with cron temporarily patched to minute cadence — observed exactly **one** keys aggregate per tick (`IXSCAN { revoked: 1, expireAt: 1 }`), real fixture (API/app/subscription/key) `daysToExpirationOnLastNotification` set to 30 after first matching tick, no re-notification on next tick (idempotency).

[APIM-14132]: https://gravitee.atlassian.net/browse/APIM-14132?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ