### PR TITLE
fix(console): emit fresh array on each gio-select-search toggle

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs-native/api-runtime-logs-native.component.harness.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs-native/api-runtime-logs-native.component.harness.ts
@@ -17,6 +17,8 @@ import { ComponentHarness } from '@angular/cdk/testing';
 import { DivHarness } from '@gravitee/ui-particles-angular/testing';
 import { MatButtonHarness } from '@angular/material/button/testing';
 
+import { GioSelectSearchHarness } from '../../../../shared/components/gio-select-search/gio-select-search.harness';
+
 export class ApiRuntimeLogsNativeHarness extends ComponentHarness {
   static hostSelector = 'api-runtime-logs-native';
 
@@ -25,6 +27,8 @@ export class ApiRuntimeLogsNativeHarness extends ComponentHarness {
   );
   public emptyState = this.locatorForOptional(DivHarness.with({ selector: '.table__empty-state' }));
   public configureReportingLink = this.locatorFor(MatButtonHarness.with({ selector: '[data-testid=native_logs_configure_reporting]' }));
+
+  public connectionStatusFilter = this.locatorFor(GioSelectSearchHarness.with({ formControlName: 'connectionStatuses' }));
 
   async isReportingDisabledBannerVisible(): Promise<boolean> {
     return this.reportingDisabledBanner().then(banner => banner != null);

--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs-native/api-runtime-logs-native.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/runtime-logs-native/api-runtime-logs-native.component.spec.ts
@@ -368,6 +368,51 @@ describe('ApiRuntimeLogsNativeComponent', () => {
     expect(publishedRows).toBeGreaterThan(0);
   }));
 
+  it('fires a new search on each successive connection-status toggle (regression: aliased-array swallow)', fakeAsync(async () => {
+    await initComponent();
+    expectApiCalls();
+    expectInitialNativeLogsRequest().flush(fakeNativeApiLogsResponse());
+    flushRowAppResolution();
+    drainSummary();
+    flush();
+    fixture.detectChanges();
+
+    const statusSelect = await harness.connectionStatusFilter();
+
+    await statusSelect.open();
+    flush();
+    fixture.detectChanges();
+
+    await statusSelect.checkOptionByLabel('Connected');
+    flush();
+    fixture.detectChanges();
+
+    httpTestingController
+      .expectOne(
+        r =>
+          r.url === `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${API_ID}/logs/native` && r.params.get('connectionStatuses') === 'CONNECTED',
+      )
+      .flush(fakeNativeApiLogsResponse());
+    flushRowAppResolution();
+    drainSummary();
+    flush();
+    fixture.detectChanges();
+
+    await statusSelect.checkOptionByLabel('Failed');
+    flush();
+    fixture.detectChanges();
+
+    httpTestingController
+      .expectOne(
+        r =>
+          r.url === `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${API_ID}/logs/native` &&
+          r.params.get('connectionStatuses') === 'CONNECTED,CONNECTION_ERROR',
+      )
+      .flush(fakeNativeApiLogsResponse());
+    flushRowAppResolution();
+    flush();
+  }));
+
   it('navigates to the detail route preserving current query params on view request', fakeAsync(async () => {
     await initComponent({ period: '1h' });
     expectApiCalls();

--- a/gravitee-apim-console-webui/src/shared/components/gio-select-search/gio-select-search.component.ts
+++ b/gravitee-apim-console-webui/src/shared/components/gio-select-search/gio-select-search.component.ts
@@ -150,7 +150,9 @@ export class GioSelectSearchComponent implements ControlValueAccessor, OnDestroy
 
   // CONTROL VALUE ACCESSOR IMPLEMENTATION
   writeValue(value: string[]): void {
-    this._value = value || [];
+    // Parent-supplied array must not be aliased — onSelectionChange builds a fresh array
+    // each toggle, and the parent's FormControl should never observe internal mutation.
+    this._value = value ? [...value] : [];
     this.selectedCount.set(this._value.length);
   }
 
@@ -270,16 +272,12 @@ export class GioSelectSearchComponent implements ControlValueAccessor, OnDestroy
 
   // VALUE MANAGEMENT
   private onSelectionChange(selectedValue: string) {
-    const currentValues = this._value || [];
-
-    const index = currentValues.indexOf(selectedValue);
-    if (index > -1) {
-      currentValues.splice(index, 1);
-    } else {
-      currentValues.push(selectedValue);
-    }
-
-    this.updateValue(currentValues);
+    // New array each toggle. In-place mutation would alias the value the parent FormControl
+    // already holds, so reference-equality checks downstream see prev === curr and swallow
+    // the emission.
+    const current = this._value ?? [];
+    const next = current.includes(selectedValue) ? current.filter(v => v !== selectedValue) : [...current, selectedValue];
+    this.updateValue(next);
   }
 
   private updateValue(value: string[]) {


### PR DESCRIPTION
## Summary

Multi-select filters on the native API connection logs LIST page silently swallowed every toggle after the first — user had to click refresh between selections. Root cause: `gio-select-search` mutated its selected-values array in place; the parent's `form.valueChanges.pipe(distinctUntilChanged(isEqual))` then saw `prev` and `curr` pointing at the same post-mutation array and deduped the emission.

## Key changes

- `gio-select-search.component.ts` — `onSelectionChange` builds a fresh array each toggle (`filter` / spread); `writeValue` defensive-copies the parent-supplied array to break aliasing.
- New regression test in `api-runtime-logs-native.component.spec.ts` — drives two consecutive toggles via `GioSelectSearchHarness`, asserts a second `/logs/native` request fires with the cumulated `connectionStatuses` param.
- Harness exposes `connectionStatusFilter` locator.

## Test plan

- [x] Existing `gio-select-search` spec unchanged, passes
- [x] All 17 native logs LIST spec tests pass (incl. new regression)
- [x] Analytics filter-bar specs pass (no collateral damage in other consumers)
- [ ] Manual smoke: open native logs page, toggle multiple status filters in a row, confirm each toggle fires a `/logs/native` request in DevTools