### PR TITLE
feat(portal): integrate GraviteeDashboardComponent in analytics detail page

### DIFF
--- a/gravitee-apim-portal-webui-next/src/app/dashboard/analytics/analytics-details/analytics-details.component.html
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/analytics/analytics-details/analytics-details.component.html
@@ -22,15 +22,35 @@
     An error occurred while loading the dashboard. Try again later or contact your Portal administrator.
   </app-banner>
 } @else if (dashboard(); as db) {
-  <gd-dashboard [dashboard]="db" [baseURL]="baseURL" [timeRange]="timeRange()" [interval]="interval()" [refreshToken]="refreshToken()">
-    <div gdToolbarBelow class="analytics-details__timeframe">
-      <gd-timeframe-selector
-        data-testid="analytics-details-timeframe"
-        [formControl]="periodControl"
-        [timeFrames]="timeFrames"
-        [defaultPeriod]="defaultPeriod"
-        (refresh)="refresh()"
-      />
+  <gd-dashboard
+    [dashboard]="db"
+    [baseURL]="baseURL"
+    [timeRange]="timeRange()"
+    [interval]="interval()"
+    [refreshToken]="refreshToken()"
+    [requestFilters]="filtersStore.requestFilters()"
+  >
+    <div gdToolbarBelow class="analytics-details__toolbar">
+      <div class="analytics-details__timeframe">
+        <gd-timeframe-selector
+          data-testid="analytics-details-timeframe"
+          [formControl]="periodControl"
+          [timeFrames]="timeFrames"
+          [defaultPeriod]="defaultPeriod"
+          (refresh)="refresh()"
+        />
+      </div>
+      <div class="analytics-details__filters">
+        <gd-dynamic-filter-bar
+          data-testid="analytics-details-filters"
+          [conditions]="filtersStore.conditions()"
+          [editable]="true"
+          (addRequested)="openAddFilter()"
+          (editRequested)="openEditFilter($event.index, $event.condition)"
+          (removeRequested)="filtersStore.remove($event)"
+          (clearRequested)="filtersStore.clear()"
+        />
+      </div>
     </div>
   </gd-dashboard>
 }

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/analytics/analytics-details/analytics-details.component.html
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/analytics/analytics-details/analytics-details.component.html
@@ -15,4 +15,12 @@
     limitations under the License.
 
 -->
-<h1 class="next-gen-h3">{{ dashboardName() }}</h1>
+@if (dashboardResource.isLoading()) {
+  <app-loader />
+} @else if (dashboardResource.error()) {
+  <app-banner type="error" role="alert" data-testid="analytics-details-error" i18n="@@analyticsDashboardLoadError">
+    An error occurred while loading the dashboard. Try again later or contact your Portal administrator.
+  </app-banner>
+} @else if (dashboard(); as db) {
+  <gd-dashboard [dashboard]="db" [baseURL]="baseURL" [timeRange]="timeRange" [interval]="interval" />
+}

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/analytics/analytics-details/analytics-details.component.html
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/analytics/analytics-details/analytics-details.component.html
@@ -22,5 +22,15 @@
     An error occurred while loading the dashboard. Try again later or contact your Portal administrator.
   </app-banner>
 } @else if (dashboard(); as db) {
-  <gd-dashboard [dashboard]="db" [baseURL]="baseURL" [timeRange]="timeRange" [interval]="interval" />
+  <gd-dashboard [dashboard]="db" [baseURL]="baseURL" [timeRange]="timeRange()" [interval]="interval()" [refreshToken]="refreshToken()">
+    <div gdToolbarBelow class="analytics-details__timeframe">
+      <gd-timeframe-selector
+        data-testid="analytics-details-timeframe"
+        [formControl]="periodControl"
+        [timeFrames]="timeFrames"
+        [defaultPeriod]="defaultPeriod"
+        (refresh)="refresh()"
+      />
+    </div>
+  </gd-dashboard>
 }

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/analytics/analytics-details/analytics-details.component.scss
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/analytics/analytics-details/analytics-details.component.scss
@@ -13,3 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+:host {
+  display: block;
+  width: 100%;
+}

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/analytics/analytics-details/analytics-details.component.scss
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/analytics/analytics-details/analytics-details.component.scss
@@ -18,8 +18,18 @@
   width: 100%;
 }
 
+.analytics-details__toolbar {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-right: 32px;
+}
+
 .analytics-details__timeframe {
   display: flex;
   justify-content: flex-end;
-  margin-right: 32px;
+}
+
+.analytics-details__filters {
+  display: flex;
 }

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/analytics/analytics-details/analytics-details.component.scss
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/analytics/analytics-details/analytics-details.component.scss
@@ -17,3 +17,9 @@
   display: block;
   width: 100%;
 }
+
+.analytics-details__timeframe {
+  display: flex;
+  justify-content: flex-end;
+  margin-right: 32px;
+}

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/analytics/analytics-details/analytics-details.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/analytics/analytics-details/analytics-details.component.spec.ts
@@ -120,4 +120,16 @@ describe('AnalyticsDetailsComponent', () => {
     const breadcrumbs = breadcrumbService.breadcrumbs();
     expect(breadcrumbs[1].label).toBe(DASHBOARD_ID);
   });
+
+  it('should_display_dynamic_filter_bar', async () => {
+    await setup();
+    expect(await harness.isFilterBarDisplayed()).toBe(true);
+  });
+
+  it('should_pass_request_filters_to_gd_dashboard', async () => {
+    await setup();
+    const dashboardElement = fixture.nativeElement.querySelector('gd-dashboard');
+    expect(dashboardElement).not.toBeNull();
+    expect(fixture.componentInstance.filtersStore.requestFilters()).toEqual([]);
+  });
 });

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/analytics/analytics-details/analytics-details.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/analytics/analytics-details/analytics-details.component.spec.ts
@@ -76,6 +76,26 @@ describe('AnalyticsDetailsComponent', () => {
     expect(await harness.isTimeframeSelectorDisplayed()).toBe(true);
   });
 
+  it('should_recompute_time_range_on_refresh_for_preset_periods', async () => {
+    jest.useFakeTimers({ doNotFake: ['queueMicrotask'] });
+    try {
+      jest.setSystemTime(new Date('2026-01-01T12:00:00Z'));
+      await setup();
+
+      const initialRange = fixture.componentInstance.timeRange();
+
+      jest.setSystemTime(new Date('2026-01-01T12:01:00Z'));
+      fixture.componentInstance.refresh();
+      fixture.detectChanges();
+
+      const refreshedRange = fixture.componentInstance.timeRange();
+      expect(new Date(refreshedRange.from).getTime() - new Date(initialRange.from).getTime()).toBe(60_000);
+      expect(new Date(refreshedRange.to).getTime() - new Date(initialRange.to).getTime()).toBe(60_000);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
   it('should_show_loader_while_loading', async () => {
     fixture.detectChanges();
     // Read the loader from the DOM, not the harness: harnessForFixture() stabilizes and would

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/analytics/analytics-details/analytics-details.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/analytics/analytics-details/analytics-details.component.spec.ts
@@ -71,6 +71,11 @@ describe('AnalyticsDetailsComponent', () => {
     expect(await harness.isDashboardDisplayed()).toBe(true);
   });
 
+  it('should_display_timeframe_selector', async () => {
+    await setup();
+    expect(await harness.isTimeframeSelectorDisplayed()).toBe(true);
+  });
+
   it('should_show_loader_while_loading', async () => {
     fixture.detectChanges();
     // Read the loader from the DOM, not the harness: harnessForFixture() stabilizes and would

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/analytics/analytics-details/analytics-details.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/analytics/analytics-details/analytics-details.component.spec.ts
@@ -1,0 +1,118 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { provideHttpClient } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { provideRouter } from '@angular/router';
+
+import { Dashboard } from '@gravitee/gravitee-dashboard';
+
+import AnalyticsDetailsComponent from './analytics-details.component';
+import { AnalyticsDetailsHarness } from './analytics-details.harness';
+import { fakeDashboard } from '../../../../entities/analytics-dashboard/analytics-dashboard.fixtures';
+import { BreadcrumbService } from '../../../../services/breadcrumb.service';
+import { ConfigService } from '../../../../services/config.service';
+import { TESTING_BASE_URL } from '../../../../testing/app-testing.module';
+import { analyticsListBreadcrumb } from '../analytics-breadcrumbs';
+
+describe('AnalyticsDetailsComponent', () => {
+  let fixture: ComponentFixture<AnalyticsDetailsComponent>;
+  let httpTestingController: HttpTestingController;
+  let harness: AnalyticsDetailsHarness;
+
+  const DASHBOARD_ID = 'dashboard-1';
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [AnalyticsDetailsComponent],
+      providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        provideNoopAnimations(),
+        provideRouter([]),
+        { provide: ConfigService, useValue: { baseURL: TESTING_BASE_URL } },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(AnalyticsDetailsComponent);
+    httpTestingController = TestBed.inject(HttpTestingController);
+    fixture.componentRef.setInput('dashboardId', DASHBOARD_ID);
+  });
+
+  afterEach(() => {
+    httpTestingController.verify();
+  });
+
+  async function setup(response: Dashboard = fakeDashboard()) {
+    fixture.detectChanges();
+    httpTestingController.expectOne(req => req.url === `${TESTING_BASE_URL}/analytics/dashboards/${DASHBOARD_ID}`).flush(response);
+    await fixture.whenStable();
+    fixture.detectChanges();
+    harness = await TestbedHarnessEnvironment.harnessForFixture(fixture, AnalyticsDetailsHarness);
+  }
+
+  it('should_display_gd_dashboard_component_after_loading', async () => {
+    await setup();
+    expect(await harness.isDashboardDisplayed()).toBe(true);
+  });
+
+  it('should_show_loader_while_loading', async () => {
+    fixture.detectChanges();
+    // Read the loader from the DOM, not the harness: harnessForFixture() stabilizes and would
+    // deadlock on the still-pending rxResource request (flush only happens below).
+    expect(fixture.nativeElement.querySelector('app-loader')).not.toBeNull();
+
+    httpTestingController.expectOne(req => req.url === `${TESTING_BASE_URL}/analytics/dashboards/${DASHBOARD_ID}`).flush(fakeDashboard());
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    // Request settled → the harness no longer deadlocks.
+    harness = await TestbedHarnessEnvironment.harnessForFixture(fixture, AnalyticsDetailsHarness);
+    expect(await harness.getLoader()).toBeNull();
+  });
+
+  it('should_show_error_when_dashboard_load_fails', async () => {
+    fixture.detectChanges();
+    httpTestingController
+      .expectOne(req => req.url === `${TESTING_BASE_URL}/analytics/dashboards/${DASHBOARD_ID}`)
+      .flush('Not Found', { status: 404, statusText: 'Not Found' });
+    await fixture.whenStable();
+    fixture.detectChanges();
+    harness = await TestbedHarnessEnvironment.harnessForFixture(fixture, AnalyticsDetailsHarness);
+    expect(await harness.getErrorMessage()).toContain('error occurred while loading the dashboard');
+    expect(await harness.isDashboardDisplayed()).toBe(false);
+  });
+
+  it('should_set_breadcrumbs_with_dashboard_name', async () => {
+    const dashboard = fakeDashboard({ name: 'My Dashboard' });
+    await setup(dashboard);
+    const breadcrumbService = TestBed.inject(BreadcrumbService);
+    expect(breadcrumbService.breadcrumbs()).toEqual([
+      analyticsListBreadcrumb(true),
+      { id: `analytics-${DASHBOARD_ID}`, label: 'My Dashboard' },
+    ]);
+  });
+
+  it('should_use_dashboard_id_as_breadcrumb_label_when_name_is_empty', async () => {
+    const dashboard = fakeDashboard({ name: '' });
+    await setup(dashboard);
+    const breadcrumbService = TestBed.inject(BreadcrumbService);
+    const breadcrumbs = breadcrumbService.breadcrumbs();
+    expect(breadcrumbs[1].label).toBe(DASHBOARD_ID);
+  });
+});

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/analytics/analytics-details/analytics-details.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/analytics/analytics-details/analytics-details.component.ts
@@ -13,10 +13,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Component, computed, effect, inject, input } from '@angular/core';
-import { rxResource } from '@angular/core/rxjs-interop';
+import { Component, computed, effect, inject, input, signal } from '@angular/core';
+import { rxResource, toSignal } from '@angular/core/rxjs-interop';
+import { FormControl, ReactiveFormsModule } from '@angular/forms';
+import { MAT_FORM_FIELD_DEFAULT_OPTIONS } from '@angular/material/form-field';
 
-import { Dashboard, GraviteeDashboardComponent, timeFrameRangesParams, TimeRange } from '@gravitee/gravitee-dashboard';
+import {
+  BasicTimeframe,
+  Dashboard,
+  GraviteeDashboardComponent,
+  TimeframeSelectorComponent,
+  TimeframeValue,
+  timeFrameRangesParams,
+  timeFrames,
+  TimeRange,
+} from '@gravitee/gravitee-dashboard';
 
 import { BannerComponent } from '../../../../components/banner/banner.component';
 import { LoaderComponent } from '../../../../components/loader/loader.component';
@@ -25,11 +36,14 @@ import { BreadcrumbService } from '../../../../services/breadcrumb.service';
 import { ConfigService } from '../../../../services/config.service';
 import { analyticsListBreadcrumb } from '../analytics-breadcrumbs';
 
+const DEFAULT_PERIOD: BasicTimeframe = '5m';
+
 @Component({
   selector: 'app-analytics-details',
-  imports: [GraviteeDashboardComponent, LoaderComponent, BannerComponent],
+  imports: [GraviteeDashboardComponent, LoaderComponent, BannerComponent, TimeframeSelectorComponent, ReactiveFormsModule],
   templateUrl: './analytics-details.component.html',
   styleUrl: './analytics-details.component.scss',
+  providers: [{ provide: MAT_FORM_FIELD_DEFAULT_OPTIONS, useValue: { appearance: 'outline' } }],
 })
 export default class AnalyticsDetailsComponent {
   private readonly configService = inject(ConfigService);
@@ -39,6 +53,16 @@ export default class AnalyticsDetailsComponent {
   readonly dashboardId = input.required<string>();
 
   readonly baseURL = this.configService.baseURL;
+  protected readonly defaultPeriod = DEFAULT_PERIOD;
+  protected readonly timeFrames = timeFrames;
+  protected readonly periodControl = new FormControl<TimeframeValue>(
+    { period: DEFAULT_PERIOD, from: null, to: null },
+    { nonNullable: true },
+  );
+  private readonly refreshTokenSignal = signal(0);
+  readonly refreshToken = this.refreshTokenSignal.asReadonly();
+
+  private readonly period = toSignal(this.periodControl.valueChanges, { initialValue: this.periodControl.value });
 
   readonly dashboardResource = rxResource<Dashboard | undefined, string>({
     params: () => this.dashboardId(),
@@ -46,11 +70,17 @@ export default class AnalyticsDetailsComponent {
   });
   readonly dashboard = computed(() => (this.dashboardResource.error() ? undefined : this.dashboardResource.value()));
   readonly dashboardName = computed(() => this.dashboard()?.name ?? '');
-  readonly timeRange: TimeRange = (() => {
-    const params = timeFrameRangesParams('5m');
+
+  private readonly timeframeParams = computed(() => {
+    const id = this.period().period;
+    const known = timeFrames.some(timeFrame => timeFrame.id === id);
+    return timeFrameRangesParams(known ? (id as BasicTimeframe) : DEFAULT_PERIOD);
+  });
+  readonly timeRange = computed<TimeRange>(() => {
+    const params = this.timeframeParams();
     return { from: new Date(params.from).toISOString(), to: new Date(params.to).toISOString() };
-  })();
-  readonly interval = timeFrameRangesParams('5m').interval;
+  });
+  readonly interval = computed(() => this.timeframeParams().interval);
 
   constructor() {
     effect(() => {
@@ -58,5 +88,9 @@ export default class AnalyticsDetailsComponent {
       const name = this.dashboardName();
       this.breadcrumbService.set([analyticsListBreadcrumb(true), { id: `analytics-${id}`, label: name || id }]);
     });
+  }
+
+  refresh(): void {
+    this.refreshTokenSignal.update(token => token + 1);
   }
 }

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/analytics/analytics-details/analytics-details.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/analytics/analytics-details/analytics-details.component.ts
@@ -14,25 +14,49 @@
  * limitations under the License.
  */
 import { Component, computed, effect, inject, input } from '@angular/core';
+import { rxResource } from '@angular/core/rxjs-interop';
 
-import { BreadcrumbService } from 'src/services/breadcrumb.service';
+import { Dashboard, GraviteeDashboardComponent, timeFrameRangesParams, TimeRange } from '@gravitee/gravitee-dashboard';
 
+import { BannerComponent } from '../../../../components/banner/banner.component';
+import { LoaderComponent } from '../../../../components/loader/loader.component';
+import { AnalyticsDashboardService } from '../../../../services/analytics-dashboard.service';
+import { BreadcrumbService } from '../../../../services/breadcrumb.service';
+import { ConfigService } from '../../../../services/config.service';
 import { analyticsListBreadcrumb } from '../analytics-breadcrumbs';
 
 @Component({
   selector: 'app-analytics-details',
+  imports: [GraviteeDashboardComponent, LoaderComponent, BannerComponent],
   templateUrl: './analytics-details.component.html',
   styleUrl: './analytics-details.component.scss',
 })
 export default class AnalyticsDetailsComponent {
-  readonly breadcrumbService = inject(BreadcrumbService);
+  private readonly configService = inject(ConfigService);
+  private readonly breadcrumbService = inject(BreadcrumbService);
+  private readonly analyticsDashboardService = inject(AnalyticsDashboardService);
+
   readonly dashboardId = input.required<string>();
-  readonly dashboardName = computed(() => `Dummy dashboard name ${this.dashboardId()}`);
+
+  readonly baseURL = this.configService.baseURL;
+
+  readonly dashboardResource = rxResource<Dashboard | undefined, string>({
+    params: () => this.dashboardId(),
+    stream: ({ params }) => this.analyticsDashboardService.getById(params),
+  });
+  readonly dashboard = computed(() => (this.dashboardResource.error() ? undefined : this.dashboardResource.value()));
+  readonly dashboardName = computed(() => this.dashboard()?.name ?? '');
+  readonly timeRange: TimeRange = (() => {
+    const params = timeFrameRangesParams('5m');
+    return { from: new Date(params.from).toISOString(), to: new Date(params.to).toISOString() };
+  })();
+  readonly interval = timeFrameRangesParams('5m').interval;
 
   constructor() {
     effect(() => {
       const id = this.dashboardId();
-      this.breadcrumbService.set([analyticsListBreadcrumb(true), { id: `analytics-${id}`, label: this.dashboardName() }]);
+      const name = this.dashboardName();
+      this.breadcrumbService.set([analyticsListBreadcrumb(true), { id: `analytics-${id}`, label: name || id }]);
     });
   }
 }

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/analytics/analytics-details/analytics-details.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/analytics/analytics-details/analytics-details.component.ts
@@ -13,15 +13,22 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Component, computed, effect, inject, input, signal } from '@angular/core';
-import { rxResource, toSignal } from '@angular/core/rxjs-interop';
+import { Component, computed, DestroyRef, effect, inject, Injector, input, signal } from '@angular/core';
+import { rxResource, takeUntilDestroyed, toSignal } from '@angular/core/rxjs-interop';
 import { FormControl, ReactiveFormsModule } from '@angular/forms';
 import { MAT_FORM_FIELD_DEFAULT_OPTIONS } from '@angular/material/form-field';
+import { MatDialog } from '@angular/material/dialog';
 
 import {
+  AddFilterDialogComponent,
+  AddFilterDialogData,
   BasicTimeframe,
   Dashboard,
+  DynamicFilterBarComponent,
+  FilterCondition,
   GraviteeDashboardComponent,
+  provideFilterDefinitions,
+  provideFilterValues,
   TimeframeSelectorComponent,
   TimeframeValue,
   timeFrameRangesParams,
@@ -29,6 +36,8 @@ import {
   TimeRange,
 } from '@gravitee/gravitee-dashboard';
 
+import { DashboardFiltersStore } from './dashboard-filters.store';
+import { PortalAnalyticsFiltersService } from './portal-analytics-filters.service';
 import { BannerComponent } from '../../../../components/banner/banner.component';
 import { LoaderComponent } from '../../../../components/loader/loader.component';
 import { AnalyticsDashboardService } from '../../../../services/analytics-dashboard.service';
@@ -40,16 +49,26 @@ const DEFAULT_PERIOD: BasicTimeframe = '5m';
 
 @Component({
   selector: 'app-analytics-details',
-  imports: [GraviteeDashboardComponent, LoaderComponent, BannerComponent, TimeframeSelectorComponent, ReactiveFormsModule],
+  imports: [GraviteeDashboardComponent, LoaderComponent, BannerComponent, TimeframeSelectorComponent, ReactiveFormsModule, DynamicFilterBarComponent],
   templateUrl: './analytics-details.component.html',
   styleUrl: './analytics-details.component.scss',
-  providers: [{ provide: MAT_FORM_FIELD_DEFAULT_OPTIONS, useValue: { appearance: 'outline' } }],
+  providers: [
+    { provide: MAT_FORM_FIELD_DEFAULT_OPTIONS, useValue: { appearance: 'outline' } },
+    DashboardFiltersStore,
+    PortalAnalyticsFiltersService,
+    provideFilterDefinitions(PortalAnalyticsFiltersService),
+    provideFilterValues(PortalAnalyticsFiltersService),
+  ],
 })
 export default class AnalyticsDetailsComponent {
   private readonly configService = inject(ConfigService);
   private readonly breadcrumbService = inject(BreadcrumbService);
   private readonly analyticsDashboardService = inject(AnalyticsDashboardService);
+  private readonly dialog = inject(MatDialog);
+  private readonly injector = inject(Injector);
+  private readonly destroyRef = inject(DestroyRef);
 
+  readonly filtersStore = inject(DashboardFiltersStore);
   readonly dashboardId = input.required<string>();
 
   readonly baseURL = this.configService.baseURL;
@@ -92,5 +111,39 @@ export default class AnalyticsDetailsComponent {
 
   refresh(): void {
     this.refreshTokenSignal.update(token => token + 1);
+  }
+
+  openAddFilter(): void {
+    const params = this.timeframeParams();
+    this.dialog
+      .open<AddFilterDialogComponent, AddFilterDialogData, FilterCondition>(AddFilterDialogComponent, {
+        data: { timeFrom: params.from, timeTo: params.to },
+        injector: this.injector,
+        autoFocus: 'dialog',
+      })
+      .afterClosed()
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe(condition => {
+        if (condition) {
+          this.filtersStore.add(condition);
+        }
+      });
+  }
+
+  openEditFilter(index: number, condition: FilterCondition): void {
+    const params = this.timeframeParams();
+    this.dialog
+      .open<AddFilterDialogComponent, AddFilterDialogData, FilterCondition>(AddFilterDialogComponent, {
+        data: { existingCondition: condition, timeFrom: params.from, timeTo: params.to },
+        injector: this.injector,
+        autoFocus: 'dialog',
+      })
+      .afterClosed()
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe(updated => {
+        if (updated) {
+          this.filtersStore.edit(index, updated);
+        }
+      });
   }
 }

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/analytics/analytics-details/analytics-details.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/analytics/analytics-details/analytics-details.component.ts
@@ -16,8 +16,8 @@
 import { Component, computed, DestroyRef, effect, inject, Injector, input, signal } from '@angular/core';
 import { rxResource, takeUntilDestroyed, toSignal } from '@angular/core/rxjs-interop';
 import { FormControl, ReactiveFormsModule } from '@angular/forms';
-import { MAT_FORM_FIELD_DEFAULT_OPTIONS } from '@angular/material/form-field';
 import { MatDialog } from '@angular/material/dialog';
+import { MAT_FORM_FIELD_DEFAULT_OPTIONS } from '@angular/material/form-field';
 
 import {
   AddFilterDialogComponent,
@@ -49,7 +49,14 @@ const DEFAULT_PERIOD: BasicTimeframe = '5m';
 
 @Component({
   selector: 'app-analytics-details',
-  imports: [GraviteeDashboardComponent, LoaderComponent, BannerComponent, TimeframeSelectorComponent, ReactiveFormsModule, DynamicFilterBarComponent],
+  imports: [
+    GraviteeDashboardComponent,
+    LoaderComponent,
+    BannerComponent,
+    TimeframeSelectorComponent,
+    ReactiveFormsModule,
+    DynamicFilterBarComponent,
+  ],
   templateUrl: './analytics-details.component.html',
   styleUrl: './analytics-details.component.scss',
   providers: [
@@ -91,6 +98,7 @@ export default class AnalyticsDetailsComponent {
   readonly dashboardName = computed(() => this.dashboard()?.name ?? '');
 
   private readonly timeframeParams = computed(() => {
+    this.refreshToken();
     const id = this.period().period;
     const known = timeFrames.some(timeFrame => timeFrame.id === id);
     return timeFrameRangesParams(known ? (id as BasicTimeframe) : DEFAULT_PERIOD);

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/analytics/analytics-details/analytics-details.harness.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/analytics/analytics-details/analytics-details.harness.ts
@@ -24,6 +24,7 @@ export class AnalyticsDetailsHarness extends ComponentHarness {
   private readonly locateDashboard = this.locatorForOptional('gd-dashboard');
   private readonly locateError = this.locatorForOptional('[data-testid="analytics-details-error"]');
   private readonly locateTimeframeSelector = this.locatorForOptional('[data-testid="analytics-details-timeframe"]');
+  private readonly locateFilterBar = this.locatorForOptional('[data-testid="analytics-details-filters"]');
 
   public async getLoader(): Promise<LoaderHarness | null> {
     return this.locateLoader();
@@ -40,5 +41,9 @@ export class AnalyticsDetailsHarness extends ComponentHarness {
   public async getErrorMessage(): Promise<string | null> {
     const error = await this.locateError();
     return error ? error.text() : null;
+  }
+
+  public async isFilterBarDisplayed(): Promise<boolean> {
+    return !!(await this.locateFilterBar());
   }
 }

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/analytics/analytics-details/analytics-details.harness.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/analytics/analytics-details/analytics-details.harness.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ComponentHarness } from '@angular/cdk/testing';
+
+import { LoaderHarness } from '../../../../components/loader/loader.harness';
+
+export class AnalyticsDetailsHarness extends ComponentHarness {
+  public static readonly hostSelector = 'app-analytics-details';
+
+  private readonly locateLoader = this.locatorForOptional(LoaderHarness);
+  private readonly locateDashboard = this.locatorForOptional('gd-dashboard');
+  private readonly locateError = this.locatorForOptional('[data-testid="analytics-details-error"]');
+
+  public async getLoader(): Promise<LoaderHarness | null> {
+    return this.locateLoader();
+  }
+
+  public async isDashboardDisplayed(): Promise<boolean> {
+    return !!(await this.locateDashboard());
+  }
+
+  public async getErrorMessage(): Promise<string | null> {
+    const error = await this.locateError();
+    return error ? error.text() : null;
+  }
+}

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/analytics/analytics-details/analytics-details.harness.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/analytics/analytics-details/analytics-details.harness.ts
@@ -23,6 +23,7 @@ export class AnalyticsDetailsHarness extends ComponentHarness {
   private readonly locateLoader = this.locatorForOptional(LoaderHarness);
   private readonly locateDashboard = this.locatorForOptional('gd-dashboard');
   private readonly locateError = this.locatorForOptional('[data-testid="analytics-details-error"]');
+  private readonly locateTimeframeSelector = this.locatorForOptional('[data-testid="analytics-details-timeframe"]');
 
   public async getLoader(): Promise<LoaderHarness | null> {
     return this.locateLoader();
@@ -30,6 +31,10 @@ export class AnalyticsDetailsHarness extends ComponentHarness {
 
   public async isDashboardDisplayed(): Promise<boolean> {
     return !!(await this.locateDashboard());
+  }
+
+  public async isTimeframeSelectorDisplayed(): Promise<boolean> {
+    return !!(await this.locateTimeframeSelector());
   }
 
   public async getErrorMessage(): Promise<string | null> {

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/analytics/analytics-details/dashboard-filters.store.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/analytics/analytics-details/dashboard-filters.store.spec.ts
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 import { TestBed } from '@angular/core/testing';
-import { provideRouter } from '@angular/router';
-import { ActivatedRoute } from '@angular/router';
+import { provideRouter, ActivatedRoute } from '@angular/router';
 
 import { FilterCondition } from '@gravitee/gravitee-dashboard';
 

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/analytics/analytics-details/dashboard-filters.store.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/analytics/analytics-details/dashboard-filters.store.spec.ts
@@ -1,0 +1,120 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { TestBed } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
+import { ActivatedRoute } from '@angular/router';
+
+import { FilterCondition } from '@gravitee/gravitee-dashboard';
+
+import { DashboardFiltersStore } from './dashboard-filters.store';
+
+function createCondition(overrides: Partial<FilterCondition> = {}): FilterCondition {
+  return {
+    field: 'API',
+    label: 'API',
+    operator: 'EQ',
+    values: ['api-1'],
+    ...overrides,
+  };
+}
+
+describe('DashboardFiltersStore', () => {
+  let store: DashboardFiltersStore;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        DashboardFiltersStore,
+        provideRouter([]),
+        {
+          provide: ActivatedRoute,
+          useValue: {
+            snapshot: { queryParams: {} },
+            queryParams: { pipe: () => ({ subscribe: () => {} }) },
+          },
+        },
+      ],
+    });
+
+    store = TestBed.inject(DashboardFiltersStore);
+  });
+
+  it('should_start_with_empty_conditions', () => {
+    expect(store.conditions()).toEqual([]);
+  });
+
+  it('should_add_condition', () => {
+    const condition = createCondition();
+    store.add(condition);
+    expect(store.conditions()).toEqual([condition]);
+  });
+
+  it('should_merge_conditions_with_same_field_and_operator', () => {
+    store.add(createCondition({ values: ['api-1'], valueLabels: ['API 1'] }));
+    store.add(createCondition({ values: ['api-2'], valueLabels: ['API 2'] }));
+    expect(store.conditions()).toHaveLength(1);
+    expect(store.conditions()[0].values).toEqual(['api-1', 'api-2']);
+    expect(store.conditions()[0].operator).toBe('IN');
+  });
+
+  it('should_not_merge_conditions_with_different_fields', () => {
+    store.add(createCondition({ field: 'API', values: ['api-1'] }));
+    store.add(createCondition({ field: 'APPLICATION', values: ['app-1'] }));
+    expect(store.conditions()).toHaveLength(2);
+  });
+
+  it('should_remove_condition_by_index', () => {
+    store.add(createCondition({ field: 'API', values: ['api-1'] }));
+    store.add(createCondition({ field: 'APPLICATION', values: ['app-1'] }));
+    store.remove(0);
+    expect(store.conditions()).toHaveLength(1);
+    expect(store.conditions()[0].field).toBe('APPLICATION');
+  });
+
+  it('should_clear_all_conditions', () => {
+    store.add(createCondition({ field: 'API', values: ['api-1'] }));
+    store.add(createCondition({ field: 'APPLICATION', values: ['app-1'] }));
+    store.clear();
+    expect(store.conditions()).toEqual([]);
+  });
+
+  it('should_edit_condition_at_index', () => {
+    store.add(createCondition({ values: ['api-1'] }));
+    const updated = createCondition({ values: ['api-2'], valueLabels: ['Updated API'] });
+    store.edit(0, updated);
+    expect(store.conditions()[0].values).toEqual(['api-2']);
+  });
+
+  it('should_compute_request_filters_from_conditions', () => {
+    store.add(createCondition({ field: 'API', operator: 'EQ', values: ['api-1'] }));
+    const filters = store.requestFilters();
+    expect(filters).toHaveLength(1);
+    expect(filters[0].name).toBe('API');
+    expect(filters[0].value).toBe('api-1');
+  });
+
+  it('should_not_remove_when_index_is_out_of_bounds', () => {
+    store.add(createCondition());
+    store.remove(5);
+    expect(store.conditions()).toHaveLength(1);
+  });
+
+  it('should_not_edit_when_index_is_out_of_bounds', () => {
+    store.add(createCondition({ values: ['api-1'] }));
+    store.edit(5, createCondition({ values: ['api-2'] }));
+    expect(store.conditions()[0].values).toEqual(['api-1']);
+  });
+});

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/analytics/analytics-details/dashboard-filters.store.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/analytics/analytics-details/dashboard-filters.store.ts
@@ -17,7 +17,14 @@ import { computed, DestroyRef, inject, Injectable, signal } from '@angular/core'
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, Router } from '@angular/router';
 
-import { decodeViewState, encodeViewState, FilterCondition, RequestFilter, toRequestFilter, ViewStateTimeframe } from '@gravitee/gravitee-dashboard';
+import {
+  decodeViewState,
+  encodeViewState,
+  FilterCondition,
+  RequestFilter,
+  toRequestFilter,
+  ViewStateTimeframe,
+} from '@gravitee/gravitee-dashboard';
 
 @Injectable()
 export class DashboardFiltersStore {

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/analytics/analytics-details/dashboard-filters.store.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/analytics/analytics-details/dashboard-filters.store.ts
@@ -1,0 +1,134 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { computed, DestroyRef, inject, Injectable, signal } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { ActivatedRoute, Router } from '@angular/router';
+
+import { decodeViewState, encodeViewState, FilterCondition, RequestFilter, toRequestFilter, ViewStateTimeframe } from '@gravitee/gravitee-dashboard';
+
+@Injectable()
+export class DashboardFiltersStore {
+  private readonly route = inject(ActivatedRoute);
+  private readonly router = inject(Router);
+  private readonly destroyRef = inject(DestroyRef);
+
+  private readonly _conditions = signal<FilterCondition[]>([]);
+  readonly conditions = this._conditions.asReadonly();
+
+  readonly requestFilters = computed<RequestFilter[]>(() => this._conditions().map(toRequestFilter));
+
+  private _skipNextQueryParamsEmit = false;
+
+  constructor() {
+    this.hydrateFromRoute(this.route.snapshot.queryParams);
+    this.listenQueryParams();
+  }
+
+  add(condition: FilterCondition): void {
+    this._conditions.update(prev => {
+      const compatIdx = prev.findIndex(c => c.field === condition.field && areMergeableOperators(c.operator, condition.operator));
+      if (compatIdx === -1) return [...prev, condition];
+
+      const existing = prev[compatIdx];
+      const mergedValues = [...new Set([...existing.values, ...condition.values])];
+      if (mergedValues.length === existing.values.length) return prev;
+
+      const existingLabels = existing.valueLabels ?? existing.values;
+      const newLabels = condition.valueLabels ?? condition.values;
+      const labelMap = new Map<string, string>();
+      existing.values.forEach((v, i) => labelMap.set(v, existingLabels[i] ?? v));
+      condition.values.forEach((v, i) => labelMap.set(v, newLabels[i] ?? v));
+      const mergedLabels = mergedValues.map(v => labelMap.get(v) ?? v);
+
+      const operator = mergedValues.length >= 2 ? promoteMembershipOperator(existing.operator) : existing.operator;
+
+      const next = [...prev];
+      next[compatIdx] = { ...existing, operator, values: mergedValues, valueLabels: mergedLabels };
+      return next;
+    });
+    this.syncToRouter();
+  }
+
+  edit(index: number, condition: FilterCondition): void {
+    this._conditions.update(prev => {
+      if (index < 0 || index >= prev.length) return prev;
+      const next = [...prev];
+      next[index] = condition;
+      return next;
+    });
+    this.syncToRouter();
+  }
+
+  remove(index: number): void {
+    this._conditions.update(prev => {
+      if (index < 0 || index >= prev.length) return prev;
+      return prev.filter((_, i) => i !== index);
+    });
+    this.syncToRouter();
+  }
+
+  clear(): void {
+    this._conditions.set([]);
+    this.syncToRouter();
+  }
+
+  private hydrateFromRoute(params: Record<string, string>): void {
+    const q = params['q'] as string | undefined;
+    const v = params['v'] as string | undefined;
+    const { conditions } = decodeViewState(q, v);
+    this._conditions.set(conditions);
+  }
+
+  private syncToRouter(): void {
+    const timeframe: ViewStateTimeframe = { period: '5m', from: null, to: null };
+    const encoded = encodeViewState(this._conditions(), timeframe);
+
+    const queryParams: Record<string, string | null> = {
+      q: encoded?.q ?? null,
+      v: encoded?.v ?? null,
+    };
+
+    this._skipNextQueryParamsEmit = true;
+    this.router.navigate([], {
+      relativeTo: this.route,
+      queryParams,
+      queryParamsHandling: 'merge',
+      replaceUrl: true,
+    });
+  }
+
+  private listenQueryParams(): void {
+    this.route.queryParams.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(params => {
+      if (this._skipNextQueryParamsEmit) {
+        this._skipNextQueryParamsEmit = false;
+        return;
+      }
+      this.hydrateFromRoute(params);
+    });
+  }
+}
+
+const MEMBERSHIP_FAMILIES: ReadonlyArray<ReadonlySet<string>> = [new Set(['EQ', 'IN']), new Set(['NEQ', 'NOT_IN'])];
+
+function areMergeableOperators(a: string, b: string): boolean {
+  return MEMBERSHIP_FAMILIES.some(family => family.has(a) && family.has(b));
+}
+
+function promoteMembershipOperator(op: string): string {
+  if (op === 'EQ') return 'IN';
+  if (op === 'NEQ') return 'NOT_IN';
+  return op;
+}

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/analytics/analytics-details/portal-analytics-filters.service.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/analytics/analytics-details/portal-analytics-filters.service.spec.ts
@@ -1,0 +1,109 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { provideHttpClient } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+
+import { PortalAnalyticsFiltersService } from './portal-analytics-filters.service';
+import { ConfigService } from '../../../../services/config.service';
+import { TESTING_BASE_URL } from '../../../../testing/app-testing.module';
+
+describe('PortalAnalyticsFiltersService', () => {
+  let service: PortalAnalyticsFiltersService;
+  let httpTestingController: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        PortalAnalyticsFiltersService,
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        { provide: ConfigService, useValue: { baseURL: TESTING_BASE_URL } },
+      ],
+    });
+
+    service = TestBed.inject(PortalAnalyticsFiltersService);
+    httpTestingController = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpTestingController.verify();
+  });
+
+  it('should_return_three_filter_definitions', done => {
+    service.getDefinitions().subscribe(definitions => {
+      expect(definitions).toHaveLength(3);
+      expect(definitions.map(d => d.name)).toEqual(['API', 'APPLICATION', 'HTTP_STATUS_CODE_GROUP']);
+      expect(definitions[0].type).toBe('KEYWORD');
+      expect(definitions[1].type).toBe('KEYWORD');
+      expect(definitions[2].type).toBe('ENUM');
+      expect(definitions[2].values).toEqual(['2xx', '4xx', '5xx']);
+      done();
+    });
+  });
+
+  it('should_search_apis_for_api_filter_values', done => {
+    service.getValues({ filterName: 'API', page: 1, perPage: 10, query: 'test' }).subscribe(result => {
+      expect(result.data).toEqual([
+        { value: 'api-1', label: 'My API' },
+        { value: 'api-2', label: 'Other API' },
+      ]);
+      expect(result.hasNextPage).toBe(true);
+      done();
+    });
+
+    httpTestingController.expectOne(req => req.url === `${TESTING_BASE_URL}/apis/_search`).flush({
+      data: [
+        { id: 'api-1', name: 'My API' },
+        { id: 'api-2', name: 'Other API' },
+      ],
+      metadata: { pagination: { current_page: 1, total_pages: 2 } },
+    });
+  });
+
+  it('should_list_applications_for_application_filter_values', done => {
+    service.getValues({ filterName: 'APPLICATION', page: 1, perPage: 10 }).subscribe(result => {
+      expect(result.data).toEqual([{ value: 'app-1', label: 'My App' }]);
+      expect(result.hasNextPage).toBe(false);
+      done();
+    });
+
+    httpTestingController.expectOne(req => req.url.includes('/applications')).flush({
+      data: [{ id: 'app-1', name: 'My App' }],
+      metadata: { pagination: { current_page: 1, total_pages: 1 } },
+    });
+  });
+
+  it('should_return_static_status_code_groups', done => {
+    service.getValues({ filterName: 'HTTP_STATUS_CODE_GROUP', page: 1, perPage: 10 }).subscribe(result => {
+      expect(result.data).toEqual([
+        { value: '2xx', label: '2xx' },
+        { value: '4xx', label: '4xx' },
+        { value: '5xx', label: '5xx' },
+      ]);
+      expect(result.hasNextPage).toBe(false);
+      done();
+    });
+  });
+
+  it('should_return_empty_for_unknown_filter', done => {
+    service.getValues({ filterName: 'UNKNOWN', page: 1, perPage: 10 }).subscribe(result => {
+      expect(result.data).toEqual([]);
+      expect(result.hasNextPage).toBe(false);
+      done();
+    });
+  });
+});

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/analytics/analytics-details/portal-analytics-filters.service.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/analytics/analytics-details/portal-analytics-filters.service.spec.ts
@@ -65,13 +65,15 @@ describe('PortalAnalyticsFiltersService', () => {
       done();
     });
 
-    httpTestingController.expectOne(req => req.url === `${TESTING_BASE_URL}/apis/_search`).flush({
-      data: [
-        { id: 'api-1', name: 'My API' },
-        { id: 'api-2', name: 'Other API' },
-      ],
-      metadata: { pagination: { current_page: 1, total_pages: 2 } },
-    });
+    httpTestingController
+      .expectOne(req => req.url === `${TESTING_BASE_URL}/apis/_search`)
+      .flush({
+        data: [
+          { id: 'api-1', name: 'My API' },
+          { id: 'api-2', name: 'Other API' },
+        ],
+        metadata: { pagination: { current_page: 1, total_pages: 2 } },
+      });
   });
 
   it('should_list_applications_for_application_filter_values', done => {
@@ -81,10 +83,12 @@ describe('PortalAnalyticsFiltersService', () => {
       done();
     });
 
-    httpTestingController.expectOne(req => req.url.includes('/applications')).flush({
-      data: [{ id: 'app-1', name: 'My App' }],
-      metadata: { pagination: { current_page: 1, total_pages: 1 } },
-    });
+    httpTestingController
+      .expectOne(req => req.url.includes('/applications'))
+      .flush({
+        data: [{ id: 'app-1', name: 'My App' }],
+        metadata: { pagination: { current_page: 1, total_pages: 1 } },
+      });
   });
 
   it('should_return_static_status_code_groups', done => {

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/analytics/analytics-details/portal-analytics-filters.service.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/analytics/analytics-details/portal-analytics-filters.service.ts
@@ -1,0 +1,79 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { inject, Injectable } from '@angular/core';
+import { Observable, of } from 'rxjs';
+import { map } from 'rxjs/operators';
+
+import {
+  FilterDefinition,
+  FilterDefinitionProvider,
+  FilterValuesProvider,
+  FilterValuesQuery,
+  FilterValuesResult,
+} from '@gravitee/gravitee-dashboard';
+
+import { ApiService } from '../../../../services/api.service';
+import { ApplicationService } from '../../../../services/application.service';
+
+@Injectable()
+export class PortalAnalyticsFiltersService implements FilterDefinitionProvider, FilterValuesProvider {
+  private readonly apiService = inject(ApiService);
+  private readonly applicationService = inject(ApplicationService);
+
+  getDefinitions(): Observable<FilterDefinition[]> {
+    return of([
+      { name: 'API', label: $localize`:@@analyticsFilterApi:API`, type: 'KEYWORD', operators: ['EQ', 'IN'] },
+      { name: 'APPLICATION', label: $localize`:@@analyticsFilterApplication:Application`, type: 'KEYWORD', operators: ['EQ', 'IN'] },
+      {
+        name: 'HTTP_STATUS_CODE_GROUP',
+        label: $localize`:@@analyticsFilterStatusCode:Status Code`,
+        type: 'ENUM',
+        operators: ['EQ', 'IN'],
+        values: ['2xx', '4xx', '5xx'],
+      },
+    ]);
+  }
+
+  getValues(query: FilterValuesQuery): Observable<FilterValuesResult> {
+    switch (query.filterName) {
+      case 'API':
+        return this.apiService.search(query.page, 'all', query.query ?? '', query.perPage).pipe(
+          map(response => ({
+            data: (response.data ?? []).map(api => ({ value: api.id, label: api.name })),
+            hasNextPage: (response.metadata?.pagination?.current_page ?? 1) < (response.metadata?.pagination?.total_pages ?? 1),
+          })),
+        );
+      case 'APPLICATION':
+        return this.applicationService.list(query.page, query.perPage).pipe(
+          map(response => ({
+            data: (response.data ?? []).map(app => ({ value: app.id, label: app.name })),
+            hasNextPage: (response.metadata?.pagination?.current_page ?? 1) < (response.metadata?.pagination?.total_pages ?? 1),
+          })),
+        );
+      case 'HTTP_STATUS_CODE_GROUP':
+        return of({
+          data: [
+            { value: '2xx', label: '2xx' },
+            { value: '4xx', label: '4xx' },
+            { value: '5xx', label: '5xx' },
+          ],
+          hasNextPage: false,
+        });
+      default:
+        return of({ data: [], hasNextPage: false });
+    }
+  }
+}

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/analytics/analytics.component.html
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/analytics/analytics.component.html
@@ -45,9 +45,9 @@
   @if (dashboardsResource.isLoading()) {
     <app-loader class="analytics-list__loader" />
   } @else if (dashboardsResource.error()) {
-    <div class="analytics-list__error next-gen-body" role="alert" data-testid="analytics-list-error" i18n="@@analyticsListError">
+    <app-banner type="error" role="alert" data-testid="analytics-list-error" i18n="@@analyticsListError">
       An error occurred while loading analytics dashboards. Try again later or contact your Portal administrator.
-    </div>
+    </app-banner>
   } @else {
     <app-cards-grid
       class="analytics-list__grid"

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/analytics/analytics.component.scss
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/analytics/analytics.component.scss
@@ -78,12 +78,4 @@
   &__pagination {
     margin-top: 16px;
   }
-
-  &__error {
-    padding: 12px 16px;
-    margin-bottom: 16px;
-    background: app-theme.$banner-error-background-color;
-    color: app-theme.$banner-error-text-color;
-    border-radius: 4px;
-  }
 }

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/analytics/analytics.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/analytics/analytics.component.spec.ts
@@ -91,11 +91,16 @@ describe('AnalyticsComponent', () => {
     });
 
     it('should_navigate_to_dashboard_on_card_select', async () => {
-      await setup();
+      await setup(
+        fakeAnalyticsDashboardsResponse({
+          data: [fakeDashboard({ id: 'dash-1', name: 'HTTP Overview' })],
+        }),
+      );
       const router = TestBed.inject(Router);
-      const navigateSpy = jest.spyOn(router, 'navigate');
+      const navigateSpy = jest.spyOn(router, 'navigate').mockResolvedValue(true);
 
-      fixture.componentInstance.navigateToDashboard('dash-1');
+      const cards = await harness.getGridCards();
+      await cards[0].click();
 
       expect(navigateSpy).toHaveBeenCalledWith(['dash-1'], expect.anything());
     });
@@ -252,14 +257,14 @@ describe('AnalyticsComponent', () => {
   describe('partial response', () => {
     it('should_apply_fallbacks_when_metadata_is_missing', async () => {
       await setup({ data: [] });
-      const vm = fixture.componentInstance['dashboardPaginator']();
-      expect(vm.page).toBe(1);
-      expect(vm.totalResults).toBe(0);
+      expect(await harness.isEmptyStateDisplayed()).toBe(true);
+      expect(await harness.getCards()).toHaveLength(0);
     });
 
     it('should_default_data_to_empty_array_when_field_missing', async () => {
       await setup({});
-      expect(fixture.componentInstance['dashboardPaginator']().data).toEqual([]);
+      expect(await harness.isEmptyStateDisplayed()).toBe(true);
+      expect(await harness.getCards()).toHaveLength(0);
     });
   });
 

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/analytics/analytics.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/analytics/analytics.component.ts
@@ -23,6 +23,7 @@ import { Dashboard } from '@gravitee/gravitee-dashboard';
 
 import { analyticsListBreadcrumb } from './analytics-breadcrumbs';
 import { AnalyticsDashboardCardComponent } from '../../../components/analytics-dashboard-card/analytics-dashboard-card.component';
+import { BannerComponent } from '../../../components/banner/banner.component';
 import { CardsGridComponent } from '../../../components/cards-grid/cards-grid.component';
 import { LoaderComponent } from '../../../components/loader/loader.component';
 import { PaginationComponent } from '../../../components/pagination/pagination.component';
@@ -43,7 +44,7 @@ export interface DashboardPaginatorVM {
 
 @Component({
   selector: 'app-analytics',
-  imports: [AnalyticsDashboardCardComponent, CardsGridComponent, PaginationComponent, LoaderComponent],
+  imports: [AnalyticsDashboardCardComponent, CardsGridComponent, PaginationComponent, LoaderComponent, BannerComponent],
   templateUrl: './analytics.component.html',
   styleUrl: './analytics.component.scss',
 })

--- a/gravitee-apim-webui-libs/gravitee-dashboard/src/lib/components/filter/timeframe-selector/timeframe-selector.component.html
+++ b/gravitee-apim-webui-libs/gravitee-dashboard/src/lib/components/filter/timeframe-selector/timeframe-selector.component.html
@@ -15,8 +15,8 @@
     limitations under the License.
 
 -->
-<div class="gio-timeframe" [formGroup]="form">
-  <mat-form-field class="custom-date">
+<div class="gd-timeframe" [formGroup]="form">
+  <mat-form-field class="custom-date" subscriptSizing="dynamic">
     <mat-label>Timeframe</mat-label>
     <mat-select formControlName="period" (selectionChange)="onPeriodChange($event.value)">
       @for (timeFrame of timeFrames(); track timeFrame.id) {
@@ -28,7 +28,7 @@
   </mat-form-field>
 
   @if (form.controls.period.value === customPeriod()) {
-    <mat-form-field class="custom-date">
+    <mat-form-field class="custom-date" subscriptSizing="dynamic">
       <mat-label>From</mat-label>
       <input
         matInput
@@ -41,7 +41,7 @@
       <owl-date-time #fromDateTimePicker />
     </mat-form-field>
 
-    <mat-form-field class="custom-date">
+    <mat-form-field class="custom-date" subscriptSizing="dynamic">
       <mat-label>To</mat-label>
       <input
         matInput


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-13652
https://gravitee.atlassian.net/browse/APIM-12890

## Description

  Adds the analytics dashboard **detail page** to the portal: fetches a dashboard by id and renders it via `@gravitee/gravitee-dashboard`, with loading / error / loaded states and a breadcrumb built from the dashboard name.

  Includes a **timeframe selector** (preset periods, default "Last 5 minutes", with refresh) wired to the dashboard.

  ### Also in this PR
  - **Refactor**: analytics list & detail error states now use the shared `app-banner` component instead of hand-rolled inline banners.
  - **Tests**: analytics list tests driven through the harness (no more `componentInstance` access).
  - **Lib fix** (`gravitee-dashboard`): the timeframe selector's container class didn't match its stylesheet, so its flex layout never applied — fixed, and form fields use `subscriptSizing="dynamic"` for proper alignment.
  ⚠️ Shared component → also applies the intended layout to the **console** observability dashboards.

## Additional context

<img width="1898" height="957" alt="Capture d’écran 2026-05-27 à 11 56 18" src="https://github.com/user-attachments/assets/932e7bdb-7433-4b33-842f-572d886c2cd3" />
