### PR TITLE
feat(gamma): wire context sidebar slots through ShellLayout

### DIFF
--- a/gravitee-gamma/gravitee-gamma-control-plane-webui/src/shared/components/ShellLayout.tsx
+++ b/gravitee-gamma/gravitee-gamma-control-plane-webui/src/shared/components/ShellLayout.tsx
@@ -119,9 +119,14 @@ function ShellLayoutInner({ modules }: { readonly modules: readonly GammaModule[
                     onEnvironmentChange={handleEnvironmentChange}
                 />
             }
+            contextSidebar={slots.contextSidebar}
+            viewMode={slots.viewMode}
+            contextExpanded={slots.contextExpanded}
+            contentVariant={slots.contentVariant}
             subheader={
                 <ContentHeader
                     breadcrumbs={slots.breadcrumbs}
+                    leading={slots.leading}
                     trailing={user ? <TopNavUser name={user.displayName} email={user.email} onSignOut={handleSignOut} /> : undefined}
                 />
             }


### PR DESCRIPTION
## Intent

The Gamma control-plane shell already exposed a `LayoutSlotsProvider` so feature modules could push slot content (navigation, breadcrumbs) up to the top-level `AppLayout`. This PR plugs four additional slots from `useLayoutSlots()` into the `AppLayout` / `ContentHeader`: `contextSidebar`, `viewMode`, `contextExpanded`, `contentVariant`, plus a `leading` slot on the content header. The decision: route the right-side context panel and content-layout controls through the same slot mechanism instead of having each feature own its own layout wiring.
