### PR TITLE
security(nginx): update NGINX_VERSION to 1.30.2

### DIFF
--- a/gravitee-apim-console-webui/docker/Dockerfile
+++ b/gravitee-apim-console-webui/docker/Dockerfile
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-FROM graviteeio/nginx:1.30.0
+FROM graviteeio/nginx:1.30.2
 LABEL maintainer="contact@graviteesource.com"
 
 ENV CONSOLE_BASE_HREF="/"

--- a/gravitee-apim-portal-webui/docker/Dockerfile
+++ b/gravitee-apim-portal-webui/docker/Dockerfile
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-FROM graviteeio/nginx:1.30.0
+FROM graviteeio/nginx:1.30.2
 LABEL maintainer="contact@graviteesource.com"
 
 EXPOSE 8080


### PR DESCRIPTION

## Issue

https://gravitee.atlassian.net/browse/APIM-14227

## Description

Adding a security patch for CVE-2026-9256

## Additional context

Fix provided by nginx in 1.30.2 release [nginx news: 2026](https://nginx.org/2026.html)

