### PR TITLE
feat(rest-api): emit ETag and Last-Modified on GET plan

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiPlansResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiPlansResource.java
@@ -74,6 +74,7 @@ import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.Response;
+import java.util.Date;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -241,7 +242,22 @@ public class ApiPlansResource extends AbstractResource {
             return Response.status(Response.Status.NOT_FOUND).entity(planNotFoundError(planId)).build();
         }
 
-        return Response.ok(planMapper.mapGenericPlan(planEntity)).build();
+        Response.ResponseBuilder builder = Response.ok(planMapper.mapGenericPlan(planEntity));
+        Date updatedAt = resolvePlanUpdatedAt(planEntity);
+        if (updatedAt != null) {
+            builder.tag(Long.toString(updatedAt.getTime())).lastModified(updatedAt);
+        }
+        return builder.build();
+    }
+
+    private static Date resolvePlanUpdatedAt(GenericPlanEntity planEntity) {
+        if (planEntity instanceof BasePlanEntity v4Plan) {
+            return v4Plan.getUpdatedAt();
+        }
+        if (planEntity instanceof io.gravitee.rest.api.model.BasePlanEntity v2Plan) {
+            return v2Plan.getUpdatedAt();
+        }
+        throw new IllegalStateException("Unexpected plan entity type: " + planEntity.getClass());
     }
 
     @PUT

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiPlansResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiPlansResource.java
@@ -26,6 +26,7 @@ import io.gravitee.apim.core.subscription.model.SubscriptionEntity;
 import io.gravitee.apim.core.subscription.query_service.SubscriptionQueryService;
 import io.gravitee.common.http.MediaType;
 import io.gravitee.definition.model.v4.plan.PlanMode;
+import io.gravitee.node.logging.NodeLoggerFactory;
 import io.gravitee.repository.management.model.Group;
 import io.gravitee.rest.api.management.v2.rest.mapper.FlowMapper;
 import io.gravitee.rest.api.management.v2.rest.mapper.PlanMapper;
@@ -79,6 +80,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import org.slf4j.Logger;
 
 /**
  * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
@@ -86,6 +88,7 @@ import java.util.stream.Stream;
  */
 public class ApiPlansResource extends AbstractResource {
 
+    private static final Logger log = NodeLoggerFactory.getLogger(ApiPlansResource.class);
     private static final String FLOW = "flow";
 
     private final PlanMapper planMapper = PlanMapper.INSTANCE;
@@ -257,7 +260,8 @@ public class ApiPlansResource extends AbstractResource {
         if (planEntity instanceof io.gravitee.rest.api.model.BasePlanEntity v2Plan) {
             return v2Plan.getUpdatedAt();
         }
-        throw new IllegalStateException("Unexpected plan entity type: " + planEntity.getClass());
+        log.warn("Cannot resolve updatedAt for unknown plan entity type: {}", planEntity.getClass());
+        return null;
     }
 
     @PUT

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-apis.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-apis.yaml
@@ -1288,6 +1288,21 @@ paths:
             responses:
                 "200":
                     description: An API's plan
+                    headers:
+                        ETag:
+                            description: |-
+                                Entity tag identifying the plan version. Value is the plan's last-updated timestamp expressed as epoch milliseconds (quoted per RFC 7232).
+                                Clients may pass this value back in `If-Match` on subsequent mutating requests to detect concurrent updates.
+                            schema:
+                                type: string
+                                example: '"1705314645123"'
+                        Last-Modified:
+                            description: |-
+                                Plan's last-updated timestamp as an RFC 7231 HTTP-date (one-second resolution). Informational only.
+                                Use the `ETag` value, not `Last-Modified`, for `If-Match` requests — `Last-Modified` loses millisecond precision.
+                            schema:
+                                type: string
+                                example: "Mon, 15 Jan 2024 10:30:45 GMT"
                     content:
                         application/json:
                             schema:

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiPlansResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiPlansResourceTest.java
@@ -74,15 +74,19 @@ import io.gravitee.rest.api.service.exceptions.PlanNotFoundException;
 import io.gravitee.rest.api.service.v4.PlanSearchService;
 import jakarta.ws.rs.client.Entity;
 import jakarta.ws.rs.client.WebTarget;
+import jakarta.ws.rs.core.EntityTag;
 import jakarta.ws.rs.core.Response;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Stream;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
@@ -810,6 +814,99 @@ public class ApiPlansResourceTest extends AbstractResourceTest {
             final Response response = target.request().get();
 
             assertThat(response).hasStatus(OK_200).asEntity(PlanV2.class).isEqualTo(PlanMapper.INSTANCE.map(planEntity));
+        }
+
+        @Test
+        public void should_emit_ETag_and_Last_Modified_headers_from_updatedAt_on_GET() {
+            final Date updatedAt = Date.from(Instant.parse("2024-01-15T10:30:45.000Z"));
+            final PlanEntity planEntity = PlanFixtures.aPlanEntityV4()
+                .toBuilder()
+                .id(PLAN)
+                .referenceId(API)
+                .referenceType(GenericPlanEntity.ReferenceType.API)
+                .updatedAt(updatedAt)
+                .build();
+            when(planSearchService.findById(GraviteeContext.getExecutionContext(), PLAN)).thenReturn(planEntity);
+
+            final Response response = target.request().get();
+
+            assertThat(response).hasStatus(OK_200).asEntity(PlanV4.class).isEqualTo(PlanMapper.INSTANCE.map(planEntity));
+            Assertions.assertThat(response.getEntityTag()).isEqualTo(new EntityTag(Long.toString(updatedAt.getTime())));
+            Assertions.assertThat(response.getLastModified().getTime() / 1000).isEqualTo(updatedAt.getTime() / 1000);
+        }
+
+        @Test
+        public void should_emit_ETag_and_Last_Modified_headers_for_v2_plan_on_GET() {
+            final Date updatedAt = Date.from(Instant.parse("2024-03-20T08:15:30.000Z"));
+            final io.gravitee.rest.api.model.PlanEntity planEntity = PlanFixtures.aPlanEntityV2()
+                .toBuilder()
+                .id(PLAN)
+                .referenceId(API)
+                .referenceType(GenericPlanEntity.ReferenceType.API)
+                .updatedAt(updatedAt)
+                .build();
+            when(planSearchService.findById(GraviteeContext.getExecutionContext(), PLAN)).thenReturn(planEntity);
+
+            final Response response = target.request().get();
+
+            assertThat(response).hasStatus(OK_200).asEntity(PlanV2.class).isEqualTo(PlanMapper.INSTANCE.map(planEntity));
+            Assertions.assertThat(response.getEntityTag()).isEqualTo(new EntityTag(Long.toString(updatedAt.getTime())));
+            Assertions.assertThat(response.getLastModified().getTime() / 1000).isEqualTo(updatedAt.getTime() / 1000);
+        }
+
+        @Test
+        public void should_emit_ETag_and_Last_Modified_headers_for_native_v4_plan_on_GET() {
+            final Date updatedAt = Date.from(Instant.parse("2024-06-10T14:45:00.000Z"));
+            final var planEntity = PlanFixtures.aNativePlanEntityV4()
+                .toBuilder()
+                .id(PLAN)
+                .referenceId(API)
+                .referenceType(GenericPlanEntity.ReferenceType.API)
+                .updatedAt(updatedAt)
+                .build();
+            when(planSearchService.findById(GraviteeContext.getExecutionContext(), PLAN)).thenReturn(planEntity);
+
+            final Response response = target.request().get();
+
+            assertThat(response).hasStatus(OK_200).asEntity(PlanV4.class).isEqualTo(PlanMapper.INSTANCE.map(planEntity));
+            Assertions.assertThat(response.getEntityTag()).isEqualTo(new EntityTag(Long.toString(updatedAt.getTime())));
+            Assertions.assertThat(response.getLastModified().getTime() / 1000).isEqualTo(updatedAt.getTime() / 1000);
+        }
+
+        @Test
+        public void should_not_emit_ETag_or_Last_Modified_when_updatedAt_is_null_on_GET() {
+            final PlanEntity planEntity = PlanFixtures.aPlanEntityV4()
+                .toBuilder()
+                .id(PLAN)
+                .referenceId(API)
+                .referenceType(GenericPlanEntity.ReferenceType.API)
+                .updatedAt(null)
+                .build();
+            when(planSearchService.findById(GraviteeContext.getExecutionContext(), PLAN)).thenReturn(planEntity);
+
+            final Response response = target.request().get();
+
+            assertThat(response).hasStatus(OK_200).asEntity(PlanV4.class).isEqualTo(PlanMapper.INSTANCE.map(planEntity));
+            Assertions.assertThat(response.getEntityTag()).isNull();
+            Assertions.assertThat(response.getLastModified()).isNull();
+        }
+
+        @Test
+        public void should_not_emit_ETag_or_Last_Modified_when_updatedAt_is_null_on_v2_plan_GET() {
+            final io.gravitee.rest.api.model.PlanEntity planEntity = PlanFixtures.aPlanEntityV2()
+                .toBuilder()
+                .id(PLAN)
+                .referenceId(API)
+                .referenceType(GenericPlanEntity.ReferenceType.API)
+                .updatedAt(null)
+                .build();
+            when(planSearchService.findById(GraviteeContext.getExecutionContext(), PLAN)).thenReturn(planEntity);
+
+            final Response response = target.request().get();
+
+            assertThat(response).hasStatus(OK_200).asEntity(PlanV2.class).isEqualTo(PlanMapper.INSTANCE.map(planEntity));
+            Assertions.assertThat(response.getEntityTag()).isNull();
+            Assertions.assertThat(response.getLastModified()).isNull();
         }
     }
 


### PR DESCRIPTION
## Issue

[APIM-14081](https://gravitee.atlassian.net/browse/APIM-14081)

## Why

The PATCH plan endpoint requires callers to supply an `If-Match` header for concurrency control. Without ETag emission on GET, clients have no way to obtain a valid precondition value before making mutating requests. Adding `ETag` and `Last-Modified` to the GET response unblocks the full conditional-request workflow for plan consumers.

## What changed

- `ApiPlansResource#getApiPlan`: Added `.tag(...)` and `.lastModified(...)` on the 200-path response builder, populated via a new private `resolvePlanUpdatedAt` helper. The helper pattern-matches over `BasePlanEntity` subtypes (v4 and v2) to locate `updatedAt`, failing open (omitting both headers) when the value is null.
- `openapi-apis.yaml`: Documented the `ETag` and `Last-Modified` response headers on the GET plan 200 response.

## User-facing impact

`GET /plans/{planId}` now returns two new response headers:
- `ETag`: the plan's last-update timestamp as an epoch-millis string.
- `Last-Modified`: the same timestamp in RFC 1123 format.

This is a backwards-compatible addition — existing clients that ignore unknown response headers are unaffected.

[APIM-14081]: https://gravitee.atlassian.net/browse/APIM-14081?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ