### PR TITLE
feat(portal): add invitation search to portal application invitations

### DIFF
--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-invitations/application-tab-invitations.component.harness.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-invitations/application-tab-invitations.component.harness.ts
@@ -25,6 +25,8 @@ export class ApplicationTabInvitationsComponentHarness extends ComponentHarness 
   private readonly locateSectionTitle = this.locatorForOptional('[data-testid="invitations-section-title"]');
   private readonly locateErrorMessage = this.locatorForOptional('[data-testid="invitations-list-error"]');
   private readonly locateEmptyState = this.locatorForOptional('[data-testid="invitations-empty-state"]');
+  private readonly locateSearchBar = this.locatorForOptional('app-search-bar');
+  private readonly locateSearchNoMatch = this.locatorForOptional('[data-testid="invitations-search-no-match"]');
   private readonly locatePaginatedTable = this.locatorForOptional(PaginatedTableHarness);
 
   public async getLoader(): Promise<LoaderHarness | null> {
@@ -41,6 +43,14 @@ export class ApplicationTabInvitationsComponentHarness extends ComponentHarness 
 
   public async getEmptyState(): Promise<TestElement | null> {
     return this.locateEmptyState();
+  }
+
+  public async getSearchBar(): Promise<TestElement | null> {
+    return this.locateSearchBar();
+  }
+
+  public async getSearchNoMatch(): Promise<TestElement | null> {
+    return this.locateSearchNoMatch();
   }
 
   public async getPaginatedTable(): Promise<PaginatedTableHarness | null> {

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-invitations/application-tab-invitations.component.html
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-invitations/application-tab-invitations.component.html
@@ -16,8 +16,11 @@
 
 -->
 @if (canRead()) {
-  <h4 class="next-gen-h4 invitations__title" data-testid="invitations-section-title" i18n="@@applicationInvitationsTitle">
-    Invitations ({{ totalElements() }})
+  <div class="invitations__toolbar">
+    <app-search-bar (searchTerm)="onSearchTermChange($event)" />
+  </div>
+  <h4 class="next-gen-h4 invitations__title" data-testid="invitations-section-title">
+    {{ sectionTitle() }}
   </h4>
   @if (invitationsResource.isLoading()) {
     <app-loader />
@@ -26,9 +29,15 @@
       An error occurred while loading invitations. Try again later or contact your Portal administrator.
     </div>
   } @else if (totalElements() === 0) {
-    <div class="invitations__empty-state" data-testid="invitations-empty-state">
-      <p class="next-gen-body" i18n="@@invitationsEmptyState">No pending invitations found.</p>
-    </div>
+    @if (hasSearchTerm()) {
+      <div class="invitations__empty-state" data-testid="invitations-search-no-match">
+        <p class="next-gen-body" i18n="@@invitationsSearchNoMatch">No invitations match your search.</p>
+      </div>
+    } @else {
+      <div class="invitations__empty-state" data-testid="invitations-empty-state">
+        <p class="next-gen-body" i18n="@@invitationsEmptyState">No pending invitations found.</p>
+      </div>
+    }
   } @else {
     <app-paginated-table
       [columns]="tableColumns"

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-invitations/application-tab-invitations.component.scss
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-invitations/application-tab-invitations.component.scss
@@ -15,7 +15,20 @@
  */
 @use '../../../../scss/theme/index' as app-theme;
 
+app-search-bar {
+  display: block;
+  max-width: 400px;
+}
+
 .invitations {
+  &__toolbar {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 16px;
+    margin-bottom: 24px;
+  }
+
   &__title {
     margin: 0 0 16px;
   }

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-invitations/application-tab-invitations.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-invitations/application-tab-invitations.component.spec.ts
@@ -22,7 +22,10 @@ import { provideRouter } from '@angular/router';
 
 import { ApplicationTabInvitationsComponent } from './application-tab-invitations.component';
 import { ApplicationTabInvitationsComponentHarness } from './application-tab-invitations.component.harness';
-import { ApplicationInvitationsResponse } from '../../../../entities/application/application-invitation';
+import {
+  ApplicationInvitationsResponse,
+  ApplicationInvitationsSearchFilters,
+} from '../../../../entities/application/application-invitation';
 import {
   fakeApplicationInvitation,
   fakeApplicationInvitationsResponse,
@@ -60,13 +63,16 @@ describe('ApplicationTabInvitationsComponent', () => {
     return TestbedHarnessEnvironment.harnessForFixture(fixture, ApplicationTabInvitationsComponentHarness);
   }
 
-  async function flush(response: ApplicationInvitationsResponse): Promise<ApplicationTabInvitationsComponentHarness> {
+  async function flush(
+    response: ApplicationInvitationsResponse,
+    expectedFilters: ApplicationInvitationsSearchFilters = {},
+  ): Promise<ApplicationTabInvitationsComponentHarness> {
     fixture.detectChanges();
     const request = httpTestingController.expectOne(req => req.url.includes('invitations/_search'));
     expect(request.request.method).toBe('POST');
     expect(request.request.params.get('page')).toBe(`${fixture.componentInstance.currentPage()}`);
     expect(request.request.params.get('size')).toBe(`${fixture.componentInstance.pageSize()}`);
-    expect(request.request.body).toEqual({ filters: {} });
+    expect(request.request.body).toEqual({ filters: expectedFilters });
     request.flush(response);
     await fixture.whenStable();
     fixture.detectChanges();
@@ -113,6 +119,35 @@ describe('ApplicationTabInvitationsComponent', () => {
     expect((await title!.text())?.replace(/\s+/g, ' ').trim()).toBe('Invitations (0)');
   });
 
+  it('should not show invitation count before the first response is loaded', async () => {
+    fixture.detectChanges();
+    const title = fixture.nativeElement.querySelector('[data-testid="invitations-section-title"]');
+    expect(title).not.toBeNull();
+    expect(title.textContent?.replace(/\s+/g, ' ').trim()).toBe('Invitations');
+
+    httpTestingController.expectOne(req => req.url.includes('invitations/_search')).flush(fakeApplicationInvitationsResponse([]));
+    await fixture.whenStable();
+  });
+
+  it('should keep previous invitation count while a reload is pending', async () => {
+    await flush(fakeApplicationInvitationsResponse([fakeApplicationInvitation()], 12));
+
+    fixture.componentInstance.onSearchTermChange('alice@example.com');
+    fixture.detectChanges();
+
+    const title = fixture.nativeElement.querySelector('[data-testid="invitations-section-title"]');
+    expect(title).not.toBeNull();
+    expect(title.textContent?.replace(/\s+/g, ' ').trim()).toBe('Invitations (12)');
+
+    httpTestingController
+      .expectOne(req => req.url.includes('invitations/_search'))
+      .flush(fakeApplicationInvitationsResponse([fakeApplicationInvitation()], 3));
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    expect(title.textContent?.replace(/\s+/g, ' ').trim()).toBe('Invitations (3)');
+  });
+
   it('should show loader until the first search response', async () => {
     fixture.detectChanges();
     expect(fixture.nativeElement.querySelector('app-loader')).not.toBeNull();
@@ -144,6 +179,98 @@ describe('ApplicationTabInvitationsComponent', () => {
     httpTestingController.expectNone(req => req.url.includes('invitations/_search'));
     const harness = await getHarness();
     expect(await harness.getPaginatedTable()).toBeNull();
+    expect(await harness.getSearchBar()).toBeNull();
+  });
+
+  describe('search behavior', () => {
+    it('should render search bar when canRead', async () => {
+      const harness = await flush(fakeApplicationInvitationsResponse([fakeApplicationInvitation()]));
+      expect(await harness.getSearchBar()).not.toBeNull();
+    });
+
+    it('should send email filter when search term is set', async () => {
+      await flush(fakeApplicationInvitationsResponse([fakeApplicationInvitation()]));
+
+      fixture.componentInstance.onSearchTermChange(' alice@example.com ');
+      fixture.detectChanges();
+
+      const request = httpTestingController.expectOne(req => req.url.includes('invitations/_search') && req.params.get('page') === '1');
+      expect(request.request.body).toEqual({ filters: { email: 'alice@example.com' } });
+      request.flush(fakeApplicationInvitationsResponse([fakeApplicationInvitation({ email: 'alice@example.com' })]));
+      await fixture.whenStable();
+    });
+
+    it('should reset page to 1 when search term changes', async () => {
+      await flush(fakeApplicationInvitationsResponse([fakeApplicationInvitation()], 25));
+      fixture.componentInstance.onPageChange(2);
+      fixture.detectChanges();
+      httpTestingController
+        .expectOne(req => req.url.includes('invitations/_search') && req.params.get('page') === '2')
+        .flush(fakeApplicationInvitationsResponse([fakeApplicationInvitation({ id: 'invitation-p2' })]));
+      await fixture.whenStable();
+
+      fixture.componentInstance.onSearchTermChange('alice@example.com');
+      fixture.detectChanges();
+
+      const request = httpTestingController.expectOne(req => req.url.includes('invitations/_search'));
+      expect(request.request.params.get('page')).toBe('1');
+      expect(request.request.body).toEqual({ filters: { email: 'alice@example.com' } });
+      request.flush(fakeApplicationInvitationsResponse([fakeApplicationInvitation({ email: 'alice@example.com' })]));
+      await fixture.whenStable();
+    });
+
+    it('should show no-match empty state when search is active and returns no invitations', async () => {
+      await flush(fakeApplicationInvitationsResponse([fakeApplicationInvitation()]));
+
+      fixture.componentInstance.onSearchTermChange('missing@example.com');
+      fixture.detectChanges();
+      httpTestingController.expectOne(req => req.url.includes('invitations/_search')).flush(fakeApplicationInvitationsResponse([]));
+      await fixture.whenStable();
+      fixture.detectChanges();
+
+      const harness = await getHarness();
+      expect(await harness.getSearchNoMatch()).not.toBeNull();
+      expect(await harness.getEmptyState()).toBeNull();
+      expect(await harness.getPaginatedTable()).toBeNull();
+    });
+
+    it('should send no filters after clearing the search term', async () => {
+      await flush(fakeApplicationInvitationsResponse([fakeApplicationInvitation()]));
+      fixture.componentInstance.onSearchTermChange('alice@example.com');
+      fixture.detectChanges();
+      httpTestingController
+        .expectOne(req => req.url.includes('invitations/_search'))
+        .flush(fakeApplicationInvitationsResponse([fakeApplicationInvitation()]));
+      await fixture.whenStable();
+
+      fixture.componentInstance.onSearchTermChange('');
+      fixture.detectChanges();
+
+      const request = httpTestingController.expectOne(req => req.url.includes('invitations/_search'));
+      expect(request.request.body).toEqual({ filters: {} });
+      request.flush(fakeApplicationInvitationsResponse([fakeApplicationInvitation()]));
+      await fixture.whenStable();
+    });
+
+    it('should keep active search filter when page size changes', async () => {
+      await flush(fakeApplicationInvitationsResponse([fakeApplicationInvitation()], 25));
+      fixture.componentInstance.onSearchTermChange('alice@example.com');
+      fixture.detectChanges();
+      httpTestingController
+        .expectOne(req => req.url.includes('invitations/_search'))
+        .flush(fakeApplicationInvitationsResponse([fakeApplicationInvitation()]));
+      await fixture.whenStable();
+
+      fixture.componentInstance.onPageSizeChange(25);
+      fixture.detectChanges();
+
+      const request = httpTestingController.expectOne(
+        req => req.url.includes('invitations/_search') && req.params.get('page') === '1' && req.params.get('size') === '25',
+      );
+      expect(request.request.body).toEqual({ filters: { email: 'alice@example.com' } });
+      request.flush(fakeApplicationInvitationsResponse([fakeApplicationInvitation()]));
+      await fixture.whenStable();
+    });
   });
 
   it('should render invitation email icon, email and role cells', async () => {

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-invitations/application-tab-invitations.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-invitations/application-tab-invitations.component.ts
@@ -16,12 +16,17 @@
 import { Component, computed, inject, input, signal } from '@angular/core';
 import { rxResource } from '@angular/core/rxjs-interop';
 import { MatIcon } from '@angular/material/icon';
-import { of } from 'rxjs';
+import { map, of, tap } from 'rxjs';
 
 import { LoaderComponent } from '../../../../components/loader/loader.component';
 import { PaginatedTableComponent, TableColumn } from '../../../../components/paginated-table/paginated-table.component';
 import { TableCellDirective } from '../../../../components/paginated-table/table-cell.directive';
-import { ApplicationInvitation, ApplicationInvitationsResponse } from '../../../../entities/application/application-invitation';
+import { SearchBarComponent } from '../../../../components/search-bar/search-bar.component';
+import {
+  ApplicationInvitation,
+  ApplicationInvitationsResponse,
+  ApplicationInvitationsSearchFilters,
+} from '../../../../entities/application/application-invitation';
 import { UserApplicationPermissions } from '../../../../entities/permission/permission';
 import { ApplicationInvitationService } from '../../../../services/application-invitation.service';
 
@@ -35,12 +40,18 @@ interface InvitationsRequestParams {
   applicationId: string;
   page: number;
   size: number;
+  filters: ApplicationInvitationsSearchFilters;
+}
+
+interface InvitationsResourceValue {
+  params: InvitationsRequestParams;
+  response: ApplicationInvitationsResponse;
 }
 
 @Component({
   selector: 'app-application-tab-invitations',
   standalone: true,
-  imports: [LoaderComponent, MatIcon, PaginatedTableComponent, TableCellDirective],
+  imports: [LoaderComponent, MatIcon, PaginatedTableComponent, SearchBarComponent, TableCellDirective],
   templateUrl: './application-tab-invitations.component.html',
   styleUrl: './application-tab-invitations.component.scss',
 })
@@ -52,6 +63,15 @@ export class ApplicationTabInvitationsComponent {
 
   readonly currentPage = signal(1);
   readonly pageSize = signal(10);
+  readonly searchTerm = signal('');
+  readonly displayedTotalElements = signal<number | null>(null);
+  readonly sectionTitle = computed(() => {
+    const totalElements = this.displayedTotalElements();
+
+    return totalElements === null
+      ? $localize`:@@applicationInvitationsTitle:Invitations`
+      : $localize`:@@applicationInvitationsTitleWithCount:Invitations (${totalElements}:count:)`;
+  });
 
   readonly tableColumns: TableColumn[] = [
     { id: 'email', label: $localize`:@@applicationInvitationsColumnEmail:Email` },
@@ -60,35 +80,58 @@ export class ApplicationTabInvitationsComponent {
   ];
 
   readonly canRead = computed(() => this.userApplicationPermissions().MEMBER?.includes('R') ?? false);
+  readonly hasSearchTerm = computed(() => this.searchTerm().trim().length > 0);
+  readonly searchFilters = computed<ApplicationInvitationsSearchFilters>(() => {
+    const email = this.searchTerm().trim();
+    return email ? { email } : {};
+  });
 
-  protected readonly invitationsResource = rxResource<ApplicationInvitationsResponse | undefined, InvitationsRequestParams | null>({
-    params: () =>
-      this.canRead()
-        ? {
-            applicationId: this.applicationId(),
-            page: this.currentPage(),
-            size: this.pageSize(),
-          }
-        : null,
+  readonly requestParams = computed<InvitationsRequestParams | null>(() =>
+    this.canRead()
+      ? {
+          applicationId: this.applicationId(),
+          page: this.currentPage(),
+          size: this.pageSize(),
+          filters: this.searchFilters(),
+        }
+      : null,
+  );
+
+  protected readonly invitationsResource = rxResource<InvitationsResourceValue | undefined, InvitationsRequestParams | null>({
+    params: () => this.requestParams(),
     stream: ({ params }) =>
       params
-        ? this.applicationInvitationService.searchApplicationInvitations(params.applicationId, params.page, params.size)
+        ? this.applicationInvitationService
+            .searchApplicationInvitations(params.applicationId, params.page, params.size, params.filters)
+            .pipe(
+              tap(response => this.displayedTotalElements.set(this.getTotalElements(response))),
+              map(response => ({ params, response })),
+            )
         : of(undefined),
+  });
+
+  readonly currentResponse = computed<ApplicationInvitationsResponse | undefined>(() => {
+    const value = this.invitationsResource.value();
+    const params = this.requestParams();
+    if (!value || !params || !this.isSameRequestParams(value.params, params)) {
+      return undefined;
+    }
+    return value.response;
   });
 
   readonly rows = computed<InvitationTableRow[]>(() => {
     if (this.invitationsResource.error()) {
       return [];
     }
-    return (this.invitationsResource.value()?.data ?? []).map(invitation => this.toRow(invitation));
+    return (this.currentResponse()?.data ?? []).map(invitation => this.toRow(invitation));
   });
 
-  readonly totalElements = computed(() => {
+  readonly totalElements = computed<number>(() => {
     if (this.invitationsResource.error()) {
       return 0;
     }
-    const response = this.invitationsResource.value();
-    return response?.metadata?.paginateMetaData?.totalElements ?? response?.metadata?.pagination?.total ?? response?.data?.length ?? 0;
+    const response = this.currentResponse();
+    return response ? this.getTotalElements(response) : 0;
   });
 
   onPageChange(page: number): void {
@@ -100,11 +143,29 @@ export class ApplicationTabInvitationsComponent {
     this.currentPage.set(1);
   }
 
+  onSearchTermChange(term: string): void {
+    this.searchTerm.set(term);
+    this.currentPage.set(1);
+  }
+
   private toRow(invitation: ApplicationInvitation): InvitationTableRow {
     return {
       id: invitation.id,
       email: invitation.email,
       role: invitation.role,
     };
+  }
+
+  private isSameRequestParams(left: InvitationsRequestParams, right: InvitationsRequestParams): boolean {
+    return (
+      left.applicationId === right.applicationId &&
+      left.page === right.page &&
+      left.size === right.size &&
+      left.filters?.email === right.filters?.email
+    );
+  }
+
+  private getTotalElements(response: ApplicationInvitationsResponse): number {
+    return response.metadata?.paginateMetaData?.totalElements ?? response.metadata?.pagination?.total ?? response.data?.length ?? 0;
   }
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-13763

## Description

Adds search support to the application invitations tab in the new Developer Portal.

Changes:
- Added search bar to the invitations list.
- Search filters invitations by email.
- Reset pagination to page 1 when the search term changes.
- Added search-specific empty state.
- Kept invitation count stable while new search results are loading.


https://github.com/user-attachments/assets/6dd7cd51-6fd0-4563-8e9a-3e5c6af7955d


