### PR TITLE
refactor(rest-api): extract cache-header helper to AbstractResource

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/AbstractResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/AbstractResource.java
@@ -49,6 +49,7 @@ import jakarta.inject.Inject;
 import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.EntityTag;
 import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.SecurityContext;
 import jakarta.ws.rs.core.UriBuilder;
 import jakarta.ws.rs.core.UriInfo;
@@ -56,12 +57,14 @@ import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Date;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import lombok.CustomLog;
 import org.glassfish.jersey.message.internal.HttpHeaderReader;
 import org.glassfish.jersey.message.internal.MatchingEntityTag;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -73,6 +76,7 @@ import org.springframework.util.CollectionUtils;
  * @author Azize ELAMRANI (azize.elamrani at graviteesource.com)
  * @author GraviteeSource Team
  */
+@CustomLog
 public abstract class AbstractResource {
 
     public static final String ORGANIZATION_ADMIN = RoleScope.ORGANIZATION.name() + ':' + SystemRole.ADMIN.name();
@@ -275,6 +279,16 @@ public abstract class AbstractResource {
             requestUriBuilder.path(path);
         }
         return requestUriBuilder.build();
+    }
+
+    protected Response.ResponseBuilder applyCacheHeaders(Response.ResponseBuilder builder, Date updatedAt) {
+        if (updatedAt != null) {
+            builder.tag(Long.toString(updatedAt.getTime())).lastModified(updatedAt);
+        } else {
+            log.warn("Record has no updatedAt date set, Last-Modified header won't be added to the response.");
+        }
+
+        return builder;
     }
 
     protected void evaluateIfMatch(final HttpHeaders headers, final String etagValue) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiPlansResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiPlansResource.java
@@ -247,10 +247,7 @@ public class ApiPlansResource extends AbstractResource {
 
         Response.ResponseBuilder builder = Response.ok(planMapper.mapGenericPlan(planEntity));
         Date updatedAt = resolvePlanUpdatedAt(planEntity);
-        if (updatedAt != null) {
-            builder.tag(Long.toString(updatedAt.getTime())).lastModified(updatedAt);
-        }
-        return builder.build();
+        return applyCacheHeaders(builder, updatedAt).build();
     }
 
     private static Date resolvePlanUpdatedAt(GenericPlanEntity planEntity) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource.java
@@ -173,6 +173,7 @@ import jakarta.ws.rs.core.UriBuilder;
 import jakarta.ws.rs.core.UriInfo;
 import java.io.ByteArrayOutputStream;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -563,12 +564,8 @@ public class ApiResource extends AbstractResource {
         apiV4.primaryOwner(ApiMapper.INSTANCE.map(output.primaryOwner()));
         apiV4.workflowState(output.workflowState() != null ? ApiWorkflowState.valueOf(output.workflowState().name()) : null);
         var rawUpdatedAt = output.api().getUpdatedAt();
-        var updatedAt = rawUpdatedAt != null ? rawUpdatedAt.toInstant() : null;
-        var builder = Response.ok(apiV4);
-        if (updatedAt != null) {
-            builder.tag(Long.toString(updatedAt.toEpochMilli())).lastModified(java.util.Date.from(updatedAt));
-        }
-        return builder.build();
+        var updatedAt = rawUpdatedAt != null ? Date.from(rawUpdatedAt.toInstant()) : null;
+        return applyCacheHeaders(Response.ok(apiV4), updatedAt).build();
     }
 
     @PUT
@@ -677,7 +674,7 @@ public class ApiResource extends AbstractResource {
         ExecutionContext executionContext = GraviteeContext.getExecutionContext();
         apiLicenseService.checkLicense(executionContext, apiId);
         GenericApiEntity apiEntity = apiStateService.deploy(executionContext, apiId, getAuthenticatedUser(), apiDeploymentEntity);
-        return Response.accepted().tag(Long.toString(apiEntity.getUpdatedAt().getTime())).lastModified(apiEntity.getUpdatedAt()).build();
+        return applyCacheHeaders(Response.accepted(), apiEntity.getUpdatedAt()).build();
     }
 
     @GET
@@ -845,7 +842,7 @@ public class ApiResource extends AbstractResource {
         checkApiLifeCycle(genericApiEntity, LifecycleAction.START);
         GenericApiEntity updatedApi = apiStateService.start(executionContext, genericApiEntity.getId(), getAuthenticatedUser());
 
-        return Response.noContent().tag(Long.toString(updatedApi.getUpdatedAt().getTime())).lastModified(updatedApi.getUpdatedAt()).build();
+        return applyCacheHeaders(Response.noContent(), updatedApi.getUpdatedAt()).build();
     }
 
     @POST
@@ -862,7 +859,7 @@ public class ApiResource extends AbstractResource {
             getAuthenticatedUser()
         );
 
-        return Response.noContent().tag(Long.toString(updatedApi.getUpdatedAt().getTime())).lastModified(updatedApi.getUpdatedAt()).build();
+        return applyCacheHeaders(Response.noContent(), updatedApi.getUpdatedAt()).build();
     }
 
     @Path("/scoring")
@@ -1021,7 +1018,7 @@ public class ApiResource extends AbstractResource {
             ApiMapper.INSTANCE.map(apiReview)
         );
 
-        return Response.noContent().tag(Long.toString(updatedApi.getUpdatedAt().getTime())).lastModified(updatedApi.getUpdatedAt()).build();
+        return applyCacheHeaders(Response.noContent(), updatedApi.getUpdatedAt()).build();
     }
 
     @POST
@@ -1039,7 +1036,7 @@ public class ApiResource extends AbstractResource {
             ApiMapper.INSTANCE.map(apiReview)
         );
 
-        return Response.noContent().tag(Long.toString(updatedApi.getUpdatedAt().getTime())).lastModified(updatedApi.getUpdatedAt()).build();
+        return applyCacheHeaders(Response.noContent(), updatedApi.getUpdatedAt()).build();
     }
 
     @POST
@@ -1057,7 +1054,7 @@ public class ApiResource extends AbstractResource {
             ApiMapper.INSTANCE.map(apiReview)
         );
 
-        return Response.noContent().tag(Long.toString(updatedApi.getUpdatedAt().getTime())).lastModified(updatedApi.getUpdatedAt()).build();
+        return applyCacheHeaders(Response.noContent(), updatedApi.getUpdatedAt()).build();
     }
 
     @POST
@@ -1345,10 +1342,7 @@ public class ApiResource extends AbstractResource {
 
     private Response apiResponse(GenericApiEntity apiEntity) {
         boolean isSynchronized = apiStateService.isSynchronized(GraviteeContext.getExecutionContext(), apiEntity);
-        return Response.ok(ApiMapper.INSTANCE.map(apiEntity, uriInfo, isSynchronized))
-            .tag(Long.toString(apiEntity.getUpdatedAt().getTime()))
-            .lastModified(apiEntity.getUpdatedAt())
-            .build();
+        return applyCacheHeaders(Response.ok(ApiMapper.INSTANCE.map(apiEntity, uriInfo, isSynchronized)), apiEntity.getUpdatedAt()).build();
     }
 
     private Error apiInvalid(String apiId) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/AbstractResourceCacheHeaderTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/AbstractResourceCacheHeaderTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.management.v2.rest.resource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.ws.rs.core.EntityTag;
+import jakarta.ws.rs.core.Response;
+import java.util.Date;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+public class AbstractResourceCacheHeaderTest {
+
+    private static final AbstractResource RESOURCE = new AbstractResource() {};
+
+    @Nested
+    class WithCacheHeaders {
+
+        @Test
+        void emits_etag_and_last_modified_with_correct_epoch_millis_formula() {
+            Date date = new Date(12345L);
+            Response.ResponseBuilder builder = Response.ok();
+
+            Response.ResponseBuilder returned = RESOURCE.applyCacheHeaders(builder, date);
+            Response response = returned.build();
+
+            SoftAssertions.assertSoftly(softly -> {
+                softly.assertThat(returned).isSameAs(builder);
+                softly.assertThat(response.getEntityTag()).isEqualTo(new EntityTag("12345"));
+                softly.assertThat(response.getLastModified()).isNotNull();
+                softly.assertThat(response.getLastModified().getTime()).isEqualTo(12345L);
+            });
+        }
+
+        @Test
+        void suppresses_both_headers_when_updatedAt_is_null_without_throwing() {
+            Response response = RESOURCE.applyCacheHeaders(Response.ok("body"), null).build();
+
+            SoftAssertions.assertSoftly(softly -> {
+                softly.assertThat(response.getEntityTag()).isNull();
+                softly.assertThat(response.getLastModified()).isNull();
+            });
+        }
+
+        @Test
+        void emits_headers_for_zero_epoch_date() {
+            Response response = RESOURCE.applyCacheHeaders(Response.ok(), new Date(0L)).build();
+
+            SoftAssertions.assertSoftly(softly -> {
+                softly.assertThat(response.getEntityTag()).isEqualTo(new EntityTag("0"));
+                softly.assertThat(response.getLastModified()).isNotNull();
+                softly.assertThat(response.getLastModified().getTime()).isEqualTo(0L);
+            });
+        }
+
+        @Test
+        void etag_value_and_last_modified_encode_same_instant() {
+            Date date = new Date(1_700_000_000_000L);
+            Response response = RESOURCE.applyCacheHeaders(Response.ok(), date).build();
+
+            long etagMillis = Long.parseLong(response.getEntityTag().getValue());
+            assertThat(etagMillis).isEqualTo(response.getLastModified().getTime());
+        }
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiPlansResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiPlansResourceTest.java
@@ -831,8 +831,7 @@ public class ApiPlansResourceTest extends AbstractResourceTest {
             final Response response = target.request().get();
 
             assertThat(response).hasStatus(OK_200).asEntity(PlanV4.class).isEqualTo(PlanMapper.INSTANCE.map(planEntity));
-            Assertions.assertThat(response.getEntityTag()).isEqualTo(new EntityTag(Long.toString(updatedAt.getTime())));
-            Assertions.assertThat(response.getLastModified().getTime() / 1000).isEqualTo(updatedAt.getTime() / 1000);
+            assertCacheHeaders(response, updatedAt);
         }
 
         @Test
@@ -850,8 +849,7 @@ public class ApiPlansResourceTest extends AbstractResourceTest {
             final Response response = target.request().get();
 
             assertThat(response).hasStatus(OK_200).asEntity(PlanV2.class).isEqualTo(PlanMapper.INSTANCE.map(planEntity));
-            Assertions.assertThat(response.getEntityTag()).isEqualTo(new EntityTag(Long.toString(updatedAt.getTime())));
-            Assertions.assertThat(response.getLastModified().getTime() / 1000).isEqualTo(updatedAt.getTime() / 1000);
+            assertCacheHeaders(response, updatedAt);
         }
 
         @Test
@@ -869,8 +867,7 @@ public class ApiPlansResourceTest extends AbstractResourceTest {
             final Response response = target.request().get();
 
             assertThat(response).hasStatus(OK_200).asEntity(PlanV4.class).isEqualTo(PlanMapper.INSTANCE.map(planEntity));
-            Assertions.assertThat(response.getEntityTag()).isEqualTo(new EntityTag(Long.toString(updatedAt.getTime())));
-            Assertions.assertThat(response.getLastModified().getTime() / 1000).isEqualTo(updatedAt.getTime() / 1000);
+            assertCacheHeaders(response, updatedAt);
         }
 
         @Test
@@ -887,8 +884,7 @@ public class ApiPlansResourceTest extends AbstractResourceTest {
             final Response response = target.request().get();
 
             assertThat(response).hasStatus(OK_200).asEntity(PlanV4.class).isEqualTo(PlanMapper.INSTANCE.map(planEntity));
-            Assertions.assertThat(response.getEntityTag()).isNull();
-            Assertions.assertThat(response.getLastModified()).isNull();
+            assertNoCacheHeaders(response);
         }
 
         @Test
@@ -905,6 +901,15 @@ public class ApiPlansResourceTest extends AbstractResourceTest {
             final Response response = target.request().get();
 
             assertThat(response).hasStatus(OK_200).asEntity(PlanV2.class).isEqualTo(PlanMapper.INSTANCE.map(planEntity));
+            assertNoCacheHeaders(response);
+        }
+
+        private void assertCacheHeaders(Response response, Date updatedAt) {
+            Assertions.assertThat(response.getEntityTag()).isEqualTo(new EntityTag(Long.toString(updatedAt.getTime())));
+            Assertions.assertThat(response.getLastModified().getTime() / 1000).isEqualTo(updatedAt.getTime() / 1000);
+        }
+
+        private void assertNoCacheHeaders(Response response) {
             Assertions.assertThat(response.getEntityTag()).isNull();
             Assertions.assertThat(response.getLastModified()).isNull();
         }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource_PatchApiConcurrencyTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource_PatchApiConcurrencyTest.java
@@ -57,6 +57,9 @@ public class ApiResource_PatchApiConcurrencyTest extends ApiResourceTest {
 
     private static final String MERGE_PATCH_TYPE = "application/merge-patch+json";
 
+    private static final Instant updatedAt = Instant.parse("2026-06-01T13:45:30Z");
+    private static final String updatedAtStr = String.format("\"%s\"", updatedAt.toEpochMilli());
+
     @Inject
     UpdateApiDomainService updateApiDomainService;
 
@@ -67,7 +70,6 @@ public class ApiResource_PatchApiConcurrencyTest extends ApiResourceTest {
 
     @BeforeEach
     void setUpApiAndPrimaryOwner() {
-        var updatedAt = Instant.ofEpochMilli(1000);
         var existingApi = ApiFixtures.aProxyApiV4()
             .toBuilder()
             .updatedAt(ZonedDateTime.ofInstant(updatedAt, ZoneId.systemDefault()))
@@ -118,7 +120,7 @@ public class ApiResource_PatchApiConcurrencyTest extends ApiResourceTest {
     void should_succeed_when_If_Match_matches_ETag() {
         var response = rootTarget(API)
             .request()
-            .header(HttpHeaders.IF_MATCH, "\"1000\"")
+            .header(HttpHeaders.IF_MATCH, updatedAtStr)
             .method("PATCH", Entity.entity("{\"name\":\"patched\"}", MERGE_PATCH_TYPE));
 
         assertThat(response).hasStatus(OK_200);
@@ -168,7 +170,7 @@ public class ApiResource_PatchApiConcurrencyTest extends ApiResourceTest {
         v2Entity.setId(API);
         v2Entity.setDefinitionVersion(DefinitionVersion.V2);
         v2Entity.setType(ApiType.PROXY);
-        v2Entity.setUpdatedAt(Date.from(Instant.ofEpochMilli(1000)));
+        v2Entity.setUpdatedAt(Date.from(updatedAt));
         when(apiSearchServiceV4.findGenericById(any(), eq(API), any(boolean.class), any(boolean.class), any(boolean.class))).thenReturn(
             v2Entity
         );
@@ -218,18 +220,18 @@ public class ApiResource_PatchApiConcurrencyTest extends ApiResourceTest {
     void should_return_new_ETag_and_Last_Modified_on_successful_patch() {
         var response = rootTarget(API)
             .request()
-            .header(HttpHeaders.IF_MATCH, "\"1000\"")
+            .header(HttpHeaders.IF_MATCH, updatedAtStr)
             .method("PATCH", Entity.entity("{\"name\":\"patched\"}", MERGE_PATCH_TYPE));
 
         assertThat(response).hasStatus(OK_200);
-        org.assertj.core.api.Assertions.assertThat(response.getHeaderString(HttpHeaders.ETAG)).isEqualTo("\"1000\"");
+        org.assertj.core.api.Assertions.assertThat(response.getHeaderString(HttpHeaders.ETAG)).isEqualTo(updatedAtStr);
         org.assertj.core.api.Assertions.assertThat(response.getHeaderString(HttpHeaders.LAST_MODIFIED)).isNotNull();
     }
 
     @Test
     void should_round_trip_GET_PATCH_GET_with_consistent_ETag_chain() {
         var firstGetEntity = fixtures.ApiFixtures.aModelHttpApiV4().toBuilder().id(API).name(API).build();
-        firstGetEntity.setUpdatedAt(Date.from(Instant.ofEpochMilli(1000)));
+        firstGetEntity.setUpdatedAt(Date.from(updatedAt));
         when(apiSearchServiceV4.findGenericById(any(), eq(API), any(boolean.class), any(boolean.class), any(boolean.class))).thenReturn(
             firstGetEntity
         );
@@ -237,7 +239,7 @@ public class ApiResource_PatchApiConcurrencyTest extends ApiResourceTest {
         var firstGetResponse = rootTarget(API).request().get();
         assertThat(firstGetResponse).hasStatus(OK_200);
         var firstEtag = firstGetResponse.getHeaderString(HttpHeaders.ETAG);
-        org.assertj.core.api.Assertions.assertThat(firstEtag).isEqualTo("\"1000\"");
+        org.assertj.core.api.Assertions.assertThat(firstEtag).isEqualTo(updatedAtStr);
 
         var newUpdatedAt = Instant.ofEpochMilli(2000);
         doAnswer(inv -> {
@@ -271,12 +273,45 @@ public class ApiResource_PatchApiConcurrencyTest extends ApiResourceTest {
     }
 
     @Test
+    void should_suppress_cache_headers_when_updatedAt_is_null_on_patch() {
+        var existingApi = ApiFixtures.aProxyApiV4().toBuilder().updatedAt(null).build();
+        apiCrudService.initWith(List.of(existingApi));
+
+        var apiEntity = new ApiEntity();
+        apiEntity.setId(API);
+        apiEntity.setDefinitionVersion(DefinitionVersion.V4);
+        apiEntity.setType(ApiType.PROXY);
+        apiEntity.setUpdatedAt(null);
+        when(apiSearchServiceV4.findGenericById(any(), eq(API), any(boolean.class), any(boolean.class), any(boolean.class))).thenReturn(
+            apiEntity
+        );
+
+        var response = rootTarget(API).request().method("PATCH", Entity.entity("{\"name\":\"patched\"}", MERGE_PATCH_TYPE));
+
+        assertThat(response).hasStatus(OK_200);
+        org.assertj.core.api.Assertions.assertThat(response.getEntityTag()).isNull();
+        org.assertj.core.api.Assertions.assertThat(response.getLastModified()).isNull();
+    }
+
+    @Test
+    void should_have_Last_Modified_encoding_same_instant_as_ETag_on_successful_patch() {
+        var response = rootTarget(API)
+            .request()
+            .header(HttpHeaders.IF_MATCH, updatedAtStr)
+            .method("PATCH", Entity.entity("{\"name\":\"patched\"}", MERGE_PATCH_TYPE));
+
+        assertThat(response).hasStatus(OK_200);
+        org.assertj.core.api.Assertions.assertThat(response.getHeaderString(HttpHeaders.ETAG)).isEqualTo(updatedAtStr);
+        org.assertj.core.api.Assertions.assertThat(response.getLastModified().getTime()).isEqualTo(updatedAt.toEpochMilli());
+    }
+
+    @Test
     void should_reject_with_scope_error_for_native_api_even_when_If_Match_is_mismatched() {
         var nativeEntity = new NativeApiEntity();
         nativeEntity.setId(API);
         nativeEntity.setDefinitionVersion(DefinitionVersion.V4);
         nativeEntity.setType(ApiType.NATIVE);
-        nativeEntity.setUpdatedAt(Date.from(Instant.ofEpochMilli(1000)));
+        nativeEntity.setUpdatedAt(Date.from(updatedAt));
         when(apiSearchServiceV4.findGenericById(any(), eq(API), any(boolean.class), any(boolean.class), any(boolean.class))).thenReturn(
             nativeEntity
         );

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource_ReviewsTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource_ReviewsTest.java
@@ -18,6 +18,7 @@ package io.gravitee.rest.api.management.v2.rest.resource.api;
 import static io.gravitee.common.http.HttpStatusCode.BAD_REQUEST_400;
 import static io.gravitee.common.http.HttpStatusCode.NO_CONTENT_204;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
@@ -190,5 +191,87 @@ public class ApiResource_ReviewsTest extends ApiResourceTest {
 
         assertEquals(BAD_REQUEST_400, response.getStatus());
         verify(apiWorkflowStateService, never()).askForReview(any(), any(), any(), any());
+    }
+
+    @Test
+    public void should_emit_ETag_and_Last_Modified_on_ask_review() {
+        ApiReview apiReview = new ApiReview();
+        apiReview.setMessage("My comment");
+
+        var apiEntity = ApiFixtures.aModelHttpApiV4().toBuilder().id(API).updatedAt(new Date(1000L)).build();
+        when(
+            apiSearchServiceV4.findGenericById(eq(GraviteeContext.getExecutionContext()), eq(API), eq(false), eq(false), eq(false))
+        ).thenReturn(apiEntity);
+        when(
+            apiWorkflowStateService.askForReview(eq(GraviteeContext.getExecutionContext()), eq(API), eq(USER_NAME), any(ReviewEntity.class))
+        ).thenReturn(apiEntity);
+
+        final Response response = rootTarget("_ask").request().post(Entity.json(apiReview));
+
+        assertEquals(NO_CONTENT_204, response.getStatus());
+        assertEquals("\"1000\"", response.getHeaderString("ETag"));
+        assertEquals(1000L, response.getLastModified().getTime());
+    }
+
+    @Test
+    public void should_suppress_cache_headers_when_updatedAt_is_null_on_ask_review() {
+        ApiReview apiReview = new ApiReview();
+        apiReview.setMessage("My comment");
+
+        var currentApi = ApiFixtures.aModelHttpApiV4().toBuilder().id(API).updatedAt(new Date(1000L)).build();
+        when(
+            apiSearchServiceV4.findGenericById(eq(GraviteeContext.getExecutionContext()), eq(API), eq(false), eq(false), eq(false))
+        ).thenReturn(currentApi);
+
+        var updatedApi = ApiFixtures.aModelHttpApiV4().toBuilder().id(API).updatedAt(null).build();
+        when(
+            apiWorkflowStateService.askForReview(eq(GraviteeContext.getExecutionContext()), eq(API), eq(USER_NAME), any(ReviewEntity.class))
+        ).thenReturn(updatedApi);
+
+        final Response response = rootTarget("_ask").request().post(Entity.json(apiReview));
+
+        assertEquals(NO_CONTENT_204, response.getStatus());
+        assertNull(response.getEntityTag());
+        assertNull(response.getLastModified());
+    }
+
+    @Test
+    public void should_emit_ETag_and_Last_Modified_on_accept_review() {
+        ApiReview apiReview = new ApiReview();
+        apiReview.setMessage("My comment");
+
+        var apiEntity = ApiFixtures.aModelHttpApiV4().toBuilder().id(API).updatedAt(new Date(1000L)).build();
+        when(
+            apiSearchServiceV4.findGenericById(eq(GraviteeContext.getExecutionContext()), eq(API), eq(false), eq(false), eq(false))
+        ).thenReturn(apiEntity);
+        when(
+            apiWorkflowStateService.acceptReview(eq(GraviteeContext.getExecutionContext()), eq(API), eq(USER_NAME), any(ReviewEntity.class))
+        ).thenReturn(apiEntity);
+
+        final Response response = rootTarget("_accept").request().post(Entity.json(apiReview));
+
+        assertEquals(NO_CONTENT_204, response.getStatus());
+        assertEquals("\"1000\"", response.getHeaderString("ETag"));
+        assertEquals(1000L, response.getLastModified().getTime());
+    }
+
+    @Test
+    public void should_emit_ETag_and_Last_Modified_on_reject_review() {
+        ApiReview apiReview = new ApiReview();
+        apiReview.setMessage("My comment");
+
+        var apiEntity = ApiFixtures.aModelHttpApiV4().toBuilder().id(API).updatedAt(new Date(1000L)).build();
+        when(
+            apiSearchServiceV4.findGenericById(eq(GraviteeContext.getExecutionContext()), eq(API), eq(false), eq(false), eq(false))
+        ).thenReturn(apiEntity);
+        when(
+            apiWorkflowStateService.rejectReview(eq(GraviteeContext.getExecutionContext()), eq(API), eq(USER_NAME), any(ReviewEntity.class))
+        ).thenReturn(apiEntity);
+
+        final Response response = rootTarget("_reject").request().post(Entity.json(apiReview));
+
+        assertEquals(NO_CONTENT_204, response.getStatus());
+        assertEquals("\"1000\"", response.getHeaderString("ETag"));
+        assertEquals(1000L, response.getLastModified().getTime());
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource_StopTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource_StopTest.java
@@ -131,6 +131,7 @@ public class ApiResource_StopTest extends ApiResourceTest {
         assertEquals(HttpStatusCode.NO_CONTENT_204, response.getStatus());
 
         assertEquals("\"" + updatedEntity.getUpdatedAt().getTime() + "\"", response.getHeaders().get("Etag").get(0));
+        assertEquals(updatedEntity.getUpdatedAt().getTime() / 1000, response.getLastModified().getTime() / 1000);
 
         verify(apiStateServiceV4, times(1)).stop(eq(GraviteeContext.getExecutionContext()), eq(API), eq(USER_NAME));
     }


### PR DESCRIPTION
## Issue

[APIM-14212](https://gravitee.atlassian.net/browse/APIM-14212)

## Why

The `Cache-Control` / `Last-Modified` header pattern (`builder.tag(Long.toString(date.getTime())).lastModified(date)`) was duplicated across several v2 API resource classes. Consolidating it into one place removes the duplication and guarantees consistent null-handling — `Last-Modified`/`ETag` are derived from `updatedAt` in a single helper rather than re-implemented per call site.

## What changed

- Added a protected `applyCacheHeaders(ResponseBuilder, Date updatedAt)` helper to `AbstractResource` that sets the `Last-Modified`/`ETag` headers from `updatedAt`, suppressing them when `updatedAt` is `null`.
- Migrated the cache-header call sites in `ApiResource` (review, PATCH, GET, stop endpoints) and `ApiPlansResource` to use the helper.

## How to test

No special setup — this is a behaviour-preserving refactor covered by the unit tests in `AbstractResourceCacheHeaderTest`, `ApiResource_ReviewsTest`, `ApiResource_PatchApiConcurrencyTest`, `ApiResource_StopTest`, and `ApiPlansResourceTest`. Run the rest-api module test suite to verify.


[APIM-14212]: https://gravitee.atlassian.net/browse/APIM-14212?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ