### PR TITLE
fix(logging): prevent overwriting valid max duration

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/validation/AnalyticsValidationServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/validation/AnalyticsValidationServiceImpl.java
@@ -208,7 +208,7 @@ public class AnalyticsValidationServiceImpl extends TransactionalService impleme
                     String after = formatExpression(matcher, "after");
                     try {
                         final long currentDuration = Long.parseLong(currentDurationAsStr);
-                        if (currentDuration > maxEndDate || (!before.isEmpty() || !after.isEmpty())) {
+                        if (currentDuration > maxEndDate) {
                             return "{" + before + String.format(LOGGING_MAX_DURATION_CONDITION, maxEndDate) + after + "}";
                         }
                     } catch (NumberFormatException nfe) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/validation/AnalyticsValidationServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/validation/AnalyticsValidationServiceImplTest.java
@@ -421,7 +421,7 @@ public class AnalyticsValidationServiceImplTest {
             "{#request.timestamp <= 1234l  || #request.timestamp > 2l}",
             "{#request.timestamp <= 1l && (#request.timestamp > 2l)}"
         );
-        checkCondition(analytics, "#request.timestamp <= 1l || true", "{#request.timestamp <= 1l && (true)}");
+        checkCondition(analytics, "#request.timestamp <= 1l || true", "#request.timestamp <= 1l || true");
         checkCondition(analytics, "{#request.timestamp <= 0l}", "{#request.timestamp <= 0l}");
     }
 


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-14176

## Description

### Before:
If the existing condition had additional expressions (meaning before or after were not empty), the code would overwrite the user's currentDuration with the system's maxEndDate—even if the user's duration was shorter (stricter) than the maximum allowed.

### After:
By removing the || (!before.isEmpty() || !after.isEmpty()) check, the logic now behaves exactly as it should:
  - Duration Exceeds Max: If currentDuration > maxEndDate, it overwrites the timestamp with the maxEndDate while preserving the before and after expressions.
  - Duration is Valid: If currentDuration <= maxEndDate, the if statement evaluates to false. The code then safely falls through the rest of the method and hits return existingCondition; at the very bottom. This preserves the original, valid timeout along with any compound expressions it came with.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

