### PR TITLE
docs: add Automation API sync guidelines to coding documentation

### DIFF
--- a/.agent-rules/java.md
+++ b/.agent-rules/java.md
@@ -93,7 +93,20 @@ mvn prettier:write -pl <module>
 - **Method names**: Must follow **snake_case** convention (e.g., `should_return_error_when_api_not_found()`).
 - **Prefer real objects over mocks**: In clean/hexagonal architecture, instantiate real domain objects and in-memory adapters instead of mocking. Reserve mocks for external I/O boundaries (HTTP clients, databases) that are costly or impractical to instantiate.
 
-## 5. Common Pitfalls
+## 5. Automation API Sync
+
+The **Automation API** (`gravitee-apim-rest-api/gravitee-apim-rest-api-automation/`) is a separate API surface that partially mirrors the Management API v2 for GitOps/automation use cases. It has its **own OpenAPI spec** and **generated models**, mapped to/from Management v2 models via MapStruct.
+
+**When any of these changes happen, check whether the Automation API needs the same update:**
+
+- Adding/modifying fields on v4 API definition models (`gravitee-apim-definition`)
+- Adding/modifying database entity fields surfaced through Management API v2 (`gravitee-apim-repository`)
+- Adding/changing enum values or schema properties in Management API v2 OpenAPI specs
+- Adding/changing fields in core CRD models (`gravitee-apim-rest-api-service/.../api/model/crd/`)
+
+**What to update** — see the *Automation API sync checklist* section in [`gravitee-apim-rest-api/AGENTS.md`](../gravitee-apim-rest-api/AGENTS.md) for the exact files and steps.
+
+## 6. Common Pitfalls
 
 ### JsonNode vs ObjectNode in Lists
 

--- a/gravitee-apim-definition/AGENTS.md
+++ b/gravitee-apim-definition/AGENTS.md
@@ -1,1 +1,5 @@
 # Coding Guidelines for gravitee-apim-definition
+
+## Automation API impact
+
+When adding or modifying v4 API definition models, check whether the **Automation API** needs the same change. Fields that are surfaced through Management API v2 are likely also needed in the Automation API. See the *Automation API sync checklist* in [`gravitee-apim-rest-api/AGENTS.md`](../gravitee-apim-rest-api/AGENTS.md).

--- a/gravitee-apim-repository/AGENTS.md
+++ b/gravitee-apim-repository/AGENTS.md
@@ -1,1 +1,5 @@
 # Coding Guidelines for gravitee-apim-repository
+
+## Automation API impact
+
+When adding or modifying database entity fields that are surfaced through Management API v2, check whether the **Automation API** needs the same change. See the *Automation API sync checklist* in [`gravitee-apim-rest-api/AGENTS.md`](../gravitee-apim-rest-api/AGENTS.md).

--- a/gravitee-apim-rest-api/AGENTS.md
+++ b/gravitee-apim-rest-api/AGENTS.md
@@ -18,3 +18,21 @@ Use this when you add or change **HTTP endpoints** (paths, operations, request/r
 3. **Implement JAX-RS** — resource classes and mappers import those generated types (e.g. `io.gravitee.rest.api.management.v2.rest.model.*`, `io.gravitee.rest.api.kafkaexplorer.rest.model.*`, `io.gravitee.rest.api.portal.rest.model.*`; v2 also uses subpackages such as `...model.analytics.engine` / `...model.logs.engine` where the POM overrides `modelPackage`).
 
 **Rule for new endpoints:** always **API-first** — update the right OpenAPI file, run Maven on that module so generation runs, then add or change resources. Starting from the resource skips step 2, so the model classes do not exist yet and tooling breaks.
+
+## Automation API sync
+
+The **Automation API** partially mirrors Management API v2 for GitOps/automation use cases. When a field, enum value, or schema is added or changed in the Management API v2 (or in lower layers like the v4 definition or repository), the Automation API must reflect that change.
+
+**Step1 (mandatory) Assess impact: determine if the change affects the Automation API**
+**Step2 (if Automation API is impacted) execute the implementation checklist below: 
+1. **Update the Automation API OpenAPI spec** — add/modify the schema.
+2. **Regenerate models** — compile the module so the openapi-generator produces the updated Java DTOs:
+   ```bash
+   mvn -pl gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest compile
+   ```
+3. **Update MapStruct mappers** — if the new field needs explicit mapping (not auto-mapped by name), update the relevant mapper in:
+   `gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/java/io/gravitee/apim/rest/api/automation/mapper/`
+4. **Update core CRD models if needed** — the CRD models in `gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/model/crd/` act as a bridge between Management v2 and Automation API. If the field is new to the CRD layer, add it there first.
+5. **Make sure that HRID fields or copied during update** - Update operations in the service layer must copy any hrid fields from the existing entity to updated entity.
+
+**Typical data flow:** Automation OpenAPI spec → generated Automation DTOs ↔ MapStruct mappers ↔ core CRD models ↔ Management v2 generated DTOs ← Management v2 OpenAPI specs.


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/GKO-2587

## Description

I updated AGENTS.md to specify that Automation should not be forgotten when it comes to add a new fields to Management API.

```text
I want to add a new field in the Application domain object. It's called rating it is an int from 1 to 5. It is not mandatory.
I want you to add it to the database and map it all up to the management API. It can set by the user upon creation and user can also update it.
Plan the backend implementation, from API to database.  
```

I did a plan: Claude (Opus 4.6) tends to forget it, Cursor did not.
I think this is the first step, we should have a reviewing agent to ensure this is not forgotten.



