### PR TITLE
feat(authz-ui): import resources from AIM Context Catalog + LLM→Model rename

### DIFF
--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/app/AppRoutes.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/app/AppRoutes.tsx
@@ -23,7 +23,7 @@ import { AUTHZ_ROUTE_CONFIG, ROUTES, type RouteKey } from '../config/routes';
 import { DashboardPage } from '../features/dashboard/DashboardPage';
 import { ApisPage } from '../features/policy-management/pages/ApisPage';
 import { CustomPoliciesPage } from '../features/policy-management/pages/CustomPoliciesPage';
-import { LlmsPage } from '../features/policy-management/pages/LlmsPage';
+import { ModelsPage } from '../features/policy-management/pages/ModelsPage';
 import { McpsPage } from '../features/policy-management/pages/McpsPage';
 import { EntitiesPage } from '../features/policy-structure/EntitiesPage';
 import { ModuleErrorBoundary } from './ModuleErrorBoundary';
@@ -61,7 +61,7 @@ export function AppRoutes() {
                         <Route index element={<Navigate to="dashboard" replace />} />
                         <Route path="dashboard" element={<DashboardPage />} />
                         <Route path="mcps" element={<McpsPage />} />
-                        <Route path="llms" element={<LlmsPage />} />
+                        <Route path="models" element={<ModelsPage />} />
                         <Route path="apis" element={<ApisPage />} />
                         <Route path="custom-policies" element={<CustomPoliciesPage />} />
                         <Route path="entities" element={<EntitiesPage />} />

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/config/navigation.ts
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/config/navigation.ts
@@ -33,7 +33,7 @@ export const NAV_GROUPS: NavGroup[] = [
         label: 'Policy Management',
         items: [
             { key: 'mcps', title: ROUTES.mcps.label, icon: ShieldCheckIcon },
-            { key: 'llms', title: ROUTES.llms.label, icon: BrainIcon },
+            { key: 'models', title: ROUTES.models.label, icon: BrainIcon },
             { key: 'apis', title: ROUTES.apis.label, icon: GlobeIcon },
             { key: 'custom-policies', title: ROUTES['custom-policies'].label, icon: SlidersHorizontalIcon },
         ],

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/config/routes.ts
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/config/routes.ts
@@ -20,7 +20,7 @@ export const ROUTE_KEYS = [
     'dashboard',
     // Policy Management
     'mcps',
-    'llms',
+    'models',
     'apis',
     'custom-policies',
     // Policy Structure
@@ -31,7 +31,7 @@ export type RouteKey = (typeof ROUTE_KEYS)[number];
 export const ROUTES: Record<RouteKey, { readonly path: string; readonly label: string }> = {
     dashboard: { path: 'dashboard', label: 'Dashboard' },
     mcps: { path: 'mcps', label: 'MCPs' },
-    llms: { path: 'llms', label: 'AI Models' },
+    models: { path: 'models', label: 'AI Models' },
     apis: { path: 'apis', label: 'APIs' },
     'custom-policies': { path: 'custom-policies', label: 'Custom Policies' },
     entities: { path: 'entities', label: 'Entities' },

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/features/dashboard/DashboardPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/features/dashboard/DashboardPage.tsx
@@ -49,7 +49,7 @@ const KPI_CARDS: readonly KpiCardMeta[] = [
     {
         label: 'AI Models',
         description: 'Manage access to providers and models — tailor who can use which model, in which environment, and when.',
-        to: '../llms',
+        to: '../models',
         linkLabel: 'Manage AI models',
         Icon: BrainIcon,
         iconClassName: 'bg-primary/10 text-primary',
@@ -82,9 +82,9 @@ function useDashboardCounts(environmentId: string) {
         staleTime: 30_000,
     });
 
-    const llmCount = useQuery({
-        queryKey: authzQueryKeys.policies.page(environmentId, 1, POLICY_FETCH_LIMIT, 'LLM'),
-        queryFn: () => authzApiService.listPolicies(environmentId, { type: 'LLM', perPage: POLICY_FETCH_LIMIT }),
+    const modelCount = useQuery({
+        queryKey: authzQueryKeys.policies.page(environmentId, 1, POLICY_FETCH_LIMIT, 'MODEL'),
+        queryFn: () => authzApiService.listPolicies(environmentId, { type: 'MODEL', perPage: POLICY_FETCH_LIMIT }),
         enabled: Boolean(environmentId),
         staleTime: 30_000,
     });
@@ -99,7 +99,7 @@ function useDashboardCounts(environmentId: string) {
     return {
         MCP: { total: mcpCount.data?.total, isLoading: mcpCount.isLoading },
         Agents: { total: agentCount.data?.total, isLoading: agentCount.isLoading },
-        'AI Models': { total: llmCount.data?.total, isLoading: llmCount.isLoading },
+        'AI Models': { total: modelCount.data?.total, isLoading: modelCount.isLoading },
         'Users and groups': { total: principalCount.data?.total, isLoading: principalCount.isLoading },
     };
 }

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/features/policy-management/ServicePolicyPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/features/policy-management/ServicePolicyPage.tsx
@@ -50,7 +50,7 @@ import { useSchema } from '../../shared/hooks/useSchema';
 import { PolicyEditorSheet } from './PolicyEditorSheet';
 import { PolicyListTable } from './PolicyListTable';
 
-export type CatalogEntryType = 'MCP' | 'AGENT' | 'LLM' | 'API' | 'EVENT';
+export type CatalogEntryType = 'MCP' | 'AGENT' | 'MODEL' | 'API' | 'EVENT';
 
 export type CatalogEntry = {
     readonly id: string;
@@ -60,7 +60,7 @@ export type CatalogEntry = {
     readonly subResources: readonly never[];
 };
 
-const CATALOG_ENTRY_TYPES: readonly CatalogEntryType[] = ['MCP', 'AGENT', 'LLM', 'API', 'EVENT'];
+const CATALOG_ENTRY_TYPES: readonly CatalogEntryType[] = ['MCP', 'AGENT', 'MODEL', 'API', 'EVENT'];
 
 function toCatalogEntryType(type: PolicyType): CatalogEntryType {
     return CATALOG_ENTRY_TYPES.includes(type as CatalogEntryType) ? (type as CatalogEntryType) : 'API';
@@ -87,7 +87,7 @@ type SheetState = { kind: 'closed' } | { kind: 'create'; target: CatalogEntry | 
 const DEFAULT_RESOURCE_GROUPS: readonly { key: string; label: string }[] = [
     { key: 'API', label: 'API' },
     { key: 'MCP', label: 'MCP' },
-    { key: 'LLM', label: 'LLM' },
+    { key: 'Model', label: 'Model' },
     { key: 'Agent', label: 'Agent' },
     { key: 'Resource', label: 'Resource' },
 ];
@@ -225,8 +225,8 @@ export function ServicePolicyPage({ config }: { readonly config: ServicePageConf
             const group =
                 firstSeg === 'mcp'
                     ? 'MCP'
-                    : firstSeg === 'llm'
-                      ? 'LLM'
+                    : firstSeg === 'model' || firstSeg === 'llm'
+                      ? 'Model'
                       : firstSeg === 'agent'
                         ? 'Agent'
                         : firstSeg === 'api'

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/features/policy-management/pages/ModelsPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/features/policy-management/pages/ModelsPage.tsx
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 import { ServicePolicyPage } from '../ServicePolicyPage';
-import { llmsServiceConfig } from '../service-defs/llms';
+import { modelsServiceConfig } from '../service-defs/models';
 
-export function LlmsPage() {
-    return <ServicePolicyPage config={llmsServiceConfig} />;
+export function ModelsPage() {
+    return <ServicePolicyPage config={modelsServiceConfig} />;
 }

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/features/policy-management/service-defs/custom.ts
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/features/policy-management/service-defs/custom.ts
@@ -27,7 +27,7 @@ export const customServiceConfig: ServicePageConfig = {
     type: 'CUSTOM',
     title: 'Custom Policies',
     description:
-        'Write policies against anything that is not already routed as an MCP, API, Agent, LLM or Event — internal applications, data assets, and bespoke resources.',
+        'Write policies against anything that is not already routed as an MCP, API, Agent, AI Model or Event — internal applications, data assets, and bespoke resources.',
     createButtonLabel: 'Create Custom Policy',
     searchPlaceholder: 'Search custom policies…',
     icon: SlidersHorizontalIcon,

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/features/policy-management/service-defs/models.ts
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/features/policy-management/service-defs/models.ts
@@ -23,8 +23,8 @@ const conditionSnippets: readonly { label: string; snippet: string }[] = [
     { label: 'Model size small', snippet: 'resource.size in ["small", "medium"]' },
 ];
 
-export const llmsServiceConfig: ServicePageConfig = {
-    type: 'LLM',
+export const modelsServiceConfig: ServicePageConfig = {
+    type: 'MODEL',
     title: 'AI Model Policies',
     description: 'Control who can invoke each AI Provider or specific Model, and under what usage or cost ceilings.',
     createButtonLabel: 'Create Policy for AI Models',
@@ -34,7 +34,7 @@ export const llmsServiceConfig: ServicePageConfig = {
     serviceLabel: 'AI Model',
     resourceGroups: [
         { key: 'LLMProvider', label: 'AI Provider' },
-        { key: 'LLMModel', label: 'Model' },
+        { key: 'Model', label: 'Model' },
     ],
     conditionSnippets,
 };

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/features/policy-structure/EntitiesPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/features/policy-structure/EntitiesPage.tsx
@@ -19,8 +19,15 @@ import {
     AlertDescription,
     AlertTitle,
     Badge,
+    Button,
     DataTable,
     DataTablePagination,
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
     Empty,
     EmptyDescription,
     EmptyHeader,
@@ -35,19 +42,23 @@ import {
     TabsContent,
     TabsList,
     TabsTrigger,
+    toast,
 } from '@gravitee/graphene-core';
-import { BoxesIcon, ShieldIcon, UsersIcon } from '@gravitee/graphene-core/icons';
+import { BoxesIcon, DownloadIcon, ShieldIcon, Trash2Icon, UsersIcon } from '@gravitee/graphene-core/icons';
+import { useQueryClient } from '@tanstack/react-query';
 import type { ColumnDef } from '@tanstack/react-table';
 import { useDeferredValue, useMemo, useState } from 'react';
 import { KpiTile } from '../../components/KpiTile';
+import { authzApiService } from '../../shared/api/authz-api.service';
+import { authzQueryKeys } from '../../shared/api/query-keys';
 import { formatEntityUid, fromBackend } from '../../shared/entity-adapter';
-import { useEntities } from '../../shared/hooks/useEntities';
-import type { EntityInstance } from './entity-types';
+import { useEntities, type UseEntitiesResult } from '../../shared/hooks/useEntities';
+import { CATEGORIES, getEntityCategoryId, type EntityInstance } from './entity-types';
+import { ImportFromCatalogDialog } from './ImportFromCatalogDialog';
 
 type SourceFilter = 'all' | string;
 type TypeFilter = 'all' | string;
 type TabKey = 'principals' | 'resources';
-type EntityKind = 'PRINCIPAL' | 'RESOURCE';
 
 const PAGE_SIZE_OPTIONS = [10, 25, 50, 100];
 const ACTION_PREFIX = 'action.';
@@ -55,88 +66,27 @@ const ACTION_PREFIX = 'action.';
 const PRINCIPALS_HELP =
     'Principals (users, groups, service accounts, agent identities) live in this environment. Edit and import flows are in a follow-up PR.';
 const RESOURCES_HELP =
-    'Resources are imported from the Context Catalog — MCP servers, tools, prompts, APIs, agents, and LLM models. Edit and import flows are in a follow-up PR.';
+    'Resources are imported from the Context Catalog — MCP servers, AI models, and agents keep the same Entity ID in Authorization. Catalog-sourced entries are read-only; you can remove imported instances but cannot edit them here.';
 
 function displayNameOf(entity: EntityInstance): string {
     if (entity.displayName) return entity.displayName;
-    const attrName = entity.attrs.name;
-    if (typeof attrName === 'string' && attrName) return attrName;
-    const attrDisplayName = entity.attrs.displayName;
-    if (typeof attrDisplayName === 'string' && attrDisplayName) return attrDisplayName;
+    const name = entity.attrs.name;
+    if (typeof name === 'string' && name) return name;
+    const displayName = entity.attrs.displayName;
+    if (typeof displayName === 'string' && displayName) return displayName;
     return entity.uid.id;
 }
 
 function sourceLabelOf(entity: EntityInstance): string {
-    return entity.source === 'apim' ? 'APIM' : 'Local';
+    if (entity.source === 'apim') return 'APIM';
+    if (entity.source === 'gravitee-catalog') return 'Gravitee Catalog';
+    return 'Local';
 }
 
-function applyFilters(entities: readonly EntityInstance[], search: string, typeFilter: TypeFilter, sourceFilter: SourceFilter) {
-    const needle = search.trim().toLowerCase();
-    return entities.filter(e => {
-        if (typeFilter !== 'all' && e.uid.type !== typeFilter) return false;
-        if (sourceFilter !== 'all' && sourceLabelOf(e) !== sourceFilter) return false;
-        if (!needle) return true;
-        if (e.uid.id.toLowerCase().includes(needle)) return true;
-        if (formatEntityUid(e.uid).toLowerCase().includes(needle)) return true;
-        if (e.uid.type.toLowerCase().includes(needle)) return true;
-        return displayNameOf(e).toLowerCase().includes(needle);
-    });
-}
-
-function distinctSorted<T extends string>(values: Iterable<T>): T[] {
-    return Array.from(new Set(values)).sort();
-}
-
-interface UseEntitiesTabOptions {
-    readonly environmentId: string;
-    readonly kind: EntityKind;
-    readonly excludeEntityIdPrefix?: string;
-}
-
-function useEntitiesTab({ environmentId, kind, excludeEntityIdPrefix }: UseEntitiesTabOptions) {
-    const query = useEntities(environmentId, undefined, { kind, excludeEntityIdPrefix });
-    const [search, setSearch] = useState('');
-    const [typeFilter, setTypeFilter] = useState<TypeFilter>('all');
-    const [sourceFilter, setSourceFilter] = useState<SourceFilter>('all');
-    const deferredSearch = useDeferredValue(search);
-
-    // TODO(authz-ui): server-side filters for search/type/source — these stay
-    // client-side and operate on the currently visible page only. The warning
-    // banner below alerts users when a filtered view may be hiding matches.
-    const entities = useMemo(() => (query.data?.data ?? []).map(fromBackend), [query.data]);
-    const types = useMemo(() => distinctSorted(entities.map(e => e.uid.type)), [entities]);
-    const sources = useMemo(() => distinctSorted(entities.map(sourceLabelOf)), [entities]);
-    const filtered = useMemo(
-        () => applyFilters(entities, deferredSearch, typeFilter, sourceFilter),
-        [entities, deferredSearch, typeFilter, sourceFilter],
-    );
-
-    const total = query.data?.total ?? 0;
-    const isFiltering = deferredSearch.trim() !== '' || typeFilter !== 'all' || sourceFilter !== 'all';
-    const hasMoreThanCurrentPage = total > entities.length;
-
-    return {
-        entities,
-        filtered,
-        total,
-        types,
-        sources,
-        search,
-        setSearch,
-        deferredSearch,
-        typeFilter,
-        setTypeFilter,
-        sourceFilter,
-        setSourceFilter,
-        isFiltering,
-        hasMoreThanCurrentPage,
-        isLoading: query.isLoading,
-        error: query.error,
-        page: query.page,
-        perPage: query.perPage,
-        setPage: query.setPage,
-        setPerPage: query.setPerPage,
-    };
+function categoryTextColorFor(entity: EntityInstance): string | undefined {
+    const id = getEntityCategoryId(entity.uid.type);
+    if (!id) return undefined;
+    return CATEGORIES.find(c => c.id === id)?.textColor;
 }
 
 interface EntitiesTableProps {
@@ -149,6 +99,8 @@ interface EntitiesTableProps {
     readonly totalCount: number;
     readonly onPageChange: (page: number) => void;
     readonly onPerPageChange: (perPage: number) => void;
+    readonly onDelete?: (entity: EntityInstance) => void;
+    readonly deletingEntityId?: string;
 }
 
 function EntitiesTable({
@@ -161,18 +113,23 @@ function EntitiesTable({
     totalCount,
     onPageChange,
     onPerPageChange,
+    onDelete,
+    deletingEntityId,
 }: EntitiesTableProps) {
-    const columns = useMemo<ColumnDef<EntityInstance>[]>(
-        () => [
+    const columns = useMemo<ColumnDef<EntityInstance>[]>(() => {
+        const baseColumns: ColumnDef<EntityInstance>[] = [
             {
                 id: 'type',
                 header: 'Type',
                 size: 180,
-                cell: ({ row }) => (
-                    <Badge variant="outline" className="font-mono">
-                        {row.original.uid.type}
-                    </Badge>
-                ),
+                cell: ({ row }) => {
+                    const textColor = categoryTextColorFor(row.original);
+                    return (
+                        <Badge variant="outline" className={`font-mono ${textColor ?? ''}`}>
+                            {row.original.uid.type}
+                        </Badge>
+                    );
+                },
             },
             {
                 id: 'entityId',
@@ -192,9 +149,32 @@ function EntitiesTable({
                 size: 140,
                 cell: ({ row }) => <Badge variant="secondary">{sourceLabelOf(row.original)}</Badge>,
             },
-        ],
-        [],
-    );
+        ];
+        if (onDelete) {
+            baseColumns.push({
+                id: 'actions',
+                header: '',
+                size: 60,
+                cell: ({ row }) => {
+                    const uid = formatEntityUid(row.original.uid);
+                    const isDeleting = deletingEntityId === uid;
+                    return (
+                        <Button
+                            variant="ghost"
+                            size="sm"
+                            onClick={() => onDelete(row.original)}
+                            disabled={isDeleting}
+                            aria-label={`Delete ${uid}`}
+                            title="Remove from Authorization"
+                        >
+                            <Trash2Icon className="size-4 text-muted-foreground" aria-hidden />
+                        </Button>
+                    );
+                },
+            });
+        }
+        return baseColumns;
+    }, [onDelete, deletingEntityId]);
 
     if (!isLoading && entities.length === 0) {
         return (
@@ -297,38 +277,109 @@ function EntitiesFilterBar({
     );
 }
 
-function ClientFilterWarning({ visible, total }: { readonly visible: number; readonly total: number }) {
-    return (
-        <Alert role="status" aria-live="polite">
-            <AlertDescription>
-                Filters apply only to the {visible} entities on this page — {total - visible} more entities are not yet searched. Increase
-                the page size or paginate to broaden the view.
-            </AlertDescription>
-        </Alert>
-    );
+function applyFilters(entities: readonly EntityInstance[], search: string, typeFilter: TypeFilter, sourceFilter: SourceFilter) {
+    const needle = search.trim().toLowerCase();
+    return entities.filter(e => {
+        if (typeFilter !== 'all' && e.uid.type !== typeFilter) return false;
+        if (sourceFilter !== 'all' && sourceLabelOf(e) !== sourceFilter) return false;
+        if (!needle) return true;
+        if (e.uid.id.toLowerCase().includes(needle)) return true;
+        if (formatEntityUid(e.uid).toLowerCase().includes(needle)) return true;
+        if (e.uid.type.toLowerCase().includes(needle)) return true;
+        return displayNameOf(e).toLowerCase().includes(needle);
+    });
+}
+
+function distinctSorted<T extends string>(values: Iterable<T>): T[] {
+    return Array.from(new Set(values)).sort();
+}
+
+function pageEntities(query: UseEntitiesResult): readonly EntityInstance[] {
+    if (!query.data) return [];
+    return query.data.data.map(fromBackend);
 }
 
 export function EntitiesPage() {
     const env = useEnvironment();
     const environmentId = env?.id ?? '';
+    const queryClient = useQueryClient();
+    const principalsQuery = useEntities(environmentId, undefined, { kind: 'PRINCIPAL' });
+    const resourcesQuery = useEntities(environmentId, undefined, { kind: 'RESOURCE', excludeEntityIdPrefix: ACTION_PREFIX });
 
-    const principals = useEntitiesTab({ environmentId, kind: 'PRINCIPAL' });
-    const resources = useEntitiesTab({ environmentId, kind: 'RESOURCE', excludeEntityIdPrefix: ACTION_PREFIX });
+    const [principalSearch, setPrincipalSearch] = useState('');
+    const [principalTypeFilter, setPrincipalTypeFilter] = useState<TypeFilter>('all');
+    const [principalSourceFilter, setPrincipalSourceFilter] = useState<SourceFilter>('all');
+    const [resourceSearch, setResourceSearch] = useState('');
+    const [resourceTypeFilter, setResourceTypeFilter] = useState<TypeFilter>('all');
+    const [resourceSourceFilter, setResourceSourceFilter] = useState<SourceFilter>('all');
+    const [importOpen, setImportOpen] = useState(false);
+    const [pendingDelete, setPendingDelete] = useState<EntityInstance | null>(null);
+    const [deletingEntityId, setDeletingEntityId] = useState<string | undefined>();
 
-    const isLoading = principals.isLoading || resources.isLoading;
-    const error = principals.error ?? resources.error;
+    const pendingDeleteUid = pendingDelete ? formatEntityUid(pendingDelete.uid) : '';
+    const pendingDeleteName = pendingDelete ? displayNameOf(pendingDelete) : '';
+
+    async function confirmDeleteResource() {
+        if (!pendingDelete) return;
+        const uid = formatEntityUid(pendingDelete.uid);
+        const friendly = displayNameOf(pendingDelete);
+        setDeletingEntityId(uid);
+        try {
+            await authzApiService.deleteEntity(environmentId, uid);
+            toast.success(`Removed ${friendly}`);
+            setDeletingEntityId(undefined);
+            setPendingDelete(null);
+            void queryClient.invalidateQueries({ queryKey: authzQueryKeys.entities.all(environmentId) });
+            void queryClient.invalidateQueries({ queryKey: authzQueryKeys.importedCatalogIds(environmentId) });
+        } catch (err) {
+            toast.error(`Failed to remove: ${err instanceof Error ? err.message : String(err)}`);
+            setDeletingEntityId(undefined);
+        }
+    }
+
+    function handleImported() {
+        void queryClient.invalidateQueries({ queryKey: authzQueryKeys.entities.all(environmentId) });
+    }
+
+    const deferredPrincipalSearch = useDeferredValue(principalSearch);
+    const deferredResourceSearch = useDeferredValue(resourceSearch);
+
+    const principals = useMemo(() => pageEntities(principalsQuery), [principalsQuery]);
+    const resources = useMemo(() => pageEntities(resourcesQuery), [resourcesQuery]);
+
+    const principalTotal = principalsQuery.data?.total ?? 0;
+    const resourceTotal = resourcesQuery.data?.total ?? 0;
+
+    const principalTypes = useMemo(() => distinctSorted(principals.map(e => e.uid.type)), [principals]);
+    const resourceTypes = useMemo(() => distinctSorted(resources.map(e => e.uid.type)), [resources]);
+    const principalSources = useMemo(() => distinctSorted(principals.map(sourceLabelOf)), [principals]);
+    const resourceSources = useMemo(() => distinctSorted(resources.map(sourceLabelOf)), [resources]);
+
+    // TODO(authz-ui): server-side filters for search/type/source — these stay
+    // client-side and operate on the currently visible page only.
+    const filteredPrincipals = useMemo(
+        () => applyFilters(principals, deferredPrincipalSearch, principalTypeFilter, principalSourceFilter),
+        [principals, deferredPrincipalSearch, principalTypeFilter, principalSourceFilter],
+    );
+    const filteredResources = useMemo(
+        () => applyFilters(resources, deferredResourceSearch, resourceTypeFilter, resourceSourceFilter),
+        [resources, deferredResourceSearch, resourceTypeFilter, resourceSourceFilter],
+    );
 
     const kpis = useMemo(() => {
         const visibleTypes = new Set<string>();
-        principals.entities.forEach(e => visibleTypes.add(e.uid.type));
-        resources.entities.forEach(e => visibleTypes.add(e.uid.type));
+        principals.forEach(e => visibleTypes.add(e.uid.type));
+        resources.forEach(e => visibleTypes.add(e.uid.type));
         return {
-            total: principals.total + resources.total,
-            typesOnPage: visibleTypes.size,
-            principals: principals.total,
-            resources: resources.total,
+            total: principalTotal + resourceTotal,
+            types: visibleTypes.size,
+            principals: principalTotal,
+            resources: resourceTotal,
         };
-    }, [principals.entities, resources.entities, principals.total, resources.total]);
+    }, [principals, resources, principalTotal, resourceTotal]);
+
+    const isLoading = principalsQuery.isLoading || resourcesQuery.isLoading;
+    const error = principalsQuery.error ?? resourcesQuery.error;
 
     return (
         <div className="flex flex-col gap-4">
@@ -345,12 +396,12 @@ export function EntitiesPage() {
 
             <div className="grid grid-cols-2 gap-3 md:grid-cols-4" aria-label="Key metrics">
                 <KpiTile label="Total entities" value={kpis.total} loading={isLoading} />
-                <KpiTile label="Types (this page)" value={kpis.typesOnPage} loading={isLoading} />
+                <KpiTile label="Types (this page)" value={kpis.types} loading={isLoading} />
                 <KpiTile label="Principals" value={kpis.principals} loading={isLoading} />
                 <KpiTile label="Resources" value={kpis.resources} loading={isLoading} />
             </div>
 
-            {error && (
+            {error !== undefined && (
                 <Alert variant="destructive">
                     <AlertTitle>Could not load entities</AlertTitle>
                     <AlertDescription>{error}</AlertDescription>
@@ -362,12 +413,12 @@ export function EntitiesPage() {
                     <TabsTrigger value="principals">
                         <UsersIcon className="size-4" aria-hidden />
                         Principals
-                        <Badge variant="secondary">{principals.total}</Badge>
+                        <Badge variant="secondary">{principalTotal}</Badge>
                     </TabsTrigger>
                     <TabsTrigger value="resources">
                         <ShieldIcon className="size-4" aria-hidden />
                         Resources
-                        <Badge variant="secondary">{resources.total}</Badge>
+                        <Badge variant="secondary">{resourceTotal}</Badge>
                     </TabsTrigger>
                 </TabsList>
 
@@ -376,29 +427,26 @@ export function EntitiesPage() {
                         <AlertDescription>{PRINCIPALS_HELP}</AlertDescription>
                     </Alert>
                     <EntitiesFilterBar
-                        search={principals.search}
-                        onSearch={principals.setSearch}
-                        typesPresent={principals.types}
-                        typeFilter={principals.typeFilter}
-                        onTypeFilter={principals.setTypeFilter}
-                        sourcesPresent={principals.sources}
-                        sourceFilter={principals.sourceFilter}
-                        onSourceFilter={principals.setSourceFilter}
+                        search={principalSearch}
+                        onSearch={setPrincipalSearch}
+                        typesPresent={principalTypes}
+                        typeFilter={principalTypeFilter}
+                        onTypeFilter={setPrincipalTypeFilter}
+                        sourcesPresent={principalSources}
+                        sourceFilter={principalSourceFilter}
+                        onSourceFilter={setPrincipalSourceFilter}
                         searchLabel="Search principals"
                     />
-                    {principals.isFiltering && principals.hasMoreThanCurrentPage && (
-                        <ClientFilterWarning visible={principals.entities.length} total={principals.total} />
-                    )}
                     <EntitiesTable
                         tab="principals"
-                        entities={principals.filtered}
-                        searchValue={principals.deferredSearch}
-                        isLoading={principals.isLoading}
-                        page={principals.page}
-                        perPage={principals.perPage}
-                        totalCount={principals.total}
-                        onPageChange={principals.setPage}
-                        onPerPageChange={principals.setPerPage}
+                        entities={filteredPrincipals}
+                        searchValue={deferredPrincipalSearch}
+                        isLoading={principalsQuery.isLoading}
+                        page={principalsQuery.page}
+                        perPage={principalsQuery.perPage}
+                        totalCount={principalTotal}
+                        onPageChange={principalsQuery.setPage}
+                        onPerPageChange={principalsQuery.setPerPage}
                     />
                 </TabsContent>
 
@@ -406,33 +454,84 @@ export function EntitiesPage() {
                     <Alert>
                         <AlertDescription>{RESOURCES_HELP}</AlertDescription>
                     </Alert>
-                    <EntitiesFilterBar
-                        search={resources.search}
-                        onSearch={resources.setSearch}
-                        typesPresent={resources.types}
-                        typeFilter={resources.typeFilter}
-                        onTypeFilter={resources.setTypeFilter}
-                        sourcesPresent={resources.sources}
-                        sourceFilter={resources.sourceFilter}
-                        onSourceFilter={resources.setSourceFilter}
-                        searchLabel="Search resources"
-                    />
-                    {resources.isFiltering && resources.hasMoreThanCurrentPage && (
-                        <ClientFilterWarning visible={resources.entities.length} total={resources.total} />
-                    )}
+                    <div className="flex flex-wrap items-center gap-2">
+                        <EntitiesFilterBar
+                            search={resourceSearch}
+                            onSearch={setResourceSearch}
+                            typesPresent={resourceTypes}
+                            typeFilter={resourceTypeFilter}
+                            onTypeFilter={setResourceTypeFilter}
+                            sourcesPresent={resourceSources}
+                            sourceFilter={resourceSourceFilter}
+                            onSourceFilter={setResourceSourceFilter}
+                            searchLabel="Search resources"
+                        />
+                        <div className="ml-auto">
+                            <Button onClick={() => setImportOpen(true)}>
+                                <DownloadIcon className="mr-2 size-4" aria-hidden />
+                                Import from Context Catalog
+                            </Button>
+                        </div>
+                    </div>
                     <EntitiesTable
                         tab="resources"
-                        entities={resources.filtered}
-                        searchValue={resources.deferredSearch}
-                        isLoading={resources.isLoading}
-                        page={resources.page}
-                        perPage={resources.perPage}
-                        totalCount={resources.total}
-                        onPageChange={resources.setPage}
-                        onPerPageChange={resources.setPerPage}
+                        entities={filteredResources}
+                        searchValue={deferredResourceSearch}
+                        isLoading={resourcesQuery.isLoading}
+                        page={resourcesQuery.page}
+                        perPage={resourcesQuery.perPage}
+                        totalCount={resourceTotal}
+                        onPageChange={resourcesQuery.setPage}
+                        onPerPageChange={resourcesQuery.setPerPage}
+                        onDelete={setPendingDelete}
+                        deletingEntityId={deletingEntityId}
                     />
                 </TabsContent>
             </Tabs>
+
+            <ImportFromCatalogDialog
+                open={importOpen}
+                environmentId={environmentId}
+                onOpenChange={setImportOpen}
+                onImported={handleImported}
+            />
+
+            <Dialog
+                open={pendingDelete !== null}
+                onOpenChange={open => {
+                    if (!open && !deletingEntityId) setPendingDelete(null);
+                }}
+            >
+                <DialogContent>
+                    <DialogHeader>
+                        <DialogTitle>Remove entity from Authorization?</DialogTitle>
+                        <DialogDescription>
+                            {pendingDelete
+                                ? `"${pendingDeleteName}" (${pendingDeleteUid}) will be removed from Authorization. This won't delete it from the Context Catalog — you can re-import it later.`
+                                : ''}
+                        </DialogDescription>
+                    </DialogHeader>
+                    <DialogFooter>
+                        <Button
+                            type="button"
+                            variant="outline"
+                            onClick={() => setPendingDelete(null)}
+                            disabled={deletingEntityId !== undefined}
+                        >
+                            Cancel
+                        </Button>
+                        <Button
+                            type="button"
+                            variant="destructive"
+                            onClick={confirmDeleteResource}
+                            disabled={deletingEntityId !== undefined}
+                            aria-label={pendingDelete ? `Confirm remove ${pendingDeleteName}` : 'Confirm remove'}
+                        >
+                            {deletingEntityId !== undefined ? 'Removing…' : 'Remove'}
+                        </Button>
+                    </DialogFooter>
+                </DialogContent>
+            </Dialog>
         </div>
     );
 }

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/features/policy-structure/ImportFromCatalogDialog.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/features/policy-structure/ImportFromCatalogDialog.tsx
@@ -1,0 +1,474 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+import {
+    Alert,
+    AlertDescription,
+    Badge,
+    Button,
+    Checkbox,
+    Input,
+    Sheet,
+    SheetContent,
+    SheetTitle,
+    Spinner,
+    Tabs,
+    TabsContent,
+    TabsList,
+    TabsTrigger,
+    cn,
+    toast,
+} from '@gravitee/graphene-core';
+import { DownloadIcon } from '@gravitee/graphene-core/icons';
+import { useQueryClient } from '@tanstack/react-query';
+import { useDeferredValue, useMemo, useState } from 'react';
+import type { AgentCatalogItem, CatalogItem, McpServerCatalogItem, ModelCatalogItem } from '../../shared/api/aim-catalog.types';
+import { authzApiService } from '../../shared/api/authz-api.service';
+import { authzQueryKeys } from '../../shared/api/query-keys';
+import { useAimCatalogItems, type UseAimCatalogItemsResult } from '../../shared/hooks/useAimCatalogItems';
+import { useImportedCatalogIds } from '../../shared/hooks/useImportedCatalogIds';
+
+type TabKey = 'mcp-server' | 'model' | 'agent';
+
+interface TabDef {
+    readonly key: TabKey;
+    readonly label: string;
+    readonly entityKindPrefix: string;
+    readonly uiTypeBadge: string;
+}
+
+const TABS: readonly TabDef[] = [
+    { key: 'mcp-server', label: 'MCP Servers', entityKindPrefix: 'mcp', uiTypeBadge: 'MCPServer' },
+    { key: 'model', label: 'AI Models', entityKindPrefix: 'model', uiTypeBadge: 'Model' },
+    { key: 'agent', label: 'Agents', entityKindPrefix: 'agent', uiTypeBadge: 'Agent' },
+];
+
+const SOURCE_LABEL = 'gravitee-catalog';
+const IMPORT_CONCURRENCY = 4;
+
+function slugify(s: string | undefined | null): string {
+    if (!s) return '';
+    return s
+        .toString()
+        .toLowerCase()
+        .replace(/[^a-z0-9._-]+/g, '-')
+        .replace(/^-+|-+$/g, '');
+}
+
+function deriveDisplayName(item: CatalogItem): string {
+    switch (item.kind) {
+        case 'mcp-server':
+            return item.definition.serverInfo?.title ?? item.definition.serverInfo?.name ?? item.id;
+        case 'model':
+            return item.definition.name ?? item.definition.queryName ?? item.id;
+        case 'agent':
+            return item.definition.name ?? item.id;
+    }
+}
+
+/**
+ * Slug used as the trailing segment(s) of the Authorization entityId.
+ *
+ *   mcp-servers  → `mcp.{slug}`                e.g. mcp.filesystem
+ *   models       → `model.{provider}.{slug}`   e.g. model.openai.gpt-4o
+ *   agents       → `agent.{slug}`              e.g. agent.code-reviewer
+ *
+ * Since aim ≥ 1.0.0-alpha.71 the catalog persists `entityId` server-side via
+ * `EntityId.toSlug(...)`, so we prefer it and only fall back to in-app derivation
+ * for older rows that haven't been touched by the importer yet.
+ */
+function deriveSlug(item: CatalogItem): string {
+    switch (item.kind) {
+        case 'mcp-server': {
+            const fromServer = slugify(item.entityId);
+            if (fromServer) return fromServer;
+            const fromExtensions = slugify(item.extensions?.entityId);
+            if (fromExtensions) return fromExtensions;
+            return slugify(item.definition.serverInfo?.name) || slugify(item.definition.serverInfo?.title) || item.id;
+        }
+        case 'model': {
+            const provider = providerFromSourceKind(item.sourceKind) || slugify(item.definition.provider);
+            const name = slugify(item.entityId) || slugify(item.definition.queryName) || slugify(item.definition.name);
+            if (provider && name) return `${provider}.${name}`;
+            return name || item.id;
+        }
+        case 'agent':
+            return slugify(item.entityId) || slugify(item.definition.name) || item.id;
+    }
+}
+
+/** Extract `openai` from `llm.provider.openai` (catalog sourceKind format). */
+function providerFromSourceKind(sourceKind: string | null | undefined): string {
+    if (!sourceKind) return '';
+    const segments = sourceKind.split('.');
+    const last = segments[segments.length - 1];
+    return slugify(last);
+}
+
+function deriveDescription(item: CatalogItem): string | undefined {
+    switch (item.kind) {
+        case 'mcp-server':
+            return item.extensions?.description;
+        case 'model':
+            return item.definition.description;
+        case 'agent':
+            return item.definition.description;
+    }
+}
+
+function buildEntityId(item: CatalogItem): string {
+    const tab = TABS.find(t => t.key === item.kind);
+    if (!tab) throw new Error(`unknown catalog kind: ${item.kind}`);
+    return `${tab.entityKindPrefix}.${deriveSlug(item)}`;
+}
+
+/** Run `tasks` with up to `concurrency` in-flight at a time. Preserves order in the returned settled array. */
+async function runWithConcurrency<T>(tasks: ReadonlyArray<() => Promise<T>>, concurrency: number): Promise<PromiseSettledResult<T>[]> {
+    const results: PromiseSettledResult<T>[] = new Array(tasks.length);
+    let cursor = 0;
+    const workers = Array.from({ length: Math.min(concurrency, tasks.length) }, async () => {
+        while (true) {
+            const idx = cursor++;
+            if (idx >= tasks.length) return;
+            try {
+                results[idx] = { status: 'fulfilled', value: await tasks[idx]() };
+            } catch (err) {
+                results[idx] = { status: 'rejected', reason: err };
+            }
+        }
+    });
+    await Promise.all(workers);
+    return results;
+}
+
+export interface ImportFromCatalogDialogProps {
+    readonly open: boolean;
+    readonly environmentId: string;
+    readonly onOpenChange: (open: boolean) => void;
+    readonly onImported: () => void;
+}
+
+export function ImportFromCatalogDialog({ open, environmentId, onOpenChange, onImported }: ImportFromCatalogDialogProps) {
+    const [activeTab, setActiveTab] = useState<TabKey>('mcp-server');
+    const [search, setSearch] = useState('');
+    const deferredSearch = useDeferredValue(search);
+    const [selected, setSelected] = useState<Map<string, CatalogItem>>(new Map());
+    const [submitting, setSubmitting] = useState(false);
+    const [progress, setProgress] = useState<{ done: number; total: number } | null>(null);
+    const queryClient = useQueryClient();
+
+    const mcpQuery = useAimCatalogItems<McpServerCatalogItem>(environmentId, 'mcp-server', { enabled: open });
+    const modelQuery = useAimCatalogItems<ModelCatalogItem>(environmentId, 'model', { enabled: open });
+    const agentQuery = useAimCatalogItems<AgentCatalogItem>(environmentId, 'agent', { enabled: open });
+    const { catalogIds: importedCatalogIds, truncated: importedTruncated, markImported } = useImportedCatalogIds(environmentId, {
+        enabled: open,
+    });
+
+    const queryByTab: Record<TabKey, UseAimCatalogItemsResult<CatalogItem>> = useMemo(
+        () => ({
+            'mcp-server': mcpQuery as UseAimCatalogItemsResult<CatalogItem>,
+            model: modelQuery as UseAimCatalogItemsResult<CatalogItem>,
+            agent: agentQuery as UseAimCatalogItemsResult<CatalogItem>,
+        }),
+        [mcpQuery, modelQuery, agentQuery],
+    );
+
+    function toggleSelect(item: CatalogItem) {
+        if (importedCatalogIds.has(item.id)) return;
+        setSelected(prev => {
+            const next = new Map(prev);
+            if (next.has(item.id)) next.delete(item.id);
+            else next.set(item.id, item);
+            return next;
+        });
+    }
+
+    function selectVisible(items: readonly CatalogItem[]) {
+        setSelected(prev => {
+            const next = new Map(prev);
+            items.forEach(it => {
+                if (!importedCatalogIds.has(it.id)) next.set(it.id, it);
+            });
+            return next;
+        });
+    }
+
+    function clearSelection() {
+        setSelected(new Map());
+    }
+
+    function resetAndClose(nextOpen: boolean) {
+        if (!nextOpen) {
+            setSelected(new Map());
+            setSearch('');
+            setActiveTab('mcp-server');
+            setProgress(null);
+        }
+        onOpenChange(nextOpen);
+    }
+
+    async function handleImport() {
+        if (selected.size === 0 || submitting) return;
+        setSubmitting(true);
+        const items = Array.from(selected.values());
+        setProgress({ done: 0, total: items.length });
+
+        const successCatalogIds: string[] = [];
+        let doneCount = 0;
+
+        const tasks = items.map(item => async () => {
+            const tab = TABS.find(t => t.key === item.kind)!;
+            const entityId = buildEntityId(item);
+            const displayName = deriveDisplayName(item);
+            const description = deriveDescription(item);
+            const attributes: Record<string, unknown> = {
+                _displayName: displayName,
+                _catalogId: item.id,
+                _importedAt: new Date().toISOString(),
+            };
+            if (description) attributes.description = description;
+            try {
+                await authzApiService.createEntity(environmentId, {
+                    entityId,
+                    kind: 'RESOURCE',
+                    attributes,
+                    parents: [],
+                    source: SOURCE_LABEL,
+                });
+                successCatalogIds.push(item.id);
+                return item;
+            } finally {
+                doneCount++;
+                setProgress({ done: doneCount, total: items.length });
+            }
+        });
+
+        const settled = await runWithConcurrency(tasks, IMPORT_CONCURRENCY);
+        const failed = settled.filter(r => r.status === 'rejected') as PromiseRejectedResult[];
+        const success = settled.length - failed.length;
+
+        setSubmitting(false);
+        setProgress(null);
+
+        if (success > 0) {
+            markImported(successCatalogIds);
+            toast.success(`Imported ${success} ${success === 1 ? 'entity' : 'entities'}`);
+            void queryClient.invalidateQueries({ queryKey: authzQueryKeys.entities.all(environmentId) });
+            void queryClient.invalidateQueries({ queryKey: authzQueryKeys.importedCatalogIds(environmentId) });
+            onImported();
+        }
+        if (failed.length > 0) {
+            const sample = failed
+                .slice(0, 2)
+                .map(r => (r.reason instanceof Error ? r.reason.message : String(r.reason)))
+                .join('; ');
+            toast.error(`Failed to import ${failed.length}: ${sample}`);
+            failed.forEach(r => console.error('catalog import failed:', r.reason));
+        }
+        if (failed.length === 0) {
+            resetAndClose(false);
+        }
+    }
+
+    const selectedCount = selected.size;
+    const tabCount = (key: TabKey): number => queryByTab[key].data?.total ?? 0;
+
+    const ariaLabel = 'Import from Context Catalog';
+
+    function renderTabBody(tab: TabDef, query: UseAimCatalogItemsResult<CatalogItem>) {
+        const items: readonly CatalogItem[] = query.data?.data ?? [];
+        const needle = deferredSearch.trim().toLowerCase();
+        const filtered = needle
+            ? items.filter(
+                  it =>
+                      deriveDisplayName(it).toLowerCase().includes(needle) ||
+                      deriveSlug(it).toLowerCase().includes(needle) ||
+                      buildEntityId(it).toLowerCase().includes(needle),
+              )
+            : items;
+
+        return (
+            <div className="flex min-h-0 flex-1 flex-col">
+                <div className="flex items-center gap-2 border-b px-6 py-3">
+                    <Input
+                        value={search}
+                        onChange={e => setSearch(e.target.value)}
+                        placeholder={`Search ${tab.label.toLowerCase()}…`}
+                        className="min-w-0 flex-1"
+                        aria-label="Search catalog entries"
+                    />
+                    <Button variant="ghost" size="sm" onClick={() => selectVisible(filtered)} disabled={filtered.length === 0}>
+                        Select visible
+                    </Button>
+                    <Button variant="ghost" size="sm" onClick={clearSelection} disabled={selectedCount === 0}>
+                        Clear ({selectedCount})
+                    </Button>
+                </div>
+
+                {(query.truncated || importedTruncated) && (
+                    <Alert className="mx-6 mt-3" role="status">
+                        <AlertDescription>
+                            {query.truncated && (
+                                <div>
+                                    Showing the first {query.data?.data.length ?? 0} of {query.data?.total ?? 0} catalog entries. Narrow
+                                    your search in the Catalog page if the item you need is not visible.
+                                </div>
+                            )}
+                            {importedTruncated && (
+                                <div>
+                                    More than the displayed imports exist in this environment — some already-imported items may not be
+                                    flagged as such.
+                                </div>
+                            )}
+                        </AlertDescription>
+                    </Alert>
+                )}
+
+                <div className="min-h-0 flex-1 overflow-y-auto">
+                    {query.isLoading && (
+                        <div className="flex items-center justify-center p-6">
+                            <Spinner />
+                        </div>
+                    )}
+                    {query.error && (
+                        <Alert variant="destructive" className="m-4">
+                            <AlertDescription>{query.error}</AlertDescription>
+                        </Alert>
+                    )}
+                    {!query.isLoading && !query.error && filtered.length === 0 && (
+                        <div className="flex h-full min-h-48 items-center justify-center p-6 text-sm text-muted-foreground">
+                            {items.length === 0 ? 'No items in this catalog category yet.' : 'No matches for the current search.'}
+                        </div>
+                    )}
+                    {!query.isLoading &&
+                        !query.error &&
+                        filtered.map(item => {
+                            const isSelected = selected.has(item.id);
+                            const isImported = importedCatalogIds.has(item.id);
+                            const entityId = buildEntityId(item);
+                            const description = deriveDescription(item);
+                            return (
+                                <label
+                                    key={item.id}
+                                    className={cn(
+                                        'flex items-start gap-3 border-b px-6 py-3 transition-colors',
+                                        isImported && 'cursor-not-allowed opacity-60',
+                                        !isImported && 'cursor-pointer hover:bg-muted/40',
+                                        !isImported && isSelected && 'bg-muted/30',
+                                    )}
+                                >
+                                    <Checkbox
+                                        checked={isImported || isSelected}
+                                        disabled={isImported}
+                                        onCheckedChange={() => toggleSelect(item)}
+                                        className="mt-0.5"
+                                        aria-label={
+                                            isImported ? `${deriveDisplayName(item)} already imported` : `Select ${deriveDisplayName(item)}`
+                                        }
+                                    />
+                                    <div className="min-w-0 flex-1">
+                                        <div className="flex items-center gap-2">
+                                            <span className="truncate text-sm font-medium">{deriveDisplayName(item)}</span>
+                                            <Badge variant="outline" className="shrink-0 font-mono text-xs">
+                                                {tab.uiTypeBadge}
+                                            </Badge>
+                                            {isImported && (
+                                                <Badge variant="secondary" className="shrink-0 text-xs">
+                                                    Imported
+                                                </Badge>
+                                            )}
+                                        </div>
+                                        <code className="mt-1 block truncate font-mono text-xs text-muted-foreground" title={entityId}>
+                                            {entityId}
+                                        </code>
+                                        {description && (
+                                            <p
+                                                className="mt-1 line-clamp-2 text-xs text-muted-foreground"
+                                                title={description.length > 500 ? description.slice(0, 500) + '…' : description}
+                                            >
+                                                {description}
+                                            </p>
+                                        )}
+                                    </div>
+                                </label>
+                            );
+                        })}
+                </div>
+            </div>
+        );
+    }
+
+    return (
+        <Sheet open={open} onOpenChange={resetAndClose}>
+            <SheetContent
+                side="right"
+                showCloseButton={false}
+                aria-label={ariaLabel}
+                style={{ width: 'min(820px, 100vw)', maxWidth: 'min(820px, 100vw)' }}
+                className="flex h-full flex-col gap-0 p-0"
+            >
+                <SheetTitle className="sr-only">{ariaLabel}</SheetTitle>
+
+                <div className="border-b px-6 py-4">
+                    <h2 className="text-lg font-semibold">Import from Context Catalog</h2>
+                    <p className="mt-1 text-sm text-muted-foreground">
+                        Select catalog entries to register as read-only resource entities in the Policy Engine. Imported entities keep the
+                        same Entity ID as in the Catalog, so policies always refer to one canonical identifier.
+                    </p>
+                </div>
+
+                <Tabs
+                    value={activeTab}
+                    onValueChange={value => setActiveTab(value as TabKey)}
+                    className="flex min-h-0 flex-1 flex-col"
+                >
+                    <TabsList className="flex-none gap-1 border-b px-6 pt-2">
+                        {TABS.map(tab => (
+                            <TabsTrigger key={tab.key} value={tab.key}>
+                                {tab.label}
+                                <Badge variant="secondary" className="ml-1 text-xs">
+                                    {tabCount(tab.key)}
+                                </Badge>
+                            </TabsTrigger>
+                        ))}
+                    </TabsList>
+
+                    {TABS.map(tab => (
+                        <TabsContent key={tab.key} value={tab.key} className="mt-0 flex min-h-0 flex-1 flex-col">
+                            {renderTabBody(tab, queryByTab[tab.key])}
+                        </TabsContent>
+                    ))}
+                </Tabs>
+
+                <div className="flex flex-none items-center justify-between border-t bg-muted/40 px-6 py-3.5">
+                    <span className="text-sm text-muted-foreground">
+                        {progress
+                            ? `Importing ${progress.done} / ${progress.total}…`
+                            : selectedCount === 0
+                              ? 'No items selected'
+                              : `${selectedCount} item${selectedCount === 1 ? '' : 's'} selected`}
+                    </span>
+                    <div className="flex gap-2">
+                        <Button variant="outline" onClick={() => resetAndClose(false)} disabled={submitting}>
+                            Cancel
+                        </Button>
+                        <Button onClick={handleImport} disabled={selectedCount === 0 || submitting}>
+                            {submitting ? (
+                                <Spinner className="mr-2 size-4" aria-hidden />
+                            ) : (
+                                <DownloadIcon className="mr-2 size-4" aria-hidden />
+                            )}
+                            Import
+                        </Button>
+                    </div>
+                </div>
+            </SheetContent>
+        </Sheet>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/features/policy-structure/__tests__/EntitiesPage.test.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/features/policy-structure/__tests__/EntitiesPage.test.tsx
@@ -21,6 +21,26 @@ import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { EntityResponse } from '../../../shared/api/authz-api.types';
 import { EntitiesPage } from '../EntitiesPage';
 
+const toastSuccessSpy = vi.fn();
+const toastErrorSpy = vi.fn();
+
+vi.mock('@gravitee/graphene-core', async importOriginal => {
+    const actual = await importOriginal<Record<string, unknown>>();
+    return {
+        ...actual,
+        toast: {
+            success: (msg: string) => toastSuccessSpy(msg),
+            error: (msg: string) => toastErrorSpy(msg),
+        },
+    };
+});
+
+// The dialog itself is unit-tested separately (ImportFromCatalogDialog.test.tsx);
+// here we just need it to render without firing real catalog queries.
+vi.mock('../ImportFromCatalogDialog', () => ({
+    ImportFromCatalogDialog: ({ open }: { open: boolean }) => (open ? <div data-testid="import-dialog-stub" /> : null),
+}));
+
 // jsdom doesn't implement scrollIntoView; Radix Select calls it on item activation.
 beforeAll(() => {
     if (!Element.prototype.scrollIntoView) {
@@ -36,6 +56,7 @@ interface ListEntitiesParams {
 }
 
 const listEntitiesSpy = vi.fn();
+const deleteEntitySpy = vi.fn();
 
 vi.mock('@gravitee/gamma-modules-sdk', async importOriginal => ({
     ...(await importOriginal<object>()),
@@ -46,6 +67,7 @@ vi.mock('../../../shared/api/authz-api.service', () => ({
     DEFAULT_PER_PAGE: 10,
     authzApiService: {
         listEntities: (env: string, params?: ListEntitiesParams) => listEntitiesSpy(env, params),
+        deleteEntity: (env: string, entityId: string) => deleteEntitySpy(env, entityId),
     },
 }));
 
@@ -91,6 +113,9 @@ function mockByKind(opts: {
 
 beforeEach(() => {
     listEntitiesSpy.mockReset();
+    deleteEntitySpy.mockReset();
+    toastSuccessSpy.mockReset();
+    toastErrorSpy.mockReset();
 });
 
 describe('EntitiesPage', () => {
@@ -178,5 +203,121 @@ describe('EntitiesPage', () => {
             expect(screen.queryByText('bob')).not.toBeInTheDocument();
             expect(screen.getAllByText('alice').length).toBeGreaterThan(0);
         });
+    });
+
+    it('exposes the Import-from-Catalog button only on the Resources tab', async () => {
+        mockByKind({
+            principals: [makeEntity({ id: 'p1', uid: 'user.alice' })],
+            resources: [makeEntity({ id: 'r1', uid: 'mcp.flight' })],
+        });
+        renderPage();
+
+        await waitFor(() => expect(screen.getAllByText('alice').length).toBeGreaterThan(0));
+        expect(screen.queryByRole('button', { name: /Import from Context Catalog/i })).not.toBeInTheDocument();
+
+        const user = userEvent.setup();
+        await user.click(screen.getByRole('tab', { name: /Resources/i }));
+
+        await waitFor(() => expect(screen.getByRole('button', { name: /Import from Context Catalog/i })).toBeInTheDocument());
+    });
+
+    it('opens the import dialog stub when the button is clicked', async () => {
+        mockByKind({ resources: [makeEntity({ id: 'r1', uid: 'mcp.flight' })] });
+        renderPage();
+
+        const user = userEvent.setup();
+        await user.click(screen.getByRole('tab', { name: /Resources/i }));
+        await waitFor(() => expect(screen.getByRole('button', { name: /Import from Context Catalog/i })).toBeInTheDocument());
+
+        expect(screen.queryByTestId('import-dialog-stub')).not.toBeInTheDocument();
+        await user.click(screen.getByRole('button', { name: /Import from Context Catalog/i }));
+        expect(screen.getByTestId('import-dialog-stub')).toBeInTheDocument();
+    });
+
+    it('shows the row-level Remove action only on the Resources tab', async () => {
+        mockByKind({
+            principals: [makeEntity({ id: 'p1', uid: 'user.alice' })],
+            resources: [makeEntity({ id: 'r1', uid: 'mcp.flight' })],
+        });
+        renderPage();
+
+        await waitFor(() => expect(screen.getAllByText('alice').length).toBeGreaterThan(0));
+        // Principal rows have no Delete button.
+        expect(screen.queryByLabelText('Delete user.alice')).not.toBeInTheDocument();
+
+        const user = userEvent.setup();
+        await user.click(screen.getByRole('tab', { name: /Resources/i }));
+
+        await waitFor(() => expect(screen.getByLabelText('Delete mcp.flight')).toBeInTheDocument());
+    });
+
+    it('opens the Remove confirmation dialog when the trash icon is clicked', async () => {
+        mockByKind({
+            resources: [makeEntity({ id: 'r1', uid: 'mcp.flight', attributes: { _displayName: 'Flight Status' } })],
+        });
+        renderPage();
+
+        const user = userEvent.setup();
+        await user.click(screen.getByRole('tab', { name: /Resources/i }));
+
+        await waitFor(() => expect(screen.getByLabelText('Delete mcp.flight')).toBeInTheDocument());
+        await user.click(screen.getByLabelText('Delete mcp.flight'));
+
+        const dialog = await screen.findByRole('dialog');
+        expect(within(dialog).getByText('Remove entity from Authorization?')).toBeInTheDocument();
+        expect(within(dialog).getByText(/mcp\.flight/)).toBeInTheDocument();
+        expect(deleteEntitySpy).not.toHaveBeenCalled();
+    });
+
+    it('does not call deleteEntity when the confirmation dialog is cancelled', async () => {
+        mockByKind({ resources: [makeEntity({ id: 'r1', uid: 'mcp.flight' })] });
+        renderPage();
+
+        const user = userEvent.setup();
+        await user.click(screen.getByRole('tab', { name: /Resources/i }));
+        await waitFor(() => expect(screen.getByLabelText('Delete mcp.flight')).toBeInTheDocument());
+        await user.click(screen.getByLabelText('Delete mcp.flight'));
+
+        const dialog = await screen.findByRole('dialog');
+        await user.click(within(dialog).getByRole('button', { name: /^Cancel$/i }));
+
+        await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
+        expect(deleteEntitySpy).not.toHaveBeenCalled();
+    });
+
+    it('calls deleteEntity, fires toast.success, and closes the dialog on confirm', async () => {
+        mockByKind({ resources: [makeEntity({ id: 'r1', uid: 'mcp.flight' })] });
+        deleteEntitySpy.mockResolvedValue(undefined);
+        renderPage();
+
+        const user = userEvent.setup();
+        await user.click(screen.getByRole('tab', { name: /Resources/i }));
+        await waitFor(() => expect(screen.getByLabelText('Delete mcp.flight')).toBeInTheDocument());
+        await user.click(screen.getByLabelText('Delete mcp.flight'));
+
+        const dialog = await screen.findByRole('dialog');
+        await user.click(within(dialog).getByRole('button', { name: /Confirm remove/i }));
+
+        await waitFor(() => expect(deleteEntitySpy).toHaveBeenCalledWith('DEFAULT', 'mcp.flight'));
+        await waitFor(() => expect(toastSuccessSpy).toHaveBeenCalled());
+        await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
+    });
+
+    it('keeps the dialog open and surfaces a toast.error when delete fails', async () => {
+        mockByKind({ resources: [makeEntity({ id: 'r1', uid: 'mcp.flight' })] });
+        deleteEntitySpy.mockRejectedValue(new Error('upstream 500'));
+        renderPage();
+
+        const user = userEvent.setup();
+        await user.click(screen.getByRole('tab', { name: /Resources/i }));
+        await waitFor(() => expect(screen.getByLabelText('Delete mcp.flight')).toBeInTheDocument());
+        await user.click(screen.getByLabelText('Delete mcp.flight'));
+
+        const dialog = await screen.findByRole('dialog');
+        await user.click(within(dialog).getByRole('button', { name: /Confirm remove/i }));
+
+        await waitFor(() => expect(toastErrorSpy).toHaveBeenCalledWith(expect.stringContaining('upstream 500')));
+        // Dialog stays open after a failed delete so the user can retry / cancel.
+        expect(screen.getByRole('dialog')).toBeInTheDocument();
     });
 });

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/features/policy-structure/__tests__/ImportFromCatalogDialog.test.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/features/policy-structure/__tests__/ImportFromCatalogDialog.test.tsx
@@ -1,0 +1,586 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { ReactNode } from 'react';
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import type {
+    AgentCatalogItem,
+    CatalogItemKind,
+    McpServerCatalogItem,
+    ModelCatalogItem,
+} from '../../../shared/api/aim-catalog.types';
+import { ImportFromCatalogDialog } from '../ImportFromCatalogDialog';
+
+beforeAll(() => {
+    if (!Element.prototype.scrollIntoView) {
+        Element.prototype.scrollIntoView = () => undefined;
+    }
+});
+
+const listItemsSpy = vi.fn();
+const listEntitiesSpy = vi.fn();
+const createEntitySpy = vi.fn();
+const toastSuccessSpy = vi.fn();
+const toastErrorSpy = vi.fn();
+
+vi.mock('../../../shared/api/aim-catalog.service', () => ({
+    aimCatalogService: {
+        listItems: (env: string, kind: string, page: number, perPage: number) => listItemsSpy(env, kind, page, perPage),
+    },
+}));
+
+vi.mock('../../../shared/api/authz-api.service', () => ({
+    DEFAULT_PER_PAGE: 10,
+    authzApiService: {
+        listEntities: (env: string, params?: unknown) => listEntitiesSpy(env, params),
+        createEntity: (env: string, req: unknown) => createEntitySpy(env, req),
+    },
+}));
+
+interface EntityFixture {
+    readonly id: string;
+    readonly uid: string;
+    readonly catalogId?: string;
+}
+
+function seedImported(entities: readonly EntityFixture[]) {
+    listEntitiesSpy.mockImplementation(() =>
+        Promise.resolve({
+            data: entities.map(e => ({
+                id: e.id,
+                environmentId: 'DEFAULT',
+                uid: e.uid,
+                attributes: e.catalogId ? { _catalogId: e.catalogId } : {},
+                parents: [],
+                createdAt: '2026-05-27T10:00:00.000Z',
+                updatedAt: '2026-05-27T10:00:00.000Z',
+            })),
+            total: entities.length,
+            page: 1,
+            perPage: 1000,
+        }),
+    );
+}
+
+vi.mock('@gravitee/graphene-core', async importOriginal => {
+    const actual = await importOriginal<Record<string, unknown>>();
+    return {
+        ...actual,
+        toast: {
+            success: (msg: string) => toastSuccessSpy(msg),
+            error: (msg: string) => toastErrorSpy(msg),
+        },
+    };
+});
+
+function makeModel(
+    id: string,
+    name: string,
+    opts: { provider?: string; sourceKind?: string; entityId?: string | null } = {},
+): ModelCatalogItem {
+    return {
+        id,
+        entityId: opts.entityId ?? null,
+        kind: 'model',
+        sourceId: null,
+        sourceKind: opts.sourceKind ?? null,
+        parentId: null,
+        environmentId: 'DEFAULT',
+        organizationId: 'DEFAULT',
+        creationDate: '2026-05-27T10:00:00.000Z',
+        updateDate: '2026-05-27T10:00:00.000Z',
+        definition: { name, queryName: name.toLowerCase(), provider: opts.provider, description: `Model ${name}` },
+    };
+}
+
+function makeMcp(id: string, name: string, opts: { canonicalEntityId?: string; entityId?: string | null } = {}): McpServerCatalogItem {
+    return {
+        id,
+        entityId: opts.entityId ?? null,
+        kind: 'mcp-server',
+        sourceId: null,
+        sourceKind: null,
+        parentId: null,
+        environmentId: 'DEFAULT',
+        organizationId: 'DEFAULT',
+        creationDate: '2026-05-27T10:00:00.000Z',
+        updateDate: '2026-05-27T10:00:00.000Z',
+        definition: { serverInfo: { name, title: `${name} server` } },
+        extensions: { entityId: opts.canonicalEntityId, description: `MCP ${name}` },
+    };
+}
+
+function makeAgent(id: string, name: string, opts: { entityId?: string | null } = {}): AgentCatalogItem {
+    return {
+        id,
+        entityId: opts.entityId ?? null,
+        kind: 'agent',
+        sourceId: null,
+        sourceKind: null,
+        parentId: null,
+        environmentId: 'DEFAULT',
+        organizationId: 'DEFAULT',
+        creationDate: '2026-05-27T10:00:00.000Z',
+        updateDate: '2026-05-27T10:00:00.000Z',
+        definition: { name, description: `Agent ${name}`, url: `https://${name}.example` },
+    };
+}
+
+interface CatalogSeed {
+    readonly models?: readonly ModelCatalogItem[];
+    readonly mcpServers?: readonly McpServerCatalogItem[];
+    readonly agents?: readonly AgentCatalogItem[];
+}
+
+function seedCatalog(seed: CatalogSeed) {
+    const models = seed.models ?? [];
+    const mcpServers = seed.mcpServers ?? [];
+    const agents = seed.agents ?? [];
+    listItemsSpy.mockImplementation((_env: string, kind: CatalogItemKind) => {
+        if (kind === 'model') return Promise.resolve({ data: models, page: 1, perPage: 100, total: models.length });
+        if (kind === 'mcp-server') return Promise.resolve({ data: mcpServers, page: 1, perPage: 100, total: mcpServers.length });
+        if (kind === 'agent') return Promise.resolve({ data: agents, page: 1, perPage: 100, total: agents.length });
+        return Promise.resolve({ data: [], page: 1, perPage: 100, total: 0 });
+    });
+}
+
+interface RenderOptions {
+    readonly onImported?: () => void;
+    readonly onOpenChange?: (open: boolean) => void;
+}
+
+function renderDialog(opts: RenderOptions = {}) {
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const wrapper = ({ children }: { children: ReactNode }) => (
+        <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return render(
+        <ImportFromCatalogDialog
+            open={true}
+            environmentId="DEFAULT"
+            onOpenChange={opts.onOpenChange ?? (() => undefined)}
+            onImported={opts.onImported ?? (() => undefined)}
+        />,
+        { wrapper },
+    );
+}
+
+async function waitForList() {
+    await waitFor(() => expect(listItemsSpy).toHaveBeenCalled());
+}
+
+function getDialog() {
+    return screen.getByRole('dialog');
+}
+
+beforeEach(() => {
+    listItemsSpy.mockReset();
+    listEntitiesSpy.mockReset();
+    createEntitySpy.mockReset();
+    toastSuccessSpy.mockReset();
+    toastErrorSpy.mockReset();
+    // Default: no prior imports — tests can override via seedImported().
+    seedImported([]);
+});
+
+describe('ImportFromCatalogDialog', () => {
+    it('queries all three catalog kinds when opened', async () => {
+        seedCatalog({});
+        renderDialog();
+
+        await waitFor(() => expect(listItemsSpy).toHaveBeenCalledTimes(3));
+        const kinds = listItemsSpy.mock.calls.map(args => args[1]).sort();
+        expect(kinds).toEqual(['agent', 'mcp-server', 'model']);
+    });
+
+    it('shows MCP servers tab by default and switches to AI Models on click', async () => {
+        seedCatalog({
+            models: [makeModel('m1', 'Gemini')],
+            mcpServers: [makeMcp('s1', 'flight-status')],
+        });
+        renderDialog();
+        await waitForList();
+
+        const dialog = getDialog();
+        // MCP Servers tab open initially → server item visible.
+        await waitFor(() => expect(within(dialog).getByText('flight-status server')).toBeInTheDocument());
+
+        const user = userEvent.setup();
+        await user.click(within(dialog).getByRole('tab', { name: /AI Models/i }));
+
+        await waitFor(() => expect(within(dialog).getByText('Gemini')).toBeInTheDocument());
+        expect(within(dialog).queryByText('flight-status server')).not.toBeInTheDocument();
+    });
+
+    it('filters the visible list by search text', async () => {
+        seedCatalog({
+            mcpServers: [makeMcp('s1', 'flight-status'), makeMcp('s2', 'hotel-booking')],
+        });
+        renderDialog();
+        await waitForList();
+
+        const dialog = getDialog();
+        await waitFor(() => expect(within(dialog).getByText('flight-status server')).toBeInTheDocument());
+        expect(within(dialog).getByText('hotel-booking server')).toBeInTheDocument();
+
+        const search = within(dialog).getByLabelText('Search catalog entries');
+        const user = userEvent.setup();
+        await user.type(search, 'flight');
+
+        await waitFor(() => {
+            expect(within(dialog).queryByText('hotel-booking server')).not.toBeInTheDocument();
+            expect(within(dialog).getByText('flight-status server')).toBeInTheDocument();
+        });
+    });
+
+    it('disables Import until at least one item is selected', async () => {
+        seedCatalog({ mcpServers: [makeMcp('s1', 'flight-status')] });
+        renderDialog();
+        await waitForList();
+
+        const dialog = getDialog();
+        const importBtn = within(dialog).getByRole('button', { name: /^Import$/i });
+        expect(importBtn).toBeDisabled();
+
+        await waitFor(() => expect(within(dialog).getByText('flight-status server')).toBeInTheDocument());
+        const user = userEvent.setup();
+        await user.click(within(dialog).getByLabelText('Select flight-status server'));
+
+        expect(importBtn).not.toBeDisabled();
+        expect(within(dialog).getByText('1 item selected')).toBeInTheDocument();
+    });
+
+    it('imports selected items as RESOURCE entities with the gravitee-catalog source label', async () => {
+        seedCatalog({
+            mcpServers: [makeMcp('s1', 'flight-status', { canonicalEntityId: 'flight-status' })],
+            models: [makeModel('m1', 'Gemini', { provider: 'google' })],
+        });
+        createEntitySpy.mockResolvedValue({});
+        const onImported = vi.fn();
+        const onOpenChange = vi.fn();
+        renderDialog({ onImported, onOpenChange });
+        await waitForList();
+
+        const dialog = getDialog();
+        const user = userEvent.setup();
+
+        await waitFor(() => expect(within(dialog).getByText('flight-status server')).toBeInTheDocument());
+        await user.click(within(dialog).getByLabelText('Select flight-status server'));
+
+        await user.click(within(dialog).getByRole('tab', { name: /AI Models/i }));
+        await waitFor(() => expect(within(dialog).getByText('Gemini')).toBeInTheDocument());
+        await user.click(within(dialog).getByLabelText('Select Gemini'));
+
+        expect(within(dialog).getByText('2 items selected')).toBeInTheDocument();
+        await user.click(within(dialog).getByRole('button', { name: /^Import$/i }));
+
+        await waitFor(() => expect(createEntitySpy).toHaveBeenCalledTimes(2));
+
+        const callsByEntityId = new Map<string, unknown>();
+        for (const [, req] of createEntitySpy.mock.calls) {
+            const r = req as { entityId: string };
+            callsByEntityId.set(r.entityId, req);
+        }
+        // Catalog convention: mcp.{extensions.entityId}, model.{provider}.{queryName}.
+        expect(callsByEntityId.has('mcp.flight-status')).toBe(true);
+        expect(callsByEntityId.has('model.google.gemini')).toBe(true);
+
+        for (const [, req] of createEntitySpy.mock.calls) {
+            const r = req as {
+                kind: string;
+                source: string;
+                attributes: Record<string, unknown>;
+                parents: readonly string[];
+            };
+            expect(r.kind).toBe('RESOURCE');
+            expect(r.source).toBe('gravitee-catalog');
+            expect(r.parents).toEqual([]);
+            expect(r.attributes._displayName).toBeTypeOf('string');
+            expect(r.attributes._catalogId).toBeTypeOf('string');
+            expect(r.attributes._importedAt).toBeTypeOf('string');
+            // _kind intentionally omitted — the entityId prefix carries the same information.
+            expect(r.attributes._kind).toBeUndefined();
+        }
+
+        await waitFor(() => expect(onImported).toHaveBeenCalledTimes(1));
+        expect(toastSuccessSpy).toHaveBeenCalledWith('Imported 2 entities');
+        await waitFor(() => expect(onOpenChange).toHaveBeenCalledWith(false));
+    });
+
+    it('uses the agent canonical prefix for A2A catalog agents (not a2a)', async () => {
+        seedCatalog({ agents: [makeAgent('a1', 'Researcher')] });
+        createEntitySpy.mockResolvedValue({});
+        renderDialog();
+        await waitForList();
+
+        const dialog = getDialog();
+        const user = userEvent.setup();
+        await user.click(within(dialog).getByRole('tab', { name: /^Agents/i }));
+        await waitFor(() => expect(within(dialog).getByText('Researcher')).toBeInTheDocument());
+        await user.click(within(dialog).getByLabelText('Select Researcher'));
+        await user.click(within(dialog).getByRole('button', { name: /^Import$/i }));
+
+        await waitFor(() => expect(createEntitySpy).toHaveBeenCalledTimes(1));
+        const [, req] = createEntitySpy.mock.calls[0];
+        expect((req as { entityId: string }).entityId).toBe('agent.researcher');
+    });
+
+    it('reports partial failure via toast.error and keeps the dialog open', async () => {
+        seedCatalog({
+            mcpServers: [makeMcp('s1', 'flight-status'), makeMcp('s2', 'hotel-booking')],
+        });
+        createEntitySpy.mockResolvedValueOnce({}).mockRejectedValueOnce(new Error('boom'));
+        const onOpenChange = vi.fn();
+        renderDialog({ onOpenChange });
+        await waitForList();
+
+        const dialog = getDialog();
+        const user = userEvent.setup();
+        await waitFor(() => expect(within(dialog).getByText('flight-status server')).toBeInTheDocument());
+        await user.click(within(dialog).getByRole('button', { name: /Select visible/i }));
+        await user.click(within(dialog).getByRole('button', { name: /^Import$/i }));
+
+        await waitFor(() => expect(createEntitySpy).toHaveBeenCalledTimes(2));
+        await waitFor(() => expect(toastSuccessSpy).toHaveBeenCalledWith('Imported 1 entity'));
+        expect(toastErrorSpy).toHaveBeenCalledWith(expect.stringContaining('Failed to import 1'));
+        // partial failure ⇒ stay open so user sees the error
+        expect(onOpenChange).not.toHaveBeenCalledWith(false);
+    });
+
+    it('shows an empty-state when a tab has no catalog items', async () => {
+        seedCatalog({});
+        renderDialog();
+        await waitForList();
+
+        const dialog = getDialog();
+        await waitFor(() => expect(within(dialog).getByText(/No items in this catalog category yet/)).toBeInTheDocument());
+    });
+
+    describe('entityId convention (mirrors AIM catalog fixtures)', () => {
+        async function importSingleAndCaptureEntityId(): Promise<string> {
+            createEntitySpy.mockResolvedValue({});
+            renderDialog();
+            await waitForList();
+            const dialog = getDialog();
+            const user = userEvent.setup();
+            // Caller seeded exactly one item across all kinds — find it and select it.
+            const importBtn = within(dialog).getByRole('button', { name: /^Import$/i });
+            // Walk through the tabs until something is visible to select.
+            for (const tabName of ['MCP Servers', 'AI Models', 'Agents']) {
+                await user.click(within(dialog).getByRole('tab', { name: new RegExp(tabName, 'i') }));
+                const selectables = within(dialog).queryAllByRole('checkbox');
+                const enabled = selectables.find(cb => !(cb as HTMLInputElement).disabled);
+                if (enabled) {
+                    await user.click(enabled);
+                    break;
+                }
+            }
+            await user.click(importBtn);
+            await waitFor(() => expect(createEntitySpy).toHaveBeenCalledTimes(1));
+            return (createEntitySpy.mock.calls[0][1] as { entityId: string }).entityId;
+        }
+
+        it('model with provider → `model.{provider}.{queryName}` (matches model.openai.gpt-4o)', async () => {
+            seedCatalog({ models: [makeModel('m1', 'GPT-4o', { provider: 'openai' })] });
+            const entityId = await importSingleAndCaptureEntityId();
+            expect(entityId).toBe('model.openai.gpt-4o');
+        });
+
+        it('model without explicit provider falls back to sourceKind (catalog uses `llm.provider.openai`)', async () => {
+            seedCatalog({ models: [makeModel('m1', 'GPT-4o', { sourceKind: 'llm.provider.openai' })] });
+            const entityId = await importSingleAndCaptureEntityId();
+            expect(entityId).toBe('model.openai.gpt-4o');
+        });
+
+        it('model with neither provider nor sourceKind falls back to single-segment slug', async () => {
+            seedCatalog({ models: [makeModel('m1', 'GPT-4o')] });
+            const entityId = await importSingleAndCaptureEntityId();
+            // No provider info → user gets the legacy short form; collision risk surfaces via Imported badge.
+            expect(entityId).toBe('model.gpt-4o');
+        });
+
+        it('mcp-server uses extensions.entityId when present (matches mcp.filesystem)', async () => {
+            seedCatalog({ mcpServers: [makeMcp('s1', 'filesystem-server', { canonicalEntityId: 'filesystem' })] });
+            const entityId = await importSingleAndCaptureEntityId();
+            expect(entityId).toBe('mcp.filesystem');
+        });
+
+        it('mcp-server without extensions.entityId falls back to serverInfo.name', async () => {
+            seedCatalog({ mcpServers: [makeMcp('s1', 'filesystem')] });
+            const entityId = await importSingleAndCaptureEntityId();
+            expect(entityId).toBe('mcp.filesystem');
+        });
+
+        it('agent uses single-segment `agent.{name}` (matches agent.code-reviewer)', async () => {
+            seedCatalog({ agents: [makeAgent('a1', 'Code Reviewer')] });
+            const entityId = await importSingleAndCaptureEntityId();
+            expect(entityId).toBe('agent.code-reviewer');
+        });
+
+        it('prefers the server-derived `item.entityId` over re-deriving from definition for models', async () => {
+            // aim ≥ 1.0.0-alpha.71 persists `entityId` on the CatalogItem; we keep the
+            // legacy {definition.queryName} fallback for older rows.
+            seedCatalog({ models: [makeModel('m1', 'Display Name', { provider: 'openai', entityId: 'gpt-4o-mini' })] });
+            const entityId = await importSingleAndCaptureEntityId();
+            expect(entityId).toBe('model.openai.gpt-4o-mini');
+        });
+
+        it('prefers the server-derived `item.entityId` over re-deriving for MCP servers', async () => {
+            seedCatalog({ mcpServers: [makeMcp('s1', 'wrong-name', { entityId: 'github' })] });
+            const entityId = await importSingleAndCaptureEntityId();
+            expect(entityId).toBe('mcp.github');
+        });
+
+        it('prefers the server-derived `item.entityId` over re-deriving for agents', async () => {
+            seedCatalog({ agents: [makeAgent('a1', 'Wrong Name', { entityId: 'planner' })] });
+            const entityId = await importSingleAndCaptureEntityId();
+            expect(entityId).toBe('agent.planner');
+        });
+
+        it('renders a truncation banner when the catalog reports more items than the hook fetched', async () => {
+            // Pretend the catalog has 12k models, but page 2 returns empty so the loop stops early.
+            listItemsSpy.mockImplementation((_env: string, kind: CatalogItemKind, page: number) => {
+                if (kind === 'model') {
+                    if (page === 1) {
+                        return Promise.resolve({
+                            data: [makeModel('m1', 'GPT-4o', { provider: 'openai' })],
+                            page: 1,
+                            perPage: 500,
+                            total: 12_000,
+                        });
+                    }
+                    return Promise.resolve({ data: [], page, perPage: 500, total: 12_000 });
+                }
+                return Promise.resolve({ data: [], page: 1, perPage: 500, total: 0 });
+            });
+            renderDialog();
+            await waitFor(() => expect(listItemsSpy).toHaveBeenCalled());
+
+            const dialog = getDialog();
+            const user = userEvent.setup();
+            await user.click(within(dialog).getByRole('tab', { name: /AI Models/i }));
+
+            await waitFor(() => expect(within(dialog).getByRole('status')).toHaveTextContent(/Showing the first 1 of 12000/));
+        });
+
+        it('two providers hosting the same queryName produce distinct entityIds (collision-safe)', async () => {
+            seedCatalog({
+                models: [
+                    makeModel('m1', 'Claude Sonnet 4', { provider: 'anthropic' }),
+                    makeModel('m2', 'Claude Sonnet 4', { provider: 'bedrock' }),
+                ],
+            });
+            createEntitySpy.mockResolvedValue({});
+            renderDialog();
+            await waitForList();
+
+            const dialog = getDialog();
+            const user = userEvent.setup();
+            await user.click(within(dialog).getByRole('tab', { name: /AI Models/i }));
+            await waitFor(() => expect(within(dialog).getAllByText('Claude Sonnet 4').length).toBe(2));
+            await user.click(within(dialog).getByRole('button', { name: /Select visible/i }));
+            await user.click(within(dialog).getByRole('button', { name: /^Import$/i }));
+
+            await waitFor(() => expect(createEntitySpy).toHaveBeenCalledTimes(2));
+            const ids = new Set(createEntitySpy.mock.calls.map(c => (c[1] as { entityId: string }).entityId));
+            expect(ids).toEqual(new Set(['model.anthropic.claude-sonnet-4', 'model.bedrock.claude-sonnet-4']));
+        });
+    });
+
+    describe('idempotency — items already imported', () => {
+        it('queries authz for catalog-sourced resources to detect duplicates', async () => {
+            seedCatalog({ mcpServers: [makeMcp('s1', 'flight-status')] });
+            renderDialog();
+
+            await waitFor(() => expect(listEntitiesSpy).toHaveBeenCalled());
+            expect(listEntitiesSpy).toHaveBeenCalledWith(
+                'DEFAULT',
+                expect.objectContaining({ kind: 'RESOURCE', source: 'gravitee-catalog' }),
+            );
+        });
+
+        it('marks already-imported items with an Imported badge and a disabled checkbox', async () => {
+            seedCatalog({ mcpServers: [makeMcp('s1', 'flight-status')] });
+            seedImported([{ id: 'e1', uid: 'mcp.flight-status', catalogId: 's1' }]);
+            renderDialog();
+            await waitForList();
+
+            const dialog = getDialog();
+            await waitFor(() => expect(within(dialog).getByText('flight-status server')).toBeInTheDocument());
+            await waitFor(() =>
+                expect(within(dialog).getByLabelText('flight-status server already imported')).toBeDisabled(),
+            );
+            expect(within(dialog).getByText('Imported')).toBeInTheDocument();
+        });
+
+        it('toggleSelect is a no-op for already-imported items', async () => {
+            seedCatalog({ mcpServers: [makeMcp('s1', 'flight-status')] });
+            seedImported([{ id: 'e1', uid: 'mcp.flight-status', catalogId: 's1' }]);
+            renderDialog();
+            await waitForList();
+
+            const dialog = getDialog();
+            await waitFor(() =>
+                expect(within(dialog).getByLabelText('flight-status server already imported')).toBeDisabled(),
+            );
+            const user = userEvent.setup();
+            // userEvent skips disabled controls, so just confirm the counter never changes
+            // and Import stays disabled — we don't want a side door via keyboard either.
+            await user.click(within(dialog).getByLabelText('flight-status server already imported'));
+            expect(within(dialog).getByText('No items selected')).toBeInTheDocument();
+            expect(within(dialog).getByRole('button', { name: /^Import$/i })).toBeDisabled();
+        });
+
+        it('"Select visible" skips already-imported items', async () => {
+            seedCatalog({
+                mcpServers: [makeMcp('s1', 'flight-status'), makeMcp('s2', 'hotel-booking')],
+            });
+            seedImported([{ id: 'e1', uid: 'mcp.flight-status', catalogId: 's1' }]);
+            renderDialog();
+            await waitForList();
+
+            const dialog = getDialog();
+            await waitFor(() =>
+                expect(within(dialog).getByLabelText('flight-status server already imported')).toBeDisabled(),
+            );
+            const user = userEvent.setup();
+            await user.click(within(dialog).getByRole('button', { name: /Select visible/i }));
+
+            // Only the not-yet-imported item gets selected.
+            expect(within(dialog).getByText('1 item selected')).toBeInTheDocument();
+        });
+
+        it('a successful import invalidates the entities cache so badges refresh', async () => {
+            seedCatalog({ mcpServers: [makeMcp('s1', 'flight-status')] });
+            createEntitySpy.mockResolvedValue({});
+            const onImported = vi.fn();
+            renderDialog({ onImported });
+            await waitForList();
+
+            const dialog = getDialog();
+            const user = userEvent.setup();
+            await waitFor(() => expect(within(dialog).getByText('flight-status server')).toBeInTheDocument());
+            await user.click(within(dialog).getByLabelText('Select flight-status server'));
+            await user.click(within(dialog).getByRole('button', { name: /^Import$/i }));
+
+            // onImported is the parent's invalidation hook; firing it is the
+            // observable signal that downstream caches will be refreshed.
+            await waitFor(() => expect(onImported).toHaveBeenCalledTimes(1));
+        });
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/features/policy-structure/entity-types.ts
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/features/policy-structure/entity-types.ts
@@ -14,21 +14,24 @@
  * limitations under the License.
  */
 
-export type EntityCategoryId = 'principal' | 'mcp' | 'api' | 'agent' | 'llm' | 'event' | 'custom';
+export type EntityCategoryId = 'principal' | 'mcp' | 'api' | 'agent' | 'model' | 'event' | 'custom';
 
 export interface EntityCategory {
     id: EntityCategoryId;
     label: string;
+    textColor: string;
 }
 
+// chart-1..chart-10 are graphene's categorical palette (designed for distinct categories).
+// We pick a stable mapping per entity category; custom falls back to a neutral muted tone.
 export const CATEGORIES: EntityCategory[] = [
-    { id: 'principal', label: 'Principals' },
-    { id: 'mcp', label: 'MCP' },
-    { id: 'api', label: 'APIs' },
-    { id: 'agent', label: 'Agents' },
-    { id: 'llm', label: 'LLMs' },
-    { id: 'event', label: 'Events' },
-    { id: 'custom', label: 'Custom' },
+    { id: 'principal', label: 'Principals', textColor: 'text-chart-1' },
+    { id: 'mcp', label: 'MCP', textColor: 'text-chart-2' },
+    { id: 'api', label: 'APIs', textColor: 'text-chart-8' },
+    { id: 'agent', label: 'Agents', textColor: 'text-chart-7' },
+    { id: 'model', label: 'AI Models', textColor: 'text-chart-5' },
+    { id: 'event', label: 'Events', textColor: 'text-chart-10' },
+    { id: 'custom', label: 'Custom', textColor: 'text-muted-foreground' },
 ];
 
 export function getCategory(id: EntityCategoryId): EntityCategory | undefined {
@@ -56,9 +59,7 @@ const ENTITY_CATEGORIES: Readonly<Record<string, EntityCategoryId>> = {
     AgentMemory: 'agent',
     AgentKnowledge: 'agent',
 
-    LLMRoute: 'llm',
-    LLMModel: 'llm',
-    LLMProvider: 'llm',
+    Model: 'model',
 
     EventStream: 'event',
     Topic: 'event',

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/shared/__tests__/entity-kind-registry.test.ts
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/shared/__tests__/entity-kind-registry.test.ts
@@ -21,16 +21,21 @@ describe('kindToUiType', () => {
         expect(kindToUiType('user')).toBe('User');
         expect(kindToUiType('group')).toBe('Group');
         expect(kindToUiType('mcp')).toBe('MCPServer');
-        expect(kindToUiType('llm')).toBe('LLMRoute');
-        expect(kindToUiType('agent')).toBe('AgentIdentity');
+        expect(kindToUiType('llm')).toBe('Model');
+        expect(kindToUiType('model')).toBe('Model');
+        expect(kindToUiType('agent')).toBe('Agent');
+        expect(kindToUiType('agent-identity')).toBe('AgentIdentity');
         expect(kindToUiType('api')).toBe('API');
         expect(kindToUiType('serviceaccount')).toBe('ServiceAccount');
     });
 
     it('honours aliases', () => {
         expect(kindToUiType('mcpserver')).toBe('MCPServer');
-        expect(kindToUiType('llmroute')).toBe('LLMRoute');
+        expect(kindToUiType('llmroute')).toBe('Model');
+        expect(kindToUiType('llmmodel')).toBe('Model');
         expect(kindToUiType('agentidentity')).toBe('AgentIdentity');
+        expect(kindToUiType('a2a')).toBe('Agent');
+        expect(kindToUiType('a2aagent')).toBe('Agent');
         expect(kindToUiType('service-account')).toBe('ServiceAccount');
         expect(kindToUiType('service_account')).toBe('ServiceAccount');
     });
@@ -51,8 +56,9 @@ describe('uiTypeToKind', () => {
     it('maps UI types to canonical lowercase kinds', () => {
         expect(uiTypeToKind('User')).toBe('user');
         expect(uiTypeToKind('MCPServer')).toBe('mcp');
-        expect(uiTypeToKind('LLMRoute')).toBe('llm');
-        expect(uiTypeToKind('AgentIdentity')).toBe('agent');
+        expect(uiTypeToKind('Model')).toBe('model');
+        expect(uiTypeToKind('AgentIdentity')).toBe('agent-identity');
+        expect(uiTypeToKind('Agent')).toBe('agent');
         expect(uiTypeToKind('ServiceAccount')).toBe('serviceaccount');
     });
 
@@ -71,7 +77,8 @@ describe('deriveServiceType', () => {
     it('maps known prefixes to their policy type', () => {
         expect(deriveServiceType('mcp.flight')).toBe('MCP');
         expect(deriveServiceType('agent.deploy')).toBe('AGENT');
-        expect(deriveServiceType('llm.gpt')).toBe('LLM');
+        expect(deriveServiceType('llm.gpt')).toBe('MODEL');
+        expect(deriveServiceType('model.openai.gpt-4o')).toBe('MODEL');
         expect(deriveServiceType('api.products')).toBe('API');
         expect(deriveServiceType('event.user-signup')).toBe('EVENT');
     });

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/shared/api/__tests__/aim-catalog.service.test.ts
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/shared/api/__tests__/aim-catalog.service.test.ts
@@ -1,0 +1,64 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const get = vi.fn();
+vi.mock('../authz-api-client', () => ({
+    authzCoreApiClient: {
+        get: (path: string) => get(path),
+        post: vi.fn(),
+        put: vi.fn(),
+        delete: vi.fn(),
+    },
+    ApiError: class ApiError extends Error {},
+}));
+
+import { aimCatalogService } from '../aim-catalog.service';
+
+describe('aimCatalogService.listItems', () => {
+    beforeEach(() => get.mockReset());
+
+    it('targets the AIM module catalog path with kind/page/perPage query params', async () => {
+        get.mockResolvedValue({ data: [], pagination: { page: 1, perPage: 50, totalCount: 0 } });
+
+        await aimCatalogService.listItems('env one', 'model', 2, 50);
+
+        const path = get.mock.calls[0][0] as string;
+        expect(path).toContain('/environments/env%20one/modules/aim/catalog/items');
+        expect(path).toContain('kind=model');
+        expect(path).toContain('page=2');
+        expect(path).toContain('perPage=50');
+    });
+
+    it('flattens the AIM pagination envelope into a CatalogItemPage', async () => {
+        const item = { id: 'm1', kind: 'model', definition: { name: 'GPT', queryName: 'gpt' } };
+        get.mockResolvedValue({ data: [item], pagination: { page: 3, perPage: 25, totalCount: 120 } });
+
+        const page = await aimCatalogService.listItems('DEFAULT', 'model', 3, 25);
+
+        expect(page).toEqual({ data: [item], page: 3, perPage: 25, total: 120 });
+    });
+
+    it('encodes the kind for each catalog item type', async () => {
+        get.mockResolvedValue({ data: [], pagination: { page: 1, perPage: 10, totalCount: 0 } });
+
+        await aimCatalogService.listItems('DEFAULT', 'mcp-server', 1, 10);
+        expect(get.mock.calls[0][0]).toContain('kind=mcp-server');
+
+        await aimCatalogService.listItems('DEFAULT', 'agent', 1, 10);
+        expect(get.mock.calls[1][0]).toContain('kind=agent');
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/shared/api/aim-catalog.service.ts
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/shared/api/aim-catalog.service.ts
@@ -1,0 +1,51 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { authzCoreApiClient } from './authz-api-client';
+import type { AimPagedResponse, CatalogItem, CatalogItemKind, CatalogItemPage } from './aim-catalog.types';
+
+/**
+ * AIM catalog client. The AIM module is mounted next to authz under the same
+ * Gamma SPI tree, so we reuse the authz core client and just swap the module path.
+ */
+function aimPath(environmentId: string, suffix: string): string {
+    return `/environments/${encodeURIComponent(environmentId)}/modules/aim${suffix}`;
+}
+
+function itemsQuery(kind: CatalogItemKind, page: number, perPage: number): string {
+    const q = new URLSearchParams();
+    q.set('kind', kind);
+    q.set('page', String(page));
+    q.set('perPage', String(perPage));
+    return `?${q.toString()}`;
+}
+
+export const aimCatalogService = {
+    listItems: <T extends CatalogItem>(
+        environmentId: string,
+        kind: CatalogItemKind,
+        page: number,
+        perPage: number,
+    ): Promise<CatalogItemPage<T>> =>
+        // Backend filters by `kind` server-side; we trust it and cast at the type level.
+        authzCoreApiClient
+            .get<AimPagedResponse<CatalogItem>>(aimPath(environmentId, `/catalog/items${itemsQuery(kind, page, perPage)}`))
+            .then(p => ({
+                data: p.data as readonly T[],
+                page: p.pagination.page,
+                perPage: p.pagination.perPage,
+                total: p.pagination.totalCount,
+            })),
+};

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/shared/api/aim-catalog.types.ts
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/shared/api/aim-catalog.types.ts
@@ -1,0 +1,99 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+export type CatalogItemKind = 'mcp-server' | 'model' | 'agent';
+
+export interface ModelDefinition {
+    readonly name: string;
+    readonly queryName: string;
+    readonly provider?: string;
+    readonly family?: string;
+    readonly contextWindow?: number;
+    readonly description?: string;
+}
+
+export interface McpServerDefinition {
+    readonly serverInfo?: {
+        readonly name: string;
+        readonly title?: string;
+    };
+}
+
+export interface McpServerExtensions {
+    /** Catalog-side short slug ("filesystem", "github"). When set, the canonical
+     * Authorization entityId becomes `mcp.<entityId>` — see ImportFromCatalogDialog. */
+    readonly entityId?: string;
+    readonly description?: string;
+}
+
+export interface AgentDefinition {
+    readonly name: string;
+    readonly description?: string;
+    readonly url?: string;
+}
+
+interface CatalogItemBase {
+    readonly id: string;
+    /**
+     * Catalog-side stable slug, server-derived (aim ≥ 1.0.0-alpha.71). The
+     * leaf segment only — does NOT include the kind prefix. Older catalog
+     * rows may have `null` until the importer touches them again.
+     */
+    readonly entityId: string | null;
+    readonly sourceId: string | null;
+    readonly sourceKind: string | null;
+    readonly parentId: string | null;
+    readonly environmentId: string;
+    readonly organizationId: string;
+    readonly creationDate: string;
+    readonly updateDate: string;
+    readonly metadata?: Record<string, string>;
+}
+
+export interface ModelCatalogItem extends CatalogItemBase {
+    readonly kind: 'model';
+    readonly definition: ModelDefinition;
+}
+
+export interface McpServerCatalogItem extends CatalogItemBase {
+    readonly kind: 'mcp-server';
+    readonly definition: McpServerDefinition;
+    readonly extensions?: McpServerExtensions;
+}
+
+export interface AgentCatalogItem extends CatalogItemBase {
+    readonly kind: 'agent';
+    readonly definition: AgentDefinition;
+}
+
+export type CatalogItem = ModelCatalogItem | McpServerCatalogItem | AgentCatalogItem;
+
+export interface AimPagination {
+    readonly page: number;
+    readonly perPage: number;
+    readonly totalCount: number;
+}
+
+export interface AimPagedResponse<T> {
+    readonly data: readonly T[];
+    readonly pagination: AimPagination;
+}
+
+export interface CatalogItemPage<T extends CatalogItem = CatalogItem> {
+    readonly data: readonly T[];
+    readonly page: number;
+    readonly perPage: number;
+    readonly total: number;
+}

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/shared/api/authz-api.service.ts
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/shared/api/authz-api.service.ts
@@ -287,4 +287,20 @@ export const authzApiService = {
             perPage: response.perPage,
         };
     },
+
+    createEntity: async (environmentId: string, request: CreateEntityRequest): Promise<EntityResponse> => {
+        const created = await authzCoreApiClient.post<CanonicalEntity>(corePath(environmentId, '/entities'), request);
+        return adaptEntityResponse(created);
+    },
+
+    deleteEntity: (environmentId: string, entityId: string): Promise<void> =>
+        authzCoreApiClient.delete<void>(corePath(environmentId, `/entities/${encodeURIComponent(entityId)}`)),
 };
+
+export interface CreateEntityRequest {
+    readonly entityId: string;
+    readonly kind: 'PRINCIPAL' | 'RESOURCE';
+    readonly attributes: Record<string, unknown>;
+    readonly parents: readonly string[];
+    readonly source: string;
+}

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/shared/api/authz-api.types.ts
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/shared/api/authz-api.types.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export type PolicyType = 'MCP' | 'AGENT' | 'LLM' | 'API' | 'EVENT' | 'CUSTOM';
+export type PolicyType = 'MCP' | 'AGENT' | 'MODEL' | 'API' | 'EVENT' | 'CUSTOM';
 export type PolicyStatus = 'DRAFT' | 'DEPLOYED' | 'DISABLED';
 
 export interface PolicyTarget {

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/shared/api/query-keys.ts
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/shared/api/query-keys.ts
@@ -34,4 +34,11 @@ export const authzQueryKeys = {
     },
     schema: (environmentId: string) => ['authz', 'schema', environmentId] as const,
     entityOptions: (environmentId: string) => ['authz', 'entity-options', environmentId] as const,
+    importedCatalogIds: (environmentId: string) => ['authz', 'imported-catalog-ids', environmentId] as const,
+} as const;
+
+export const aimQueryKeys = {
+    catalog: {
+        items: (environmentId: string, kind: string) => ['aim', 'catalog', 'items', environmentId, kind] as const,
+    },
 } as const;

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/shared/entity-kind-registry.ts
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/shared/entity-kind-registry.ts
@@ -15,19 +15,6 @@
  */
 import type { PolicyType } from './api/authz-api.types';
 
-/**
- * Single source of truth for the kind ↔ UI type ↔ policy type mapping.
- *
- * The canonical backend speaks lowercase kinds (`user`, `mcp`, `llm`, …) that
- * appear both as the first dotted segment of an entityId (`mcp.flight-status`)
- * and as the `_kind` attribute. The UI uses richer camel-case types
- * (`MCPServer`, `LLMRoute`) and a smaller policy taxonomy
- * (`MCP | AGENT | LLM | API | EVENT | CUSTOM`).
- *
- * Each entry maps one kind to one UI type and (optionally) one policy type.
- * `aliases` lets older or longer forms (`mcpserver`, `service-account`) resolve
- * to the same UI type without polluting the canonical form used on the wire.
- */
 export interface EntityKindEntry {
     readonly canonical: string;
     readonly uiType: string;
@@ -39,13 +26,13 @@ export const ENTITY_KIND_REGISTRY: readonly EntityKindEntry[] = [
     { canonical: 'user', uiType: 'User' },
     { canonical: 'group', uiType: 'Group' },
     { canonical: 'serviceaccount', uiType: 'ServiceAccount', aliases: ['service-account', 'service_account'] },
-    { canonical: 'agent', uiType: 'AgentIdentity', aliases: ['agentidentity'], policyType: 'AGENT' },
+    { canonical: 'agent-identity', uiType: 'AgentIdentity', aliases: ['agentidentity'], policyType: 'AGENT' },
     { canonical: 'mcp', uiType: 'MCPServer', aliases: ['mcpserver'], policyType: 'MCP' },
-    { canonical: 'llm', uiType: 'LLMRoute', aliases: ['llmroute'], policyType: 'LLM' },
+    { canonical: 'model', uiType: 'Model', aliases: ['llm', 'llmmodel', 'llmroute'], policyType: 'MODEL' },
+    { canonical: 'agent', uiType: 'Agent', aliases: ['a2a', 'a2aagent'], policyType: 'AGENT' },
     { canonical: 'api', uiType: 'API', policyType: 'API' },
     { canonical: 'event', uiType: 'Event', policyType: 'EVENT' },
     { canonical: 'resource', uiType: 'Resource' },
-    // `action` entities live on their own page; mapped here so EntitiesPage can hide them.
     { canonical: 'action', uiType: 'Action' },
 ];
 

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/shared/entity.types.ts
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/shared/entity.types.ts
@@ -17,10 +17,11 @@ export type AttrValue = string | number | boolean;
 
 /**
  * Where an entity record came from.
- *   - `local` : hand-created in Authorization (fully editable).
- *   - `apim`  : derived from an APIM-managed API (read-only).
+ *   - `local`            : hand-created in Authorization (fully editable).
+ *   - `apim`             : derived from an APIM-managed API (read-only).
+ *   - `gravitee-catalog` : imported from the AIM Context Catalog (read-only).
  */
-export type EntitySource = 'local' | 'apim';
+export type EntitySource = 'local' | 'apim' | 'gravitee-catalog';
 
 export interface EntityInstance {
     uid: { type: string; id: string };

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/shared/hooks/__tests__/useAimCatalogItems.test.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/shared/hooks/__tests__/useAimCatalogItems.test.tsx
@@ -1,0 +1,183 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { CatalogItemKind, ModelCatalogItem } from '../../api/aim-catalog.types';
+import { useAimCatalogItems } from '../useAimCatalogItems';
+
+const listItemsSpy = vi.fn();
+
+vi.mock('../../api/aim-catalog.service', () => ({
+    aimCatalogService: {
+        listItems: (env: string, kind: string, page: number, perPage: number) => listItemsSpy(env, kind, page, perPage),
+    },
+}));
+
+function makeWrapper() {
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    return ({ children }: { children: ReactNode }) => <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+}
+
+function Probe({ env, kind }: { env: string; kind: CatalogItemKind }) {
+    const state = useAimCatalogItems<ModelCatalogItem>(env, kind);
+    return (
+        <div>
+            <span data-testid="loading">{String(state.isLoading)}</span>
+            <span data-testid="total">{state.data?.total ?? 'null'}</span>
+            <span data-testid="fetched">{state.data?.data.length ?? 'null'}</span>
+            <span data-testid="truncated">{String(state.truncated)}</span>
+            <span data-testid="error">{state.error ?? 'none'}</span>
+        </div>
+    );
+}
+
+function makeModel(id: string): ModelCatalogItem {
+    return {
+        id,
+        kind: 'model',
+        sourceId: null,
+        sourceKind: null,
+        parentId: null,
+        environmentId: 'DEFAULT',
+        organizationId: 'DEFAULT',
+        creationDate: '2026-05-27T10:00:00.000Z',
+        updateDate: '2026-05-27T10:00:00.000Z',
+        definition: { name: id, queryName: id },
+    };
+}
+
+beforeEach(() => {
+    listItemsSpy.mockReset();
+});
+
+describe('useAimCatalogItems', () => {
+    it('does not fire the query when environmentId is empty', async () => {
+        listItemsSpy.mockResolvedValue({ data: [], page: 1, perPage: 500, total: 0 });
+        render(<Probe env="" kind="model" />, { wrapper: makeWrapper() });
+
+        await Promise.resolve();
+        await Promise.resolve();
+        expect(listItemsSpy).not.toHaveBeenCalled();
+    });
+
+    it('issues a single call when the first page already covers the total', async () => {
+        listItemsSpy.mockResolvedValue({ data: [makeModel('m1'), makeModel('m2')], page: 1, perPage: 500, total: 2 });
+
+        const { getByTestId } = render(<Probe env="env-1" kind="model" />, { wrapper: makeWrapper() });
+
+        await waitFor(() => expect(getByTestId('total').textContent).toBe('2'));
+        expect(getByTestId('fetched').textContent).toBe('2');
+        expect(getByTestId('truncated').textContent).toBe('false');
+        expect(listItemsSpy).toHaveBeenCalledTimes(1);
+        expect(listItemsSpy).toHaveBeenCalledWith('env-1', 'model', 1, 500);
+    });
+
+    it('loops through pages until the accumulated set covers the reported total', async () => {
+        listItemsSpy
+            .mockResolvedValueOnce({ data: Array.from({ length: 500 }, (_, i) => makeModel(`m${i}`)), page: 1, perPage: 500, total: 1200 })
+            .mockResolvedValueOnce({
+                data: Array.from({ length: 500 }, (_, i) => makeModel(`m${500 + i}`)),
+                page: 2,
+                perPage: 500,
+                total: 1200,
+            })
+            .mockResolvedValueOnce({
+                data: Array.from({ length: 200 }, (_, i) => makeModel(`m${1000 + i}`)),
+                page: 3,
+                perPage: 500,
+                total: 1200,
+            });
+
+        const { getByTestId } = render(<Probe env="env-1" kind="model" />, { wrapper: makeWrapper() });
+
+        await waitFor(() => expect(getByTestId('fetched').textContent).toBe('1200'));
+        expect(getByTestId('truncated').textContent).toBe('false');
+        expect(listItemsSpy).toHaveBeenCalledTimes(3);
+        expect(listItemsSpy.mock.calls.map(c => c[2])).toEqual([1, 2, 3]);
+    });
+
+    it('reports truncated=true when MAX_PAGES safety cap is hit before all items are fetched', async () => {
+        // MAX_PAGES = 20, PER_PAGE = 500 → fetch 10000, total 12000.
+        listItemsSpy.mockImplementation((_env: string, _kind: string, page: number) =>
+            Promise.resolve({
+                data: Array.from({ length: 500 }, (_, i) => makeModel(`p${page}-i${i}`)),
+                page,
+                perPage: 500,
+                total: 12000,
+            }),
+        );
+
+        const { getByTestId } = render(<Probe env="env-1" kind="model" />, { wrapper: makeWrapper() });
+
+        await waitFor(() => expect(getByTestId('truncated').textContent).toBe('true'));
+        expect(listItemsSpy).toHaveBeenCalledTimes(20);
+        expect(getByTestId('fetched').textContent).toBe('10000');
+        expect(getByTestId('total').textContent).toBe('12000');
+    });
+
+    it('stops early when the server returns an empty page (defensive against inconsistent total)', async () => {
+        listItemsSpy
+            .mockResolvedValueOnce({ data: [makeModel('m1')], page: 1, perPage: 500, total: 999 })
+            .mockResolvedValueOnce({ data: [], page: 2, perPage: 500, total: 999 });
+
+        const { getByTestId } = render(<Probe env="env-1" kind="model" />, { wrapper: makeWrapper() });
+
+        await waitFor(() => expect(getByTestId('fetched').textContent).toBe('1'));
+        expect(listItemsSpy).toHaveBeenCalledTimes(2);
+    });
+
+    it('treats a nullish data slice as an empty page instead of crashing', async () => {
+        // A garbled/partial payload may report a total but omit `data`. The hook
+        // must not spread `undefined` — it should coalesce to [] and stop.
+        listItemsSpy.mockResolvedValue({ data: undefined, page: 1, perPage: 500, total: 5 });
+
+        const { getByTestId } = render(<Probe env="env-1" kind="model" />, { wrapper: makeWrapper() });
+
+        await waitFor(() => expect(getByTestId('loading').textContent).toBe('false'));
+        expect(getByTestId('error').textContent).toBe('none');
+        expect(getByTestId('fetched').textContent).toBe('0');
+        expect(listItemsSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('exposes an error message when the service rejects', async () => {
+        listItemsSpy.mockRejectedValue(new Error('catalog unreachable'));
+
+        const { getByTestId } = render(<Probe env="env-1" kind="agent" />, { wrapper: makeWrapper() });
+
+        await waitFor(() => expect(getByTestId('error').textContent).toBe('catalog unreachable'));
+    });
+
+    it('issues a separate query per kind for the same environment', async () => {
+        listItemsSpy.mockResolvedValue({ data: [], page: 1, perPage: 500, total: 0 });
+
+        function ThreeProbes() {
+            return (
+                <div>
+                    <Probe env="env-1" kind="model" />
+                    <Probe env="env-1" kind="mcp-server" />
+                    <Probe env="env-1" kind="agent" />
+                </div>
+            );
+        }
+        render(<ThreeProbes />, { wrapper: makeWrapper() });
+
+        await waitFor(() => expect(listItemsSpy).toHaveBeenCalledTimes(3));
+        const kinds = listItemsSpy.mock.calls.map(args => args[1]).sort();
+        expect(kinds).toEqual(['agent', 'mcp-server', 'model']);
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/shared/hooks/__tests__/useImportedCatalogIds.test.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/shared/hooks/__tests__/useImportedCatalogIds.test.tsx
@@ -1,0 +1,141 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { EntityResponse } from '../../api/authz-api.types';
+import { useImportedCatalogIds } from '../useImportedCatalogIds';
+
+const listSpy = vi.fn();
+
+vi.mock('../../api/authz-api.service', () => ({
+    DEFAULT_PER_PAGE: 10,
+    authzApiService: {
+        listEntities: (env: string, params?: unknown) => listSpy(env, params),
+    },
+}));
+
+function makeWrapper() {
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    return ({ children }: { children: ReactNode }) => <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+}
+
+function Probe({ env }: { env: string }) {
+    const { catalogIds, isLoading, error } = useImportedCatalogIds(env);
+    return (
+        <div>
+            <span data-testid="loading">{String(isLoading)}</span>
+            <span data-testid="error">{error ?? 'none'}</span>
+            <span data-testid="ids">{[...catalogIds].sort().join(',')}</span>
+        </div>
+    );
+}
+
+function makeEntity(overrides: Partial<EntityResponse> = {}): EntityResponse {
+    return {
+        id: overrides.id ?? `e-${Math.random().toString(36).slice(2)}`,
+        environmentId: 'DEFAULT',
+        uid: 'mcp.something',
+        attributes: {},
+        parents: [],
+        createdAt: '2026-05-27T10:00:00.000Z',
+        updatedAt: '2026-05-27T10:00:00.000Z',
+        ...overrides,
+    };
+}
+
+beforeEach(() => {
+    listSpy.mockReset();
+});
+
+describe('useImportedCatalogIds', () => {
+    it('does not fire the query when environmentId is empty', async () => {
+        listSpy.mockResolvedValue({ data: [], total: 0, page: 1, perPage: 1000 });
+        render(<Probe env="" />, { wrapper: makeWrapper() });
+
+        await Promise.resolve();
+        await Promise.resolve();
+        expect(listSpy).not.toHaveBeenCalled();
+    });
+
+    it('queries RESOURCE entities filtered by source=gravitee-catalog with a large page size', async () => {
+        listSpy.mockResolvedValue({ data: [], total: 0, page: 1, perPage: 1000 });
+
+        render(<Probe env="env-1" />, { wrapper: makeWrapper() });
+
+        await waitFor(() => expect(listSpy).toHaveBeenCalledTimes(1));
+        expect(listSpy).toHaveBeenCalledWith(
+            'env-1',
+            expect.objectContaining({ kind: 'RESOURCE', source: 'gravitee-catalog', perPage: 1000, page: 1 }),
+        );
+    });
+
+    it('extracts a set of _catalogId attribute values from the response', async () => {
+        listSpy.mockResolvedValue({
+            data: [
+                makeEntity({ uid: 'mcp.a', attributes: { _catalogId: 'cat-1' } }),
+                makeEntity({ uid: 'model.b', attributes: { _catalogId: 'cat-2', other: 'x' } }),
+                makeEntity({ uid: 'agent.c', attributes: { _catalogId: 'cat-3' } }),
+            ],
+            total: 3,
+            page: 1,
+            perPage: 1000,
+        });
+
+        const { getByTestId } = render(<Probe env="env-1" />, { wrapper: makeWrapper() });
+
+        await waitFor(() => expect(getByTestId('ids').textContent).toBe('cat-1,cat-2,cat-3'));
+    });
+
+    it('silently skips entities without a _catalogId attribute', async () => {
+        listSpy.mockResolvedValue({
+            data: [
+                makeEntity({ uid: 'mcp.a', attributes: { _catalogId: 'cat-1' } }),
+                makeEntity({ uid: 'mcp.b', attributes: {} }), // hand-created — no catalogId
+                makeEntity({ uid: 'mcp.c', attributes: { _catalogId: '' } }), // empty string ignored
+                makeEntity({ uid: 'mcp.d', attributes: { _catalogId: 42 as unknown as string } }), // wrong type ignored
+            ],
+            total: 4,
+            page: 1,
+            perPage: 1000,
+        });
+
+        const { getByTestId } = render(<Probe env="env-1" />, { wrapper: makeWrapper() });
+
+        await waitFor(() => expect(getByTestId('ids').textContent).toBe('cat-1'));
+    });
+
+    it('exposes an error string when the query rejects', async () => {
+        listSpy.mockRejectedValue(new Error('listEntities down'));
+
+        const { getByTestId } = render(<Probe env="env-1" />, { wrapper: makeWrapper() });
+
+        await waitFor(() => expect(getByTestId('error').textContent).toBe('listEntities down'));
+    });
+
+    it('treats a nullish data slice as empty without crashing', async () => {
+        // Partial payload: a total is reported but `data` is missing. The hook
+        // must coalesce to [] rather than reading `.length` off undefined.
+        listSpy.mockResolvedValue({ data: undefined, total: 3, page: 1, perPage: 1000 });
+
+        const { getByTestId } = render(<Probe env="env-1" />, { wrapper: makeWrapper() });
+
+        await waitFor(() => expect(getByTestId('loading').textContent).toBe('false'));
+        expect(getByTestId('error').textContent).toBe('none');
+        expect(getByTestId('ids').textContent).toBe('');
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/shared/hooks/__tests__/usePolicies.test.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/shared/hooks/__tests__/usePolicies.test.tsx
@@ -39,7 +39,7 @@ function makeWrapper() {
     return ({ children }: { children: ReactNode }) => <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
 }
 
-function Probe({ env, type }: { env: string; type?: 'MCP' | 'AGENT' | 'LLM' | 'API' | 'EVENT' | 'CUSTOM' }) {
+function Probe({ env, type }: { env: string; type?: 'MCP' | 'AGENT' | 'MODEL' | 'API' | 'EVENT' | 'CUSTOM' }) {
     const state = usePolicies(env, { type });
     return (
         <div>

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/shared/hooks/useAimCatalogItems.ts
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/shared/hooks/useAimCatalogItems.ts
@@ -1,0 +1,72 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useQuery } from '@tanstack/react-query';
+import { aimCatalogService } from '../api/aim-catalog.service';
+import type { CatalogItem, CatalogItemKind, CatalogItemPage } from '../api/aim-catalog.types';
+import { aimQueryKeys } from '../api/query-keys';
+
+const PER_PAGE = 500;
+const MAX_PAGES = 20;
+
+export interface UseAimCatalogItemsResult<T extends CatalogItem = CatalogItem> {
+    readonly data: CatalogItemPage<T> | null;
+    readonly isLoading: boolean;
+    readonly error: string | undefined;
+    /** True when the catalog has more items than we fetched (hit MAX_PAGES * PER_PAGE cap). */
+    readonly truncated: boolean;
+}
+
+async function fetchAllPages<T extends CatalogItem>(
+    environmentId: string,
+    kind: CatalogItemKind,
+): Promise<CatalogItemPage<T>> {
+    const accumulated: T[] = [];
+    let page = 1;
+    let total = 0;
+    while (page <= MAX_PAGES) {
+        const slice = await aimCatalogService.listItems<T>(environmentId, kind, page, PER_PAGE);
+        const data = slice.data ?? [];
+        accumulated.push(...data);
+        total = slice.total;
+        if (accumulated.length >= total || data.length === 0) break;
+        page++;
+    }
+    return { data: accumulated, page: 1, perPage: accumulated.length, total };
+}
+
+export function useAimCatalogItems<T extends CatalogItem = CatalogItem>(
+    environmentId: string,
+    kind: CatalogItemKind,
+    options: { enabled?: boolean } = {},
+): UseAimCatalogItemsResult<T> {
+    const { enabled = true } = options;
+    const query = useQuery({
+        queryKey: aimQueryKeys.catalog.items(environmentId, kind),
+        queryFn: () => fetchAllPages<T>(environmentId, kind),
+        enabled: enabled && Boolean(environmentId),
+        staleTime: 30_000,
+    });
+
+    const page = query.data;
+    const truncated = page ? page.total > page.data.length : false;
+
+    return {
+        data: page ?? null,
+        isLoading: query.isLoading,
+        error: query.error instanceof Error ? query.error.message : query.error ? String(query.error) : undefined,
+        truncated,
+    };
+}

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/shared/hooks/useImportedCatalogIds.ts
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/shared/hooks/useImportedCatalogIds.ts
@@ -1,0 +1,92 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { useCallback, useMemo } from 'react';
+import { authzApiService } from '../api/authz-api.service';
+import { authzQueryKeys } from '../api/query-keys';
+
+const CATALOG_SOURCE = 'gravitee-catalog';
+const PER_PAGE = 1000;
+const MAX_PAGES = 50;
+
+export interface UseImportedCatalogIdsResult {
+    readonly catalogIds: ReadonlySet<string>;
+    readonly isLoading: boolean;
+    readonly error: string | undefined;
+    /** True when the tenant has more imported catalog rows than we could fetch (hit MAX_PAGES * PER_PAGE cap). */
+    readonly truncated: boolean;
+    /** Optimistic push so a freshly-imported item is flagged before the refetch lands. */
+    readonly markImported: (catalogIds: readonly string[]) => void;
+}
+
+async function fetchAllImportedIds(environmentId: string): Promise<{ ids: string[]; truncated: boolean }> {
+    const ids: string[] = [];
+    let page = 1;
+    let total = 0;
+    while (page <= MAX_PAGES) {
+        const slice = await authzApiService.listEntities(environmentId, {
+            page,
+            perPage: PER_PAGE,
+            kind: 'RESOURCE',
+            source: CATALOG_SOURCE,
+        });
+        const data = slice.data ?? [];
+        for (const entity of data) {
+            const value = entity.attributes?._catalogId;
+            if (typeof value === 'string' && value.length > 0) ids.push(value);
+        }
+        total = slice.total;
+        if (data.length === 0 || ids.length >= total) break;
+        page++;
+    }
+    return { ids, truncated: total > ids.length };
+}
+
+export function useImportedCatalogIds(environmentId: string, options: { enabled?: boolean } = {}): UseImportedCatalogIdsResult {
+    const { enabled = true } = options;
+    const queryClient = useQueryClient();
+    const queryKey = authzQueryKeys.importedCatalogIds(environmentId);
+
+    const query = useQuery({
+        queryKey,
+        queryFn: () => fetchAllImportedIds(environmentId),
+        enabled: enabled && Boolean(environmentId),
+        staleTime: 30_000,
+    });
+
+    const catalogIds = useMemo<ReadonlySet<string>>(() => new Set(query.data?.ids ?? []), [query.data]);
+
+    const markImported = useCallback(
+        (newIds: readonly string[]) => {
+            if (newIds.length === 0) return;
+            queryClient.setQueryData(queryKey, (current: { ids: string[]; truncated: boolean } | undefined) => {
+                if (!current) return current;
+                const next = new Set(current.ids);
+                newIds.forEach(id => next.add(id));
+                return { ...current, ids: Array.from(next) };
+            });
+        },
+        [queryClient, queryKey],
+    );
+
+    return {
+        catalogIds,
+        isLoading: query.isLoading,
+        error: query.error instanceof Error ? query.error.message : query.error ? String(query.error) : undefined,
+        truncated: query.data?.truncated ?? false,
+        markImported,
+    };
+}


### PR DESCRIPTION
## Issue

Stack PR — ui-8 of authz-ui chain. Builds on #17050 (ui-7, entities list).

## Description

Three commits:

**1. `fix(gamma-rest-api): add definition-model to runtime classpath`**
Authz plugin's `EventRepositoryAuthzEventPublisher` directly instantiates `io.gravitee.gamma.definition.authz.AuthzPolicy` / `AuthzEntity`. The plugin zip doesn't bundle `gravitee-gamma-definition-model` and the rest-api standalone distribution didn't ship it either — `NoClassDefFoundError` at first authz event publish. Adds the dep with compile scope to `gravitee-gamma-rest-api/pom.xml` so it transitively reaches `standalone-container` and lands in `dist/lib/`. Verified empirically with a clean `mvn clean install` of the full APIM monorepo and a fresh start of rest-api.

**2. `refactor(authz-ui): rename LLM → Model across registry, routes, and pages`**
Aligns Authorization with the AIM Context Catalog convention where AI models use the `model.{provider}.{queryName}` entityId form (e.g. `model.openai.gpt-4o`). Drops the redundant `LLMRoute` concept.
- `entity-kind-registry`: drops `llm` canonical, renames `LLMModel` → `Model`. Keeps `llm`/`llmmodel`/`llmroute` as aliases so existing policies with `llm.*` entityIds still classify as `MODEL`.
- `PolicyType`: `LLM` → `MODEL` (UI-side enum, derived from entityId prefix — not on the wire).
- Route `/llms` → `/models`, file `LlmsPage` → `ModelsPage`, service-def `llms.ts` → `models.ts`.
- Legacy `llm.*` entityIds keep working in the resource picker via a fallback branch.

**3. `feat(authz-ui): import resources from AIM Context Catalog`**
Adds an Import dialog on the Entities → Resources tab that pulls MCP servers, AI models, and agents from the sibling AIM Gamma module and registers them as read-only `RESOURCE` entities under source `gravitee-catalog`. Imported entities carry the same canonical entityId as in the catalog so policies always refer to one identifier.

- `ImportFromCatalogDialog`: Sheet with MCP / AI Models / Agents tabs, multi-select, "Select visible" / "Clear" controls, deferred-value search. Per-tab queries gated on `open` so 3× catalog scans only fire when the user opens the dialog. Bulk import runs with concurrency limit 4 (`Promise.allSettled`), reports progress in the footer, and optimistically marks just-imported items via `markImported` so the badge updates without waiting for the refetch.
- `useAimCatalogItems`: paginated catalog client (cap 20×500); `truncated` flag when the catalog has more items than fetched.
- `useImportedCatalogIds`: own query-key namespace; paginates up to 50×1000 with a warning banner if it hits the cap. `markImported` pushes newly-imported ids into the cache for optimistic UI.
- `authz-api.service`: `createEntity` + `deleteEntity` methods.
- `entity.types`: extends `EntitySource` with `gravitee-catalog`.
- `EntitiesPage`: wires the Import button + delete-confirmation dialog; invalidates both `entities` and `importedCatalogIds` caches on delete.
- `query-keys`: new `importedCatalogIds` under authz namespace; AIM catalog keys moved into a dedicated `aimQueryKeys` export.

## Additional context

- 333 vitest specs in `gravitee-gamma-module-authz` pass green.
- Rebased on top of the rebased ui-7 (which was rebased on the force-pushed ui-5 that migrated `ChipCombobox` → graphene-core 2.28 `Combobox`).
- Verified runtime: rest-api boots cleanly, authz plugin loads, no `NoClassDefFoundError`.