### PR TITLE
[CI] Rest-API tests improvement

### DIFF
--- a/.circleci/ci/src/jobs/backend/job-test-rest-api.ts
+++ b/.circleci/ci/src/jobs/backend/job-test-rest-api.ts
@@ -36,7 +36,7 @@ export class TestRestApiJob extends AbstractTestJob {
           command: `mvn --fail-fast -s ${config.maven.settingsFile} test --no-transfer-progress -Drest-api-modules -Dskip.validation=true -Dgravitee.archrules.skip=true -T 2C`,
         }),
       ],
-      UbuntuExecutor.create('medium'),
+      UbuntuExecutor.create('large'),
       ['gravitee-apim-rest-api/gravitee-apim-rest-api-coverage/target/site/jacoco-aggregate/'],
     );
   }

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-4-1-x.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-4-1-x.yml
@@ -341,7 +341,7 @@ jobs:
     machine:
       image: ubuntu-2204:current
       docker_layer_caching: false
-    resource_class: medium
+    resource_class: large
     steps:
       - checkout
       - attach_workspace:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-only.yml
@@ -252,7 +252,7 @@ jobs:
     machine:
       image: ubuntu-2204:current
       docker_layer_caching: false
-    resource_class: medium
+    resource_class: large
     steps:
       - checkout
       - attach_workspace:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-rest-api-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-backend-rest-api-only.yml
@@ -153,7 +153,7 @@ jobs:
     machine:
       image: ubuntu-2204:current
       docker_layer_caching: false
-    resource_class: medium
+    resource_class: large
     steps:
       - checkout
       - attach_workspace:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch.yml
@@ -317,7 +317,7 @@ jobs:
     machine:
       image: ubuntu-2204:current
       docker_layer_caching: false
-    resource_class: medium
+    resource_class: large
     steps:
       - checkout
       - attach_workspace:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-master.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-master.yml
@@ -341,7 +341,7 @@ jobs:
     machine:
       image: ubuntu-2204:current
       docker_layer_caching: false
-    resource_class: medium
+    resource_class: large
     steps:
       - checkout
       - attach_workspace:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-mergify.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-mergify.yml
@@ -317,7 +317,7 @@ jobs:
     machine:
       image: ubuntu-2204:current
       docker_layer_caching: false
-    resource_class: medium
+    resource_class: large
     steps:
       - checkout
       - attach_workspace:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-run-e2e.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-run-e2e.yml
@@ -342,7 +342,7 @@ jobs:
     machine:
       image: ubuntu-2204:current
       docker_layer_caching: false
-    resource_class: medium
+    resource_class: large
     steps:
       - checkout
       - attach_workspace:

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/test/java/io/gravitee/rest/api/kafkaexplorer/resource/AbstractKafkaExplorerResourceIntegrationTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-kafka-explorer/src/test/java/io/gravitee/rest/api/kafkaexplorer/resource/AbstractKafkaExplorerResourceIntegrationTest.java
@@ -59,8 +59,6 @@ abstract class AbstractKafkaExplorerResourceIntegrationTest {
             .withExposedService(BROKER_SERVICE, SASL_PLAINTEXT_PORT);
         kafka.start();
 
-        GraviteeContext.setCurrentEnvironment(ENVIRONMENT_ID);
-
         try {
             resource = new KafkaExplorerResource();
             clusterCrudService = new ClusterCrudServiceInMemory();
@@ -95,6 +93,7 @@ abstract class AbstractKafkaExplorerResourceIntegrationTest {
     @BeforeEach
     void resetClusterCrudService() {
         clusterCrudService.reset();
+        GraviteeContext.setCurrentEnvironment(ENVIRONMENT_ID);
     }
 
     protected static String plaintextBootstrapServers() {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/pom.xml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/pom.xml
@@ -438,6 +438,10 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
+				<configuration>
+					<forkCount>2</forkCount>
+					<reuseForks>true</reuseForks>
+				</configuration>
 				<executions>
 					<execution>
 						<id>default-test</id>

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/testing/GraviteeContextCleanupExtension.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/testing/GraviteeContextCleanupExtension.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.testing;
+
+import io.gravitee.rest.api.service.common.GraviteeContext;
+import org.junit.jupiter.api.extension.AfterAllCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+// Auto-registered via META-INF/services/org.junit.jupiter.api.extension.Extension
+// together with junit-platform.properties enabling autodetection. Guards against
+// ThreadLocal pollution leaking from one test class to the next when forks share
+// a JVM (forkCount>1, reuseForks=true). Cleanup happens after the entire class
+// so @BeforeAll setups inside a class keep working.
+public class GraviteeContextCleanupExtension implements AfterAllCallback {
+
+    @Override
+    public void afterAll(ExtensionContext context) {
+        GraviteeContext.cleanContext();
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/META-INF/services/org.junit.jupiter.api.extension.Extension
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/META-INF/services/org.junit.jupiter.api.extension.Extension
@@ -1,0 +1,1 @@
+io.gravitee.rest.api.service.testing.GraviteeContextCleanupExtension

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/junit-platform.properties
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/resources/junit-platform.properties
@@ -1,0 +1,1 @@
+junit.jupiter.extensions.autodetection.enabled=true

--- a/gravitee-apim-rest-api/pom.xml
+++ b/gravitee-apim-rest-api/pom.xml
@@ -90,4 +90,32 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <!-- Resolve mockito-core jar location into ${org.mockito:mockito-core:jar} so we can pass it to surefire as a static javaagent below. -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <version>${maven-dependency-plugin.version}</version>
+                <executions>
+                    <execution>
+                        <id>resolve-mockito-agent</id>
+                        <phase>initialize</phase>
+                        <goals>
+                            <goal>properties</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <!-- Override surefire argLine to prepend -javaagent:mockito-core. Avoids the ~3 s self-attach cost on every surefire fork. -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <argLine>@{argLine} -javaagent:${org.mockito:mockito-core:jar} --add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.util=ALL-UNNAMED --add-opens java.base/java.util.regex=ALL-UNNAMED --add-opens java.base/java.util.stream=ALL-UNNAMED --add-opens java.base/java.net=ALL-UNNAMED</argLine>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/gravitee-gamma/pom.xml
+++ b/gravitee-gamma/pom.xml
@@ -70,6 +70,29 @@
                     </execution>
                 </executions>
             </plugin>
+            <!-- Resolve mockito-core jar location into ${org.mockito:mockito-core:jar} so we can pass it to surefire as a static javaagent below. -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <version>${maven-dependency-plugin.version}</version>
+                <executions>
+                    <execution>
+                        <id>resolve-mockito-agent</id>
+                        <phase>initialize</phase>
+                        <goals>
+                            <goal>properties</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <!-- Override surefire argLine to prepend -javaagent:mockito-core. Avoids the ~3 s self-attach cost on every surefire fork. -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <argLine>@{argLine} -javaagent:${org.mockito:mockito-core:jar} --add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.util=ALL-UNNAMED --add-opens java.base/java.util.regex=ALL-UNNAMED --add-opens java.base/java.util.stream=ALL-UNNAMED --add-opens java.base/java.net=ALL-UNNAMED</argLine>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
## Description
  
  Trims the `Test rest-api` CircleCI job from ~18:30 down to ~11:50 wall-clock (−36 %), without skipping any test. Three changes, each commit standalone:

### `ci(rest-api): bump test rest-api job to large resource class`
the job runs `mvn ... -T 2C`, i.e. 4 parallel Maven threads on a `medium` VM with 2 vCPUs. Bumping the resource class to `large` (4 vCPUs) lets the existing parallelism actually run in parallel. Applied both in `.circleci/ci/src/jobs/backend/job-test-rest-api.ts` and in the 7 pull-requests fixtures.

### `chore(build): load mockito as a static javaagent on rest-api and gamma surefire forks`
Mockito 5+ self-attaches its byte-buddy agent at runtime, which adds ~3 s of bootstrap per Surefire fork and prints a deprecation warning. Resolve the `mockito-core` jar via `maven-dependency-plugin:properties` and pass it as `-javaagent` in Surefire's `argLine`. Locally the `services-audit` submodule wall-clock drops from ~26 s to ~2 s.

The plugin and the argline override live under `gravitee-apim-rest-api/pom.xml` and `gravitee-gamma/pom.xml` — the two parents whose modules actually run in the `Test rest-api` job. Keeping the config out of the global `gravitee-apim-parent` avoids activating the inherited `unpack-repository-tests` execution on modules like `gravitee-apim-repository-elasticsearch` (which was a regression caught during review and fixed here, not in a follow-up).

### `test(rest-api): parallelize the service module surefire run`
Set `forkCount=2 reuseForks=true` on the `maven-surefire-plugin` of `gravitee-apim-rest-api-service`. On the ~7700-test module this roughly halves wall-clock CPU usage of the Maven thread that owns the module.

The module had latent ThreadLocal leaks via `GraviteeContext`: several JUnit 5 use-case tests call `setCurrentEnvironment` without cleanup, which used to work only because `forkCount=1` made class order deterministic. With multiple forks the cross-fork class ordering changes and `ApiDuplicatorServiceImplTest` starts failing as a victim.

The fix is a JUnit 5 extension auto-registered via service loader plus `junit-platform.properties` enabling autodetection. It calls `GraviteeContext.cleanContext()` in `AfterAllCallback`, so each test class starts from a fresh ThreadLocal regardless of order. Cleanup happens after the class, not after each test, so `@BeforeAll` setups inside a class still work.

One pre-existing test (`AbstractKafkaExplorerResourceIntegrationTest`) was setting `GraviteeContext` inside a `static { }` block — fine when nothing ever cleaned the context, fragile by design. Moved the `setCurrentEnvironment` call into the existing `@BeforeEach` so each test starts deterministically.

## Additional context
  
Measured progression of the `Test rest-api` job wall-clock, sample CircleCI run:

  | Step | Wall-clock |
  |---|---|
  | baseline (master) | 18:31 |
  | + `resource_class: large` | ~15:00 |
  | + Mockito static javaagent (rest-api + gamma) | 13:10 |
  | + `forkCount=2` on service + cleanup extension | **11:50** |

  Modules outside the `Test rest-api` job scope (`gravitee-apim-repository`, `-gateway`, etc.) keep the previous Surefire config unchanged.

  Identified follow-ups, intentionally NOT in this PR:
  
  - `*RulesTest` / `CycleChecks*` / `NamingConventionTest` still run despite `-Dgravitee.archrules.skip=true` — that flag only disables the `gravitee-archrules-maven-plugin`, not the ArchUnit JUnit tests. Worth a Surefire `<excludes>` behind a dedicated flag.
  - A handful of resource tests still take 30+ s each (e.g. `PlatformAnalyticsResource_Admin_GetTest`, `ThemeResourceTest`, `HttpProviderTest`). Most look bootstrap-dominated (`JerseySpringTest` rebuilding the Spring context per class, `WireMockRule` restarting per method). Better addressed in a follow-up audit.