### PR TITLE
feat(authz-ui): dashboard landing with global KPI tiles

### DIFF
--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/app/AppRoutes.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/app/AppRoutes.tsx
@@ -20,6 +20,7 @@ import { useMemo } from 'react';
 import { Navigate, Outlet, Route, Routes, useNavigate } from 'react-router-dom';
 import { NAV_GROUPS } from '../config/navigation';
 import { AUTHZ_ROUTE_CONFIG, ROUTES, type RouteKey } from '../config/routes';
+import { DashboardPage } from '../features/dashboard/DashboardPage';
 import { ApisPage } from '../features/policy-management/pages/ApisPage';
 import { CustomPoliciesPage } from '../features/policy-management/pages/CustomPoliciesPage';
 import { LlmsPage } from '../features/policy-management/pages/LlmsPage';
@@ -56,8 +57,8 @@ export function AppRoutes() {
             <ModuleErrorBoundary>
                 <Routes>
                     <Route element={<ModuleLayout />}>
-                        <Route index element={<Navigate to="mcps" replace />} />
-                        <Route path="dashboard" element={<Navigate to="../mcps" replace />} />
+                        <Route index element={<Navigate to="dashboard" replace />} />
+                        <Route path="dashboard" element={<DashboardPage />} />
                         <Route path="mcps" element={<McpsPage />} />
                         <Route path="llms" element={<LlmsPage />} />
                         <Route path="apis" element={<ApisPage />} />

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/config/navigation.ts
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/config/navigation.ts
@@ -14,15 +14,19 @@
  * limitations under the License.
  */
 import type { NavGroup } from '@gravitee/graphene-core';
-import { BrainIcon, GlobeIcon, ShieldCheckIcon, SlidersHorizontalIcon } from '@gravitee/graphene-core/icons';
+import { BrainIcon, GlobeIcon, LayoutDashboardIcon, ShieldCheckIcon, SlidersHorizontalIcon } from '@gravitee/graphene-core/icons';
 import { ROUTES } from './routes';
 
 /**
- * Sidebar IA. Exposes Policy Management only. Policy structure
+ * Sidebar IA. Dashboard landing + Policy Management. Policy structure
  * (entities · actions · schema) is introduced incrementally by
  * follow-up PRs in the gamma-ui stack.
  */
 export const NAV_GROUPS: NavGroup[] = [
+    {
+        label: 'Authorization',
+        items: [{ key: 'dashboard', title: ROUTES.dashboard.label, icon: LayoutDashboardIcon }],
+    },
     {
         label: 'Policy Management',
         items: [

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/config/routes.ts
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/config/routes.ts
@@ -16,6 +16,8 @@
 import type { ModuleRouteConfig } from '@gravitee/gamma-modules-sdk/routing';
 
 export const ROUTE_KEYS = [
+    // Overview
+    'dashboard',
     // Policy Management
     'mcps',
     'llms',
@@ -25,6 +27,7 @@ export const ROUTE_KEYS = [
 export type RouteKey = (typeof ROUTE_KEYS)[number];
 
 export const ROUTES: Record<RouteKey, { readonly path: string; readonly label: string }> = {
+    dashboard: { path: 'dashboard', label: 'Dashboard' },
     mcps: { path: 'mcps', label: 'MCPs' },
     llms: { path: 'llms', label: 'AI Models' },
     apis: { path: 'apis', label: 'APIs' },
@@ -34,5 +37,5 @@ export const ROUTES: Record<RouteKey, { readonly path: string; readonly label: s
 export const AUTHZ_ROUTE_CONFIG: ModuleRouteConfig<RouteKey> = {
     routeKeys: ROUTE_KEYS,
     routes: ROUTES,
-    defaultRouteKey: 'mcps',
+    defaultRouteKey: 'dashboard',
 } as const;

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/features/dashboard/DashboardPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/features/dashboard/DashboardPage.tsx
@@ -1,0 +1,148 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useEnvironment } from '@gravitee/gamma-modules-sdk';
+import { Card, Skeleton } from '@gravitee/graphene-core';
+import { BotIcon, BrainIcon, ShieldCheckIcon, UsersIcon } from '@gravitee/graphene-core/icons';
+import { useQuery } from '@tanstack/react-query';
+import type { ComponentType, SVGProps } from 'react';
+import { Link } from 'react-router-dom';
+import { authzApiService } from '../../shared/api/authz-api.service';
+import { authzQueryKeys } from '../../shared/api/query-keys';
+interface KpiCardMeta {
+    readonly label: string;
+    readonly description: string;
+    readonly to?: string;
+    readonly linkLabel?: string;
+    readonly Icon: ComponentType<SVGProps<SVGSVGElement>>;
+    readonly iconClassName: string;
+}
+
+const KPI_CARDS: readonly KpiCardMeta[] = [
+    {
+        label: 'MCP',
+        description:
+            'Manage access to tools and control what agents can access on behalf of users — clear boundaries for every MCP surface.',
+        to: '../mcps',
+        linkLabel: 'Manage MCPs',
+        Icon: ShieldCheckIcon,
+        iconClassName: 'bg-highlight/10 text-highlight',
+    },
+    {
+        label: 'Agents',
+        description: 'Manage access to agent skills and workflows so only trusted agents can act with the right scopes and identities.',
+        Icon: BotIcon,
+        iconClassName: 'bg-success/10 text-success',
+    },
+    {
+        label: 'AI Models',
+        description: 'Manage access to providers and models — tailor who can use which model, in which environment, and when.',
+        to: '../llms',
+        linkLabel: 'Manage AI models',
+        Icon: BrainIcon,
+        iconClassName: 'bg-primary/10 text-primary',
+    },
+    {
+        label: 'Users and groups',
+        description: 'Manage users, groups, and how they relate — membership and hierarchy stay consistent for policy decisions.',
+        Icon: UsersIcon,
+        iconClassName: 'bg-warning/10 text-warning',
+    },
+];
+
+function useDashboardCounts(environmentId: string) {
+    const mcpCount = useQuery({
+        queryKey: authzQueryKeys.policies.page(environmentId, 1, 1, 'MCP'),
+        queryFn: () => authzApiService.listPolicies(environmentId, { type: 'MCP', perPage: 1 }),
+        enabled: Boolean(environmentId),
+        staleTime: 30_000,
+    });
+
+    const agentCount = useQuery({
+        queryKey: authzQueryKeys.policies.page(environmentId, 1, 1, 'AGENT'),
+        queryFn: () => authzApiService.listPolicies(environmentId, { type: 'AGENT', perPage: 1 }),
+        enabled: Boolean(environmentId),
+        staleTime: 30_000,
+    });
+
+    const llmCount = useQuery({
+        queryKey: authzQueryKeys.policies.page(environmentId, 1, 1, 'LLM'),
+        queryFn: () => authzApiService.listPolicies(environmentId, { type: 'LLM', perPage: 1 }),
+        enabled: Boolean(environmentId),
+        staleTime: 30_000,
+    });
+
+    const entityCount = useQuery({
+        queryKey: authzQueryKeys.entities.page(environmentId, 1, 1),
+        queryFn: () => authzApiService.listEntities(environmentId, { perPage: 1 }),
+        enabled: Boolean(environmentId),
+        staleTime: 30_000,
+    });
+
+    return {
+        MCP: { total: mcpCount.data?.total, isLoading: mcpCount.isLoading },
+        Agents: { total: agentCount.data?.total, isLoading: agentCount.isLoading },
+        'AI Models': { total: llmCount.data?.total, isLoading: llmCount.isLoading },
+        'Users and groups': { total: entityCount.data?.total, isLoading: entityCount.isLoading },
+    };
+}
+
+export function DashboardPage() {
+    const env = useEnvironment();
+    const counts = useDashboardCounts(env?.id ?? '');
+
+    return (
+        <div className="flex flex-col gap-6">
+            <header className="flex flex-col gap-2">
+                <h1 className="text-2xl font-semibold">Dashboard</h1>
+                <p className="max-w-3xl text-sm text-muted-foreground">
+                    Decide what <span className="font-medium text-foreground">users</span> and{' '}
+                    <span className="font-medium text-foreground">agents</span> may do on{' '}
+                    <span className="font-medium text-foreground">entity resources</span> — policies, identities, groups, deployments, and
+                    PDPs stay aligned so access stays explicit and observable.
+                </p>
+            </header>
+
+            <div className="grid gap-4" style={{ gridTemplateColumns: 'repeat(auto-fit, minmax(240px, 1fr))' }}>
+                {KPI_CARDS.map(kpi => {
+                    const count = counts[kpi.label as keyof typeof counts];
+                    return (
+                        <Card key={kpi.label} className="flex flex-col gap-3 p-5">
+                            <div className={`flex size-10 items-center justify-center rounded-lg ${kpi.iconClassName}`}>
+                                <kpi.Icon className="size-5" aria-hidden />
+                            </div>
+                            <div className="flex flex-col gap-0.5">
+                                {count.isLoading ? (
+                                    <Skeleton className="h-8 w-12" />
+                                ) : (
+                                    <div className="text-3xl font-semibold leading-none">{count.total ?? '—'}</div>
+                                )}
+                                <div className="text-sm font-medium">{kpi.label}</div>
+                            </div>
+                            <p className="text-xs text-muted-foreground">{kpi.description}</p>
+                            {kpi.to && kpi.linkLabel ? (
+                                <Link to={kpi.to} className="text-sm font-medium text-primary hover:underline">
+                                    {kpi.linkLabel} →
+                                </Link>
+                            ) : (
+                                <span className="text-sm font-medium text-muted-foreground">Coming soon</span>
+                            )}
+                        </Card>
+                    );
+                })}
+            </div>
+        </div>
+    );
+}


### PR DESCRIPTION
Add a Dashboard page as the module landing route (was: redirect to /mcps). Renders four KPI cards (MCP / Agents / AI Models / Users & groups) with graphene semantic-token icon chips, plus a one-line description and a deep-link to the relevant section.

Sidebar gets a new 'Authorization' group above 'Policy Management' hosting the Dashboard entry; default route key flipped to 'dashboard'.
