### PR TITLE
feat(console): configure Kafka port-routing on native plans

### DIFF
--- a/gravitee-apim-console-webui/src/entities/Constants.ts
+++ b/gravitee-apim-console-webui/src/entities/Constants.ts
@@ -64,6 +64,9 @@ export interface EnvSettings {
   apiScore: {
     enabled: boolean;
   };
+  kafkaPortRouting: {
+    enabled: boolean;
+  };
   apiQualityMetrics: {
     enabled: boolean;
     functionalDocumentationWeight: number;

--- a/gravitee-apim-console-webui/src/entities/management-api-v2/plan/v4/createPlanV4.ts
+++ b/gravitee-apim-console-webui/src/entities/management-api-v2/plan/v4/createPlanV4.ts
@@ -22,4 +22,10 @@ export interface CreatePlanV4 extends CreateBasePlan {
   definitionVersion: 'V4';
   flows?: FlowV4[];
   mode: PlanMode;
+  /** @description Bootstrap port for Kafka port-based routing (1024–65535). Only relevant for NATIVE APIs. */
+  bootstrapPort?: number;
+  /** @description Start of the broker port range for Kafka port-based routing (1024–65535). Only relevant for NATIVE APIs. */
+  brokerRangeStart?: number;
+  /** @description End of the broker port range for Kafka port-based routing (1024–65535). Only relevant for NATIVE APIs. */
+  brokerRangeEnd?: number;
 }

--- a/gravitee-apim-console-webui/src/entities/management-api-v2/plan/v4/planV4.ts
+++ b/gravitee-apim-console-webui/src/entities/management-api-v2/plan/v4/planV4.ts
@@ -31,4 +31,10 @@ export interface PlanV4 extends BasePlan {
   tags?: string[];
   flows?: FlowV4[];
   mode: PlanMode;
+  /** @description Bootstrap port for Kafka port-based routing (1024–65535). Only relevant for NATIVE APIs. */
+  bootstrapPort?: number;
+  /** @description Start of the broker port range for Kafka port-based routing (1024–65535). Only relevant for NATIVE APIs. */
+  brokerRangeStart?: number;
+  /** @description End of the broker port range for Kafka port-based routing (1024–65535). Only relevant for NATIVE APIs. */
+  brokerRangeEnd?: number;
 }

--- a/gravitee-apim-console-webui/src/entities/management-api-v2/plan/v4/updatePlanV4.ts
+++ b/gravitee-apim-console-webui/src/entities/management-api-v2/plan/v4/updatePlanV4.ts
@@ -29,4 +29,10 @@ export interface UpdatePlanV4 extends UpdateBasePlan {
    */
   tags?: string[];
   flows?: FlowV4[];
+  /** @description Bootstrap port for Kafka port-based routing (1024–65535). Only relevant for NATIVE APIs. */
+  bootstrapPort?: number;
+  /** @description Start of the broker port range for Kafka port-based routing (1024–65535). Only relevant for NATIVE APIs. */
+  brokerRangeStart?: number;
+  /** @description End of the broker port range for Kafka port-based routing (1024–65535). Only relevant for NATIVE APIs. */
+  brokerRangeEnd?: number;
 }

--- a/gravitee-apim-console-webui/src/entities/portal/portalSettings.fixture.ts
+++ b/gravitee-apim-console-webui/src/entities/portal/portalSettings.fixture.ts
@@ -138,6 +138,9 @@ export function fakePortalConfiguration(attributes?: Partial<PortalConfiguration
     apiReview: {
       enabled: false,
     },
+    kafkaPortRouting: {
+      enabled: false,
+    },
     application: {
       registration: {
         enabled: false,

--- a/gravitee-apim-console-webui/src/entities/portal/portalSettings.ts
+++ b/gravitee-apim-console-webui/src/entities/portal/portalSettings.ts
@@ -27,6 +27,7 @@ export interface PortalConfiguration {
   apiScore?: PortalSettingsApiScore;
   apiQualityMetrics?: PortalSettingsApiQualityMetrics;
   apiReview?: PortalSettingsApiReview;
+  kafkaPortRouting?: PortalSettingsKafkaPortRouting;
   authentication?: PortalSettingsAuthentication;
   company?: PortalSettingsCompany;
   plan?: PortalSettingsPlan;
@@ -138,6 +139,10 @@ export interface PortalSettingsApiScore {
 }
 
 export interface PortalSettingsApiReview {
+  enabled: boolean;
+}
+
+export interface PortalSettingsKafkaPortRouting {
   enabled: boolean;
 }
 

--- a/gravitee-apim-console-webui/src/management/api/component/plan/1-general-step/plan-edit-general-step.component.html
+++ b/gravitee-apim-console-webui/src/management/api/component/plan/1-general-step/plan-edit-general-step.component.html
@@ -126,7 +126,7 @@
       </mat-form-field>
     }
 
-    @if (isNative) {
+    @if (isNative && kafkaPortRoutingEnabled) {
       <h2>Kafka port routing</h2>
       <p class="kafka-port-routing__hint">These ports apply when the gateway is configured for port-based routing.</p>
 

--- a/gravitee-apim-console-webui/src/management/api/component/plan/1-general-step/plan-edit-general-step.component.html
+++ b/gravitee-apim-console-webui/src/management/api/component/plan/1-general-step/plan-edit-general-step.component.html
@@ -152,9 +152,6 @@
         ) {
           <mat-error>Bootstrap port must not fall within the broker port range.</mat-error>
         }
-        @if (generalForm.get('bootstrapPort').disabled) {
-          <mat-hint>Bootstrap port cannot be changed after the API has been deployed.</mat-hint>
-        }
       </mat-form-field>
 
       <mat-form-field class="kafka-port-routing__field">
@@ -204,6 +201,13 @@
           <mat-error>Broker range start must be less than or equal to broker range end.</mat-error>
         }
       </mat-form-field>
+
+      @if (showBrokerRangeChangeWarning) {
+        <gio-banner-info
+          >Changing the broker port range will cause a brief reconnection for active consumers. Clients will automatically reconnect on
+          their next metadata refresh — no configuration change required on the client side.</gio-banner-info
+        >
+      }
     }
   </ng-container>
 }

--- a/gravitee-apim-console-webui/src/management/api/component/plan/1-general-step/plan-edit-general-step.component.html
+++ b/gravitee-apim-console-webui/src/management/api/component/plan/1-general-step/plan-edit-general-step.component.html
@@ -125,5 +125,85 @@
         </mat-select>
       </mat-form-field>
     }
+
+    @if (isNative) {
+      <h2>Kafka port routing</h2>
+      <p class="kafka-port-routing__hint">These ports apply when the gateway is configured for port-based routing.</p>
+
+      <mat-form-field class="kafka-port-routing__field">
+        <mat-label>Bootstrap port</mat-label>
+        <input
+          matInput
+          formControlName="bootstrapPort"
+          type="number"
+          [errorStateMatcher]="bootstrapInRangeErrorMatcher"
+          data-testid="bootstrap_port_field"
+        />
+        @if (generalForm.get('bootstrapPort').hasError('min')) {
+          <mat-error>Bootstrap port must be at least 1024.</mat-error>
+        }
+        @if (generalForm.get('bootstrapPort').hasError('max')) {
+          <mat-error>Bootstrap port must be at most 65535.</mat-error>
+        }
+        @if (
+          generalForm.hasError('bootstrapInRange') &&
+          !generalForm.get('bootstrapPort').hasError('min') &&
+          !generalForm.get('bootstrapPort').hasError('max')
+        ) {
+          <mat-error>Bootstrap port must not fall within the broker port range.</mat-error>
+        }
+        @if (generalForm.get('bootstrapPort').disabled) {
+          <mat-hint>Bootstrap port cannot be changed after the API has been deployed.</mat-hint>
+        }
+      </mat-form-field>
+
+      <mat-form-field class="kafka-port-routing__field">
+        <mat-label>Broker range start</mat-label>
+        <input
+          matInput
+          formControlName="brokerRangeStart"
+          type="number"
+          [errorStateMatcher]="rangeOrderErrorMatcher"
+          data-testid="broker_range_start_field"
+        />
+        @if (generalForm.get('brokerRangeStart').hasError('min')) {
+          <mat-error>Broker range start must be at least 1024.</mat-error>
+        }
+        @if (generalForm.get('brokerRangeStart').hasError('max')) {
+          <mat-error>Broker range start must be at most 65535.</mat-error>
+        }
+        @if (
+          generalForm.hasError('rangeOrder') &&
+          !generalForm.get('brokerRangeStart').hasError('min') &&
+          !generalForm.get('brokerRangeStart').hasError('max')
+        ) {
+          <mat-error>Broker range start must be less than or equal to broker range end.</mat-error>
+        }
+      </mat-form-field>
+
+      <mat-form-field class="kafka-port-routing__field">
+        <mat-label>Broker range end</mat-label>
+        <input
+          matInput
+          formControlName="brokerRangeEnd"
+          type="number"
+          [errorStateMatcher]="rangeOrderErrorMatcher"
+          data-testid="broker_range_end_field"
+        />
+        @if (generalForm.get('brokerRangeEnd').hasError('min')) {
+          <mat-error>Broker range end must be at least 1024.</mat-error>
+        }
+        @if (generalForm.get('brokerRangeEnd').hasError('max')) {
+          <mat-error>Broker range end must be at most 65535.</mat-error>
+        }
+        @if (
+          generalForm.hasError('rangeOrder') &&
+          !generalForm.get('brokerRangeEnd').hasError('min') &&
+          !generalForm.get('brokerRangeEnd').hasError('max')
+        ) {
+          <mat-error>Broker range start must be less than or equal to broker range end.</mat-error>
+        }
+      </mat-form-field>
+    }
   </ng-container>
 }

--- a/gravitee-apim-console-webui/src/management/api/component/plan/1-general-step/plan-edit-general-step.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/component/plan/1-general-step/plan-edit-general-step.component.spec.ts
@@ -1,0 +1,258 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { HttpTestingController } from '@angular/common/http/testing';
+import { HarnessLoader } from '@angular/cdk/testing';
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { MatInputHarness } from '@angular/material/input/testing';
+import { MatFormFieldHarness } from '@angular/material/form-field/testing';
+import { MatIconTestingModule } from '@angular/material/icon/testing';
+
+import { PlanEditGeneralStepComponent } from './plan-edit-general-step.component';
+
+import { ApiPlanFormModule } from '../api-plan-form.module';
+import { GioTestingModule, CONSTANTS_TESTING } from '../../../../../shared/testing';
+import { fakeNativeKafkaApiV4, fakeApiV4 } from '../../../../../entities/management-api-v2';
+
+describe('PlanEditGeneralStepComponent — Kafka port routing', () => {
+  let fixture: ComponentFixture<PlanEditGeneralStepComponent>;
+  let component: PlanEditGeneralStepComponent;
+  let loader: HarnessLoader;
+  let httpTestingController: HttpTestingController;
+
+  const setupComponent = (mode: 'create' | 'edit' = 'create', isNative = false, api = fakeNativeKafkaApiV4()) => {
+    TestBed.configureTestingModule({
+      declarations: [PlanEditGeneralStepComponent],
+      imports: [NoopAnimationsModule, GioTestingModule, ApiPlanFormModule, MatIconTestingModule],
+    });
+
+    fixture = TestBed.createComponent(PlanEditGeneralStepComponent);
+    component = fixture.componentInstance;
+    loader = TestbedHarnessEnvironment.loader(fixture);
+    httpTestingController = TestBed.inject(HttpTestingController);
+
+    component.mode = mode;
+    component.isNative = isNative;
+    component.api = api;
+    fixture.detectChanges();
+  };
+
+  afterEach(() => {
+    httpTestingController.verify();
+  });
+
+  const flushDefaultRequests = (apiId: string) => {
+    httpTestingController
+      .expectOne({ method: 'GET', url: `${CONSTANTS_TESTING.env.baseURL}/apis/${apiId}/pages?type=MARKDOWN&api=${apiId}` })
+      .flush([]);
+    httpTestingController.expectOne({ method: 'GET', url: `${CONSTANTS_TESTING.org.baseURL}/configuration/tags` }).flush([]);
+    httpTestingController.expectOne({ method: 'GET', url: `${CONSTANTS_TESTING.org.baseURL}/user/tags` }).flush([]);
+    httpTestingController.expectOne({ method: 'GET', url: `${CONSTANTS_TESTING.env.baseURL}/configuration/groups` }).flush([]);
+    fixture.detectChanges();
+  };
+
+  describe('Kafka port routing section visibility', () => {
+    it('should render the Kafka port routing section when isNative is true', async () => {
+      setupComponent('create', true);
+      flushDefaultRequests(fakeNativeKafkaApiV4().id);
+
+      const bootstrapPortInput = await loader.getHarnessOrNull(MatInputHarness.with({ selector: '[data-testid="bootstrap_port_field"]' }));
+      expect(bootstrapPortInput).not.toBeNull();
+
+      const brokerRangeStartInput = await loader.getHarnessOrNull(
+        MatInputHarness.with({ selector: '[data-testid="broker_range_start_field"]' }),
+      );
+      expect(brokerRangeStartInput).not.toBeNull();
+
+      const brokerRangeEndInput = await loader.getHarnessOrNull(
+        MatInputHarness.with({ selector: '[data-testid="broker_range_end_field"]' }),
+      );
+      expect(brokerRangeEndInput).not.toBeNull();
+    });
+
+    it('should NOT render the Kafka port routing section when isNative is false', async () => {
+      const nonNativeApi = fakeApiV4({ type: 'PROXY' });
+      setupComponent('create', false, nonNativeApi);
+      flushDefaultRequests(nonNativeApi.id);
+
+      const bootstrapPortInput = await loader.getHarnessOrNull(MatInputHarness.with({ selector: '[data-testid="bootstrap_port_field"]' }));
+      expect(bootstrapPortInput).toBeNull();
+    });
+  });
+
+  describe('Port field min/max validation', () => {
+    beforeEach(() => {
+      setupComponent('create', true);
+      flushDefaultRequests(fakeNativeKafkaApiV4().id);
+    });
+
+    it('should report a min error when bootstrapPort is below 1024', async () => {
+      component.generalForm.get('bootstrapPort').setValue(100);
+      component.generalForm.get('bootstrapPort').markAsTouched();
+      fixture.detectChanges();
+
+      expect(component.generalForm.get('bootstrapPort').hasError('min')).toBe(true);
+    });
+
+    it('should report a max error when bootstrapPort is above 65535', async () => {
+      component.generalForm.get('bootstrapPort').setValue(70000);
+      component.generalForm.get('bootstrapPort').markAsTouched();
+      fixture.detectChanges();
+
+      expect(component.generalForm.get('bootstrapPort').hasError('max')).toBe(true);
+    });
+
+    it('should report a min error when brokerRangeStart is below 1024', async () => {
+      component.generalForm.get('brokerRangeStart').setValue(500);
+      component.generalForm.get('brokerRangeStart').markAsTouched();
+      fixture.detectChanges();
+
+      expect(component.generalForm.get('brokerRangeStart').hasError('min')).toBe(true);
+    });
+
+    it('should report a max error when brokerRangeEnd is above 65535', async () => {
+      component.generalForm.get('brokerRangeEnd').setValue(99999);
+      component.generalForm.get('brokerRangeEnd').markAsTouched();
+      fixture.detectChanges();
+
+      expect(component.generalForm.get('brokerRangeEnd').hasError('max')).toBe(true);
+    });
+
+    it('should have no port errors when values are within valid range', async () => {
+      component.generalForm.get('bootstrapPort').setValue(9092);
+      component.generalForm.get('brokerRangeStart').setValue(9093);
+      component.generalForm.get('brokerRangeEnd').setValue(9095);
+      fixture.detectChanges();
+
+      expect(component.generalForm.get('bootstrapPort').valid).toBe(true);
+      expect(component.generalForm.get('brokerRangeStart').valid).toBe(true);
+      expect(component.generalForm.get('brokerRangeEnd').valid).toBe(true);
+    });
+  });
+
+  describe('Cross-field validation', () => {
+    beforeEach(() => {
+      setupComponent('create', true);
+      flushDefaultRequests(fakeNativeKafkaApiV4().id);
+    });
+
+    it('should report rangeOrder error when brokerRangeStart > brokerRangeEnd', () => {
+      component.generalForm.get('brokerRangeStart').setValue(9095);
+      component.generalForm.get('brokerRangeEnd').setValue(9093);
+      component.generalForm.updateValueAndValidity();
+      fixture.detectChanges();
+
+      expect(component.generalForm.hasError('rangeOrder')).toBe(true);
+    });
+
+    it('should not report rangeOrder error when brokerRangeStart <= brokerRangeEnd', () => {
+      component.generalForm.get('brokerRangeStart').setValue(9093);
+      component.generalForm.get('brokerRangeEnd').setValue(9095);
+      component.generalForm.updateValueAndValidity();
+      fixture.detectChanges();
+
+      expect(component.generalForm.hasError('rangeOrder')).toBe(false);
+    });
+
+    it('should report bootstrapInRange error when bootstrapPort is within [rangeStart, rangeEnd]', () => {
+      component.generalForm.get('bootstrapPort').setValue(9094);
+      component.generalForm.get('brokerRangeStart').setValue(9093);
+      component.generalForm.get('brokerRangeEnd').setValue(9095);
+      component.generalForm.updateValueAndValidity();
+      fixture.detectChanges();
+
+      expect(component.generalForm.hasError('bootstrapInRange')).toBe(true);
+    });
+
+    it('should not report bootstrapInRange error when bootstrapPort is outside the broker range', () => {
+      component.generalForm.get('bootstrapPort').setValue(9092);
+      component.generalForm.get('brokerRangeStart').setValue(9093);
+      component.generalForm.get('brokerRangeEnd').setValue(9095);
+      component.generalForm.updateValueAndValidity();
+      fixture.detectChanges();
+
+      expect(component.generalForm.hasError('bootstrapInRange')).toBe(false);
+    });
+
+    it('should not report bootstrapInRange error when range bounds are not set', () => {
+      component.generalForm.get('bootstrapPort').setValue(9092);
+      component.generalForm.get('brokerRangeStart').setValue(null);
+      component.generalForm.get('brokerRangeEnd').setValue(null);
+      component.generalForm.updateValueAndValidity();
+      fixture.detectChanges();
+
+      expect(component.generalForm.hasError('bootstrapInRange')).toBe(false);
+    });
+  });
+
+  describe('Cross-field error display (DOM)', () => {
+    beforeEach(() => {
+      setupComponent('create', true);
+      flushDefaultRequests(fakeNativeKafkaApiV4().id);
+    });
+
+    it('should DISPLAY the rangeOrder error message on the broker range end field', async () => {
+      component.generalForm.get('brokerRangeStart').setValue(9095);
+      component.generalForm.get('brokerRangeEnd').setValue(9093);
+      component.generalForm.get('brokerRangeStart').markAsTouched();
+      component.generalForm.get('brokerRangeEnd').markAsTouched();
+      component.generalForm.updateValueAndValidity();
+      fixture.detectChanges();
+
+      const endField = await loader.getHarness(MatFormFieldHarness.with({ floatingLabelText: 'Broker range end' }));
+      expect((await endField.getTextErrors()).join(' ')).toContain('less than or equal to broker range end');
+    });
+
+    it('should DISPLAY the bootstrapInRange error message on the bootstrap port field', async () => {
+      component.generalForm.get('bootstrapPort').setValue(9094);
+      component.generalForm.get('brokerRangeStart').setValue(9093);
+      component.generalForm.get('brokerRangeEnd').setValue(9095);
+      component.generalForm.get('bootstrapPort').markAsTouched();
+      component.generalForm.updateValueAndValidity();
+      fixture.detectChanges();
+
+      const bootstrapField = await loader.getHarness(MatFormFieldHarness.with({ floatingLabelText: 'Bootstrap port' }));
+      expect((await bootstrapField.getTextErrors()).join(' ')).toContain('must not fall within the broker port range');
+    });
+  });
+
+  describe('Bootstrap port disable in edit mode when API is deployed', () => {
+    it('should disable bootstrapPort control when mode is edit and API has deployedAt', () => {
+      const deployedApi = fakeNativeKafkaApiV4({ deployedAt: new Date() });
+      setupComponent('edit', true, deployedApi);
+      flushDefaultRequests(deployedApi.id);
+
+      expect(component.generalForm.get('bootstrapPort').disabled).toBe(true);
+    });
+
+    it('should keep bootstrapPort enabled in create mode even when API has deployedAt', () => {
+      const deployedApi = fakeNativeKafkaApiV4({ deployedAt: new Date() });
+      setupComponent('create', true, deployedApi);
+      flushDefaultRequests(deployedApi.id);
+
+      expect(component.generalForm.get('bootstrapPort').disabled).toBe(false);
+    });
+
+    it('should keep bootstrapPort enabled when in edit mode but API has no deployedAt', () => {
+      const undeployedApi = fakeNativeKafkaApiV4({ deployedAt: undefined });
+      setupComponent('edit', true, undeployedApi);
+      flushDefaultRequests(undeployedApi.id);
+
+      expect(component.generalForm.get('bootstrapPort').disabled).toBe(false);
+    });
+  });
+});

--- a/gravitee-apim-console-webui/src/management/api/component/plan/1-general-step/plan-edit-general-step.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/component/plan/1-general-step/plan-edit-general-step.component.spec.ts
@@ -199,6 +199,39 @@ describe('PlanEditGeneralStepComponent — Kafka port routing', () => {
     });
   });
 
+  describe('Broker range change warning banner', () => {
+    beforeEach(() => {
+      setupComponent('edit', true);
+      flushDefaultRequests(fakeNativeKafkaApiV4().id);
+    });
+
+    it('should show the broker range change warning banner when showBrokerRangeChangeWarning is true', async () => {
+      component.showBrokerRangeChangeWarning = true;
+      fixture.detectChanges();
+
+      const compiled = fixture.nativeElement as HTMLElement;
+      expect(compiled.textContent).toContain('Changing the broker port range will cause a brief reconnection');
+    });
+
+    it('should NOT show the broker range change warning banner when showBrokerRangeChangeWarning is false', async () => {
+      component.showBrokerRangeChangeWarning = false;
+      fixture.detectChanges();
+
+      const compiled = fixture.nativeElement as HTMLElement;
+      expect(compiled.textContent).not.toContain('Changing the broker port range will cause a brief reconnection');
+    });
+
+    it('should NOT show the broker range change warning banner when isNative is false even if showBrokerRangeChangeWarning is true', () => {
+      // The `isNative` flag is true in this describe's beforeEach; toggle it off to simulate non-native.
+      component.isNative = false;
+      component.showBrokerRangeChangeWarning = true;
+      fixture.detectChanges();
+
+      const compiled = fixture.nativeElement as HTMLElement;
+      expect(compiled.textContent).not.toContain('Changing the broker port range will cause a brief reconnection');
+    });
+  });
+
   describe('Cross-field error display (DOM)', () => {
     beforeEach(() => {
       setupComponent('create', true);
@@ -227,32 +260,6 @@ describe('PlanEditGeneralStepComponent — Kafka port routing', () => {
 
       const bootstrapField = await loader.getHarness(MatFormFieldHarness.with({ floatingLabelText: 'Bootstrap port' }));
       expect((await bootstrapField.getTextErrors()).join(' ')).toContain('must not fall within the broker port range');
-    });
-  });
-
-  describe('Bootstrap port disable in edit mode when API is deployed', () => {
-    it('should disable bootstrapPort control when mode is edit and API has deployedAt', () => {
-      const deployedApi = fakeNativeKafkaApiV4({ deployedAt: new Date() });
-      setupComponent('edit', true, deployedApi);
-      flushDefaultRequests(deployedApi.id);
-
-      expect(component.generalForm.get('bootstrapPort').disabled).toBe(true);
-    });
-
-    it('should keep bootstrapPort enabled in create mode even when API has deployedAt', () => {
-      const deployedApi = fakeNativeKafkaApiV4({ deployedAt: new Date() });
-      setupComponent('create', true, deployedApi);
-      flushDefaultRequests(deployedApi.id);
-
-      expect(component.generalForm.get('bootstrapPort').disabled).toBe(false);
-    });
-
-    it('should keep bootstrapPort enabled when in edit mode but API has no deployedAt', () => {
-      const undeployedApi = fakeNativeKafkaApiV4({ deployedAt: undefined });
-      setupComponent('edit', true, undeployedApi);
-      flushDefaultRequests(undeployedApi.id);
-
-      expect(component.generalForm.get('bootstrapPort').disabled).toBe(false);
     });
   });
 });

--- a/gravitee-apim-console-webui/src/management/api/component/plan/1-general-step/plan-edit-general-step.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/component/plan/1-general-step/plan-edit-general-step.component.spec.ts
@@ -262,4 +262,58 @@ describe('PlanEditGeneralStepComponent — Kafka port routing', () => {
       expect((await bootstrapField.getTextErrors()).join(' ')).toContain('must not fall within the broker port range');
     });
   });
+
+  describe('Broker range default from bootstrap port', () => {
+    beforeEach(() => {
+      setupComponent('create', true);
+      flushDefaultRequests(fakeNativeKafkaApiV4().id);
+    });
+
+    it('should pre-fill empty broker range from the bootstrap port (start = port+1, end = port+3)', () => {
+      component.generalForm.get('bootstrapPort').setValue(9092);
+      fixture.detectChanges();
+
+      expect(component.generalForm.get('brokerRangeStart').value).toBe(9093);
+      expect(component.generalForm.get('brokerRangeEnd').value).toBe(9095);
+    });
+
+    it('should keep following the bootstrap port while the range has not been edited', () => {
+      component.generalForm.get('bootstrapPort').setValue(9092);
+      fixture.detectChanges();
+      component.generalForm.get('bootstrapPort').setValue(9100);
+      fixture.detectChanges();
+
+      expect(component.generalForm.get('brokerRangeStart').value).toBe(9101);
+      expect(component.generalForm.get('brokerRangeEnd').value).toBe(9103);
+    });
+
+    it('should not overwrite a range the user has edited', () => {
+      component.generalForm.get('bootstrapPort').setValue(9092);
+      fixture.detectChanges();
+
+      // User overrides the range.
+      component.generalForm.get('brokerRangeStart').setValue(9500);
+      component.generalForm.get('brokerRangeEnd').setValue(9510);
+      fixture.detectChanges();
+
+      // Changing the bootstrap port again must not clobber the user's values.
+      component.generalForm.get('bootstrapPort').setValue(9200);
+      fixture.detectChanges();
+
+      expect(component.generalForm.get('brokerRangeStart').value).toBe(9500);
+      expect(component.generalForm.get('brokerRangeEnd').value).toBe(9510);
+    });
+
+    it('should not overwrite a pre-set (loaded) range', () => {
+      component.generalForm.get('brokerRangeStart').setValue(9200);
+      component.generalForm.get('brokerRangeEnd').setValue(9202);
+      fixture.detectChanges();
+
+      component.generalForm.get('bootstrapPort').setValue(9092);
+      fixture.detectChanges();
+
+      expect(component.generalForm.get('brokerRangeStart').value).toBe(9200);
+      expect(component.generalForm.get('brokerRangeEnd').value).toBe(9202);
+    });
+  });
 });

--- a/gravitee-apim-console-webui/src/management/api/component/plan/1-general-step/plan-edit-general-step.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/component/plan/1-general-step/plan-edit-general-step.component.spec.ts
@@ -34,7 +34,12 @@ describe('PlanEditGeneralStepComponent — Kafka port routing', () => {
   let loader: HarnessLoader;
   let httpTestingController: HttpTestingController;
 
-  const setupComponent = (mode: 'create' | 'edit' = 'create', isNative = false, api = fakeNativeKafkaApiV4()) => {
+  const setupComponent = (
+    mode: 'create' | 'edit' = 'create',
+    isNative = false,
+    api = fakeNativeKafkaApiV4(),
+    kafkaPortRoutingEnabled = true,
+  ) => {
     TestBed.configureTestingModule({
       declarations: [PlanEditGeneralStepComponent],
       imports: [NoopAnimationsModule, GioTestingModule, ApiPlanFormModule, MatIconTestingModule],
@@ -47,6 +52,7 @@ describe('PlanEditGeneralStepComponent — Kafka port routing', () => {
 
     component.mode = mode;
     component.isNative = isNative;
+    component.kafkaPortRoutingEnabled = kafkaPortRoutingEnabled;
     component.api = api;
     fixture.detectChanges();
   };
@@ -88,6 +94,14 @@ describe('PlanEditGeneralStepComponent — Kafka port routing', () => {
       const nonNativeApi = fakeApiV4({ type: 'PROXY' });
       setupComponent('create', false, nonNativeApi);
       flushDefaultRequests(nonNativeApi.id);
+
+      const bootstrapPortInput = await loader.getHarnessOrNull(MatInputHarness.with({ selector: '[data-testid="bootstrap_port_field"]' }));
+      expect(bootstrapPortInput).toBeNull();
+    });
+
+    it('should NOT render the Kafka port routing section when the env toggle is disabled, even for a native API', async () => {
+      setupComponent('create', true, fakeNativeKafkaApiV4(), false);
+      flushDefaultRequests(fakeNativeKafkaApiV4().id);
 
       const bootstrapPortInput = await loader.getHarnessOrNull(MatInputHarness.with({ selector: '[data-testid="bootstrap_port_field"]' }));
       expect(bootstrapPortInput).toBeNull();

--- a/gravitee-apim-console-webui/src/management/api/component/plan/1-general-step/plan-edit-general-step.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/component/plan/1-general-step/plan-edit-general-step.component.ts
@@ -126,6 +126,11 @@ export class PlanEditGeneralStepComponent implements OnInit {
   @Input()
   isNative = false;
 
+  // Gated by the environment-level "Kafka port routing" setting (console.kafka.portRouting.enabled).
+  // When false, the Kafka port-routing fields are hidden even for native APIs.
+  @Input()
+  kafkaPortRoutingEnabled = false;
+
   @Input()
   showBrokerRangeChangeWarning = false;
 

--- a/gravitee-apim-console-webui/src/management/api/component/plan/1-general-step/plan-edit-general-step.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/component/plan/1-general-step/plan-edit-general-step.component.ts
@@ -14,7 +14,18 @@
  * limitations under the License.
  */
 import { Component, Input, inject, OnInit, DestroyRef } from '@angular/core';
-import { UntypedFormControl, UntypedFormGroup, Validators } from '@angular/forms';
+import {
+  AbstractControl,
+  FormControl,
+  FormGroupDirective,
+  NgForm,
+  UntypedFormControl,
+  UntypedFormGroup,
+  ValidationErrors,
+  ValidatorFn,
+  Validators,
+} from '@angular/forms';
+import { ErrorStateMatcher } from '@angular/material/core';
 import { includes } from 'lodash';
 import { combineLatest, of, ReplaySubject } from 'rxjs';
 import { map, startWith, switchMap } from 'rxjs/operators';
@@ -25,6 +36,52 @@ import { CurrentUserService } from '../../../../../services-ngx/current-user.ser
 import { DocumentationService } from '../../../../../services-ngx/documentation.service';
 import { GroupService } from '../../../../../services-ngx/group.service';
 import { TagService } from '../../../../../services-ngx/tag.service';
+
+/**
+ * Cross-field validator for the Kafka port routing group.
+ * Validates that:
+ *  - brokerRangeStart <= brokerRangeEnd (error key: rangeOrder)
+ *  - bootstrapPort is NOT within [brokerRangeStart, brokerRangeEnd] (error key: bootstrapInRange)
+ */
+function kafkaPortRoutingValidator(): ValidatorFn {
+  return (group: AbstractControl): ValidationErrors | null => {
+    const bootstrapPort: number | null | undefined = group.get('bootstrapPort')?.value;
+    const brokerRangeStart: number | null | undefined = group.get('brokerRangeStart')?.value;
+    const brokerRangeEnd: number | null | undefined = group.get('brokerRangeEnd')?.value;
+
+    const hasStart = brokerRangeStart !== null && brokerRangeStart !== undefined && !isNaN(brokerRangeStart);
+    const hasEnd = brokerRangeEnd !== null && brokerRangeEnd !== undefined && !isNaN(brokerRangeEnd);
+    const hasBootstrap = bootstrapPort !== null && bootstrapPort !== undefined && !isNaN(bootstrapPort);
+
+    const errors: ValidationErrors = {};
+
+    if (hasStart && hasEnd && brokerRangeStart > brokerRangeEnd) {
+      errors['rangeOrder'] = { brokerRangeStart, brokerRangeEnd };
+    }
+
+    if (hasBootstrap && hasStart && hasEnd && bootstrapPort >= brokerRangeStart && bootstrapPort <= brokerRangeEnd) {
+      errors['bootstrapInRange'] = { bootstrapPort, brokerRangeStart, brokerRangeEnd };
+    }
+
+    return Object.keys(errors).length > 0 ? errors : null;
+  };
+}
+
+/**
+ * Surfaces a parent group-level error (e.g. rangeOrder, bootstrapInRange) on the individual field so that
+ * mat-form-field actually displays the cross-field <mat-error> (it only shows errors when the control's own
+ * error state is true).
+ */
+class GroupErrorStateMatcher implements ErrorStateMatcher {
+  constructor(private readonly groupErrorKey: string) {}
+
+  isErrorState(control: FormControl | null, form: FormGroupDirective | NgForm | null): boolean {
+    const interacted = !!(control && (control.dirty || control.touched || form?.submitted));
+    const controlInvalid = !!(control && control.invalid && interacted);
+    const groupInvalid = !!(control?.parent?.hasError(this.groupErrorKey) && interacted);
+    return controlInvalid || groupInvalid;
+  }
+}
 
 @Component({
   selector: 'plan-edit-general-step',
@@ -47,6 +104,7 @@ export class PlanEditGeneralStepComponent implements OnInit {
   public set api(api: ApiV2 | ApiV4 | ApiFederated) {
     if (api) {
       this.api$.next(api);
+      this._api = api;
     }
   }
 
@@ -65,6 +123,15 @@ export class PlanEditGeneralStepComponent implements OnInit {
 
   @Input()
   hideAccessControl = false;
+
+  @Input()
+  isNative = false;
+
+  // Surface the cross-field group errors on the individual Kafka port-routing inputs.
+  protected readonly bootstrapInRangeErrorMatcher = new GroupErrorStateMatcher('bootstrapInRange');
+  protected readonly rangeOrderErrorMatcher = new GroupErrorStateMatcher('rangeOrder');
+
+  private _api?: ApiV2 | ApiV4 | ApiFederated;
 
   conditionPages$ = this.api$.pipe(
     switchMap(api =>
@@ -89,17 +156,23 @@ export class PlanEditGeneralStepComponent implements OnInit {
   groups$ = this.groupService.list();
 
   ngOnInit(): void {
-    this.generalForm = new UntypedFormGroup({
-      name: new UntypedFormControl('', [Validators.required, Validators.maxLength(50)]),
-      description: new UntypedFormControl(''),
-      characteristics: new UntypedFormControl([]),
-      generalConditions: new UntypedFormControl(''),
-      autoValidation: new UntypedFormControl(false),
-      commentRequired: new UntypedFormControl(false),
-      commentMessage: new UntypedFormControl(''),
-      shardingTags: new UntypedFormControl([]),
-      excludedGroups: new UntypedFormControl([]),
-    });
+    this.generalForm = new UntypedFormGroup(
+      {
+        name: new UntypedFormControl('', [Validators.required, Validators.maxLength(50)]),
+        description: new UntypedFormControl(''),
+        characteristics: new UntypedFormControl([]),
+        generalConditions: new UntypedFormControl(''),
+        autoValidation: new UntypedFormControl(false),
+        commentRequired: new UntypedFormControl(false),
+        commentMessage: new UntypedFormControl(''),
+        shardingTags: new UntypedFormControl([]),
+        excludedGroups: new UntypedFormControl([]),
+        bootstrapPort: new UntypedFormControl(null, [Validators.min(1024), Validators.max(65535)]),
+        brokerRangeStart: new UntypedFormControl(null, [Validators.min(1024), Validators.max(65535)]),
+        brokerRangeEnd: new UntypedFormControl(null, [Validators.min(1024), Validators.max(65535)]),
+      },
+      { validators: kafkaPortRoutingValidator() },
+    );
 
     // Enable comment message only if comment required is checked
     this.generalForm
@@ -108,5 +181,10 @@ export class PlanEditGeneralStepComponent implements OnInit {
       .subscribe(value => {
         value ? this.generalForm.get('commentMessage').enable() : this.generalForm.get('commentMessage').disable();
       });
+
+    // Disable bootstrapPort in edit mode when the API has been deployed
+    if (this.mode === 'edit' && (this._api as ApiV4)?.deployedAt != null) {
+      this.generalForm.get('bootstrapPort').disable();
+    }
   }
 }

--- a/gravitee-apim-console-webui/src/management/api/component/plan/1-general-step/plan-edit-general-step.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/component/plan/1-general-step/plan-edit-general-step.component.ts
@@ -49,9 +49,9 @@ function kafkaPortRoutingValidator(): ValidatorFn {
     const brokerRangeStart: number | null | undefined = group.get('brokerRangeStart')?.value;
     const brokerRangeEnd: number | null | undefined = group.get('brokerRangeEnd')?.value;
 
-    const hasStart = brokerRangeStart !== null && brokerRangeStart !== undefined && !isNaN(brokerRangeStart);
-    const hasEnd = brokerRangeEnd !== null && brokerRangeEnd !== undefined && !isNaN(brokerRangeEnd);
-    const hasBootstrap = bootstrapPort !== null && bootstrapPort !== undefined && !isNaN(bootstrapPort);
+    const hasStart = Number.isFinite(brokerRangeStart as number);
+    const hasEnd = Number.isFinite(brokerRangeEnd as number);
+    const hasBootstrap = Number.isFinite(bootstrapPort as number);
 
     const errors: ValidationErrors = {};
 

--- a/gravitee-apim-console-webui/src/management/api/component/plan/1-general-step/plan-edit-general-step.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/component/plan/1-general-step/plan-edit-general-step.component.ts
@@ -133,6 +133,14 @@ export class PlanEditGeneralStepComponent implements OnInit {
   protected readonly bootstrapInRangeErrorMatcher = new GroupErrorStateMatcher('bootstrapInRange');
   protected readonly rangeOrderErrorMatcher = new GroupErrorStateMatcher('rangeOrder');
 
+  // Default broker range size when deriving the range from the bootstrap port (matches the gateway's
+  // kafka.routingPortMode.defaultBrokersRangeSize default of 3).
+  private static readonly DEFAULT_BROKER_RANGE_SIZE = 3;
+  // The last range values we auto-filled, used to keep following the bootstrap port until the user
+  // edits the range themselves.
+  private autoFilledBrokerRangeStart?: number;
+  private autoFilledBrokerRangeEnd?: number;
+
   conditionPages$ = this.api$.pipe(
     switchMap(api =>
       this.documentationService.apiSearch(api.id, {
@@ -180,6 +188,34 @@ export class PlanEditGeneralStepComponent implements OnInit {
       .valueChanges.pipe(startWith(this.generalForm.get('commentRequired').value), takeUntilDestroyed(this.destroyRef))
       .subscribe(value => {
         value ? this.generalForm.get('commentMessage').enable() : this.generalForm.get('commentMessage').disable();
+      });
+
+    // Pre-fill the broker range from the bootstrap port (start = bootstrap + 1, end = bootstrap + size).
+    // The fields stay editable: we only update a range field while it is still empty or still holds the
+    // value we last auto-filled, so a user-entered range (or a loaded one) is never overwritten.
+    this.generalForm
+      .get('bootstrapPort')
+      .valueChanges.pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe(raw => {
+        const bootstrapPort = Number.isFinite(raw as number) ? (raw as number) : null;
+        if (bootstrapPort == null) {
+          return;
+        }
+        const startControl = this.generalForm.get('brokerRangeStart');
+        const endControl = this.generalForm.get('brokerRangeEnd');
+
+        const isEmpty = (value: unknown) => value === null || value === undefined || (value as unknown) === '';
+        const defaultStart = bootstrapPort + 1;
+        const defaultEnd = bootstrapPort + PlanEditGeneralStepComponent.DEFAULT_BROKER_RANGE_SIZE;
+
+        if (isEmpty(startControl.value) || startControl.value === this.autoFilledBrokerRangeStart) {
+          startControl.setValue(defaultStart);
+          this.autoFilledBrokerRangeStart = defaultStart;
+        }
+        if (isEmpty(endControl.value) || endControl.value === this.autoFilledBrokerRangeEnd) {
+          endControl.setValue(defaultEnd);
+          this.autoFilledBrokerRangeEnd = defaultEnd;
+        }
       });
   }
 }

--- a/gravitee-apim-console-webui/src/management/api/component/plan/1-general-step/plan-edit-general-step.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/component/plan/1-general-step/plan-edit-general-step.component.ts
@@ -104,7 +104,6 @@ export class PlanEditGeneralStepComponent implements OnInit {
   public set api(api: ApiV2 | ApiV4 | ApiFederated) {
     if (api) {
       this.api$.next(api);
-      this._api = api;
     }
   }
 
@@ -127,11 +126,12 @@ export class PlanEditGeneralStepComponent implements OnInit {
   @Input()
   isNative = false;
 
+  @Input()
+  showBrokerRangeChangeWarning = false;
+
   // Surface the cross-field group errors on the individual Kafka port-routing inputs.
   protected readonly bootstrapInRangeErrorMatcher = new GroupErrorStateMatcher('bootstrapInRange');
   protected readonly rangeOrderErrorMatcher = new GroupErrorStateMatcher('rangeOrder');
-
-  private _api?: ApiV2 | ApiV4 | ApiFederated;
 
   conditionPages$ = this.api$.pipe(
     switchMap(api =>
@@ -181,10 +181,5 @@ export class PlanEditGeneralStepComponent implements OnInit {
       .subscribe(value => {
         value ? this.generalForm.get('commentMessage').enable() : this.generalForm.get('commentMessage').disable();
       });
-
-    // Disable bootstrapPort in edit mode when the API has been deployed
-    if (this.mode === 'edit' && (this._api as ApiV4)?.deployedAt != null) {
-      this.generalForm.get('bootstrapPort').disable();
-    }
   }
 }

--- a/gravitee-apim-console-webui/src/management/api/component/plan/1-general-step/plan-edit-general-step.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/component/plan/1-general-step/plan-edit-general-step.component.ts
@@ -138,8 +138,7 @@ export class PlanEditGeneralStepComponent implements OnInit {
   protected readonly bootstrapInRangeErrorMatcher = new GroupErrorStateMatcher('bootstrapInRange');
   protected readonly rangeOrderErrorMatcher = new GroupErrorStateMatcher('rangeOrder');
 
-  // Default broker range size when deriving the range from the bootstrap port (matches the gateway's
-  // kafka.routingPortMode.defaultBrokersRangeSize default of 3).
+  // Default broker range: 3 brokers ([bootstrap+1 .. bootstrap+3], inclusive).
   private static readonly DEFAULT_BROKER_RANGE_SIZE = 3;
   // The last range values we auto-filled, used to keep following the bootstrap port until the user
   // edits the range themselves.

--- a/gravitee-apim-console-webui/src/management/api/component/plan/api-plan-form.component.html
+++ b/gravitee-apim-console-webui/src/management/api/component/plan/api-plan-form.component.html
@@ -30,6 +30,7 @@
       [mode]="mode"
       [displaySubscriptionsSection]="displaySubscriptionsSection"
       [planStatus]="planStatus"
+      [showBrokerRangeChangeWarning]="showBrokerRangeChangeWarning"
     ></plan-edit-general-step>
   </mat-step>
 

--- a/gravitee-apim-console-webui/src/management/api/component/plan/api-plan-form.component.html
+++ b/gravitee-apim-console-webui/src/management/api/component/plan/api-plan-form.component.html
@@ -27,6 +27,7 @@
       [isFederated]="isFederated"
       [hideAccessControl]="hideAccessControl"
       [isNative]="isNative"
+      [kafkaPortRoutingEnabled]="kafkaPortRoutingEnabled"
       [mode]="mode"
       [displaySubscriptionsSection]="displaySubscriptionsSection"
       [planStatus]="planStatus"

--- a/gravitee-apim-console-webui/src/management/api/component/plan/api-plan-form.component.html
+++ b/gravitee-apim-console-webui/src/management/api/component/plan/api-plan-form.component.html
@@ -26,6 +26,7 @@
       [api]="api"
       [isFederated]="isFederated"
       [hideAccessControl]="hideAccessControl"
+      [isNative]="isNative"
       [mode]="mode"
       [displaySubscriptionsSection]="displaySubscriptionsSection"
       [planStatus]="planStatus"

--- a/gravitee-apim-console-webui/src/management/api/component/plan/api-plan-form.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/component/plan/api-plan-form.component.spec.ts
@@ -132,7 +132,10 @@ describe('ApiPlanFormComponent', () => {
     testComponent.isNative = isNative;
   };
 
-  afterEach(() => {
+  afterEach(async () => {
+    // Let any deferred ui-particles GioFormJsonSchema setTimeout(0) fire while the component is still
+    // alive, otherwise it throws ObjectUnsubscribedError into a later test after teardown.
+    await new Promise<void>(resolve => setTimeout(resolve, 0));
     httpTestingController.verify();
   });
 
@@ -1583,6 +1586,85 @@ describe('ApiPlanFormComponent', () => {
         expect(testComponent.planControl.value.bootstrapPort).toBeUndefined();
         expect(testComponent.planControl.value.brokerRangeStart).toBeUndefined();
         expect(testComponent.planControl.value.brokerRangeEnd).toBeUndefined();
+      });
+    });
+
+    describe('showBrokerRangeChangeWarning getter', () => {
+      it('should return false when not in edit mode (create mode)', async () => {
+        const deployedApi = fakeNativeKafkaApiV4({ deployedAt: new Date() });
+        configureTestingModule('create', 'KEY_LESS', deployedApi, 'NATIVE', true);
+        testComponent.planControl = new FormControl(fakePlanV4({ brokerRangeStart: 9093, brokerRangeEnd: 9095 }));
+        fixture.detectChanges();
+
+        const planForm = await loader.getHarness(ApiPlanFormHarness);
+        planForm.httpRequest(httpTestingController).expectGroupListRequest([]);
+        planForm.httpRequest(httpTestingController).expectDocumentationSearchRequest(deployedApi.id, []);
+        planForm.httpRequest(httpTestingController).expectCurrentUserTagsRequest([]);
+        planForm.httpRequest(httpTestingController).expectTagsListRequest([]);
+        fixture.detectChanges();
+
+        expect(testComponent.apiPlanForm.showBrokerRangeChangeWarning).toBe(false);
+      });
+
+      it('should return false when edit mode on a non-deployed API', async () => {
+        const nonDeployedApi = fakeNativeKafkaApiV4({ deployedAt: undefined });
+        configureTestingModule('edit', 'KEY_LESS', nonDeployedApi, 'NATIVE', true);
+        testComponent.planControl = new FormControl(fakePlanV4({ brokerRangeStart: 9093, brokerRangeEnd: 9095 }));
+        fixture.detectChanges();
+
+        const planForm = await loader.getHarness(ApiPlanFormHarness);
+        planForm.httpRequest(httpTestingController).expectGroupListRequest([]);
+        planForm.httpRequest(httpTestingController).expectDocumentationSearchRequest(nonDeployedApi.id, []);
+        planForm.httpRequest(httpTestingController).expectCurrentUserTagsRequest([]);
+        planForm.httpRequest(httpTestingController).expectTagsListRequest([]);
+        fixture.detectChanges();
+
+        const brokerRangeStartInput = await planForm.getBrokerRangeStartInput();
+        await brokerRangeStartInput.setValue('9099');
+
+        expect(testComponent.apiPlanForm.showBrokerRangeChangeWarning).toBe(false);
+      });
+
+      it('should return true after changing broker range in edit mode on a deployed API', async () => {
+        const deployedApi = fakeNativeKafkaApiV4({ deployedAt: new Date() });
+        configureTestingModule('edit', 'KEY_LESS', deployedApi, 'NATIVE', true);
+        testComponent.planControl = new FormControl(fakePlanV4({ brokerRangeStart: 9093, brokerRangeEnd: 9095 }));
+        fixture.detectChanges();
+
+        const planForm = await loader.getHarness(ApiPlanFormHarness);
+        planForm.httpRequest(httpTestingController).expectGroupListRequest([]);
+        planForm.httpRequest(httpTestingController).expectDocumentationSearchRequest(deployedApi.id, []);
+        planForm.httpRequest(httpTestingController).expectCurrentUserTagsRequest([]);
+        planForm.httpRequest(httpTestingController).expectTagsListRequest([]);
+        fixture.detectChanges();
+
+        expect(testComponent.apiPlanForm.showBrokerRangeChangeWarning).toBe(false);
+
+        const brokerRangeStartInput = await planForm.getBrokerRangeStartInput();
+        await brokerRangeStartInput.setValue('9099');
+        fixture.detectChanges();
+
+        expect(testComponent.apiPlanForm.showBrokerRangeChangeWarning).toBe(true);
+      });
+
+      it('should return false when broker range is unchanged in edit mode on a deployed API', async () => {
+        const deployedApi = fakeNativeKafkaApiV4({ deployedAt: new Date() });
+        configureTestingModule('edit', 'KEY_LESS', deployedApi, 'NATIVE', true);
+        testComponent.planControl = new FormControl(fakePlanV4({ brokerRangeStart: 9093, brokerRangeEnd: 9095 }));
+        fixture.detectChanges();
+
+        const planForm = await loader.getHarness(ApiPlanFormHarness);
+        planForm.httpRequest(httpTestingController).expectGroupListRequest([]);
+        planForm.httpRequest(httpTestingController).expectDocumentationSearchRequest(deployedApi.id, []);
+        planForm.httpRequest(httpTestingController).expectCurrentUserTagsRequest([]);
+        planForm.httpRequest(httpTestingController).expectTagsListRequest([]);
+        fixture.detectChanges();
+
+        const nameInput = await planForm.getNameInput();
+        await nameInput.setValue('New name');
+        fixture.detectChanges();
+
+        expect(testComponent.apiPlanForm.showBrokerRangeChangeWarning).toBe(false);
       });
     });
   });

--- a/gravitee-apim-console-webui/src/management/api/component/plan/api-plan-form.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/component/plan/api-plan-form.component.spec.ts
@@ -40,6 +40,7 @@ import {
   CreatePlanV4,
   fakeApiV2,
   fakeApiV4,
+  fakeNativeKafkaApiV4,
   fakePlanV2,
   fakePlanV4,
   fakeProxyTcpApiV4,
@@ -62,6 +63,7 @@ import { isApiV4 } from '../../../../util';
       [apiType]="apiType"
       [planMenuItem]="planMenuItem"
       [isTcpApi]="isTcpApi"
+      [isNative]="isNative"
     ></api-plan-form>
   `,
   standalone: false,
@@ -75,6 +77,7 @@ class TestComponent {
   apiType?: ApiType;
   plan?: Plan;
   isTcpApi?: boolean = false;
+  isNative?: boolean = false;
 }
 
 const fakeApiKeySchema = {
@@ -95,7 +98,7 @@ describe('ApiPlanFormComponent', () => {
   let loader: HarnessLoader;
   let httpTestingController: HttpTestingController;
 
-  const configureTestingModule = (mode: 'create' | 'edit', planFormType: PlanFormType, api?: Api, apiType?: ApiType) => {
+  const configureTestingModule = (mode: 'create' | 'edit', planFormType: PlanFormType, api?: Api, apiType?: ApiType, isNative = false) => {
     TestBed.configureTestingModule({
       declarations: [TestComponent],
       imports: [ReactiveFormsModule, NoopAnimationsModule, GioTestingModule, ApiPlanFormModule, MatIconTestingModule],
@@ -126,6 +129,7 @@ describe('ApiPlanFormComponent', () => {
     testComponent.api = api;
     testComponent.apiType = apiType;
     testComponent.isTcpApi = isApiV4(api) && api.listeners.find(listener => listener.type === 'TCP') != null;
+    testComponent.isNative = isNative;
   };
 
   afterEach(() => {
@@ -1510,6 +1514,76 @@ describe('ApiPlanFormComponent', () => {
       const stepsHarness = await loader.getAllHarnesses(MatStepHarness);
       const steps = await Promise.all(stepsHarness.map(step => step.getLabel()));
       expect(steps).toEqual(['General']);
+    });
+  });
+
+  describe('NATIVE Kafka API — Kafka port routing fields', () => {
+    const NATIVE_API = fakeNativeKafkaApiV4();
+
+    describe('Create mode', () => {
+      beforeEach(() => {
+        configureTestingModule('create', 'KEY_LESS', NATIVE_API, 'NATIVE', true);
+        fixture.detectChanges();
+      });
+
+      it('should round-trip port values through planToInternalFormValue and internalFormValueToPlanV4', async () => {
+        const planWithPorts = fakePlanV4({
+          bootstrapPort: 9092,
+          brokerRangeStart: 9093,
+          brokerRangeEnd: 9095,
+        });
+        testComponent.planControl = new FormControl(planWithPorts);
+        fixture.detectChanges();
+
+        const planForm = await loader.getHarness(ApiPlanFormHarness);
+        planForm.httpRequest(httpTestingController).expectGroupListRequest([]);
+        planForm.httpRequest(httpTestingController).expectDocumentationSearchRequest(NATIVE_API.id, []);
+        planForm.httpRequest(httpTestingController).expectCurrentUserTagsRequest([]);
+        planForm.httpRequest(httpTestingController).expectTagsListRequest([]);
+        fixture.detectChanges();
+
+        const bootstrapPortInput = await planForm.getBootstrapPortInput();
+        expect(await bootstrapPortInput.getValue()).toEqual('9092');
+
+        const brokerRangeStartInput = await planForm.getBrokerRangeStartInput();
+        expect(await brokerRangeStartInput.getValue()).toEqual('9093');
+
+        const brokerRangeEndInput = await planForm.getBrokerRangeEndInput();
+        expect(await brokerRangeEndInput.getValue()).toEqual('9095');
+
+        // Change name so form is valid
+        const nameInput = await planForm.getNameInput();
+        await nameInput.setValue('Kafka Plan');
+
+        expect(testComponent.planControl.value.bootstrapPort).toEqual(9092);
+        expect(testComponent.planControl.value.brokerRangeStart).toEqual(9093);
+        expect(testComponent.planControl.value.brokerRangeEnd).toEqual(9095);
+      });
+
+      it('should map empty port inputs to undefined in the emitted plan value', async () => {
+        const planWithoutPorts = fakePlanV4({
+          name: 'Kafka Plan',
+          bootstrapPort: undefined,
+          brokerRangeStart: undefined,
+          brokerRangeEnd: undefined,
+        });
+        testComponent.planControl = new FormControl(planWithoutPorts);
+        fixture.detectChanges();
+
+        const planForm = await loader.getHarness(ApiPlanFormHarness);
+        planForm.httpRequest(httpTestingController).expectGroupListRequest([]);
+        planForm.httpRequest(httpTestingController).expectDocumentationSearchRequest(NATIVE_API.id, []);
+        planForm.httpRequest(httpTestingController).expectCurrentUserTagsRequest([]);
+        planForm.httpRequest(httpTestingController).expectTagsListRequest([]);
+        fixture.detectChanges();
+
+        const nameInput = await planForm.getNameInput();
+        await nameInput.setValue('Kafka Plan');
+
+        expect(testComponent.planControl.value.bootstrapPort).toBeUndefined();
+        expect(testComponent.planControl.value.brokerRangeStart).toBeUndefined();
+        expect(testComponent.planControl.value.brokerRangeEnd).toBeUndefined();
+      });
     });
   });
 });

--- a/gravitee-apim-console-webui/src/management/api/component/plan/api-plan-form.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/component/plan/api-plan-form.component.ts
@@ -354,6 +354,18 @@ export class ApiPlanFormComponent implements OnInit, AfterViewInit, OnDestroy, C
     this.matStepper.previous();
   }
 
+  get showBrokerRangeChangeWarning(): boolean {
+    if (this.mode !== 'edit' || (this.api as ApiV4)?.deployedAt == null) {
+      return false;
+    }
+    const current = this.planForm?.getRawValue()?.general;
+    const initial = (this.initialPlanFormValue as any)?.general;
+    if (!current || !initial) {
+      return false;
+    }
+    return current.brokerRangeStart !== initial.brokerRangeStart || current.brokerRangeEnd !== initial.brokerRangeEnd;
+  }
+
   private initPlanForm() {
     this.planForm = new UntypedFormGroup({
       general: this.planEditGeneralStepComponent.generalForm,

--- a/gravitee-apim-console-webui/src/management/api/component/plan/api-plan-form.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/component/plan/api-plan-form.component.ts
@@ -68,6 +68,7 @@ import {
 } from '../../../../entities/management-api-v2';
 import { isApiV2FromMAPIV2 } from '../../../../util';
 import { PlanFormType, PlanMenuItemVM } from '../../../../services-ngx/constants.service';
+import { Constants } from '../../../../entities/Constants';
 
 export type InternalPlanFormValue = {
   general: {
@@ -194,6 +195,7 @@ export class ApiPlanFormComponent implements OnInit, AfterViewInit, OnDestroy, C
    */
   private readonly _stepChangeCounter = signal(0);
   private readonly destroyRef = inject(DestroyRef);
+  private readonly constants = inject(Constants);
 
   private _onChange: (_: PlanFormValue) => void;
   private _onTouched: () => void;
@@ -352,6 +354,12 @@ export class ApiPlanFormComponent implements OnInit, AfterViewInit, OnDestroy, C
 
   previousStep() {
     this.matStepper.previous();
+  }
+
+  // Environment-level toggle (console.kafka.portRouting.enabled): when disabled, the Kafka
+  // port-routing fields stay hidden on native plans.
+  get kafkaPortRoutingEnabled(): boolean {
+    return !!this.constants.env?.settings?.kafkaPortRouting?.enabled;
   }
 
   get showBrokerRangeChangeWarning(): boolean {

--- a/gravitee-apim-console-webui/src/management/api/component/plan/api-plan-form.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/component/plan/api-plan-form.component.ts
@@ -661,18 +661,9 @@ const internalFormValueToPlanV4 = (
     ];
   };
 
-  const bootstrapPort =
-    value.general.bootstrapPort !== null && value.general.bootstrapPort !== undefined && !isNaN(value.general.bootstrapPort)
-      ? value.general.bootstrapPort
-      : undefined;
-  const brokerRangeStart =
-    value.general.brokerRangeStart !== null && value.general.brokerRangeStart !== undefined && !isNaN(value.general.brokerRangeStart)
-      ? value.general.brokerRangeStart
-      : undefined;
-  const brokerRangeEnd =
-    value.general.brokerRangeEnd !== null && value.general.brokerRangeEnd !== undefined && !isNaN(value.general.brokerRangeEnd)
-      ? value.general.brokerRangeEnd
-      : undefined;
+  const bootstrapPort = Number.isFinite(value.general.bootstrapPort as number) ? value.general.bootstrapPort : undefined;
+  const brokerRangeStart = Number.isFinite(value.general.brokerRangeStart as number) ? value.general.brokerRangeStart : undefined;
+  const brokerRangeEnd = Number.isFinite(value.general.brokerRangeEnd as number) ? value.general.brokerRangeEnd : undefined;
 
   return {
     name: value.general.name,

--- a/gravitee-apim-console-webui/src/management/api/component/plan/api-plan-form.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/component/plan/api-plan-form.component.ts
@@ -80,6 +80,9 @@ export type InternalPlanFormValue = {
     commentMessage: string;
     autoValidation: boolean;
     excludedGroups: string[];
+    bootstrapPort?: number;
+    brokerRangeStart?: number;
+    brokerRangeEnd?: number;
   };
   secure: {
     securityConfig: unknown;
@@ -107,7 +110,15 @@ export type PlanFormValue = Pick<
   | 'validation'
   | 'excludedGroups'
   | 'security'
-> & { mode?: PlanMode; selectionRule?: string; tags?: string[]; flows?: Array<FlowV2 | FlowV4> };
+> & {
+  mode?: PlanMode;
+  selectionRule?: string;
+  tags?: string[];
+  flows?: Array<FlowV2 | FlowV4>;
+  bootstrapPort?: number;
+  brokerRangeStart?: number;
+  brokerRangeEnd?: number;
+};
 
 @Component({
   selector: 'api-plan-form',
@@ -475,6 +486,9 @@ const planToInternalFormValue = (
       commentMessage: plan.commentMessage,
       autoValidation: plan.validation === 'AUTO',
       excludedGroups: plan.excludedGroups,
+      bootstrapPort: plan.bootstrapPort ?? undefined,
+      brokerRangeStart: plan.brokerRangeStart ?? undefined,
+      brokerRangeEnd: plan.brokerRangeEnd ?? undefined,
     },
     secure: {
       securityConfig: plan.security?.configuration,
@@ -635,6 +649,19 @@ const internalFormValueToPlanV4 = (
     ];
   };
 
+  const bootstrapPort =
+    value.general.bootstrapPort !== null && value.general.bootstrapPort !== undefined && !isNaN(value.general.bootstrapPort)
+      ? value.general.bootstrapPort
+      : undefined;
+  const brokerRangeStart =
+    value.general.brokerRangeStart !== null && value.general.brokerRangeStart !== undefined && !isNaN(value.general.brokerRangeStart)
+      ? value.general.brokerRangeStart
+      : undefined;
+  const brokerRangeEnd =
+    value.general.brokerRangeEnd !== null && value.general.brokerRangeEnd !== undefined && !isNaN(value.general.brokerRangeEnd)
+      ? value.general.brokerRangeEnd
+      : undefined;
+
   return {
     name: value.general.name,
     description: value.general.description,
@@ -659,6 +686,11 @@ const internalFormValueToPlanV4 = (
 
     excludedGroups: value.general.excludedGroups,
     selectionRule: value.secure.selectionRule,
+
+    // Kafka port-routing fields (NATIVE APIs only; undefined when not set)
+    bootstrapPort,
+    brokerRangeStart,
+    brokerRangeEnd,
 
     // Restriction (only for create mode)
     ...(mode === 'edit' ? {} : { flows: initFlowsWithRestriction(value.restriction) }),

--- a/gravitee-apim-console-webui/src/management/api/component/plan/api-plan-form.harness.ts
+++ b/gravitee-apim-console-webui/src/management/api/component/plan/api-plan-form.harness.ts
@@ -51,6 +51,11 @@ export class ApiPlanFormHarness extends ComponentHarness {
   public getShardingTagsInput = this.locatorForOptional(MatSelectHarness.with({ selector: '[formControlName="shardingTags"]' }));
   public getExcludedGroupsInput = this.locatorFor(MatSelectHarness.with({ selector: '[formControlName="excludedGroups"]' }));
 
+  // Kafka port routing
+  public getBootstrapPortInput = this.locatorForOptional(MatInputHarness.with({ selector: '[data-testid="bootstrap_port_field"]' }));
+  public getBrokerRangeStartInput = this.locatorForOptional(MatInputHarness.with({ selector: '[data-testid="broker_range_start_field"]' }));
+  public getBrokerRangeEndInput = this.locatorForOptional(MatInputHarness.with({ selector: '[data-testid="broker_range_end_field"]' }));
+
   // 2- Secure Step
   public getSelectionRuleInput = this.locatorForOptional(MatInputHarness.with({ selector: '[formControlName="selectionRule"]' }));
 

--- a/gravitee-apim-console-webui/src/management/api/plans/api-plans.module.ts
+++ b/gravitee-apim-console-webui/src/management/api/plans/api-plans.module.ts
@@ -32,6 +32,7 @@ import { RouterModule } from '@angular/router';
 
 import { ApiPlanListComponent } from './list/api-plan-list.component';
 import { ApiPlanEditComponent } from './edit/api-plan-edit.component';
+import { KafkaBootstrapPortChangeDialogComponent } from './edit/kafka-bootstrap-port-change-dialog/kafka-bootstrap-port-change-dialog.component';
 
 import { GioPermissionModule } from '../../../shared/components/gio-permission/gio-permission.module';
 import { ApiPlanFormModule } from '../component/plan/api-plan-form.module';
@@ -65,6 +66,7 @@ import { PlanListComponent } from '../component/plan/plan-list/plan-list.compone
     ApiPlanFormModule,
     MatMenuModule,
     PlanListComponent,
+    KafkaBootstrapPortChangeDialogComponent,
   ],
 })
 export class ApiPlansModule {}

--- a/gravitee-apim-console-webui/src/management/api/plans/edit/api-plan-edit.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/plans/edit/api-plan-edit.component.spec.ts
@@ -663,6 +663,42 @@ describe('ApiPlanEditComponent', () => {
       req.flush({});
       expect(routerNavigationSpy).toHaveBeenCalled();
     });
+
+    it('should save directly (no dialog) when setting a bootstrap port for the first time (host -> port migration)', async () => {
+      const HOST_MODE_PLAN = fakePlanV4({ apiId: API_ID, security: { type: 'KEY_LESS' } }); // no bootstrapPort
+      configureTestingModule(HOST_MODE_PLAN.id);
+      fixture.detectChanges();
+      expectApiGetRequest(DEPLOYED_NATIVE_API);
+      expectPlanGetRequest(API_ID, HOST_MODE_PLAN);
+
+      const planForm = await loader.getHarness(ApiPlanFormHarness);
+      flushPlanFormRequests(planForm);
+      fixture.detectChanges();
+
+      const nameInput = await planForm.getNameInput();
+      await nameInput.setValue('Updated plan');
+
+      // Set a bootstrap port for the first time — the plan was host mode (no port) before.
+      const bootstrapPortInput = await planForm.getBootstrapPortInput();
+      await bootstrapPortInput.setValue('19092');
+      fixture.detectChanges();
+
+      const matDialog = TestBed.inject(MatDialog);
+      const dialogSpy = jest.spyOn(matDialog, 'open');
+
+      const saveBar = await loader.getHarness(GioSaveBarHarness);
+      await saveBar.clickSubmit();
+
+      expect(dialogSpy).not.toHaveBeenCalled();
+
+      expectPlanGetRequest(API_ID, HOST_MODE_PLAN);
+      const req = httpTestingController.expectOne({
+        url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${API_ID}/plans/${HOST_MODE_PLAN.id}`,
+        method: 'PUT',
+      });
+      req.flush({});
+      expect(routerNavigationSpy).toHaveBeenCalled();
+    });
   });
 
   describe('With a Federated API', () => {

--- a/gravitee-apim-console-webui/src/management/api/plans/edit/api-plan-edit.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/plans/edit/api-plan-edit.component.spec.ts
@@ -699,6 +699,37 @@ describe('ApiPlanEditComponent', () => {
       req.flush({});
       expect(routerNavigationSpy).toHaveBeenCalled();
     });
+
+    it('should open the dialog when clearing an existing bootstrap port (port -> host migration)', async () => {
+      setupDeployedNativeEdit();
+
+      const planForm = await loader.getHarness(ApiPlanFormHarness);
+      flushPlanFormRequests(planForm);
+      fixture.detectChanges();
+
+      const nameInput = await planForm.getNameInput();
+      await nameInput.setValue('Updated plan');
+
+      // Clear the existing bootstrap port — this disables port-based routing and breaks port-mode clients.
+      const bootstrapPortInput = await planForm.getBootstrapPortInput();
+      await bootstrapPortInput.setValue('');
+      fixture.detectChanges();
+
+      const matDialog = TestBed.inject(MatDialog);
+      const dialogSpy = jest.spyOn(matDialog, 'open').mockReturnValue({
+        afterClosed: () => of(false),
+      } as any);
+
+      const saveBar = await loader.getHarness(GioSaveBarHarness);
+      await saveBar.clickSubmit();
+
+      expect(dialogSpy).toHaveBeenCalled();
+      httpTestingController.expectNone({
+        url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${API_ID}/plans/${PLAN_WITH_BOOTSTRAP.id}`,
+        method: 'PUT',
+      });
+      expect(routerNavigationSpy).not.toHaveBeenCalled();
+    });
   });
 
   describe('With a Federated API', () => {

--- a/gravitee-apim-console-webui/src/management/api/plans/edit/api-plan-edit.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/plans/edit/api-plan-edit.component.spec.ts
@@ -630,7 +630,7 @@ describe('ApiPlanEditComponent', () => {
         url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${API_ID}/plans/${PLAN_WITH_BOOTSTRAP.id}`,
         method: 'PUT',
       });
-      expect(req.request.body).toEqual(expect.objectContaining({ name: 'Updated plan' }));
+      expect(req.request.body).toEqual(expect.objectContaining({ name: 'Updated plan', bootstrapPort: 9999 }));
       req.flush({});
       expect(routerNavigationSpy).toHaveBeenCalled();
     });
@@ -724,6 +724,66 @@ describe('ApiPlanEditComponent', () => {
       await saveBar.clickSubmit();
 
       expect(dialogSpy).toHaveBeenCalled();
+      httpTestingController.expectNone({
+        url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${API_ID}/plans/${PLAN_WITH_BOOTSTRAP.id}`,
+        method: 'PUT',
+      });
+      expect(routerNavigationSpy).not.toHaveBeenCalled();
+    });
+
+    it('should block save (no dialog, no PUT, no navigation) when the broker range is out of order', async () => {
+      setupDeployedNativeEdit();
+
+      const planForm = await loader.getHarness(ApiPlanFormHarness);
+      flushPlanFormRequests(planForm);
+      fixture.detectChanges();
+
+      const nameInput = await planForm.getNameInput();
+      await nameInput.setValue('Updated plan');
+
+      // start > end -> rangeOrder error -> form invalid.
+      await (await planForm.getBrokerRangeStartInput()).setValue('9095');
+      await (await planForm.getBrokerRangeEndInput()).setValue('9093');
+      fixture.detectChanges();
+
+      const matDialog = TestBed.inject(MatDialog);
+      const dialogSpy = jest.spyOn(matDialog, 'open');
+
+      const saveBar = await loader.getHarness(GioSaveBarHarness);
+      await saveBar.clickSubmit();
+
+      expect(dialogSpy).not.toHaveBeenCalled();
+      httpTestingController.expectNone({
+        url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${API_ID}/plans/${PLAN_WITH_BOOTSTRAP.id}`,
+        method: 'PUT',
+      });
+      expect(routerNavigationSpy).not.toHaveBeenCalled();
+    });
+
+    it('should block save (no dialog, no PUT, no navigation) when the bootstrap port falls within the broker range', async () => {
+      setupDeployedNativeEdit();
+
+      const planForm = await loader.getHarness(ApiPlanFormHarness);
+      flushPlanFormRequests(planForm);
+      fixture.detectChanges();
+
+      const nameInput = await planForm.getNameInput();
+      await nameInput.setValue('Updated plan');
+
+      // bootstrap (9094) inside [9093, 9095] -> bootstrapInRange error -> form invalid.
+      // Set bootstrap first (its valueChanges auto-fills the range), then override the range explicitly.
+      await (await planForm.getBootstrapPortInput()).setValue('9094');
+      await (await planForm.getBrokerRangeStartInput()).setValue('9093');
+      await (await planForm.getBrokerRangeEndInput()).setValue('9095');
+      fixture.detectChanges();
+
+      const matDialog = TestBed.inject(MatDialog);
+      const dialogSpy = jest.spyOn(matDialog, 'open');
+
+      const saveBar = await loader.getHarness(GioSaveBarHarness);
+      await saveBar.clickSubmit();
+
+      expect(dialogSpy).not.toHaveBeenCalled();
       httpTestingController.expectNone({
         url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${API_ID}/plans/${PLAN_WITH_BOOTSTRAP.id}`,
         method: 'PUT',

--- a/gravitee-apim-console-webui/src/management/api/plans/edit/api-plan-edit.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/plans/edit/api-plan-edit.component.spec.ts
@@ -23,6 +23,8 @@ import { set } from 'lodash';
 import { GioSaveBarHarness } from '@gravitee/ui-particles-angular';
 import { ActivatedRoute, Router } from '@angular/router';
 import { MatStepperHarness } from '@angular/material/stepper/testing';
+import { MatDialog } from '@angular/material/dialog';
+import { of } from 'rxjs';
 
 import { ApiPlanEditComponent } from './api-plan-edit.component';
 
@@ -38,6 +40,7 @@ import {
   fakeApiFederated,
   fakeApiV2,
   fakeApiV4,
+  fakeNativeKafkaApiV4,
   fakePlanFederated,
   fakePlanV2,
   fakePlanV4,
@@ -546,6 +549,119 @@ describe('ApiPlanEditComponent', () => {
         req.flush({});
         expect(routerNavigationSpy).toHaveBeenCalled();
       });
+    });
+  });
+
+  describe('With a deployed Native Kafka API — bootstrap port confirmation dialog', () => {
+    const TAG_1_ID = 'tag-1';
+    const PLAN_WITH_BOOTSTRAP = fakePlanV4({ apiId: API_ID, security: { type: 'KEY_LESS' }, bootstrapPort: 9092 });
+    const DEPLOYED_NATIVE_API = fakeNativeKafkaApiV4({ id: API_ID, deployedAt: new Date() });
+
+    const setupDeployedNativeEdit = () => {
+      configureTestingModule(PLAN_WITH_BOOTSTRAP.id);
+      fixture.detectChanges();
+      expectApiGetRequest(DEPLOYED_NATIVE_API);
+      expectPlanGetRequest(API_ID, PLAN_WITH_BOOTSTRAP);
+    };
+
+    const flushPlanFormRequests = (planForm: any) => {
+      planForm.httpRequest(httpTestingController).expectTagsListRequest([{ id: TAG_1_ID, name: 'Tag 1', key: TAG_1_ID }]);
+      planForm.httpRequest(httpTestingController).expectGroupListRequest([]);
+      planForm.httpRequest(httpTestingController).expectDocumentationSearchRequest(API_ID, []);
+      planForm.httpRequest(httpTestingController).expectCurrentUserTagsRequest([]);
+    };
+
+    it('should open the dialog when bootstrap port changes, and abort save when dialog resolves false', async () => {
+      setupDeployedNativeEdit();
+
+      const planForm = await loader.getHarness(ApiPlanFormHarness);
+      flushPlanFormRequests(planForm);
+      fixture.detectChanges();
+
+      // Change the name to dirty the form
+      const nameInput = await planForm.getNameInput();
+      await nameInput.setValue('Updated plan');
+
+      // Change the bootstrap port to a new value
+      const bootstrapPortInput = await planForm.getBootstrapPortInput();
+      await bootstrapPortInput.setValue('9999');
+      fixture.detectChanges();
+
+      const matDialog = TestBed.inject(MatDialog);
+      const dialogSpy = jest.spyOn(matDialog, 'open').mockReturnValue({
+        afterClosed: () => of(false),
+      } as any);
+
+      const saveBar = await loader.getHarness(GioSaveBarHarness);
+      await saveBar.clickSubmit();
+
+      expect(dialogSpy).toHaveBeenCalled();
+      httpTestingController.expectNone({
+        url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${API_ID}/plans/${PLAN_WITH_BOOTSTRAP.id}`,
+        method: 'PUT',
+      });
+      expect(routerNavigationSpy).not.toHaveBeenCalled();
+    });
+
+    it('should save when dialog resolves true after bootstrap port change', async () => {
+      setupDeployedNativeEdit();
+
+      const planForm = await loader.getHarness(ApiPlanFormHarness);
+      flushPlanFormRequests(planForm);
+      fixture.detectChanges();
+
+      const nameInput = await planForm.getNameInput();
+      await nameInput.setValue('Updated plan');
+
+      const bootstrapPortInput = await planForm.getBootstrapPortInput();
+      await bootstrapPortInput.setValue('9999');
+      fixture.detectChanges();
+
+      const matDialog = TestBed.inject(MatDialog);
+      jest.spyOn(matDialog, 'open').mockReturnValue({
+        afterClosed: () => of(true),
+      } as any);
+
+      const saveBar = await loader.getHarness(GioSaveBarHarness);
+      await saveBar.clickSubmit();
+
+      expectPlanGetRequest(API_ID, PLAN_WITH_BOOTSTRAP);
+      const req = httpTestingController.expectOne({
+        url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${API_ID}/plans/${PLAN_WITH_BOOTSTRAP.id}`,
+        method: 'PUT',
+      });
+      expect(req.request.body).toEqual(expect.objectContaining({ name: 'Updated plan' }));
+      req.flush({});
+      expect(routerNavigationSpy).toHaveBeenCalled();
+    });
+
+    it('should save directly (no dialog) when bootstrap port is unchanged', async () => {
+      setupDeployedNativeEdit();
+
+      const planForm = await loader.getHarness(ApiPlanFormHarness);
+      flushPlanFormRequests(planForm);
+      fixture.detectChanges();
+
+      // Change only the name, not the bootstrap port
+      const nameInput = await planForm.getNameInput();
+      await nameInput.setValue('Updated plan');
+      fixture.detectChanges();
+
+      const matDialog = TestBed.inject(MatDialog);
+      const dialogSpy = jest.spyOn(matDialog, 'open');
+
+      const saveBar = await loader.getHarness(GioSaveBarHarness);
+      await saveBar.clickSubmit();
+
+      expect(dialogSpy).not.toHaveBeenCalled();
+
+      expectPlanGetRequest(API_ID, PLAN_WITH_BOOTSTRAP);
+      const req = httpTestingController.expectOne({
+        url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${API_ID}/plans/${PLAN_WITH_BOOTSTRAP.id}`,
+        method: 'PUT',
+      });
+      req.flush({});
+      expect(routerNavigationSpy).toHaveBeenCalled();
     });
   });
 

--- a/gravitee-apim-console-webui/src/management/api/plans/edit/api-plan-edit.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/plans/edit/api-plan-edit.component.ts
@@ -142,7 +142,16 @@ export class ApiPlanEditComponent implements OnInit, OnDestroy {
     const newBootstrapPort = (planFormValue as any).bootstrapPort ?? undefined;
     const oldBootstrapPort = (this.originalPlan as any)?.bootstrapPort ?? undefined;
     const deployed = (this.api as ApiV4)?.deployedAt != null;
-    const needsBootstrapConfirm = this.mode === 'edit' && this.isNative && deployed && newBootstrapPort !== oldBootstrapPort;
+    // Only confirm when an EXISTING bootstrap port is being changed to a different one — that breaks
+    // currently-connected consumers. Setting a port for the first time (host -> port migration) or
+    // clearing it is not a breaking change for existing port-mode clients, so no dialog is shown.
+    const needsBootstrapConfirm =
+      this.mode === 'edit' &&
+      this.isNative &&
+      deployed &&
+      oldBootstrapPort != null &&
+      newBootstrapPort != null &&
+      newBootstrapPort !== oldBootstrapPort;
 
     const kafkaHost = (this.api as ApiV4)?.listeners?.find((listener): listener is KafkaListener => listener.type === 'KAFKA')?.host;
 

--- a/gravitee-apim-console-webui/src/management/api/plans/edit/api-plan-edit.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/plans/edit/api-plan-edit.component.ts
@@ -18,12 +18,15 @@ import { UntypedFormControl, UntypedFormGroup } from '@angular/forms';
 import { EMPTY, of, Subject } from 'rxjs';
 import { catchError, switchMap, takeUntil, tap } from 'rxjs/operators';
 import { ActivatedRoute, Router } from '@angular/router';
+import { MatDialog } from '@angular/material/dialog';
+
+import { KafkaBootstrapPortChangeDialogComponent } from './kafka-bootstrap-port-change-dialog/kafka-bootstrap-port-change-dialog.component';
 
 import { SnackBarService } from '../../../../services-ngx/snack-bar.service';
 import { GioPermissionService } from '../../../../shared/components/gio-permission/gio-permission.service';
 import { ApiPlanFormComponent, PlanFormValue } from '../../component/plan/api-plan-form.component';
 import { AVAILABLE_PLANS_FOR_MENU, PlanFormType, PlanMenuItemVM } from '../../../../services-ngx/constants.service';
-import { Api, ApiV4, CreatePlanV2, CreatePlanV4, Plan, PlanStatus } from '../../../../entities/management-api-v2';
+import { Api, ApiV4, CreatePlanV2, CreatePlanV4, KafkaListener, Plan, PlanStatus } from '../../../../entities/management-api-v2';
 import { ApiV2Service } from '../../../../services-ngx/api-v2.service';
 import { ApiPlanV2Service } from '../../../../services-ngx/api-plan-v2.service';
 import { isApiV4 } from '../../../../util';
@@ -51,6 +54,8 @@ export class ApiPlanEditComponent implements OnInit, OnDestroy {
   public hasTcpListeners;
   public isNative: boolean = false;
 
+  private originalPlan?: Plan;
+
   constructor(
     private readonly router: Router,
     private readonly activatedRoute: ActivatedRoute,
@@ -59,6 +64,7 @@ export class ApiPlanEditComponent implements OnInit, OnDestroy {
     private readonly snackBarService: SnackBarService,
     private readonly permissionService: GioPermissionService,
     private readonly changeDetectorRef: ChangeDetectorRef,
+    private readonly matDialog: MatDialog,
   ) {}
 
   ngOnInit() {
@@ -79,6 +85,7 @@ export class ApiPlanEditComponent implements OnInit, OnDestroy {
             : of(undefined),
         ),
         tap((plan: Plan) => {
+          this.originalPlan = plan;
           this.currentPlanStatus = plan?.status;
           this.planForm = new UntypedFormGroup({
             plan: new UntypedFormControl({
@@ -132,8 +139,29 @@ export class ApiPlanEditComponent implements OnInit, OnDestroy {
               : createV2Plan(planFormValue, this.planMenuItem.planFormType)),
           });
 
-    savePlan$
+    const newBootstrapPort = (planFormValue as any).bootstrapPort ?? undefined;
+    const oldBootstrapPort = (this.originalPlan as any)?.bootstrapPort ?? undefined;
+    const deployed = (this.api as ApiV4)?.deployedAt != null;
+    const needsBootstrapConfirm = this.mode === 'edit' && this.isNative && deployed && newBootstrapPort !== oldBootstrapPort;
+
+    const kafkaHost = (this.api as ApiV4)?.listeners?.find((listener): listener is KafkaListener => listener.type === 'KAFKA')?.host;
+
+    const confirm$ = needsBootstrapConfirm
+      ? this.matDialog
+          .open<KafkaBootstrapPortChangeDialogComponent, { host?: string; oldPort?: number; newPort?: number }, boolean>(
+            KafkaBootstrapPortChangeDialogComponent,
+            {
+              data: { host: kafkaHost, oldPort: oldBootstrapPort, newPort: newBootstrapPort },
+              width: '500px',
+              role: 'alertdialog',
+            },
+          )
+          .afterClosed()
+      : of(true);
+
+    confirm$
       .pipe(
+        switchMap(confirmed => (confirmed ? savePlan$ : EMPTY)),
         tap(() => this.snackBarService.success('Configuration successfully saved!')),
         catchError(error => {
           this.snackBarService.error(error.error?.message ?? 'An error occurs while saving configuration');

--- a/gravitee-apim-console-webui/src/management/api/plans/edit/api-plan-edit.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/plans/edit/api-plan-edit.component.ts
@@ -139,18 +139,18 @@ export class ApiPlanEditComponent implements OnInit, OnDestroy {
               : createV2Plan(planFormValue, this.planMenuItem.planFormType)),
           });
 
-    const newBootstrapPort = (planFormValue as any).bootstrapPort ?? undefined;
-    const oldBootstrapPort = (this.originalPlan as any)?.bootstrapPort ?? undefined;
+    const newBootstrapPort = (planFormValue as any).bootstrapPort;
+    const oldBootstrapPort = (this.originalPlan as any)?.bootstrapPort;
     const deployed = (this.api as ApiV4)?.deployedAt != null;
-    // Only confirm when an EXISTING bootstrap port is being changed to a different one — that breaks
-    // currently-connected consumers. Setting a port for the first time (host -> port migration) or
-    // clearing it is not a breaking change for existing port-mode clients, so no dialog is shown.
+    // Confirm whenever a deployed plan's EXISTING bootstrap port changes — including being cleared.
+    // Changing the port breaks currently-connected consumers; clearing it disables port-based routing
+    // entirely (the API reverts to host-based routing), which also breaks existing port-mode clients.
+    // Setting a port for the first time (host -> port migration) is NOT breaking, so no dialog is shown.
     const needsBootstrapConfirm =
       this.mode === 'edit' &&
       this.isNative &&
       deployed &&
       oldBootstrapPort != null &&
-      newBootstrapPort != null &&
       newBootstrapPort !== oldBootstrapPort;
 
     const kafkaHost = (this.api as ApiV4)?.listeners?.find((listener): listener is KafkaListener => listener.type === 'KAFKA')?.host;

--- a/gravitee-apim-console-webui/src/management/api/plans/edit/api-plan-edit.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/plans/edit/api-plan-edit.component.ts
@@ -147,11 +147,7 @@ export class ApiPlanEditComponent implements OnInit, OnDestroy {
     // entirely (the API reverts to host-based routing), which also breaks existing port-mode clients.
     // Setting a port for the first time (host -> port migration) is NOT breaking, so no dialog is shown.
     const needsBootstrapConfirm =
-      this.mode === 'edit' &&
-      this.isNative &&
-      deployed &&
-      oldBootstrapPort != null &&
-      newBootstrapPort !== oldBootstrapPort;
+      this.mode === 'edit' && this.isNative && deployed && oldBootstrapPort != null && newBootstrapPort !== oldBootstrapPort;
 
     const kafkaHost = (this.api as ApiV4)?.listeners?.find((listener): listener is KafkaListener => listener.type === 'KAFKA')?.host;
 

--- a/gravitee-apim-console-webui/src/management/api/plans/edit/kafka-bootstrap-port-change-dialog/kafka-bootstrap-port-change-dialog.component.html
+++ b/gravitee-apim-console-webui/src/management/api/plans/edit/kafka-bootstrap-port-change-dialog/kafka-bootstrap-port-change-dialog.component.html
@@ -1,0 +1,44 @@
+<!--
+
+    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<h2 mat-dialog-title>Change bootstrap port</h2>
+
+<mat-dialog-content>
+  <gio-banner-warning> Warning: changing the bootstrap port will break all consumers of this plan. </gio-banner-warning>
+
+  @if (data.host) {
+    <p>
+      The new bootstrap address will be <strong>{{ data.host }}:{{ data.newPort }}</strong
+      >. All clients currently configured with <strong>{{ data.host }}:{{ data.oldPort }}</strong> will lose connectivity until they update
+      their Kafka bootstrap configuration.
+    </p>
+  } @else {
+    <p>
+      The bootstrap port is changing from <strong>{{ data.oldPort }}</strong> to <strong>{{ data.newPort }}</strong
+      >. All clients currently configured with the old port will lose connectivity until they update their Kafka bootstrap configuration.
+    </p>
+  }
+
+  <mat-checkbox (change)="isConfirmed = $event.checked"
+    >I understand that all consumers of this plan must update their bootstrap configuration.</mat-checkbox
+  >
+</mat-dialog-content>
+
+<mat-dialog-actions align="end">
+  <button mat-flat-button [mat-dialog-close]="false">Cancel</button>
+  <button mat-raised-button color="primary" [mat-dialog-close]="true" [disabled]="!isConfirmed">Confirm and save</button>
+</mat-dialog-actions>

--- a/gravitee-apim-console-webui/src/management/api/plans/edit/kafka-bootstrap-port-change-dialog/kafka-bootstrap-port-change-dialog.component.html
+++ b/gravitee-apim-console-webui/src/management/api/plans/edit/kafka-bootstrap-port-change-dialog/kafka-bootstrap-port-change-dialog.component.html
@@ -15,12 +15,25 @@
     limitations under the License.
 
 -->
-<h2 mat-dialog-title>Change bootstrap port</h2>
+<h2 mat-dialog-title>{{ data.newPort == null ? 'Remove bootstrap port' : 'Change bootstrap port' }}</h2>
 
 <mat-dialog-content>
-  <gio-banner-warning> Warning: changing the bootstrap port will break all consumers of this plan. </gio-banner-warning>
+  <gio-banner-warning>
+    Warning:
+    {{
+      data.newPort == null
+        ? 'removing the bootstrap port will disable port-based routing and break all consumers of this plan.'
+        : 'changing the bootstrap port will break all consumers of this plan.'
+    }}
+  </gio-banner-warning>
 
-  @if (data.host) {
+  @if (data.newPort == null) {
+    <p>
+      Removing the bootstrap port will disable port-based routing for this API; it will revert to host-based routing. All clients currently
+      configured with <strong>{{ data.host ? data.host + ':' + data.oldPort : data.oldPort }}</strong> will lose connectivity until they
+      update their Kafka bootstrap configuration.
+    </p>
+  } @else if (data.host) {
     <p>
       The new bootstrap address will be <strong>{{ data.host }}:{{ data.newPort }}</strong
       >. All clients currently configured with <strong>{{ data.host }}:{{ data.oldPort }}</strong> will lose connectivity until they update

--- a/gravitee-apim-console-webui/src/management/api/plans/edit/kafka-bootstrap-port-change-dialog/kafka-bootstrap-port-change-dialog.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/plans/edit/kafka-bootstrap-port-change-dialog/kafka-bootstrap-port-change-dialog.component.spec.ts
@@ -116,4 +116,22 @@ describe('KafkaBootstrapPortChangeDialogComponent', () => {
       expect(compiled.textContent).not.toContain(':9092');
     });
   });
+
+  describe('removing the port (no newPort)', () => {
+    beforeEach(() => {
+      createComponent({ host: 'kafka.example.com', oldPort: 9092 });
+    });
+
+    it('should render the removal title', () => {
+      const compiled = fixture.nativeElement as HTMLElement;
+      expect(compiled.textContent).toContain('Remove bootstrap port');
+    });
+
+    it('should warn that port-based routing will be disabled', () => {
+      const compiled = fixture.nativeElement as HTMLElement;
+      expect(compiled.textContent).toContain('disable port-based routing');
+      expect(compiled.textContent).toContain('revert to host-based routing');
+      expect(compiled.textContent).toContain('kafka.example.com:9092');
+    });
+  });
 });

--- a/gravitee-apim-console-webui/src/management/api/plans/edit/kafka-bootstrap-port-change-dialog/kafka-bootstrap-port-change-dialog.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/plans/edit/kafka-bootstrap-port-change-dialog/kafka-bootstrap-port-change-dialog.component.spec.ts
@@ -1,0 +1,119 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+import { HarnessLoader } from '@angular/cdk/testing';
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { MatButtonHarness } from '@angular/material/button/testing';
+import { MatCheckboxHarness } from '@angular/material/checkbox/testing';
+import { MatIconTestingModule } from '@angular/material/icon/testing';
+
+import { KafkaBootstrapPortChangeDialogComponent } from './kafka-bootstrap-port-change-dialog.component';
+
+describe('KafkaBootstrapPortChangeDialogComponent', () => {
+  let fixture: ComponentFixture<KafkaBootstrapPortChangeDialogComponent>;
+  let component: KafkaBootstrapPortChangeDialogComponent;
+  let loader: HarnessLoader;
+  let dialogRefClose: jest.Mock;
+
+  const createComponent = (data: { host?: string; oldPort?: number; newPort?: number }) => {
+    dialogRefClose = jest.fn();
+
+    TestBed.configureTestingModule({
+      imports: [KafkaBootstrapPortChangeDialogComponent, NoopAnimationsModule, MatIconTestingModule],
+      providers: [
+        { provide: MAT_DIALOG_DATA, useValue: data },
+        { provide: MatDialogRef, useValue: { close: dialogRefClose } },
+      ],
+    });
+
+    fixture = TestBed.createComponent(KafkaBootstrapPortChangeDialogComponent);
+    component = fixture.componentInstance;
+    loader = TestbedHarnessEnvironment.loader(fixture);
+    fixture.detectChanges();
+  };
+
+  describe('with host and ports', () => {
+    beforeEach(() => {
+      createComponent({ host: 'kafka.example.com', oldPort: 9092, newPort: 9999 });
+    });
+
+    it('should render the warning banner', () => {
+      const compiled = fixture.nativeElement as HTMLElement;
+      expect(compiled.textContent).toContain('Warning: changing the bootstrap port will break all consumers of this plan.');
+    });
+
+    it('should display the full address change text', () => {
+      const compiled = fixture.nativeElement as HTMLElement;
+      expect(compiled.textContent).toContain('kafka.example.com:9999');
+      expect(compiled.textContent).toContain('kafka.example.com:9092');
+    });
+
+    it('should have the Confirm button disabled initially', async () => {
+      const confirmButton = await loader.getHarness(MatButtonHarness.with({ text: 'Confirm and save' }));
+      expect(await confirmButton.isDisabled()).toBe(true);
+    });
+
+    it('should enable the Confirm button after checking the checkbox', async () => {
+      const checkbox = await loader.getHarness(MatCheckboxHarness);
+      await checkbox.check();
+
+      const confirmButton = await loader.getHarness(MatButtonHarness.with({ text: 'Confirm and save' }));
+      expect(await confirmButton.isDisabled()).toBe(false);
+    });
+
+    it('should set isConfirmed to true after checking the checkbox', async () => {
+      expect(component.isConfirmed).toBe(false);
+
+      const checkbox = await loader.getHarness(MatCheckboxHarness);
+      await checkbox.check();
+
+      expect(component.isConfirmed).toBe(true);
+    });
+
+    it('should have the Cancel button in the DOM', async () => {
+      const cancelButton = await loader.getHarness(MatButtonHarness.with({ text: 'Cancel' }));
+      expect(cancelButton).not.toBeNull();
+    });
+
+    it('should keep the Confirm button disabled after unchecking the checkbox', async () => {
+      const checkbox = await loader.getHarness(MatCheckboxHarness);
+      await checkbox.check();
+      await checkbox.uncheck();
+
+      const confirmButton = await loader.getHarness(MatButtonHarness.with({ text: 'Confirm and save' }));
+      expect(await confirmButton.isDisabled()).toBe(true);
+    });
+  });
+
+  describe('without host (port-only variant)', () => {
+    beforeEach(() => {
+      createComponent({ oldPort: 9092, newPort: 9999 });
+    });
+
+    it('should display port-only change text', () => {
+      const compiled = fixture.nativeElement as HTMLElement;
+      expect(compiled.textContent).toContain('9092');
+      expect(compiled.textContent).toContain('9999');
+    });
+
+    it('should not display host-based address text', () => {
+      const compiled = fixture.nativeElement as HTMLElement;
+      expect(compiled.textContent).not.toContain(':9092');
+    });
+  });
+});

--- a/gravitee-apim-console-webui/src/management/api/plans/edit/kafka-bootstrap-port-change-dialog/kafka-bootstrap-port-change-dialog.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/plans/edit/kafka-bootstrap-port-change-dialog/kafka-bootstrap-port-change-dialog.component.ts
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Component, Inject } from '@angular/core';
+import {
+  MAT_DIALOG_DATA,
+  MatDialogActions,
+  MatDialogClose,
+  MatDialogContent,
+  MatDialogRef,
+  MatDialogTitle,
+} from '@angular/material/dialog';
+import { MatButton } from '@angular/material/button';
+import { MatCheckbox } from '@angular/material/checkbox';
+import { GioBannerModule } from '@gravitee/ui-particles-angular';
+
+export interface KafkaBootstrapPortChangeDialogData {
+  host?: string;
+  oldPort?: number;
+  newPort?: number;
+}
+
+@Component({
+  selector: 'kafka-bootstrap-port-change-dialog',
+  standalone: true,
+  imports: [GioBannerModule, MatDialogTitle, MatDialogContent, MatDialogActions, MatDialogClose, MatButton, MatCheckbox],
+  templateUrl: './kafka-bootstrap-port-change-dialog.component.html',
+})
+export class KafkaBootstrapPortChangeDialogComponent {
+  public isConfirmed = false;
+
+  constructor(
+    public readonly dialogRef: MatDialogRef<KafkaBootstrapPortChangeDialogComponent, boolean>,
+    @Inject(MAT_DIALOG_DATA) public readonly data: KafkaBootstrapPortChangeDialogData,
+  ) {}
+}

--- a/gravitee-apim-console-webui/src/management/settings/portal-settings/portal-settings.component.html
+++ b/gravitee-apim-console-webui/src/management/settings/portal-settings/portal-settings.component.html
@@ -184,7 +184,8 @@
           class="portal__form__card__form-field"
         >
           <gio-form-label
-            >Enable Kafka port-based routing configuration on native plans (exposes the bootstrap port and broker range fields)</gio-form-label
+            >Enable Kafka port-based routing configuration on native plans (exposes the bootstrap port and broker range
+            fields)</gio-form-label
           >
           <mat-slide-toggle formControlName="enabled" gioFormSlideToggle aria-label="Enable Kafka port routing"></mat-slide-toggle>
         </gio-form-slide-toggle>

--- a/gravitee-apim-console-webui/src/management/settings/portal-settings/portal-settings.component.html
+++ b/gravitee-apim-console-webui/src/management/settings/portal-settings/portal-settings.component.html
@@ -175,6 +175,20 @@
           </mat-radio-button>
         </mat-radio-group>
       </mat-card-content>
+
+      <mat-card-content formGroupName="kafkaPortRouting">
+        <h3 class="portal__form__card__title">Kafka port routing</h3>
+        <gio-form-slide-toggle
+          [matTooltip]="'Configuration provided by the system'"
+          [matTooltipDisabled]="!isReadonly('console.kafka.portRouting.enabled')"
+          class="portal__form__card__form-field"
+        >
+          <gio-form-label
+            >Enable Kafka port-based routing configuration on native plans (exposes the bootstrap port and broker range fields)</gio-form-label
+          >
+          <mat-slide-toggle formControlName="enabled" gioFormSlideToggle aria-label="Enable Kafka port routing"></mat-slide-toggle>
+        </gio-form-slide-toggle>
+      </mat-card-content>
     </mat-card>
 
     <h2>Portal</h2>

--- a/gravitee-apim-console-webui/src/management/settings/portal-settings/portal-settings.component.ts
+++ b/gravitee-apim-console-webui/src/management/settings/portal-settings/portal-settings.component.ts
@@ -71,6 +71,9 @@ interface PortalForm {
       enabled: FormControl<boolean>;
     }>;
   }>;
+  kafkaPortRouting: FormGroup<{
+    enabled: FormControl<boolean>;
+  }>;
   portal: FormGroup<{
     apikeyHeader: FormControl<string>;
     url: FormControl<string>;
@@ -324,6 +327,12 @@ export class PortalSettingsComponent implements OnInit {
             value: this.settings.dashboards.apiStatus.enabled,
             disabled: this.isReadonly('console.dashboards.apiStatus.enabled'),
           }),
+        }),
+      }),
+      kafkaPortRouting: new FormGroup({
+        enabled: new FormControl({
+          value: this.settings.kafkaPortRouting?.enabled ?? false,
+          disabled: this.isReadonly('console.kafka.portRouting.enabled'),
         }),
       }),
       portal: new FormGroup({
@@ -633,6 +642,10 @@ export class PortalSettingsComponent implements OnInit {
       dashboards: {
         ...this.settings.dashboards,
         ...this.portalForm.get('dashboards').value,
+      },
+      kafkaPortRouting: {
+        ...this.settings.kafkaPortRouting,
+        ...this.portalForm.get('kafkaPortRouting').value,
       },
       portal: {
         ...this.settings.portal,

--- a/gravitee-apim-console-webui/src/shared/testing/gio-testing.module.ts
+++ b/gravitee-apim-console-webui/src/shared/testing/gio-testing.module.ts
@@ -50,6 +50,9 @@ export const CONSTANTS_TESTING: Constants = {
       apiQualityMetrics: {
         enabled: false,
       },
+      kafkaPortRouting: {
+        enabled: true,
+      },
     } as any,
     v2BaseURL: 'https://url.test:3000/management/v2/environments/DEFAULT',
   },

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/parameters/Key.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/parameters/Key.java
@@ -317,6 +317,7 @@ public enum Key {
     ),
 
     API_REVIEW_ENABLED("api.review.enabled", Boolean.FALSE.toString(), new HashSet<>(Arrays.asList(ENVIRONMENT, ORGANIZATION, SYSTEM))),
+    KAFKA_PORT_ROUTING_ENABLED("console.kafka.portRouting.enabled", Boolean.FALSE.toString(), new HashSet<>(singletonList(ENVIRONMENT))),
     MAINTENANCE_MODE_ENABLED("maintenance.enabled", Boolean.FALSE.toString(), new HashSet<>(Arrays.asList(ORGANIZATION, SYSTEM))),
     NEWSLETTER_ENABLED("newsletter.enabled", "true", new HashSet<>(Arrays.asList(ORGANIZATION, SYSTEM))),
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/settings/KafkaPortRouting.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/settings/KafkaPortRouting.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.model.settings;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import io.gravitee.rest.api.model.annotations.ParameterKey;
+import io.gravitee.rest.api.model.parameters.Key;
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * @author GraviteeSource Team
+ */
+@Getter
+@Setter
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class KafkaPortRouting {
+
+    @ParameterKey(Key.KAFKA_PORT_ROUTING_ENABLED)
+    private Boolean enabled;
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/settings/PortalConfigEntity.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/settings/PortalConfigEntity.java
@@ -45,6 +45,7 @@ public class PortalConfigEntity {
     private Dashboards dashboards;
     private AccessPoints accessPoints;
     private Logging logging;
+    private KafkaPortRouting kafkaPortRouting;
 
     public PortalConfigEntity() {
         super();
@@ -67,5 +68,6 @@ public class PortalConfigEntity {
         dashboards = new Dashboards();
         accessPoints = new AccessPoints();
         logging = new Logging();
+        kafkaPortRouting = new KafkaPortRouting();
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/settings/PortalSettingsEntity.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/settings/PortalSettingsEntity.java
@@ -55,6 +55,7 @@ public class PortalSettingsEntity extends AbstractCommonSettingsEntity {
     private PortalReCaptcha reCaptcha;
     private PortalScheduler scheduler;
     private Dashboards dashboards;
+    private KafkaPortRouting kafkaPortRouting;
 
     public PortalSettingsEntity() {
         super();
@@ -76,6 +77,7 @@ public class PortalSettingsEntity extends AbstractCommonSettingsEntity {
         reCaptcha = new PortalReCaptcha();
         scheduler = new PortalScheduler();
         dashboards = new Dashboards();
+        kafkaPortRouting = new KafkaPortRouting();
         logging = new Logging();
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ConfigServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ConfigServiceImpl.java
@@ -482,6 +482,7 @@ public class ConfigServiceImpl extends AbstractService implements ConfigService 
             portalConfigEntity.getLogging().getMessageSampling().getProbabilistic(),
             portalConfigEntity.getLogging().getMessageSampling().getTemporal(),
             portalConfigEntity.getLogging().getMessageSampling().getWindowedCount(),
+            portalConfigEntity.getKafkaPortRouting(),
         };
     }
 


### PR DESCRIPTION
## Issue

- https://gravitee.atlassian.net/browse/APIM-13600
- https://gravitee.atlassian.net/browse/APIM-13484

## Description

Surface per-plan Kafka port-routing configuration in the Console for **native Kafka APIs** (v4, `type: NATIVE`). The gateway/REST/persistence layers already support `bootstrapPort`, `brokerRangeStart`, `brokerRangeEnd` on the native plan; this PR exposes them in the UI.

Changes live in the **shared plan form** (`api-plan-form` / `plan-edit-general-step`), so they apply to both the standalone plan edit screen and the v4 creation wizard (which reuses the form with `[isNative]`).

A NATIVE-only "Kafka port routing" section adds three **optional** number inputs — **Bootstrap port**, **Broker range start**, **Broker range end** (the ticket's `nodeIdRange`) — with live client-side validation:

- each value within `[1024, 65535]`
- `brokerRangeStart <= brokerRangeEnd`
- `bootstrapPort` must not fall inside `[brokerRangeStart, brokerRangeEnd]`

Cross-plan port conflicts remain enforced server-side at save and surface via the existing error snackbar. Empty inputs map to `undefined` (host/SNI mode).

<img width="880" height="302" alt="Capture d’écran 2026-05-28 à 21 02 21" src="https://github.com/user-attachments/assets/a9820d80-984b-44cb-a4f3-46dcd1a64544" />

### Editing port fields on a deployed plan (per the port-based-routing PRD)

All three port fields **remain editable after deployment** — the field is **not** disabled. Instead:

- Changing the **bootstrap port** (breaking change) prompts a **confirmation dialog** with an acknowledgement checkbox before saving; cancelling aborts the save.
- Changing the **broker range** (transparent — clients auto-recover via metadata refresh) shows a **non-blocking informational banner**.

This keeps the **host-mode → port-mode migration** path open: an API deployed in host mode (no bootstrap port) can still set one and redeploy.

## Additional context

- The original APIM-13600 AC *"Console allows selecting routingMode=port"* is intentionally **not** implemented — `kafka.routingMode` is gateway-level config (`gravitee.yml`), not per-API. That AC should be removed.
- The APIM-13600 AC *"bootstrap port can no longer be modified once deployed (field disabled)"* is superseded by the PRD's warn/confirm behavior above and should be reworded.
- No backend changes — OpenAPI `PlanV4`/`CreatePlanV4`/`UpdatePlanV4` already carry these fields.
- Tests: unit specs for the form fields + live validation (incl. DOM-level cross-field error assertions), the confirmation dialog, the save-gating in `api-plan-edit`, and the broker-range banner. eslint + prettier clean.
- Verified locally against a running Console + management API.