### PR TITLE
fix(gamma-console): align Authorization card moduleId with authz plugin id

### DIFF
--- a/gravitee-gamma/gravitee-gamma-control-plane-webui/src/features/modules/modules.types.ts
+++ b/gravitee-gamma/gravitee-gamma-control-plane-webui/src/features/modules/modules.types.ts
@@ -17,7 +17,7 @@ export interface GammaModuleResponse {
     id: string;
     name: string;
     version: string;
-    /** Module Federation manifest. Absent for backend-only modules that ship no UI (e.g. authz). */
+    /** Module Federation manifest. Absent for backend-only modules that ship no UI. */
     mfManifest?: { name: string; exposes?: Array<{ name: string; [key: string]: unknown }>; [key: string]: unknown };
 }
 

--- a/gravitee-gamma/gravitee-gamma-control-plane-webui/src/pages/home/HomePage.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-control-plane-webui/src/pages/home/HomePage.spec.tsx
@@ -28,10 +28,10 @@ const ALL_MODULES: readonly GammaModule[] = [
     { id: 'platform', name: 'Platform', version: '1.0.0', remoteName: 'gravitee_gamma_module_platform', exposedModule: 'App' },
     { id: 'catalog', name: 'Catalog', version: '1.0.0', remoteName: 'gravitee_gamma_module_catalog', exposedModule: 'App' },
     {
-        id: 'authorization',
+        id: 'authz',
         name: 'Authorization',
         version: '1.0.0',
-        remoteName: 'gravitee_gamma_module_authorization',
+        remoteName: 'gravitee_gamma_module_authz',
         exposedModule: 'App',
     },
 ];

--- a/gravitee-gamma/gravitee-gamma-control-plane-webui/src/pages/home/HomePage.stories.tsx
+++ b/gravitee-gamma/gravitee-gamma-control-plane-webui/src/pages/home/HomePage.stories.tsx
@@ -37,10 +37,10 @@ const ALL_MODULES: readonly GammaModule[] = [
     { id: 'platform', name: 'Platform', version: '1.0.0', remoteName: 'gravitee_gamma_module_platform', exposedModule: 'App' },
     { id: 'catalog', name: 'Catalog', version: '1.0.0', remoteName: 'gravitee_gamma_module_catalog', exposedModule: 'App' },
     {
-        id: 'authorization',
+        id: 'authz',
         name: 'Authorization',
         version: '1.0.0',
-        remoteName: 'gravitee_gamma_module_authorization',
+        remoteName: 'gravitee_gamma_module_authz',
         exposedModule: 'App',
     },
 ];

--- a/gravitee-gamma/gravitee-gamma-control-plane-webui/src/pages/home/components/application-card/applications.ts
+++ b/gravitee-gamma/gravitee-gamma-control-plane-webui/src/pages/home/components/application-card/applications.ts
@@ -21,7 +21,7 @@ import type { Accent } from '../accents';
 /** Plugin ids of modules we render a card for. Must match `plugin.properties#id` of
  *  the corresponding Gamma module (`gravitee-gamma-module-<id>`). Typed as a literal
  *  union so the badge map (`DynamicBadges`) can key on the same names — review #13. */
-export type ModuleId = 'aim' | 'apim' | 'platform' | 'catalog' | 'authorization';
+export type ModuleId = 'aim' | 'apim' | 'platform' | 'catalog' | 'authz';
 
 export type Application =
     | {
@@ -94,7 +94,7 @@ export const APPLICATIONS: readonly Application[] = [
         kind: 'module',
         title: 'Authorization',
         description: 'Define fine-grained authorization rules, relationship tuples, and scopes across the platform.',
-        moduleId: 'authorization',
+        moduleId: 'authz', // plugin.properties#id of gravitee-gamma-module-authz
         Icon: KeyIcon,
         accent: 'success', // allows / grants
     },


### PR DESCRIPTION
## Issue

_No Jira ticket — small follow-up fix._

## Description

The gamma-console home page (`gravitee-gamma-control-plane-webui`) renders an **Authorization** application card, but it was wired to `moduleId: 'authorization'` while the gamma authz module ships plugin id `authz` (`gravitee-gamma-module-authz/.../plugin.properties` → `id=authz`).

The host resolves a card to a working link only when its `moduleId` matches a module id returned by `/modules`, and routes modules by their backend id (`AppRoutes.tsx`: `path={`${m.id}/*`}`). Because of the mismatch:

- `isAvailable('authorization')` was always `false` → the card rendered permanently disabled, with no working "Open →" link (unlike the APIM card, which correctly uses `'apim'`).
- Even if it had resolved, `/environments/{env}/authorization` would not have matched the `authz/*` route.

This aligns the card's `moduleId` to `'authz'` so it behaves like the APIM card once the authz module is served by `/modules` with its UI manifest.

Changes:
- `applications.ts` — `ModuleId` union and the Authorization card: `'authorization'` → `'authz'`.
- `HomePage.spec.tsx` / `HomePage.stories.tsx` — fixture `id`/`remoteName` updated to `authz`.
- `modules.types.ts` — dropped the now-stale "(e.g. authz)" backend-only example (the authz module now ships a UI).

## Additional context

The link appears at runtime only when `GET /organizations/{org}/modules` returns `authz` with a non-null `mfManifest` (i.e. the authz plugin is packaged with its compiled `ui/mf-manifest.json`, same packaging as APIM). This PR is the UI-side prerequisite; it does not change module packaging.

Verification: `HomePage.spec.tsx` passes (6/6); `tsc` reports no new errors from this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)