### PR TITLE
fix(GKO-2822): preserve HRID on management API updates

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/plan/model/Plan.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/plan/model/Plan.java
@@ -299,7 +299,7 @@ public class Plan implements GenericPlanEntity {
             .name(updated.name)
             .description(updated.description)
             .order(updated.order)
-            .hrid(updated.hrid)
+            .hrid(updated.hrid == null ? hrid : updated.hrid)
             .updatedAt(TimeProvider.now())
             .planDefinitionHttpV4(updated.planDefinitionHttpV4)
             .planDefinitionNativeV4(updated.planDefinitionNativeV4)

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/shared_policy_group/model/SharedPolicyGroup.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/shared_policy_group/model/SharedPolicyGroup.java
@@ -193,7 +193,7 @@ public class SharedPolicyGroup {
 
     public SharedPolicyGroup update(UpdateSharedPolicyGroup updateSharedPolicyGroup) {
         return this.toBuilder()
-            .hrid(updateSharedPolicyGroup.getHrid())
+            .hrid(updateSharedPolicyGroup.getHrid() == null ? this.getHrid() : updateSharedPolicyGroup.getHrid())
             .crossId(updateSharedPolicyGroup.getCrossId() == null ? this.getCrossId() : updateSharedPolicyGroup.getCrossId())
             .name(updateSharedPolicyGroup.getName() == null ? this.getName() : updateSharedPolicyGroup.getName())
             .description(

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/GroupServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/GroupServiceImpl.java
@@ -1069,6 +1069,7 @@ public class GroupServiceImpl extends AbstractService implements GroupService {
 
         Group group = new Group();
         group.setId(entity.getId());
+        group.setHrid(entity.getHrid());
         group.setName(entity.getName());
 
         if (entity.getEventRules() != null && !entity.getEventRules().isEmpty()) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/ApiServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/ApiServiceImpl.java
@@ -490,6 +490,10 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
                 api.setCrossId(apiToUpdate.getCrossId());
             }
 
+            if (updateApiEntity.getHrid() == null) {
+                api.setHrid(apiToUpdate.getHrid());
+            }
+
             // Keep existing picture as picture update has dedicated service
             api.setPicture(apiToUpdate.getPicture());
             api.setBackground(apiToUpdate.getBackground());

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/plan/domain_service/UpdatePlanDomainServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/plan/domain_service/UpdatePlanDomainServiceTest.java
@@ -553,6 +553,32 @@ class UpdatePlanDomainServiceTest {
         }
 
         @Test
+        void should_preserve_existing_hrid_when_update_does_not_provide_one() {
+            // Given
+            var plan = givenExistingPlan(PlanFixtures.HttpV4.aKeyless().toBuilder().apiId(API_ID).hrid("my-plan-hrid").build());
+
+            // When
+            var toUpdate = plan.toBuilder().hrid(null).name("updated name").build();
+            var result = service.update(toUpdate, List.of(), null, API_PROXY_V4, AUDIT_INFO);
+
+            // Then
+            assertThat(result.getHrid()).isEqualTo("my-plan-hrid");
+        }
+
+        @Test
+        void should_use_hrid_from_update_when_provided() {
+            // Given
+            var plan = givenExistingPlan(PlanFixtures.HttpV4.aKeyless().toBuilder().apiId(API_ID).hrid("old-hrid").build());
+
+            // When
+            var toUpdate = plan.toBuilder().hrid("new-hrid").name("updated name").build();
+            var result = service.update(toUpdate, List.of(), null, API_PROXY_V4, AUDIT_INFO);
+
+            // Then
+            assertThat(result.getHrid()).isEqualTo("new-hrid");
+        }
+
+        @Test
         void should_reorder_all_plans_when_order_is_updated() {
             // Given
             var plans = givenExistingPlans(

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/shared_policy_group/use_case/UpdateSharedPolicyGroupUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/shared_policy_group/use_case/UpdateSharedPolicyGroupUseCaseTest.java
@@ -236,6 +236,30 @@ public class UpdateSharedPolicyGroupUseCaseTest {
     }
 
     @Test
+    void should_update_and_keep_hrid() {
+        // Given
+        var existingSharedPolicyGroup = SharedPolicyGroupFixtures.aSharedPolicyGroup().toBuilder().hrid("hrid").build();
+        sharedPolicyGroupCrudService.initWith(List.of(existingSharedPolicyGroup));
+
+        // When
+        var toUpdate = UpdateSharedPolicyGroup.builder().description("new-description").build();
+        var updatedSharedPolicyGroup = updateSharedPolicyGroupUseCase.execute(
+            new UpdateSharedPolicyGroupUseCase.Input(existingSharedPolicyGroup.getId(), toUpdate, AUDIT_INFO)
+        );
+
+        // Then
+        var expected = existingSharedPolicyGroup
+            .toBuilder()
+            .description("new-description")
+            .hrid("hrid")
+            .lifecycleState(SharedPolicyGroup.SharedPolicyGroupLifecycleState.PENDING)
+            .updatedAt(INSTANT_NOW.atZone(ZoneId.systemDefault()))
+            .build();
+        assertThat(updatedSharedPolicyGroup.sharedPolicyGroup()).isNotNull();
+        assertThat(updatedSharedPolicyGroup.sharedPolicyGroup()).usingRecursiveComparison().isEqualTo(expected);
+    }
+
+    @Test
     void should_throw_exception_when_sharedPolicyGroup_with_crossId_already_exists() {
         // Given
         var existingSharedPolicyGroup_1 = SharedPolicyGroupFixtures.aSharedPolicyGroup();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/GroupService_UpdateTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/GroupService_UpdateTest.java
@@ -104,6 +104,8 @@ public class GroupService_UpdateTest {
         updatedGroupEntity.setSystemInvitation(false);
 
         final Group group = new Group();
+        group.setId(GROUP_ID);
+        group.setHrid("my-group-hrid");
         group.setApiPrimaryOwner("api-primary-owner");
         group.setEnvironmentId(GraviteeContext.getCurrentEnvironment());
 
@@ -133,7 +135,8 @@ public class GroupService_UpdateTest {
                     updatedGroup.getMaxInvitation() == 100 &&
                     updatedGroup.getName().equals("my-group-name") &&
                     !updatedGroup.isSystemInvitation() &&
-                    updatedGroup.getApiPrimaryOwner().equals("api-primary-owner")
+                    updatedGroup.getApiPrimaryOwner().equals("api-primary-owner") &&
+                    "my-group-hrid".equals(updatedGroup.getHrid())
             )
         );
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/ApiServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/ApiServiceImplTest.java
@@ -831,6 +831,17 @@ public class ApiServiceImplTest {
     }
 
     @Test
+    public void shouldPreserveHridWhenUpdateEntityDoesNotProvideOne() throws TechnicalException {
+        prepareUpdate();
+        api.setHrid("api-hrid");
+        updateApiEntity.setHrid(null);
+
+        apiService.update(GraviteeContext.getExecutionContext(), API_ID, updateApiEntity, USER_NAME);
+
+        verify(apiRepository).update(argThat(updated -> "api-hrid".equals(updated.getHrid())));
+    }
+
+    @Test
     public void shouldUpdatePlans() throws TechnicalException {
         prepareUpdate();
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/ApiServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/ApiServiceImplTest.java
@@ -437,7 +437,7 @@ public class ApiServiceImplTest {
     }
 
     @Test
-    public void shouldNotDeleteBecauseRunningState() throws TechnicalException {
+    public void should_not_delete_because_running_state() throws TechnicalException {
         assertThrows(ApiRunningStateException.class, () -> {
             Api api = new Api();
             api.setId(API_ID);
@@ -450,7 +450,7 @@ public class ApiServiceImplTest {
     }
 
     @Test
-    public void shouldDeleteWithNoPlan() throws TechnicalException {
+    public void should_delete_with_no_plan() throws TechnicalException {
         Api api = new Api();
         api.setId(API_ID);
         api.setLifecycleState(LifecycleState.STOPPED);
@@ -473,7 +473,7 @@ public class ApiServiceImplTest {
     }
 
     @Test
-    public void shouldRemoveApiFromAllApiProductsWhenDeleting() throws TechnicalException {
+    public void should_remove_api_from_all_api_products_when_deleting() throws TechnicalException {
         Api api = new Api();
         api.setId(API_ID);
         api.setLifecycleState(LifecycleState.STOPPED);
@@ -831,7 +831,7 @@ public class ApiServiceImplTest {
     }
 
     @Test
-    public void shouldPreserveHridWhenUpdateEntityDoesNotProvideOne() throws TechnicalException {
+    public void should_preserve_hrid_when_update_entity_does_not_provide_one() throws TechnicalException {
         prepareUpdate();
         api.setHrid("api-hrid");
         updateApiEntity.setHrid(null);
@@ -839,6 +839,17 @@ public class ApiServiceImplTest {
         apiService.update(GraviteeContext.getExecutionContext(), API_ID, updateApiEntity, USER_NAME);
 
         verify(apiRepository).update(argThat(updated -> "api-hrid".equals(updated.getHrid())));
+    }
+
+    @Test
+    public void should_use_hrid_from_update_entity_when_provided() throws TechnicalException {
+        prepareUpdate();
+        api.setHrid("old-hrid");
+        updateApiEntity.setHrid("new-hrid");
+
+        apiService.update(GraviteeContext.getExecutionContext(), API_ID, updateApiEntity, USER_NAME);
+
+        verify(apiRepository).update(argThat(updated -> "new-hrid".equals(updated.getHrid())));
     }
 
     @Test


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/GKO-2822

## Summary

- Preserve existing API HRID when Management API v4 updates omit it (fixes detached APIs losing HRID after console edits; Automation API then returned `hrid: null`).
- Apply the same null-coalescing pattern for plan and shared policy group updates.
- Same for groups

