### PR TITLE
docs: consolidate agent instructions

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -1,4 +1,0 @@
-AI agent entrypoint
-
-Read `CONTRIBUTING.adoc`, section "AI Agent Context (Docker Compose Full Stack)".
-That section is the source of truth for setup, build, and runtime instructions.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,10 @@
 
 This repository contains multiple backend modules in Java (Maven) and multiple frontend applications and libraries in Angular.
 
+## Setup, build, and runtime
+
+For setup, build, and runtime instructions, read `CONTRIBUTING.adoc`, section **AI Agent Context (Docker Compose Full Stack)**. That section is the source of truth for AI tools.
+
 ## Common rules
 
 Shared coding standards live under [`.agent-rules/`](.agent-rules/).


### PR DESCRIPTION
**Description**

Consolidated the AI agent entrypoint instructions into AGENTS.md.

The setup/build/runtime source-of-truth pointer now lives in AGENTS.md, and the duplicate AGENT.md file was removed.

**Additional context**

CONTRIBUTING.adoc, section AI Agent Context (Docker Compose Full Stack), remains the source of truth for AI tooling setup, build, and runtime instructions.