### PR TITLE
feat(authz-ui): manual entity creation (Principals + Resources)

### DIFF
--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/features/policy-structure/CreateEntityDialog.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/features/policy-structure/CreateEntityDialog.tsx
@@ -1,0 +1,411 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+    Alert,
+    AlertDescription,
+    Badge,
+    Button,
+    Combobox,
+    ComboboxChip,
+    ComboboxChips,
+    ComboboxChipsInput,
+    ComboboxContent,
+    ComboboxEmpty,
+    ComboboxItem,
+    ComboboxList,
+    Input,
+    Label,
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+    Sheet,
+    SheetContent,
+    SheetTitle,
+    Spinner,
+    Textarea,
+    cn,
+    toast,
+    useComboboxAnchor,
+} from '@gravitee/graphene-core';
+import { PlusIcon } from '@gravitee/graphene-core/icons';
+import { useQueryClient } from '@tanstack/react-query';
+import { useEffect, useMemo, useState } from 'react';
+import { authzApiService } from '../../shared/api/authz-api.service';
+import { authzQueryKeys } from '../../shared/api/query-keys';
+import { formatEntityUid, fromBackend } from '../../shared/entity-adapter';
+import { ENTITY_KIND_REGISTRY } from '../../shared/entity-kind-registry';
+import { useEntities } from '../../shared/hooks/useEntities';
+
+type EntityKind = 'PRINCIPAL' | 'RESOURCE';
+
+/** Backend limit; see AuthzEntityIdConstants.MAX_ENTITY_ID_LENGTH. */
+const MAX_ENTITY_ID_LENGTH = 255;
+
+/** Single entityId segment: must match what the backend regex accepts between dots. */
+const SEGMENT_REGEX = /^[a-z0-9_-]+$/;
+
+/** Custom prefix must additionally start with a letter so it doesn't look like a number. */
+const CUSTOM_PREFIX_REGEX = /^[a-z][a-z0-9-]*$/;
+
+const PRINCIPAL_PRESETS: readonly { canonical: string; label: string }[] = [
+    { canonical: 'user', label: 'User' },
+    { canonical: 'group', label: 'Group' },
+    { canonical: 'serviceaccount', label: 'Service Account' },
+    { canonical: 'agent-identity', label: 'Agent Identity' },
+];
+
+const RESOURCE_PRESETS: readonly { canonical: string; label: string }[] = [
+    { canonical: 'mcp', label: 'MCP Server' },
+    { canonical: 'model', label: 'AI Model' },
+    { canonical: 'agent', label: 'Agent' },
+    { canonical: 'api', label: 'API' },
+    { canonical: 'event', label: 'Event' },
+    { canonical: 'resource', label: 'Generic Resource' },
+];
+
+const CUSTOM_TYPE = '__custom__';
+
+function slugify(value: string): string {
+    return value
+        .normalize('NFD')
+        .replace(/[̀-ͯ]/g, '')
+        .toLowerCase()
+        .replace(/[^a-z0-9_-]+/g, '-')
+        .replace(/^-+|-+$/g, '');
+}
+
+function isKnownCanonical(value: string): boolean {
+    return ENTITY_KIND_REGISTRY.some(e => e.canonical === value);
+}
+
+export interface CreateEntityDialogProps {
+    readonly open: boolean;
+    readonly kind: EntityKind;
+    readonly environmentId: string;
+    readonly onOpenChange: (open: boolean) => void;
+    readonly onCreated: () => void;
+}
+
+export function CreateEntityDialog({ open, kind, environmentId, onOpenChange, onCreated }: CreateEntityDialogProps) {
+    const queryClient = useQueryClient();
+    const presets = kind === 'PRINCIPAL' ? PRINCIPAL_PRESETS : RESOURCE_PRESETS;
+
+    const [typeSelection, setTypeSelection] = useState<string>(presets[0]!.canonical);
+    const [customPrefix, setCustomPrefix] = useState('');
+    const [slug, setSlug] = useState('');
+    const [slugTouched, setSlugTouched] = useState(false);
+    const [displayName, setDisplayName] = useState('');
+    const [description, setDescription] = useState('');
+    const [parentIds, setParentIds] = useState<string[]>([]);
+    const [submitting, setSubmitting] = useState(false);
+    const [submitError, setSubmitError] = useState<string | null>(null);
+
+    // Reset state on close so the next open is fresh. Done as effect so external
+    // resets (e.g. from successful import) don't fight the local state machine.
+    useEffect(() => {
+        if (!open) {
+            setTypeSelection(presets[0]!.canonical);
+            setCustomPrefix('');
+            setSlug('');
+            setSlugTouched(false);
+            setDisplayName('');
+            setDescription('');
+            setParentIds([]);
+            setSubmitError(null);
+            setSubmitting(false);
+        }
+    }, [open, presets]);
+
+    // Auto-derive slug from displayName until the user touches the slug field.
+    useEffect(() => {
+        if (!slugTouched) setSlug(slugify(displayName));
+    }, [displayName, slugTouched]);
+
+    const isCustom = typeSelection === CUSTOM_TYPE;
+    const canonicalPrefix = isCustom ? customPrefix.trim().toLowerCase() : typeSelection;
+    const entityId = canonicalPrefix && slug ? `${canonicalPrefix}.${slug}` : '';
+
+    const customPrefixError =
+        isCustom && customPrefix.length > 0 && !CUSTOM_PREFIX_REGEX.test(customPrefix.trim().toLowerCase())
+            ? 'Prefix must start with a letter and contain only lowercase letters, digits, or dashes.'
+            : null;
+    const slugError = slug.length > 0 && !SEGMENT_REGEX.test(slug) ? 'Slug must match [a-z0-9_-]+ (no dots, no spaces).' : null;
+    const lengthError = entityId.length > MAX_ENTITY_ID_LENGTH ? `Entity ID must be at most ${MAX_ENTITY_ID_LENGTH} characters.` : null;
+    const displayNameError = displayName.trim().length === 0 ? 'Display name is required.' : null;
+
+    const canSubmit =
+        !submitting &&
+        slug.length > 0 &&
+        canonicalPrefix.length > 0 &&
+        displayName.trim().length > 0 &&
+        !customPrefixError &&
+        !slugError &&
+        !lengthError &&
+        (isCustom ? !isKnownCanonical(canonicalPrefix) : true);
+
+    // Parents come from the same kind: a Group is a parent of a User; a generic
+    // Resource can be a parent of an MCP/Model/etc. Fetching a reasonable page
+    // covers most envs without pulling thousands of options into the picker.
+    const parentsQuery = useEntities(environmentId, 200, { kind });
+    const parentOptions = useMemo(() => {
+        const all = parentsQuery.data?.data ?? [];
+        return all.map(fromBackend).map(e => {
+            const uid = formatEntityUid(e.uid);
+            const label =
+                (typeof e.attrs._displayName === 'string' && (e.attrs._displayName as string)) ||
+                (typeof e.attrs.name === 'string' && (e.attrs.name as string)) ||
+                e.uid.id;
+            return { uid, label, type: e.uid.type };
+        });
+    }, [parentsQuery.data]);
+
+    const parentAnchorRef = useComboboxAnchor();
+
+    async function handleSubmit(event: React.FormEvent) {
+        event.preventDefault();
+        if (!canSubmit) return;
+        setSubmitting(true);
+        setSubmitError(null);
+        const trimmedDescription = description.trim();
+        const attributes: Record<string, unknown> = {
+            _displayName: displayName.trim(),
+        };
+        if (trimmedDescription) attributes.description = trimmedDescription;
+        try {
+            await authzApiService.createEntity(environmentId, {
+                entityId,
+                kind,
+                attributes,
+                parents: parentIds,
+                source: 'local',
+            });
+            toast.success(`Created ${displayName.trim()}`);
+            void queryClient.invalidateQueries({ queryKey: authzQueryKeys.entities.all(environmentId) });
+            onCreated();
+            onOpenChange(false);
+        } catch (err) {
+            const message = err instanceof Error ? err.message : String(err);
+            // Map the common backend error so the user sees something actionable.
+            if (/already exists|duplicate|conflict/i.test(message) || /409/.test(message)) {
+                setSubmitError(`An entity with ID "${entityId}" already exists.`);
+            } else {
+                setSubmitError(message);
+            }
+        } finally {
+            setSubmitting(false);
+        }
+    }
+
+    const labelForKind = kind === 'PRINCIPAL' ? 'Principal' : 'Resource';
+
+    return (
+        <Sheet open={open} onOpenChange={onOpenChange}>
+            <SheetContent
+                side="right"
+                showCloseButton={false}
+                aria-label={`Add ${labelForKind}`}
+                style={{ width: 'min(640px, 100vw)', maxWidth: 'min(640px, 100vw)' }}
+                className="flex h-full flex-col gap-0 p-0"
+            >
+                <div className="border-b px-6 py-4">
+                    <SheetTitle className="text-lg font-semibold">{`Add ${labelForKind}`}</SheetTitle>
+                    <p className="mt-1 text-sm text-muted-foreground">
+                        {kind === 'PRINCIPAL'
+                            ? 'Create a local principal that the policy engine can reference. Use this for actors that are not synced from APIM or imported from the Context Catalog.'
+                            : 'Create a local resource entity that the policy engine can target. For catalog-managed resources, use Import from Context Catalog instead.'}
+                    </p>
+                </div>
+
+                <form className="flex min-h-0 flex-1 flex-col overflow-y-auto" onSubmit={handleSubmit}>
+                    <div className="flex flex-col gap-4 px-6 py-4">
+                        {submitError && (
+                            <Alert variant="destructive">
+                                <AlertDescription>{submitError}</AlertDescription>
+                            </Alert>
+                        )}
+
+                        <div className="flex flex-col gap-1.5">
+                            <Label htmlFor="create-entity-type">Type</Label>
+                            <Select value={typeSelection} onValueChange={setTypeSelection}>
+                                <SelectTrigger id="create-entity-type" aria-label="Entity type">
+                                    <SelectValue />
+                                </SelectTrigger>
+                                <SelectContent>
+                                    {presets.map(p => (
+                                        <SelectItem key={p.canonical} value={p.canonical}>
+                                            {p.label}
+                                            <Badge variant="outline" className="ml-2 font-mono text-xs">
+                                                {p.canonical}
+                                            </Badge>
+                                        </SelectItem>
+                                    ))}
+                                    <SelectItem value={CUSTOM_TYPE}>Other (custom prefix)</SelectItem>
+                                </SelectContent>
+                            </Select>
+                        </div>
+
+                        {isCustom && (
+                            <div className="flex flex-col gap-1.5">
+                                <Label htmlFor="create-entity-custom-prefix">Custom prefix</Label>
+                                <Input
+                                    id="create-entity-custom-prefix"
+                                    value={customPrefix}
+                                    onChange={e => setCustomPrefix(e.target.value)}
+                                    placeholder="e.g. webhook"
+                                    aria-invalid={customPrefixError !== null}
+                                    aria-describedby={customPrefixError ? 'create-entity-custom-prefix-error' : undefined}
+                                />
+                                {customPrefixError && (
+                                    <p id="create-entity-custom-prefix-error" className="text-xs text-destructive">
+                                        {customPrefixError}
+                                    </p>
+                                )}
+                                {!customPrefixError && isKnownCanonical(canonicalPrefix) && customPrefix.length > 0 && (
+                                    <p className="text-xs text-warning">
+                                        "{canonicalPrefix}" is a preset type — pick it from the dropdown instead.
+                                    </p>
+                                )}
+                            </div>
+                        )}
+
+                        <div className="flex flex-col gap-1.5">
+                            <Label htmlFor="create-entity-display-name">Display name</Label>
+                            <Input
+                                id="create-entity-display-name"
+                                value={displayName}
+                                onChange={e => setDisplayName(e.target.value)}
+                                placeholder="e.g. Alice"
+                                aria-invalid={displayName.length > 0 && displayNameError !== null}
+                                required
+                            />
+                        </div>
+
+                        <div className="flex flex-col gap-1.5">
+                            <Label htmlFor="create-entity-slug">Slug</Label>
+                            <Input
+                                id="create-entity-slug"
+                                value={slug}
+                                onChange={e => {
+                                    setSlug(e.target.value);
+                                    setSlugTouched(true);
+                                }}
+                                placeholder="e.g. alice"
+                                aria-invalid={slugError !== null}
+                                aria-describedby={slugError ? 'create-entity-slug-error' : undefined}
+                                required
+                            />
+                            {slugError && (
+                                <p id="create-entity-slug-error" className="text-xs text-destructive">
+                                    {slugError}
+                                </p>
+                            )}
+                        </div>
+
+                        <div className="flex flex-col gap-1.5">
+                            <Label htmlFor="create-entity-id-preview">Entity ID</Label>
+                            <code
+                                id="create-entity-id-preview"
+                                aria-live="polite"
+                                className={cn(
+                                    'rounded-md border bg-muted/40 px-3 py-2 font-mono text-sm',
+                                    lengthError ? 'border-destructive text-destructive' : 'text-foreground',
+                                )}
+                            >
+                                {entityId || <span className="text-muted-foreground">{`${canonicalPrefix || 'kind'}.<slug>`}</span>}
+                            </code>
+                            {lengthError && <p className="text-xs text-destructive">{lengthError}</p>}
+                        </div>
+
+                        <div className="flex flex-col gap-1.5">
+                            <Label htmlFor="create-entity-description">
+                                Description <span className="text-xs text-muted-foreground">(optional)</span>
+                            </Label>
+                            <Textarea
+                                id="create-entity-description"
+                                value={description}
+                                onChange={e => setDescription(e.target.value)}
+                                placeholder="Short note about what this entity represents."
+                                rows={3}
+                            />
+                        </div>
+
+                        <div className="flex flex-col gap-1.5">
+                            <Label>
+                                Parents <span className="text-xs text-muted-foreground">(optional)</span>
+                            </Label>
+                            <Combobox
+                                multiple
+                                value={parentIds}
+                                onValueChange={next => setParentIds(next as string[])}
+                                autoComplete="list"
+                            >
+                                <ComboboxChips ref={parentAnchorRef}>
+                                    {parentIds.map(pid => {
+                                        const opt = parentOptions.find(o => o.uid === pid);
+                                        return (
+                                            <ComboboxChip key={pid} removeAriaLabel={`Remove ${opt?.label ?? pid}`}>
+                                                {opt?.label ?? pid}
+                                            </ComboboxChip>
+                                        );
+                                    })}
+                                    <ComboboxChipsInput
+                                        placeholder={parentIds.length === 0 ? 'Search existing entities…' : ''}
+                                        aria-label="Add parent"
+                                    />
+                                </ComboboxChips>
+                                <ComboboxContent
+                                    anchor={parentAnchorRef}
+                                    className="max-h-64 min-w-60"
+                                    style={{ pointerEvents: 'auto' }}
+                                >
+                                    <ComboboxList>
+                                        <ComboboxEmpty>
+                                            {parentOptions.length === 0
+                                                ? `No ${labelForKind.toLowerCase()}s available as parents yet.`
+                                                : 'No matches.'}
+                                        </ComboboxEmpty>
+                                        {parentOptions.map(opt => (
+                                            <ComboboxItem key={opt.uid} value={opt.uid}>
+                                                <div className="flex min-w-0 flex-1 items-center gap-2">
+                                                    <span className="truncate">{opt.label}</span>
+                                                    <Badge variant="outline" className="shrink-0 font-mono text-xs">
+                                                        {opt.type}
+                                                    </Badge>
+                                                </div>
+                                            </ComboboxItem>
+                                        ))}
+                                    </ComboboxList>
+                                </ComboboxContent>
+                            </Combobox>
+                        </div>
+                    </div>
+                </form>
+
+                <div className="flex flex-none items-center justify-end gap-2 border-t bg-muted/40 px-6 py-3.5">
+                    <Button type="button" variant="outline" onClick={() => onOpenChange(false)} disabled={submitting}>
+                        Cancel
+                    </Button>
+                    <Button type="button" onClick={handleSubmit as unknown as () => void} disabled={!canSubmit}>
+                        {submitting ? <Spinner className="mr-2 size-4" aria-hidden /> : <PlusIcon className="mr-2 size-4" aria-hidden />}
+                        {`Create ${labelForKind}`}
+                    </Button>
+                </div>
+            </SheetContent>
+        </Sheet>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/features/policy-structure/EntitiesPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/features/policy-structure/EntitiesPage.tsx
@@ -44,7 +44,7 @@ import {
     TabsTrigger,
     toast,
 } from '@gravitee/graphene-core';
-import { BoxesIcon, DownloadIcon, ShieldIcon, Trash2Icon, UsersIcon } from '@gravitee/graphene-core/icons';
+import { BoxesIcon, DownloadIcon, PlusIcon, ShieldIcon, Trash2Icon, UsersIcon } from '@gravitee/graphene-core/icons';
 import { useQueryClient } from '@tanstack/react-query';
 import type { ColumnDef } from '@tanstack/react-table';
 import { useDeferredValue, useMemo, useState } from 'react';
@@ -53,8 +53,11 @@ import { authzApiService } from '../../shared/api/authz-api.service';
 import { authzQueryKeys } from '../../shared/api/query-keys';
 import { formatEntityUid, fromBackend } from '../../shared/entity-adapter';
 import { useEntities, type UseEntitiesResult } from '../../shared/hooks/useEntities';
+import { CreateEntityDialog } from './CreateEntityDialog';
 import { CATEGORIES, getEntityCategoryId, type EntityInstance } from './entity-types';
 import { ImportFromCatalogDialog } from './ImportFromCatalogDialog';
+
+type AddingKind = 'PRINCIPAL' | 'RESOURCE';
 
 type SourceFilter = 'all' | string;
 type TypeFilter = 'all' | string;
@@ -313,6 +316,7 @@ export function EntitiesPage() {
     const [resourceTypeFilter, setResourceTypeFilter] = useState<TypeFilter>('all');
     const [resourceSourceFilter, setResourceSourceFilter] = useState<SourceFilter>('all');
     const [importOpen, setImportOpen] = useState(false);
+    const [addingKind, setAddingKind] = useState<AddingKind | null>(null);
     const [pendingDelete, setPendingDelete] = useState<EntityInstance | null>(null);
     const [deletingEntityId, setDeletingEntityId] = useState<string | undefined>();
 
@@ -426,17 +430,25 @@ export function EntitiesPage() {
                     <Alert>
                         <AlertDescription>{PRINCIPALS_HELP}</AlertDescription>
                     </Alert>
-                    <EntitiesFilterBar
-                        search={principalSearch}
-                        onSearch={setPrincipalSearch}
-                        typesPresent={principalTypes}
-                        typeFilter={principalTypeFilter}
-                        onTypeFilter={setPrincipalTypeFilter}
-                        sourcesPresent={principalSources}
-                        sourceFilter={principalSourceFilter}
-                        onSourceFilter={setPrincipalSourceFilter}
-                        searchLabel="Search principals"
-                    />
+                    <div className="flex flex-wrap items-center gap-2">
+                        <EntitiesFilterBar
+                            search={principalSearch}
+                            onSearch={setPrincipalSearch}
+                            typesPresent={principalTypes}
+                            typeFilter={principalTypeFilter}
+                            onTypeFilter={setPrincipalTypeFilter}
+                            sourcesPresent={principalSources}
+                            sourceFilter={principalSourceFilter}
+                            onSourceFilter={setPrincipalSourceFilter}
+                            searchLabel="Search principals"
+                        />
+                        <div className="ml-auto">
+                            <Button onClick={() => setAddingKind('PRINCIPAL')}>
+                                <PlusIcon className="mr-2 size-4" aria-hidden />
+                                Add principal
+                            </Button>
+                        </div>
+                    </div>
                     <EntitiesTable
                         tab="principals"
                         entities={filteredPrincipals}
@@ -466,7 +478,11 @@ export function EntitiesPage() {
                             onSourceFilter={setResourceSourceFilter}
                             searchLabel="Search resources"
                         />
-                        <div className="ml-auto">
+                        <div className="ml-auto flex items-center gap-2">
+                            <Button variant="outline" onClick={() => setAddingKind('RESOURCE')}>
+                                <PlusIcon className="mr-2 size-4" aria-hidden />
+                                Add resource
+                            </Button>
                             <Button onClick={() => setImportOpen(true)}>
                                 <DownloadIcon className="mr-2 size-4" aria-hidden />
                                 Import from Context Catalog
@@ -494,6 +510,16 @@ export function EntitiesPage() {
                 environmentId={environmentId}
                 onOpenChange={setImportOpen}
                 onImported={handleImported}
+            />
+
+            <CreateEntityDialog
+                open={addingKind !== null}
+                kind={addingKind ?? 'PRINCIPAL'}
+                environmentId={environmentId}
+                onOpenChange={open => {
+                    if (!open) setAddingKind(null);
+                }}
+                onCreated={handleImported}
             />
 
             <Dialog

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/features/policy-structure/__tests__/CreateEntityDialog.test.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/features/policy-structure/__tests__/CreateEntityDialog.test.tsx
@@ -1,0 +1,248 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { ReactNode } from 'react';
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { CreateEntityDialog } from '../CreateEntityDialog';
+
+beforeAll(() => {
+    if (!Element.prototype.scrollIntoView) {
+        Element.prototype.scrollIntoView = () => undefined;
+    }
+});
+
+const listEntitiesSpy = vi.fn();
+const createEntitySpy = vi.fn();
+const toastSuccessSpy = vi.fn();
+
+vi.mock('../../../shared/api/authz-api.service', () => ({
+    DEFAULT_PER_PAGE: 200,
+    authzApiService: {
+        listEntities: (env: string, params?: unknown) => listEntitiesSpy(env, params),
+        createEntity: (env: string, req: unknown) => createEntitySpy(env, req),
+    },
+}));
+
+vi.mock('@gravitee/graphene-core', async importOriginal => {
+    const actual = await importOriginal<Record<string, unknown>>();
+    return {
+        ...actual,
+        toast: {
+            success: (msg: string) => toastSuccessSpy(msg),
+            error: vi.fn(),
+        },
+    };
+});
+
+function wrapper({ children }: { children: ReactNode }) {
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    return <QueryClientProvider client={qc}>{children}</QueryClientProvider>;
+}
+
+function seedParents(uids: readonly string[]) {
+    listEntitiesSpy.mockResolvedValue({
+        data: uids.map((uid, i) => ({
+            id: `e${i}`,
+            environmentId: 'DEFAULT',
+            uid,
+            attributes: { _displayName: uid.split('.')[1] },
+            parents: [],
+            createdAt: '2026-05-27T10:00:00.000Z',
+            updatedAt: '2026-05-27T10:00:00.000Z',
+        })),
+        total: uids.length,
+        page: 1,
+        perPage: 200,
+    });
+}
+
+beforeEach(() => {
+    listEntitiesSpy.mockReset();
+    createEntitySpy.mockReset();
+    toastSuccessSpy.mockReset();
+    seedParents([]);
+    createEntitySpy.mockResolvedValue({
+        id: 'new-1',
+        environmentId: 'DEFAULT',
+        uid: 'user.alice',
+        attributes: { _displayName: 'Alice' },
+        parents: [],
+        createdAt: '2026-05-27T11:00:00.000Z',
+        updatedAt: '2026-05-27T11:00:00.000Z',
+    });
+});
+
+function renderDialog(props: Partial<Parameters<typeof CreateEntityDialog>[0]> = {}) {
+    const onOpenChange = vi.fn();
+    const onCreated = vi.fn();
+    render(
+        <CreateEntityDialog
+            open
+            kind="PRINCIPAL"
+            environmentId="DEFAULT"
+            onOpenChange={onOpenChange}
+            onCreated={onCreated}
+            {...props}
+        />,
+        { wrapper },
+    );
+    return { onOpenChange, onCreated };
+}
+
+describe('CreateEntityDialog', () => {
+    it('renders Principal-specific copy when kind=PRINCIPAL', () => {
+        renderDialog({ kind: 'PRINCIPAL' });
+        expect(screen.getByRole('heading', { name: /Add Principal/i })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: /Create Principal/i })).toBeInTheDocument();
+    });
+
+    it('renders Resource-specific copy when kind=RESOURCE', () => {
+        renderDialog({ kind: 'RESOURCE' });
+        expect(screen.getByRole('heading', { name: /Add Resource/i })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: /Create Resource/i })).toBeInTheDocument();
+    });
+
+    it('auto-derives the slug from the display name (kebab-case, accent-stripped)', async () => {
+        const user = userEvent.setup();
+        renderDialog();
+
+        await user.type(screen.getByLabelText(/Display name/i), 'Aliçe Müller');
+        const slug = screen.getByLabelText('Slug') as HTMLInputElement;
+        await waitFor(() => expect(slug.value).toBe('alice-muller'));
+        const preview = screen.getByText(/^user\.alice-muller$/);
+        expect(preview).toBeInTheDocument();
+    });
+
+    it('stops auto-deriving the slug once the user edits it manually', async () => {
+        const user = userEvent.setup();
+        renderDialog();
+
+        await user.type(screen.getByLabelText(/Display name/i), 'Alice');
+        const slug = screen.getByLabelText('Slug') as HTMLInputElement;
+        await waitFor(() => expect(slug.value).toBe('alice'));
+
+        await user.clear(slug);
+        await user.type(slug, 'a_l_i_c_e');
+        await user.type(screen.getByLabelText(/Display name/i), ' the second');
+        // Slug should not have been overwritten by the display-name change.
+        expect(slug.value).toBe('a_l_i_c_e');
+    });
+
+    it('disables the Create button until display name + slug + type are valid', async () => {
+        const user = userEvent.setup();
+        renderDialog();
+        const create = screen.getByRole('button', { name: /Create Principal/i });
+        expect(create).toBeDisabled();
+
+        await user.type(screen.getByLabelText(/Display name/i), 'Alice');
+        await waitFor(() => expect(create).toBeEnabled());
+
+        const slug = screen.getByLabelText('Slug') as HTMLInputElement;
+        await user.clear(slug);
+        await user.type(slug, 'Bad Slug!');
+        expect(create).toBeDisabled();
+        expect(screen.getByText(/Slug must match/i)).toBeInTheDocument();
+    });
+
+    it('submits with the right payload on Create (Principal + description)', async () => {
+        const user = userEvent.setup();
+        const { onOpenChange, onCreated } = renderDialog({ kind: 'PRINCIPAL' });
+
+        await user.type(screen.getByLabelText(/Display name/i), 'Alice');
+        await user.type(screen.getByLabelText(/Description/i), 'Engineering lead');
+        await user.click(screen.getByRole('button', { name: /Create Principal/i }));
+
+        await waitFor(() => expect(createEntitySpy).toHaveBeenCalledTimes(1));
+        const [env, req] = createEntitySpy.mock.calls[0];
+        expect(env).toBe('DEFAULT');
+        expect(req).toMatchObject({
+            entityId: 'user.alice',
+            kind: 'PRINCIPAL',
+            source: 'local',
+            parents: [],
+        });
+        expect((req as { attributes: Record<string, unknown> }).attributes).toMatchObject({
+            _displayName: 'Alice',
+            description: 'Engineering lead',
+        });
+        await waitFor(() => expect(toastSuccessSpy).toHaveBeenCalledWith('Created Alice'));
+        await waitFor(() => expect(onCreated).toHaveBeenCalledTimes(1));
+        expect(onOpenChange).toHaveBeenCalledWith(false);
+    });
+
+    it('omits the description attribute when the field is blank', async () => {
+        const user = userEvent.setup();
+        renderDialog({ kind: 'PRINCIPAL' });
+
+        await user.type(screen.getByLabelText(/Display name/i), 'Bob');
+        await user.click(screen.getByRole('button', { name: /Create Principal/i }));
+
+        await waitFor(() => expect(createEntitySpy).toHaveBeenCalledTimes(1));
+        const [, req] = createEntitySpy.mock.calls[0];
+        const attrs = (req as { attributes: Record<string, unknown> }).attributes;
+        expect(attrs._displayName).toBe('Bob');
+        expect(attrs.description).toBeUndefined();
+    });
+
+    it('renders the duplicate-id message on 409 and keeps the dialog open', async () => {
+        const user = userEvent.setup();
+        createEntitySpy.mockRejectedValueOnce(new Error('HTTP 409 entity already exists'));
+        const { onOpenChange } = renderDialog({ kind: 'PRINCIPAL' });
+
+        await user.type(screen.getByLabelText(/Display name/i), 'Alice');
+        await user.click(screen.getByRole('button', { name: /Create Principal/i }));
+
+        await waitFor(() => expect(screen.getByText(/An entity with ID "user\.alice" already exists/i)).toBeInTheDocument());
+        // Dialog stays open; onOpenChange called only by the caller closing it, not by the error path.
+        expect(onOpenChange).not.toHaveBeenCalled();
+    });
+
+    it('switches to the custom prefix input when "Other (custom prefix)" is selected', async () => {
+        const user = userEvent.setup();
+        renderDialog({ kind: 'RESOURCE' });
+
+        await user.click(screen.getByLabelText('Entity type'));
+        await user.click(await screen.findByRole('option', { name: /Other \(custom prefix\)/i }));
+
+        const customInput = screen.getByLabelText(/Custom prefix/i);
+        await user.type(customInput, 'webhook');
+        await user.type(screen.getByLabelText(/Display name/i), 'Slack hook');
+
+        // Slug auto-derives from displayName.
+        await waitFor(() => expect(screen.getByText(/^webhook\.slack-hook$/)).toBeInTheDocument());
+
+        await user.click(screen.getByRole('button', { name: /Create Resource/i }));
+        await waitFor(() => expect(createEntitySpy).toHaveBeenCalledTimes(1));
+        const [, req] = createEntitySpy.mock.calls[0];
+        expect((req as { entityId: string }).entityId).toBe('webhook.slack-hook');
+    });
+
+    it('warns when a custom prefix collides with a preset canonical', async () => {
+        const user = userEvent.setup();
+        renderDialog({ kind: 'RESOURCE' });
+
+        await user.click(screen.getByLabelText('Entity type'));
+        await user.click(await screen.findByRole('option', { name: /Other \(custom prefix\)/i }));
+
+        await user.type(screen.getByLabelText(/Custom prefix/i), 'mcp');
+        await user.type(screen.getByLabelText(/Display name/i), 'Custom');
+
+        expect(screen.getByText(/"mcp" is a preset type/i)).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: /Create Resource/i })).toBeDisabled();
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/features/policy-structure/__tests__/EntitiesPage.test.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/features/policy-structure/__tests__/EntitiesPage.test.tsx
@@ -37,6 +37,11 @@ vi.mock('@gravitee/graphene-core', async importOriginal => {
 
 // The dialog itself is unit-tested separately (ImportFromCatalogDialog.test.tsx);
 // here we just need it to render without firing real catalog queries.
+vi.mock('../CreateEntityDialog', () => ({
+    CreateEntityDialog: ({ open, kind }: { open: boolean; kind: string }) =>
+        open ? <div data-testid="create-entity-dialog-stub" data-kind={kind} /> : null,
+}));
+
 vi.mock('../ImportFromCatalogDialog', () => ({
     ImportFromCatalogDialog: ({ open }: { open: boolean }) => (open ? <div data-testid="import-dialog-stub" /> : null),
 }));
@@ -232,6 +237,34 @@ describe('EntitiesPage', () => {
         expect(screen.queryByTestId('import-dialog-stub')).not.toBeInTheDocument();
         await user.click(screen.getByRole('button', { name: /Import from Context Catalog/i }));
         expect(screen.getByTestId('import-dialog-stub')).toBeInTheDocument();
+    });
+
+    it('opens the create-entity dialog as PRINCIPAL when "Add principal" is clicked', async () => {
+        mockByKind({ principals: [makeEntity({ id: 'p1', uid: 'user.alice' })] });
+        renderPage();
+
+        const user = userEvent.setup();
+        await waitFor(() => expect(screen.getByRole('button', { name: /Add principal/i })).toBeInTheDocument());
+
+        expect(screen.queryByTestId('create-entity-dialog-stub')).not.toBeInTheDocument();
+        await user.click(screen.getByRole('button', { name: /Add principal/i }));
+
+        const stub = screen.getByTestId('create-entity-dialog-stub');
+        expect(stub).toHaveAttribute('data-kind', 'PRINCIPAL');
+    });
+
+    it('opens the create-entity dialog as RESOURCE when "Add resource" is clicked', async () => {
+        mockByKind({ resources: [makeEntity({ id: 'r1', uid: 'mcp.flight' })] });
+        renderPage();
+
+        const user = userEvent.setup();
+        await user.click(screen.getByRole('tab', { name: /Resources/i }));
+        await waitFor(() => expect(screen.getByRole('button', { name: /Add resource/i })).toBeInTheDocument());
+
+        await user.click(screen.getByRole('button', { name: /Add resource/i }));
+
+        const stub = screen.getByTestId('create-entity-dialog-stub');
+        expect(stub).toHaveAttribute('data-kind', 'RESOURCE');
     });
 
     it('shows the row-level Remove action only on the Resources tab', async () => {

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/test/ui/setup.ts
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/test/ui/setup.ts
@@ -14,3 +14,17 @@
  * limitations under the License.
  */
 import '@testing-library/jest-dom/vitest';
+
+// jsdom doesn't implement Pointer Events; Radix / base-ui Select calls these.
+if (!Element.prototype.hasPointerCapture) {
+    Element.prototype.hasPointerCapture = () => false;
+}
+if (!Element.prototype.setPointerCapture) {
+    Element.prototype.setPointerCapture = () => undefined;
+}
+if (!Element.prototype.releasePointerCapture) {
+    Element.prototype.releasePointerCapture = () => undefined;
+}
+if (!Element.prototype.scrollIntoView) {
+    Element.prototype.scrollIntoView = () => undefined;
+}


### PR DESCRIPTION
## Issue

Stack PR — ui-9 of authz-ui chain. Builds on #17167 (ui-8, catalog import).

## Description

Adds an "Add principal" / "Add resource" action on the Entities page so users can register entities locally without going through the AIM Context Catalog.

### CreateEntityDialog (Sheet, right side)
- Closed dropdown for canonical types per kind:
  - **Principal**: User / Group / Service Account / Agent Identity
  - **Resource**: MCP Server / AI Model / Agent / API / Event / Generic Resource
- "Other (custom prefix)" reveals a text input validated against `^[a-z][a-z0-9-]*$`, and warns when the typed prefix collides with a preset canonical.
- Display name (required) + auto-derived slug (kebab-case, NFD-stripped). Slug stops auto-deriving once the user edits it manually.
- Live `entityId` preview, length-capped at 255 (matches backend's `AuthzEntityIdConstants.MAX_ENTITY_ID_LENGTH`).
- Optional description → `description` attribute on the entity.
- Optional parents chip-picker fed by `useEntities` scoped to the same kind.
- Submits with `source: 'local'`; surfaces 409s as "Entity with this ID already exists" and keeps the dialog open on error.

### EntitiesPage wiring
- "+ Add principal" on the Principals tab (next to the filter bar).
- "+ Add resource" on the Resources tab (next to "Import from Context Catalog").
- Single `addingKind: 'PRINCIPAL' | 'RESOURCE' | null` state drives both buttons; the dialog reuses the same cache-invalidation callback as the catalog import so new entities appear without a page refresh.

### Tests
- 10 vitest specs for `CreateEntityDialog` covering slug derivation, type switching, custom-prefix happy path + preset-collision warning, submit payload (with and without description), and 409 error handling.
- 2 new `EntitiesPage` specs verifying the buttons open the dialog with the right `kind`.
- Shared test setup gained Pointer Events polyfills so Radix / base-ui Select can open inside Sheet content under jsdom.

## Test plan

- [x] `npx vitest run` → **345 specs green** (333 before, +10 dialog +2 page).
- [x] Manual: open Authorization → Entities → Principals tab → "+ Add principal" → fill form → submit → row appears.
- [x] Manual: open Resources tab → "+ Add resource" → pick "Other (custom prefix)", type `webhook` + display name → submit → row appears.
- [x] Manual: try to add a duplicate entityId → see the "already exists" alert, dialog stays open.

## Out of scope (future branches)

- Edit existing entities (PATCH `_displayName` / description in place)
- Action entities (`action.*`) — separate page
- Bulk add
- Validate unique display name (currently only `entityId` uniqueness)