### PR TITLE
Am connection to core

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/AmConnectionRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/AmConnectionRepository.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.management.api;
+
+import io.gravitee.repository.exceptions.TechnicalException;
+import io.gravitee.repository.management.model.AmConnection;
+import java.util.Optional;
+
+/**
+ * @author GraviteeSource Team
+ */
+public interface AmConnectionRepository {
+    Optional<AmConnection> findByOrganizationId(String organizationId) throws TechnicalException;
+
+    AmConnection create(AmConnection amConnection) throws TechnicalException;
+
+    AmConnection update(AmConnection amConnection) throws TechnicalException;
+
+    void delete(String organizationId) throws TechnicalException;
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/AmConnectionRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/AmConnectionRepository.java
@@ -27,6 +27,10 @@ public interface AmConnectionRepository {
 
     AmConnection create(AmConnection amConnection) throws TechnicalException;
 
+    /**
+     * Updates an existing connection. Throws if no connection exists for the organization (it does not
+     * upsert) so the JDBC and Mongo adapters behave the same way.
+     */
     AmConnection update(AmConnection amConnection) throws TechnicalException;
 
     void delete(String organizationId) throws TechnicalException;

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/AmConnection.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/AmConnection.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.management.model;
+
+import java.util.Date;
+import java.util.Objects;
+
+/**
+ * @author GraviteeSource Team
+ */
+public class AmConnection {
+
+    private String organizationId;
+    private String baseUrl;
+    private String serviceAccountAccessTokenEncrypted;
+    private String defaultDomainId;
+    private String defaultDomainHrid;
+    private String gatewayUrl;
+    private Date updatedAt;
+
+    public AmConnection() {}
+
+    public String getOrganizationId() {
+        return organizationId;
+    }
+
+    public void setOrganizationId(String organizationId) {
+        this.organizationId = organizationId;
+    }
+
+    public String getBaseUrl() {
+        return baseUrl;
+    }
+
+    public void setBaseUrl(String baseUrl) {
+        this.baseUrl = baseUrl;
+    }
+
+    public String getServiceAccountAccessTokenEncrypted() {
+        return serviceAccountAccessTokenEncrypted;
+    }
+
+    public void setServiceAccountAccessTokenEncrypted(String serviceAccountAccessTokenEncrypted) {
+        this.serviceAccountAccessTokenEncrypted = serviceAccountAccessTokenEncrypted;
+    }
+
+    public String getDefaultDomainId() {
+        return defaultDomainId;
+    }
+
+    public void setDefaultDomainId(String defaultDomainId) {
+        this.defaultDomainId = defaultDomainId;
+    }
+
+    public String getDefaultDomainHrid() {
+        return defaultDomainHrid;
+    }
+
+    public void setDefaultDomainHrid(String defaultDomainHrid) {
+        this.defaultDomainHrid = defaultDomainHrid;
+    }
+
+    public String getGatewayUrl() {
+        return gatewayUrl;
+    }
+
+    public void setGatewayUrl(String gatewayUrl) {
+        this.gatewayUrl = gatewayUrl;
+    }
+
+    public Date getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public void setUpdatedAt(Date updatedAt) {
+        this.updatedAt = updatedAt;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        AmConnection that = (AmConnection) o;
+        return Objects.equals(organizationId, that.organizationId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(organizationId);
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcAmConnectionRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcAmConnectionRepository.java
@@ -43,7 +43,7 @@ public class JdbcAmConnectionRepository extends JdbcAbstractRepository<AmConnect
         return JdbcObjectMapper.builder(AmConnection.class, this.tableName, "organization_id")
             .addColumn("organization_id", Types.NVARCHAR, String.class)
             .addColumn("base_url", Types.NVARCHAR, String.class)
-            .addColumn("service_account_access_token_encrypted", Types.NVARCHAR, String.class)
+            .addColumn("service_account_access_token_encrypted", Types.CLOB, String.class)
             .addColumn("default_domain_id", Types.NVARCHAR, String.class)
             .addColumn("default_domain_hrid", Types.NVARCHAR, String.class)
             .addColumn("gateway_url", Types.NVARCHAR, String.class)

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcAmConnectionRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcAmConnectionRepository.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.jdbc.management;
+
+import io.gravitee.repository.exceptions.TechnicalException;
+import io.gravitee.repository.jdbc.orm.JdbcObjectMapper;
+import io.gravitee.repository.management.api.AmConnectionRepository;
+import io.gravitee.repository.management.model.AmConnection;
+import java.sql.Types;
+import java.util.Date;
+import java.util.List;
+import java.util.Optional;
+import lombok.CustomLog;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Repository;
+
+/**
+ * @author GraviteeSource Team
+ */
+@CustomLog
+@Repository
+public class JdbcAmConnectionRepository extends JdbcAbstractRepository<AmConnection> implements AmConnectionRepository {
+
+    JdbcAmConnectionRepository(@Value("${management.jdbc.prefix:}") String tablePrefix) {
+        super(tablePrefix, "am_connections");
+    }
+
+    @Override
+    protected JdbcObjectMapper<AmConnection> buildOrm() {
+        return JdbcObjectMapper.builder(AmConnection.class, this.tableName, "organization_id")
+            .addColumn("organization_id", Types.NVARCHAR, String.class)
+            .addColumn("base_url", Types.NVARCHAR, String.class)
+            .addColumn("service_account_access_token_encrypted", Types.NVARCHAR, String.class)
+            .addColumn("default_domain_id", Types.NVARCHAR, String.class)
+            .addColumn("default_domain_hrid", Types.NVARCHAR, String.class)
+            .addColumn("gateway_url", Types.NVARCHAR, String.class)
+            .addColumn("updated_at", Types.TIMESTAMP, Date.class)
+            .build();
+    }
+
+    @Override
+    public Optional<AmConnection> findByOrganizationId(String organizationId) throws TechnicalException {
+        log.debug("JdbcAmConnectionRepository.findByOrganizationId({})", organizationId);
+        try {
+            List<AmConnection> items = jdbcTemplate.query(
+                getOrm().getSelectAllSql() + " where organization_id = ?",
+                getOrm().getRowMapper(),
+                organizationId
+            );
+            return items.stream().findFirst();
+        } catch (final Exception ex) {
+            log.error("Failed to find am connection by organizationId: {}", organizationId, ex);
+            throw new TechnicalException("Failed to find am connection by organizationId", ex);
+        }
+    }
+
+    @Override
+    public AmConnection create(AmConnection amConnection) throws TechnicalException {
+        log.debug("JdbcAmConnectionRepository.create({})", amConnection.getOrganizationId());
+        try {
+            jdbcTemplate.update(getOrm().buildInsertPreparedStatementCreator(amConnection));
+            return findByOrganizationId(amConnection.getOrganizationId()).orElse(null);
+        } catch (final Exception ex) {
+            log.error("Failed to create am connection:", ex);
+            throw new TechnicalException("Failed to create am connection", ex);
+        }
+    }
+
+    @Override
+    public AmConnection update(AmConnection amConnection) throws TechnicalException {
+        log.debug("JdbcAmConnectionRepository.update({})", amConnection.getOrganizationId());
+        if (amConnection == null) {
+            throw new IllegalStateException("Unable to update null am connection");
+        }
+        try {
+            int rows = jdbcTemplate.update(getOrm().buildUpdatePreparedStatementCreator(amConnection, amConnection.getOrganizationId()));
+            if (rows == 0) {
+                throw new IllegalStateException("Unable to update am connection " + amConnection.getOrganizationId());
+            }
+            return findByOrganizationId(amConnection.getOrganizationId()).orElse(null);
+        } catch (final IllegalStateException ex) {
+            throw ex;
+        } catch (final Exception ex) {
+            log.error("Failed to update am connection:", ex);
+            throw new TechnicalException("Failed to update am connection", ex);
+        }
+    }
+
+    @Override
+    public void delete(String organizationId) throws TechnicalException {
+        log.debug("JdbcAmConnectionRepository.delete({})", organizationId);
+        try {
+            jdbcTemplate.update("delete from " + this.tableName + " where organization_id = ?", organizationId);
+        } catch (final Exception ex) {
+            log.error("Failed to delete am connection:", ex);
+            throw new TechnicalException("Failed to delete am connection", ex);
+        }
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcAmConnectionRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcAmConnectionRepository.java
@@ -72,8 +72,9 @@ public class JdbcAmConnectionRepository extends JdbcAbstractRepository<AmConnect
         log.debug("JdbcAmConnectionRepository.create({})", amConnection.getOrganizationId());
         try {
             jdbcTemplate.update(getOrm().buildInsertPreparedStatementCreator(amConnection));
-            return findByOrganizationId(amConnection.getOrganizationId())
-                .orElseThrow(() -> new TechnicalException("Failed to retrieve inserted am connection " + amConnection.getOrganizationId()));
+            return findByOrganizationId(amConnection.getOrganizationId()).orElseThrow(() ->
+                new TechnicalException("Failed to retrieve inserted am connection " + amConnection.getOrganizationId())
+            );
         } catch (final Exception ex) {
             log.error("Failed to create am connection:", ex);
             throw new TechnicalException("Failed to create am connection", ex);
@@ -91,8 +92,9 @@ public class JdbcAmConnectionRepository extends JdbcAbstractRepository<AmConnect
             if (rows == 0) {
                 throw new IllegalStateException("Unable to update am connection " + amConnection.getOrganizationId());
             }
-            return findByOrganizationId(amConnection.getOrganizationId())
-                .orElseThrow(() -> new TechnicalException("Failed to retrieve updated am connection " + amConnection.getOrganizationId()));
+            return findByOrganizationId(amConnection.getOrganizationId()).orElseThrow(() ->
+                new TechnicalException("Failed to retrieve updated am connection " + amConnection.getOrganizationId())
+            );
         } catch (final IllegalStateException ex) {
             throw ex;
         } catch (final Exception ex) {

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcAmConnectionRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcAmConnectionRepository.java
@@ -72,7 +72,8 @@ public class JdbcAmConnectionRepository extends JdbcAbstractRepository<AmConnect
         log.debug("JdbcAmConnectionRepository.create({})", amConnection.getOrganizationId());
         try {
             jdbcTemplate.update(getOrm().buildInsertPreparedStatementCreator(amConnection));
-            return findByOrganizationId(amConnection.getOrganizationId()).orElse(null);
+            return findByOrganizationId(amConnection.getOrganizationId())
+                .orElseThrow(() -> new TechnicalException("Failed to retrieve inserted am connection " + amConnection.getOrganizationId()));
         } catch (final Exception ex) {
             log.error("Failed to create am connection:", ex);
             throw new TechnicalException("Failed to create am connection", ex);
@@ -90,7 +91,8 @@ public class JdbcAmConnectionRepository extends JdbcAbstractRepository<AmConnect
             if (rows == 0) {
                 throw new IllegalStateException("Unable to update am connection " + amConnection.getOrganizationId());
             }
-            return findByOrganizationId(amConnection.getOrganizationId()).orElse(null);
+            return findByOrganizationId(amConnection.getOrganizationId())
+                .orElseThrow(() -> new TechnicalException("Failed to retrieve updated am connection " + amConnection.getOrganizationId()));
         } catch (final IllegalStateException ex) {
             throw ex;
         } catch (final Exception ex) {

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_12_0/10_add_am_connections_table.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_12_0/10_add_am_connections_table.yml
@@ -1,0 +1,15 @@
+databaseChangeLog:
+  - changeSet:
+      id: 4.12.0_10_add_am_connections_table
+      author: GraviteeSource Team
+      changes:
+        - createTable:
+            tableName: ${gravitee_prefix}am_connections
+            columns:
+              - column: {name: organization_id, type: nvarchar(64), constraints: { nullable: false, primaryKey: true, primaryKeyName: "pk_${gravitee_prefix}am_connections" } }
+              - column: {name: base_url, type: nvarchar(256)}
+              - column: {name: service_account_access_token_encrypted, type: nvarchar(4000)}
+              - column: {name: default_domain_id, type: nvarchar(64)}
+              - column: {name: default_domain_hrid, type: nvarchar(256)}
+              - column: {name: gateway_url, type: nvarchar(256)}
+              - column: {name: updated_at, type: timestamp(6)}

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_12_0/10_add_am_connections_table.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_12_0/10_add_am_connections_table.yml
@@ -8,7 +8,7 @@ databaseChangeLog:
             columns:
               - column: {name: organization_id, type: nvarchar(64), constraints: { nullable: false, primaryKey: true, primaryKeyName: "pk_${gravitee_prefix}am_connections" } }
               - column: {name: base_url, type: nvarchar(256)}
-              - column: {name: service_account_access_token_encrypted, type: nvarchar(4000)}
+              - column: {name: service_account_access_token_encrypted, type: clob}
               - column: {name: default_domain_id, type: nvarchar(64)}
               - column: {name: default_domain_hrid, type: nvarchar(256)}
               - column: {name: gateway_url, type: nvarchar(256)}

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/master.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/master.yml
@@ -359,3 +359,5 @@ databaseChangeLog:
         - file: liquibase/changelogs/v4_12_0/08_add_disable_membership_notifications_to_api_products.yml
     - include:
         - file: liquibase/changelogs/v4_12_0/09_add_kafka_port_ranges_table.yml
+    - include:
+        - file: liquibase/changelogs/v4_12_0/10_add_am_connections_table.yml

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/test/java/io/gravitee/repository/jdbc/JdbcTestRepositoryInitializer.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/test/java/io/gravitee/repository/jdbc/JdbcTestRepositoryInitializer.java
@@ -162,7 +162,8 @@ public class JdbcTestRepositoryInitializer implements TestRepositoryInitializer 
         "portal_page_contents",
         "portal_navigation_items",
         "subscription_forms",
-        "kafka_port_ranges"
+        "kafka_port_ranges",
+        "am_connections"
     );
     private static final List<String> tablesToDrop = concatenate(tablesToTruncate, List.of("databasechangelog", "databasechangeloglock"));
     private final DataSource dataSource;

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoAmConnectionRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoAmConnectionRepository.java
@@ -48,18 +48,23 @@ public class MongoAmConnectionRepository implements AmConnectionRepository {
             return map(internalAmConnectionRepository.insert(map(amConnection)));
         } catch (Exception e) {
             log.error("An error occurs when creating am connection [{}]", amConnection.getOrganizationId(), e);
-            throw new TechnicalException("An error occurs when creating am connection");
+            throw new TechnicalException("An error occurs when creating am connection", e);
         }
     }
 
     @Override
     public AmConnection update(AmConnection amConnection) throws TechnicalException {
         log.debug("Update am connection [{}]", amConnection.getOrganizationId());
+        // Match the JDBC adapter's SPI contract: updating a connection that does not exist throws
+        // rather than silently upserting (internal.save() would otherwise create it).
+        if (!internalAmConnectionRepository.existsById(amConnection.getOrganizationId())) {
+            throw new IllegalStateException("Unable to update am connection " + amConnection.getOrganizationId());
+        }
         try {
             return map(internalAmConnectionRepository.save(map(amConnection)));
         } catch (Exception e) {
             log.error("An error occurs when updating am connection [{}]", amConnection.getOrganizationId(), e);
-            throw new TechnicalException("An error occurs when updating am connection");
+            throw new TechnicalException("An error occurs when updating am connection", e);
         }
     }
 
@@ -70,7 +75,7 @@ public class MongoAmConnectionRepository implements AmConnectionRepository {
             internalAmConnectionRepository.deleteById(organizationId);
         } catch (Exception e) {
             log.error("An error occurs when deleting am connection [{}]", organizationId, e);
-            throw new TechnicalException("An error occurs when deleting am connection");
+            throw new TechnicalException("An error occurs when deleting am connection", e);
         }
     }
 

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoAmConnectionRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoAmConnectionRepository.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.mongodb.management;
+
+import io.gravitee.repository.exceptions.TechnicalException;
+import io.gravitee.repository.management.api.AmConnectionRepository;
+import io.gravitee.repository.management.model.AmConnection;
+import io.gravitee.repository.mongodb.management.internal.amconnection.AmConnectionMongoRepository;
+import io.gravitee.repository.mongodb.management.internal.model.AmConnectionMongo;
+import java.util.Optional;
+import lombok.CustomLog;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+/**
+ * @author GraviteeSource Team
+ */
+@CustomLog
+@Component
+public class MongoAmConnectionRepository implements AmConnectionRepository {
+
+    @Autowired
+    private AmConnectionMongoRepository internalAmConnectionRepository;
+
+    @Override
+    public Optional<AmConnection> findByOrganizationId(String organizationId) throws TechnicalException {
+        log.debug("Find am connection by organization [{}]", organizationId);
+        return internalAmConnectionRepository.findById(organizationId).map(this::map);
+    }
+
+    @Override
+    public AmConnection create(AmConnection amConnection) throws TechnicalException {
+        log.debug("Create am connection [{}]", amConnection.getOrganizationId());
+        try {
+            return map(internalAmConnectionRepository.insert(map(amConnection)));
+        } catch (Exception e) {
+            log.error("An error occurs when creating am connection [{}]", amConnection.getOrganizationId(), e);
+            throw new TechnicalException("An error occurs when creating am connection");
+        }
+    }
+
+    @Override
+    public AmConnection update(AmConnection amConnection) throws TechnicalException {
+        log.debug("Update am connection [{}]", amConnection.getOrganizationId());
+        try {
+            return map(internalAmConnectionRepository.save(map(amConnection)));
+        } catch (Exception e) {
+            log.error("An error occurs when updating am connection [{}]", amConnection.getOrganizationId(), e);
+            throw new TechnicalException("An error occurs when updating am connection");
+        }
+    }
+
+    @Override
+    public void delete(String organizationId) throws TechnicalException {
+        log.debug("Delete am connection [{}]", organizationId);
+        try {
+            internalAmConnectionRepository.deleteById(organizationId);
+        } catch (Exception e) {
+            log.error("An error occurs when deleting am connection [{}]", organizationId, e);
+            throw new TechnicalException("An error occurs when deleting am connection");
+        }
+    }
+
+    private AmConnectionMongo map(AmConnection amConnection) {
+        if (amConnection == null) {
+            return null;
+        }
+        AmConnectionMongo mongo = new AmConnectionMongo();
+        mongo.setOrganizationId(amConnection.getOrganizationId());
+        mongo.setBaseUrl(amConnection.getBaseUrl());
+        mongo.setServiceAccountAccessTokenEncrypted(amConnection.getServiceAccountAccessTokenEncrypted());
+        mongo.setDefaultDomainId(amConnection.getDefaultDomainId());
+        mongo.setDefaultDomainHrid(amConnection.getDefaultDomainHrid());
+        mongo.setGatewayUrl(amConnection.getGatewayUrl());
+        mongo.setUpdatedAt(amConnection.getUpdatedAt());
+        return mongo;
+    }
+
+    private AmConnection map(AmConnectionMongo mongo) {
+        if (mongo == null) {
+            return null;
+        }
+        AmConnection amConnection = new AmConnection();
+        amConnection.setOrganizationId(mongo.getOrganizationId());
+        amConnection.setBaseUrl(mongo.getBaseUrl());
+        amConnection.setServiceAccountAccessTokenEncrypted(mongo.getServiceAccountAccessTokenEncrypted());
+        amConnection.setDefaultDomainId(mongo.getDefaultDomainId());
+        amConnection.setDefaultDomainHrid(mongo.getDefaultDomainHrid());
+        amConnection.setGatewayUrl(mongo.getGatewayUrl());
+        amConnection.setUpdatedAt(mongo.getUpdatedAt());
+        return amConnection;
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/amconnection/AmConnectionMongoRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/amconnection/AmConnectionMongoRepository.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.mongodb.management.internal.amconnection;
+
+import io.gravitee.repository.mongodb.management.internal.model.AmConnectionMongo;
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+/**
+ * @author GraviteeSource Team
+ */
+public interface AmConnectionMongoRepository extends MongoRepository<AmConnectionMongo, String> {}

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/model/AmConnectionMongo.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/model/AmConnectionMongo.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.mongodb.management.internal.model;
+
+import java.util.Date;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+/**
+ * @author GraviteeSource Team
+ */
+@Getter
+@Setter
+@EqualsAndHashCode(of = { "organizationId" })
+@Document(collection = "#{@environment.getProperty('management.mongodb.prefix')}am_connections")
+public class AmConnectionMongo {
+
+    @Id
+    private String organizationId;
+
+    private String baseUrl;
+    private String serviceAccountAccessTokenEncrypted;
+    private String defaultDomainId;
+    private String defaultDomainHrid;
+    private String gatewayUrl;
+    private Date updatedAt;
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/AbstractManagementRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/AbstractManagementRepositoryTest.java
@@ -126,6 +126,9 @@ public abstract class AbstractManagementRepositoryTest extends AbstractRepositor
     protected IdentityProviderRepository identityProviderRepository;
 
     @Inject
+    protected AmConnectionRepository amConnectionRepository;
+
+    @Inject
     protected AlertTriggerRepository alertRepository;
 
     @Inject
@@ -282,6 +285,7 @@ public abstract class AbstractManagementRepositoryTest extends AbstractRepositor
             case ApiHeader apiHeader -> apiHeaderRepository.create(apiHeader);
             case Command command -> commandRepository.create(command);
             case IdentityProvider identityProvider -> identityProviderRepository.create(identityProvider);
+            case AmConnection amConnection -> amConnectionRepository.create(amConnection);
             case AlertTrigger alertTrigger -> alertRepository.create(alertTrigger);
             case Entrypoint entrypoint -> entrypointRepository.create(entrypoint);
             case Invitation invitation -> invitationRepository.create(invitation);

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/AmConnectionRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/AmConnectionRepositoryTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.management;
+
+import static io.gravitee.repository.utils.DateUtils.compareDate;
+import static org.junit.Assert.*;
+
+import io.gravitee.repository.management.model.AmConnection;
+import java.util.Date;
+import java.util.Optional;
+import org.junit.Test;
+
+/**
+ * @author GraviteeSource Team
+ */
+public class AmConnectionRepositoryTest extends AbstractManagementRepositoryTest {
+
+    @Override
+    protected String getTestCasesPath() {
+        return "/data/amconnection-tests/";
+    }
+
+    @Test
+    public void shouldCreateAndFindByOrganizationId() throws Exception {
+        final AmConnection amConnection = new AmConnection();
+        amConnection.setOrganizationId("org-create");
+        amConnection.setBaseUrl("https://am-create.example.com");
+        amConnection.setServiceAccountAccessTokenEncrypted("cipher-create");
+        amConnection.setDefaultDomainId("domain-create");
+        amConnection.setDefaultDomainHrid("domain-hrid-create");
+        amConnection.setGatewayUrl("https://gw-create.example.com");
+        amConnection.setUpdatedAt(new Date(1439032010883L));
+
+        amConnectionRepository.create(amConnection);
+
+        final Optional<AmConnection> optional = amConnectionRepository.findByOrganizationId("org-create");
+        assertTrue("Am connection saved not found", optional.isPresent());
+
+        final AmConnection saved = optional.get();
+        assertEquals("org-create", saved.getOrganizationId());
+        assertEquals("https://am-create.example.com", saved.getBaseUrl());
+        assertEquals("cipher-create", saved.getServiceAccountAccessTokenEncrypted());
+        assertEquals("domain-create", saved.getDefaultDomainId());
+        assertEquals("domain-hrid-create", saved.getDefaultDomainHrid());
+        assertEquals("https://gw-create.example.com", saved.getGatewayUrl());
+        assertTrue("Invalid updatedAt", compareDate(new Date(1439032010883L), saved.getUpdatedAt()));
+    }
+
+    @Test
+    public void shouldUpdate() throws Exception {
+        final Optional<AmConnection> optional = amConnectionRepository.findByOrganizationId("org-update");
+        assertTrue("Am connection to update not found", optional.isPresent());
+
+        final AmConnection amConnection = optional.get();
+        amConnection.setBaseUrl("https://am-updated.example.com");
+        amConnection.setServiceAccountAccessTokenEncrypted("cipher-updated");
+        amConnection.setUpdatedAt(new Date(1486771200000L));
+
+        amConnectionRepository.update(amConnection);
+
+        final Optional<AmConnection> optionalUpdated = amConnectionRepository.findByOrganizationId("org-update");
+        assertTrue("Updated am connection not found", optionalUpdated.isPresent());
+
+        final AmConnection updated = optionalUpdated.get();
+        assertEquals("https://am-updated.example.com", updated.getBaseUrl());
+        assertEquals("cipher-updated", updated.getServiceAccountAccessTokenEncrypted());
+        assertTrue("Invalid updatedAt", compareDate(new Date(1486771200000L), updated.getUpdatedAt()));
+    }
+
+    @Test
+    public void shouldDelete() throws Exception {
+        assertTrue(amConnectionRepository.findByOrganizationId("org-delete").isPresent());
+
+        amConnectionRepository.delete("org-delete");
+
+        assertFalse(amConnectionRepository.findByOrganizationId("org-delete").isPresent());
+    }
+
+    @Test
+    public void shouldReturnEmptyForUnknownOrganization() throws Exception {
+        assertTrue(amConnectionRepository.findByOrganizationId("unknown-org").isEmpty());
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/AmConnectionRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/AmConnectionRepositoryTest.java
@@ -80,6 +80,15 @@ public class AmConnectionRepositoryTest extends AbstractManagementRepositoryTest
         assertTrue("Invalid updatedAt", compareDate(new Date(1486771200000L), updated.getUpdatedAt()));
     }
 
+    @Test(expected = IllegalStateException.class)
+    public void shouldThrowWhenUpdatingUnknownOrganization() throws Exception {
+        final AmConnection amConnection = new AmConnection();
+        amConnection.setOrganizationId("unknown-org");
+        amConnection.setBaseUrl("https://am-unknown.example.com");
+
+        amConnectionRepository.update(amConnection);
+    }
+
     @Test
     public void shouldDelete() throws Exception {
         assertTrue(amConnectionRepository.findByOrganizationId("org-delete").isPresent());

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/resources/data/amconnection-tests/amConnections.json
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/resources/data/amconnection-tests/amConnections.json
@@ -1,0 +1,20 @@
+[
+  {
+    "organizationId": "org-update",
+    "baseUrl": "https://am.example.com",
+    "serviceAccountAccessTokenEncrypted": "cipher-update",
+    "defaultDomainId": "domain-1",
+    "defaultDomainHrid": "domain-hrid-1",
+    "gatewayUrl": "https://gw.example.com",
+    "updatedAt": 1000000000000
+  },
+  {
+    "organizationId": "org-delete",
+    "baseUrl": "https://am-delete.example.com",
+    "serviceAccountAccessTokenEncrypted": "cipher-delete",
+    "defaultDomainId": "domain-2",
+    "defaultDomainHrid": "domain-hrid-2",
+    "gatewayUrl": "https://gw-delete.example.com",
+    "updatedAt": 1000000000000
+  }
+]

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/AmConnectionEntity.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/AmConnectionEntity.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.model;
+
+import java.util.Date;
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * @author GraviteeSource Team
+ */
+@Getter
+@Setter
+public class AmConnectionEntity {
+
+    private String organizationId;
+    private String baseUrl;
+    private String serviceAccountAccessToken;
+    private String defaultDomainId;
+    private String defaultDomainHrid;
+    private String gatewayUrl;
+    private Date updatedAt;
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/AmConnectionService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/AmConnectionService.java
@@ -29,6 +29,8 @@ public interface AmConnectionService {
     /**
      * Token semantics: a null token preserves the stored token, a blank token clears it, a non-blank
      * token is encrypted and replaces the stored one.
+     * <p>All other fields (baseUrl, defaultDomainId, defaultDomainHrid, gatewayUrl) fully replace the
+     * stored values, so a null on any of them clears it.
      */
     AmConnectionEntity save(String organizationId, AmConnectionEntity entity);
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/AmConnectionService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/AmConnectionService.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service;
+
+import io.gravitee.rest.api.model.AmConnectionEntity;
+import java.util.Optional;
+
+/**
+ * @author GraviteeSource Team
+ */
+public interface AmConnectionService {
+    Optional<AmConnectionEntity> findByOrganizationId(String organizationId);
+
+    boolean hasToken(String organizationId);
+
+    /**
+     * Token semantics: a null token preserves the stored token, a blank token clears it, a non-blank
+     * token is encrypted and replaces the stored one.
+     */
+    AmConnectionEntity save(String organizationId, AmConnectionEntity entity);
+
+    void delete(String organizationId);
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/cockpit/command/handler/DeleteOrganizationCommandHandler.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/cockpit/command/handler/DeleteOrganizationCommandHandler.java
@@ -52,6 +52,7 @@ public class DeleteOrganizationCommandHandler implements CommandHandler<DeleteOr
 
     private final AccessPointCrudService accessPointService;
     private final AccessPointRepository accessPointRepository;
+    private final AmConnectionRepository amConnectionRepository;
     private final AuditRepository auditRepository;
     private final CommandRepository commandRepository;
     private final CustomUserFieldsRepository customUserFieldsRepository;
@@ -81,6 +82,7 @@ public class DeleteOrganizationCommandHandler implements CommandHandler<DeleteOr
 
     public DeleteOrganizationCommandHandler(
         @Lazy AccessPointRepository accessPointRepository,
+        @Lazy AmConnectionRepository amConnectionRepository,
         @Lazy AuditRepository auditRepository,
         @Lazy CommandRepository commandRepository,
         @Lazy CustomUserFieldsRepository customUserFieldsRepository,
@@ -111,6 +113,7 @@ public class DeleteOrganizationCommandHandler implements CommandHandler<DeleteOr
     ) {
         this.accessPointRepository = accessPointRepository;
         this.accessPointService = accessPointService;
+        this.amConnectionRepository = amConnectionRepository;
         this.auditRepository = auditRepository;
         this.commandRepository = commandRepository;
         this.customUserFieldsRepository = customUserFieldsRepository;
@@ -233,5 +236,7 @@ public class DeleteOrganizationCommandHandler implements CommandHandler<DeleteOr
         );
         entrypointRepository.deleteByReferenceIdAndReferenceType(organization.getId(), EntrypointReferenceType.ORGANIZATION);
         clusterRepository.deleteByOrganizationId(organization.getId());
+        log.debug("Deleting am connection for organization [{}]", organization.getId());
+        amConnectionRepository.delete(organization.getId());
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/AmConnectionServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/AmConnectionServiceImpl.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.impl;
+
+import io.gravitee.common.util.DataEncryptor;
+import io.gravitee.repository.exceptions.TechnicalException;
+import io.gravitee.repository.management.api.AmConnectionRepository;
+import io.gravitee.repository.management.model.AmConnection;
+import io.gravitee.rest.api.model.AmConnectionEntity;
+import io.gravitee.rest.api.service.AmConnectionService;
+import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
+import java.security.GeneralSecurityException;
+import java.util.Date;
+import java.util.Optional;
+import lombok.CustomLog;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+/**
+ * @author GraviteeSource Team
+ */
+@CustomLog
+@Component
+public class AmConnectionServiceImpl implements AmConnectionService {
+
+    private final AmConnectionRepository amConnectionRepository;
+    private final DataEncryptor dataEncryptor;
+
+    public AmConnectionServiceImpl(
+        AmConnectionRepository amConnectionRepository,
+        @Qualifier("apiPropertiesEncryptor") DataEncryptor dataEncryptor
+    ) {
+        this.amConnectionRepository = amConnectionRepository;
+        this.dataEncryptor = dataEncryptor;
+    }
+
+    @Override
+    public Optional<AmConnectionEntity> findByOrganizationId(String organizationId) {
+        try {
+            return amConnectionRepository.findByOrganizationId(organizationId).map(this::toEntity);
+        } catch (TechnicalException e) {
+            throw new TechnicalManagementException("Failed to find am connection for organization " + organizationId, e);
+        }
+    }
+
+    @Override
+    public boolean hasToken(String organizationId) {
+        try {
+            return amConnectionRepository
+                .findByOrganizationId(organizationId)
+                .map(AmConnection::getServiceAccountAccessTokenEncrypted)
+                .filter(StringUtils::hasText)
+                .isPresent();
+        } catch (TechnicalException e) {
+            throw new TechnicalManagementException("Failed to read am connection for organization " + organizationId, e);
+        }
+    }
+
+    @Override
+    public AmConnectionEntity save(String organizationId, AmConnectionEntity entity) {
+        try {
+            Optional<AmConnection> existing = amConnectionRepository.findByOrganizationId(organizationId);
+
+            AmConnection model = new AmConnection();
+            model.setOrganizationId(organizationId);
+            model.setBaseUrl(stripTrailingSlashes(entity.getBaseUrl()));
+            model.setDefaultDomainId(entity.getDefaultDomainId());
+            model.setDefaultDomainHrid(entity.getDefaultDomainHrid());
+            model.setGatewayUrl(entity.getGatewayUrl());
+            model.setServiceAccountAccessTokenEncrypted(encryptOrPreserve(entity.getServiceAccountAccessToken(), existing.orElse(null)));
+            model.setUpdatedAt(new Date());
+
+            AmConnection saved = existing.isPresent() ? amConnectionRepository.update(model) : amConnectionRepository.create(model);
+            return toEntity(saved);
+        } catch (TechnicalException e) {
+            throw new TechnicalManagementException("Failed to save am connection for organization " + organizationId, e);
+        }
+    }
+
+    @Override
+    public void delete(String organizationId) {
+        try {
+            amConnectionRepository.delete(organizationId);
+        } catch (TechnicalException e) {
+            throw new TechnicalManagementException("Failed to delete am connection for organization " + organizationId, e);
+        }
+    }
+
+    private String encryptOrPreserve(String plaintextToken, AmConnection existing) {
+        if (plaintextToken == null) {
+            return existing == null ? null : existing.getServiceAccountAccessTokenEncrypted();
+        }
+        if (!StringUtils.hasText(plaintextToken)) {
+            return null;
+        }
+        try {
+            return dataEncryptor.encrypt(plaintextToken);
+        } catch (GeneralSecurityException e) {
+            throw new TechnicalManagementException("Failed to encrypt am service account access token", e);
+        }
+    }
+
+    private AmConnectionEntity toEntity(AmConnection model) {
+        AmConnectionEntity entity = new AmConnectionEntity();
+        entity.setOrganizationId(model.getOrganizationId());
+        entity.setBaseUrl(model.getBaseUrl());
+        entity.setServiceAccountAccessToken(decryptOrNull(model.getServiceAccountAccessTokenEncrypted()));
+        entity.setDefaultDomainId(model.getDefaultDomainId());
+        entity.setDefaultDomainHrid(model.getDefaultDomainHrid());
+        entity.setGatewayUrl(model.getGatewayUrl());
+        entity.setUpdatedAt(model.getUpdatedAt());
+        return entity;
+    }
+
+    private String decryptOrNull(String ciphertext) {
+        if (!StringUtils.hasText(ciphertext)) {
+            return null;
+        }
+        try {
+            return dataEncryptor.decrypt(ciphertext);
+        } catch (GeneralSecurityException | IllegalArgumentException e) {
+            log.warn("Failed to decrypt am service account access token, treating it as absent", e);
+            return null;
+        }
+    }
+
+    private static String stripTrailingSlashes(String baseUrl) {
+        return baseUrl == null ? null : baseUrl.replaceAll("/+$", "");
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/AmConnectionServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/AmConnectionServiceImpl.java
@@ -74,6 +74,8 @@ public class AmConnectionServiceImpl implements AmConnectionService {
     @Override
     public AmConnectionEntity save(String organizationId, AmConnectionEntity entity) {
         try {
+            // find-then-create/update is not atomic; two concurrent first saves for the same org can
+            // both take the create path and hit a PK violation. Acceptable for this rare admin endpoint.
             Optional<AmConnection> existing = amConnectionRepository.findByOrganizationId(organizationId);
 
             AmConnection model = new AmConnection();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/AmConnectionServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/AmConnectionServiceImpl.java
@@ -134,8 +134,7 @@ public class AmConnectionServiceImpl implements AmConnectionService {
         try {
             return dataEncryptor.decrypt(ciphertext);
         } catch (GeneralSecurityException | IllegalArgumentException e) {
-            log.warn("Failed to decrypt am service account access token, treating it as absent", e);
-            return null;
+            throw new TechnicalManagementException("Failed to decrypt am service account access token", e);
         }
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/AmConnectionServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/AmConnectionServiceImpl.java
@@ -27,6 +27,7 @@ import java.util.Date;
 import java.util.Optional;
 import lombok.CustomLog;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 
@@ -41,7 +42,7 @@ public class AmConnectionServiceImpl implements AmConnectionService {
     private final DataEncryptor dataEncryptor;
 
     public AmConnectionServiceImpl(
-        AmConnectionRepository amConnectionRepository,
+        @Lazy AmConnectionRepository amConnectionRepository,
         @Qualifier("apiPropertiesEncryptor") DataEncryptor dataEncryptor
     ) {
         this.amConnectionRepository = amConnectionRepository;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/cockpit/command/handler/DeleteOrganizationCommandHandlerTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/cockpit/command/handler/DeleteOrganizationCommandHandlerTest.java
@@ -32,6 +32,7 @@ import io.gravitee.cockpit.api.command.v1.organization.DeleteOrganizationReply;
 import io.gravitee.exchange.api.command.CommandStatus;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.AccessPointRepository;
+import io.gravitee.repository.management.api.AmConnectionRepository;
 import io.gravitee.repository.management.api.AuditRepository;
 import io.gravitee.repository.management.api.ClusterRepository;
 import io.gravitee.repository.management.api.CommandRepository;
@@ -97,6 +98,9 @@ public class DeleteOrganizationCommandHandlerTest {
 
     @Mock
     private AccessPointRepository accessPointRepository;
+
+    @Mock
+    private AmConnectionRepository amConnectionRepository;
 
     @Mock
     private FlowRepository flowRepository;
@@ -197,6 +201,7 @@ public class DeleteOrganizationCommandHandlerTest {
 
         cut = new DeleteOrganizationCommandHandler(
             accessPointRepository,
+            amConnectionRepository,
             auditRepository,
             commandRepository,
             customUserFieldsRepository,
@@ -360,6 +365,7 @@ public class DeleteOrganizationCommandHandlerTest {
             EntrypointReferenceType.ORGANIZATION
         );
         verify(clusterRepository).deleteByOrganizationId(executionContext.getOrganizationId());
+        verify(amConnectionRepository).delete(executionContext.getOrganizationId());
     }
 
     private void verifyDisableOrganization(ExecutionContext context) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/AmConnectionServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/AmConnectionServiceImplTest.java
@@ -79,10 +79,11 @@ public class AmConnectionServiceImplTest {
 
     @Test
     public void save_with_null_token_preserves_existing_ciphertext() throws Exception {
+        String existingCipher = dataEncryptor.encrypt("existing-token");
         AmConnection existing = new AmConnection();
         existing.setOrganizationId("org-1");
         existing.setBaseUrl("https://old.example.com");
-        existing.setServiceAccountAccessTokenEncrypted("existing-cipher");
+        existing.setServiceAccountAccessTokenEncrypted(existingCipher);
         when(amConnectionRepository.findByOrganizationId("org-1")).thenReturn(Optional.of(existing));
         when(amConnectionRepository.update(any())).thenAnswer(i -> i.getArgument(0));
 
@@ -90,7 +91,7 @@ public class AmConnectionServiceImplTest {
 
         ArgumentCaptor<AmConnection> captor = ArgumentCaptor.forClass(AmConnection.class);
         verify(amConnectionRepository).update(captor.capture());
-        assertThat(captor.getValue().getServiceAccountAccessTokenEncrypted()).isEqualTo("existing-cipher");
+        assertThat(captor.getValue().getServiceAccountAccessTokenEncrypted()).isEqualTo(existingCipher);
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/AmConnectionServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/AmConnectionServiceImplTest.java
@@ -16,15 +16,18 @@
 package io.gravitee.rest.api.service.impl;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.gravitee.common.util.DataEncryptor;
+import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.AmConnectionRepository;
 import io.gravitee.repository.management.model.AmConnection;
 import io.gravitee.rest.api.model.AmConnectionEntity;
+import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
 import java.security.GeneralSecurityException;
 import java.util.Optional;
 import org.junit.Before;
@@ -32,6 +35,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.mock.env.MockEnvironment;
 
@@ -147,6 +151,44 @@ public class AmConnectionServiceImplTest {
         assertThat(result).isPresent();
         assertThat(result.get().getServiceAccountAccessToken()).isEqualTo("secret-token");
         assertThat(result.get().getBaseUrl()).isEqualTo("https://am.example.com");
+    }
+
+    @Test
+    public void save_throws_when_encryption_fails() throws Exception {
+        DataEncryptor brokenEncryptor = Mockito.mock(DataEncryptor.class);
+        when(brokenEncryptor.encrypt(any())).thenThrow(new GeneralSecurityException("key error"));
+        AmConnectionServiceImpl broken = new AmConnectionServiceImpl(amConnectionRepository, brokenEncryptor);
+
+        when(amConnectionRepository.findByOrganizationId("org-1")).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> broken.save("org-1", entity("https://am.example.com", "tok")))
+            .isInstanceOf(TechnicalManagementException.class)
+            .hasMessageContaining("encrypt");
+    }
+
+    @Test
+    public void find_throws_when_decryption_fails() throws Exception {
+        DataEncryptor brokenEncryptor = Mockito.mock(DataEncryptor.class);
+        when(brokenEncryptor.decrypt(any())).thenThrow(new GeneralSecurityException("corrupted"));
+        AmConnectionServiceImpl broken = new AmConnectionServiceImpl(amConnectionRepository, brokenEncryptor);
+
+        AmConnection stored = new AmConnection();
+        stored.setOrganizationId("org-1");
+        stored.setServiceAccountAccessTokenEncrypted("some-cipher");
+        when(amConnectionRepository.findByOrganizationId("org-1")).thenReturn(Optional.of(stored));
+
+        assertThatThrownBy(() -> broken.findByOrganizationId("org-1"))
+            .isInstanceOf(TechnicalManagementException.class)
+            .hasMessageContaining("decrypt");
+    }
+
+    @Test
+    public void find_wraps_repository_exception() throws Exception {
+        when(amConnectionRepository.findByOrganizationId("org-1")).thenThrow(new TechnicalException("DB down"));
+
+        assertThatThrownBy(() -> service.findByOrganizationId("org-1"))
+            .isInstanceOf(TechnicalManagementException.class)
+            .hasMessageContaining("org-1");
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/AmConnectionServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/AmConnectionServiceImplTest.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.common.util.DataEncryptor;
+import io.gravitee.repository.management.api.AmConnectionRepository;
+import io.gravitee.repository.management.model.AmConnection;
+import io.gravitee.rest.api.model.AmConnectionEntity;
+import java.security.GeneralSecurityException;
+import java.util.Optional;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.mock.env.MockEnvironment;
+
+@RunWith(MockitoJUnitRunner.class)
+public class AmConnectionServiceImplTest {
+
+    @Mock
+    private AmConnectionRepository amConnectionRepository;
+
+    private DataEncryptor dataEncryptor;
+    private AmConnectionServiceImpl service;
+
+    @Before
+    public void setUp() {
+        dataEncryptor = new DataEncryptor(new MockEnvironment(), "test.secret", "vvLJ4Q8Khvv9tm2tIPdkGEdmgKUruAL6");
+        service = new AmConnectionServiceImpl(amConnectionRepository, dataEncryptor);
+    }
+
+    private static AmConnectionEntity entity(String baseUrl, String token) {
+        AmConnectionEntity e = new AmConnectionEntity();
+        e.setBaseUrl(baseUrl);
+        e.setServiceAccountAccessToken(token);
+        return e;
+    }
+
+    @Test
+    public void save_with_non_blank_token_stores_ciphertext_and_returns_plaintext() throws Exception {
+        when(amConnectionRepository.findByOrganizationId("org-1")).thenReturn(Optional.empty());
+        when(amConnectionRepository.create(any())).thenAnswer(i -> i.getArgument(0));
+
+        AmConnectionEntity result = service.save("org-1", entity("https://am.example.com", "my-token"));
+
+        ArgumentCaptor<AmConnection> captor = ArgumentCaptor.forClass(AmConnection.class);
+        verify(amConnectionRepository).create(captor.capture());
+        AmConnection stored = captor.getValue();
+
+        assertThat(stored.getServiceAccountAccessTokenEncrypted()).isNotNull().isNotEqualTo("my-token");
+        assertThat(dataEncryptor.decrypt(stored.getServiceAccountAccessTokenEncrypted())).isEqualTo("my-token");
+        assertThat(result.getServiceAccountAccessToken()).isEqualTo("my-token");
+    }
+
+    @Test
+    public void save_with_null_token_preserves_existing_ciphertext() throws Exception {
+        AmConnection existing = new AmConnection();
+        existing.setOrganizationId("org-1");
+        existing.setBaseUrl("https://old.example.com");
+        existing.setServiceAccountAccessTokenEncrypted("existing-cipher");
+        when(amConnectionRepository.findByOrganizationId("org-1")).thenReturn(Optional.of(existing));
+        when(amConnectionRepository.update(any())).thenAnswer(i -> i.getArgument(0));
+
+        service.save("org-1", entity("https://am.example.com", null));
+
+        ArgumentCaptor<AmConnection> captor = ArgumentCaptor.forClass(AmConnection.class);
+        verify(amConnectionRepository).update(captor.capture());
+        assertThat(captor.getValue().getServiceAccountAccessTokenEncrypted()).isEqualTo("existing-cipher");
+    }
+
+    @Test
+    public void save_with_blank_token_clears_ciphertext() throws Exception {
+        AmConnection existing = new AmConnection();
+        existing.setOrganizationId("org-1");
+        existing.setServiceAccountAccessTokenEncrypted("existing-cipher");
+        when(amConnectionRepository.findByOrganizationId("org-1")).thenReturn(Optional.of(existing));
+        when(amConnectionRepository.update(any())).thenAnswer(i -> i.getArgument(0));
+
+        service.save("org-1", entity("https://am.example.com", "  "));
+
+        ArgumentCaptor<AmConnection> captor = ArgumentCaptor.forClass(AmConnection.class);
+        verify(amConnectionRepository).update(captor.capture());
+        assertThat(captor.getValue().getServiceAccountAccessTokenEncrypted()).isNull();
+    }
+
+    @Test
+    public void save_strips_trailing_slashes_and_sets_updated_at() throws Exception {
+        when(amConnectionRepository.findByOrganizationId("org-1")).thenReturn(Optional.empty());
+        when(amConnectionRepository.create(any())).thenAnswer(i -> i.getArgument(0));
+
+        service.save("org-1", entity("https://am.example.com///", "tok"));
+
+        ArgumentCaptor<AmConnection> captor = ArgumentCaptor.forClass(AmConnection.class);
+        verify(amConnectionRepository).create(captor.capture());
+        assertThat(captor.getValue().getBaseUrl()).isEqualTo("https://am.example.com");
+        assertThat(captor.getValue().getUpdatedAt()).isNotNull();
+        assertThat(captor.getValue().getOrganizationId()).isEqualTo("org-1");
+    }
+
+    @Test
+    public void save_inserts_when_absent_updates_when_present() throws Exception {
+        when(amConnectionRepository.findByOrganizationId("org-1")).thenReturn(Optional.empty());
+        when(amConnectionRepository.create(any())).thenAnswer(i -> i.getArgument(0));
+        service.save("org-1", entity("https://am.example.com", "tok"));
+        verify(amConnectionRepository).create(any());
+        verify(amConnectionRepository, never()).update(any());
+
+        AmConnection existing = new AmConnection();
+        existing.setOrganizationId("org-2");
+        when(amConnectionRepository.findByOrganizationId("org-2")).thenReturn(Optional.of(existing));
+        when(amConnectionRepository.update(any())).thenAnswer(i -> i.getArgument(0));
+        service.save("org-2", entity("https://am.example.com", "tok"));
+        verify(amConnectionRepository).update(any());
+    }
+
+    @Test
+    public void find_by_organization_id_returns_decrypted_token() throws Exception {
+        AmConnection stored = new AmConnection();
+        stored.setOrganizationId("org-1");
+        stored.setBaseUrl("https://am.example.com");
+        stored.setServiceAccountAccessTokenEncrypted(dataEncryptor.encrypt("secret-token"));
+        when(amConnectionRepository.findByOrganizationId("org-1")).thenReturn(Optional.of(stored));
+
+        Optional<AmConnectionEntity> result = service.findByOrganizationId("org-1");
+
+        assertThat(result).isPresent();
+        assertThat(result.get().getServiceAccountAccessToken()).isEqualTo("secret-token");
+        assertThat(result.get().getBaseUrl()).isEqualTo("https://am.example.com");
+    }
+
+    @Test
+    public void has_token_only_when_ciphertext_present() throws Exception {
+        AmConnection withToken = new AmConnection();
+        withToken.setServiceAccountAccessTokenEncrypted("cipher");
+        when(amConnectionRepository.findByOrganizationId("with")).thenReturn(Optional.of(withToken));
+        assertThat(service.hasToken("with")).isTrue();
+
+        AmConnection withoutToken = new AmConnection();
+        when(amConnectionRepository.findByOrganizationId("without")).thenReturn(Optional.of(withoutToken));
+        assertThat(service.hasToken("without")).isFalse();
+
+        when(amConnectionRepository.findByOrganizationId("absent")).thenReturn(Optional.empty());
+        assertThat(service.hasToken("absent")).isFalse();
+    }
+}

--- a/gravitee-gamma/gravitee-gamma-plugin/gravitee-gamma-plugin-module/gravitee-gamma-plugin-module-api/pom.xml
+++ b/gravitee-gamma/gravitee-gamma-plugin/gravitee-gamma-plugin-module/gravitee-gamma-plugin-module-api/pom.xml
@@ -28,4 +28,44 @@
 
     <artifactId>gravitee-gamma-plugin-module-api</artifactId>
     <name>Gravitee.io Gamma - Plugin - Module - Api</name>
+
+    <dependencies>
+        <!-- Shared AM connection plumbing: model + port + adapter over rest-api core's AmConnectionService.
+             All provided — the host rest-api supplies these at runtime. -->
+        <dependency>
+            <groupId>io.gravitee.apim.common</groupId>
+            <artifactId>gravitee-apim-common</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.gravitee.apim.rest.api</groupId>
+            <artifactId>gravitee-apim-rest-api-service</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.gravitee.apim.rest.api</groupId>
+            <artifactId>gravitee-apim-rest-api-model</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- Test dependencies -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
 </project>

--- a/gravitee-gamma/gravitee-gamma-plugin/gravitee-gamma-plugin-module/gravitee-gamma-plugin-module-api/src/main/java/io/gravitee/apim/plugin/gamma/api/identity/AmConnection.java
+++ b/gravitee-gamma/gravitee-gamma-plugin/gravitee-gamma-plugin-module/gravitee-gamma-plugin-module-api/src/main/java/io/gravitee/apim/plugin/gamma/api/identity/AmConnection.java
@@ -32,4 +32,22 @@ public record AmConnection(
     public boolean isConfigured() {
         return baseUrl != null && !baseUrl.isBlank() && serviceAccountAccessToken != null && !serviceAccountAccessToken.isBlank();
     }
+
+    // Redact the token so it never leaks into logs or exception messages via the record's toString().
+    @Override
+    public String toString() {
+        return (
+            "AmConnection[baseUrl=" +
+            baseUrl +
+            ", serviceAccountAccessToken=" +
+            (serviceAccountAccessToken == null ? "null" : "***") +
+            ", defaultDomainId=" +
+            defaultDomainId +
+            ", defaultDomainHrid=" +
+            defaultDomainHrid +
+            ", gatewayUrl=" +
+            gatewayUrl +
+            "]"
+        );
+    }
 }

--- a/gravitee-gamma/gravitee-gamma-plugin/gravitee-gamma-plugin-module/gravitee-gamma-plugin-module-api/src/main/java/io/gravitee/apim/plugin/gamma/api/identity/AmConnection.java
+++ b/gravitee-gamma/gravitee-gamma-plugin/gravitee-gamma-plugin-module/gravitee-gamma-plugin-module-api/src/main/java/io/gravitee/apim/plugin/gamma/api/identity/AmConnection.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.plugin.gamma.api.identity;
+
+/**
+ * Shared connection details a gamma module uses to reach an AM instance for an organization.
+ * Storage and token encryption are owned by APIM rest-api core; see {@link AmConnectionRepository}.
+ *
+ * <p>Nullable fields ({@code serviceAccountAccessToken}, {@code defaultDomainId},
+ * {@code defaultDomainHrid}, {@code gatewayUrl}) may be {@code null} when not yet configured.
+ */
+public record AmConnection(
+    String baseUrl,
+    String serviceAccountAccessToken,
+    String defaultDomainId,
+    String defaultDomainHrid,
+    String gatewayUrl
+) {
+    public boolean isConfigured() {
+        return baseUrl != null && !baseUrl.isBlank() && serviceAccountAccessToken != null && !serviceAccountAccessToken.isBlank();
+    }
+}

--- a/gravitee-gamma/gravitee-gamma-plugin/gravitee-gamma-plugin-module/gravitee-gamma-plugin-module-api/src/main/java/io/gravitee/apim/plugin/gamma/api/identity/AmConnectionRepository.java
+++ b/gravitee-gamma/gravitee-gamma-plugin/gravitee-gamma-plugin-module/gravitee-gamma-plugin-module-api/src/main/java/io/gravitee/apim/plugin/gamma/api/identity/AmConnectionRepository.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.plugin.gamma.api.identity;
+
+import java.util.Optional;
+
+/**
+ * Read/write access to the per-organization AM connection, shared by gamma modules.
+ * The single implementation ({@link ApimAmConnectionRepository}) delegates to APIM rest-api core,
+ * which owns persistence and token encryption.
+ */
+public interface AmConnectionRepository {
+    Optional<AmConnection> findByOrg(String orgId);
+
+    boolean hasTokenForOrg(String orgId);
+
+    /**
+     * Save semantics for {@link AmConnection#serviceAccountAccessToken()}:
+     * {@code null} preserves the existing ciphertext, blank clears the saved token,
+     * non-blank encrypts and replaces.
+     */
+    AmConnection save(String orgId, AmConnection connection);
+
+    void deleteByOrg(String orgId);
+
+    default AmConnection requireByOrg(String orgId) {
+        return findByOrg(orgId).filter(AmConnection::isConfigured).orElseThrow(AmNotConfiguredException::new);
+    }
+}

--- a/gravitee-gamma/gravitee-gamma-plugin/gravitee-gamma-plugin-module/gravitee-gamma-plugin-module-api/src/main/java/io/gravitee/apim/plugin/gamma/api/identity/AmNotConfiguredException.java
+++ b/gravitee-gamma/gravitee-gamma-plugin/gravitee-gamma-plugin-module/gravitee-gamma-plugin-module-api/src/main/java/io/gravitee/apim/plugin/gamma/api/identity/AmNotConfiguredException.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.plugin.gamma.api.identity;
+
+import io.gravitee.apim.core.exception.AbstractDomainException;
+
+// APIM's plugin SPI does not allow registering a plugin-local JAX-RS exception mapper, so each
+// module's REST boundary translates this explicitly to 503 {"code": "am_not_configured", ...}.
+public class AmNotConfiguredException extends AbstractDomainException {
+
+    public static final String CODE = "am_not_configured";
+
+    public AmNotConfiguredException() {
+        super("Access Management is not configured for this module.");
+    }
+
+    public AmNotConfiguredException(String message) {
+        super(message);
+    }
+
+    public String code() {
+        return CODE;
+    }
+}

--- a/gravitee-gamma/gravitee-gamma-plugin/gravitee-gamma-plugin-module/gravitee-gamma-plugin-module-api/src/main/java/io/gravitee/apim/plugin/gamma/api/identity/AmNotConfiguredException.java
+++ b/gravitee-gamma/gravitee-gamma-plugin/gravitee-gamma-plugin-module/gravitee-gamma-plugin-module-api/src/main/java/io/gravitee/apim/plugin/gamma/api/identity/AmNotConfiguredException.java
@@ -18,7 +18,9 @@ package io.gravitee.apim.plugin.gamma.api.identity;
 import io.gravitee.apim.core.exception.AbstractDomainException;
 
 // APIM's plugin SPI does not allow registering a plugin-local JAX-RS exception mapper, so each
-// module's REST boundary translates this explicitly to 503 {"code": "am_not_configured", ...}.
+// module's REST boundary translates this explicitly to 409 {"code": "am_not_configured", ...}.
+// AbstractDomainException carries no status, so a missing AM connection is a client-side config gap
+// (409 Conflict), not a transient outage (503).
 public class AmNotConfiguredException extends AbstractDomainException {
 
     public static final String CODE = "am_not_configured";

--- a/gravitee-gamma/gravitee-gamma-plugin/gravitee-gamma-plugin-module/gravitee-gamma-plugin-module-api/src/main/java/io/gravitee/apim/plugin/gamma/api/identity/ApimAmConnectionRepository.java
+++ b/gravitee-gamma/gravitee-gamma-plugin/gravitee-gamma-plugin-module/gravitee-gamma-plugin-module-api/src/main/java/io/gravitee/apim/plugin/gamma/api/identity/ApimAmConnectionRepository.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.plugin.gamma.api.identity;
+
+import io.gravitee.rest.api.model.AmConnectionEntity;
+import io.gravitee.rest.api.service.AmConnectionService;
+import java.util.Optional;
+
+// Delegates AM connection storage + token encryption to APIM rest-api core (AmConnectionService),
+// which is injected from the plugin's parent Spring context.
+public class ApimAmConnectionRepository implements AmConnectionRepository {
+
+    private final AmConnectionService amConnectionService;
+
+    public ApimAmConnectionRepository(AmConnectionService amConnectionService) {
+        this.amConnectionService = amConnectionService;
+    }
+
+    @Override
+    public Optional<AmConnection> findByOrg(String orgId) {
+        return amConnectionService.findByOrganizationId(orgId).map(this::toModel);
+    }
+
+    @Override
+    public boolean hasTokenForOrg(String orgId) {
+        return amConnectionService.hasToken(orgId);
+    }
+
+    @Override
+    public AmConnection save(String orgId, AmConnection connection) {
+        return toModel(amConnectionService.save(orgId, toEntity(orgId, connection)));
+    }
+
+    @Override
+    public void deleteByOrg(String orgId) {
+        amConnectionService.delete(orgId);
+    }
+
+    private AmConnection toModel(AmConnectionEntity e) {
+        return new AmConnection(
+            e.getBaseUrl(),
+            e.getServiceAccountAccessToken(),
+            e.getDefaultDomainId(),
+            e.getDefaultDomainHrid(),
+            e.getGatewayUrl()
+        );
+    }
+
+    private AmConnectionEntity toEntity(String orgId, AmConnection c) {
+        AmConnectionEntity e = new AmConnectionEntity();
+        e.setOrganizationId(orgId);
+        e.setBaseUrl(c.baseUrl());
+        e.setServiceAccountAccessToken(c.serviceAccountAccessToken());
+        e.setDefaultDomainId(c.defaultDomainId());
+        e.setDefaultDomainHrid(c.defaultDomainHrid());
+        e.setGatewayUrl(c.gatewayUrl());
+        return e;
+    }
+}

--- a/gravitee-gamma/gravitee-gamma-plugin/gravitee-gamma-plugin-module/gravitee-gamma-plugin-module-api/src/test/java/io/gravitee/apim/plugin/gamma/api/identity/ApimAmConnectionRepositoryTest.java
+++ b/gravitee-gamma/gravitee-gamma-plugin/gravitee-gamma-plugin-module/gravitee-gamma-plugin-module-api/src/test/java/io/gravitee/apim/plugin/gamma/api/identity/ApimAmConnectionRepositoryTest.java
@@ -121,4 +121,16 @@ class ApimAmConnectionRepositoryTest {
         repository().deleteByOrg("org-1");
         verify(amConnectionService).delete("org-1");
     }
+
+    @Test
+    void toString_redacts_the_token() {
+        AmConnection connection = new AmConnection(
+            "https://am.example.com",
+            "plain-token",
+            "dom-1",
+            "dom-hrid-1",
+            "https://gw.example.com"
+        );
+        assertThat(connection.toString()).doesNotContain("plain-token").contains("***").contains("https://am.example.com");
+    }
 }

--- a/gravitee-gamma/gravitee-gamma-plugin/gravitee-gamma-plugin-module/gravitee-gamma-plugin-module-api/src/test/java/io/gravitee/apim/plugin/gamma/api/identity/ApimAmConnectionRepositoryTest.java
+++ b/gravitee-gamma/gravitee-gamma-plugin/gravitee-gamma-plugin-module/gravitee-gamma-plugin-module-api/src/test/java/io/gravitee/apim/plugin/gamma/api/identity/ApimAmConnectionRepositoryTest.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.plugin.gamma.api.identity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.rest.api.model.AmConnectionEntity;
+import io.gravitee.rest.api.service.AmConnectionService;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ApimAmConnectionRepositoryTest {
+
+    @Mock
+    AmConnectionService amConnectionService;
+
+    ApimAmConnectionRepository repository() {
+        return new ApimAmConnectionRepository(amConnectionService);
+    }
+
+    @Test
+    void findByOrg_maps_entity_to_model() {
+        AmConnectionEntity entity = new AmConnectionEntity();
+        entity.setBaseUrl("https://am.example.com");
+        entity.setServiceAccountAccessToken("plain-token");
+        entity.setDefaultDomainId("dom-1");
+        entity.setDefaultDomainHrid("dom-hrid-1");
+        entity.setGatewayUrl("https://gw.example.com");
+        when(amConnectionService.findByOrganizationId("org-1")).thenReturn(Optional.of(entity));
+
+        Optional<AmConnection> result = repository().findByOrg("org-1");
+
+        assertThat(result).isPresent();
+        AmConnection model = result.get();
+        assertThat(model.baseUrl()).isEqualTo("https://am.example.com");
+        assertThat(model.serviceAccountAccessToken()).isEqualTo("plain-token");
+        assertThat(model.defaultDomainId()).isEqualTo("dom-1");
+        assertThat(model.defaultDomainHrid()).isEqualTo("dom-hrid-1");
+        assertThat(model.gatewayUrl()).isEqualTo("https://gw.example.com");
+    }
+
+    @Test
+    void findByOrg_returns_empty_when_service_empty() {
+        when(amConnectionService.findByOrganizationId("org-1")).thenReturn(Optional.empty());
+        assertThat(repository().findByOrg("org-1")).isEmpty();
+    }
+
+    @Test
+    void hasTokenForOrg_delegates_to_service() {
+        when(amConnectionService.hasToken("org-1")).thenReturn(true);
+        assertThat(repository().hasTokenForOrg("org-1")).isTrue();
+        verify(amConnectionService).hasToken("org-1");
+    }
+
+    @Test
+    void save_builds_entity_from_model_and_returns_mapped_result() {
+        AmConnection connection = new AmConnection(
+            "https://am.example.com",
+            "plain-token",
+            "dom-1",
+            "dom-hrid-1",
+            "https://gw.example.com"
+        );
+        AmConnectionEntity returned = new AmConnectionEntity();
+        returned.setBaseUrl("https://am.example.com");
+        returned.setServiceAccountAccessToken("plain-token");
+        when(amConnectionService.save(eq("org-1"), any())).thenReturn(returned);
+
+        AmConnection result = repository().save("org-1", connection);
+
+        ArgumentCaptor<AmConnectionEntity> captor = ArgumentCaptor.forClass(AmConnectionEntity.class);
+        verify(amConnectionService).save(eq("org-1"), captor.capture());
+        AmConnectionEntity sent = captor.getValue();
+        assertThat(sent.getOrganizationId()).isEqualTo("org-1");
+        assertThat(sent.getBaseUrl()).isEqualTo("https://am.example.com");
+        assertThat(sent.getServiceAccountAccessToken()).isEqualTo("plain-token");
+        assertThat(sent.getDefaultDomainId()).isEqualTo("dom-1");
+        assertThat(sent.getDefaultDomainHrid()).isEqualTo("dom-hrid-1");
+        assertThat(sent.getGatewayUrl()).isEqualTo("https://gw.example.com");
+
+        assertThat(result.baseUrl()).isEqualTo("https://am.example.com");
+        assertThat(result.serviceAccountAccessToken()).isEqualTo("plain-token");
+    }
+
+    @Test
+    void save_passes_null_token_through() {
+        AmConnection connection = new AmConnection("https://am.example.com", null, null, null, null);
+        when(amConnectionService.save(eq("org-1"), any())).thenReturn(new AmConnectionEntity());
+
+        repository().save("org-1", connection);
+
+        ArgumentCaptor<AmConnectionEntity> captor = ArgumentCaptor.forClass(AmConnectionEntity.class);
+        verify(amConnectionService).save(eq("org-1"), captor.capture());
+        assertThat(captor.getValue().getServiceAccountAccessToken()).isNull();
+    }
+
+    @Test
+    void deleteByOrg_delegates_to_service() {
+        repository().deleteByOrg("org-1");
+        verify(amConnectionService).delete("org-1");
+    }
+}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/GMA-309

## Description

First phase of the AM user sync work. This lands all the AM-connection plumbing in APIM core, ahead of the actual sync mechanism which lands separately in `gravitee-gamma-module-authz`.

Three layers:

Repository layer. New `AmConnectionRepository` SPI with Mongo and JDBC adapters, a Liquibase migration for the `am_connections` table, and a TCK test. One connection per organization, with the service-account token stored encrypted.

Core service layer. `AmConnectionService` / `AmConnectionServiceImpl` in `rest-api-service` plus `AmConnectionEntity` in `rest-api-model`. The service decrypts the token via `DataEncryptor` and exposes `findByOrganizationId`, `hasToken`, `save` and `delete`. Deleting an organization now also clears its connection (wired into `DeleteOrganizationCommandHandler`).

Shared gamma-sdk port. An `AmConnection` record and `AmConnectionRepository` port in `gravitee-gamma-plugin-module-api`, with `ApimAmConnectionRepository` delegating to the core service. `findByOrg` / `requireByOrg` return an `AmConnection` carrying the decrypted token plus `baseUrl`, `defaultDomainId`, `defaultDomainHrid` and `gatewayUrl`. `requireByOrg` throws `AmNotConfiguredException` when none is configured. This is the injection point the gamma modules use, not the core service directly.

## Additional context

Follow-up phase (syncing AM users into the FGA engine as PRINCIPAL entities) builds on this port and lands in `gravitee-gamma-module-authz`.

Compile on JDK 21. JDK 25 breaks lombok in `rest-api-service`.
