### PR TITLE
fix: handle message phases in shared policy groups

### DIFF
--- a/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/sharedpolicygroup/SharedPolicyGroup.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-model/src/main/java/io/gravitee/definition/model/v4/sharedpolicygroup/SharedPolicyGroup.java
@@ -80,7 +80,17 @@ public class SharedPolicyGroup implements Serializable {
     public enum Phase {
         REQUEST,
         RESPONSE,
+        PUBLISH,
+        SUBSCRIBE,
+        /**
+         * @deprecated since 4.11.8, use {@link #PUBLISH} instead.
+         */
+        @Deprecated
         MESSAGE_REQUEST,
+        /**
+         * @deprecated since 4.11.8, use {@link #SUBSCRIBE} instead.
+         */
+        @Deprecated
         MESSAGE_RESPONSE,
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-shared-policy-group/src/main/java/io/gravitee/gateway/handlers/sharedpolicygroup/reactor/impl/DefaultSharedPolicyGroupReactor.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-shared-policy-group/src/main/java/io/gravitee/gateway/handlers/sharedpolicygroup/reactor/impl/DefaultSharedPolicyGroupReactor.java
@@ -16,6 +16,7 @@
 package io.gravitee.gateway.handlers.sharedpolicygroup.reactor.impl;
 
 import io.gravitee.common.component.AbstractLifecycleComponent;
+import io.gravitee.definition.model.v4.sharedpolicygroup.SharedPolicyGroup;
 import io.gravitee.gateway.handlers.sharedpolicygroup.ReactableSharedPolicyGroup;
 import io.gravitee.gateway.handlers.sharedpolicygroup.SharedPolicyGroupPolicyManager;
 import io.gravitee.gateway.handlers.sharedpolicygroup.policy.SharedPolicyGroupPolicyChainFactory;
@@ -67,8 +68,18 @@ public class DefaultSharedPolicyGroupReactor
             reactableSharedPolicyGroup.getId(),
             reactableSharedPolicyGroup.getEnvironmentId(),
             reactableSharedPolicyGroup.getDefinition().getPolicies(),
-            ExecutionPhase.valueOf(reactableSharedPolicyGroup.getDefinition().getPhase().name())
+            toExecutionPhase(reactableSharedPolicyGroup.getDefinition().getPhase())
         );
+    }
+
+    @SuppressWarnings("deprecation")
+    static ExecutionPhase toExecutionPhase(SharedPolicyGroup.Phase phase) {
+        return switch (phase) {
+            case REQUEST -> ExecutionPhase.REQUEST;
+            case RESPONSE -> ExecutionPhase.RESPONSE;
+            case PUBLISH, MESSAGE_REQUEST -> ExecutionPhase.MESSAGE_REQUEST;
+            case SUBSCRIBE, MESSAGE_RESPONSE -> ExecutionPhase.MESSAGE_RESPONSE;
+        };
     }
 
     @Override

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-shared-policy-group/src/main/java/io/gravitee/gateway/handlers/sharedpolicygroup/reactor/impl/DefaultSharedPolicyGroupReactor.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-shared-policy-group/src/main/java/io/gravitee/gateway/handlers/sharedpolicygroup/reactor/impl/DefaultSharedPolicyGroupReactor.java
@@ -72,7 +72,6 @@ public class DefaultSharedPolicyGroupReactor
         );
     }
 
-    @SuppressWarnings("deprecation")
     static ExecutionPhase toExecutionPhase(SharedPolicyGroup.Phase phase) {
         return switch (phase) {
             case REQUEST -> ExecutionPhase.REQUEST;

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-shared-policy-group/src/main/java/io/gravitee/gateway/handlers/sharedpolicygroup/reactor/impl/DefaultSharedPolicyGroupReactorFactory.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-shared-policy-group/src/main/java/io/gravitee/gateway/handlers/sharedpolicygroup/reactor/impl/DefaultSharedPolicyGroupReactorFactory.java
@@ -56,7 +56,8 @@ public class DefaultSharedPolicyGroupReactorFactory implements SharedPolicyGroup
             return false;
         }
         return switch (phase) {
-            case REQUEST, RESPONSE, PUBLISH, SUBSCRIBE, MESSAGE_REQUEST, MESSAGE_RESPONSE -> true;
+            case REQUEST, RESPONSE -> true;
+            case PUBLISH, SUBSCRIBE, MESSAGE_REQUEST, MESSAGE_RESPONSE -> false;
         };
     }
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-shared-policy-group/src/main/java/io/gravitee/gateway/handlers/sharedpolicygroup/reactor/impl/DefaultSharedPolicyGroupReactorFactory.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-shared-policy-group/src/main/java/io/gravitee/gateway/handlers/sharedpolicygroup/reactor/impl/DefaultSharedPolicyGroupReactorFactory.java
@@ -50,11 +50,15 @@ public class DefaultSharedPolicyGroupReactorFactory implements SharedPolicyGroup
     private final OpenTelemetryConfiguration openTelemetryConfiguration;
 
     @Override
+    @SuppressWarnings("deprecation")
     public boolean canCreate(ReactableSharedPolicyGroup reactableSharedPolicyGroup) {
-        return (
-            SharedPolicyGroup.Phase.REQUEST.equals(reactableSharedPolicyGroup.getDefinition().getPhase()) ||
-            SharedPolicyGroup.Phase.RESPONSE.equals(reactableSharedPolicyGroup.getDefinition().getPhase())
-        );
+        var phase = reactableSharedPolicyGroup.getDefinition().getPhase();
+        if (phase == null) {
+            return false;
+        }
+        return switch (phase) {
+            case REQUEST, RESPONSE, PUBLISH, SUBSCRIBE, MESSAGE_REQUEST, MESSAGE_RESPONSE -> true;
+        };
     }
 
     @Override

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-shared-policy-group/src/main/java/io/gravitee/gateway/handlers/sharedpolicygroup/reactor/impl/DefaultSharedPolicyGroupReactorFactory.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-shared-policy-group/src/main/java/io/gravitee/gateway/handlers/sharedpolicygroup/reactor/impl/DefaultSharedPolicyGroupReactorFactory.java
@@ -50,7 +50,6 @@ public class DefaultSharedPolicyGroupReactorFactory implements SharedPolicyGroup
     private final OpenTelemetryConfiguration openTelemetryConfiguration;
 
     @Override
-    @SuppressWarnings("deprecation")
     public boolean canCreate(ReactableSharedPolicyGroup reactableSharedPolicyGroup) {
         var phase = reactableSharedPolicyGroup.getDefinition().getPhase();
         if (phase == null) {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-shared-policy-group/src/test/java/io/gravitee/gateway/handlers/sharedpolicygroup/reactor/impl/DefaultSharedPolicyGroupReactorFactoryTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-shared-policy-group/src/test/java/io/gravitee/gateway/handlers/sharedpolicygroup/reactor/impl/DefaultSharedPolicyGroupReactorFactoryTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.handlers.sharedpolicygroup.reactor.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.definition.model.v4.sharedpolicygroup.SharedPolicyGroup;
+import io.gravitee.gateway.handlers.sharedpolicygroup.ReactableSharedPolicyGroup;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@SuppressWarnings("deprecation")
+class DefaultSharedPolicyGroupReactorFactoryTest {
+
+    @ParameterizedTest
+    @EnumSource(
+        value = SharedPolicyGroup.Phase.class,
+        names = { "REQUEST", "RESPONSE", "PUBLISH", "SUBSCRIBE", "MESSAGE_REQUEST", "MESSAGE_RESPONSE" }
+    )
+    void should_create_reactor_for_supported_phases(SharedPolicyGroup.Phase phase) {
+        var cut = new DefaultSharedPolicyGroupReactorFactory(null, null, null, null, null, null);
+        var reactableSharedPolicyGroup = ReactableSharedPolicyGroup.builder()
+            .definition(SharedPolicyGroup.builder().phase(phase).build())
+            .build();
+
+        assertThat(cut.canCreate(reactableSharedPolicyGroup)).isTrue();
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-shared-policy-group/src/test/java/io/gravitee/gateway/handlers/sharedpolicygroup/reactor/impl/DefaultSharedPolicyGroupReactorFactoryTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-shared-policy-group/src/test/java/io/gravitee/gateway/handlers/sharedpolicygroup/reactor/impl/DefaultSharedPolicyGroupReactorFactoryTest.java
@@ -28,10 +28,7 @@ import org.junit.jupiter.params.provider.EnumSource;
 class DefaultSharedPolicyGroupReactorFactoryTest {
 
     @ParameterizedTest
-    @EnumSource(
-        value = SharedPolicyGroup.Phase.class,
-        names = { "REQUEST", "RESPONSE", "PUBLISH", "SUBSCRIBE", "MESSAGE_REQUEST", "MESSAGE_RESPONSE" }
-    )
+    @EnumSource(value = SharedPolicyGroup.Phase.class, names = { "REQUEST", "RESPONSE" })
     void should_create_reactor_for_supported_phases(SharedPolicyGroup.Phase phase) {
         var cut = new DefaultSharedPolicyGroupReactorFactory(null, null, null, null, null, null);
         var reactableSharedPolicyGroup = ReactableSharedPolicyGroup.builder()

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-shared-policy-group/src/test/java/io/gravitee/gateway/handlers/sharedpolicygroup/reactor/impl/DefaultSharedPolicyGroupReactorFactoryTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-shared-policy-group/src/test/java/io/gravitee/gateway/handlers/sharedpolicygroup/reactor/impl/DefaultSharedPolicyGroupReactorFactoryTest.java
@@ -25,7 +25,6 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
-@SuppressWarnings("deprecation")
 class DefaultSharedPolicyGroupReactorFactoryTest {
 
     @ParameterizedTest

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-shared-policy-group/src/test/java/io/gravitee/gateway/handlers/sharedpolicygroup/reactor/impl/DefaultSharedPolicyGroupReactorTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-shared-policy-group/src/test/java/io/gravitee/gateway/handlers/sharedpolicygroup/reactor/impl/DefaultSharedPolicyGroupReactorTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.handlers.sharedpolicygroup.reactor.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.definition.model.v4.sharedpolicygroup.SharedPolicyGroup;
+import io.gravitee.gateway.reactive.api.ExecutionPhase;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@SuppressWarnings("deprecation")
+class DefaultSharedPolicyGroupReactorTest {
+
+    @ParameterizedTest
+    @MethodSource("providePhases")
+    void should_map_shared_policy_group_phase_to_execution_phase(SharedPolicyGroup.Phase phase, ExecutionPhase expectedPhase) {
+        assertThat(DefaultSharedPolicyGroupReactor.toExecutionPhase(phase)).isEqualTo(expectedPhase);
+    }
+
+    private static Stream<Arguments> providePhases() {
+        return Stream.of(
+            Arguments.of(SharedPolicyGroup.Phase.REQUEST, ExecutionPhase.REQUEST),
+            Arguments.of(SharedPolicyGroup.Phase.RESPONSE, ExecutionPhase.RESPONSE),
+            Arguments.of(SharedPolicyGroup.Phase.PUBLISH, ExecutionPhase.MESSAGE_REQUEST),
+            Arguments.of(SharedPolicyGroup.Phase.SUBSCRIBE, ExecutionPhase.MESSAGE_RESPONSE),
+            Arguments.of(SharedPolicyGroup.Phase.MESSAGE_REQUEST, ExecutionPhase.MESSAGE_REQUEST),
+            Arguments.of(SharedPolicyGroup.Phase.MESSAGE_RESPONSE, ExecutionPhase.MESSAGE_RESPONSE)
+        );
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-shared-policy-group/src/test/java/io/gravitee/gateway/handlers/sharedpolicygroup/reactor/impl/DefaultSharedPolicyGroupReactorTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-shared-policy-group/src/test/java/io/gravitee/gateway/handlers/sharedpolicygroup/reactor/impl/DefaultSharedPolicyGroupReactorTest.java
@@ -27,7 +27,6 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
-@SuppressWarnings("deprecation")
 class DefaultSharedPolicyGroupReactorTest {
 
     @ParameterizedTest

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/mapper/SharedPolicyGroupMapperTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/mapper/SharedPolicyGroupMapperTest.java
@@ -34,8 +34,9 @@ import lombok.SneakyThrows;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -63,8 +64,9 @@ class SharedPolicyGroupMapperTest {
     }
 
     @SneakyThrows
-    @Test
-    void should_map_shared_policy_group() {
+    @ParameterizedTest
+    @EnumSource(value = SharedPolicyGroup.Phase.class, names = { "REQUEST", "PUBLISH", "SUBSCRIBE" })
+    void should_map_shared_policy_group(SharedPolicyGroup.Phase phase) {
         Organization organization = new Organization();
         organization.setId("orga");
         organization.setHrids(List.of("orga-hrid"));
@@ -80,7 +82,7 @@ class SharedPolicyGroupMapperTest {
         event.setPayload(
             objectMapper.writeValueAsString(
                 SharedPolicyGroup.builder()
-                    .phase(SharedPolicyGroup.Phase.REQUEST)
+                    .phase(phase)
                     .policies(List.of())
                     .id("spg_id")
                     .name("name")
@@ -105,7 +107,7 @@ class SharedPolicyGroupMapperTest {
                     assertThat(definition.getId()).isEqualTo("spg_id");
                     assertThat(definition.getName()).isEqualTo("name");
                     assertThat(definition.getPolicies()).isEmpty();
-                    assertThat(definition.getPhase()).isEqualTo(SharedPolicyGroup.Phase.REQUEST);
+                    assertThat(definition.getPhase()).isEqualTo(phase);
                 });
 
                 return true;

--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/messages/sharedpolicygroups/SharedPolicyGroupMessageIntegrationTest.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/messages/sharedpolicygroups/SharedPolicyGroupMessageIntegrationTest.java
@@ -54,7 +54,6 @@ import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Nested;
@@ -65,7 +64,6 @@ import org.junit.jupiter.api.Test;
  * @author GraviteeSource Team
  */
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
-@Disabled("Disabled for the time of Message Reactor migration")
 class SharedPolicyGroupMessageIntegrationTest {
 
     @Nested

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/shared_policy_group/model/SharedPolicyGroup.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/shared_policy_group/model/SharedPolicyGroup.java
@@ -139,7 +139,6 @@ public class SharedPolicyGroup {
             .build();
     }
 
-    @SuppressWarnings("deprecation")
     static io.gravitee.definition.model.v4.sharedpolicygroup.SharedPolicyGroup.Phase toDefinitionPhase(FlowPhase phase) {
         return switch (phase) {
             case REQUEST -> io.gravitee.definition.model.v4.sharedpolicygroup.SharedPolicyGroup.Phase.REQUEST;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/shared_policy_group/model/SharedPolicyGroup.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/shared_policy_group/model/SharedPolicyGroup.java
@@ -132,11 +132,22 @@ public class SharedPolicyGroup {
             .id(crossId)
             .environmentId(environmentId)
             .policies(steps)
-            .phase(io.gravitee.definition.model.v4.sharedpolicygroup.SharedPolicyGroup.Phase.valueOf(phase.name()))
+            .phase(toDefinitionPhase(phase))
             .name(name)
             .version(version != null ? String.valueOf(version) : null)
             .deployedAt(Date.from(deployedAt.toInstant()))
             .build();
+    }
+
+    @SuppressWarnings("deprecation")
+    static io.gravitee.definition.model.v4.sharedpolicygroup.SharedPolicyGroup.Phase toDefinitionPhase(FlowPhase phase) {
+        return switch (phase) {
+            case REQUEST -> io.gravitee.definition.model.v4.sharedpolicygroup.SharedPolicyGroup.Phase.REQUEST;
+            case RESPONSE -> io.gravitee.definition.model.v4.sharedpolicygroup.SharedPolicyGroup.Phase.RESPONSE;
+            case PUBLISH -> io.gravitee.definition.model.v4.sharedpolicygroup.SharedPolicyGroup.Phase.MESSAGE_REQUEST;
+            case SUBSCRIBE -> io.gravitee.definition.model.v4.sharedpolicygroup.SharedPolicyGroup.Phase.MESSAGE_RESPONSE;
+            case ENTRYPOINT_CONNECT, INTERACT -> throw new IllegalArgumentException("Unsupported shared policy group phase: " + phase);
+        };
     }
 
     public SharedPolicyGroupBuilder toBuilder() {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/shared_policy_group/model/SharedPolicyGroupTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/shared_policy_group/model/SharedPolicyGroupTest.java
@@ -28,7 +28,6 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
-@SuppressWarnings("deprecation")
 class SharedPolicyGroupTest {
 
     @ParameterizedTest

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/shared_policy_group/model/SharedPolicyGroupTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/shared_policy_group/model/SharedPolicyGroupTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.shared_policy_group.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.apim.core.plugin.model.FlowPhase;
+import java.time.ZonedDateTime;
+import java.util.List;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@SuppressWarnings("deprecation")
+class SharedPolicyGroupTest {
+
+    @ParameterizedTest
+    @MethodSource("providePhases")
+    void should_map_flow_phase_to_definition_phase(
+        FlowPhase flowPhase,
+        io.gravitee.definition.model.v4.sharedpolicygroup.SharedPolicyGroup.Phase expectedPhase
+    ) {
+        var sharedPolicyGroup = SharedPolicyGroup.builder()
+            .crossId("cross-id")
+            .environmentId("environment-id")
+            .name("name")
+            .phase(flowPhase)
+            .steps(List.of())
+            .version(1)
+            .deployedAt(ZonedDateTime.now())
+            .build();
+
+        var definition = sharedPolicyGroup.toDefinition();
+
+        assertThat(definition.getPhase()).isEqualTo(expectedPhase);
+    }
+
+    private static Stream<Arguments> providePhases() {
+        return Stream.of(
+            Arguments.of(FlowPhase.REQUEST, io.gravitee.definition.model.v4.sharedpolicygroup.SharedPolicyGroup.Phase.REQUEST),
+            Arguments.of(FlowPhase.RESPONSE, io.gravitee.definition.model.v4.sharedpolicygroup.SharedPolicyGroup.Phase.RESPONSE),
+            Arguments.of(FlowPhase.PUBLISH, io.gravitee.definition.model.v4.sharedpolicygroup.SharedPolicyGroup.Phase.MESSAGE_REQUEST),
+            Arguments.of(FlowPhase.SUBSCRIBE, io.gravitee.definition.model.v4.sharedpolicygroup.SharedPolicyGroup.Phase.MESSAGE_RESPONSE)
+        );
+    }
+}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-12903

## Description

Fixes Shared Policy Group deployment and runtime handling for message API phases.

The REST/core deployment mapping now converts `PUBLISH` and `SUBSCRIBE` to the legacy definition phases `MESSAGE_REQUEST` and `MESSAGE_RESPONSE`, keeping Management API deploy payloads compatible with older gateways. The gateway side now accepts both the new phase names and the legacy message phase names, and maps them to the correct `ExecutionPhase`.

Added unit coverage for REST/core phase mapping, gateway sync deserialization, reactor phase mapping, and reactor factory phase acceptance.

## Additional context

This keeps the wire format backward-compatible for mixed-version MAPI-to-gateway deployments while allowing gateways with this fix to consume both `PUBLISH`/`SUBSCRIBE` and `MESSAGE_REQUEST`/`MESSAGE_RESPONSE`.

