### PR TITLE
fix: allow default role mapping via api v2 group endpoint

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/model/GroupCRDSpec.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/model/GroupCRDSpec.java
@@ -40,6 +40,10 @@ public class GroupCRDSpec {
 
     private boolean notifyMembers;
 
+    private String apiRole;
+
+    private String applicationRole;
+
     @AllArgsConstructor
     @NoArgsConstructor
     @Data

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/AbstractResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/AbstractResourceTest.java
@@ -23,6 +23,7 @@ import inmemory.ApiCrudServiceInMemory;
 import inmemory.ApplicationCrudServiceInMemory;
 import inmemory.ApplicationMetadataCrudServiceInMemory;
 import inmemory.ApplicationMetadataQueryServiceInMemory;
+import inmemory.CRDMembersDomainServiceInMemory;
 import inmemory.CategoryQueryServiceInMemory;
 import inmemory.GroupCrudServiceInMemory;
 import inmemory.GroupQueryServiceInMemory;
@@ -218,6 +219,9 @@ public abstract class AbstractResourceTest extends JerseySpringTest {
 
     @Autowired
     protected GroupCrudServiceInMemory groupCrudServiceInMemory;
+
+    @Autowired
+    protected CRDMembersDomainServiceInMemory crdMembersDomainServiceInMemory;
 
     @BeforeEach
     public void setUp() {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/group/GroupsResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/group/GroupsResourceTest.java
@@ -59,6 +59,7 @@ import java.time.Instant;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Stream;
 import org.apache.commons.io.IOUtils;
@@ -305,6 +306,7 @@ public class GroupsResourceTest extends AbstractResourceTest {
             groupCrudServiceInMemory.reset();
             userDomainServiceInMemory.reset();
             userCrudService.reset();
+            crdMembersDomainServiceInMemory.reset();
 
             when(roleService.findDefaultRoleByScopes(ORGANIZATION, RoleScope.API, RoleScope.APPLICATION, RoleScope.INTEGRATION)).thenReturn(
                 List.of(
@@ -448,6 +450,36 @@ public class GroupsResourceTest extends AbstractResourceTest {
                     );
 
                 soft.assertThat(groupCrudServiceInMemory.storage()).hasSize(1);
+            });
+        }
+
+        @Test
+        void should_set_default_roles() {
+            when(roleService.findByScopeAndName(RoleScope.API, "OWNER", ORGANIZATION)).thenReturn(
+                Optional.of(RoleEntity.builder().name("OWNER").build())
+            );
+            when(roleService.findByScopeAndName(RoleScope.APPLICATION, "OWNER", ORGANIZATION)).thenReturn(
+                Optional.of(RoleEntity.builder().name("OWNER").build())
+            );
+
+            var crdStatus = doImport("/crd/group/with-default-roles.json", false);
+
+            SoftAssertions.assertSoftly(soft -> {
+                soft
+                    .assertThat(crdStatus)
+                    .isEqualTo(
+                        GroupCRDStatus.builder()
+                            .id("2868ef55-561e-4b99-a981-450015a248d9")
+                            .errors(GroupCRDStatus.Errors.EMPTY)
+                            .members(0)
+                            .build()
+                    );
+
+                soft.assertThat(groupCrudServiceInMemory.storage()).hasSize(1);
+                soft.assertThat(crdMembersDomainServiceInMemory.getGroupApiRole("2868ef55-561e-4b99-a981-450015a248d9")).isEqualTo("OWNER");
+                soft
+                    .assertThat(crdMembersDomainServiceInMemory.getGroupApplicationRole("2868ef55-561e-4b99-a981-450015a248d9"))
+                    .isEqualTo("OWNER");
             });
         }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/resources/crd/group/with-default-roles.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/resources/crd/group/with-default-roles.json
@@ -1,0 +1,7 @@
+{
+  "id": "2868ef55-561e-4b99-a981-450015a248d9",
+  "name": "with-default-roles",
+  "notifyMembers": false,
+  "apiRole": "OWNER",
+  "applicationRole": "OWNER"
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/group/model/crd/GroupCRDSpec.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/group/model/crd/GroupCRDSpec.java
@@ -44,6 +44,10 @@ public class GroupCRDSpec {
 
     private boolean notifyMembers;
 
+    private String apiRole;
+
+    private String applicationRole;
+
     @Builder.Default
     private String origin = Origin.KUBERNETES.name();
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/group/use_case/ImportGroupCRDUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/group/use_case/ImportGroupCRDUseCase.java
@@ -75,6 +75,16 @@ public class ImportGroupCRDUseCase {
         var errors = validationResult.errors().map(GroupCRDStatus.Errors::fromErrorList).orElse(GroupCRDStatus.Errors.EMPTY);
 
         crudService.create(input.spec.toGroup(input.auditInfo.environmentId()));
+        return updateGroupDefaultRoles(input, errors);
+    }
+
+    private ImportGroupCRDUseCase.Output updateGroupDefaultRoles(Input input, GroupCRDStatus.Errors errors) {
+        membersService.updateGroupDefaultRoles(
+            input.auditInfo,
+            input.spec.getId(),
+            input.spec.getApiRole(),
+            input.spec.getApplicationRole()
+        );
         membersService.updateGroupMembers(input.auditInfo, input.spec.getId(), input.spec.getMembers());
         return new Output(new GroupCRDStatus(input.spec.getId(), input.spec.getMembers().size(), errors));
     }
@@ -91,7 +101,6 @@ public class ImportGroupCRDUseCase {
         var errors = validationResult.errors().map(GroupCRDStatus.Errors::fromErrorList).orElse(GroupCRDStatus.Errors.EMPTY);
 
         crudService.update(input.spec.toGroup(input.auditInfo.environmentId()));
-        membersService.updateGroupMembers(input.auditInfo, input.spec.getId(), input.spec.getMembers());
-        return new Output(new GroupCRDStatus(input.spec.getId(), input.spec.getMembers().size(), errors));
+        return updateGroupDefaultRoles(input, errors);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/member/domain_service/CRDMembersDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/member/domain_service/CRDMembersDomainService.java
@@ -28,4 +28,6 @@ public interface CRDMembersDomainService {
     void updateApiMembers(AuditInfo auditInfo, String apiId, Set<MemberCRD> members);
     void updateApplicationMembers(AuditInfo auditInfo, String applicationId, Set<MemberCRD> members);
     void updateGroupMembers(AuditInfo auditInfo, String groupId, Set<GroupCRDSpec.Member> members);
+
+    void updateGroupDefaultRoles(AuditInfo auditInfo, String groupId, String apiRole, String applicationRole);
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/group/ValidateGroupCRDDomainServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/group/ValidateGroupCRDDomainServiceImpl.java
@@ -15,6 +15,8 @@
  */
 package io.gravitee.apim.infra.domain_service.group;
 
+import static io.gravitee.apim.core.member.model.SystemRole.PRIMARY_OWNER;
+
 import io.gravitee.apim.core.audit.model.AuditInfo;
 import io.gravitee.apim.core.group.domain_service.ValidateGroupCRDDomainService;
 import io.gravitee.apim.core.group.model.crd.GroupCRDSpec;
@@ -35,6 +37,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
+import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -57,6 +60,7 @@ public class ValidateGroupCRDDomainServiceImpl implements ValidateGroupCRDDomain
 
         validateAndSanitizeId(input.spec().getId()).peek(id -> input.spec().setId(id), errors::addAll);
         validateAndSanitizedName(input.spec().getName()).peek(name -> input.spec().setName(name), errors::addAll);
+        validateAndSanitizeDefaultRoles(input, errors);
         validateAndSanitizeMembers(input).peek(members -> input.spec().setMembers(members), errors::addAll);
 
         return Result.ofBoth(input, errors);
@@ -78,6 +82,49 @@ public class ValidateGroupCRDDomainServiceImpl implements ValidateGroupCRDDomain
             return Result.ofErrors(List.of(Error.severe("property [name] must not be empty")));
         }
         return Result.ofValue(name);
+    }
+
+    private void validateAndSanitizeDefaultRoles(ValidateGroupCRDDomainService.Input input, ArrayList<Error> errors) {
+        validateAndSanitizeDefaultRole(input, input.spec().getApiRole(), RoleScope.API, role -> input.spec().setApiRole(role), errors);
+        validateAndSanitizeDefaultRole(
+            input,
+            input.spec().getApplicationRole(),
+            RoleScope.APPLICATION,
+            role -> input.spec().setApplicationRole(role),
+            errors
+        );
+    }
+
+    private void validateAndSanitizeDefaultRole(
+        ValidateGroupCRDDomainService.Input input,
+        String roleName,
+        RoleScope roleScope,
+        Consumer<String> roleSetter,
+        ArrayList<Error> errors
+    ) {
+        if (StringUtils.isEmpty(roleName)) {
+            return;
+        }
+
+        if (PRIMARY_OWNER.name().equals(roleName)) {
+            errors.add(Error.severe("setting primary owner as default %s role is not allowed", roleScope.name().toLowerCase()));
+            roleSetter.accept(null);
+            return;
+        }
+
+        roleService
+            .findByScopeAndName(
+                io.gravitee.rest.api.model.permissions.RoleScope.valueOf(roleScope.name()),
+                roleName,
+                input.auditInfo().organizationId()
+            )
+            .ifPresentOrElse(
+                role -> roleSetter.accept(role.getName()),
+                () -> {
+                    errors.add(Error.warning("default %s role [%s] doesn't exist", roleScope.name().toLowerCase(), roleName));
+                    roleSetter.accept(null);
+                }
+            );
     }
 
     private Result<Set<GroupCRDSpec.Member>> validateAndSanitizeMembers(ValidateGroupCRDDomainService.Input input) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/member/CRDMembersDomainServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/member/CRDMembersDomainServiceImpl.java
@@ -21,6 +21,7 @@ import io.gravitee.apim.core.exception.ValidationDomainException;
 import io.gravitee.apim.core.group.model.crd.GroupCRDSpec;
 import io.gravitee.apim.core.member.domain_service.CRDMembersDomainService;
 import io.gravitee.apim.core.member.model.RoleScope;
+import io.gravitee.apim.core.member.model.SystemRole;
 import io.gravitee.apim.core.member.model.crd.MemberCRD;
 import io.gravitee.apim.core.utils.CollectionUtils;
 import io.gravitee.apim.core.utils.StringUtils;
@@ -83,6 +84,48 @@ public class CRDMembersDomainServiceImpl implements CRDMembersDomainService {
         deleteOrphans(auditInfo, groupId, RoleScope.API, MembershipReferenceType.GROUP, apiMembers);
         deleteOrphans(auditInfo, groupId, RoleScope.APPLICATION, MembershipReferenceType.GROUP, applicationMembers);
         deleteOrphans(auditInfo, groupId, RoleScope.INTEGRATION, MembershipReferenceType.GROUP, integrationMembers);
+    }
+
+    @Override
+    public void updateGroupDefaultRoles(AuditInfo auditInfo, String groupId, String apiRole, String applicationRole) {
+        var executionContext = new ExecutionContext(auditInfo.organizationId(), auditInfo.environmentId());
+
+        if (!StringUtils.isEmpty(apiRole)) {
+            updateDefaultRole(executionContext, groupId, apiRole, RoleScope.API);
+        }
+
+        if (!StringUtils.isEmpty(applicationRole)) {
+            updateDefaultRole(executionContext, groupId, applicationRole, RoleScope.APPLICATION);
+        }
+    }
+
+    private void updateDefaultRole(ExecutionContext executionContext, String groupId, String roleName, RoleScope roleScope) {
+        if (SystemRole.PRIMARY_OWNER.name().equals(roleName)) {
+            return;
+        }
+
+        var referenceType = MembershipReferenceType.valueOf(roleScope.name());
+        var currentRole = membershipService
+            .getRoles(referenceType, null, MembershipMemberType.GROUP, groupId)
+            .stream()
+            .findFirst()
+            .map(RoleEntity::getName)
+            .orElse(null);
+
+        if (roleName.equals(currentRole)) {
+            return;
+        }
+
+        if (currentRole != null) {
+            membershipService.deleteReferenceMember(executionContext, referenceType, null, MembershipMemberType.GROUP, groupId);
+        }
+
+        membershipService.addRoleToMemberOnReference(
+            executionContext,
+            new MembershipService.MembershipReference(referenceType, null),
+            new MembershipService.MembershipMember(groupId, null, MembershipMemberType.GROUP),
+            new MembershipService.MembershipRole(mapRoleScope(roleScope), roleName)
+        );
     }
 
     private void updateMembers(

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/CRDMembersDomainServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/CRDMembersDomainServiceInMemory.java
@@ -31,6 +31,8 @@ public class CRDMembersDomainServiceInMemory implements CRDMembersDomainService 
     private final HashMap<String, Set<MemberCRD>> apiMembers = new HashMap<>();
     private final HashMap<String, Set<MemberCRD>> applicationMembers = new HashMap<>();
     private final HashMap<String, Set<GroupCRDSpec.Member>> groupMembers = new HashMap<>();
+    private final HashMap<String, String> groupApiRoles = new HashMap<>();
+    private final HashMap<String, String> groupApplicationRoles = new HashMap<>();
 
     @Override
     public void updateApiMembers(AuditInfo auditInfo, String apiId, Set<MemberCRD> members) {
@@ -47,10 +49,22 @@ public class CRDMembersDomainServiceInMemory implements CRDMembersDomainService 
         groupMembers.put(groupId, members);
     }
 
+    @Override
+    public void updateGroupDefaultRoles(AuditInfo auditInfo, String groupId, String apiRole, String applicationRole) {
+        if (apiRole != null) {
+            groupApiRoles.put(groupId, apiRole);
+        }
+        if (applicationRole != null) {
+            groupApplicationRoles.put(groupId, applicationRole);
+        }
+    }
+
     public void reset() {
         apiMembers.clear();
         applicationMembers.clear();
         groupMembers.clear();
+        groupApiRoles.clear();
+        groupApplicationRoles.clear();
     }
 
     public Set<MemberCRD> getApiMembers(String id) {
@@ -63,5 +77,13 @@ public class CRDMembersDomainServiceInMemory implements CRDMembersDomainService 
 
     public Set<GroupCRDSpec.Member> getGroupMembers(String id) {
         return groupMembers.getOrDefault(id, Set.of());
+    }
+
+    public String getGroupApiRole(String id) {
+        return groupApiRoles.get(id);
+    }
+
+    public String getGroupApplicationRole(String id) {
+        return groupApplicationRoles.get(id);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/group/use_case/ImportGroupCRDUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/group/use_case/ImportGroupCRDUseCaseTest.java
@@ -16,6 +16,7 @@
 package io.gravitee.apim.core.group.use_case;
 
 import static org.assertj.core.api.SoftAssertions.*;
+import static org.mockito.Mockito.when;
 
 import fixtures.core.model.AuditInfoFixtures;
 import inmemory.CRDMembersDomainServiceInMemory;
@@ -28,10 +29,12 @@ import io.gravitee.apim.core.group.model.crd.GroupCRDSpec;
 import io.gravitee.apim.core.member.domain_service.ValidateCRDMembersDomainService;
 import io.gravitee.apim.core.member.model.RoleScope;
 import io.gravitee.apim.infra.domain_service.group.ValidateGroupCRDDomainServiceImpl;
+import io.gravitee.rest.api.model.RoleEntity;
 import io.gravitee.rest.api.model.context.OriginContext;
 import io.gravitee.rest.api.service.MembershipService;
 import io.gravitee.rest.api.service.RoleService;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
@@ -102,6 +105,25 @@ public class ImportGroupCRDUseCaseTest {
             soft.assertThat(storage).hasSize(1);
             soft.assertThat(storage.get(GROUP_ID)).isNotNull();
             soft.assertThat(storage.get(GROUP_ID).getOrigin()).isEqualTo(OriginContext.Origin.KUBERNETES.name());
+        });
+    }
+
+    @Test
+    void should_set_default_roles_on_create() {
+        when(roleService.findByScopeAndName(io.gravitee.rest.api.model.permissions.RoleScope.API, "OWNER", ORGANIZATION_ID)).thenReturn(
+            Optional.of(RoleEntity.builder().name("OWNER").build())
+        );
+        when(
+            roleService.findByScopeAndName(io.gravitee.rest.api.model.permissions.RoleScope.APPLICATION, "USER", ORGANIZATION_ID)
+        ).thenReturn(Optional.of(RoleEntity.builder().name("USER").build()));
+
+        var spec = GroupCRDSpec.builder().id(GROUP_ID).name("kubernetes-spec").apiRole("OWNER").applicationRole("USER");
+
+        cut.execute(new ImportGroupCRDUseCase.Input(AUDIT_INFO, spec.build()));
+
+        assertSoftly(soft -> {
+            soft.assertThat(membersService.getGroupApiRole(GROUP_ID)).isEqualTo("OWNER");
+            soft.assertThat(membersService.getGroupApplicationRole(GROUP_ID)).isEqualTo("USER");
         });
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/member/CRDMembersDomainServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/member/CRDMembersDomainServiceImplTest.java
@@ -661,4 +661,76 @@ class CRDMembersDomainServiceImplTest {
             );
         }
     }
+
+    @Nested
+    class GroupDefaultRoles {
+
+        private static final String GROUP_ID = "group-id";
+
+        @BeforeEach
+        void setUp() {
+            reset(membershipService, roleService);
+        }
+
+        @Test
+        void should_set_default_roles() {
+            when(membershipService.getRoles(MembershipReferenceType.API, null, MembershipMemberType.GROUP, GROUP_ID)).thenReturn(Set.of());
+
+            cut.updateGroupDefaultRoles(AUDIT_INFO, GROUP_ID, "OWNER", null);
+
+            verify(membershipService).addRoleToMemberOnReference(
+                eq(new ExecutionContext(AUDIT_INFO.organizationId(), AUDIT_INFO.environmentId())),
+                argThat(ref -> ref.getType() == MembershipReferenceType.API && ref.getId() == null),
+                eq(new MembershipService.MembershipMember(GROUP_ID, null, MembershipMemberType.GROUP)),
+                eq(new MembershipService.MembershipRole(RoleScope.API, "OWNER"))
+            );
+        }
+
+        @Test
+        void should_replace_existing_default_role() {
+            when(membershipService.getRoles(MembershipReferenceType.API, null, MembershipMemberType.GROUP, GROUP_ID)).thenReturn(
+                Set.of(RoleEntity.builder().id("api-owner-role").name("OWNER").scope(RoleScope.API).build())
+            );
+
+            cut.updateGroupDefaultRoles(AUDIT_INFO, GROUP_ID, "USER", null);
+
+            verify(membershipService).deleteReferenceMember(
+                new ExecutionContext(AUDIT_INFO.organizationId(), AUDIT_INFO.environmentId()),
+                MembershipReferenceType.API,
+                null,
+                MembershipMemberType.GROUP,
+                GROUP_ID
+            );
+
+            verify(membershipService).addRoleToMemberOnReference(
+                eq(new ExecutionContext(AUDIT_INFO.organizationId(), AUDIT_INFO.environmentId())),
+                argThat(ref -> ref.getType() == MembershipReferenceType.API && ref.getId() == null),
+                eq(new MembershipService.MembershipMember(GROUP_ID, null, MembershipMemberType.GROUP)),
+                eq(new MembershipService.MembershipRole(RoleScope.API, "USER"))
+            );
+        }
+
+        @Test
+        void should_not_update_when_role_is_unchanged() {
+            when(membershipService.getRoles(MembershipReferenceType.API, null, MembershipMemberType.GROUP, GROUP_ID)).thenReturn(
+                Set.of(RoleEntity.builder().id("api-owner-role").name("OWNER").scope(RoleScope.API).build())
+            );
+
+            cut.updateGroupDefaultRoles(AUDIT_INFO, GROUP_ID, "OWNER", null);
+
+            verify(membershipService, never()).deleteReferenceMember(
+                any(),
+                eq(MembershipReferenceType.API),
+                eq(null),
+                eq(MembershipMemberType.GROUP),
+                eq(GROUP_ID)
+            );
+            verify(membershipService, never()).addRoleToMemberOnReference(
+                any(ExecutionContext.class),
+                any(MembershipService.MembershipReference.class),
+                any(MembershipService.MembershipMember.class),
+                any(MembershipService.MembershipRole.class)
+            );
+        }
+    }
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-13400

## Description

**Changes**
Added apiRole and applicationRole to the REST and core GroupCRDSpec models.
Validated both fields during CRD import:
reject PRIMARY_OWNER
warn and skip unknown role names
Added CRDMembersDomainService.updateGroupDefaultRoles() to create or replace default role memberships.
Updated ImportGroupCRDUseCase to call this on both create and update, before member sync.

**Behaviour**
If apiRole / applicationRole are provided and valid, the group’s default roles are set or updated.
If omitted, existing default roles are left unchanged.
Invalid roles produce warnings and are not applied; PRIMARY_OWNER is rejected

**Default Roles are updated from OWNER to USER:**
<img width="1066" height="680" alt="image" src="https://github.com/user-attachments/assets/b51dfeed-ad9a-44b9-a128-e70bbbcc8abc" />
<img width="1066" height="680" alt="image" src="https://github.com/user-attachments/assets/630d2fb0-3321-4f02-992f-a7f790583e9a" />
<img width="1066" height="680" alt="image" src="https://github.com/user-attachments/assets/90d13ce9-d480-4fbd-bf8a-cffa4f4de258" />


**Default PO role update is Rejected:**
<img width="1066" height="680" alt="image" src="https://github.com/user-attachments/assets/a318980d-b851-46a1-b547-80f996ad7e4f" />