### PR TITLE
feat(portal): add application invitation create flow

### DIFF
--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-invitation-create-dialog/application-invitation-create-dialog.component.harness.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-invitation-create-dialog/application-invitation-create-dialog.component.harness.ts
@@ -1,0 +1,124 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ComponentHarness, TestKey } from '@angular/cdk/testing';
+import { MatButtonHarness } from '@angular/material/button/testing';
+import { MatCheckboxHarness } from '@angular/material/checkbox/testing';
+import { MatChipHarness } from '@angular/material/chips/testing';
+import { MatSelectHarness } from '@angular/material/select/testing';
+
+export class ApplicationInvitationCreateDialogHarness extends ComponentHarness {
+  public static readonly hostSelector = 'app-application-invitation-create-dialog';
+
+  private readonly locateEmailInput = this.locatorFor('[data-testid="create-invitation-email-input"]');
+  private readonly locateRoleSelect = this.locatorFor(MatSelectHarness.with({ selector: '[data-testid="create-invitation-role-select"]' }));
+  private readonly locateSubmitButton = this.locatorFor(
+    MatButtonHarness.with({ selector: '[data-testid="create-invitation-submit-button"]' }),
+  );
+  private readonly locateCancelButton = this.locatorFor(
+    MatButtonHarness.with({ selector: '[data-testid="create-invitation-cancel-button"]' }),
+  );
+  private readonly locateNotifyCheckbox = this.locatorFor(
+    MatCheckboxHarness.with({ selector: '[data-testid="create-invitation-notify-checkbox"]' }),
+  );
+  private readonly locateEmailError = this.locatorForOptional('[data-testid="create-invitation-email-error"]');
+  private readonly locateSubmitError = this.locatorForOptional('[data-testid="create-invitation-submit-error"]');
+  private readonly locateRolesError = this.locatorForOptional('[data-testid="create-invitation-roles-error"]');
+  private readonly locateSelectedEmailChips = this.locatorForAll(
+    MatChipHarness.with({ selector: '[data-testid="create-invitation-email-chip"]' }),
+  );
+
+  async enterEmail(email: string): Promise<void> {
+    const input = await this.locateEmailInput();
+    await input.focus();
+    return input.sendKeys(email, TestKey.ENTER);
+  }
+
+  async getSelectedEmailChipTexts(): Promise<string[]> {
+    return Promise.all((await this.locateSelectedEmailChips()).map(chip => chip.getText()));
+  }
+
+  async removeSelectedEmailChip(text: string | RegExp): Promise<void> {
+    const chips = await this.locateSelectedEmailChips();
+    for (const chip of chips) {
+      const chipText = await chip.getText();
+      const matches = typeof text === 'string' ? chipText.includes(text) : text.test(chipText);
+      if (matches) {
+        await chip.remove();
+        return;
+      }
+    }
+    throw new Error(`Unable to find selected email chip matching ${text.toString()}`);
+  }
+
+  async selectRole(role: string): Promise<void> {
+    const select = await this.locateRoleSelect();
+    await select.open();
+    return select.clickOptions({ text: role });
+  }
+
+  async getRoleOptionTexts(): Promise<string[]> {
+    const select = await this.locateRoleSelect();
+    await select.open();
+    return Promise.all((await select.getOptions()).map(option => option.getText()));
+  }
+
+  async getRoleValueText(): Promise<string> {
+    return (await this.locateRoleSelect()).getValueText();
+  }
+
+  async clickSubmit(): Promise<void> {
+    return (await this.locateSubmitButton()).click();
+  }
+
+  async getSubmitButtonText(): Promise<string> {
+    return (await this.locateSubmitButton()).getText();
+  }
+
+  async isSubmitDisabled(): Promise<boolean> {
+    return (await this.locateSubmitButton()).isDisabled();
+  }
+
+  async clickCancel(): Promise<void> {
+    return (await this.locateCancelButton()).click();
+  }
+
+  async isNotifyChecked(): Promise<boolean> {
+    return (await this.locateNotifyCheckbox()).isChecked();
+  }
+
+  async isNotifyDisabled(): Promise<boolean> {
+    return (await this.locateNotifyCheckbox()).isDisabled();
+  }
+
+  async toggleNotify(): Promise<void> {
+    return (await this.locateNotifyCheckbox()).toggle();
+  }
+
+  async getEmailErrorText(): Promise<string | null> {
+    const element = await this.locateEmailError();
+    return element ? element.text() : null;
+  }
+
+  async getSubmitErrorText(): Promise<string | null> {
+    const element = await this.locateSubmitError();
+    return element ? element.text() : null;
+  }
+
+  async getRolesErrorText(): Promise<string | null> {
+    const element = await this.locateRolesError();
+    return element ? element.text() : null;
+  }
+}

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-invitation-create-dialog/application-invitation-create-dialog.component.html
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-invitation-create-dialog/application-invitation-create-dialog.component.html
@@ -1,0 +1,116 @@
+<!--
+
+    Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<h2 mat-dialog-title i18n="@@createApplicationInvitationDialogTitle">Invite users</h2>
+
+<mat-dialog-content class="application-invitation-create-dialog">
+  <section class="application-invitation-create-dialog__section">
+    <mat-form-field appearance="outline" class="application-invitation-create-dialog__field">
+      <mat-label i18n="@@createApplicationInvitationRoleLabel">Member Role</mat-label>
+      <mat-select
+        [formControl]="roleControl"
+        data-testid="create-invitation-role-select"
+        aria-label="Member role"
+        i18n-aria-label="@@createApplicationInvitationRoleAriaLabel"
+      >
+        @for (role of assignableRoles(); track role.name) {
+          <mat-option [value]="role.name">{{ role.name }}</mat-option>
+        }
+      </mat-select>
+      @if (roleControl.hasError('required') && roleControl.touched) {
+        <mat-error i18n="@@createApplicationInvitationRoleRequired">Application role is required.</mat-error>
+      }
+    </mat-form-field>
+
+    @if (rolesResource.isLoading()) {
+      <div class="application-invitation-create-dialog__loading" aria-live="polite" data-testid="create-invitation-roles-loading">
+        <mat-progress-spinner diameter="20" mode="indeterminate" />
+        <span class="next-gen-small" i18n="@@createApplicationInvitationRolesLoading">Loading roles...</span>
+      </div>
+    } @else if (rolesResource.error()) {
+      <p class="application-invitation-create-dialog__error next-gen-small" role="alert" data-testid="create-invitation-roles-error" i18n>
+        An error occurred while loading application roles. Please try again.
+      </p>
+    } @else if (assignableRoles().length === 0) {
+      <p class="application-invitation-create-dialog__error next-gen-small" role="alert" data-testid="create-invitation-no-roles" i18n>
+        No assignable application roles are available.
+      </p>
+    }
+  </section>
+
+  <section class="application-invitation-create-dialog__section">
+    <mat-form-field appearance="outline" class="application-invitation-create-dialog__field">
+      <mat-label i18n="@@createApplicationInvitationEmailsLabel">Email addresses</mat-label>
+      <input
+        matInput
+        type="email"
+        [formControl]="emailControl"
+        (keydown.enter)="addEmailFromInput($event)"
+        data-testid="create-invitation-email-input"
+        aria-label="Email address"
+        i18n-aria-label="@@createApplicationInvitationEmailInputAriaLabel"
+        placeholder="name@example.com"
+        i18n-placeholder="@@createApplicationInvitationEmailPlaceholder"
+      />
+      <mat-hint i18n="@@createApplicationInvitationEmailHint">Press Enter to add each email address.</mat-hint>
+    </mat-form-field>
+    @if (selectedEmails().length > 0) {
+      <div class="application-invitation-create-dialog__selected-emails" data-testid="create-invitation-selected-emails">
+        <mat-chip-set aria-label="Invitation email addresses" i18n-aria-label="@@createApplicationInvitationSelectedEmailsAriaLabel">
+          @for (selectedEmail of selectedEmails(); track selectedEmail.email) {
+            <mat-chip data-testid="create-invitation-email-chip" [removable]="!isSubmitting()" (removed)="removeEmail(selectedEmail.email)">
+              {{ selectedEmail.email }}
+              <button matChipRemove type="button" [disabled]="isSubmitting()" [attr.aria-label]="selectedEmail.removeLabel">
+                <mat-icon aria-hidden="true">cancel</mat-icon>
+              </button>
+            </mat-chip>
+          }
+        </mat-chip-set>
+      </div>
+    }
+    @if (emailInputError(); as error) {
+      <p class="application-invitation-create-dialog__error next-gen-small" data-testid="create-invitation-email-error" role="alert">
+        {{ error }}
+      </p>
+    }
+    <mat-checkbox [formControl]="notifyControl" data-testid="create-invitation-notify-checkbox" i18n>
+      Notify users when invitations are created
+    </mat-checkbox>
+  </section>
+
+  @if (submitError(); as error) {
+    <p class="application-invitation-create-dialog__error next-gen-small" data-testid="create-invitation-submit-error" role="alert">
+      {{ error }}
+    </p>
+  }
+</mat-dialog-content>
+
+<mat-dialog-actions align="end">
+  <button mat-stroked-button type="button" (click)="onCancel()" data-testid="create-invitation-cancel-button" i18n>Cancel</button>
+  <button
+    mat-flat-button
+    color="primary"
+    type="button"
+    [disabled]="!canSubmit()"
+    (click)="onSubmit()"
+    data-testid="create-invitation-submit-button"
+  >
+    <span i18n="@@createApplicationInvitationSubmitButton">
+      {selectedEmails().length, plural, =0 {Send invitation} =1 {Send invitation} other {Send {{ selectedEmails().length }} invitations}}
+    </span>
+  </button>
+</mat-dialog-actions>

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-invitation-create-dialog/application-invitation-create-dialog.component.scss
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-invitation-create-dialog/application-invitation-create-dialog.component.scss
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@use '../../../../scss/theme/index' as app-theme;
+
+.application-invitation-create-dialog {
+  display: flex;
+  width: 640px;
+  max-width: 100%;
+  flex-direction: column;
+  gap: 24px;
+  padding-top: app-theme.$form-field-container-vertical-padding;
+
+  &__section {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+  }
+
+  &__field {
+    width: 100%;
+  }
+
+  &__section:first-child &__field {
+    margin-top: app-theme.$form-field-container-vertical-padding;
+  }
+
+  &__loading {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    color: app-theme.$paragraph-color;
+  }
+
+  &__error {
+    margin: 0;
+    color: app-theme.$error-main-color;
+  }
+}

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-invitation-create-dialog/application-invitation-create-dialog.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-invitation-create-dialog/application-invitation-create-dialog.component.spec.ts
@@ -1,0 +1,245 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { provideHttpClient } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+
+import {
+  ApplicationInvitationCreateDialogComponent,
+  ApplicationInvitationCreateDialogData,
+} from './application-invitation-create-dialog.component';
+import { ApplicationInvitationCreateDialogHarness } from './application-invitation-create-dialog.component.harness';
+import { APPLICATION_PRIMARY_OWNER_ROLE_NAME, ApplicationRole } from '../../../../entities/application/application';
+import { fakeApplicationInvitationsResponse } from '../../../../entities/application/application-invitation.fixture';
+import { ConfigService } from '../../../../services/config.service';
+import { TESTING_BASE_URL } from '../../../../testing/app-testing.module';
+
+const APPLICATION_ID = 'app-1';
+const ROLES_URL = `${TESTING_BASE_URL}/configuration/applications/roles`;
+const INVITATIONS_URL = `${TESTING_BASE_URL}/applications/${APPLICATION_ID}/invitations`;
+
+const APPLICATION_ROLES: ApplicationRole[] = [
+  { id: APPLICATION_PRIMARY_OWNER_ROLE_NAME, name: APPLICATION_PRIMARY_OWNER_ROLE_NAME, default: false, system: true },
+  { id: 'SYSTEM_AUDITOR', name: 'SYSTEM_AUDITOR', default: false, system: true },
+  { id: 'EMPTY', name: '', default: false, system: false },
+  { id: 'OWNER', name: 'OWNER', default: false, system: false },
+  { id: 'USER', name: 'USER', default: true, system: false },
+];
+
+describe('ApplicationInvitationCreateDialogComponent', () => {
+  let fixture: ComponentFixture<ApplicationInvitationCreateDialogComponent>;
+  let harness: ApplicationInvitationCreateDialogHarness;
+  let httpTestingController: HttpTestingController;
+  let dialogRef: { close: jest.Mock };
+
+  async function init(
+    data: ApplicationInvitationCreateDialogData = { applicationId: APPLICATION_ID },
+    options: { flushRolesOnInit: boolean } = { flushRolesOnInit: true },
+  ): Promise<void> {
+    dialogRef = { close: jest.fn() };
+
+    await TestBed.configureTestingModule({
+      imports: [ApplicationInvitationCreateDialogComponent],
+      providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        provideNoopAnimations(),
+        { provide: ConfigService, useValue: { baseURL: TESTING_BASE_URL } },
+        { provide: MAT_DIALOG_DATA, useValue: data },
+        { provide: MatDialogRef, useValue: dialogRef },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ApplicationInvitationCreateDialogComponent);
+    httpTestingController = TestBed.inject(HttpTestingController);
+
+    fixture.detectChanges();
+    if (options.flushRolesOnInit) {
+      flushRoles();
+      await fixture.whenStable();
+      fixture.detectChanges();
+      harness = await TestbedHarnessEnvironment.harnessForFixture(fixture, ApplicationInvitationCreateDialogHarness);
+    }
+  }
+
+  function flushRoles(roles: ApplicationRole[] = APPLICATION_ROLES): void {
+    const req = httpTestingController.expectOne(ROLES_URL);
+    expect(req.request.method).toBe('GET');
+    req.flush({ data: roles });
+  }
+
+  async function enterEmail(email: string): Promise<void> {
+    await harness.enterEmail(email);
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+  }
+
+  afterEach(() => {
+    httpTestingController.verify();
+  });
+
+  it('should preselect default application role', async () => {
+    await init();
+
+    expect(fixture.componentInstance.roleControl.value).toBe('USER');
+    expect(await harness.getRoleValueText()).toBe('USER');
+  });
+
+  it('should offer only assignable application roles', async () => {
+    await init();
+
+    expect(await harness.getRoleOptionTexts()).toEqual(['OWNER', 'USER']);
+  });
+
+  it('should show roles loading error when application roles cannot be loaded', async () => {
+    await init({ applicationId: APPLICATION_ID }, { flushRolesOnInit: false });
+
+    httpTestingController.expectOne(ROLES_URL).flush({ message: 'error' }, { status: 500, statusText: 'Server Error' });
+    await fixture.whenStable();
+    fixture.detectChanges();
+    harness = await TestbedHarnessEnvironment.harnessForFixture(fixture, ApplicationInvitationCreateDialogHarness);
+
+    expect(await harness.getRolesErrorText()).toContain('An error occurred while loading application roles');
+  });
+
+  it('should add normalized selected email chips and allow removing them', async () => {
+    await init();
+
+    await enterEmail(' Alice@Example.com ');
+    await enterEmail('bob@example.com');
+
+    expect(await harness.getSelectedEmailChipTexts()).toEqual([
+      expect.stringContaining('alice@example.com'),
+      expect.stringContaining('bob@example.com'),
+    ]);
+    expect(await harness.getSubmitButtonText()).toBe('Send 2 invitations');
+    expect(await harness.isSubmitDisabled()).toBe(false);
+
+    await harness.removeSelectedEmailChip(/alice@example.com/);
+
+    expect(await harness.getSelectedEmailChipTexts()).toEqual([expect.stringContaining('bob@example.com')]);
+    expect(await harness.getSubmitButtonText()).toBe('Send invitation');
+  });
+
+  it('should keep notify unchecked and disabled while backend notifications are unavailable', async () => {
+    await init();
+
+    expect(await harness.isNotifyChecked()).toBe(false);
+    expect(await harness.isNotifyDisabled()).toBe(true);
+  });
+
+  it('should reject invalid email address', async () => {
+    await init();
+
+    await enterEmail('not-an-email');
+
+    expect(await harness.getEmailErrorText()).toContain('Enter a valid email address');
+    expect(await harness.getSelectedEmailChipTexts()).toEqual([]);
+    expect(await harness.isSubmitDisabled()).toBe(true);
+    httpTestingController.expectNone(INVITATIONS_URL);
+  });
+
+  it('should not submit when pending email is invalid', async () => {
+    await init();
+    await enterEmail('alice@example.com');
+    fixture.componentInstance.emailControl.setValue('not-an-email');
+    fixture.detectChanges();
+
+    fixture.componentInstance.onSubmit();
+    fixture.detectChanges();
+
+    expect(await harness.getEmailErrorText()).toContain('Enter a valid email address');
+    expect(dialogRef.close).not.toHaveBeenCalled();
+    httpTestingController.expectNone(INVITATIONS_URL);
+  });
+
+  it('should reject duplicate email address', async () => {
+    await init();
+
+    await enterEmail('alice@example.com');
+    await enterEmail(' Alice@Example.com ');
+
+    expect(await harness.getEmailErrorText()).toContain('already selected');
+    expect(await harness.getSelectedEmailChipTexts()).toEqual([expect.stringContaining('alice@example.com')]);
+  });
+
+  it('should create invitations and close dialog on success', async () => {
+    await init();
+    await enterEmail('alice@example.com');
+    await enterEmail('bob@example.com');
+
+    await harness.clickSubmit();
+    fixture.detectChanges();
+
+    const request = httpTestingController.expectOne(INVITATIONS_URL);
+    expect(request.request.method).toBe('POST');
+    expect(request.request.body).toEqual({
+      recipients: [{ email: 'alice@example.com' }, { email: 'bob@example.com' }],
+      role: 'USER',
+      notify: false,
+    });
+    request.flush(fakeApplicationInvitationsResponse());
+    await fixture.whenStable();
+
+    expect(dialogRef.close).toHaveBeenCalledWith(true);
+  });
+
+  it('should submit notify disabled default value', async () => {
+    await init();
+    await enterEmail('alice@example.com');
+
+    await harness.clickSubmit();
+    fixture.detectChanges();
+
+    const request = httpTestingController.expectOne(INVITATIONS_URL);
+    expect(request.request.body).toEqual({
+      recipients: [{ email: 'alice@example.com' }],
+      role: 'USER',
+      notify: false,
+    });
+    request.flush(fakeApplicationInvitationsResponse());
+    await fixture.whenStable();
+
+    expect(dialogRef.close).toHaveBeenCalledWith(true);
+  });
+
+  it('should keep dialog open and show conflict error when backend rejects a pending invitation', async () => {
+    await init();
+    await enterEmail('alice@example.com');
+
+    await harness.clickSubmit();
+    fixture.detectChanges();
+
+    httpTestingController.expectOne(INVITATIONS_URL).flush({ message: 'Already exists' }, { status: 409, statusText: 'Conflict' });
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    expect(dialogRef.close).not.toHaveBeenCalled();
+    expect(await harness.getSubmitErrorText()).toContain('already has a pending invitation');
+  });
+
+  it('should close dialog with false on cancel', async () => {
+    await init();
+
+    await harness.clickCancel();
+
+    expect(dialogRef.close).toHaveBeenCalledWith(false);
+  });
+});

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-invitation-create-dialog/application-invitation-create-dialog.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-invitation-create-dialog/application-invitation-create-dialog.component.ts
@@ -1,0 +1,225 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { HttpErrorResponse } from '@angular/common/http';
+import { Component, computed, DestroyRef, effect, inject, signal } from '@angular/core';
+import { rxResource, takeUntilDestroyed, toSignal } from '@angular/core/rxjs-interop';
+import { FormControl, ReactiveFormsModule, Validators } from '@angular/forms';
+import { MatButtonModule } from '@angular/material/button';
+import { MatCheckboxModule } from '@angular/material/checkbox';
+import { MatChipsModule } from '@angular/material/chips';
+import { MAT_DIALOG_DATA, MatDialogModule, MatDialogRef } from '@angular/material/dialog';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatIconModule } from '@angular/material/icon';
+import { MatInputModule } from '@angular/material/input';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+import { MatSelectModule } from '@angular/material/select';
+import { startWith } from 'rxjs';
+
+import { isAssignableApplicationRole } from '../../../../entities/application/application';
+import { ApplicationInvitationService } from '../../../../services/application-invitation.service';
+import { ApplicationService } from '../../../../services/application.service';
+
+export interface ApplicationInvitationCreateDialogData {
+  applicationId: string;
+}
+
+interface SelectedInvitationEmail {
+  email: string;
+  removeLabel: string;
+}
+
+@Component({
+  selector: 'app-application-invitation-create-dialog',
+  standalone: true,
+  imports: [
+    MatButtonModule,
+    MatCheckboxModule,
+    MatChipsModule,
+    MatDialogModule,
+    MatFormFieldModule,
+    MatIconModule,
+    MatInputModule,
+    MatProgressSpinnerModule,
+    MatSelectModule,
+    ReactiveFormsModule,
+  ],
+  templateUrl: './application-invitation-create-dialog.component.html',
+  styleUrl: './application-invitation-create-dialog.component.scss',
+})
+export class ApplicationInvitationCreateDialogComponent {
+  private readonly applicationInvitationService = inject(ApplicationInvitationService);
+  private readonly applicationService = inject(ApplicationService);
+  private readonly destroyRef = inject(DestroyRef);
+  private readonly dialogRef = inject(MatDialogRef<ApplicationInvitationCreateDialogComponent, boolean>);
+  private readonly data: ApplicationInvitationCreateDialogData = inject(MAT_DIALOG_DATA);
+
+  readonly emailControl = new FormControl('', { nonNullable: true, validators: [Validators.email] });
+  readonly notifyControl = new FormControl({ value: false, disabled: true }, { nonNullable: true });
+  readonly roleControl = new FormControl('', { nonNullable: true, validators: [Validators.required] });
+
+  readonly selectedEmails = signal<SelectedInvitationEmail[]>([]);
+  readonly emailInputError = signal<string | null>(null);
+  readonly submitError = signal<string | null>(null);
+  readonly isSubmitting = signal(false);
+
+  private hasInitializedDefaultRole = false;
+
+  private readonly selectedRole = toSignal(this.roleControl.valueChanges.pipe(startWith(this.roleControl.value)), {
+    initialValue: this.roleControl.value,
+  });
+
+  protected readonly rolesResource = rxResource({
+    stream: () => this.applicationService.getApplicationRoles(),
+  });
+
+  readonly assignableRoles = computed(() =>
+    this.rolesResource.error() ? [] : (this.rolesResource.value() ?? []).filter(isAssignableApplicationRole),
+  );
+  readonly selectedEmailValues = computed(() => new Set(this.selectedEmails().map(selectedEmail => selectedEmail.email)));
+  readonly canSubmit = computed(
+    () =>
+      !this.isSubmitting() &&
+      this.selectedEmails().length > 0 &&
+      !!this.selectedRole() &&
+      this.assignableRoles().some(role => role.name === this.selectedRole()) &&
+      !this.rolesResource.error(),
+  );
+
+  private readonly defaultRoleSelectionEffect = effect(() => {
+    if (this.hasInitializedDefaultRole || this.roleControl.value) {
+      return;
+    }
+
+    const defaultRole = this.assignableRoles().find(role => role.default);
+    if (!defaultRole) {
+      return;
+    }
+
+    this.hasInitializedDefaultRole = true;
+    this.roleControl.setValue(defaultRole.name);
+  });
+
+  addEmailFromInput(event: Event): void {
+    event.preventDefault();
+    this.collectPendingEmail();
+  }
+
+  removeEmail(email: string): void {
+    this.emailInputError.set(null);
+    this.submitError.set(null);
+    this.selectedEmails.update(emails => emails.filter(selectedEmail => selectedEmail.email !== email));
+  }
+
+  onCancel(): void {
+    this.dialogRef.close(false);
+  }
+
+  onSubmit(): void {
+    this.roleControl.markAsTouched();
+    const pendingEmailCollected = this.collectPendingEmail();
+    if (!pendingEmailCollected) {
+      return;
+    }
+
+    if (this.selectedEmails().length === 0) {
+      this.emailControl.markAsTouched();
+      this.emailInputError.set($localize`:@@createApplicationInvitationEmailRequired:Add at least one email address.`);
+      return;
+    }
+
+    if (!this.canSubmit()) {
+      return;
+    }
+
+    this.isSubmitting.set(true);
+    this.submitError.set(null);
+
+    this.applicationInvitationService
+      .createApplicationInvitations(this.data.applicationId, {
+        recipients: this.selectedEmails().map(selectedEmail => ({ email: selectedEmail.email })),
+        role: this.roleControl.value,
+        notify: this.notifyControl.value,
+      })
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: () => this.dialogRef.close(true),
+        error: (error: HttpErrorResponse) => this.handleSubmitError(error),
+      });
+  }
+
+  private collectPendingEmail(): boolean {
+    const pendingEmail = this.emailControl.value;
+    if (pendingEmail.trim().length === 0) {
+      return true;
+    }
+
+    return this.addEmailValue(pendingEmail);
+  }
+
+  private addEmailValue(value: string): boolean {
+    const email = this.normalizeEmail(value);
+    this.submitError.set(null);
+
+    if (!email) {
+      this.clearEmailControl();
+      return true;
+    }
+
+    this.emailControl.setValue(email);
+    this.emailControl.markAsTouched();
+    this.emailControl.updateValueAndValidity();
+
+    if (this.emailControl.hasError('email')) {
+      this.emailInputError.set($localize`:@@createApplicationInvitationInvalidEmail:Enter a valid email address.`);
+      return false;
+    }
+
+    if (this.selectedEmailValues().has(email)) {
+      this.emailInputError.set($localize`:@@createApplicationInvitationDuplicateEmail:This email address is already selected.`);
+      this.clearEmailControl();
+      return false;
+    }
+
+    this.emailInputError.set(null);
+    this.selectedEmails.update(emails => [
+      ...emails,
+      {
+        email,
+        removeLabel: $localize`:@@removeApplicationInvitationEmailAriaLabel:Remove ${email}:email: from selected invitations`,
+      },
+    ]);
+    this.clearEmailControl();
+    return true;
+  }
+
+  private clearEmailControl(): void {
+    this.emailControl.setValue('');
+    this.emailControl.setErrors(null);
+  }
+
+  private normalizeEmail(value: string): string {
+    return value.trim().toLowerCase();
+  }
+
+  private handleSubmitError(error: HttpErrorResponse): void {
+    this.isSubmitting.set(false);
+    this.submitError.set(
+      error.status === 409
+        ? $localize`:@@createApplicationInvitationConflictError:At least one selected email already has a pending invitation.`
+        : $localize`:@@createApplicationInvitationGenericError:Invitations could not be created. Please try again.`,
+    );
+  }
+}

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-invitations/application-tab-invitations.component.harness.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-invitations/application-tab-invitations.component.harness.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 import { ComponentHarness, TestElement } from '@angular/cdk/testing';
+import { MatButtonHarness } from '@angular/material/button/testing';
 
 import { LoaderHarness } from '../../../../components/loader/loader.harness';
 import { PaginatedTableHarness } from '../../../../components/paginated-table/paginated-table.harness';
@@ -27,6 +28,9 @@ export class ApplicationTabInvitationsComponentHarness extends ComponentHarness 
   private readonly locateEmptyState = this.locatorForOptional('[data-testid="invitations-empty-state"]');
   private readonly locateSearchBar = this.locatorForOptional('app-search-bar');
   private readonly locateSearchNoMatch = this.locatorForOptional('[data-testid="invitations-search-no-match"]');
+  private readonly locateCreateInvitationButton = this.locatorForOptional(
+    MatButtonHarness.with({ selector: '[data-testid="create-invitation-button"]' }),
+  );
   private readonly locatePaginatedTable = this.locatorForOptional(PaginatedTableHarness);
 
   public async getLoader(): Promise<LoaderHarness | null> {
@@ -51,6 +55,14 @@ export class ApplicationTabInvitationsComponentHarness extends ComponentHarness 
 
   public async getSearchNoMatch(): Promise<TestElement | null> {
     return this.locateSearchNoMatch();
+  }
+
+  public async getCreateInvitationButton(): Promise<MatButtonHarness | null> {
+    return this.locateCreateInvitationButton();
+  }
+
+  public async clickCreateInvitation(): Promise<void> {
+    return (await this.locateCreateInvitationButton())!.click();
   }
 
   public async getPaginatedTable(): Promise<PaginatedTableHarness | null> {

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-invitations/application-tab-invitations.component.html
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-invitations/application-tab-invitations.component.html
@@ -18,6 +18,21 @@
 @if (canRead()) {
   <div class="invitations__toolbar">
     <app-search-bar (searchTerm)="onSearchTermChange($event)" />
+    <div class="invitations__toolbar-actions">
+      @if (canCreate()) {
+        <button
+          mat-flat-button
+          color="primary"
+          type="button"
+          data-testid="create-invitation-button"
+          (click)="openCreateInvitationDialog()"
+          i18n="@@applicationInvitationsCreateButton"
+        >
+          <mat-icon aria-hidden="true">mail_outline</mat-icon>
+          Invite users
+        </button>
+      }
+    </div>
   </div>
   <h4 class="next-gen-h4 invitations__title" data-testid="invitations-section-title">
     {{ sectionTitle() }}

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-invitations/application-tab-invitations.component.scss
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-invitations/application-tab-invitations.component.scss
@@ -29,6 +29,12 @@ app-search-bar {
     margin-bottom: 24px;
   }
 
+  &__toolbar-actions {
+    display: flex;
+    align-items: center;
+    gap: 16px;
+  }
+
   &__title {
     margin: 0 0 16px;
   }

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-invitations/application-tab-invitations.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-invitations/application-tab-invitations.component.spec.ts
@@ -17,8 +17,10 @@ import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { provideHttpClient } from '@angular/common/http';
 import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MatDialog, MatDialogRef } from '@angular/material/dialog';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { provideRouter } from '@angular/router';
+import { Subject } from 'rxjs';
 
 import { ApplicationTabInvitationsComponent } from './application-tab-invitations.component';
 import { ApplicationTabInvitationsComponentHarness } from './application-tab-invitations.component.harness';
@@ -33,6 +35,7 @@ import {
 import { fakeUserApplicationPermissions } from '../../../../entities/permission/permission.fixtures';
 import { ConfigService } from '../../../../services/config.service';
 import { TESTING_BASE_URL } from '../../../../testing/app-testing.module';
+import { ApplicationInvitationCreateDialogComponent } from '../application-invitation-create-dialog/application-invitation-create-dialog.component';
 
 describe('ApplicationTabInvitationsComponent', () => {
   let fixture: ComponentFixture<ApplicationTabInvitationsComponent>;
@@ -180,6 +183,45 @@ describe('ApplicationTabInvitationsComponent', () => {
     const harness = await getHarness();
     expect(await harness.getPaginatedTable()).toBeNull();
     expect(await harness.getSearchBar()).toBeNull();
+  });
+
+  it('should show create invitation button when user has MEMBER[C] permission', async () => {
+    fixture.componentRef.setInput('userApplicationPermissions', fakeUserApplicationPermissions({ MEMBER: ['R', 'C'] }));
+
+    const harness = await flush(fakeApplicationInvitationsResponse([fakeApplicationInvitation()]));
+
+    expect(await harness.getCreateInvitationButton()).not.toBeNull();
+  });
+
+  it('should hide create invitation button when user lacks MEMBER[C] permission', async () => {
+    const harness = await flush(fakeApplicationInvitationsResponse([fakeApplicationInvitation()]));
+
+    expect(await harness.getCreateInvitationButton()).toBeNull();
+  });
+
+  it('should open create invitation dialog and reload invitations after successful creation', async () => {
+    fixture.componentRef.setInput('userApplicationPermissions', fakeUserApplicationPermissions({ MEMBER: ['R', 'C'] }));
+    const afterClosed = new Subject<boolean>();
+    const openDialogSpy = jest.spyOn(fixture.debugElement.injector.get(MatDialog), 'open').mockReturnValue({
+      afterClosed: () => afterClosed.asObservable(),
+    } as MatDialogRef<ApplicationInvitationCreateDialogComponent, boolean>);
+    const harness = await flush(fakeApplicationInvitationsResponse([fakeApplicationInvitation()]));
+
+    await harness.clickCreateInvitation();
+    fixture.detectChanges();
+
+    expect(openDialogSpy).toHaveBeenCalledWith(ApplicationInvitationCreateDialogComponent, {
+      data: { applicationId },
+      disableClose: true,
+    });
+
+    afterClosed.next(true);
+    afterClosed.complete();
+    fixture.detectChanges();
+    httpTestingController
+      .expectOne(req => req.url.includes('invitations/_search'))
+      .flush(fakeApplicationInvitationsResponse([fakeApplicationInvitation()], 2));
+    await fixture.whenStable();
   });
 
   describe('search behavior', () => {

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-invitations/application-tab-invitations.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-invitations/application-tab-invitations.component.ts
@@ -13,10 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Component, computed, inject, input, signal } from '@angular/core';
-import { rxResource } from '@angular/core/rxjs-interop';
+import { Component, computed, DestroyRef, inject, input, signal } from '@angular/core';
+import { rxResource, takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { MatButtonModule } from '@angular/material/button';
+import { MatDialog, MatDialogModule } from '@angular/material/dialog';
 import { MatIcon } from '@angular/material/icon';
-import { map, of, tap } from 'rxjs';
+import { filter, map, of, tap } from 'rxjs';
 
 import { LoaderComponent } from '../../../../components/loader/loader.component';
 import { PaginatedTableComponent, TableColumn } from '../../../../components/paginated-table/paginated-table.component';
@@ -29,6 +31,10 @@ import {
 } from '../../../../entities/application/application-invitation';
 import { UserApplicationPermissions } from '../../../../entities/permission/permission';
 import { ApplicationInvitationService } from '../../../../services/application-invitation.service';
+import {
+  ApplicationInvitationCreateDialogComponent,
+  ApplicationInvitationCreateDialogData,
+} from '../application-invitation-create-dialog/application-invitation-create-dialog.component';
 
 interface InvitationTableRow {
   id: string;
@@ -51,12 +57,14 @@ interface InvitationsResourceValue {
 @Component({
   selector: 'app-application-tab-invitations',
   standalone: true,
-  imports: [LoaderComponent, MatIcon, PaginatedTableComponent, SearchBarComponent, TableCellDirective],
+  imports: [LoaderComponent, MatButtonModule, MatDialogModule, MatIcon, PaginatedTableComponent, SearchBarComponent, TableCellDirective],
   templateUrl: './application-tab-invitations.component.html',
   styleUrl: './application-tab-invitations.component.scss',
 })
 export class ApplicationTabInvitationsComponent {
   private readonly applicationInvitationService = inject(ApplicationInvitationService);
+  private readonly destroyRef = inject(DestroyRef);
+  private readonly matDialog = inject(MatDialog);
 
   readonly applicationId = input.required<string>();
   readonly userApplicationPermissions = input.required<UserApplicationPermissions>();
@@ -80,6 +88,7 @@ export class ApplicationTabInvitationsComponent {
   ];
 
   readonly canRead = computed(() => this.userApplicationPermissions().MEMBER?.includes('R') ?? false);
+  readonly canCreate = computed(() => this.userApplicationPermissions().MEMBER?.includes('C') ?? false);
   readonly hasSearchTerm = computed(() => this.searchTerm().trim().length > 0);
   readonly searchFilters = computed<ApplicationInvitationsSearchFilters>(() => {
     const email = this.searchTerm().trim();
@@ -146,6 +155,24 @@ export class ApplicationTabInvitationsComponent {
   onSearchTermChange(term: string): void {
     this.searchTerm.set(term);
     this.currentPage.set(1);
+  }
+
+  openCreateInvitationDialog(): void {
+    this.matDialog
+      .open<ApplicationInvitationCreateDialogComponent, ApplicationInvitationCreateDialogData, boolean>(
+        ApplicationInvitationCreateDialogComponent,
+        {
+          data: { applicationId: this.applicationId() },
+          disableClose: true,
+        },
+      )
+      .afterClosed()
+      .pipe(
+        filter((invitationsCreated): invitationsCreated is true => invitationsCreated === true),
+        tap(() => this.invitationsResource.reload()),
+        takeUntilDestroyed(this.destroyRef),
+      )
+      .subscribe();
   }
 
   private toRow(invitation: ApplicationInvitation): InvitationTableRow {

--- a/gravitee-apim-portal-webui-next/src/entities/application/application-invitation.fixture.ts
+++ b/gravitee-apim-portal-webui-next/src/entities/application/application-invitation.fixture.ts
@@ -15,7 +15,7 @@
  */
 import { isFunction } from 'lodash';
 
-import { ApplicationInvitation, ApplicationInvitationsResponse } from './application-invitation';
+import { ApplicationInvitation, ApplicationInvitationsCreateInput, ApplicationInvitationsResponse } from './application-invitation';
 
 export function fakeApplicationInvitation(
   modifier?: Partial<ApplicationInvitation> | ((base: ApplicationInvitation) => ApplicationInvitation),
@@ -44,5 +44,16 @@ export function fakeApplicationInvitationsResponse(
         total,
       },
     },
+  };
+}
+
+export function fakeApplicationInvitationsCreateInput(
+  modifier?: Partial<ApplicationInvitationsCreateInput>,
+): ApplicationInvitationsCreateInput {
+  return {
+    recipients: [{ email: 'alice@example.com' }],
+    role: 'USER',
+    notify: false,
+    ...modifier,
   };
 }

--- a/gravitee-apim-portal-webui-next/src/entities/application/application-invitation.ts
+++ b/gravitee-apim-portal-webui-next/src/entities/application/application-invitation.ts
@@ -19,6 +19,16 @@ export interface ApplicationInvitation {
   role: string;
 }
 
+export interface ApplicationInvitationRecipientInput {
+  email: string;
+}
+
+export interface ApplicationInvitationsCreateInput {
+  recipients: ApplicationInvitationRecipientInput[];
+  role: string;
+  notify: boolean;
+}
+
 export interface ApplicationInvitationsSearchFilters {
   email?: string;
 }

--- a/gravitee-apim-portal-webui-next/src/services/application-invitation.service.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/services/application-invitation.service.spec.ts
@@ -17,7 +17,10 @@ import { HttpTestingController } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
 
 import { ApplicationInvitationService } from './application-invitation.service';
-import { fakeApplicationInvitationsResponse } from '../entities/application/application-invitation.fixture';
+import {
+  fakeApplicationInvitationsCreateInput,
+  fakeApplicationInvitationsResponse,
+} from '../entities/application/application-invitation.fixture';
 import { AppTestingModule, TESTING_BASE_URL } from '../testing/app-testing.module';
 
 describe('ApplicationInvitationService', () => {
@@ -62,6 +65,23 @@ describe('ApplicationInvitationService', () => {
     const req = httpTestingController.expectOne(`${TESTING_BASE_URL}/applications/${applicationId}/invitations/_search?page=2&size=25`);
     expect(req.request.method).toEqual('POST');
     expect(req.request.body).toEqual({ filters: { email: 'alice@example.com' } });
+    req.flush(response);
+  });
+
+  it('should create application invitations', done => {
+    const input = fakeApplicationInvitationsCreateInput({
+      recipients: [{ email: 'alice@example.com' }, { email: 'bob@example.com' }],
+    });
+    const response = fakeApplicationInvitationsResponse();
+
+    service.createApplicationInvitations(applicationId, input).subscribe(res => {
+      expect(res).toMatchObject(response);
+      done();
+    });
+
+    const req = httpTestingController.expectOne(`${TESTING_BASE_URL}/applications/${applicationId}/invitations`);
+    expect(req.request.method).toEqual('POST');
+    expect(req.request.body).toEqual(input);
     req.flush(response);
   });
 });

--- a/gravitee-apim-portal-webui-next/src/services/application-invitation.service.ts
+++ b/gravitee-apim-portal-webui-next/src/services/application-invitation.service.ts
@@ -18,7 +18,11 @@ import { inject, Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
 
 import { ConfigService } from './config.service';
-import { ApplicationInvitationsResponse, ApplicationInvitationsSearchFilters } from '../entities/application/application-invitation';
+import {
+  ApplicationInvitationsCreateInput,
+  ApplicationInvitationsResponse,
+  ApplicationInvitationsSearchFilters,
+} from '../entities/application/application-invitation';
 
 @Injectable({
   providedIn: 'root',
@@ -40,5 +44,12 @@ export class ApplicationInvitationService {
         params: { page, size },
       },
     );
+  }
+
+  createApplicationInvitations(
+    applicationId: string,
+    input: ApplicationInvitationsCreateInput,
+  ): Observable<ApplicationInvitationsResponse> {
+    return this.http.post<ApplicationInvitationsResponse>(`${this.configService.baseURL}/applications/${applicationId}/invitations`, input);
   }
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-13765

## Summary
Adds the application invitation create flow in the Developer Portal.

Changes
- Adds application-invitation-create-dialog
- Supports entering multiple email addresses and displaying selected emails as chips
- Adds application role selection with default role preselected
- Adds optional Notify users checkbox
- Wires POST /applications/{applicationId}/invitations
- Shows invite action only for users with MEMBER[C]
- Reloads the invitations list after successful creation


https://github.com/user-attachments/assets/d96e2fb0-4b6f-4e80-94c9-934402e20c8d


