### PR TITLE
feat: re-enable Remote source for V4 API update via URL

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/import-v4/api-import-v4-form/api-import-v4-form.component.html
+++ b/gravitee-apim-console-webui/src/management/api/import-v4/api-import-v4-form/api-import-v4-form.component.html
@@ -112,7 +112,7 @@
               <div class="configure-file-source__col configure-file-source__col--sources">
                 <span class="configure-file-source__col-heading">Source</span>
                 <gio-form-selection-inline formControlName="source" class="configure-file-source__source-selection">
-                  @for (source of sources(); track source.value) {
+                  @for (source of sources; track source.value) {
                     <gio-form-selection-inline-card
                       [value]="source.value"
                       [disabled]="!!source.disabledReason"

--- a/gravitee-apim-console-webui/src/management/api/import-v4/api-import-v4-form/api-import-v4-form.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/import-v4/api-import-v4-form/api-import-v4-form.component.spec.ts
@@ -397,33 +397,32 @@ describe('ApiImportV4FormComponent', () => {
       fixture.detectChanges();
     });
 
-    it('should disable the Remote source card with a tooltip explaining the limitation', () => {
-      // `sources` is a protected signal exposed only to the template; bracket-access keeps the component API clean.
-      const sources = (
-        fixture.componentInstance as unknown as { sources: () => { value: string; disabledReason: string | null }[] }
-      ).sources();
-      const remote = sources.find(s => s.value === 'remote');
-      expect(remote?.disabledReason).toBe('Updating an API from a remote URL is not yet supported');
+    it('should keep both source cards enabled in update mode', () => {
+      // `sources` is a protected field exposed only to the template; bracket-access keeps the component API clean.
+      const sources = (fixture.componentInstance as unknown as { sources: { value: string; disabledReason: string | null }[] }).sources;
+      expect(sources.find(s => s.value === 'remote')?.disabledReason).toBeNull();
       expect(sources.find(s => s.value === 'local')?.disabledReason).toBeNull();
     });
 
-    it('should refuse to call importFromUrl when the form is forced to remote in update mode', () => {
-      const apiV2 = TestBed.inject(ApiV2Service);
-      const importFromUrlSpy = jest.spyOn(apiV2, 'importFromUrl');
-      const snackBarService = TestBed.inject(SnackBarService);
-      const snackBarErrorSpy = jest.spyOn(snackBarService, 'error');
+    it('should PUT the remote URL as text/plain to the update endpoint for Gravitee remote in update mode', async () => {
+      const httpMock = TestBed.inject(HttpTestingController);
 
-      // The UI disables the Remote card in update mode (covered above). Bypass the UI guard by forcing
-      // the form to source=remote programmatically, then trigger the import. The component layer must
-      // also refuse — otherwise we would silently create a new API via the create endpoint.
-      fixture.componentInstance.configureFileSourceForm.controls.source.setValue('remote');
-      fixture.componentInstance.configureFileSourceForm.controls.remoteUrl.setValue('https://cdn.example/def.json');
+      await harness.selectFormat('gravitee');
       fixture.detectChanges();
+      await harness.clickNext();
+      await harness.selectSource('remote');
+      await harness.setRemoteUrl('https://cdn.example/def.json');
+      fixture.detectChanges();
+      await harness.clickNext();
+      await harness.clickImport();
 
-      (fixture.componentInstance as unknown as { importApi: () => void }).importApi();
-
-      expect(importFromUrlSpy).not.toHaveBeenCalled();
-      expect(snackBarErrorSpy).toHaveBeenCalled();
+      const req = httpMock.expectOne(
+        r => r.method === 'PUT' && r.url === `${CONSTANTS_TESTING.env.v2BaseURL}/apis/existing-api/_import/definition-url`,
+      );
+      expect(req.request.body).toBe('https://cdn.example/def.json');
+      expect(req.request.headers.get('Content-Type')).toBe('text/plain');
+      req.flush(fakeApiV4({ id: 'existing-api' }));
+      httpMock.verify();
     });
   });
 });
@@ -703,6 +702,31 @@ describe('ApiImportV4FormComponent (rest-to-soap policy installed)', () => {
       expect.objectContaining({
         withPolicies: ['rest-to-soap'],
       }),
+    );
+    expect(apiV2.importWsdlApi).not.toHaveBeenCalled();
+  });
+
+  it('should call updateApiFromWsdl with remote URL when updateTargetApiId is set', async () => {
+    const apiV2 = TestBed.inject(ApiV2Service);
+    jest.spyOn(apiV2, 'importWsdlApi');
+    jest.spyOn(apiV2, 'updateApiFromWsdl').mockReturnValue(of(fakeApiV4({ id: 'existing-api' })));
+    fixture.componentRef.setInput('updateTargetApiId', 'existing-api');
+    fixture.detectChanges();
+
+    await harness.selectFormat('wsdl');
+    fixture.detectChanges();
+    await harness.clickNext();
+    await harness.selectSource('remote');
+    await harness.setRemoteUrl('https://example.com/calculator.wsdl');
+    fixture.detectChanges();
+    await harness.clickNext();
+    fixture.detectChanges();
+    await harness.clickNext();
+    await harness.clickImport();
+
+    expect(apiV2.updateApiFromWsdl).toHaveBeenCalledWith(
+      'existing-api',
+      expect.objectContaining({ payload: 'https://example.com/calculator.wsdl', type: 'URL' }),
     );
     expect(apiV2.importWsdlApi).not.toHaveBeenCalled();
   });

--- a/gravitee-apim-console-webui/src/management/api/import-v4/api-import-v4-form/api-import-v4-form.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/import-v4/api-import-v4-form/api-import-v4-form.component.ts
@@ -109,22 +109,10 @@ export class ApiImportV4FormComponent {
     { value: 'wsdl', label: 'WSDL', icon: 'gio:language' },
   ];
 
-  /**
-   * Remote source is disabled in update mode until APIM-12142 introduces a backend update-from-URL flow;
-   * the current create endpoint would silently create a new API instead of updating the target.
-   */
-  protected readonly sources = computed(() => {
-    const updateOnlySupportsLocal = !!this.updateTargetApiId();
-    return [
-      { value: 'local', label: 'Local file', icon: 'gio:laptop', disabledReason: null as string | null },
-      {
-        value: 'remote',
-        label: 'Remote source',
-        icon: 'gio:language',
-        disabledReason: updateOnlySupportsLocal ? 'Updating an API from a remote URL is not yet supported' : null,
-      },
-    ];
-  });
+  protected readonly sources = [
+    { value: 'local', label: 'Local file', icon: 'gio:laptop', disabledReason: null as string | null },
+    { value: 'remote', label: 'Remote source', icon: 'gio:language', disabledReason: null as string | null },
+  ];
 
   private readonly importFileContent = signal<string | undefined>(undefined);
 
@@ -203,7 +191,7 @@ export class ApiImportV4FormComponent {
 
   protected readonly selectedSourceLabel = computed(() => {
     const value = this.importSourceMode();
-    return this.sources().find(s => s.value === value)?.label ?? '-';
+    return this.sources.find(s => s.value === value)?.label ?? '-';
   });
 
   protected readonly showImportOptionsStep = computed(() => {
@@ -498,13 +486,7 @@ export class ApiImportV4FormComponent {
     const url = this.configureFileSourceForm.controls.remoteUrl.value?.trim() as string;
 
     if (format === 'gravitee') {
-      // Defense-in-depth: the Remote source card is disabled in update mode (see `sources`), but if the form is
-      // forced to remote programmatically, refuse rather than silently creating a new API via the create endpoint.
-      // APIM-12142 will introduce the backend update-from-URL path.
-      if (updateId) {
-        return null;
-      }
-      return this.apiV2Service.importFromUrl(url);
+      return updateId ? this.apiV2Service.updateFromUrl(updateId, url) : this.apiV2Service.importFromUrl(url);
     }
     if (format === 'wsdl') {
       return updateId

--- a/gravitee-apim-console-webui/src/services-ngx/api-v2.service.spec.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/api-v2.service.spec.ts
@@ -271,6 +271,28 @@ describe('ApiV2Service', () => {
     });
   });
 
+  describe('updateFromUrl', () => {
+    it('should PUT the URL as text/plain to the per-api definition-url endpoint', done => {
+      const fakeApi = fakeApiV4();
+      const apiId = 'existing-api';
+      const definitionUrl = 'https://cdn.example/def.json';
+
+      apiV2Service.updateFromUrl(apiId, definitionUrl).subscribe(api => {
+        expect(api).toEqual(fakeApi);
+        done();
+      });
+
+      const req = httpTestingController.expectOne({
+        url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${apiId}/_import/definition-url`,
+        method: 'PUT',
+      });
+      expect(req.request.body).toBe(definitionUrl);
+      expect(req.request.headers.get('Content-Type')).toBe('text/plain');
+
+      req.flush(fakeApi);
+    });
+  });
+
   describe('search', () => {
     it('should call the API', done => {
       const fakeApi = fakeApiV4();

--- a/gravitee-apim-console-webui/src/services-ngx/api-v2.service.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/api-v2.service.ts
@@ -156,11 +156,21 @@ export class ApiV2Service {
   /**
    * Creates a v4 API by asking the backend to fetch a Gravitee export from `definitionUrl` and import it.
    * Body is the URL string itself (`text/plain`). The backend ignores any `Authorization` header.
-   *
-   * Create only — there is no update-from-URL equivalent yet (planned in APIM-12142).
    */
   importFromUrl(definitionUrl: string): Observable<ApiV4> {
     return this.http.post<ApiV4>(`${this.constants.env.v2BaseURL}/apis/_import/definition-url`, definitionUrl, {
+      headers: {
+        'Content-Type': 'text/plain',
+      },
+    });
+  }
+
+  /**
+   * Updates an existing v4 API by asking the backend to fetch a Gravitee export from `definitionUrl` and apply it.
+   * Body is the URL string itself (`text/plain`). The backend ignores any `Authorization` header.
+   */
+  updateFromUrl(apiId: string, definitionUrl: string): Observable<ApiV4> {
+    return this.http.put<ApiV4>(`${this.constants.env.v2BaseURL}/apis/${apiId}/_import/definition-url`, definitionUrl, {
       headers: {
         'Content-Type': 'text/plain',
       },


### PR DESCRIPTION
## Issue

Subtask: https://gravitee.atlassian.net/browse/APIM-14117
Parent: https://gravitee.atlassian.net/browse/APIM-12142

## Description

Re-enables the **Remote source** card in the V4 update flow and wires it to the backend endpoint that landed in APIM-14116 (`PUT /environments/{envId}/apis/{apiId}/_import/definition-url`). APIM-14063 had temporarily disabled the card with a tooltip while the backend was unavailable — that gate now comes off.
<img width="3000" height="1430" alt="2026-05-28 08 04 12" src="https://github.com/user-attachments/assets/1e955ef1-8dba-48ff-99f6-7b465d089c61" />
<img width="3000" height="1430" alt="2026-05-28 08 04 41" src="https://github.com/user-attachments/assets/0654ee56-2db2-4ff1-9ebc-5027aa7dbb29" />


Changes:
- `api-v2.service.ts` — new `updateFromUrl(apiId, definitionUrl)` method (PUT, `text/plain` body)
- `api-import-v4-form.component.ts` — `sources` computed signal no longer disables Remote in update mode; `resolveRemoteImport$` calls `updateFromUrl` when `updateTargetApiId` is set + format=gravitee
- Removed the comment block referencing APIM-12142 and the defense-in-depth `return null` branch that's no longer load-bearing

Tests:
- `api-v2.service.spec.ts` — new `updateFromUrl` test asserts PUT shape (`text/plain`, URL as body)
- `api-import-v4-form.component.spec.ts` — replaced the two update-mode tests:
  - "should keep both source cards enabled in update mode" (replaces "should disable the Remote source card…")
  - "should PUT the remote URL as text/plain to the update endpoint for Gravitee remote in update mode" (replaces "should refuse to call importFromUrl…")

## Test plan

- [x] `yarn jest api-import-v4-form.component.spec.ts api-v2.service.spec.ts` → 78/78 pass
- [x] `npx nx lint console` → clean, prettier ok
- [ ] Manual smoke: open an existing V4 API → Import → Remote source → enter URL of a hosted Gravitee export → Update → confirm API definition reflects the remote content

## Notes for reviewers

- Targets master; backend dependency (APIM-14116, `PUT /_import/definition-url`) merged via #16945 in `e31b627d40`
- Companion to PR #16929 (APIM-14063) which removed the legacy browser-fetch path — same shape applied to update
- The pre-existing backend UX bugs surfaced in APIM-12140 QA (NPE on wrong-schema JSON, raw Netty leak on DNS failure, empty message on 404) will manifest on this flow too since it uses the same `RemoteApiDefinitionParser` + `FetchApiDefinitionFromUrlDomainServiceImpl` chain. Worth filing as separate polish tickets if not already