### PR TITLE
Feat/clean up navigation editor page header

### DIFF
--- a/gravitee-apim-console-webui/src/portal/components/header/portal-header.component.scss
+++ b/gravitee-apim-console-webui/src/portal/components/header/portal-header.component.scss
@@ -6,7 +6,7 @@
   flex-flow: column;
   gap: 18px;
 
-  margin-bottom: 28px;
+  margin-bottom: 16px;
 
   &__subtitle {
     color: mat.m2-get-color-from-palette(gio.$mat-space-palette, 'lighter40');
@@ -14,6 +14,7 @@
 
   &__content {
     display: flex;
+    align-items: baseline;
     justify-content: space-between;
   }
 }

--- a/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.html
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.html
@@ -15,7 +15,7 @@
     limitations under the License.
 
 -->
-<portal-header title="Manage your navigation" subtitle="Manage and edit your Developer Portal pages with Markdown" />
+<portal-header title="Manage your navigation" [showTechPreviewMessage]="false" />
 
 <main class="page-layout">
   <section class="panel sections-panel" [style.width.px]="panelWidth()">


### PR DESCRIPTION
[Cleans up the navigation editor page header](https://gravitee.atlassian.net/browse/EXT-135):

Removed the subtitle ("Manage and edit your Developer Portal pages with Markdown")
Suppressed the tech-preview banner on this page only ([showTechPreviewMessage]="false")
Added an "Early access. Evolving with your feedback" badge on the right side of the header, styled with the warning palette (amber)
Reduced portal-header margin-bottom from 28px to 16px

<img width="1854" height="1084" alt="Screenshot 2026-06-03 at 19 38 55" src="https://github.com/user-attachments/assets/98dde4f5-db96-47f7-8b60-7dc57dc5d25a" />

