### PR TITLE
chore(deps): bump gravitee-node version 8.0.5

### DIFF
--- a/helm/tests/api/deployment_federation_test.yaml
+++ b/helm/tests/api/deployment_federation_test.yaml
@@ -37,7 +37,7 @@ tests:
             - command:
                 - sh
                 - -c
-                - mkdir -p /tmp/plugins && cd /tmp/plugins && ( rm  gravitee-node-cache-plugin-hazelcast-8.0.3.zip  2>/dev/null || true ) && wget https://download.gravitee.io/plugins/node-cache/gravitee-node-cache-plugin-hazelcast/gravitee-node-cache-plugin-hazelcast-8.0.3.zip && ( rm  gravitee-node-cluster-plugin-hazelcast-8.0.3.zip  2>/dev/null || true ) && wget https://download.gravitee.io/plugins/node-cluster/gravitee-node-cluster-plugin-hazelcast/gravitee-node-cluster-plugin-hazelcast-8.0.3.zip
+                - mkdir -p /tmp/plugins && cd /tmp/plugins && ( rm  gravitee-node-cache-plugin-hazelcast-8.0.5.zip  2>/dev/null || true ) && wget https://download.gravitee.io/plugins/node-cache/gravitee-node-cache-plugin-hazelcast/gravitee-node-cache-plugin-hazelcast-8.0.5.zip && ( rm  gravitee-node-cluster-plugin-hazelcast-8.0.5.zip  2>/dev/null || true ) && wget https://download.gravitee.io/plugins/node-cluster/gravitee-node-cluster-plugin-hazelcast/gravitee-node-cluster-plugin-hazelcast-8.0.5.zip
               env: [ ]
               image: alpine:latest
               imagePullPolicy: Always

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -502,8 +502,8 @@ cloud:
 
 cluster:
   plugins:
-    - https://download.gravitee.io/plugins/node-cache/gravitee-node-cache-plugin-hazelcast/gravitee-node-cache-plugin-hazelcast-8.0.3.zip
-    - https://download.gravitee.io/plugins/node-cluster/gravitee-node-cluster-plugin-hazelcast/gravitee-node-cluster-plugin-hazelcast-8.0.3.zip
+    - https://download.gravitee.io/plugins/node-cache/gravitee-node-cache-plugin-hazelcast/gravitee-node-cache-plugin-hazelcast-8.0.5.zip
+    - https://download.gravitee.io/plugins/node-cluster/gravitee-node-cluster-plugin-hazelcast/gravitee-node-cluster-plugin-hazelcast-8.0.5.zip
 
 api:
   enabled: true

--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
         <gravitee-integration-api.version>5.1.0</gravitee-integration-api.version>
         <gravitee-json-validation.version>2.2.0</gravitee-json-validation.version>
         <gravitee-kubernetes.version>3.7.1</gravitee-kubernetes.version>
-        <gravitee-node.version>8.0.3</gravitee-node.version>
+        <gravitee-node.version>8.0.5</gravitee-node.version>
         <gravitee-notifier-api.version>2.0.0</gravitee-notifier-api.version>
         <gravitee-platform-repository-api.version>1.4.0</gravitee-platform-repository-api.version>
         <gravitee-plugin.version>5.1.2</gravitee-plugin.version>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-13559

## Description

Bumps `gravitee-node` on `4.11.x` from `8.0.3` to `8.0.5` to pick up the [APIM-13559](https://gravitee.atlassian.net/browse/APIM-13559) fix on the `8.0.x` line — Vert.x Micrometer metrics now honour user-configured Prometheus labels (e.g. `http_path`) instead of being silently overwritten by the defaults. Also picks up `8.0.4`'s dependency vulnerability fixes.

## Changes

- `pom.xml`: `gravitee-node.version` → `8.0.5`
- `helm/values.yaml`: Hazelcast cache + cluster plugin URLs → `8.0.5`
- `helm/tests/api/deployment_federation_test.yaml`: expected plugin URLs → `8.0.5`

## Additional context

Companion of #17122 (bumped 4.10.x to `7.26.4` on the `7.26.x` line). The Mergify auto-backport #17132 was closed because the cherry-pick was structurally incompatible: 4.11.x has been on the `8.0.x` line since 4.11.2 (2026-04-14), so backporting a `7.26.x` patch is a downgrade. This PR lands the same APIM-13559 fix via the `8.0.x` analogue release `8.0.5` (published the same day as `7.26.4`).

[APIM-13559]: https://gravitee.atlassian.net/browse/APIM-13559?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ