### PR TITLE
Migrate rest-api-security junit 4 tests to junit 5

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-security/src/test/java/io/gravitee/rest/api/security/authentication/GraviteeAuthenticationDetailsTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-security/src/test/java/io/gravitee/rest/api/security/authentication/GraviteeAuthenticationDetailsTest.java
@@ -15,8 +15,8 @@
  */
 package io.gravitee.rest.api.security.authentication;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -24,13 +24,16 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpSession;
 import java.util.HashMap;
 import java.util.Map;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 import org.springframework.security.web.authentication.WebAuthenticationDetails;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.WARN)
 public class GraviteeAuthenticationDetailsTest {
 
     @Mock

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-security/src/test/java/io/gravitee/rest/api/security/cookies/CookieGeneratorTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-security/src/test/java/io/gravitee/rest/api/security/cookies/CookieGeneratorTest.java
@@ -15,10 +15,10 @@
  */
 package io.gravitee.rest.api.security.cookies;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import jakarta.servlet.http.Cookie;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.core.env.Environment;
 import org.springframework.mock.env.MockEnvironment;
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-security/src/test/java/io/gravitee/rest/api/security/cors/GraviteeCorsEnvironmentConfigurationTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-security/src/test/java/io/gravitee/rest/api/security/cors/GraviteeCorsEnvironmentConfigurationTest.java
@@ -39,7 +39,6 @@ import io.gravitee.rest.api.service.common.ExecutionContext;
 import io.gravitee.rest.api.service.common.GraviteeContext;
 import java.util.Arrays;
 import java.util.List;
-import org.junit.After;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-security/src/test/java/io/gravitee/rest/api/security/filter/TokenAuthenticationFilterTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-security/src/test/java/io/gravitee/rest/api/security/filter/TokenAuthenticationFilterTest.java
@@ -15,7 +15,7 @@
  */
 package io.gravitee.rest.api.security.filter;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.*;
 
 import io.gravitee.common.http.HttpHeaders;
@@ -32,17 +32,20 @@ import io.gravitee.rest.api.service.exceptions.UserNotFoundException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 import org.springframework.security.core.context.SecurityContextHolder;
 
 /**
  * @author Eric LELEU (eric.leleu at graviteesource.com)
  * @author GraviteeSource Team
  */
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.WARN)
 public class TokenAuthenticationFilterTest {
 
     @Mock

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-security/src/test/java/io/gravitee/rest/api/security/listener/AuthenticationSuccessListenerTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-security/src/test/java/io/gravitee/rest/api/security/listener/AuthenticationSuccessListenerTest.java
@@ -15,7 +15,7 @@
  */
 package io.gravitee.rest.api.security.listener;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.*;
 
 import io.gravitee.rest.api.idp.api.authentication.UserDetails;
@@ -35,12 +35,13 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Optional;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 import org.springframework.security.authentication.event.AuthenticationSuccessEvent;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
@@ -50,7 +51,8 @@ import org.springframework.security.core.context.SecurityContextHolder;
  * @author Nicolas GERAUD (nicolas.geraud at graviteesource.com)
  * @author GraviteeSource Team
  */
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.WARN)
 public class AuthenticationSuccessListenerTest {
 
     @InjectMocks

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-security/src/test/java/io/gravitee/rest/api/security/utils/AuthoritiesProviderTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-security/src/test/java/io/gravitee/rest/api/security/utils/AuthoritiesProviderTest.java
@@ -16,8 +16,8 @@
 package io.gravitee.rest.api.security.utils;
 
 import static java.util.Arrays.asList;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 
 import io.gravitee.rest.api.model.MembershipMemberType;
@@ -30,12 +30,14 @@ import io.gravitee.rest.api.service.common.GraviteeContext;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.AuthorityUtils;
 
@@ -43,7 +45,8 @@ import org.springframework.security.core.authority.AuthorityUtils;
  * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)
  * @author GraviteeSource Team
  */
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.WARN)
 public class AuthoritiesProviderTest {
 
     public static final String ENVIRONMENT_ID = "environment#id";
@@ -54,13 +57,13 @@ public class AuthoritiesProviderTest {
 
     private AuthoritiesProvider cut;
 
-    @Before
+    @BeforeEach
     public void init() {
         GraviteeContext.fromExecutionContext(new ExecutionContext(ORGANIZATION_ID, ENVIRONMENT_ID));
         cut = new AuthoritiesProvider(membershipService);
     }
 
-    @After
+    @AfterEach
     public void clean() {
         GraviteeContext.cleanContext();
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-security/src/test/java/io/gravitee/rest/api/security/utils/ImageUtilsTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-security/src/test/java/io/gravitee/rest/api/security/utils/ImageUtilsTest.java
@@ -15,32 +15,33 @@
  */
 package io.gravitee.rest.api.security.utils;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import io.gravitee.rest.api.exception.InvalidImageException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import org.apache.commons.io.IOUtils;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
  * @author GraviteeSource Team
  */
-@RunWith(MockitoJUnitRunner.class)
 public class ImageUtilsTest {
 
-    @Test(expected = InvalidImageException.class)
-    public void shouldNotVerify_svgFormat() throws InvalidImageException {
-        ImageUtils.verify(
-            "data:image/SVG+xml;base64,PHNWZw0KdmVyc2lvbj0iMS4xIiBiYXNlUHJvZmlsZT0iZnVsbCIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4NCiAgIDxyZWN0IHdpZHRoPSIzMDAiIGhlaWdodD0iMTAwIiBzdHlsZT0iZmlsbDpyZ2IoMCwwLDI1NSk7c3Ryb2tlLXdpZHRoOjM7c3Ryb2tlOnJnYigwLDAsMCkiIC8+DQogICA8c2NyaXB0PmFsZXJ0KDEpPC9zY3JpcHQ+DQo8L3NWZz4="
+    @Test
+    public void shouldNotVerify_svgFormat() {
+        assertThrows(InvalidImageException.class, () ->
+            ImageUtils.verify(
+                "data:image/SVG+xml;base64,PHNWZw0KdmVyc2lvbj0iMS4xIiBiYXNlUHJvZmlsZT0iZnVsbCIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4NCiAgIDxyZWN0IHdpZHRoPSIzMDAiIGhlaWdodD0iMTAwIiBzdHlsZT0iZmlsbDpyZ2IoMCwwLDI1NSk7c3Ryb2tlLXdpZHRoOjM7c3Ryb2tlOnJnYigwLDAsMCkiIC8+DQogICA8c2NyaXB0PmFsZXJ0KDEpPC9zY3JpcHQ+DQo8L3NWZz4="
+            )
         );
     }
 
-    @Test(expected = InvalidImageException.class)
-    public void shouldNotVerify_invalidBase64Format() throws InvalidImageException {
-        ImageUtils.verify("data:image/SVG+xml;base64,invalid_base64");
+    @Test
+    public void shouldNotVerify_invalidBase64Format() {
+        assertThrows(InvalidImageException.class, () -> ImageUtils.verify("data:image/SVG+xml;base64,invalid_base64"));
     }
 
     @Test


### PR DESCRIPTION
## Description
Uses openrewrite recipe org.openrewrite.java.testing.junit5.JUnit4to5Migration (rewrite-testing-frameworks:RELEASE) scoped to gravitee-apim-rest-api-security with `-pl <module>` (no `-am`, since `-am` rewrote 371 files across upstream modules — out of scope for this first-iteration PR).

The recipe swapped `@RunWith(MockitoJUnitRunner.class)` for `@ExtendWith(MockitoExtension.class)` + `@MockitoSettings(strictness = WARN)`, converted `@Test(expected = X.class)` to assertThrows, migrated junit imports, and removed dead exception clauses on void test methods.
No manual fix required; prettier:write reformatted one file.

87/87 tests pass (identical to baseline).
