### PR TITLE
feat(console): seed default Overview pages after bulk API nav creation

### DIFF
--- a/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.spec.ts
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.spec.ts
@@ -2124,6 +2124,7 @@ describe('PortalNavigationItemsComponent', () => {
         })),
         fakePortalNavigationItemsResponse({ items: createdApis }),
       );
+      expectSeedDefaultPages(createdApis.map(api => api.id));
 
       await expectGetNavigationItems(fakePortalNavigationItemsResponse({ items: [folder, ...createdApis] }));
     });
@@ -2164,6 +2165,7 @@ describe('PortalNavigationItemsComponent', () => {
         })),
         fakePortalNavigationItemsResponse({ items: createdApis }),
       );
+      expectSeedDefaultPages(createdApis.map(api => api.id));
 
       await expectGetNavigationItems(fakePortalNavigationItemsResponse({ items: [folder, ...createdApis] }));
     });
@@ -2205,6 +2207,7 @@ describe('PortalNavigationItemsComponent', () => {
         })),
         fakePortalNavigationItemsResponse({ items: createdApis }),
       );
+      expectSeedDefaultPages(createdApis.map(api => api.id));
 
       await expectGetNavigationItems(fakePortalNavigationItemsResponse({ items: [privateFolder, ...createdApis] }));
     });
@@ -2287,6 +2290,54 @@ describe('PortalNavigationItemsComponent', () => {
 
       expect(document.body.textContent).toContain('Failed to create API navigation items');
     });
+
+    it('should keep the create flow successful when seeding default pages fails', async () => {
+      const apiIds = ['api-1', 'api-2'];
+      const createdApis = [
+        fakePortalNavigationApi({ id: 'nav-api-1', apiId: 'api-1', title: '', parentId: folder.id }),
+        fakePortalNavigationApi({ id: 'nav-api-2', apiId: 'api-2', title: '', parentId: folder.id }),
+      ];
+
+      await harness.selectNavigationItemByTitle(folder.title);
+
+      const folderNode = { id: folder.id, label: folder.title, type: folder.type, data: folder } as any;
+      component.onNodeMenuAction({ action: 'create', itemType: 'API', node: folderNode });
+      fixture.detectChanges();
+      await fixture.whenStable();
+
+      await expectApiSearchResponse(apiIds);
+
+      const checkboxes = await rootLoader.getAllHarnesses(MatCheckboxHarness.with({ selector: '[data-testid^="api-picker-checkbox-"]' }));
+      await checkboxes[0].check();
+      await checkboxes[1].check();
+
+      const dialog = await rootLoader.getHarness(ApiSectionEditorDialogHarness);
+      await dialog.clickSubmitButton();
+
+      expectCreateNavigationItemsInBulk(
+        apiIds.map(apiId => ({
+          title: '',
+          type: 'API',
+          area: 'TOP_NAVBAR',
+          parentId: folder.id,
+          visibility: 'PUBLIC',
+          apiId,
+        })),
+        fakePortalNavigationItemsResponse({ items: createdApis }),
+      );
+      expectSeedDefaultPages(
+        createdApis.map(api => api.id),
+        500,
+      );
+
+      await expectGetNavigationItems(fakePortalNavigationItemsResponse({ items: [folder, ...createdApis] }));
+
+      await fixture.whenStable();
+      fixture.detectChanges();
+
+      expect(document.body.textContent).toContain('Failed to create default API pages');
+      expect(routerSpy).toHaveBeenCalledWith(['.'], expect.objectContaining({ queryParams: { navId: createdApis[1].id } }));
+    });
   });
 
   function fakeSectionNode(sectionNode: Partial<SectionNode>): SectionNode {
@@ -2334,6 +2385,21 @@ describe('PortalNavigationItemsComponent', () => {
     });
     expect(req.request.body).toEqual({ items: requestItems });
     req.flush(result);
+  }
+
+  function expectSeedDefaultPages(ids: string[], status = 204) {
+    const req = httpTestingController.expectOne({
+      method: 'POST',
+      url: `${CONSTANTS_TESTING.env.v2BaseURL}/portal-navigation-items/_default-pages`,
+    });
+    expect(req.request.body).toEqual({ ids });
+
+    if (status === 204) {
+      req.flush(null, { status: 204, statusText: 'No Content' });
+      return;
+    }
+
+    req.flush('Server error', { status, statusText: 'Internal Server Error' });
   }
 
   function expectPutPortalNavigationItem(id: string, expectedBody: UpdatePortalNavigationItem, response: PortalNavigationItem) {

--- a/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.ts
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.ts
@@ -420,6 +420,23 @@ export class PortalNavigationItemsComponent implements HasUnsavedChanges {
     }));
 
     return this.portalNavigationItemsService.createNavigationItemsInBulk(items).pipe(
+      switchMap(response => {
+        const createdApiNavigationItemIds = response.items
+          ?.filter((item): item is PortalNavigationApi => item.type === 'API')
+          .map(item => item.id);
+
+        if (!createdApiNavigationItemIds?.length) {
+          return of(response);
+        }
+
+        return this.portalNavigationItemsService.seedDefaultPages(createdApiNavigationItemIds).pipe(
+          map(() => response),
+          catchError(() => {
+            this.snackBarService.error('Failed to create default API pages');
+            return of(response);
+          }),
+        );
+      }),
       map(response => {
         if (response.items && response.items.length > 0) {
           return response.items[response.items.length - 1].id;

--- a/gravitee-apim-console-webui/src/services-ngx/portal-navigation-item.service.spec.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/portal-navigation-item.service.spec.ts
@@ -166,4 +166,19 @@ describe('PortalNavigationItemService', () => {
       req.flush(fakeResponse);
     });
   });
+
+  describe('seedDefaultPages', () => {
+    it('should call the seed default pages endpoint', done => {
+      const ids = ['nav-api-1', 'nav-api-2'];
+
+      service.seedDefaultPages(ids).subscribe(() => done());
+
+      const req = httpTestingController.expectOne({
+        method: 'POST',
+        url: `${CONSTANTS_TESTING.env.v2BaseURL}/portal-navigation-items/_default-pages`,
+      });
+      expect(req.request.body).toEqual({ ids });
+      req.flush(null);
+    });
+  });
 });

--- a/gravitee-apim-console-webui/src/services-ngx/portal-navigation-item.service.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/portal-navigation-item.service.ts
@@ -47,6 +47,10 @@ export class PortalNavigationItemService {
     return this.http.post<PortalNavigationItemsResponse>(`${this.constants.env.v2BaseURL}/portal-navigation-items/_bulk`, { items });
   }
 
+  public seedDefaultPages(ids: string[]): Observable<void> {
+    return this.http.post<void>(`${this.constants.env.v2BaseURL}/portal-navigation-items/_default-pages`, { ids });
+  }
+
   public updateNavigationItem(
     portalNavigationItemId: string,
     updatePortalNavigationItem: UpdatePortalNavigationItem,


### PR DESCRIPTION
After PortalNavigationItemsComponent successfully creates API navigation items in bulk, call POST /portal-navigation-items/_default-pages with the new API nav item IDs to provision unpublished draft Overview pages.

Failures of the seed call do not block the create flow: the bulk-create response is returned and the user navigates to the last created item, with an error snackbar surfaced.

Depends on APIM-14221 (backend endpoint).

## Issue

https://gravitee.atlassian.net/browse/APIM-14222

## Summary

Wires the Console portal navigation bulk-create flow to the new backend `/_default-pages` endpoint introduced in **APIM-14221**.

After API navigation items are created in bulk, the Console calls the seed endpoint with the new API nav item IDs to provision a draft "Overview" page under each one.

This is **PR 1.2** of the "Create default pages when publishing an API" story.

## What changed

- **`PortalNavigationItemService.seedDefaultPages(ids: string[])`** — new service method posting to `${v2BaseURL}/portal-navigation-items/_default-pages` with `{ ids }`.

- **`PortalNavigationItemsComponent`** — after `createNavigationItemsInBulk` succeeds:
  - Filter the response items to only `type === 'API'`
  - Call `seedDefaultPages` with the resulting IDs
  - On success: continue normal create flow (navigate to last created item)
  - On failure: show snackbar `"Failed to create default API pages"` but **do not** fail the create flow (the bulk-create response is still returned)
  - If no API items were created, skip the seed call entirely

## Tests

- Service: POST URL + `{ ids }` body
- Component:
  - 3 existing bulk-create tests now also expect the seed call
  - New test: seed `500` → create flow still completes, snackbar shown, navigation occurs

## Depends on

- **APIM-14221** (backend endpoint) — must be merged first

## Test plan

- [ ] `portal-navigation-item.service.spec.ts` (7 tests) — passing
- [ ] `portal-navigation-items.component.spec.ts` (94 tests) — passing
- [ ] Manual: bulk-create API nav items → each gets a draft "Overview" child page (visible in tree)
- [ ] Manual: with backend stub returning 500 for `_default-pages`, bulk create still completes and snackbar is shown

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

