### PR TITLE
feat(portal-nav): add backend endpoint to seed default Overview pages

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/PortalNavigationItemsMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/PortalNavigationItemsMapper.java
@@ -17,6 +17,7 @@ package io.gravitee.rest.api.management.v2.rest.mapper;
 
 import io.gravitee.apim.core.exception.TechnicalDomainException;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
+import io.gravitee.apim.core.portal_page.use_case.SeedDefaultPagesForApiNavigationItemsUseCase;
 import io.gravitee.rest.api.management.v2.rest.model.BaseCreatePortalNavigationItem;
 import io.gravitee.rest.api.management.v2.rest.model.BaseUpdatePortalNavigationItem;
 import io.gravitee.rest.api.management.v2.rest.model.CreatePortalNavigationApi;
@@ -25,6 +26,7 @@ import io.gravitee.rest.api.management.v2.rest.model.CreatePortalNavigationLink;
 import io.gravitee.rest.api.management.v2.rest.model.CreatePortalNavigationPage;
 import io.gravitee.rest.api.management.v2.rest.model.PortalNavigationItem;
 import io.gravitee.rest.api.management.v2.rest.model.PortalPageContentType;
+import io.gravitee.rest.api.management.v2.rest.model.SeedDefaultPagesRequest;
 import io.gravitee.rest.api.management.v2.rest.model.UpdatePortalNavigationApi;
 import io.gravitee.rest.api.management.v2.rest.model.UpdatePortalNavigationFolder;
 import io.gravitee.rest.api.management.v2.rest.model.UpdatePortalNavigationLink;
@@ -121,6 +123,18 @@ public interface PortalNavigationItemsMapper {
         List<io.gravitee.rest.api.management.v2.rest.model.BaseCreatePortalNavigationItem> createPortalNavigationItems
     ) {
         return createPortalNavigationItems.stream().map(this::map).toList();
+    }
+
+    default SeedDefaultPagesForApiNavigationItemsUseCase.Input mapSeedDefaultPagesInput(
+        String organizationId,
+        String environmentId,
+        SeedDefaultPagesRequest request
+    ) {
+        return new SeedDefaultPagesForApiNavigationItemsUseCase.Input(
+            organizationId,
+            environmentId,
+            request.getIds().stream().map(this::map).toList()
+        );
     }
 
     default PortalNavigationItemId map(UUID id) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/environment/PortalNavigationItemsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/environment/PortalNavigationItemsResource.java
@@ -21,13 +21,13 @@ import io.gravitee.apim.core.portal_page.model.PortalNavigationItemViewerContext
 import io.gravitee.apim.core.portal_page.use_case.BulkCreatePortalNavigationItemUseCase;
 import io.gravitee.apim.core.portal_page.use_case.CreatePortalNavigationItemUseCase;
 import io.gravitee.apim.core.portal_page.use_case.ListPortalNavigationItemsUseCase;
+import io.gravitee.apim.core.portal_page.use_case.SeedDefaultPagesForApiNavigationItemsUseCase;
 import io.gravitee.common.http.MediaType;
 import io.gravitee.rest.api.management.v2.rest.mapper.PortalNavigationItemsMapper;
 import io.gravitee.rest.api.management.v2.rest.model.BaseCreatePortalNavigationItem;
 import io.gravitee.rest.api.management.v2.rest.model.BaseCreatePortalNavigationItems;
-import io.gravitee.rest.api.management.v2.rest.model.CreatePortalNavigationItems;
-import io.gravitee.rest.api.management.v2.rest.model.PortalNavigationItem;
 import io.gravitee.rest.api.management.v2.rest.model.PortalNavigationItemsResponse;
+import io.gravitee.rest.api.management.v2.rest.model.SeedDefaultPagesRequest;
 import io.gravitee.rest.api.management.v2.rest.resource.AbstractResource;
 import io.gravitee.rest.api.model.permissions.RolePermission;
 import io.gravitee.rest.api.model.permissions.RolePermissionAction;
@@ -48,7 +48,6 @@ import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.container.ResourceContext;
 import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.Response;
-import java.util.List;
 import java.util.Optional;
 import lombok.CustomLog;
 
@@ -69,6 +68,9 @@ public class PortalNavigationItemsResource extends AbstractResource {
 
     @Inject
     private ListPortalNavigationItemsUseCase listPortalNavigationItemsUseCase;
+
+    @Inject
+    private SeedDefaultPagesForApiNavigationItemsUseCase seedDefaultPagesForApiNavigationItemsUseCase;
 
     private final PortalNavigationItemsMapper mapper = PortalNavigationItemsMapper.INSTANCE;
 
@@ -137,6 +139,24 @@ public class PortalNavigationItemsResource extends AbstractResource {
         );
 
         return Response.ok(new PortalNavigationItemsResponse().items(mapper.map(output.items()))).build();
+    }
+
+    @Path("_default-pages")
+    @POST
+    @Permissions({ @Permission(value = RolePermission.ENVIRONMENT_DOCUMENTATION, acls = { RolePermissionAction.CREATE }) })
+    @Consumes(MediaType.APPLICATION_JSON)
+    public Response seedDefaultPages(@Valid @NotNull final SeedDefaultPagesRequest seedDefaultPagesRequest) {
+        final var executionContext = GraviteeContext.getExecutionContext();
+
+        seedDefaultPagesForApiNavigationItemsUseCase.execute(
+            new SeedDefaultPagesForApiNavigationItemsUseCase.Input(
+                executionContext.getOrganizationId(),
+                executionContext.getEnvironmentId(),
+                seedDefaultPagesRequest.getIds().stream().map(PortalNavigationItemId::of).toList()
+            )
+        );
+
+        return Response.noContent().build();
     }
 
     @Path("{navId}")

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/environment/PortalNavigationItemsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/environment/PortalNavigationItemsResource.java
@@ -149,10 +149,10 @@ public class PortalNavigationItemsResource extends AbstractResource {
         final var executionContext = GraviteeContext.getExecutionContext();
 
         seedDefaultPagesForApiNavigationItemsUseCase.execute(
-            new SeedDefaultPagesForApiNavigationItemsUseCase.Input(
+            mapper.mapSeedDefaultPagesInput(
                 executionContext.getOrganizationId(),
                 executionContext.getEnvironmentId(),
-                seedDefaultPagesRequest.getIds().stream().map(PortalNavigationItemId::of).toList()
+                seedDefaultPagesRequest
             )
         );
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-environments.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-environments.yaml
@@ -2279,6 +2279,8 @@ components:
           minItems: 1
           items:
             type: string
+            format: uuid
+            pattern: '^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$'
       required: [ ids ]
 
     BaseUpdatePortalNavigationItem:

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-environments.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-environments.yaml
@@ -977,6 +977,25 @@ paths:
         default:
           $ref: "#/components/responses/Error"
 
+  /portal-navigation-items/_default-pages:
+    post:
+      tags:
+        - Portal Navigation Items
+      summary: Seed default pages for API navigation items
+      description: User must have the ENVIRONMENT_DOCUMENTATION[create] permission.
+      operationId: seedDefaultPages
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/SeedDefaultPagesRequest"
+        required: true
+      responses:
+        "204":
+          description: Default pages seeded
+        default:
+          $ref: "#/components/responses/Error"
+
   /portal-navigation-items/{navId}:
     put:
       tags:
@@ -2250,6 +2269,17 @@ components:
           items:
             $ref: "#/components/schemas/BaseCreatePortalNavigationItem"
       required: [ items ]
+
+    SeedDefaultPagesRequest:
+      type: object
+      description: Portal navigation API item ids that should receive their default overview page
+      properties:
+        ids:
+          type: array
+          minItems: 1
+          items:
+            type: string
+      required: [ ids ]
 
     BaseUpdatePortalNavigationItem:
       type: object

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/environment/PortalNavigationItemsResource_SeedDefaultPagesTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/environment/PortalNavigationItemsResource_SeedDefaultPagesTest.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.management.v2.rest.resource.environment;
+
+import static assertions.MAPIAssertions.assertThat;
+import static fixtures.core.model.PortalNavigationItemFixtures.API1_ID;
+import static fixtures.core.model.PortalNavigationItemFixtures.API2_ID;
+import static io.gravitee.common.http.HttpStatusCode.BAD_REQUEST_400;
+import static io.gravitee.common.http.HttpStatusCode.FORBIDDEN_403;
+import static io.gravitee.common.http.HttpStatusCode.NO_CONTENT_204;
+import static jakarta.ws.rs.client.Entity.json;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.apim.core.portal_page.use_case.SeedDefaultPagesForApiNavigationItemsUseCase;
+import io.gravitee.rest.api.management.v2.rest.model.SeedDefaultPagesRequest;
+import io.gravitee.rest.api.management.v2.rest.resource.AbstractResourceTest;
+import io.gravitee.rest.api.model.EnvironmentEntity;
+import io.gravitee.rest.api.model.permissions.RolePermission;
+import io.gravitee.rest.api.model.permissions.RolePermissionAction;
+import io.gravitee.rest.api.service.EnvironmentService;
+import io.gravitee.rest.api.service.common.GraviteeContext;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.client.WebTarget;
+import jakarta.ws.rs.core.Response;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class PortalNavigationItemsResource_SeedDefaultPagesTest extends AbstractResourceTest {
+
+    private static final String ENVIRONMENT = "environment-id";
+
+    @Inject
+    private SeedDefaultPagesForApiNavigationItemsUseCase seedDefaultPagesForApiNavigationItemsUseCase;
+
+    @Inject
+    private EnvironmentService environmentService;
+
+    private WebTarget target;
+
+    @Override
+    protected String contextPath() {
+        return "/environments/" + ENVIRONMENT + "/portal-navigation-items/_default-pages";
+    }
+
+    @BeforeEach
+    public void setUp() {
+        target = rootTarget();
+
+        var environmentEntity = EnvironmentEntity.builder().id(ENVIRONMENT).organizationId(ORGANIZATION).build();
+        when(environmentService.findById(ENVIRONMENT)).thenReturn(environmentEntity);
+        when(environmentService.findByOrgAndIdOrHrid(ORGANIZATION, ENVIRONMENT)).thenReturn(environmentEntity);
+
+        GraviteeContext.setCurrentEnvironment(ENVIRONMENT);
+        GraviteeContext.setCurrentOrganization(ORGANIZATION);
+
+        when(
+            permissionService.hasPermission(
+                GraviteeContext.getExecutionContext(),
+                RolePermission.ENVIRONMENT_DOCUMENTATION,
+                ENVIRONMENT,
+                RolePermissionAction.CREATE
+            )
+        ).thenReturn(true);
+    }
+
+    @AfterEach
+    public void tearDown() {
+        GraviteeContext.cleanContext();
+        Mockito.reset(seedDefaultPagesForApiNavigationItemsUseCase);
+    }
+
+    @Test
+    void should_not_seed_default_pages_when_no_permission() {
+        var request = new SeedDefaultPagesRequest().ids(List.of(API1_ID));
+        when(
+            permissionService.hasPermission(
+                GraviteeContext.getExecutionContext(),
+                RolePermission.ENVIRONMENT_DOCUMENTATION,
+                ENVIRONMENT,
+                RolePermissionAction.CREATE
+            )
+        ).thenReturn(false);
+
+        Response response = target.request().post(json(request));
+
+        assertThat(response).hasStatus(FORBIDDEN_403);
+    }
+
+    @Test
+    void should_seed_default_pages() {
+        var request = new SeedDefaultPagesRequest().ids(List.of(API1_ID, API2_ID));
+        when(seedDefaultPagesForApiNavigationItemsUseCase.execute(any())).thenReturn(
+            new SeedDefaultPagesForApiNavigationItemsUseCase.Output(List.of())
+        );
+
+        Response response = target.request().post(json(request));
+
+        assertThat(response).hasStatus(NO_CONTENT_204);
+        verify(seedDefaultPagesForApiNavigationItemsUseCase).execute(any());
+    }
+
+    @Test
+    void should_return_validation_error_when_ids_is_null() {
+        var request = new SeedDefaultPagesRequest().ids(null);
+
+        Response response = target.request().post(json(request));
+
+        assertThat(response).hasStatus(BAD_REQUEST_400);
+        verifyNoInteractions(seedDefaultPagesForApiNavigationItemsUseCase);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/environment/PortalNavigationItemsResource_SeedDefaultPagesTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/environment/PortalNavigationItemsResource_SeedDefaultPagesTest.java
@@ -39,6 +39,7 @@ import jakarta.inject.Inject;
 import jakarta.ws.rs.client.WebTarget;
 import jakarta.ws.rs.core.Response;
 import java.util.List;
+import java.util.UUID;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
@@ -93,7 +94,7 @@ class PortalNavigationItemsResource_SeedDefaultPagesTest extends AbstractResourc
 
     @Test
     void should_not_seed_default_pages_when_no_permission() {
-        var request = new SeedDefaultPagesRequest().ids(List.of(API1_ID));
+        var request = new SeedDefaultPagesRequest().ids(List.of(UUID.fromString(API1_ID)));
         when(
             permissionService.hasPermission(
                 GraviteeContext.getExecutionContext(),
@@ -110,7 +111,7 @@ class PortalNavigationItemsResource_SeedDefaultPagesTest extends AbstractResourc
 
     @Test
     void should_seed_default_pages() {
-        var request = new SeedDefaultPagesRequest().ids(List.of(API1_ID, API2_ID));
+        var request = new SeedDefaultPagesRequest().ids(List.of(UUID.fromString(API1_ID), UUID.fromString(API2_ID)));
         when(seedDefaultPagesForApiNavigationItemsUseCase.execute(any())).thenReturn(
             new SeedDefaultPagesForApiNavigationItemsUseCase.Output(List.of())
         );

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/spring/ResourceContextConfiguration.java
@@ -200,6 +200,7 @@ import io.gravitee.apim.core.portal_page.use_case.CreatePortalNavigationItemUseC
 import io.gravitee.apim.core.portal_page.use_case.DeletePortalNavigationItemUseCase;
 import io.gravitee.apim.core.portal_page.use_case.GetPortalPageContentUseCase;
 import io.gravitee.apim.core.portal_page.use_case.ListPortalNavigationItemsUseCase;
+import io.gravitee.apim.core.portal_page.use_case.SeedDefaultPagesForApiNavigationItemsUseCase;
 import io.gravitee.apim.core.portal_page.use_case.UpdatePortalNavigationItemUseCase;
 import io.gravitee.apim.core.portal_page.use_case.UpdatePortalPageContentUseCase;
 import io.gravitee.apim.core.promotion.service_provider.CockpitPromotionServiceProvider;
@@ -1288,6 +1289,11 @@ public class ResourceContextConfiguration {
     @Bean
     public BulkCreatePortalNavigationItemUseCase bulkCreatePortalNavigationItemUseCase() {
         return mock(BulkCreatePortalNavigationItemUseCase.class);
+    }
+
+    @Bean
+    public SeedDefaultPagesForApiNavigationItemsUseCase seedDefaultPagesForApiNavigationItemsUseCase() {
+        return mock(SeedDefaultPagesForApiNavigationItemsUseCase.class);
     }
 
     @Bean

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/use_case/SeedDefaultPagesForApiNavigationItemsUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/use_case/SeedDefaultPagesForApiNavigationItemsUseCase.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal_page.use_case;
+
+import io.gravitee.apim.core.UseCase;
+import io.gravitee.apim.core.gravitee_markdown.GraviteeMarkdown;
+import io.gravitee.apim.core.portal_page.crud_service.PortalPageContentCrudService;
+import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemDomainService;
+import io.gravitee.apim.core.portal_page.model.CreatePortalNavigationItem;
+import io.gravitee.apim.core.portal_page.model.GraviteeMarkdownPageContent;
+import io.gravitee.apim.core.portal_page.model.PortalArea;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationApi;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItemType;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationPage;
+import io.gravitee.apim.core.portal_page.model.PortalPageContentId;
+import io.gravitee.apim.core.portal_page.model.PortalPageContentType;
+import io.gravitee.apim.core.portal_page.query_service.PortalNavigationItemsQueryService;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.CustomLog;
+import lombok.RequiredArgsConstructor;
+
+@UseCase
+@RequiredArgsConstructor
+@CustomLog
+public class SeedDefaultPagesForApiNavigationItemsUseCase {
+
+    private static final String DEFAULT_PAGE_TITLE = "Overview";
+    private static final String DEFAULT_OVERVIEW_TEMPLATE = "api-overview-page-content.md";
+
+    private final PortalNavigationItemsQueryService portalNavigationItemsQueryService;
+    private final PortalNavigationItemDomainService portalNavigationItemDomainService;
+    private final PortalPageContentCrudService portalPageContentCrudService;
+
+    public Output execute(Input input) {
+        var seededNavigationItemIds = new ArrayList<PortalNavigationItemId>();
+
+        for (var apiNavigationItemId : input.apiNavigationItemIds()) {
+            try {
+                if (seedDefaultPage(input.organizationId(), input.environmentId(), apiNavigationItemId)) {
+                    seededNavigationItemIds.add(apiNavigationItemId);
+                }
+            } catch (Exception e) {
+                log.warn(
+                    "Skipping default page seed for portal navigation item {} in environment {}",
+                    apiNavigationItemId,
+                    input.environmentId(),
+                    e
+                );
+            }
+        }
+
+        return new Output(List.copyOf(seededNavigationItemIds));
+    }
+
+    private boolean seedDefaultPage(String organizationId, String environmentId, PortalNavigationItemId apiNavigationItemId) {
+        var navigationItem = portalNavigationItemsQueryService.findByIdAndEnvironmentId(environmentId, apiNavigationItemId);
+        if (!(navigationItem instanceof PortalNavigationApi apiNavigationItem)) {
+            return false;
+        }
+
+        var hasChildPage = portalNavigationItemsQueryService
+            .findByParentIdAndEnvironmentId(environmentId, apiNavigationItemId)
+            .stream()
+            .anyMatch(PortalNavigationPage.class::isInstance);
+        if (hasChildPage) {
+            return false;
+        }
+
+        var content = portalPageContentCrudService.create(
+            new GraviteeMarkdownPageContent(
+                PortalPageContentId.random(),
+                organizationId,
+                environmentId,
+                GraviteeMarkdown.of(loadContent(DEFAULT_OVERVIEW_TEMPLATE))
+            )
+        );
+
+        portalNavigationItemDomainService.create(
+            organizationId,
+            environmentId,
+            CreatePortalNavigationItem.builder()
+                .title(DEFAULT_PAGE_TITLE)
+                .type(PortalNavigationItemType.PAGE)
+                .area(PortalArea.TOP_NAVBAR)
+                .parentId(apiNavigationItemId)
+                .portalPageContentId(content.getId())
+                .contentType(PortalPageContentType.GRAVITEE_MARKDOWN)
+                .order(0)
+                .published(false)
+                .visibility(apiNavigationItem.getVisibility())
+                .build()
+        );
+
+        return true;
+    }
+
+    private String loadContent(String contentPath) {
+        try (
+            var inputStream = Thread.currentThread().getContextClassLoader().getResourceAsStream(String.format("templates/%s", contentPath))
+        ) {
+            if (inputStream == null) {
+                throw new IllegalStateException(String.format("Could not load default portal page template for %s", contentPath));
+            }
+            return new String(inputStream.readAllBytes());
+        } catch (Exception e) {
+            throw new IllegalStateException("Could not load default portal page template", e);
+        }
+    }
+
+    public record Input(String organizationId, String environmentId, List<PortalNavigationItemId> apiNavigationItemIds) {}
+
+    public record Output(List<PortalNavigationItemId> seededNavigationItemIds) {}
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/use_case/SeedDefaultPagesForApiNavigationItemsUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/use_case/SeedDefaultPagesForApiNavigationItemsUseCase.java
@@ -16,7 +16,6 @@
 package io.gravitee.apim.core.portal_page.use_case;
 
 import io.gravitee.apim.core.UseCase;
-import io.gravitee.apim.core.gravitee_markdown.GraviteeMarkdown;
 import io.gravitee.apim.core.portal_page.crud_service.PortalPageContentCrudService;
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemDomainService;
 import io.gravitee.apim.core.portal_page.model.CreatePortalNavigationItem;
@@ -26,7 +25,6 @@ import io.gravitee.apim.core.portal_page.model.PortalNavigationApi;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemType;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationPage;
-import io.gravitee.apim.core.portal_page.model.PortalPageContentId;
 import io.gravitee.apim.core.portal_page.model.PortalPageContentType;
 import io.gravitee.apim.core.portal_page.query_service.PortalNavigationItemsQueryService;
 import java.util.ArrayList;
@@ -82,12 +80,7 @@ public class SeedDefaultPagesForApiNavigationItemsUseCase {
         }
 
         var content = portalPageContentCrudService.create(
-            new GraviteeMarkdownPageContent(
-                PortalPageContentId.random(),
-                organizationId,
-                environmentId,
-                GraviteeMarkdown.of(loadContent(DEFAULT_OVERVIEW_TEMPLATE))
-            )
+            GraviteeMarkdownPageContent.create(organizationId, environmentId, loadContent(DEFAULT_OVERVIEW_TEMPLATE))
         );
 
         portalNavigationItemDomainService.create(

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/resources/templates/api-overview-page-content.md
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/resources/templates/api-overview-page-content.md
@@ -1,0 +1,18 @@
+# ${api.name}
+
+Welcome to the documentation for **${api.name}**.
+
+<#if api.description?? && api.description?has_content>
+${api.description}
+
+</#if>
+## API information
+
+- Version: `${api.version!""}`
+- Type: `${api.type!""}`
+- Visibility: `${api.visibility!""}`
+- Identifier: `${api.id}`
+
+## Explore the API
+
+Use this space to describe how consumers should get started with this API, which use cases it supports, and where to find the most important resources.

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/SeedDefaultPagesForApiNavigationItemsUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/SeedDefaultPagesForApiNavigationItemsUseCaseTest.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal_page.use_case;
+
+import static fixtures.core.model.PortalNavigationItemFixtures.API1_ID;
+import static fixtures.core.model.PortalNavigationItemFixtures.APIS_ID;
+import static fixtures.core.model.PortalNavigationItemFixtures.ENV_ID;
+import static fixtures.core.model.PortalNavigationItemFixtures.ORG_ID;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import fixtures.core.model.PortalNavigationItemFixtures;
+import inmemory.ApiCrudServiceInMemory;
+import inmemory.PortalNavigationItemsCrudServiceInMemory;
+import inmemory.PortalNavigationItemsQueryServiceInMemory;
+import inmemory.PortalPageContentCrudServiceInMemory;
+import io.gravitee.apim.core.api.model.Api;
+import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemDomainService;
+import io.gravitee.apim.core.portal_page.model.GraviteeMarkdownPageContent;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationApi;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItem;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationPage;
+import io.gravitee.apim.core.portal_page.model.PortalPageContentId;
+import io.gravitee.definition.model.v4.ApiType;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class SeedDefaultPagesForApiNavigationItemsUseCaseTest {
+
+    private SeedDefaultPagesForApiNavigationItemsUseCase useCase;
+    private PortalNavigationItemsCrudServiceInMemory portalNavigationItemsCrudService;
+    private PortalNavigationItemsQueryServiceInMemory portalNavigationItemsQueryService;
+    private PortalPageContentCrudServiceInMemory portalPageContentCrudService;
+
+    @BeforeEach
+    void setUp() {
+        var storage = new ArrayList<PortalNavigationItem>();
+        portalNavigationItemsCrudService = new PortalNavigationItemsCrudServiceInMemory(storage);
+        portalNavigationItemsQueryService = new PortalNavigationItemsQueryServiceInMemory(storage);
+        portalPageContentCrudService = new PortalPageContentCrudServiceInMemory();
+
+        var apiCrudService = new ApiCrudServiceInMemory();
+        apiCrudService.initWith(List.of(Api.builder().id("api-1").name("API 1").version("1.0.0").type(ApiType.PROXY).build()));
+
+        portalNavigationItemsQueryService.initWith(PortalNavigationItemFixtures.sampleNavigationItems());
+
+        useCase = new SeedDefaultPagesForApiNavigationItemsUseCase(
+            portalNavigationItemsQueryService,
+            new PortalNavigationItemDomainService(
+                portalNavigationItemsCrudService,
+                portalNavigationItemsQueryService,
+                portalPageContentCrudService,
+                apiCrudService
+            ),
+            portalPageContentCrudService
+        );
+    }
+
+    @Test
+    void should_seed_default_overview_page_for_api() {
+        var output = useCase.execute(
+            new SeedDefaultPagesForApiNavigationItemsUseCase.Input(ORG_ID, ENV_ID, List.of(PortalNavigationItemId.of(API1_ID)))
+        );
+
+        assertThat(output.seededNavigationItemIds()).containsExactly(PortalNavigationItemId.of(API1_ID));
+        assertThat(portalNavigationItemsQueryService.findByParentIdAndEnvironmentId(ENV_ID, PortalNavigationItemId.of(API1_ID)))
+            .filteredOn(PortalNavigationPage.class::isInstance)
+            .singleElement()
+            .satisfies(item -> {
+                assertThat(item.getTitle()).isEqualTo("Overview");
+                assertThat(item.getPublished()).isFalse();
+            });
+        assertThat(portalPageContentCrudService.storage())
+            .singleElement()
+            .isInstanceOfSatisfying(GraviteeMarkdownPageContent.class, content ->
+                assertThat(content.getContent().value()).isEqualTo(loadTemplate("api-overview-page-content.md"))
+            );
+    }
+
+    @Test
+    void should_skip_seeding_when_api_navigation_item_already_has_a_child_page() {
+        var apiNavigationItem = (PortalNavigationApi) portalNavigationItemsQueryService.findByIdAndEnvironmentId(
+            ENV_ID,
+            PortalNavigationItemId.of(API1_ID)
+        );
+        var existingPage = PortalNavigationItemFixtures.aPage(
+            "00000000-0000-0000-0000-000000000111",
+            "Existing page",
+            apiNavigationItem.getId(),
+            PortalPageContentId.random()
+        );
+        existingPage.updateParent(apiNavigationItem);
+        portalNavigationItemsCrudService.create(existingPage);
+
+        var output = useCase.execute(
+            new SeedDefaultPagesForApiNavigationItemsUseCase.Input(ORG_ID, ENV_ID, List.of(PortalNavigationItemId.of(API1_ID)))
+        );
+
+        assertThat(output.seededNavigationItemIds()).isEmpty();
+        assertThat(portalPageContentCrudService.storage()).isEmpty();
+    }
+
+    @Test
+    void should_skip_navigation_items_that_are_not_api_type() {
+        var output = useCase.execute(
+            new SeedDefaultPagesForApiNavigationItemsUseCase.Input(
+                ORG_ID,
+                ENV_ID,
+                List.of(PortalNavigationItemId.of(APIS_ID), PortalNavigationItemId.of(API1_ID))
+            )
+        );
+
+        assertThat(output.seededNavigationItemIds()).containsExactly(PortalNavigationItemId.of(API1_ID));
+        assertThat(portalPageContentCrudService.storage()).hasSize(1);
+    }
+
+    private String loadTemplate(String templatePath) {
+        try (
+            var inputStream = Thread.currentThread()
+                .getContextClassLoader()
+                .getResourceAsStream(String.format("templates/%s", templatePath))
+        ) {
+            assertThat(inputStream).isNotNull();
+            return new String(inputStream.readAllBytes());
+        } catch (Exception e) {
+            throw new IllegalStateException("Unable to load template " + templatePath, e);
+        }
+    }
+}


### PR DESCRIPTION
Add a Management API v2 endpoint and use case to create unpublished "Overview" child pages for API portal navigation items, using a generic Gravitee Markdown template.

- POST /environments/{envId}/portal-navigation-items/_default-pages
- SeedDefaultPagesForApiNavigationItemsUseCase with skip rules for non-API items and APIs that already have a child page
- Generic api-overview-page-content.md template
- Resource and use case tests

## Issue

https://gravitee.atlassian.net/browse/APIM-14221

## Summary

Adds the **backend** support for creating default "Overview" pages when API navigation items are published to the portal.

This is **PR 1.1** of the "Create default pages when publishing an API" story. Console wiring to call the new endpoint after bulk API nav creation will follow in a separate PR.

## What changed

- **New use case:** `SeedDefaultPagesForApiNavigationItemsUseCase`
  - Accepts a list of API navigation item IDs
  - Skips items that are not API nav items
  - Skips API nav items that already have a child page
  - Creates an unpublished draft `"Overview"` page (`published: false`) with generic GMD content
  - Inherits visibility from the parent API nav item
  - Logs and continues when seeding fails for an individual item

- **New REST endpoint:** `POST /environments/{envId}/portal-navigation-items/_default-pages`
  - Request body: `{ "ids": ["nav-id-1", "nav-id-2"] }`
  - Response: `204 No Content`
  - Permission: `ENVIRONMENT_DOCUMENTATION[CREATE]`

- **OpenAPI:** `SeedDefaultPagesRequest` schema added to `openapi-environments.yaml`

- **Template:** `api-overview-page-content.md` — generic Overview page with FreeMarker placeholders for API metadata

## Out of scope (follow-up PRs)

- Console integration (call seed endpoint after bulk API nav create)
- MCP proxy-specific overview template and install widget
- Portal rendering changes

## Test plan

- [ ] `SeedDefaultPagesForApiNavigationItemsUseCaseTest` passes (3 tests)
- [ ] `PortalNavigationItemsResource_SeedDefaultPagesTest` passes (403, 204, 400)
- [ ] Manual: `POST /_default-pages` with valid API nav item IDs creates unpublished "Overview" child page
- [ ] Manual: calling again for same API nav item does not create duplicate page
- [ ] Manual: non-API nav item IDs are skipped without error

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

