### PR TITLE
feat(distribution): add reactor-edge to bundle-default

### DIFF
--- a/gravitee-apim-distribution/pom.xml
+++ b/gravitee-apim-distribution/pom.xml
@@ -2119,6 +2119,19 @@
                         </exclusion>
                     </exclusions>
                 </dependency>
+                <dependency>
+                    <groupId>com.graviteesource.reactor</groupId>
+                    <artifactId>gravitee-reactor-edge</artifactId>
+                    <version>${gravitee-reactor-edge.version}</version>
+                    <type>zip</type>
+                    <scope>runtime</scope>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>*</groupId>
+                            <artifactId>*</artifactId>
+                        </exclusion>
+                    </exclusions>
+                </dependency>
 
                 <!-- Repositories -->
                 <dependency>

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/src/main/resources/config/gravitee.yml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/src/main/resources/config/gravitee.yml
@@ -172,6 +172,11 @@ secrets:
 #    proxyProtocol: false
 #    proxyProtocolTimeout: 10000
 
+# Edge Reactor HTTP server
+#edge:
+#  server:
+#    port: 18093
+
 # Gateway Kafka server
 #kafka:
 #  enabled: false

--- a/pom.xml
+++ b/pom.xml
@@ -313,6 +313,7 @@
         <gravitee-reactor-mcp-proxy.version>1.1.2</gravitee-reactor-mcp-proxy.version>
         <gravitee-reactor-llm-proxy.version>3.0.0-alpha.1</gravitee-reactor-llm-proxy.version>
         <gravitee-reactor-a2a-proxy.version>1.0.0</gravitee-reactor-a2a-proxy.version>
+        <gravitee-reactor-edge.version>1.0.0-alpha.4</gravitee-reactor-edge.version>
         <gravitee-resource-ai-vector-store-redis.version>1.0.1</gravitee-resource-ai-vector-store-redis.version>
         <gravitee-resource-ai-vector-store-aws-s3.version>1.0.0</gravitee-resource-ai-vector-store-aws-s3.version>
         <gravitee-resource-ai-model-text-embedding.version>1.0.0</gravitee-resource-ai-model-text-embedding.version>


### PR DESCRIPTION
## Description

- Add `gravitee-reactor-edge` plugin (v1.0.0-alpha.4) to the `bundle-default` distribution profile
- Add Edge Reactor HTTP server configuration section to the gateway's `gravitee.yml` (`edge.server.port`, default `18093`)