### PR TITLE
fix(console): isolate API detail sidebar and content scrolling

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/api-navigation/api-navigation.component.html
+++ b/gravitee-apim-console-webui/src/management/api/api-navigation/api-navigation.component.html
@@ -29,89 +29,91 @@
         [apiOrigin]="currentApi.originContext.origin"
         [definitionVersion]="currentApi.definitionVersion"
       ></api-navigation-title>
-      <ng-container *ngFor="let menuItem of subMenuItems">
-        <ng-container *ngIf="!menuItem?.routerLink && menuItem?.tabs?.length > 0">
-          <a [routerLink]="menuItem?.tabs[0]?.routerLink">
-            <gio-submenu-item
-              tabIndex="1"
-              [active]="isTabActive(menuItem?.tabs)"
-              [gioLicense]="menuItem?.license"
-              [iconRight]="menuItem?.iconRight$ | async"
-            >
-              <div class="api-navigation__submenu__item">
-                <mat-icon
-                  *ngIf="menuItem.icon"
-                  class="api-navigation__submenu__item__icon"
-                  [matTooltip]="menuItem?.displayName"
-                  [svgIcon]="'gio:' + menuItem.icon"
-                >
-                </mat-icon>
-                {{ menuItem?.displayName }}
-              </div>
-            </gio-submenu-item>
-          </a>
-        </ng-container>
-        <ng-container *ngIf="menuItem?.routerLink && menuItem.routerLink !== 'DISABLED'">
-          <a [routerLink]="menuItem?.routerLink">
-            <gio-submenu-item
-              tabIndex="1"
-              [active]="isActive(menuItem)"
-              [gioLicense]="menuItem?.license"
-              [iconRight]="menuItem?.iconRight$ | async"
-            >
-              <div class="api-navigation__submenu__item">
-                <mat-icon
-                  *ngIf="menuItem.icon"
-                  class="api-navigation__submenu__item__icon"
-                  [matTooltip]="menuItem?.displayName"
-                  [svgIcon]="'gio:' + menuItem.icon"
-                >
-                </mat-icon>
-                {{ menuItem?.displayName }}
-              </div>
-            </gio-submenu-item>
-          </a>
-        </ng-container>
-        <api-navigation-disabled
-          *ngIf="menuItem?.routerLink === 'DISABLED'"
-          class="api-navigation__menu__disabled"
-          [displayName]="menuItem.displayName"
-          [icon]="menuItem.icon"
-        ></api-navigation-disabled>
-      </ng-container>
-      <ng-container *ngFor="let group of groupItems">
-        <gio-submenu-group [title]="group.title" *ngIf="group.title">
-          <ng-container *ngFor="let subItem of group.items">
-            <ng-container *ngIf="!subItem?.routerLink && subItem?.tabs?.length > 0">
-              <a [routerLink]="subItem?.tabs[0]?.routerLink">
-                <gio-submenu-item
-                  tabIndex="1"
-                  [active]="isTabActive(subItem?.tabs)"
-                  [gioLicense]="subItem?.license"
-                  [iconRight]="subItem?.iconRight$ | async"
-                  >{{ subItem?.displayName }}</gio-submenu-item
-                ></a
-              ></ng-container
-            >
-            <ng-container *ngIf="subItem?.routerLink && subItem.routerLink !== 'DISABLED'">
-              <a [routerLink]="subItem?.routerLink">
-                <gio-submenu-item
-                  tabIndex="1"
-                  [active]="isActive(subItem)"
-                  [gioLicense]="subItem?.license"
-                  [iconRight]="subItem?.iconRight$ | async"
-                  >{{ subItem?.displayName }}</gio-submenu-item
-                ></a
-              ></ng-container
-            >
-            <api-navigation-disabled
-              *ngIf="subItem?.routerLink === 'DISABLED'"
-              class="api-navigation__submenu__disabled"
-              [displayName]="subItem.displayName"
-            ></api-navigation-disabled>
+      <div class="api-navigation__menu-items-scroll">
+        <ng-container *ngFor="let menuItem of subMenuItems">
+          <ng-container *ngIf="!menuItem?.routerLink && menuItem?.tabs?.length > 0">
+            <a [routerLink]="menuItem?.tabs[0]?.routerLink">
+              <gio-submenu-item
+                tabIndex="1"
+                [active]="isTabActive(menuItem?.tabs)"
+                [gioLicense]="menuItem?.license"
+                [iconRight]="menuItem?.iconRight$ | async"
+              >
+                <div class="api-navigation__submenu__item">
+                  <mat-icon
+                    *ngIf="menuItem.icon"
+                    class="api-navigation__submenu__item__icon"
+                    [matTooltip]="menuItem?.displayName"
+                    [svgIcon]="'gio:' + menuItem.icon"
+                  >
+                  </mat-icon>
+                  {{ menuItem?.displayName }}
+                </div>
+              </gio-submenu-item>
+            </a>
           </ng-container>
-        </gio-submenu-group>
-      </ng-container>
+          <ng-container *ngIf="menuItem?.routerLink && menuItem.routerLink !== 'DISABLED'">
+            <a [routerLink]="menuItem?.routerLink">
+              <gio-submenu-item
+                tabIndex="1"
+                [active]="isActive(menuItem)"
+                [gioLicense]="menuItem?.license"
+                [iconRight]="menuItem?.iconRight$ | async"
+              >
+                <div class="api-navigation__submenu__item">
+                  <mat-icon
+                    *ngIf="menuItem.icon"
+                    class="api-navigation__submenu__item__icon"
+                    [matTooltip]="menuItem?.displayName"
+                    [svgIcon]="'gio:' + menuItem.icon"
+                  >
+                  </mat-icon>
+                  {{ menuItem?.displayName }}
+                </div>
+              </gio-submenu-item>
+            </a>
+          </ng-container>
+          <api-navigation-disabled
+            *ngIf="menuItem?.routerLink === 'DISABLED'"
+            class="api-navigation__menu__disabled"
+            [displayName]="menuItem.displayName"
+            [icon]="menuItem.icon"
+          ></api-navigation-disabled>
+        </ng-container>
+        <ng-container *ngFor="let group of groupItems">
+          <gio-submenu-group [title]="group.title" *ngIf="group.title">
+            <ng-container *ngFor="let subItem of group.items">
+              <ng-container *ngIf="!subItem?.routerLink && subItem?.tabs?.length > 0">
+                <a [routerLink]="subItem?.tabs[0]?.routerLink">
+                  <gio-submenu-item
+                    tabIndex="1"
+                    [active]="isTabActive(subItem?.tabs)"
+                    [gioLicense]="subItem?.license"
+                    [iconRight]="subItem?.iconRight$ | async"
+                    >{{ subItem?.displayName }}</gio-submenu-item
+                  ></a
+                ></ng-container
+              >
+              <ng-container *ngIf="subItem?.routerLink && subItem.routerLink !== 'DISABLED'">
+                <a [routerLink]="subItem?.routerLink">
+                  <gio-submenu-item
+                    tabIndex="1"
+                    [active]="isActive(subItem)"
+                    [gioLicense]="subItem?.license"
+                    [iconRight]="subItem?.iconRight$ | async"
+                    >{{ subItem?.displayName }}</gio-submenu-item
+                  ></a
+                ></ng-container
+              >
+              <api-navigation-disabled
+                *ngIf="subItem?.routerLink === 'DISABLED'"
+                class="api-navigation__submenu__disabled"
+                [displayName]="subItem.displayName"
+              ></api-navigation-disabled>
+            </ng-container>
+          </gio-submenu-group>
+        </ng-container>
+      </div>
     </gio-submenu>
   </div>
   <div class="api-navigation__content">

--- a/gravitee-apim-console-webui/src/management/api/api-navigation/api-navigation.component.scss
+++ b/gravitee-apim-console-webui/src/management/api/api-navigation/api-navigation.component.scss
@@ -19,11 +19,19 @@
 
 $textColor: map.get(gio.$mat-dove-palette, default);
 
+:host {
+  display: block;
+  height: 100%;
+  min-height: 0;
+  overflow: hidden;
+}
+
 .api-navigation {
   height: 100%;
   display: grid;
   grid-template-columns: min-content auto;
   grid-template-areas: 'menu content';
+  overflow: hidden;
 
   a {
     text-decoration: none;
@@ -33,14 +41,28 @@ $textColor: map.get(gio.$mat-dove-palette, default);
     grid-area: menu;
     display: flex;
     flex-direction: column;
+    min-height: 0;
+    overflow: hidden;
+    background: var(--gio-oem-palette--sub-menu);
 
     &__disabled {
       padding-left: 12px;
     }
   }
 
+  &__menu-items-scroll {
+    flex: 1 1 auto;
+    min-height: 0;
+    overflow-x: hidden;
+    overflow-y: auto;
+  }
+
   &__submenu {
     z-index: 70;
+    display: flex;
+    flex-direction: column;
+    flex: 1 1 auto;
+    min-height: 0;
     height: 100%;
     color: $textColor;
 
@@ -75,13 +97,17 @@ $textColor: map.get(gio.$mat-dove-palette, default);
     display: flex;
     flex-direction: column;
     flex: 1 1 auto;
+    min-height: 0;
+    overflow: hidden;
 
     &__view {
       display: flex;
       flex-direction: column;
       flex: 1 1 auto;
       height: 100%;
+      min-height: 0;
       margin: 12px 24px 0 24px;
+      overflow-y: auto;
 
       &__ui {
         height: 100%;
@@ -90,7 +116,7 @@ $textColor: map.get(gio.$mat-dove-palette, default);
   }
 }
 
-.tech-preview-banner {
+:host .tech-preview-banner {
   margin-top: 0;
   margin-bottom: 24px;
 }

--- a/gravitee-apim-console-webui/src/management/settings/settings-navigation/settings-navigation.component.html
+++ b/gravitee-apim-console-webui/src/management/settings/settings-navigation/settings-navigation.component.html
@@ -17,26 +17,30 @@
 -->
 <div class="settings-navigation">
   <div class="settings-navigation__menu">
-    <gio-submenu class="settings-navigation__submenu">
-      <ng-container *ngFor="let group of groupItems">
-        <gio-submenu-group [title]="group.title" *ngIf="group.items && group.items.length > 0">
-          <ng-container *ngFor="let item of group.items">
-            <a [routerLink]="item.routerLink" routerLinkActive #rla="routerLinkActive">
-              <gio-submenu-item tabIndex="1" [active]="rla.isActive">{{ item.displayName }}</gio-submenu-item>
-            </a>
-          </ng-container>
-        </gio-submenu-group>
-      </ng-container>
-    </gio-submenu>
+    <div class="settings-navigation__menu-scroll">
+      <gio-submenu class="settings-navigation__submenu">
+        <ng-container *ngFor="let group of groupItems">
+          <gio-submenu-group [title]="group.title" *ngIf="group.items && group.items.length > 0">
+            <ng-container *ngFor="let item of group.items">
+              <a [routerLink]="item.routerLink" routerLinkActive #rla="routerLinkActive">
+                <gio-submenu-item tabIndex="1" [active]="rla.isActive">{{ item.displayName }}</gio-submenu-item>
+              </a>
+            </ng-container>
+          </gio-submenu-group>
+        </ng-container>
+      </gio-submenu>
+    </div>
   </div>
   <div class="settings-navigation__content">
-    <gio-breadcrumb *ngIf="hasBreadcrumb" class="settings-navigation__breadcrumb">
-      <span *gioBreadcrumbItem class="settings-navigation__breadcrumb__item">Settings</span>
-      <ng-template ngFor let-item [ngForOf]="computeBreadcrumbItems()">
-        <span *gioBreadcrumbItem class="settings-navigation__breadcrumb__item">{{ item }}</span>
-      </ng-template>
-    </gio-breadcrumb>
+    <div class="settings-navigation__content__view">
+      <gio-breadcrumb *ngIf="hasBreadcrumb" class="settings-navigation__breadcrumb">
+        <span *gioBreadcrumbItem class="settings-navigation__breadcrumb__item">Settings</span>
+        <ng-template ngFor let-item [ngForOf]="computeBreadcrumbItems()">
+          <span *gioBreadcrumbItem class="settings-navigation__breadcrumb__item">{{ item }}</span>
+        </ng-template>
+      </gio-breadcrumb>
 
-    <router-outlet></router-outlet>
+      <router-outlet></router-outlet>
+    </div>
   </div>
 </div>

--- a/gravitee-apim-console-webui/src/management/settings/settings-navigation/settings-navigation.component.scss
+++ b/gravitee-apim-console-webui/src/management/settings/settings-navigation/settings-navigation.component.scss
@@ -19,11 +19,19 @@
 
 $textColor: map.get(gio.$mat-dove-palette, default);
 
+:host {
+  display: block;
+  height: 100%;
+  min-height: 0;
+  overflow: hidden;
+}
+
 .settings-navigation {
   height: 100%;
   display: grid;
   grid-template-columns: min-content auto;
   grid-template-areas: 'menu content';
+  overflow: hidden;
 
   a {
     text-decoration: none;
@@ -33,11 +41,21 @@ $textColor: map.get(gio.$mat-dove-palette, default);
     grid-area: menu;
     display: flex;
     flex-direction: column;
+    min-height: 0;
+    overflow: hidden;
+
+    &-scroll {
+      flex: 1 1 auto;
+      min-height: 0;
+      overflow-x: hidden;
+      overflow-y: auto;
+    }
   }
 
   &__submenu {
     z-index: 70;
-    height: 100%;
+    display: block;
+    height: auto;
     color: $textColor;
   }
 
@@ -54,10 +72,20 @@ $textColor: map.get(gio.$mat-dove-palette, default);
     display: flex;
     flex-direction: column;
     flex: 1 1 auto;
-    height: 100%;
+    min-height: 0;
+    overflow: hidden;
 
     a {
       text-decoration: none;
+    }
+
+    &__view {
+      display: flex;
+      flex-direction: column;
+      flex: 1 1 auto;
+      height: 100%;
+      min-height: 0;
+      overflow-y: auto;
     }
   }
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-14151

## Description

Give the API navigation menu and main content separate scroll containers so scrolling the sidebar no longer shifts the content viewport. Align gio-submenu height with menu content to avoid mixed background colors when the menu is long.

https://github.com/user-attachments/assets/245d22bb-a1f1-49d8-9af4-00a3c584bf39

