### PR TITLE
chore(deps): align federated gamma shared deps and fix jest ESM configs

### DIFF
--- a/.circleci/ci/src/jobs/frontend/job-chromatic-console.ts
+++ b/.circleci/ci/src/jobs/frontend/job-chromatic-console.ts
@@ -90,6 +90,6 @@ gh pr edit --body "$CLEAN_BODY$PR_BODY_STORYBOOK_SECTION"`,
       new reusable.ReusedCommand(notifyOnFailureCommand),
     ];
 
-    return new Job(ChromaticConsoleJob.jobName, NodeLtsExecutor.create('small'), steps);
+    return new Job(ChromaticConsoleJob.jobName, NodeLtsExecutor.create('medium'), steps);
   }
 }

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-4-1-x.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-4-1-x.yml
@@ -656,7 +656,7 @@ jobs:
   job-console-webui-chromatic-deployment:
     docker:
       - image: cimg/node:22.12.0
-    resource_class: small
+    resource_class: medium
     steps:
       - checkout
       - attach_workspace:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-console-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-console-only.yml
@@ -203,7 +203,7 @@ jobs:
   job-console-webui-chromatic-deployment:
     docker:
       - image: cimg/node:22.12.0
-    resource_class: small
+    resource_class: medium
     steps:
       - checkout
       - attach_workspace:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch.yml
@@ -632,7 +632,7 @@ jobs:
   job-console-webui-chromatic-deployment:
     docker:
       - image: cimg/node:22.12.0
-    resource_class: small
+    resource_class: medium
     steps:
       - checkout
       - attach_workspace:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-master.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-master.yml
@@ -656,7 +656,7 @@ jobs:
   job-console-webui-chromatic-deployment:
     docker:
       - image: cimg/node:22.12.0
-    resource_class: small
+    resource_class: medium
     steps:
       - checkout
       - attach_workspace:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-mergify.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-mergify.yml
@@ -632,7 +632,7 @@ jobs:
   job-console-webui-chromatic-deployment:
     docker:
       - image: cimg/node:22.12.0
-    resource_class: small
+    resource_class: medium
     steps:
       - checkout
       - attach_workspace:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-run-e2e.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-run-e2e.yml
@@ -657,7 +657,7 @@ jobs:
   job-console-webui-chromatic-deployment:
     docker:
       - image: cimg/node:22.12.0
-    resource_class: small
+    resource_class: medium
     steps:
       - checkout
       - attach_workspace:

--- a/gravitee-gamma/gravitee-gamma-control-plane-webui/jest.config.ts
+++ b/gravitee-gamma/gravitee-gamma-control-plane-webui/jest.config.ts
@@ -29,5 +29,5 @@ export default {
         '^.+\\.[tj]sx?$': ['babel-jest', { presets: ['@nx/react/babel'] }],
     },
     moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
-    coverageDirectory: __dirname + '/coverage',
+    coverageDirectory: '<rootDir>/coverage',
 };

--- a/gravitee-gamma/gravitee-gamma-control-plane-webui/src/pages/home/HomePage.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-control-plane-webui/src/pages/home/HomePage.spec.tsx
@@ -62,19 +62,21 @@ describe('HomePage', () => {
         respondWith('get', `${TEST_GAMMA_BASE}/environments/env-1-id/modules/aim/catalog/agents`, { pagination: { totalCount: 0 } });
     });
 
-    it('should render one Open link per module + the Coming soon card when all modules are present', async () => {
+    it('should render one Open link per active module + the Coming soon cards when all modules are present', async () => {
         renderHome(ALL_MODULES);
 
-        // 5 cards mapped to 5 modules — each renders an "Open →" CTA inside a <Link>.
+        // 4 active module cards (aim, apim, platform, authz) — each renders an "Open →" CTA
+        // inside a <Link>. Catalog and Event API Management are now `coming-soon` so they have
+        // no Open link even though `catalog` is in the backend modules list.
         await waitFor(() => {
-            expect(screen.getAllByText('Open')).toHaveLength(5);
+            expect(screen.getAllByText('Open')).toHaveLength(4);
         });
 
-        // Static "Coming soon" placeholder is always rendered.
-        expect(screen.getByText('Coming soon')).toBeTruthy();
+        // 2 "Coming soon" placeholders are always rendered (Catalog + Event API Management).
+        expect(screen.getAllByText('Coming soon')).toHaveLength(2);
         expect(screen.getByRole('heading', { level: 3, name: 'Event API Management' })).toBeTruthy();
 
-        // Each module card title is an <h3>.
+        // Each card title is an <h3> — coming-soon cards keep their heading.
         for (const name of ['Agent Management', 'API Management', 'Platform', 'Catalog', 'Authorization']) {
             expect(screen.getByRole('heading', { level: 3, name })).toBeTruthy();
         }
@@ -89,9 +91,9 @@ describe('HomePage', () => {
         // No "Open →" CTA inside this specific card.
         expect(within(card).queryByText('Open')).toBeNull();
 
-        // The other 4 modules still get their Open CTA — 4 not 5.
+        // The other 3 active modules (apim, platform, authz) still get their Open CTA.
         await waitFor(() => {
-            expect(screen.getAllByText('Open')).toHaveLength(4);
+            expect(screen.getAllByText('Open')).toHaveLength(3);
         });
     });
 

--- a/gravitee-gamma/gravitee-gamma-module-apim/jest.config.ts
+++ b/gravitee-gamma/gravitee-gamma-module-apim/jest.config.ts
@@ -36,5 +36,5 @@ export default {
         '^.+\\.[tj]sx?$': ['babel-jest', { presets: ['@nx/react/babel'] }],
     },
     moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
-    coverageDirectory: __dirname + '/coverage',
+    coverageDirectory: '<rootDir>/coverage',
 };

--- a/gravitee-gamma/gravitee-gamma-module-apim/package.json
+++ b/gravitee-gamma/gravitee-gamma-module-apim/package.json
@@ -2,11 +2,11 @@
     "name": "gravitee-gamma-module-apim",
     "private": true,
     "dependencies": {
-        "@gravitee/gamma-modules-sdk": "1.0.0-alpha.2",
-        "@gravitee/graphene-core": "2.12.2",
-        "@tanstack/react-query": "^5.80.1",
-        "react": "19.2.4",
-        "react-dom": "19.2.4",
-        "react-router-dom": "7.13.1"
+        "@gravitee/gamma-modules-sdk": "1.0.0-alpha.4",
+        "@gravitee/graphene-core": "2.25.1",
+        "@tanstack/react-query": "5.100.14",
+        "react": "19.2.6",
+        "react-dom": "19.2.6",
+        "react-router-dom": "7.15.1"
     }
 }

--- a/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/components/list/ApiListTable.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-apim/src/main/ui/features/apis/components/list/ApiListTable.spec.tsx
@@ -46,11 +46,14 @@ describe('ApiListTable', () => {
 
     afterEach(() => jest.clearAllMocks());
 
-    it('renders skeleton rows when loading', () => {
+    it('renders skeleton rows when loading', async () => {
         const { container } = renderTable({ isLoading: true, skeletonRowCount: 3 });
-        // Each skeleton row has 5 Skeleton elements
-        const skeletons = container.querySelectorAll('[class*="animate-pulse"]');
-        expect(skeletons.length).toBeGreaterThan(0);
+        // Each skeleton row has 5 Skeleton elements. DataTable defers skeletons by ~200ms (loadingDelay)
+        // to prevent flash on fast requests, so we have to wait for them.
+        await waitFor(() => {
+            const skeletons = container.querySelectorAll('[class*="animate-pulse"]');
+            expect(skeletons.length).toBeGreaterThan(0);
+        });
     });
 
     it('renders the empty state when no APIs are present', () => {

--- a/gravitee-gamma/gravitee-gamma-module-authz/package.json
+++ b/gravitee-gamma/gravitee-gamma-module-authz/package.json
@@ -2,14 +2,14 @@
     "name": "gravitee-gamma-module-authz",
     "private": true,
     "dependencies": {
-        "@gravitee/gamma-modules-sdk": "1.0.0-alpha.2",
-        "@gravitee/graphene-core": "2.12.2",
+        "@gravitee/gamma-modules-sdk": "1.0.0-alpha.4",
+        "@gravitee/graphene-core": "2.25.1",
         "@monaco-editor/react": "4.7.0",
-        "@tanstack/react-query": "5.100.10",
+        "@tanstack/react-query": "5.100.14",
         "@tanstack/react-table": "8.21.3",
         "monaco-editor": "0.52.2",
-        "react": "19.2.4",
-        "react-dom": "19.2.4",
-        "react-router-dom": "7.13.1"
+        "react": "19.2.6",
+        "react-dom": "19.2.6",
+        "react-router-dom": "7.15.1"
     }
 }

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/components/MonacoEditor.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/components/MonacoEditor.tsx
@@ -13,9 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { useEffect, useState } from 'react';
 import Editor, { type EditorProps, type OnMount } from '@monaco-editor/react';
 import type * as monacoNs from 'monaco-editor';
+import { useEffect, useState } from 'react';
 import { GAPL_LANGUAGE_ID, registerGaplLanguage } from './gapl-language';
 
 export interface MonacoEditorProps {

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/components/__tests__/MonacoEditor.test.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/components/__tests__/MonacoEditor.test.tsx
@@ -31,11 +31,7 @@ const capturedTheme: { current: string | null } = {
 
 vi.mock('@monaco-editor/react', () => ({
     __esModule: true,
-    default: (props: {
-        onMount?: (editor: unknown, monaco: unknown) => void;
-        options?: Record<string, unknown>;
-        theme?: string;
-    }) => {
+    default: (props: { onMount?: (editor: unknown, monaco: unknown) => void; options?: Record<string, unknown>; theme?: string }) => {
         capturedOnMount.current = props.onMount ?? null;
         capturedOptions.current = props.options ?? null;
         capturedTheme.current = props.theme ?? null;

--- a/gravitee-gamma/gravitee-gamma-module-platform/jest.config.ts
+++ b/gravitee-gamma/gravitee-gamma-module-platform/jest.config.ts
@@ -36,5 +36,5 @@ export default {
         '^.+\\.[tj]sx?$': ['babel-jest', { presets: ['@nx/react/babel'] }],
     },
     moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
-    coverageDirectory: __dirname + '/coverage',
+    coverageDirectory: '<rootDir>/coverage',
 };

--- a/gravitee-gamma/gravitee-gamma-module-platform/package.json
+++ b/gravitee-gamma/gravitee-gamma-module-platform/package.json
@@ -2,11 +2,11 @@
     "name": "gravitee-gamma-module-platform",
     "private": true,
     "dependencies": {
-        "@gravitee/gamma-modules-sdk": "1.0.0-alpha.2",
-        "@gravitee/graphene-core": "1.0.0-alpha.4",
-        "@tanstack/react-query": "5.90.12",
-        "react": "19.2.4",
-        "react-dom": "19.2.4",
-        "react-router-dom": "7.13.1"
+        "@gravitee/gamma-modules-sdk": "1.0.0-alpha.4",
+        "@gravitee/graphene-core": "2.25.1",
+        "@tanstack/react-query": "5.100.14",
+        "react": "19.2.6",
+        "react-dom": "19.2.6",
+        "react-router-dom": "7.15.1"
     }
 }

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
         "@fontsource/material-icons-two-tone": "5.2.5",
         "@fontsource/montserrat": "5.2.5",
         "@fontsource/roboto": "5.2.5",
-        "@gravitee/graphene-core": "2.12.2",
+        "@gravitee/graphene-core": "2.25.1",
         "@gravitee/ui-analytics": "17.8.0",
         "@gravitee/ui-components": "4.4.0",
         "@gravitee/ui-particles-angular": "17.8.0",

--- a/pom.xml
+++ b/pom.xml
@@ -338,8 +338,7 @@
         <gravitee-resource-ai-model-token-classification.version>1.0.0</gravitee-resource-ai-model-token-classification.version>
 
         <!-- Gamma plugins -->
-        <gravitee-gamma-module-aim.version>1.0.0-alpha.58</gravitee-gamma-module-aim.version>
-        <gravitee-gamma-module-authz.version>1.0.0-alpha.3</gravitee-gamma-module-authz.version>
+        <gravitee-gamma-module-aim.version>1.0.0-alpha.62</gravitee-gamma-module-aim.version>
 
         <!-- Authz plugins -->
         <gravitee-service-authz-pdp.version>1.0.0-alpha.1</gravitee-service-authz-pdp.version>

--- a/yarn.lock
+++ b/yarn.lock
@@ -4524,9 +4524,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@gravitee/graphene-core@npm:2.12.2":
-  version: 2.12.2
-  resolution: "@gravitee/graphene-core@npm:2.12.2"
+"@gravitee/graphene-core@npm:2.25.1":
+  version: 2.25.1
+  resolution: "@gravitee/graphene-core@npm:2.25.1"
   dependencies:
     "@base-ui/react": "npm:1.4.1"
     "@types/json-schema": "npm:7.0.15"
@@ -4587,7 +4587,7 @@ __metadata:
       optional: true
   bin:
     graphene-sync-ai-rules: scripts/sync-ai-rules.mjs
-  checksum: 10c0/284850665b993ca6573f86b8c0c5c52e0ccede2ac24cf921506e54ac38401156c74b6377331770a5e1d2894bb588235270997c9cc7e7aef9d696a7a9cceaeb3d
+  checksum: 10c0/ddc2daf6d304736a891348cd3a2ffe60781fb185389afee2553c85fba015eca30ad041d640ba73e7a9f0ed7f337c46f87e8ed7b799e1c7e2139b2db19dc229ab
   languageName: node
   linkType: hard
 
@@ -21360,7 +21360,7 @@ __metadata:
     "@fontsource/montserrat": "npm:5.2.5"
     "@fontsource/roboto": "npm:5.2.5"
     "@gravitee/gamma-modules-sdk": "npm:1.0.0-alpha.2"
-    "@gravitee/graphene-core": "npm:2.12.2"
+    "@gravitee/graphene-core": "npm:2.25.1"
     "@gravitee/ui-analytics": "npm:17.8.0"
     "@gravitee/ui-components": "npm:4.4.0"
     "@gravitee/ui-particles-angular": "npm:17.8.0"


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/GMA-158

## Description

Two related changes for the federated gamma front-end stack:

**1. Align shared dependencies across federated gamma modules (`platform`, `apim`, `authz`) and the workspace root.**

- `@gravitee/graphene-core`: `1.0.0-alpha.4` / `2.12.2` → **`2.25.1`**. The `platform` module was pinned to a `1.0.0-alpha.X` pre-release track (graphene's policy-studio alpha line) while `apim`/`authz` sat at `2.12.2`. Because `platform` is the federation host, its older track was winning the `singleton: true, strictVersion: false` resolution at runtime and any consumer expecting symbols added in `2.x` (`CopyableText`, `useLayoutConfig`, several icons) got `undefined`.
- `@gravitee/gamma-modules-sdk`: `1.0.0-alpha.2` → `1.0.0-alpha.4`.
- `react` / `react-dom`: `19.2.4` → `19.2.6`.
- `react-router-dom`: `7.13.1` → `7.15.1`.
- `@tanstack/react-query`: → `5.100.14`.

**2. Fix the `__dirname` ESM crash in the three `jest.config.ts` files of the gamma modules.**

`platform`, `apim`, and `control-plane-webui` all set `coverageDirectory: __dirname + '/coverage'`. `jest-config` loads `.ts` configs as ESM under Node 24, where `__dirname` is not defined — so config parse blew up with `ReferenceError: __dirname is not defined in ES module scope` before any test could run. Replaced by Jest's own `<rootDir>` substitution token. The other `jest.config.js` (CommonJS) configs in the repo are unaffected.

** Fix tests**
Units tests now fail due to dependencies update (and maybe the fix of jest.config ?). They have been fixed

## Additional context

Bug surfaced while testing the AIM "Create API tool" wizard: clicking on a freshly-imported tool threw `Element type is invalid ... got: undefined` from a `<CopyableText>` rendered inside `ToolDetailPage`. Stack trace showed graphene loaded from the host (port 4200) while AIM (port 8083) had its own newer copy — singleton kept the host's version.

The pre-existing `gravitee-gamma-module-apim` test failure on `ApiListTable.spec.tsx` (skeleton class selector) was already failing on `master` before this branch — confirmed by stashing the changes and rerunning — out of scope here.