### PR TITLE
feat(mcp): add install-mcp GMD component and portal rendering support

### DIFF
--- a/gravitee-apim-portal-webui-next/src/entities/api/api.ts
+++ b/gravitee-apim-portal-webui-next/src/entities/api/api.ts
@@ -76,4 +76,4 @@ export interface Api {
   _links?: ApiLinks;
 }
 
-export type ApiType = 'NATIVE' | 'MESSAGE' | 'PROXY';
+export type ApiType = 'NATIVE' | 'MESSAGE' | 'PROXY' | 'A2A_PROXY' | 'LLM_PROXY' | 'MCP_PROXY';

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/v4/api/ApiModel.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/v4/api/ApiModel.java
@@ -93,6 +93,12 @@ public class ApiModel implements GenericApiModel {
     @Builder.Default
     private Map<String, String> metadata = new HashMap<>();
 
+    @Builder.Default
+    private List<String> entrypoints = new ArrayList<>();
+
+    @Builder.Default
+    private Map<String, Object> mcp = new HashMap<>();
+
     private ApiLifecycleState lifecycleState;
     private boolean disableMembershipNotifications;
     private Failover failover;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/sanitizer/HtmlSanitizer.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/sanitizer/HtmlSanitizer.java
@@ -31,7 +31,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import lombok.Getter;
-import lombok.Setter;
 import org.owasp.html.*;
 import org.springframework.core.env.Environment;
 import org.springframework.stereotype.Component;
@@ -162,6 +161,11 @@ public final class HtmlSanitizer {
          * Allow a set of HTML tags to support GitHub Flavoured Markdown. Spec is available at: <a href="https://github.github.com/gfm">https://github.github.com/gfm</a>
          */
         PolicyFactory githubFlavouredMarkdownSanitizer = new HtmlPolicyBuilder().allowElements("summary", "details").toFactory();
+        PolicyFactory graviteeMarkdownInstallMcpSanitizer = new HtmlPolicyBuilder()
+            .allowElements("gmd-install-mcp")
+            .allowAttributes("name", "transport", "url", "headers", "command", "args", "env", "clients")
+            .onElements("gmd-install-mcp")
+            .toFactory();
 
         PolicyFactory policyFactory = Sanitizers.BLOCKS.and(Sanitizers.FORMATTING)
             .and(
@@ -178,7 +182,8 @@ public final class HtmlSanitizer {
             .and(new HtmlPolicyBuilder().allowElements("ol").allowAttributes("start").onElements("ol").toFactory())
             .and(htmlImagesSanitizer)
             .and(new HtmlPolicyBuilder().allowElements("code").allowAttributes("class").globally().toFactory())
-            .and(githubFlavouredMarkdownSanitizer);
+            .and(githubFlavouredMarkdownSanitizer)
+            .and(graviteeMarkdownInstallMcpSanitizer);
 
         PolicyFactory additionalElementsSanitizer = configureAdditionalElements(policyFactory, environment);
         if (additionalElementsSanitizer != null) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/ApiTemplateServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/ApiTemplateServiceImpl.java
@@ -15,9 +15,13 @@
  */
 package io.gravitee.rest.api.service.v4.impl;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.gravitee.rest.api.model.ApiMetadataEntity;
 import io.gravitee.rest.api.model.ApiModel;
 import io.gravitee.rest.api.model.api.ApiEntity;
+import io.gravitee.rest.api.model.api.ApiEntrypointEntity;
 import io.gravitee.rest.api.model.v4.api.GenericApiEntity;
 import io.gravitee.rest.api.model.v4.api.GenericApiModel;
 import io.gravitee.rest.api.model.v4.nativeapi.NativeApiEntity;
@@ -27,6 +31,7 @@ import io.gravitee.rest.api.service.MetadataService;
 import io.gravitee.rest.api.service.common.ExecutionContext;
 import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
 import io.gravitee.rest.api.service.notification.NotificationTemplateService;
+import io.gravitee.rest.api.service.v4.ApiEntrypointService;
 import io.gravitee.rest.api.service.v4.ApiSearchService;
 import io.gravitee.rest.api.service.v4.ApiTemplateService;
 import io.gravitee.rest.api.service.v4.PrimaryOwnerService;
@@ -36,6 +41,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.stream.Collectors;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Component;
@@ -47,21 +53,26 @@ import org.springframework.stereotype.Component;
 @Component
 public class ApiTemplateServiceImpl implements ApiTemplateService {
 
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
     private final ApiSearchService apiSearchService;
     private final ApiMetadataService apiMetadataService;
     private final PrimaryOwnerService primaryOwnerService;
     private final NotificationTemplateService notificationTemplateService;
+    private final ApiEntrypointService apiEntrypointService;
 
     public ApiTemplateServiceImpl(
         @Lazy final ApiSearchService apiSearchService,
         final ApiMetadataService apiMetadataService,
         final PrimaryOwnerService primaryOwnerService,
-        final NotificationTemplateService notificationTemplateService
+        final NotificationTemplateService notificationTemplateService,
+        @Lazy final ApiEntrypointService apiEntrypointService
     ) {
         this.apiSearchService = apiSearchService;
         this.apiMetadataService = apiMetadataService;
         this.primaryOwnerService = primaryOwnerService;
         this.notificationTemplateService = notificationTemplateService;
+        this.apiEntrypointService = apiEntrypointService;
     }
 
     @Override
@@ -147,6 +158,8 @@ public class ApiTemplateServiceImpl implements ApiTemplateService {
                     apiModelEntity.setServices(apiEntity.getServices());
                     apiModelEntity.setListeners(apiEntity.getListeners());
                     apiModelEntity.setEndpointGroups(apiEntity.getEndpointGroups());
+                    apiModelEntity.setEntrypoints(computeApiEntrypoints(executionContext, apiEntity));
+                    apiModelEntity.setMcp(computeMcp(apiEntity));
 
                     apiModelEntity.setMetadata(getApiMetadata(executionContext, apiId, decodeTemplate, apiModelEntity));
                     yield apiModelEntity;
@@ -237,6 +250,35 @@ public class ApiTemplateServiceImpl implements ApiTemplateService {
             return decodedMetadata;
         } catch (Exception ex) {
             throw new TechnicalManagementException("An error occurs while evaluating API metadata", ex);
+        }
+    }
+
+    private List<String> computeApiEntrypoints(ExecutionContext executionContext, GenericApiEntity api) {
+        return apiEntrypointService.getApiEntrypoints(executionContext, api).stream().map(ApiEntrypointEntity::getTarget).toList();
+    }
+
+    private Map<String, Object> computeMcp(io.gravitee.rest.api.model.v4.api.ApiEntity api) {
+        if (api.getListeners() == null || api.getListeners().isEmpty() || api.getListeners().getFirst().getEntrypoints() == null) {
+            return Map.of();
+        }
+
+        var mcpEntrypoint = api
+            .getListeners()
+            .getFirst()
+            .getEntrypoints()
+            .stream()
+            .filter(entrypoint -> Objects.equals(entrypoint.getType(), "mcp") || Objects.equals(entrypoint.getType(), "mcp-proxy"))
+            .findFirst()
+            .orElse(null);
+
+        if (mcpEntrypoint == null || mcpEntrypoint.getConfiguration() == null) {
+            return Map.of();
+        }
+
+        try {
+            return MAPPER.readValue(mcpEntrypoint.getConfiguration(), new TypeReference<>() {});
+        } catch (JsonProcessingException e) {
+            return Map.of();
         }
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/sanitizer/HtmlSanitizerTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/sanitizer/HtmlSanitizerTest.java
@@ -20,16 +20,11 @@ import static org.junit.Assert.*;
 import org.assertj.core.api.BDDSoftAssertions;
 import org.assertj.core.api.junit.jupiter.InjectSoftAssertions;
 import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
-import org.junit.rules.ErrorCollector;
-import org.owasp.html.HtmlPolicyBuilder;
-import org.owasp.html.PolicyFactory;
-import org.springframework.core.env.ConfigurableEnvironment;
 import org.springframework.mock.env.MockEnvironment;
 
 /**
@@ -244,5 +239,17 @@ public class HtmlSanitizerTest {
         );
         assertFalse(sanitizeInfos.isSafe());
         assertEquals("[Attribute not allowed: [a][download]]", sanitizeInfos.getRejectedMessage());
+    }
+
+    @Test
+    public void shouldAllowGmdInstallMcpComponent() {
+        String content =
+            "<gmd-install-mcp name=\"weather\" transport=\"http\" url=\"https://api.example.com/mcp\" clients=\"cursor\"></gmd-install-mcp>";
+
+        HtmlSanitizer.SanitizeInfos sanitizeInfos = cut.isSafe(content);
+
+        assertTrue(sanitizeInfos.isSafe());
+        assertEquals("[]", sanitizeInfos.getRejectedMessage());
+        assertTrue(cut.sanitize(content).contains("gmd-install-mcp"));
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/ApiTemplateServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/ApiTemplateServiceImplTest.java
@@ -19,10 +19,13 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
 import io.gravitee.common.component.Lifecycle;
 import io.gravitee.definition.model.DefinitionVersion;
+import io.gravitee.definition.model.v4.listener.entrypoint.Entrypoint;
+import io.gravitee.definition.model.v4.listener.http.HttpListener;
 import io.gravitee.definition.model.v4.nativeapi.NativeApiServices;
 import io.gravitee.definition.model.v4.property.Property;
 import io.gravitee.repository.management.model.LifecycleState;
@@ -31,6 +34,7 @@ import io.gravitee.rest.api.model.ApiModel;
 import io.gravitee.rest.api.model.PrimaryOwnerEntity;
 import io.gravitee.rest.api.model.Visibility;
 import io.gravitee.rest.api.model.api.ApiEntity;
+import io.gravitee.rest.api.model.api.ApiEntrypointEntity;
 import io.gravitee.rest.api.model.api.ApiLifecycleState;
 import io.gravitee.rest.api.model.v4.api.GenericApiModel;
 import io.gravitee.rest.api.model.v4.nativeapi.NativeApiEntity;
@@ -38,6 +42,7 @@ import io.gravitee.rest.api.model.v4.nativeapi.NativeApiModel;
 import io.gravitee.rest.api.service.ApiMetadataService;
 import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.notification.NotificationTemplateService;
+import io.gravitee.rest.api.service.v4.ApiEntrypointService;
 import io.gravitee.rest.api.service.v4.ApiSearchService;
 import io.gravitee.rest.api.service.v4.ApiTemplateService;
 import io.gravitee.rest.api.service.v4.PrimaryOwnerService;
@@ -71,6 +76,9 @@ public class ApiTemplateServiceImplTest {
     @Mock
     private NotificationTemplateService notificationTemplateService;
 
+    @Mock
+    private ApiEntrypointService apiEntrypointService;
+
     private ApiTemplateService apiTemplateService;
 
     @Before
@@ -79,8 +87,10 @@ public class ApiTemplateServiceImplTest {
             apiSearchService,
             apiMetadataService,
             primaryOwnerService,
-            notificationTemplateService
+            notificationTemplateService,
+            apiEntrypointService
         );
+        when(apiEntrypointService.getApiEntrypoints(any(), any())).thenReturn(List.of());
     }
 
     @Test
@@ -134,6 +144,32 @@ public class ApiTemplateServiceImplTest {
         assertTrue(genericApiModel instanceof io.gravitee.rest.api.model.v4.api.ApiModel);
         assertEquals("value resolved", genericApiModel.getMetadata().get("key"));
         assertEquals("support@gravitee.test", genericApiModel.getMetadata().get("email-support"));
+    }
+
+    @Test
+    public void shouldExposeEntrypointsAndMcpDataForV4ApiTemplates() {
+        io.gravitee.rest.api.model.v4.api.ApiEntity apiEntity = new io.gravitee.rest.api.model.v4.api.ApiEntity();
+        apiEntity.setId("api");
+        apiEntity.setDefinitionVersion(DefinitionVersion.V4);
+        apiEntity.setListeners(
+            List.of(
+                HttpListener.builder()
+                    .entrypoints(List.of(Entrypoint.builder().type("mcp-proxy").configuration("{\"mcpPath\":\"/mcp\"}").build()))
+                    .build()
+            )
+        );
+
+        when(apiSearchService.findGenericById(GraviteeContext.getExecutionContext(), "api", false, false, false)).thenReturn(apiEntity);
+        when(apiEntrypointService.getApiEntrypoints(eq(GraviteeContext.getExecutionContext()), eq(apiEntity))).thenReturn(
+            List.of(new ApiEntrypointEntity("https://api.example.com"))
+        );
+
+        GenericApiModel genericApiModel = apiTemplateService.findByIdForTemplates(GraviteeContext.getExecutionContext(), "api");
+
+        assertTrue(genericApiModel instanceof io.gravitee.rest.api.model.v4.api.ApiModel);
+        var apiModel = (io.gravitee.rest.api.model.v4.api.ApiModel) genericApiModel;
+        assertEquals(List.of("https://api.example.com"), apiModel.getEntrypoints());
+        assertEquals("/mcp", apiModel.getMcp().get("mcpPath"));
     }
 
     @Test

--- a/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/component-attribute-selectors.ts
+++ b/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/component-attribute-selectors.ts
@@ -21,6 +21,7 @@ import { GmdCheckboxComponent } from './checkbox/gmd-checkbox.component';
 import { GmdCheckboxGroupComponent } from './checkbox-group/gmd-checkbox-group.component';
 import { GridComponent } from './grid/grid.component';
 import { GmdInputComponent } from './input/gmd-input.component';
+import { GmdInstallMcpComponent } from './install-mcp/gmd-install-mcp.component';
 import { GmdRadioComponent } from './radio/gmd-radio.component';
 import { GmdSelectComponent } from './select/gmd-select.component';
 import { GmdTextareaComponent } from './textarea/gmd-textarea.component';
@@ -47,6 +48,7 @@ export const componentAttributeNames = [
   ...getComponentInputNames(GmdCardComponent),
   ...getComponentInputNames(GridComponent),
   ...getComponentInputNames(GmdButtonComponent),
+  ...getComponentInputNames(GmdInstallMcpComponent),
   ...getComponentInputNames(GmdInputComponent),
   ...getComponentInputNames(GmdTextareaComponent),
   ...getComponentInputNames(GmdSelectComponent),

--- a/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/component-name-selectors.ts
+++ b/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/component-name-selectors.ts
@@ -18,6 +18,7 @@ import { reflectComponentType, Type } from '@angular/core';
 import { GmdCheckboxComponent } from './checkbox/gmd-checkbox.component';
 import { GmdCheckboxGroupComponent } from './checkbox-group/gmd-checkbox-group.component';
 import { GmdInputComponent } from './input/gmd-input.component';
+import { GmdInstallMcpComponent } from './install-mcp/gmd-install-mcp.component';
 import { GmdRadioComponent } from './radio/gmd-radio.component';
 import { GmdSelectComponent } from './select/gmd-select.component';
 import { GmdTextareaComponent } from './textarea/gmd-textarea.component';
@@ -54,4 +55,5 @@ export const selfClosingComponentNames = [
   getComponentName(GmdCheckboxComponent),
   getComponentName(GmdRadioComponent),
   getComponentName(GmdCheckboxGroupComponent),
+  getComponentName(GmdInstallMcpComponent),
 ];

--- a/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/install-mcp/README.md
+++ b/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/install-mcp/README.md
@@ -1,0 +1,44 @@
+# Install MCP Component
+
+`gmd-install-mcp` renders one-click installer actions and copyable configuration snippets for supported MCP clients.
+
+## Supported clients
+
+- Cursor
+- VS Code
+- Claude Desktop
+
+## Usage
+
+### Explicit configuration
+
+```html
+<gmd-install-mcp name="weather" url="https://api.example.com/mcp" clients="cursor,vscode,claude-desktop" />
+```
+
+### Local stdio server
+
+```html
+<gmd-install-mcp name="weather" transport="stdio" command="npx" args='["-y","@acme/weather-mcp"]' clients="cursor,vscode,claude-desktop" />
+```
+
+### Missing configuration
+
+If the required inputs are missing, the component renders a placeholder instead of installer actions.
+
+## Inputs
+
+| Input       | Description                                               |
+| ----------- | --------------------------------------------------------- |
+| `name`      | MCP server name used in generated client configurations   |
+| `transport` | MCP transport: `http`, `sse`, or `stdio`                  |
+| `url`       | Remote MCP endpoint URL for `http` and `sse` transports   |
+| `headers`   | JSON object of headers for remote transports              |
+| `command`   | Executable used to start a stdio MCP server               |
+| `args`      | JSON array of stdio command arguments                     |
+| `env`       | JSON object of environment variables for stdio transports |
+| `clients`   | Comma-separated list of installer ids to display          |
+
+## Theming
+
+Use the `@gmd.install-mcp-overrides()` mixin from the library SCSS public API to customize the component tokens.

--- a/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/install-mcp/_overrides.scss
+++ b/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/install-mcp/_overrides.scss
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@use '../../scss/token-utils' as token-utils;
+@use '../../scss/theme' as theme;
+
+$theme-tokens: theme.tokens();
+
+@function tokens() {
+  @return (
+    namespace: install-mcp,
+    tokens: (
+      container-color: token-utils.slot(surface-color, $theme-tokens),
+      container-outline-color: token-utils.slot(outline-color, $theme-tokens),
+      headline-color: token-utils.slot(text-color, $theme-tokens),
+      subdued-text-color: color-mix(in srgb, token-utils.slot(text-color, $theme-tokens) 70%, transparent),
+      tab-active-color: token-utils.slot(primary-color, $theme-tokens),
+      tab-active-text-color: token-utils.slot(on-primary-color, $theme-tokens),
+      tab-inactive-color: token-utils.slot(surface-color, $theme-tokens),
+      tab-inactive-text-color: token-utils.slot(text-color, $theme-tokens),
+      code-background-color: color-mix(
+          in srgb,
+          token-utils.slot(outline-color, $theme-tokens) 8%,
+          token-utils.slot(surface-color, $theme-tokens)
+        ),
+      code-text-color: token-utils.slot(text-color, $theme-tokens),
+    )
+  );
+}
+
+@mixin overrides($overrides: ()) {
+  @include token-utils.apply-token-overrides(tokens(), $overrides);
+}

--- a/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/install-mcp/gmd-install-mcp.component.harness.ts
+++ b/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/install-mcp/gmd-install-mcp.component.harness.ts
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ComponentHarness } from '@angular/cdk/testing';
+
+export class GmdInstallMcpComponentHarness extends ComponentHarness {
+  static hostSelector = 'gmd-install-mcp';
+
+  async getSnippetText(): Promise<string> {
+    const snippet = await this.locatorFor('[data-testid="gmd-install-mcp-snippet"]')();
+    return snippet.text();
+  }
+
+  async getPlaceholderText(): Promise<string | null> {
+    const placeholder = await this.locatorForOptional('[data-testid="gmd-install-mcp-placeholder"]')();
+    return placeholder ? placeholder.text() : null;
+  }
+
+  async clickClient(clientId: string): Promise<void> {
+    const clientButton = await this.locatorFor(`[data-testid="gmd-install-mcp-client-${clientId}"]`)();
+    return clientButton.click();
+  }
+
+  async hasClient(clientId: string): Promise<boolean> {
+    const clientButton = await this.locatorForOptional(`[data-testid="gmd-install-mcp-client-${clientId}"]`)();
+    return clientButton !== null;
+  }
+
+  async getInstallHref(): Promise<string | null> {
+    const installButton = await this.locatorForOptional('[data-testid="gmd-install-mcp-install-link"] a')();
+    return installButton?.getAttribute('href') ?? null;
+  }
+
+  async getFallbackHref(): Promise<string | null> {
+    const fallbackButton = await this.locatorForOptional('[data-testid="gmd-install-mcp-fallback-link"] a')();
+    return fallbackButton?.getAttribute('href') ?? null;
+  }
+
+  async copySnippet(): Promise<void> {
+    const copyButton = await this.locatorFor('[data-testid="gmd-install-mcp-copy"]')();
+    return copyButton.click();
+  }
+
+  async getCopyButtonText(): Promise<string | null> {
+    const copyButton = await this.locatorForOptional('[data-testid="gmd-install-mcp-copy"]')();
+    return copyButton ? copyButton.text() : null;
+  }
+}

--- a/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/install-mcp/gmd-install-mcp.component.html
+++ b/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/install-mcp/gmd-install-mcp.component.html
@@ -1,0 +1,71 @@
+<!--
+
+    Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+@if (selectedInstaller(); as installer) {
+  <section class="gmd-install-mcp" data-testid="gmd-install-mcp">
+    <header class="gmd-install-mcp__header">
+      <div class="gmd-install-mcp__eyebrow">Install MCP</div>
+      <div class="gmd-install-mcp__description">Choose a client to install this MCP server or copy its configuration manually.</div>
+    </header>
+
+    <div class="gmd-install-mcp__client-tabs" role="tablist" aria-label="MCP client installers">
+      @for (availableInstaller of availableInstallers(); track availableInstaller.id) {
+        <button
+          class="gmd-install-mcp__client-tab"
+          [class.gmd-install-mcp__client-tab--active]="availableInstaller.id === installer.id"
+          type="button"
+          role="tab"
+          [attr.aria-selected]="availableInstaller.id === installer.id"
+          [attr.data-testid]="'gmd-install-mcp-client-' + availableInstaller.id"
+          (click)="selectClient(availableInstaller.id)"
+        >
+          {{ availableInstaller.label }}
+        </button>
+      }
+    </div>
+
+    <div class="gmd-install-mcp__actions">
+      @if (deepLink()) {
+        <gmd-button appearance="filled" [link]="deepLink() ?? undefined" data-testid="gmd-install-mcp-install-link">
+          Install in {{ installer.label }}
+        </gmd-button>
+      }
+    </div>
+
+    <div class="gmd-install-mcp__snippet">
+      <div class="gmd-install-mcp__snippet-header">
+        <div class="gmd-install-mcp__snippet-title">Manual configuration</div>
+        <div class="gmd-install-mcp__snippet-file">Paste into {{ snippetFileName() }}</div>
+        <button
+          class="gmd-install-mcp__copy-button"
+          type="button"
+          [cdkCopyToClipboard]="snippet()"
+          data-testid="gmd-install-mcp-copy"
+          (cdkCopyToClipboardCopied)="onSnippetCopied()"
+        >
+          {{ snippetCopied() ? 'Copied' : 'Copy' }}
+        </button>
+      </div>
+
+      <pre class="gmd-install-mcp__snippet-content" data-testid="gmd-install-mcp-snippet"><code>{{ snippet() }}</code></pre>
+    </div>
+  </section>
+} @else {
+  <div class="gmd-install-mcp__placeholder" data-testid="gmd-install-mcp-placeholder">
+    {{ placeholderMessage() }}
+  </div>
+}

--- a/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/install-mcp/gmd-install-mcp.component.scss
+++ b/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/install-mcp/gmd-install-mcp.component.scss
@@ -1,0 +1,120 @@
+/*
+ * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@use '../../scss/token-utils' as token-utils;
+@use './overrides' as overrides;
+
+$tokens: overrides.tokens();
+
+.gmd-install-mcp {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 16px;
+  border: 1px solid token-utils.slot(container-outline-color, $tokens);
+  border-radius: 12px;
+  background-color: token-utils.slot(container-color, $tokens);
+  color: token-utils.slot(headline-color, $tokens);
+
+  &__header {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+
+  &__eyebrow {
+    font-size: 12px;
+    font-weight: 600;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    color: token-utils.slot(subdued-text-color, $tokens);
+  }
+
+  &__description,
+  &__snippet-file,
+  &__placeholder {
+    color: token-utils.slot(subdued-text-color, $tokens);
+  }
+
+  &__client-tabs {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+  }
+
+  &__client-tab {
+    padding: 8px 12px;
+    border: 1px solid token-utils.slot(container-outline-color, $tokens);
+    border-radius: 999px;
+    background-color: token-utils.slot(tab-inactive-color, $tokens);
+    color: token-utils.slot(tab-inactive-text-color, $tokens);
+    cursor: pointer;
+
+    &--active {
+      border-color: token-utils.slot(tab-active-color, $tokens);
+      background-color: token-utils.slot(tab-active-color, $tokens);
+      color: token-utils.slot(tab-active-text-color, $tokens);
+    }
+  }
+
+  &__actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+  }
+
+  &__snippet {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+  }
+
+  &__snippet-header {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px 12px;
+    align-items: center;
+  }
+
+  &__snippet-title {
+    font-weight: 600;
+  }
+
+  &__copy-button {
+    margin-left: auto;
+    padding: 8px 12px;
+    border: 1px solid token-utils.slot(container-outline-color, $tokens);
+    border-radius: 999px;
+    background-color: token-utils.slot(tab-inactive-color, $tokens);
+    color: token-utils.slot(tab-inactive-text-color, $tokens);
+    cursor: pointer;
+  }
+
+  &__snippet-content {
+    overflow-x: auto;
+    margin: 0;
+    padding: 16px;
+    border-radius: 12px;
+    background-color: token-utils.slot(code-background-color, $tokens);
+    color: token-utils.slot(code-text-color, $tokens);
+    white-space: pre-wrap;
+  }
+}
+
+.gmd-install-mcp__placeholder {
+  padding: 16px;
+  border: 1px dashed token-utils.slot(container-outline-color, $tokens);
+  border-radius: 12px;
+}

--- a/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/install-mcp/gmd-install-mcp.component.spec.ts
+++ b/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/install-mcp/gmd-install-mcp.component.spec.ts
@@ -1,0 +1,89 @@
+/*
+ * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { GmdInstallMcpComponent } from './gmd-install-mcp.component';
+import { GmdInstallMcpComponentHarness } from './gmd-install-mcp.component.harness';
+
+describe('GmdInstallMcpComponent', () => {
+  let fixture: ComponentFixture<GmdInstallMcpComponent>;
+  let harness: GmdInstallMcpComponentHarness;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [GmdInstallMcpComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(GmdInstallMcpComponent);
+    harness = await TestbedHarnessEnvironment.harnessForFixture(fixture, GmdInstallMcpComponentHarness);
+  });
+
+  it('should render a placeholder when neither explicit inputs nor context are available', async () => {
+    fixture.detectChanges();
+
+    expect(await harness.getPlaceholderText()).toContain('Provide a server name and URL');
+  });
+
+  it('should filter the available clients', async () => {
+    fixture.componentRef.setInput('name', 'weather');
+    fixture.componentRef.setInput('url', 'https://api.example.com/mcp');
+    fixture.componentRef.setInput('clients', 'cursor');
+    fixture.detectChanges();
+
+    expect(await harness.hasClient('cursor')).toBe(true);
+    expect(await harness.hasClient('vscode')).toBe(false);
+    expect(await harness.hasClient('claude-desktop')).toBe(false);
+  });
+
+  it('should switch installers when a different client tab is selected', async () => {
+    fixture.componentRef.setInput('name', 'weather');
+    fixture.componentRef.setInput('url', 'https://api.example.com/mcp');
+    fixture.detectChanges();
+
+    expect(await harness.getInstallHref()).toContain('cursor://anysphere.cursor-deeplink');
+
+    await harness.clickClient('vscode');
+    expect(await harness.getInstallHref()).toContain('vscode:mcp/install?');
+  });
+
+  it('should not render a default auth header in the snippet for remote servers', async () => {
+    fixture.componentRef.setInput('name', 'weather');
+    fixture.componentRef.setInput('url', 'https://api.example.com/mcp');
+    fixture.detectChanges();
+
+    expect(await harness.getSnippetText()).not.toContain('"Authorization"');
+  });
+
+  it('should not render the web installer fallback button', async () => {
+    fixture.componentRef.setInput('name', 'weather');
+    fixture.componentRef.setInput('url', 'https://api.example.com/mcp');
+    fixture.detectChanges();
+
+    expect(await harness.getFallbackHref()).toBeNull();
+  });
+
+  it('should update the copy label when the snippet is copied', async () => {
+    fixture.componentRef.setInput('name', 'weather');
+    fixture.componentRef.setInput('url', 'https://api.example.com/mcp');
+    fixture.detectChanges();
+
+    fixture.componentInstance.onSnippetCopied();
+    fixture.detectChanges();
+
+    expect(await harness.getCopyButtonText()).toBe('Copied');
+  });
+});

--- a/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/install-mcp/gmd-install-mcp.component.stories.scss
+++ b/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/install-mcp/gmd-install-mcp.component.stories.scss
@@ -13,16 +13,27 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-@forward './lib/scss/theme' as theme-* show theme-overrides;
+@use './public-api' as gmd;
 
-@forward './lib/gravitee-markdown-editor/public-api';
-@forward './lib/gravitee-markdown-form-editor/public-api';
-@forward './lib/components/grid/public-api';
-@forward './lib/components/card/public-api';
-@forward './lib/components/button/public-api';
-@forward './lib/components/install-mcp/public-api';
-@forward './lib/components/input/public-api';
-@forward './lib/components/textarea/public-api';
-@forward './lib/components/select/public-api';
-@forward './lib/components/checkbox/public-api';
-@forward './lib/components/radio/public-api';
+.gmd-install-mcp-story {
+  display: flex;
+  max-width: 960px;
+  padding: 24px;
+}
+
+.gmd-install-mcp-story--dark {
+  background: #111827;
+
+  @include gmd.install-mcp-overrides(
+    (
+      container-color: #1f2937,
+      container-outline-color: #334155,
+      headline-color: #f8fafc,
+      subdued-text-color: #cbd5e1,
+      tab-inactive-color: #0f172a,
+      tab-inactive-text-color: #e2e8f0,
+      code-background-color: #020617,
+      code-text-color: #e2e8f0,
+    )
+  );
+}

--- a/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/install-mcp/gmd-install-mcp.component.stories.ts
+++ b/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/install-mcp/gmd-install-mcp.component.stories.ts
@@ -1,0 +1,100 @@
+/*
+ * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import type { Meta, StoryObj } from '@storybook/angular';
+import { moduleMetadata } from '@storybook/angular';
+
+import { GmdInstallMcpComponent } from './gmd-install-mcp.component';
+
+export default {
+  title: 'Gravitee Markdown/Components/Install MCP',
+  component: GmdInstallMcpComponent,
+  parameters: {
+    layout: 'centered',
+  },
+  decorators: [
+    moduleMetadata({
+      imports: [GmdInstallMcpComponent],
+    }),
+  ],
+} as Meta<GmdInstallMcpComponent>;
+
+export const HttpTransport: StoryObj<GmdInstallMcpComponent> = {
+  render: () => ({
+    template: `
+      <div class="gmd-install-mcp-story">
+        <gmd-install-mcp
+          name="weather"
+          url="https://api.example.com/mcp"
+          clients="cursor,vscode,claude-desktop"
+        />
+      </div>
+    `,
+  }),
+};
+
+export const StdioTransport: StoryObj<GmdInstallMcpComponent> = {
+  render: () => ({
+    template: `
+      <div class="gmd-install-mcp-story">
+        <gmd-install-mcp
+          name="weather-local"
+          transport="stdio"
+          command="npx"
+          args='["-y","@acme/weather-mcp"]'
+          clients="cursor,vscode,claude-desktop"
+        />
+      </div>
+    `,
+  }),
+};
+
+export const CursorOnly: StoryObj<GmdInstallMcpComponent> = {
+  render: () => ({
+    template: `
+      <div class="gmd-install-mcp-story">
+        <gmd-install-mcp
+          name="weather"
+          url="https://api.example.com/mcp"
+          clients="cursor"
+        />
+      </div>
+    `,
+  }),
+};
+
+export const DarkSurface: StoryObj<GmdInstallMcpComponent> = {
+  render: () => ({
+    template: `
+      <div class="gmd-install-mcp-story gmd-install-mcp-story--dark">
+        <gmd-install-mcp
+          name="weather"
+          url="https://api.example.com/mcp"
+          clients="cursor,vscode,claude-desktop"
+        />
+      </div>
+    `,
+  }),
+};
+
+export const MissingConfiguration: StoryObj<GmdInstallMcpComponent> = {
+  render: () => ({
+    template: `
+      <div class="gmd-install-mcp-story">
+        <gmd-install-mcp />
+      </div>
+    `,
+  }),
+};

--- a/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/install-mcp/gmd-install-mcp.component.ts
+++ b/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/install-mcp/gmd-install-mcp.component.ts
@@ -1,0 +1,209 @@
+/*
+ * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { CdkCopyToClipboard } from '@angular/cdk/clipboard';
+import { CommonModule } from '@angular/common';
+import { Component, computed, effect, inject, input, signal } from '@angular/core';
+
+import { GMD_MCP_INSTALLERS } from './gmd-install-mcp.tokens';
+import { McpServerSpec } from '../../models/mcpServerSpec';
+import { GmdButtonComponent } from '../button/gmd-button.component';
+
+type StringMap = Record<string, string>;
+type StringInput<T> = T | string | undefined;
+
+@Component({
+  selector: 'gmd-install-mcp',
+  standalone: true,
+  imports: [CommonModule, CdkCopyToClipboard, GmdButtonComponent],
+  templateUrl: './gmd-install-mcp.component.html',
+  styleUrl: './gmd-install-mcp.component.scss',
+})
+export class GmdInstallMcpComponent {
+  private readonly installers = inject(GMD_MCP_INSTALLERS);
+
+  name = input<string | undefined>();
+  transport = input<'http' | 'sse' | 'stdio'>('http');
+  url = input<string | undefined>();
+  headers = input<StringInput<StringMap>>();
+  command = input<string | undefined>();
+  args = input<StringInput<string[]>>();
+  env = input<StringInput<StringMap>>();
+  clients = input<string | undefined>();
+
+  protected readonly activeClientId = signal<string | null>(null);
+  protected readonly snippetCopied = signal(false);
+
+  protected readonly requestedClientIds = computed(() =>
+    (this.clients() ?? '')
+      .split(',')
+      .map(clientId => clientId.trim())
+      .filter(Boolean),
+  );
+  protected readonly resolvedSpec = computed(() => this.buildExplicitSpec());
+  protected readonly availableInstallers = computed(() => {
+    const resolvedSpec = this.resolvedSpec();
+    if (!resolvedSpec) {
+      return [];
+    }
+
+    const requestedClientIds = this.requestedClientIds();
+    return this.installers.filter(installer => {
+      if (requestedClientIds.length > 0 && !requestedClientIds.includes(installer.id)) {
+        return false;
+      }
+
+      return installer.supports(resolvedSpec);
+    });
+  });
+  protected readonly selectedInstaller = computed(() => {
+    const availableInstallers = this.availableInstallers();
+    const activeClientId = this.activeClientId();
+
+    if (!availableInstallers.length) {
+      return null;
+    }
+
+    return availableInstallers.find(installer => installer.id === activeClientId) ?? availableInstallers[0];
+  });
+  protected readonly deepLink = computed(() => {
+    const selectedInstaller = this.selectedInstaller();
+    const resolvedSpec = this.resolvedSpec();
+
+    return selectedInstaller?.buildDeepLink && resolvedSpec ? selectedInstaller.buildDeepLink(resolvedSpec) : null;
+  });
+  protected readonly snippet = computed(() => {
+    const selectedInstaller = this.selectedInstaller();
+    const resolvedSpec = this.resolvedSpec();
+
+    return selectedInstaller && resolvedSpec ? selectedInstaller.buildSnippet(resolvedSpec) : '';
+  });
+  protected readonly snippetFileName = computed(() => this.selectedInstaller()?.snippetFileName ?? 'mcp.json');
+  protected readonly placeholderMessage = computed(() => {
+    if (!this.resolvedSpec()) {
+      return 'Provide a server name and URL, or use stdio inputs for a local MCP server.';
+    }
+
+    return 'No supported installers are available for the selected clients.';
+  });
+
+  private readonly syncSelectedInstaller = effect(() => {
+    const availableInstallers = this.availableInstallers();
+    const activeClientId = this.activeClientId();
+
+    if (!availableInstallers.length) {
+      this.activeClientId.set(null);
+      return;
+    }
+
+    if (!activeClientId || !availableInstallers.some(installer => installer.id === activeClientId)) {
+      this.activeClientId.set(availableInstallers[0].id);
+    }
+  });
+
+  selectClient(clientId: string): void {
+    this.activeClientId.set(clientId);
+  }
+
+  onSnippetCopied(): void {
+    this.snippetCopied.set(true);
+    setTimeout(() => this.snippetCopied.set(false), 2000);
+  }
+
+  private buildExplicitSpec(): McpServerSpec | null {
+    const name = this.name()?.trim();
+    if (!name) {
+      return null;
+    }
+
+    const transport = this.transport();
+    if (transport === 'stdio') {
+      const command = this.command()?.trim();
+      if (!command) {
+        return null;
+      }
+
+      return {
+        name,
+        transport,
+        command,
+        args: this.parseStringArrayInput(this.args()),
+        env: this.parseStringMapInput(this.env()),
+      };
+    }
+
+    const url = this.url()?.trim();
+    if (!url) {
+      return null;
+    }
+
+    return {
+      name,
+      transport,
+      url,
+      headers: this.parseStringMapInput(this.headers()),
+    };
+  }
+
+  private parseStringArrayInput(value: StringInput<string[]>): string[] | undefined {
+    if (Array.isArray(value)) {
+      return value;
+    }
+
+    if (!value) {
+      return undefined;
+    }
+
+    try {
+      const parsedValue = JSON.parse(value);
+      if (Array.isArray(parsedValue) && parsedValue.every(item => typeof item === 'string')) {
+        return parsedValue;
+      }
+    } catch {
+      // Fall back to comma-separated strings for simple GMD authoring.
+    }
+
+    return value
+      .split(',')
+      .map(item => item.trim())
+      .filter(Boolean);
+  }
+
+  private parseStringMapInput(value: StringInput<StringMap>): StringMap | undefined {
+    if (!value) {
+      return undefined;
+    }
+
+    if (typeof value !== 'string') {
+      return value;
+    }
+
+    try {
+      const parsedValue = JSON.parse(value);
+      if (parsedValue && typeof parsedValue === 'object' && !Array.isArray(parsedValue)) {
+        return Object.entries(parsedValue).reduce<StringMap>((acc, [key, entryValue]) => {
+          if (typeof entryValue === 'string') {
+            acc[key] = entryValue;
+          }
+          return acc;
+        }, {});
+      }
+    } catch {
+      return undefined;
+    }
+
+    return undefined;
+  }
+}

--- a/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/install-mcp/gmd-install-mcp.tokens.ts
+++ b/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/install-mcp/gmd-install-mcp.tokens.ts
@@ -13,16 +13,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-@forward './lib/scss/theme' as theme-* show theme-overrides;
+import { InjectionToken } from '@angular/core';
 
-@forward './lib/gravitee-markdown-editor/public-api';
-@forward './lib/gravitee-markdown-form-editor/public-api';
-@forward './lib/components/grid/public-api';
-@forward './lib/components/card/public-api';
-@forward './lib/components/button/public-api';
-@forward './lib/components/install-mcp/public-api';
-@forward './lib/components/input/public-api';
-@forward './lib/components/textarea/public-api';
-@forward './lib/components/select/public-api';
-@forward './lib/components/checkbox/public-api';
-@forward './lib/components/radio/public-api';
+import { claudeDesktopInstaller } from './installers/claude-desktop.installer';
+import { cursorInstaller } from './installers/cursor.installer';
+import { vscodeInstaller } from './installers/vscode.installer';
+import { McpClientInstaller } from '../../models/mcpClientInstaller';
+
+export const DEFAULT_INSTALLERS: McpClientInstaller[] = [cursorInstaller, vscodeInstaller, claudeDesktopInstaller];
+
+export const GMD_MCP_INSTALLERS = new InjectionToken<McpClientInstaller[]>('GMD_MCP_INSTALLERS', {
+  providedIn: 'root',
+  factory: () => DEFAULT_INSTALLERS,
+});

--- a/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/install-mcp/installers/claude-desktop.installer.spec.ts
+++ b/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/install-mcp/installers/claude-desktop.installer.spec.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { claudeDesktopInstaller } from './claude-desktop.installer';
+
+describe('claudeDesktopInstaller', () => {
+  const spec = {
+    name: 'weather',
+    transport: 'http' as const,
+    url: 'https://api.example.com/mcp',
+  };
+
+  it('should not build a deep link', () => {
+    expect(claudeDesktopInstaller.buildDeepLink).toBeUndefined();
+    expect(claudeDesktopInstaller.mode).toBe('snippet-only');
+  });
+
+  it('should build a Claude Desktop snippet', () => {
+    expect(claudeDesktopInstaller.buildSnippet(spec)).toContain('"mcpServers"');
+    expect(claudeDesktopInstaller.buildSnippet(spec)).toContain('"weather"');
+    expect(claudeDesktopInstaller.snippetFileName).toBe('claude_desktop_config.json');
+  });
+});

--- a/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/install-mcp/installers/claude-desktop.installer.ts
+++ b/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/install-mcp/installers/claude-desktop.installer.ts
@@ -13,16 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-@forward './lib/scss/theme' as theme-* show theme-overrides;
+import { buildSnippet } from './mcp-installer.utils';
+import { McpClientInstaller } from '../../../models/mcpClientInstaller';
 
-@forward './lib/gravitee-markdown-editor/public-api';
-@forward './lib/gravitee-markdown-form-editor/public-api';
-@forward './lib/components/grid/public-api';
-@forward './lib/components/card/public-api';
-@forward './lib/components/button/public-api';
-@forward './lib/components/install-mcp/public-api';
-@forward './lib/components/input/public-api';
-@forward './lib/components/textarea/public-api';
-@forward './lib/components/select/public-api';
-@forward './lib/components/checkbox/public-api';
-@forward './lib/components/radio/public-api';
+export const claudeDesktopInstaller: McpClientInstaller = {
+  id: 'claude-desktop',
+  label: 'Claude Desktop',
+  mode: 'snippet-only',
+  snippetFileName: 'claude_desktop_config.json',
+  supports: () => true,
+  buildSnippet: spec => buildSnippet(spec),
+};

--- a/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/install-mcp/installers/cursor.installer.spec.ts
+++ b/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/install-mcp/installers/cursor.installer.spec.ts
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { cursorInstaller } from './cursor.installer';
+
+describe('cursorInstaller', () => {
+  const spec = {
+    name: 'weather',
+    transport: 'http' as const,
+    url: 'https://api.example.com/mcp',
+  };
+
+  it('should build a cursor deep link', () => {
+    expect(cursorInstaller.buildDeepLink?.(spec)).toContain('cursor://anysphere.cursor-deeplink/mcp/install');
+  });
+
+  it('should build a cursor web fallback link', () => {
+    expect(cursorInstaller.buildFallbackLink?.(spec)).toContain('https://cursor.com/en/install-mcp');
+  });
+
+  it('should build an mcp.json snippet', () => {
+    expect(cursorInstaller.buildSnippet(spec)).toContain('"mcpServers"');
+    expect(cursorInstaller.buildSnippet(spec)).toContain('"weather"');
+  });
+});

--- a/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/install-mcp/installers/cursor.installer.ts
+++ b/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/install-mcp/installers/cursor.installer.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { buildSnippet, buildTransportConfig } from './mcp-installer.utils';
+import { McpClientInstaller } from '../../../models/mcpClientInstaller';
+import { McpServerSpec } from '../../../models/mcpServerSpec';
+
+function toBase64(value: string): string {
+  const encodedValue = new TextEncoder().encode(value);
+  const binaryValue = Array.from(encodedValue, byte => String.fromCharCode(byte)).join('');
+  return btoa(binaryValue);
+}
+
+function encodeConfig(spec: McpServerSpec): string {
+  return toBase64(JSON.stringify(buildTransportConfig(spec)));
+}
+
+export const cursorInstaller: McpClientInstaller = {
+  id: 'cursor',
+  label: 'Cursor',
+  mode: 'deep-link',
+  snippetFileName: '~/.cursor/mcp.json',
+  supports: () => true,
+  buildSnippet: spec => buildSnippet(spec),
+  buildDeepLink: spec =>
+    `cursor://anysphere.cursor-deeplink/mcp/install?name=${encodeURIComponent(spec.name)}&config=${encodeURIComponent(encodeConfig(spec))}`,
+  buildFallbackLink: spec =>
+    `https://cursor.com/en/install-mcp?name=${encodeURIComponent(spec.name)}&config=${encodeURIComponent(encodeConfig(spec))}`,
+};

--- a/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/install-mcp/installers/mcp-installer.utils.ts
+++ b/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/install-mcp/installers/mcp-installer.utils.ts
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { McpServerSpec } from '../../../models/mcpServerSpec';
+
+export function buildSnippet(spec: McpServerSpec): string {
+  return JSON.stringify(
+    {
+      mcpServers: {
+        [spec.name]: buildTransportConfig(spec),
+      },
+    },
+    null,
+    2,
+  );
+}
+
+export function buildTransportConfig(spec: McpServerSpec): Record<string, unknown> {
+  if (spec.transport === 'stdio') {
+    return {
+      command: spec.command,
+      ...(spec.args?.length ? { args: spec.args } : {}),
+      ...(spec.env && Object.keys(spec.env).length > 0 ? { env: spec.env } : {}),
+    };
+  }
+
+  return {
+    ...(spec.transport === 'sse' ? { type: 'sse' } : {}),
+    url: spec.url,
+    ...(getHeaders(spec) ? { headers: getHeaders(spec) } : {}),
+  };
+}
+
+export function buildVscodeInstallConfig(spec: McpServerSpec): Record<string, unknown> {
+  if (spec.transport === 'stdio') {
+    return {
+      name: spec.name,
+      command: spec.command,
+      ...(spec.args?.length ? { args: spec.args } : {}),
+      ...(spec.env && Object.keys(spec.env).length > 0 ? { env: spec.env } : {}),
+    };
+  }
+
+  return {
+    name: spec.name,
+    type: spec.transport,
+    url: spec.url,
+    ...(getHeaders(spec) ? { headers: getHeaders(spec) } : {}),
+  };
+}
+
+export function getHeaders(spec: McpServerSpec): Record<string, string> | undefined {
+  if (spec.transport === 'stdio') {
+    return undefined;
+  }
+
+  return spec.headers;
+}

--- a/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/install-mcp/installers/vscode.installer.spec.ts
+++ b/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/install-mcp/installers/vscode.installer.spec.ts
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { vscodeInstaller } from './vscode.installer';
+
+describe('vscodeInstaller', () => {
+  const spec = {
+    name: 'weather',
+    transport: 'http' as const,
+    url: 'https://api.example.com/mcp',
+  };
+
+  it('should build a VS Code deep link', () => {
+    expect(vscodeInstaller.buildDeepLink?.(spec)).toContain('vscode:mcp/install?');
+  });
+
+  it('should build a VS Code web fallback link', () => {
+    expect(vscodeInstaller.buildFallbackLink?.(spec)).toContain('https://insiders.vscode.dev/redirect/mcp/install');
+  });
+
+  it('should build an mcp.json snippet', () => {
+    expect(vscodeInstaller.buildSnippet(spec)).toContain('"mcpServers"');
+    expect(vscodeInstaller.buildSnippet(spec)).toContain('"weather"');
+  });
+});

--- a/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/install-mcp/installers/vscode.installer.ts
+++ b/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/install-mcp/installers/vscode.installer.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2025 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { buildSnippet, buildTransportConfig, buildVscodeInstallConfig } from './mcp-installer.utils';
+import { McpClientInstaller } from '../../../models/mcpClientInstaller';
+import { McpServerSpec } from '../../../models/mcpServerSpec';
+
+function encodeDeepLinkConfig(spec: McpServerSpec): string {
+  return encodeURIComponent(JSON.stringify(buildVscodeInstallConfig(spec)));
+}
+
+function encodeFallbackConfig(spec: McpServerSpec): string {
+  return encodeURIComponent(JSON.stringify(buildTransportConfig(spec)));
+}
+
+export const vscodeInstaller: McpClientInstaller = {
+  id: 'vscode',
+  label: 'VS Code',
+  mode: 'deep-link',
+  snippetFileName: 'mcp.json',
+  supports: () => true,
+  buildSnippet: spec => buildSnippet(spec),
+  buildDeepLink: spec => `vscode:mcp/install?${encodeDeepLinkConfig(spec)}`,
+  buildFallbackLink: spec =>
+    `https://insiders.vscode.dev/redirect/mcp/install?name=${encodeURIComponent(spec.name)}&config=${encodeFallbackConfig(spec)}`,
+};

--- a/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/install-mcp/public-api.scss
+++ b/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/install-mcp/public-api.scss
@@ -13,16 +13,4 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-@forward './lib/scss/theme' as theme-* show theme-overrides;
-
-@forward './lib/gravitee-markdown-editor/public-api';
-@forward './lib/gravitee-markdown-form-editor/public-api';
-@forward './lib/components/grid/public-api';
-@forward './lib/components/card/public-api';
-@forward './lib/components/button/public-api';
-@forward './lib/components/install-mcp/public-api';
-@forward './lib/components/input/public-api';
-@forward './lib/components/textarea/public-api';
-@forward './lib/components/select/public-api';
-@forward './lib/components/checkbox/public-api';
-@forward './lib/components/radio/public-api';
+@forward './overrides' as install-mcp-* show install-mcp-overrides;

--- a/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/install-mcp/public-api.ts
+++ b/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/install-mcp/public-api.ts
@@ -13,16 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-@forward './lib/scss/theme' as theme-* show theme-overrides;
-
-@forward './lib/gravitee-markdown-editor/public-api';
-@forward './lib/gravitee-markdown-form-editor/public-api';
-@forward './lib/components/grid/public-api';
-@forward './lib/components/card/public-api';
-@forward './lib/components/button/public-api';
-@forward './lib/components/install-mcp/public-api';
-@forward './lib/components/input/public-api';
-@forward './lib/components/textarea/public-api';
-@forward './lib/components/select/public-api';
-@forward './lib/components/checkbox/public-api';
-@forward './lib/components/radio/public-api';
+export * from './gmd-install-mcp.component';
+export * from './gmd-install-mcp.component.harness';
+export * from './gmd-install-mcp.tokens';
+export * from '../../models/mcpClientInstaller';
+export * from '../../models/mcpServerSpec';

--- a/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/prefix-stripper.parser.ts
+++ b/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/prefix-stripper.parser.ts
@@ -26,6 +26,7 @@ import { GmdCardComponent } from './card/gmd-card.component';
 import { GmdCheckboxComponent } from './checkbox/gmd-checkbox.component';
 import { GmdCheckboxGroupComponent } from './checkbox-group/gmd-checkbox-group.component';
 import { GmdInputComponent } from './input/gmd-input.component';
+import { GmdInstallMcpComponent } from './install-mcp/gmd-install-mcp.component';
 import { GmdRadioComponent } from './radio/gmd-radio.component';
 import { GmdSelectComponent } from './select/gmd-select.component';
 import { GmdTextareaComponent } from './textarea/gmd-textarea.component';
@@ -58,6 +59,10 @@ export const prefixStripperParser: HookParserEntry[] = [
   {
     component: GmdButtonComponent,
     selector: ComponentSelector.BUTTON,
+  },
+  {
+    component: GmdInstallMcpComponent,
+    selector: ComponentSelector.INSTALL_MCP,
   },
   {
     component: GmdInputComponent,

--- a/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/suggestions.index.ts
+++ b/gravitee-apim-webui-libs/gravitee-markdown/src/lib/components/suggestions.index.ts
@@ -29,9 +29,7 @@ import { radioConfiguration } from './radio/gmd-radio.suggestions';
 import { selectConfiguration } from './select/gmd-select.suggestions';
 import { textareaConfiguration } from './textarea/gmd-textarea.suggestions';
 
-type ComponentSuggestionMap = {
-  [Key in ComponentSelector]: ComponentSuggestionConfiguration;
-};
+type ComponentSuggestionMap = Partial<Record<ComponentSelector, ComponentSuggestionConfiguration>>;
 
 export const componentSuggestionMap: ComponentSuggestionMap = {
   [ComponentSelector.GRID]: gridConfiguration,

--- a/gravitee-apim-webui-libs/gravitee-markdown/src/lib/gravitee-markdown-editor/components/monaco-editor/monaco-editor.component.ts
+++ b/gravitee-apim-webui-libs/gravitee-markdown/src/lib/gravitee-markdown-editor/components/monaco-editor/monaco-editor.component.ts
@@ -277,6 +277,9 @@ export class MonacoEditorComponent implements OnDestroy {
     }
 
     const componentSuggestionConfig = componentSuggestionMap[componentSelector];
+    if (!componentSuggestionConfig) {
+      return null;
+    }
 
     // Check if hovering over an attribute name with a value
     if (lineText.includes(`${wordText}=`)) {

--- a/gravitee-apim-webui-libs/gravitee-markdown/src/lib/models/componentSelector.ts
+++ b/gravitee-apim-webui-libs/gravitee-markdown/src/lib/models/componentSelector.ts
@@ -21,6 +21,7 @@ export enum ComponentSelector {
   CARD_SUBTITLE = 'gmd-card-subtitle',
   MD_BLOCK = 'gmd-md',
   BUTTON = 'gmd-button',
+  INSTALL_MCP = 'gmd-install-mcp',
   INPUT = 'gmd-input',
   TEXTAREA = 'gmd-textarea',
   SELECT = 'gmd-select',

--- a/gravitee-apim-webui-libs/gravitee-markdown/src/lib/models/mcpClientInstaller.ts
+++ b/gravitee-apim-webui-libs/gravitee-markdown/src/lib/models/mcpClientInstaller.ts
@@ -13,16 +13,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-@forward './lib/scss/theme' as theme-* show theme-overrides;
+import { McpServerSpec } from './mcpServerSpec';
 
-@forward './lib/gravitee-markdown-editor/public-api';
-@forward './lib/gravitee-markdown-form-editor/public-api';
-@forward './lib/components/grid/public-api';
-@forward './lib/components/card/public-api';
-@forward './lib/components/button/public-api';
-@forward './lib/components/install-mcp/public-api';
-@forward './lib/components/input/public-api';
-@forward './lib/components/textarea/public-api';
-@forward './lib/components/select/public-api';
-@forward './lib/components/checkbox/public-api';
-@forward './lib/components/radio/public-api';
+export type McpInstallMode = 'deep-link' | 'snippet-only';
+
+export interface McpClientInstaller {
+  id: string;
+  label: string;
+  mode: McpInstallMode;
+  snippetFileName: string;
+  supports(spec: McpServerSpec): boolean;
+  buildSnippet(spec: McpServerSpec): string;
+  buildDeepLink?(spec: McpServerSpec): string;
+  buildFallbackLink?(spec: McpServerSpec): string;
+}

--- a/gravitee-apim-webui-libs/gravitee-markdown/src/lib/models/mcpServerSpec.ts
+++ b/gravitee-apim-webui-libs/gravitee-markdown/src/lib/models/mcpServerSpec.ts
@@ -13,16 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-@forward './lib/scss/theme' as theme-* show theme-overrides;
+export type McpTransport = 'http' | 'sse' | 'stdio';
 
-@forward './lib/gravitee-markdown-editor/public-api';
-@forward './lib/gravitee-markdown-form-editor/public-api';
-@forward './lib/components/grid/public-api';
-@forward './lib/components/card/public-api';
-@forward './lib/components/button/public-api';
-@forward './lib/components/install-mcp/public-api';
-@forward './lib/components/input/public-api';
-@forward './lib/components/textarea/public-api';
-@forward './lib/components/select/public-api';
-@forward './lib/components/checkbox/public-api';
-@forward './lib/components/radio/public-api';
+export interface McpServerSpec {
+  name: string;
+  transport: McpTransport;
+  url?: string;
+  headers?: Record<string, string>;
+  command?: string;
+  args?: string[];
+  env?: Record<string, string>;
+}

--- a/gravitee-apim-webui-libs/gravitee-markdown/src/public-api.ts
+++ b/gravitee-apim-webui-libs/gravitee-markdown/src/public-api.ts
@@ -26,4 +26,5 @@ export * from './lib/gravitee-markdown-form-validation-panel/public-api';
 export * from './lib/gravitee-markdown-viewer/public-api';
 export * from './lib/components/card/public-api';
 export * from './lib/components/button/public-api';
+export * from './lib/components/install-mcp/public-api';
 export * from './lib/services/gmd-form-state.store';


### PR DESCRIPTION
Add the gmd-install-mcp Gravitee Markdown component with client installer helpers (Cursor, VS Code, Claude Desktop), backend HTML sanitizer whitelist, FreeMarker template model exposure of API entrypoints and MCP configuration, and Studio/MCP API types on the NG Portal.
- New <gmd-install-mcp> component + harness + tests + Storybook
- Per-client installer logic with deep-link/config snippet generation
- HtmlSanitizer allowlists the new tag and its attributes
- ApiModel exposes entrypoints and mcp maps; ApiTemplateServiceImpl populates them from V4 entrypoint configuration
- Portal ApiType extended with A2A_PROXY, LLM_PROXY, MCP_PROXY

## Issue

https://gravitee.atlassian.net/browse/APIM-14224

## Summary

Foundation for MCP Proxy and Studio API types on NG Portal.

This PR adds the building blocks consumed by  (default MCP proxy Overview templates). On its own this PR is shippable: portal pages can include `<gmd-install-mcp>` manually, the sanitizer allows it, and FreeMarker has the data needed to auto-fill install URLs.

## What changed

### Gravitee Markdown library (`gravitee-apim-webui-libs/gravitee-markdown/`)
- New `<gmd-install-mcp>` component
  - Tabs for Cursor / VS Code / Claude Desktop
  - One-click install deep links and copyable MCP config snippets
  - HTTP / SSE / stdio transports
  - Component + harness + spec + Storybook stories
- New domain models: `McpServerSpec`, `McpClientInstaller`
- Per-client installer logic (`installers/{cursor,vscode,claude-desktop}.installer.ts` + shared utils)
- Library registration: `ComponentSelector.INSTALL_MCP`, parser entry, self-closing tag list, attribute autocomplete list, `Partial<Record<...>>` suggestion map, Monaco null-guard, public API exports

### Backend
- `HtmlSanitizer` now whitelists `<gmd-install-mcp>` with the relevant attributes (`name`, `transport`, `url`, `headers`, `command`, `args`, `env`, `clients`)
- `ApiModel`: new `entrypoints: List<String>` and `mcp: Map<String, Object>` fields
- `ApiTemplateServiceImpl`: injects `ApiEntrypointService`; populates `entrypoints` and `mcp` from V4 entrypoint configuration (looks for `mcp` / `mcp-proxy` entrypoint type)

### Portal NG
- `ApiType` extended with `A2A_PROXY | LLM_PROXY | MCP_PROXY`

## Out of scope

- MCP-specific Overview template (`api-overview-mcp-proxy-page-content.md`)
- Wiring the use case to pick the MCP template for `MCP_PROXY` APIs
- `PortalNavigationTemplatingServiceImplTest` MCP URL resolution tests

## Test plan

- [ ] `HtmlSanitizerTest` (18 tests) — passes
- [ ] `ApiTemplateServiceImplTest` (7 tests, incl. new `shouldExposeEntrypointsAndMcpDataForV4ApiTemplates`) — passes
- [ ] `nx test markdown` (369 tests, incl. install-mcp component + 3 installer specs) — passes
- [ ] Storybook story `Markdown / Install MCP` renders client tabs and snippets
- [ ] Manual: portal GMD page authored with `<gmd-install-mcp name="..." transport="http" url="..." />` renders the widget
- [ ] Manual: stored content with `<gmd-install-mcp>` survives sanitization

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

