### PR TITLE
fix: preserve colons in relative endpoint paths

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/reactive/core/v4/invoker/HttpEndpointInvoker.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/reactive/core/v4/invoker/HttpEndpointInvoker.java
@@ -46,7 +46,7 @@ public class HttpEndpointInvoker implements HttpInvoker, Invoker {
     private static final String MATCH_GROUP_ENDPOINT = "endpoint";
     private static final String MATCH_GROUP_PATH = "path";
     private static final Pattern ENDPOINT_PATTERN = Pattern.compile(
-        "^(?<" + MATCH_GROUP_ENDPOINT + ">[^:]+):(?<" + MATCH_GROUP_PATH + ">.*)$"
+        "^(?<" + MATCH_GROUP_ENDPOINT + ">[^/:][^:]*):(?<" + MATCH_GROUP_PATH + ">.*)$"
     );
 
     static final Set<String> KNOWN_URL_SCHEMES = Set.of("http", "https", "ws", "wss");
@@ -121,7 +121,6 @@ public class HttpEndpointInvoker implements HttpInvoker, Invoker {
                     ctx.setAttribute(ATTR_REQUEST_ENDPOINT, matcher.group(MATCH_GROUP_PATH));
                 }
             }
-            // No else needed: any string with a colon matches ENDPOINT_PATTERN, including all absolute URIs.
         }
 
         final ManagedEndpoint managedEndpoint = endpointManager.next(endpointCriteria);

--- a/gravitee-apim-gateway/gravitee-apim-gateway-core/src/test/java/io/gravitee/gateway/reactive/core/v4/invoker/HttpEndpointInvokerTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-core/src/test/java/io/gravitee/gateway/reactive/core/v4/invoker/HttpEndpointInvokerTest.java
@@ -146,6 +146,26 @@ class HttpEndpointInvokerTest {
         verify(ctx).setAttribute(ATTR_REQUEST_ENDPOINT, "with:colon:");
     }
 
+    @ParameterizedTest
+    @ValueSource(strings = { "/bar:analyze", "/document:translate", "/openai/deployments/gpt-4o/chat/completions:stream" })
+    void should_treat_relative_path_with_colon_as_literal_request_endpoint(String endpointTarget) {
+        final HttpEntrypointAsyncConnector httpEntrypointAsyncConnector = mock(HttpEntrypointAsyncConnector.class);
+        when(ctx.getInternalAttribute(ATTR_INTERNAL_ENTRYPOINT_CONNECTOR)).thenReturn(httpEntrypointAsyncConnector);
+        when(ctx.getAttribute(ATTR_REQUEST_ENDPOINT)).thenReturn(endpointTarget);
+        when(ctx.getTemplateEngine()).thenReturn(templateEngine);
+        when(templateEngine.getValue(anyString(), eq(String.class))).thenAnswer(i -> i.getArgument(0));
+        when(endpointManager.next(any(EndpointCriteria.class))).thenReturn(managedEndpoint);
+        when(managedEndpoint.getConnector()).thenReturn(endpointConnector);
+        when(endpointConnector.connect(ctx)).thenReturn(Completable.complete());
+
+        final TestObserver<Void> obs = cut.invoke(ctx).test();
+
+        obs.assertNoValues();
+
+        verify(endpointManager).next(argThat(criteria -> criteria.getName() == null));
+        verify(ctx, never()).setAttribute(eq(ATTR_REQUEST_ENDPOINT), anyString());
+    }
+
     @Test
     void shouldConnectToNextEndpointConnectorWhenUrlEndpointAttributeIsDefined() {
         final HttpEntrypointAsyncConnector httpEntrypointAsyncConnector = mock(HttpEntrypointAsyncConnector.class);


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-14220

**Description**

Fixed V4 HTTP endpoint resolution so relative endpoint paths containing colons are preserved as literal paths.

HttpEndpointInvoker no longer interprets values like /bar:analyze or /document:translate as endpointName:path references.

**Additional context**

Added regression coverage for relative paths with colons, including Azure-style endpoints such as /document:translate and /openai/deployments/gpt-4o/chat/completions:stream.