### PR TITLE
feat(edge): add provider field to EdgeRoute record

### DIFF
--- a/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/edge/EdgeRoute.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/edge/EdgeRoute.java
@@ -17,4 +17,4 @@ package io.gravitee.definition.model.v4.edge;
 
 import java.io.Serializable;
 
-public record EdgeRoute(String pathPrefix, String apiPath) implements Serializable {}
+public record EdgeRoute(String pathPrefix, String apiPath, String provider) implements Serializable {}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/GMA-364

## Description

Add a `provider` field (String, nullable) to the `EdgeRoute` record in `gravitee-apim-definition-model`.

This field identifies the AI provider of the route (e.g. `"anthropic"`, `"openai"`, `null` if unknown), so the Edge daemon knows which token extractor to use on the client side.