### PR TITLE
chore(deps): bump gravitee-resource-cache-provider-api to 2.2.0 (APIM-13628)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
         <gravitee-reporter-api.version>2.3.0</gravitee-reporter-api.version>
         <gravitee-resource-api.version>1.1.0</gravitee-resource-api.version>
         <gravitee-resource-auth-provider-api.version>1.3.0</gravitee-resource-auth-provider-api.version>
-        <gravitee-resource-cache-provider-api.version>2.1.0</gravitee-resource-cache-provider-api.version>
+        <gravitee-resource-cache-provider-api.version>2.2.0</gravitee-resource-cache-provider-api.version>
         <gravitee-resource-content-provider-api.version>1.0.0</gravitee-resource-content-provider-api.version>
         <gravitee-resource-oauth2-provider-api.version>1.5.1</gravitee-resource-oauth2-provider-api.version>
         <gravitee-resource-storage-api.version>1.1.0</gravitee-resource-storage-api.version>


### PR DESCRIPTION
## Summary

Bumps `gravitee-resource-cache-provider-api` from `2.1.0` to `2.2.0`. The 2.2.0 release adds two `default` methods to the `Cache` interface (`getBinaryAsync`, `putBinaryAsync`) for binary-safe cache values — purely additive, no breaking change for existing consumers.

## Why

Required by [APIM-13628](https://gravitee.atlassian.net/browse/APIM-13628) so that the new `gravitee-policy-cache` 4.0.0-alpha.3 and `gravitee-resource-cache-redis` 5.0.0-alpha.3 plugins (which use the new binary Cache methods) resolve their compile-time API against the published artifact.

## Jira

[APIM-13628](https://gravitee.atlassian.net/browse/APIM-13628)

## Downstream PRs

- gravitee-resource-cache-redis: https://github.com/gravitee-io/gravitee-resource-cache-redis/pull/84
- gravitee-policy-cache: https://github.com/gravitee-io/gravitee-policy-cache/pull/104

Both downstream PRs' CI is gated on this bump being merged + published to the snapshot/release feed.

## Test plan

- [x] No code changes — only a property version bump. No tests added.
- [ ] CI build green on the updated SNAPSHOT BOM.

[APIM-13628]: https://gravitee.atlassian.net/browse/APIM-13628?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[APIM-13628]: https://gravitee.atlassian.net/browse/APIM-13628?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ