### PR TITLE
Feat/automation api portal resource

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/PortalRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/PortalRepository.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.management.api;
+
+import io.gravitee.repository.exceptions.TechnicalException;
+import io.gravitee.repository.management.model.Portal;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * @author GraviteeSource Team
+ */
+public interface PortalRepository extends CrudRepository<Portal, String> {
+    Optional<Portal> findByIdAndEnvironmentId(final String portalId, final String environmentId) throws TechnicalException;
+    List<Portal> findByEnvironmentId(final String environmentId) throws TechnicalException;
+    void deleteByEnvironmentId(final String environmentId) throws TechnicalException;
+    void deleteByOrganizationId(final String organizationId) throws TechnicalException;
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/Portal.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/Portal.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.management.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+/**
+ * @author GraviteeSource Team
+ */
+@Data
+@EqualsAndHashCode(of = "id")
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Portal {
+
+    private String id;
+    private String environmentId;
+    private String organizationId;
+    private String name;
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcPortalRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcPortalRepository.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.jdbc.management;
+
+import io.gravitee.repository.exceptions.TechnicalException;
+import io.gravitee.repository.jdbc.orm.JdbcObjectMapper;
+import io.gravitee.repository.management.api.PortalRepository;
+import io.gravitee.repository.management.model.Portal;
+import java.sql.Types;
+import java.util.List;
+import java.util.Optional;
+import lombok.CustomLog;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Repository;
+
+/**
+ * @author GraviteeSource Team
+ */
+@CustomLog
+@Repository
+public class JdbcPortalRepository extends JdbcAbstractCrudRepository<Portal, String> implements PortalRepository {
+
+    JdbcPortalRepository(@Value("${management.jdbc.prefix:}") String tablePrefix) {
+        super(tablePrefix, "portals");
+    }
+
+    @Override
+    protected JdbcObjectMapper<Portal> buildOrm() {
+        return JdbcObjectMapper.builder(Portal.class, this.tableName, "id")
+            .addColumn("id", Types.NVARCHAR, String.class)
+            .addColumn("environment_id", Types.NVARCHAR, String.class)
+            .addColumn("organization_id", Types.NVARCHAR, String.class)
+            .addColumn("name", Types.NVARCHAR, String.class)
+            .build();
+    }
+
+    @Override
+    protected String getId(final Portal item) {
+        return item.getId();
+    }
+
+    @Override
+    public Optional<Portal> findByIdAndEnvironmentId(String portalId, String environmentId) throws TechnicalException {
+        log.debug("JdbcPortalRepository.findByIdAndEnvironmentId({}, {})", portalId, environmentId);
+        try {
+            return jdbcTemplate
+                .query(
+                    getOrm().getSelectAllSql() + " WHERE id = ? and environment_id = ?",
+                    getOrm().getRowMapper(),
+                    portalId,
+                    environmentId
+                )
+                .stream()
+                .findFirst();
+        } catch (final Exception ex) {
+            final String error = String.format("Failed to find portal by id (%s) and environment id (%s)", portalId, environmentId);
+            log.error(error, ex);
+            throw new TechnicalException(error, ex);
+        }
+    }
+
+    @Override
+    public List<Portal> findByEnvironmentId(String environmentId) throws TechnicalException {
+        log.debug("JdbcPortalRepository.findByEnvironmentId({})", environmentId);
+        try {
+            return jdbcTemplate.query(getOrm().getSelectAllSql() + " WHERE environment_id = ?", getOrm().getRowMapper(), environmentId);
+        } catch (final Exception ex) {
+            final String error = "Failed to find portals by environment id: " + environmentId;
+            log.error(error, ex);
+            throw new TechnicalException(error, ex);
+        }
+    }
+
+    @Override
+    public void deleteByEnvironmentId(String environmentId) throws TechnicalException {
+        log.debug("JdbcPortalRepository.deleteByEnvironmentId({})", environmentId);
+        try {
+            jdbcTemplate.update("delete from " + this.tableName + " where environment_id = ?", environmentId);
+        } catch (final Exception ex) {
+            final String error = "Failed to delete portals by environment id: " + environmentId;
+            log.error(error, ex);
+            throw new TechnicalException(error, ex);
+        }
+    }
+
+    @Override
+    public void deleteByOrganizationId(String organizationId) throws TechnicalException {
+        log.debug("JdbcPortalRepository.deleteByOrganizationId({})", organizationId);
+        try {
+            jdbcTemplate.update("delete from " + this.tableName + " where organization_id = ?", organizationId);
+        } catch (final Exception ex) {
+            final String error = "Failed to delete portals by organization id: " + organizationId;
+            log.error(error, ex);
+            throw new TechnicalException(error, ex);
+        }
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_12_0/10_add_portals_table.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_12_0/10_add_portals_table.yml
@@ -1,0 +1,28 @@
+databaseChangeLog:
+  - changeSet:
+      id: 4.12.0_add_portals
+      author: GraviteeSource Team
+      changes:
+        - createTable:
+            tableName: ${gravitee_prefix}portals
+            columns:
+              - column: {name: id, type: nvarchar(64), constraints: { nullable: false, primaryKey: true, primaryKeyName: pk_portals } }
+              - column: {name: environment_id, type: nvarchar(64), constraints: { nullable: false } }
+              - column: {name: organization_id, type: nvarchar(64), constraints: { nullable: false } }
+              - column: {name: name, type: nvarchar(256), constraints: { nullable: false } }
+
+        - createIndex:
+            indexName: idx_${gravitee_prefix}portals_environment_id
+            columns:
+              - column:
+                  name: environment_id
+                  type: nvarchar(64)
+            tableName: ${gravitee_prefix}portals
+
+        - createIndex:
+            indexName: idx_${gravitee_prefix}portals_organization_id
+            columns:
+              - column:
+                  name: organization_id
+                  type: nvarchar(64)
+            tableName: ${gravitee_prefix}portals

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/master.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/master.yml
@@ -357,3 +357,5 @@ databaseChangeLog:
         - file: liquibase/changelogs/v4_12_0/08_add_disable_membership_notifications_to_api_products.yml
     - include:
         - file: liquibase/changelogs/v4_12_0/09_add_kafka_port_ranges_table.yml
+    - include:
+        - file: liquibase/changelogs/v4_12_0/10_add_portals_table.yml

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoPortalRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoPortalRepository.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.mongodb.management;
+
+import io.gravitee.repository.exceptions.TechnicalException;
+import io.gravitee.repository.management.api.PortalRepository;
+import io.gravitee.repository.management.model.Portal;
+import io.gravitee.repository.mongodb.management.internal.model.PortalMongo;
+import io.gravitee.repository.mongodb.management.internal.portal.PortalMongoRepository;
+import io.gravitee.repository.mongodb.management.mapper.GraviteeMapper;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import lombok.CustomLog;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+/**
+ * @author GraviteeSource Team
+ */
+@CustomLog
+@Component
+public class MongoPortalRepository implements PortalRepository {
+
+    @Autowired
+    private PortalMongoRepository internalPortalRepo;
+
+    @Autowired
+    private GraviteeMapper mapper;
+
+    @Override
+    public Optional<Portal> findByIdAndEnvironmentId(String portalId, String environmentId) throws TechnicalException {
+        log.debug("Find portal by ID [{}] and environment [{}]", portalId, environmentId);
+        PortalMongo portal = internalPortalRepo.findByIdAndEnvironmentId(portalId, environmentId).orElse(null);
+        return Optional.ofNullable(mapper.map(portal));
+    }
+
+    @Override
+    public List<Portal> findByEnvironmentId(String environmentId) throws TechnicalException {
+        return mapper.mapPortals(internalPortalRepo.findByEnvironmentId(environmentId));
+    }
+
+    @Override
+    public void deleteByEnvironmentId(String environmentId) throws TechnicalException {
+        try {
+            internalPortalRepo.deleteByEnvironmentId(environmentId);
+        } catch (Exception e) {
+            log.error("An error occurred when deleting portals by environment [{}]", environmentId, e);
+            throw new TechnicalException("An error occurred when deleting portals by environment");
+        }
+    }
+
+    @Override
+    public void deleteByOrganizationId(String organizationId) throws TechnicalException {
+        try {
+            internalPortalRepo.deleteByOrganizationId(organizationId);
+        } catch (Exception e) {
+            log.error("An error occurred when deleting portals by organization [{}]", organizationId, e);
+            throw new TechnicalException("An error occurred when deleting portals by organization");
+        }
+    }
+
+    @Override
+    public Optional<Portal> findById(String portalId) throws TechnicalException {
+        log.debug("Find portal by ID [{}]", portalId);
+        PortalMongo portal = internalPortalRepo.findById(portalId).orElse(null);
+        return Optional.ofNullable(mapper.map(portal));
+    }
+
+    @Override
+    public Portal create(Portal portal) throws TechnicalException {
+        log.debug("Create portal [{}]", portal.getName());
+        PortalMongo portalMongo = mapper.map(portal);
+        PortalMongo created = internalPortalRepo.insert(portalMongo);
+        return mapper.map(created);
+    }
+
+    @Override
+    public Portal update(Portal portal) throws TechnicalException {
+        if (portal == null) {
+            throw new IllegalStateException("Portal must not be null");
+        }
+
+        PortalMongo existing = internalPortalRepo.findById(portal.getId()).orElse(null);
+        if (existing == null) {
+            throw new IllegalStateException(String.format("No portal found with id [%s]", portal.getId()));
+        }
+
+        try {
+            PortalMongo updated = internalPortalRepo.save(mapper.map(portal));
+            return mapper.map(updated);
+        } catch (Exception e) {
+            log.error("An error occurred when updating portal [{}]", portal.getId(), e);
+            throw new TechnicalException("An error occurred when updating portal");
+        }
+    }
+
+    @Override
+    public void delete(String portalId) throws TechnicalException {
+        try {
+            internalPortalRepo.deleteById(portalId);
+        } catch (Exception e) {
+            log.error("An error occurred when deleting portal [{}]", portalId, e);
+            throw new TechnicalException("An error occurred when deleting portal");
+        }
+    }
+
+    @Override
+    public Set<Portal> findAll() throws TechnicalException {
+        return internalPortalRepo.findAll().stream().map(mapper::map).collect(Collectors.toSet());
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/model/PortalMongo.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/model/PortalMongo.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.mongodb.management.internal.model;
+
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+/**
+ * @author GraviteeSource Team
+ */
+@Document(collection = "#{@environment.getProperty('management.mongodb.prefix')}portals")
+@Data
+@EqualsAndHashCode(of = "id")
+public class PortalMongo {
+
+    @Id
+    private String id;
+
+    private String environmentId;
+    private String organizationId;
+    private String name;
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/portal/PortalMongoRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/portal/PortalMongoRepository.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.mongodb.management.internal.portal;
+
+import io.gravitee.repository.mongodb.management.internal.model.PortalMongo;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.data.mongodb.repository.Query;
+import org.springframework.stereotype.Repository;
+
+/**
+ * @author GraviteeSource Team
+ */
+@Repository
+public interface PortalMongoRepository extends MongoRepository<PortalMongo, String> {
+    @Query("{ '_id': ?0, 'environmentId': ?1 }")
+    Optional<PortalMongo> findByIdAndEnvironmentId(String portalId, String environmentId);
+
+    @Query("{ 'environmentId': ?0 }")
+    List<PortalMongo> findByEnvironmentId(String environmentId);
+
+    @Query(value = "{ 'environmentId': ?0 }", delete = true)
+    void deleteByEnvironmentId(String environmentId);
+
+    @Query(value = "{ 'organizationId': ?0 }", delete = true)
+    void deleteByOrganizationId(String organizationId);
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/mapper/GraviteeMapper.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/mapper/GraviteeMapper.java
@@ -260,6 +260,11 @@ public interface GraviteeMapper {
 
     PlanMongo map(Plan toMap);
 
+    // Portal mapping
+    Portal map(PortalMongo toMap);
+    PortalMongo map(Portal toMap);
+    List<Portal> mapPortals(Collection<PortalMongo> toMap);
+
     // Portal menu links mapping
     PortalMenuLink map(PortalMenuLinkMongo toMap);
     PortalMenuLinkMongo map(PortalMenuLink toMap);

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/AbstractManagementRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/AbstractManagementRepositoryTest.java
@@ -228,6 +228,9 @@ public abstract class AbstractManagementRepositoryTest extends AbstractRepositor
     protected PortalMenuLinkRepository portalMenuLinkRepository;
 
     @Inject
+    protected PortalRepository portalRepository;
+
+    @Inject
     protected ClusterRepository clusterRepository;
 
     @Inject
@@ -327,6 +330,7 @@ public abstract class AbstractManagementRepositoryTest extends AbstractRepositor
             case ApiCategoryOrder apiCategoryOrder -> apiCategoryOrderRepository.create(apiCategoryOrder);
             case SharedPolicyGroup sharedPolicyGroup -> sharedPolicyGroupRepository.create(sharedPolicyGroup);
             case PortalMenuLink portalMenuLink -> portalMenuLinkRepository.create(portalMenuLink);
+            case Portal portal -> portalRepository.create(portal);
             case Cluster cluster -> clusterRepository.create(cluster);
             case PortalPage portalPage -> portalPageRepository.create(portalPage);
             case PortalPageContext portalPageContext -> portalPageContextRepository.create(portalPageContext);

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/PortalRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/PortalRepositoryTest.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.management;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.repository.management.model.Portal;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import org.junit.Test;
+
+/**
+ * @author GraviteeSource Team
+ */
+public class PortalRepositoryTest extends AbstractManagementRepositoryTest {
+
+    @Override
+    protected String getTestCasesPath() {
+        return "/data/portal-tests/";
+    }
+
+    @Test
+    public void should_find_by_id_and_environment() throws Exception {
+        Optional<Portal> portal = portalRepository.findByIdAndEnvironmentId("portal1", "environment1");
+
+        assertThat(portal).isPresent();
+        assertThat(portal.get().getName()).isEqualTo("Default Portal");
+        assertThat(portal.get().getOrganizationId()).isEqualTo("organization1");
+    }
+
+    @Test
+    public void should_not_find_by_id_when_environment_differs() throws Exception {
+        Optional<Portal> portal = portalRepository.findByIdAndEnvironmentId("portal1", "environment2");
+
+        assertThat(portal).isNotPresent();
+    }
+
+    @Test
+    public void should_find_by_environment() throws Exception {
+        List<Portal> portals = portalRepository.findByEnvironmentId("environment1");
+
+        assertThat(portals).extracting(Portal::getId).containsExactlyInAnyOrder("portal1", "portal2");
+    }
+
+    @Test
+    public void should_find_nothing_when_environment_unknown() throws Exception {
+        List<Portal> portals = portalRepository.findByEnvironmentId("unknown-env");
+
+        assertThat(portals).isEmpty();
+    }
+
+    @Test
+    public void should_create() throws Exception {
+        Portal toCreate = Portal.builder()
+            .id("new-portal")
+            .environmentId("environment1")
+            .organizationId("organization1")
+            .name("Created Portal")
+            .build();
+
+        Portal created = portalRepository.create(toCreate);
+
+        assertThat(created).isEqualTo(toCreate);
+        assertThat(portalRepository.findById("new-portal")).hasValue(toCreate);
+    }
+
+    @Test
+    public void should_update() throws Exception {
+        Portal toUpdate = Portal.builder()
+            .id("portal1")
+            .environmentId("environment1")
+            .organizationId("organization1")
+            .name("Renamed Portal")
+            .build();
+
+        Portal updated = portalRepository.update(toUpdate);
+
+        assertThat(updated.getName()).isEqualTo("Renamed Portal");
+        assertThat(portalRepository.findById("portal1")).hasValue(toUpdate);
+    }
+
+    @Test
+    public void should_delete() throws Exception {
+        portalRepository.delete("portal1");
+
+        assertThat(portalRepository.findById("portal1")).isNotPresent();
+    }
+
+    @Test
+    public void should_delete_by_environment() throws Exception {
+        portalRepository.deleteByEnvironmentId("environment1");
+
+        Set<Portal> remaining = portalRepository.findAll();
+        assertThat(remaining).extracting(Portal::getId).containsExactlyInAnyOrder("portal3", "portal4");
+    }
+
+    @Test
+    public void should_delete_by_organization() throws Exception {
+        portalRepository.deleteByOrganizationId("organization1");
+
+        Set<Portal> remaining = portalRepository.findAll();
+        assertThat(remaining).extracting(Portal::getId).containsExactly("portal4");
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/resources/data/portal-tests/portals.json
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/resources/data/portal-tests/portals.json
@@ -1,0 +1,26 @@
+[
+  {
+    "id": "portal1",
+    "environmentId": "environment1",
+    "organizationId": "organization1",
+    "name": "Default Portal"
+  },
+  {
+    "id": "portal2",
+    "environmentId": "environment1",
+    "organizationId": "organization1",
+    "name": "Secondary Portal"
+  },
+  {
+    "id": "portal3",
+    "environmentId": "environment2",
+    "organizationId": "organization1",
+    "name": "Env2 Portal"
+  },
+  {
+    "id": "portal4",
+    "environmentId": "environment3",
+    "organizationId": "organization2",
+    "name": "Org2 Portal"
+  }
+]

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/java/io/gravitee/apim/rest/api/automation/GraviteeAutomationApplication.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/java/io/gravitee/apim/rest/api/automation/GraviteeAutomationApplication.java
@@ -28,6 +28,8 @@ import io.gravitee.apim.rest.api.automation.resource.GroupResource;
 import io.gravitee.apim.rest.api.automation.resource.GroupsResource;
 import io.gravitee.apim.rest.api.automation.resource.OpenAPIResource;
 import io.gravitee.apim.rest.api.automation.resource.OrganizationResource;
+import io.gravitee.apim.rest.api.automation.resource.PortalResource;
+import io.gravitee.apim.rest.api.automation.resource.PortalsResource;
 import io.gravitee.apim.rest.api.automation.resource.SharedPolicyGroupsResource;
 import io.gravitee.apim.rest.api.automation.spring.PermissionsFilter;
 import io.gravitee.rest.api.management.v2.rest.exceptionmapper.BadRequestExceptionMapper;
@@ -61,6 +63,8 @@ public class GraviteeAutomationApplication extends ResourceConfig {
         register(SharedPolicyGroupsResource.class);
         register(DictionariesResource.class);
         register(DictionaryResource.class);
+        register(PortalsResource.class);
+        register(PortalResource.class);
 
         register(ValidationDomainMapper.class);
         register(HRIDNotFoundMapper.class);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/java/io/gravitee/apim/rest/api/automation/mapper/PortalMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/java/io/gravitee/apim/rest/api/automation/mapper/PortalMapper.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.rest.api.automation.mapper;
+
+import io.gravitee.apim.core.portal.model.Portal;
+import io.gravitee.apim.rest.api.automation.model.PortalState;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.MappingTarget;
+import org.mapstruct.factory.Mappers;
+
+/**
+ * @author GraviteeSource Team
+ */
+@Mapper
+public interface PortalMapper {
+    PortalMapper INSTANCE = Mappers.getMapper(PortalMapper.class);
+
+    default PortalState toPortalState(Portal portal, String hrid) {
+        var state = new PortalState(
+            portal.getId() != null ? portal.getId().toString() : null,
+            portal.getEnvironmentId(),
+            portal.getOrganizationId(),
+            null
+        );
+        state.setHrid(hrid);
+        mapPortalToState(portal, state);
+        return state;
+    }
+
+    @Mapping(target = "id", ignore = true)
+    @Mapping(target = "environmentId", ignore = true)
+    @Mapping(target = "organizationId", ignore = true)
+    @Mapping(target = "errors", ignore = true)
+    @Mapping(target = "hrid", ignore = true)
+    @Mapping(target = "navigation", ignore = true)
+    void mapPortalToState(Portal portal, @MappingTarget PortalState state);
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/java/io/gravitee/apim/rest/api/automation/resource/EnvironmentResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/java/io/gravitee/apim/rest/api/automation/resource/EnvironmentResource.java
@@ -52,4 +52,9 @@ public class EnvironmentResource {
     public DictionariesResource getDictionariesResource() {
         return resourceContext.getResource(DictionariesResource.class);
     }
+
+    @Path("/portals")
+    public PortalsResource getPortalsResource() {
+        return resourceContext.getResource(PortalsResource.class);
+    }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/java/io/gravitee/apim/rest/api/automation/resource/PortalResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/java/io/gravitee/apim/rest/api/automation/resource/PortalResource.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.rest.api.automation.resource;
+
+import io.gravitee.apim.core.portal.exception.PortalNotFoundException;
+import io.gravitee.apim.core.portal.model.PortalId;
+import io.gravitee.apim.core.portal.use_case.DeletePortalUseCase;
+import io.gravitee.apim.core.portal.use_case.GetPortalUseCase;
+import io.gravitee.apim.rest.api.automation.exception.HRIDNotFoundException;
+import io.gravitee.apim.rest.api.automation.mapper.PortalMapper;
+import io.gravitee.common.http.MediaType;
+import io.gravitee.rest.api.model.permissions.RolePermission;
+import io.gravitee.rest.api.model.permissions.RolePermissionAction;
+import io.gravitee.rest.api.rest.annotation.Permission;
+import io.gravitee.rest.api.rest.annotation.Permissions;
+import io.gravitee.rest.api.service.common.HRIDToUUID;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.Response;
+
+/**
+ * @author GraviteeSource Team
+ */
+public class PortalResource extends AbstractResource {
+
+    @Inject
+    private GetPortalUseCase getPortalUseCase;
+
+    @Inject
+    private DeletePortalUseCase deletePortalUseCase;
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    @Permissions({ @Permission(value = RolePermission.ENVIRONMENT_PORTAL, acls = RolePermissionAction.READ) })
+    public Response getPortalByHRID(@PathParam("hrid") String hrid) {
+        var auditInfo = getAuditInfo();
+        PortalId id = PortalId.of(HRIDToUUID.portal().context(auditInfo).hrid(hrid).id());
+        try {
+            var output = getPortalUseCase.execute(new GetPortalUseCase.Input(auditInfo, id));
+            return Response.ok(PortalMapper.INSTANCE.toPortalState(output.portal(), hrid)).build();
+        } catch (PortalNotFoundException e) {
+            throw new HRIDNotFoundException(hrid);
+        }
+    }
+
+    @DELETE
+    @Permissions({ @Permission(value = RolePermission.ENVIRONMENT_PORTAL, acls = RolePermissionAction.DELETE) })
+    public Response deletePortalByHrid(@PathParam("hrid") String hrid) {
+        var auditInfo = getAuditInfo();
+        PortalId id = PortalId.of(HRIDToUUID.portal().context(auditInfo).hrid(hrid).id());
+        try {
+            deletePortalUseCase.execute(new DeletePortalUseCase.Input(auditInfo, id));
+        } catch (PortalNotFoundException e) {
+            throw new HRIDNotFoundException(hrid);
+        }
+        return Response.noContent().build();
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/java/io/gravitee/apim/rest/api/automation/resource/PortalsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/java/io/gravitee/apim/rest/api/automation/resource/PortalsResource.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.rest.api.automation.resource;
+
+import static io.gravitee.rest.api.model.permissions.RolePermissionAction.CREATE;
+import static io.gravitee.rest.api.model.permissions.RolePermissionAction.UPDATE;
+
+import io.gravitee.apim.core.portal.model.Portal;
+import io.gravitee.apim.core.portal.model.PortalId;
+import io.gravitee.apim.core.portal.use_case.CreateOrUpdatePortalUseCase;
+import io.gravitee.apim.rest.api.automation.mapper.PortalMapper;
+import io.gravitee.apim.rest.api.automation.model.PortalSpec;
+import io.gravitee.common.http.MediaType;
+import io.gravitee.rest.api.model.permissions.RolePermission;
+import io.gravitee.rest.api.rest.annotation.Permission;
+import io.gravitee.rest.api.rest.annotation.Permissions;
+import io.gravitee.rest.api.service.common.HRIDToUUID;
+import jakarta.inject.Inject;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.PUT;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.container.ResourceContext;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.Response;
+
+/**
+ * @author GraviteeSource Team
+ */
+public class PortalsResource extends AbstractResource {
+
+    @Context
+    private ResourceContext resourceContext;
+
+    @Inject
+    private CreateOrUpdatePortalUseCase createOrUpdatePortalUseCase;
+
+    @Path("/{hrid}")
+    public PortalResource getPortalResource() {
+        return resourceContext.getResource(PortalResource.class);
+    }
+
+    @PUT
+    @Produces(MediaType.APPLICATION_JSON)
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Permissions({ @Permission(value = RolePermission.ENVIRONMENT_PORTAL, acls = { CREATE, UPDATE }) })
+    public Response createOrUpdate(@Valid @NotNull PortalSpec spec, @QueryParam("dryRun") boolean dryRun) {
+        var auditInfo = getAuditInfo();
+        var portal = Portal.builder()
+            .id(PortalId.of(HRIDToUUID.portal().context(auditInfo).hrid(spec.getHrid()).id()))
+            .environmentId(auditInfo.environmentId())
+            .organizationId(auditInfo.organizationId())
+            .name(spec.getName())
+            .build();
+
+        if (dryRun) {
+            return Response.ok(PortalMapper.INSTANCE.toPortalState(portal, spec.getHrid())).build();
+        }
+
+        var output = createOrUpdatePortalUseCase.execute(new CreateOrUpdatePortalUseCase.Input(auditInfo, portal));
+
+        return Response.ok(PortalMapper.INSTANCE.toPortalState(output.portal(), spec.getHrid())).build();
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/resource/PortalResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/resource/PortalResourceTest.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.rest.api.automation.resource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.apim.core.portal.exception.PortalNotFoundException;
+import io.gravitee.apim.core.portal.model.Portal;
+import io.gravitee.apim.core.portal.model.PortalId;
+import io.gravitee.apim.core.portal.use_case.DeletePortalUseCase;
+import io.gravitee.apim.core.portal.use_case.GetPortalUseCase;
+import io.gravitee.apim.rest.api.automation.model.PortalState;
+import io.gravitee.apim.rest.api.automation.resource.base.AbstractResourceTest;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.core.MediaType;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class PortalResourceTest extends AbstractResourceTest {
+
+    private static final String HRID = "default-portal";
+    private static final PortalId PORTAL_ID = PortalId.of("00000000-0000-0000-0000-0000000000a1");
+
+    @Inject
+    private GetPortalUseCase getPortalUseCase;
+
+    @Inject
+    private DeletePortalUseCase deletePortalUseCase;
+
+    @AfterEach
+    void tearDown() {
+        reset(getPortalUseCase, deletePortalUseCase);
+    }
+
+    @Override
+    protected String contextPath() {
+        return "/organizations/" + ORGANIZATION + "/environments/" + ENVIRONMENT + "/portals";
+    }
+
+    @Nested
+    class Get {
+
+        @Test
+        void should_return_portal_by_hrid() {
+            var persisted = Portal.builder()
+                .id(PORTAL_ID)
+                .environmentId(ENVIRONMENT)
+                .organizationId(ORGANIZATION)
+                .name("Default Portal")
+                .build();
+            when(getPortalUseCase.execute(any())).thenReturn(new GetPortalUseCase.Output(persisted));
+
+            try (var response = rootTarget(HRID).request().accept(MediaType.APPLICATION_JSON_TYPE).get()) {
+                assertThat(response.getStatus()).isEqualTo(200);
+                verify(getPortalUseCase).execute(any(GetPortalUseCase.Input.class));
+
+                var state = response.readEntity(PortalState.class);
+                SoftAssertions.assertSoftly(soft -> {
+                    soft.assertThat(state.getId()).isEqualTo(PORTAL_ID.toString());
+                    soft.assertThat(state.getHrid()).isEqualTo(HRID);
+                    soft.assertThat(state.getName()).isEqualTo("Default Portal");
+                });
+            }
+        }
+
+        @Test
+        void should_return_404_when_missing() {
+            when(getPortalUseCase.execute(any())).thenThrow(new PortalNotFoundException(PORTAL_ID));
+
+            try (var response = rootTarget(HRID).request().accept(MediaType.APPLICATION_JSON_TYPE).get()) {
+                assertThat(response.getStatus()).isEqualTo(404);
+            }
+        }
+    }
+
+    @Nested
+    class Delete {
+
+        @Test
+        void should_delete_portal_by_hrid() {
+            try (var response = rootTarget(HRID).request().delete()) {
+                assertThat(response.getStatus()).isEqualTo(204);
+                verify(deletePortalUseCase).execute(any(DeletePortalUseCase.Input.class));
+            }
+        }
+
+        @Test
+        void should_return_404_on_delete_missing() {
+            org.mockito.Mockito.doThrow(new PortalNotFoundException(PORTAL_ID))
+                .when(deletePortalUseCase)
+                .execute(any(DeletePortalUseCase.Input.class));
+
+            try (var response = rootTarget(HRID).request().delete()) {
+                assertThat(response.getStatus()).isEqualTo(404);
+            }
+        }
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/resource/PortalsResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/resource/PortalsResourceTest.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.rest.api.automation.resource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.apim.core.portal.model.Portal;
+import io.gravitee.apim.core.portal.model.PortalId;
+import io.gravitee.apim.core.portal.use_case.CreateOrUpdatePortalUseCase;
+import io.gravitee.apim.rest.api.automation.model.PortalState;
+import io.gravitee.apim.rest.api.automation.resource.base.AbstractResourceTest;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.client.Entity;
+import jakarta.ws.rs.core.MediaType;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class PortalsResourceTest extends AbstractResourceTest {
+
+    @Inject
+    private CreateOrUpdatePortalUseCase createOrUpdatePortalUseCase;
+
+    @AfterEach
+    void tearDown() {
+        reset(createOrUpdatePortalUseCase);
+    }
+
+    @Override
+    protected String contextPath() {
+        return "/organizations/" + ORGANIZATION + "/environments/" + ENVIRONMENT + "/portals";
+    }
+
+    @Nested
+    class DryRun {
+
+        @Test
+        void should_return_populated_state_without_calling_use_case() {
+            try (
+                var response = rootTarget()
+                    .queryParam("dryRun", true)
+                    .request()
+                    .accept(MediaType.APPLICATION_JSON_TYPE)
+                    .put(Entity.json(readJSON("portal.json")))
+            ) {
+                assertThat(response.getStatus()).isEqualTo(200);
+                verifyNoInteractions(createOrUpdatePortalUseCase);
+
+                var state = response.readEntity(PortalState.class);
+                SoftAssertions.assertSoftly(soft -> {
+                    soft.assertThat(state.getHrid()).isEqualTo("default-portal");
+                    soft.assertThat(state.getName()).isEqualTo("Default Portal");
+                    soft.assertThat(state.getEnvironmentId()).isEqualTo(ENVIRONMENT);
+                    soft.assertThat(state.getOrganizationId()).isEqualTo(ORGANIZATION);
+                    soft.assertThat(state.getId()).isNotBlank();
+                });
+            }
+        }
+
+        @Test
+        void should_return_400_when_hrid_is_missing() {
+            try (
+                var response = rootTarget()
+                    .queryParam("dryRun", true)
+                    .request()
+                    .accept(MediaType.APPLICATION_JSON_TYPE)
+                    .put(Entity.json(readJSON("invalid-portal.json")))
+            ) {
+                assertThat(response.getStatus()).isEqualTo(400);
+                verifyNoInteractions(createOrUpdatePortalUseCase);
+            }
+        }
+    }
+
+    @Nested
+    class Run {
+
+        @Test
+        void should_create_or_update_portal() {
+            var persisted = Portal.builder()
+                .id(PortalId.of("00000000-0000-0000-0000-0000000000a1"))
+                .environmentId(ENVIRONMENT)
+                .organizationId(ORGANIZATION)
+                .name("Default Portal")
+                .build();
+            when(createOrUpdatePortalUseCase.execute(any())).thenReturn(new CreateOrUpdatePortalUseCase.Output(persisted));
+
+            try (var response = rootTarget().request().accept(MediaType.APPLICATION_JSON_TYPE).put(Entity.json(readJSON("portal.json")))) {
+                assertThat(response.getStatus()).isEqualTo(200);
+                verify(createOrUpdatePortalUseCase).execute(any(CreateOrUpdatePortalUseCase.Input.class));
+
+                var state = response.readEntity(PortalState.class);
+                SoftAssertions.assertSoftly(soft -> {
+                    soft.assertThat(state.getId()).isEqualTo("00000000-0000-0000-0000-0000000000a1");
+                    soft.assertThat(state.getHrid()).isEqualTo("default-portal");
+                    soft.assertThat(state.getEnvironmentId()).isEqualTo(ENVIRONMENT);
+                    soft.assertThat(state.getOrganizationId()).isEqualTo(ORGANIZATION);
+                    soft.assertThat(state.getName()).isEqualTo("Default Portal");
+                });
+            }
+        }
+
+        @Test
+        void should_silently_ignore_navigation_field() {
+            var persisted = Portal.builder()
+                .id(PortalId.of("00000000-0000-0000-0000-0000000000a1"))
+                .environmentId(ENVIRONMENT)
+                .organizationId(ORGANIZATION)
+                .name("Default Portal")
+                .build();
+            when(createOrUpdatePortalUseCase.execute(any())).thenReturn(new CreateOrUpdatePortalUseCase.Output(persisted));
+
+            try (
+                var response = rootTarget()
+                    .request()
+                    .accept(MediaType.APPLICATION_JSON_TYPE)
+                    .put(Entity.json(readJSON("portal-with-navigation.json")))
+            ) {
+                assertThat(response.getStatus()).isEqualTo(200);
+                verify(createOrUpdatePortalUseCase).execute(any(CreateOrUpdatePortalUseCase.Input.class));
+
+                var state = response.readEntity(PortalState.class);
+                assertThat(state.getNavigation()).isNullOrEmpty();
+            }
+        }
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/spring/ResourceContextConfiguration.java
@@ -140,6 +140,9 @@ import io.gravitee.apim.core.plan.query_service.PlanSearchQueryService;
 import io.gravitee.apim.core.plugin.crud_service.PolicyPluginCrudService;
 import io.gravitee.apim.core.plugin.domain_service.EndpointConnectorPluginDomainService;
 import io.gravitee.apim.core.policy.domain_service.PolicyValidationDomainService;
+import io.gravitee.apim.core.portal.use_case.CreateOrUpdatePortalUseCase;
+import io.gravitee.apim.core.portal.use_case.DeletePortalUseCase;
+import io.gravitee.apim.core.portal.use_case.GetPortalUseCase;
 import io.gravitee.apim.core.portal_page.crud_service.PortalNavigationItemCrudService;
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemDomainService;
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemValidatorService;
@@ -1254,5 +1257,20 @@ public class ResourceContextConfiguration {
     @Bean
     public io.gravitee.apim.core.log.crud_service.NativeApiLogCrudService nativeApiLogCrudService() {
         return mock(io.gravitee.apim.core.log.crud_service.NativeApiLogCrudService.class);
+    }
+
+    @Bean
+    public CreateOrUpdatePortalUseCase createOrUpdatePortalUseCase() {
+        return mock(CreateOrUpdatePortalUseCase.class);
+    }
+
+    @Bean
+    public GetPortalUseCase getPortalUseCase() {
+        return mock(GetPortalUseCase.class);
+    }
+
+    @Bean
+    public DeletePortalUseCase deletePortalUseCase() {
+        return mock(DeletePortalUseCase.class);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/resources/io/gravitee/apim/rest/api/automation/resource/invalid-portal.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/resources/io/gravitee/apim/rest/api/automation/resource/invalid-portal.json
@@ -1,0 +1,3 @@
+{
+  "name": "Missing HRID Portal"
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/resources/io/gravitee/apim/rest/api/automation/resource/portal-with-navigation.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/resources/io/gravitee/apim/rest/api/automation/resource/portal-with-navigation.json
@@ -1,0 +1,8 @@
+{
+  "hrid": "default-portal",
+  "name": "Default Portal",
+  "navigation": [
+    { "path": "/projects/alpha", "displayName": "Alpha" },
+    { "path": "/projects/alpha/docs" }
+  ]
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/resources/io/gravitee/apim/rest/api/automation/resource/portal.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/resources/io/gravitee/apim/rest/api/automation/resource/portal.json
@@ -1,0 +1,4 @@
+{
+  "hrid": "default-portal",
+  "name": "Default Portal"
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/permissions/EnvironmentPermission.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/permissions/EnvironmentPermission.java
@@ -51,7 +51,8 @@ public enum EnvironmentPermission implements Permission {
     SHARED_POLICY_GROUP("SHARED_POLICY_GROUP", 3900),
     CLUSTER("CLUSTER", 4000),
     API_PRODUCT("API_PRODUCT", 4100),
-    AUTHORIZATION("AUTHORIZATION", 4200);
+    AUTHORIZATION("AUTHORIZATION", 4200),
+    PORTAL("PORTAL", 4300);
 
     String name;
     int mask;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/permissions/RolePermission.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/permissions/RolePermission.java
@@ -92,6 +92,7 @@ public enum RolePermission {
     ENVIRONMENT_CLUSTER(RoleScope.ENVIRONMENT, EnvironmentPermission.CLUSTER),
     ENVIRONMENT_API_PRODUCT(RoleScope.ENVIRONMENT, EnvironmentPermission.API_PRODUCT),
     ENVIRONMENT_AUTHORIZATION(RoleScope.ENVIRONMENT, EnvironmentPermission.AUTHORIZATION),
+    ENVIRONMENT_PORTAL(RoleScope.ENVIRONMENT, EnvironmentPermission.PORTAL),
 
     ORGANIZATION_USERS(RoleScope.ORGANIZATION, OrganizationPermission.USER),
     ORGANIZATION_USERS_TOKEN(RoleScope.ORGANIZATION, OrganizationPermission.USER_TOKEN),

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal/crud_service/PortalCrudService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal/crud_service/PortalCrudService.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal.crud_service;
+
+import io.gravitee.apim.core.portal.model.Portal;
+import io.gravitee.apim.core.portal.model.PortalId;
+import java.util.Optional;
+
+public interface PortalCrudService {
+    Portal create(Portal portal);
+
+    Portal update(Portal portal);
+
+    Optional<Portal> findByIdAndEnvironmentId(PortalId portalId, String environmentId);
+
+    void delete(PortalId portalId);
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal/exception/PortalNotFoundException.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal/exception/PortalNotFoundException.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal.exception;
+
+import io.gravitee.apim.core.exception.NotFoundDomainException;
+import io.gravitee.apim.core.portal.model.PortalId;
+
+/**
+ * @author GraviteeSource Team
+ */
+public class PortalNotFoundException extends NotFoundDomainException {
+
+    public PortalNotFoundException(PortalId portalId) {
+        super("Portal [ " + portalId + " ] not found", portalId.toString());
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal/model/Portal.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal/model/Portal.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal.model;
+
+import jakarta.annotation.Nonnull;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder(toBuilder = true)
+public class Portal {
+
+    @Nonnull
+    private final PortalId id;
+
+    @Nonnull
+    private final String environmentId;
+
+    @Nonnull
+    private final String organizationId;
+
+    @Nonnull
+    private final String name;
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Portal that = (Portal) o;
+        return id.equals(that.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return id.hashCode();
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal/model/PortalId.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal/model/PortalId.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal.model;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+import jakarta.annotation.Nonnull;
+import java.util.UUID;
+
+public class PortalId {
+
+    @Nonnull
+    private final UUID id;
+
+    private PortalId(@Nonnull UUID id) {
+        this.id = id;
+    }
+
+    public static PortalId random() {
+        return new PortalId(UUID.randomUUID());
+    }
+
+    public static PortalId of(String value) {
+        return new PortalId(UUID.fromString(value));
+    }
+
+    public UUID id() {
+        return id;
+    }
+
+    @JsonValue
+    public String json() {
+        return this.toString();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        PortalId that = (PortalId) o;
+        return id.equals(that.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return id.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return id.toString();
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal/use_case/CreateDefaultPortalUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal/use_case/CreateDefaultPortalUseCase.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal.use_case;
+
+import io.gravitee.apim.core.UseCase;
+import io.gravitee.apim.core.portal.crud_service.PortalCrudService;
+import io.gravitee.apim.core.portal.model.Portal;
+import io.gravitee.apim.core.portal.model.PortalId;
+import io.gravitee.rest.api.service.common.ExecutionContext;
+import io.gravitee.rest.api.service.common.HRIDToUUID;
+import lombok.RequiredArgsConstructor;
+
+@UseCase
+@RequiredArgsConstructor
+public class CreateDefaultPortalUseCase {
+
+    static final String DEFAULT_PORTAL_HRID = "default-portal";
+    static final String DEFAULT_PORTAL_NAME = "Default Portal";
+
+    private final PortalCrudService portalCrudService;
+
+    public void execute(String organizationId, String environmentId) {
+        var portalId = PortalId.of(
+            HRIDToUUID.portal().context(new ExecutionContext(organizationId, environmentId)).hrid(DEFAULT_PORTAL_HRID).id()
+        );
+        if (portalCrudService.findByIdAndEnvironmentId(portalId, environmentId).isPresent()) {
+            return;
+        }
+        portalCrudService.create(
+            Portal.builder().id(portalId).environmentId(environmentId).organizationId(organizationId).name(DEFAULT_PORTAL_NAME).build()
+        );
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal/use_case/CreateOrUpdatePortalUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal/use_case/CreateOrUpdatePortalUseCase.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal.use_case;
+
+import io.gravitee.apim.core.UseCase;
+import io.gravitee.apim.core.audit.model.AuditInfo;
+import io.gravitee.apim.core.portal.crud_service.PortalCrudService;
+import io.gravitee.apim.core.portal.model.Portal;
+import lombok.RequiredArgsConstructor;
+
+@UseCase
+@RequiredArgsConstructor
+public class CreateOrUpdatePortalUseCase {
+
+    private final PortalCrudService portalCrudService;
+
+    public record Input(AuditInfo auditInfo, Portal portal) {}
+
+    public record Output(Portal portal) {}
+
+    public Output execute(Input input) {
+        var portal = input.portal();
+        var existing = portalCrudService.findByIdAndEnvironmentId(portal.getId(), input.auditInfo().environmentId());
+        var saved = existing.isPresent() ? portalCrudService.update(portal) : portalCrudService.create(portal);
+        return new Output(saved);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal/use_case/DeletePortalUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal/use_case/DeletePortalUseCase.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal.use_case;
+
+import io.gravitee.apim.core.UseCase;
+import io.gravitee.apim.core.audit.model.AuditInfo;
+import io.gravitee.apim.core.portal.crud_service.PortalCrudService;
+import io.gravitee.apim.core.portal.exception.PortalNotFoundException;
+import io.gravitee.apim.core.portal.model.PortalId;
+import lombok.RequiredArgsConstructor;
+
+@UseCase
+@RequiredArgsConstructor
+public class DeletePortalUseCase {
+
+    private final PortalCrudService portalCrudService;
+
+    public record Input(AuditInfo auditInfo, PortalId portalId) {}
+
+    public void execute(Input input) {
+        portalCrudService
+            .findByIdAndEnvironmentId(input.portalId(), input.auditInfo().environmentId())
+            .orElseThrow(() -> new PortalNotFoundException(input.portalId()));
+        portalCrudService.delete(input.portalId());
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal/use_case/GetPortalUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal/use_case/GetPortalUseCase.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal.use_case;
+
+import io.gravitee.apim.core.UseCase;
+import io.gravitee.apim.core.audit.model.AuditInfo;
+import io.gravitee.apim.core.portal.crud_service.PortalCrudService;
+import io.gravitee.apim.core.portal.exception.PortalNotFoundException;
+import io.gravitee.apim.core.portal.model.Portal;
+import io.gravitee.apim.core.portal.model.PortalId;
+import lombok.RequiredArgsConstructor;
+
+@UseCase
+@RequiredArgsConstructor
+public class GetPortalUseCase {
+
+    private final PortalCrudService portalCrudService;
+
+    public record Input(AuditInfo auditInfo, PortalId portalId) {}
+
+    public record Output(Portal portal) {}
+
+    public Output execute(Input input) {
+        var portal = portalCrudService
+            .findByIdAndEnvironmentId(input.portalId(), input.auditInfo().environmentId())
+            .orElseThrow(() -> new PortalNotFoundException(input.portalId()));
+        return new Output(portal);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/PortalAdapter.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/PortalAdapter.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.infra.adapter;
+
+import io.gravitee.apim.core.portal.model.Portal;
+import io.gravitee.apim.core.portal.model.PortalId;
+import org.mapstruct.Mapper;
+import org.mapstruct.factory.Mappers;
+
+@Mapper
+public interface PortalAdapter {
+    PortalAdapter INSTANCE = Mappers.getMapper(PortalAdapter.class);
+
+    Portal toEntity(io.gravitee.repository.management.model.Portal portal);
+    io.gravitee.repository.management.model.Portal toRepository(Portal portal);
+
+    default String mapPortalId(PortalId id) {
+        return id != null ? id.toString() : null;
+    }
+
+    default PortalId mapPortalId(String id) {
+        return id != null ? PortalId.of(id) : null;
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/crud_service/portal/PortalCrudServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/crud_service/portal/PortalCrudServiceImpl.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.infra.crud_service.portal;
+
+import io.gravitee.apim.core.exception.TechnicalDomainException;
+import io.gravitee.apim.core.portal.crud_service.PortalCrudService;
+import io.gravitee.apim.core.portal.model.Portal;
+import io.gravitee.apim.core.portal.model.PortalId;
+import io.gravitee.apim.infra.adapter.PortalAdapter;
+import io.gravitee.repository.exceptions.TechnicalException;
+import io.gravitee.repository.management.api.PortalRepository;
+import java.util.Optional;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.stereotype.Component;
+
+@Component
+public class PortalCrudServiceImpl implements PortalCrudService {
+
+    private final PortalRepository portalRepository;
+    private final PortalAdapter portalAdapter = PortalAdapter.INSTANCE;
+
+    public PortalCrudServiceImpl(@Lazy PortalRepository portalRepository) {
+        this.portalRepository = portalRepository;
+    }
+
+    @Override
+    public Portal create(Portal portal) {
+        try {
+            var result = portalRepository.create(portalAdapter.toRepository(portal));
+            return portalAdapter.toEntity(result);
+        } catch (TechnicalException e) {
+            throw new TechnicalDomainException(
+                String.format("An error occurred while trying to create a Portal with id: %s", portal.getId()),
+                e
+            );
+        }
+    }
+
+    @Override
+    public Portal update(Portal portal) {
+        try {
+            var result = portalRepository.update(portalAdapter.toRepository(portal));
+            return portalAdapter.toEntity(result);
+        } catch (TechnicalException e) {
+            throw new TechnicalDomainException(
+                String.format("An error occurred while trying to update a Portal with id: %s", portal.getId()),
+                e
+            );
+        }
+    }
+
+    @Override
+    public Optional<Portal> findByIdAndEnvironmentId(PortalId portalId, String environmentId) {
+        try {
+            return portalRepository.findByIdAndEnvironmentId(portalId.toString(), environmentId).map(portalAdapter::toEntity);
+        } catch (TechnicalException e) {
+            throw new TechnicalDomainException(
+                String.format("An error occurred while trying to find a Portal with id (%s) in environment (%s)", portalId, environmentId),
+                e
+            );
+        }
+    }
+
+    @Override
+    public void delete(PortalId portalId) {
+        try {
+            portalRepository.delete(portalId.toString());
+        } catch (TechnicalException e) {
+            throw new TechnicalDomainException(
+                String.format("An error occurred while trying to delete the Portal with id: %s", portalId),
+                e
+            );
+        }
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/cockpit/command/handler/EnvironmentCommandHandler.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/cockpit/command/handler/EnvironmentCommandHandler.java
@@ -16,6 +16,7 @@
 package io.gravitee.rest.api.service.cockpit.command.handler;
 
 import io.gravitee.apim.core.access_point.crud_service.AccessPointCrudService;
+import io.gravitee.apim.core.portal.use_case.CreateDefaultPortalUseCase;
 import io.gravitee.apim.core.portal_page.use_case.CreateDefaultPortalNavigationItemsUseCase;
 import io.gravitee.cockpit.api.command.v1.CockpitCommandType;
 import io.gravitee.cockpit.api.command.v1.environment.EnvironmentCommand;
@@ -45,6 +46,7 @@ public class EnvironmentCommandHandler implements CommandHandler<EnvironmentComm
     private final EnvironmentService environmentService;
     private final AccessPointCrudService accessPointService;
     private final CreateDefaultPortalNavigationItemsUseCase createDefaultPortalNavigationItemsUseCase;
+    private final CreateDefaultPortalUseCase createDefaultPortalUseCase;
 
     @Override
     public String supportType() {
@@ -96,8 +98,9 @@ public class EnvironmentCommandHandler implements CommandHandler<EnvironmentComm
                 accessPointsToCreate
             );
 
-            // Seed default portal navigation items only when Cockpit registers this environment for the first time
+            // Seed default portal + navigation items only when Cockpit registers this environment for the first time
             if (existingEnvironment == null) {
+                createDefaultPortalUseCase.execute(environment.getOrganizationId(), environment.getId());
                 createDefaultPortalNavigationItemsUseCase.execute(environment.getOrganizationId(), environment.getId());
             }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/common/HRIDToUUID.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/common/HRIDToUUID.java
@@ -56,6 +56,10 @@ public final class HRIDToUUID {
         return new TopLevelBuilder();
     }
 
+    public static TopLevelBuilder portal() {
+        return new TopLevelBuilder();
+    }
+
     public static SubResourceBuilder plan() {
         return new SubResourceBuilder();
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/EnvironmentsDefaultPortalUpgrader.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/EnvironmentsDefaultPortalUpgrader.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.impl.upgrade.upgrader;
+
+import static io.gravitee.rest.api.service.impl.upgrade.upgrader.UpgraderOrder.ENVIRONMENTS_DEFAULT_PORTAL_UPGRADER;
+
+import io.gravitee.apim.core.portal.use_case.CreateDefaultPortalUseCase;
+import io.gravitee.node.api.upgrader.Upgrader;
+import io.gravitee.node.api.upgrader.UpgraderException;
+import io.gravitee.repository.exceptions.TechnicalException;
+import io.gravitee.repository.management.api.EnvironmentRepository;
+import lombok.CustomLog;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.stereotype.Component;
+
+@Component
+@CustomLog
+public class EnvironmentsDefaultPortalUpgrader implements Upgrader {
+
+    private final EnvironmentRepository environmentRepository;
+    private final CreateDefaultPortalUseCase createDefaultPortalUseCase;
+
+    public EnvironmentsDefaultPortalUpgrader(
+        @Lazy EnvironmentRepository environmentRepository,
+        CreateDefaultPortalUseCase createDefaultPortalUseCase
+    ) {
+        this.environmentRepository = environmentRepository;
+        this.createDefaultPortalUseCase = createDefaultPortalUseCase;
+    }
+
+    @Override
+    public int getOrder() {
+        return ENVIRONMENTS_DEFAULT_PORTAL_UPGRADER;
+    }
+
+    @Override
+    public boolean upgrade() throws UpgraderException {
+        return this.wrapException(this::applyUpgrade);
+    }
+
+    private boolean applyUpgrade() throws TechnicalException {
+        for (final var environment : environmentRepository.findAll()) {
+            createDefaultPortalUseCase.execute(environment.getOrganizationId(), environment.getId());
+        }
+        return true;
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/UpgraderOrder.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/UpgraderOrder.java
@@ -65,6 +65,7 @@ public class UpgraderOrder {
     public static final int TAG_KEY_UPGRADER = 716;
     public static final int TENANT_KEY_UPGRADER = 717;
     public static final int SUBSCRIPTION_FORM_CONSTRAINTS_UPGRADER = 718;
+    public static final int ENVIRONMENTS_DEFAULT_PORTAL_UPGRADER = 719;
     public static final int CLUSTER_ROLES_UPGRADER = 900;
     public static final int CLUSTER_CROSS_ID_UPGRADER = 901;
     public static final int API_ENDPOINT_WEIGHT_UPGRADER = 560;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/fixtures/core/model/PortalFixtures.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/fixtures/core/model/PortalFixtures.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package fixtures.core.model;
+
+import io.gravitee.apim.core.portal.model.Portal;
+import io.gravitee.apim.core.portal.model.PortalId;
+import java.util.function.Supplier;
+
+public class PortalFixtures {
+
+    private PortalFixtures() {}
+
+    public static final PortalId PORTAL_ID = PortalId.of("00000000-0000-0000-0000-0000000000a1");
+
+    private static final Supplier<Portal.PortalBuilder> BASE = () ->
+        Portal.builder().id(PORTAL_ID).environmentId("environment-id").organizationId("organization-id").name("Default Portal");
+
+    public static Portal aPortal() {
+        return BASE.get().build();
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/PortalCrudServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/PortalCrudServiceInMemory.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package inmemory;
+
+import io.gravitee.apim.core.portal.crud_service.PortalCrudService;
+import io.gravitee.apim.core.portal.exception.PortalNotFoundException;
+import io.gravitee.apim.core.portal.model.Portal;
+import io.gravitee.apim.core.portal.model.PortalId;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.OptionalInt;
+
+public class PortalCrudServiceInMemory implements PortalCrudService, InMemoryAlternative<Portal> {
+
+    final ArrayList<Portal> storage = new ArrayList<>();
+
+    @Override
+    public Portal create(Portal portal) {
+        storage.add(portal);
+        return portal;
+    }
+
+    @Override
+    public Portal update(Portal portal) {
+        OptionalInt index = this.findIndex(this.storage, p -> p.getId().equals(portal.getId()));
+        if (index.isPresent()) {
+            storage.set(index.getAsInt(), portal);
+            return portal;
+        }
+        throw new PortalNotFoundException(portal.getId());
+    }
+
+    @Override
+    public Optional<Portal> findByIdAndEnvironmentId(PortalId portalId, String environmentId) {
+        return storage
+            .stream()
+            .filter(p -> portalId.equals(p.getId()) && environmentId.equals(p.getEnvironmentId()))
+            .findFirst();
+    }
+
+    @Override
+    public void delete(PortalId portalId) {
+        storage.removeIf(p -> portalId.equals(p.getId()));
+    }
+
+    @Override
+    public void initWith(List<Portal> items) {
+        storage.clear();
+        storage.addAll(items);
+    }
+
+    @Override
+    public void reset() {
+        storage.clear();
+    }
+
+    @Override
+    public List<Portal> storage() {
+        return Collections.unmodifiableList(storage);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal/use_case/CreateDefaultPortalUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal/use_case/CreateDefaultPortalUseCaseTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal.use_case;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import inmemory.PortalCrudServiceInMemory;
+import io.gravitee.apim.core.portal.model.Portal;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class CreateDefaultPortalUseCaseTest {
+
+    private static final String ORGANIZATION_ID = "organization-id";
+    private static final String ENVIRONMENT_ID = "environment-id";
+
+    private final PortalCrudServiceInMemory portalCrudService = new PortalCrudServiceInMemory();
+    private CreateDefaultPortalUseCase useCase;
+
+    @BeforeEach
+    void setUp() {
+        useCase = new CreateDefaultPortalUseCase(portalCrudService);
+    }
+
+    @AfterEach
+    void tearDown() {
+        portalCrudService.reset();
+    }
+
+    @Test
+    void should_create_default_portal_when_absent() {
+        useCase.execute(ORGANIZATION_ID, ENVIRONMENT_ID);
+
+        assertThat(portalCrudService.storage()).hasSize(1);
+        Portal seeded = portalCrudService.storage().get(0);
+        assertThat(seeded.getEnvironmentId()).isEqualTo(ENVIRONMENT_ID);
+        assertThat(seeded.getOrganizationId()).isEqualTo(ORGANIZATION_ID);
+        assertThat(seeded.getName()).isEqualTo(CreateDefaultPortalUseCase.DEFAULT_PORTAL_NAME);
+        assertThat(seeded.getId()).isNotNull();
+    }
+
+    @Test
+    void should_be_idempotent_when_already_seeded() {
+        useCase.execute(ORGANIZATION_ID, ENVIRONMENT_ID);
+        useCase.execute(ORGANIZATION_ID, ENVIRONMENT_ID);
+
+        assertThat(portalCrudService.storage()).hasSize(1);
+    }
+
+    @Test
+    void should_derive_a_stable_id_per_environment() {
+        useCase.execute(ORGANIZATION_ID, ENVIRONMENT_ID);
+        var firstId = portalCrudService.storage().get(0).getId();
+        portalCrudService.reset();
+
+        useCase.execute(ORGANIZATION_ID, ENVIRONMENT_ID);
+        var secondId = portalCrudService.storage().get(0).getId();
+
+        assertThat(firstId).isEqualTo(secondId);
+    }
+
+    @Test
+    void should_derive_different_ids_for_different_environments() {
+        useCase.execute(ORGANIZATION_ID, ENVIRONMENT_ID);
+        useCase.execute(ORGANIZATION_ID, "other-env");
+
+        assertThat(portalCrudService.storage()).hasSize(2);
+        assertThat(portalCrudService.storage().get(0).getId()).isNotEqualTo(portalCrudService.storage().get(1).getId());
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal/use_case/CreateOrUpdatePortalUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal/use_case/CreateOrUpdatePortalUseCaseTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal.use_case;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import fixtures.core.model.PortalFixtures;
+import inmemory.PortalCrudServiceInMemory;
+import io.gravitee.apim.core.audit.model.AuditActor;
+import io.gravitee.apim.core.audit.model.AuditInfo;
+import io.gravitee.apim.core.portal.model.Portal;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class CreateOrUpdatePortalUseCaseTest {
+
+    private static final AuditInfo AUDIT_INFO = AuditInfo.builder()
+        .organizationId("organization-id")
+        .environmentId("environment-id")
+        .actor(AuditActor.builder().userId("user-id").build())
+        .build();
+
+    private final PortalCrudServiceInMemory portalCrudService = new PortalCrudServiceInMemory();
+    private CreateOrUpdatePortalUseCase useCase;
+
+    @BeforeEach
+    void setUp() {
+        useCase = new CreateOrUpdatePortalUseCase(portalCrudService);
+    }
+
+    @AfterEach
+    void tearDown() {
+        portalCrudService.reset();
+    }
+
+    @Test
+    void should_create_when_not_existing() {
+        var portal = PortalFixtures.aPortal();
+
+        var output = useCase.execute(new CreateOrUpdatePortalUseCase.Input(AUDIT_INFO, portal));
+
+        assertThat(output.portal()).isEqualTo(portal);
+        assertThat(portalCrudService.storage()).containsExactly(portal);
+    }
+
+    @Test
+    void should_update_when_existing() {
+        var existing = PortalFixtures.aPortal();
+        portalCrudService.initWith(java.util.List.of(existing));
+        var renamed = existing.toBuilder().name("Renamed Portal").build();
+
+        var output = useCase.execute(new CreateOrUpdatePortalUseCase.Input(AUDIT_INFO, renamed));
+
+        assertThat(output.portal().getName()).isEqualTo("Renamed Portal");
+        assertThat(portalCrudService.storage()).hasSize(1).containsExactly(renamed);
+    }
+
+    @Test
+    void should_be_idempotent_when_put_twice() {
+        var portal = PortalFixtures.aPortal();
+
+        var first = useCase.execute(new CreateOrUpdatePortalUseCase.Input(AUDIT_INFO, portal));
+        var second = useCase.execute(new CreateOrUpdatePortalUseCase.Input(AUDIT_INFO, portal));
+
+        assertThat(first.portal()).isEqualTo(second.portal());
+        assertThat(portalCrudService.storage()).hasSize(1).containsExactly(portal);
+    }
+
+    @Test
+    void should_not_consider_an_id_match_in_a_different_environment_as_existing() {
+        var existing = PortalFixtures.aPortal();
+        portalCrudService.initWith(java.util.List.of(existing));
+
+        var otherEnvAudit = AuditInfo.builder()
+            .organizationId("organization-id")
+            .environmentId("other-env")
+            .actor(AuditActor.builder().userId("user-id").build())
+            .build();
+        var inOtherEnv = Portal.builder()
+            .id(existing.getId())
+            .environmentId("other-env")
+            .organizationId("organization-id")
+            .name("Other Env Portal")
+            .build();
+
+        var output = useCase.execute(new CreateOrUpdatePortalUseCase.Input(otherEnvAudit, inOtherEnv));
+
+        assertThat(output.portal()).isEqualTo(inOtherEnv);
+        assertThat(portalCrudService.storage()).hasSize(2);
+        assertThat(portalCrudService.storage().stream().map(Portal::getEnvironmentId).toList()).containsExactlyInAnyOrder(
+            "environment-id",
+            "other-env"
+        );
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal/use_case/DeletePortalUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal/use_case/DeletePortalUseCaseTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal.use_case;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+
+import fixtures.core.model.PortalFixtures;
+import inmemory.PortalCrudServiceInMemory;
+import io.gravitee.apim.core.audit.model.AuditActor;
+import io.gravitee.apim.core.audit.model.AuditInfo;
+import io.gravitee.apim.core.portal.exception.PortalNotFoundException;
+import io.gravitee.apim.core.portal.model.PortalId;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class DeletePortalUseCaseTest {
+
+    private static final AuditInfo AUDIT_INFO = AuditInfo.builder()
+        .organizationId("organization-id")
+        .environmentId("environment-id")
+        .actor(AuditActor.builder().userId("user-id").build())
+        .build();
+
+    private final PortalCrudServiceInMemory portalCrudService = new PortalCrudServiceInMemory();
+    private DeletePortalUseCase useCase;
+
+    @BeforeEach
+    void setUp() {
+        useCase = new DeletePortalUseCase(portalCrudService);
+    }
+
+    @AfterEach
+    void tearDown() {
+        portalCrudService.reset();
+    }
+
+    @Test
+    void should_delete() {
+        var portal = PortalFixtures.aPortal();
+        portalCrudService.initWith(List.of(portal));
+
+        useCase.execute(new DeletePortalUseCase.Input(AUDIT_INFO, portal.getId()));
+
+        assertThat(portalCrudService.storage()).isEmpty();
+    }
+
+    @Test
+    void should_throw_when_missing() {
+        var unknownId = PortalId.of("00000000-0000-0000-0000-0000000000ff");
+        var throwable = catchThrowable(() -> useCase.execute(new DeletePortalUseCase.Input(AUDIT_INFO, unknownId)));
+
+        assertThat(throwable).isInstanceOf(PortalNotFoundException.class).hasMessage("Portal [ " + unknownId + " ] not found");
+    }
+
+    @Test
+    void should_throw_when_id_exists_in_different_environment() {
+        var portal = PortalFixtures.aPortal();
+        portalCrudService.initWith(List.of(portal));
+
+        var otherEnvAudit = AuditInfo.builder()
+            .organizationId("organization-id")
+            .environmentId("other-env")
+            .actor(AuditActor.builder().userId("user-id").build())
+            .build();
+
+        var throwable = catchThrowable(() -> useCase.execute(new DeletePortalUseCase.Input(otherEnvAudit, portal.getId())));
+
+        assertThat(throwable).isInstanceOf(PortalNotFoundException.class);
+        assertThat(portalCrudService.storage()).containsExactly(portal);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal/use_case/GetPortalUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal/use_case/GetPortalUseCaseTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal.use_case;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+
+import fixtures.core.model.PortalFixtures;
+import inmemory.PortalCrudServiceInMemory;
+import io.gravitee.apim.core.audit.model.AuditActor;
+import io.gravitee.apim.core.audit.model.AuditInfo;
+import io.gravitee.apim.core.portal.exception.PortalNotFoundException;
+import io.gravitee.apim.core.portal.model.PortalId;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class GetPortalUseCaseTest {
+
+    private static final AuditInfo AUDIT_INFO = AuditInfo.builder()
+        .organizationId("organization-id")
+        .environmentId("environment-id")
+        .actor(AuditActor.builder().userId("user-id").build())
+        .build();
+
+    private final PortalCrudServiceInMemory portalCrudService = new PortalCrudServiceInMemory();
+    private GetPortalUseCase useCase;
+
+    @BeforeEach
+    void setUp() {
+        useCase = new GetPortalUseCase(portalCrudService);
+    }
+
+    @AfterEach
+    void tearDown() {
+        portalCrudService.reset();
+    }
+
+    @Test
+    void should_return_portal() {
+        var portal = PortalFixtures.aPortal();
+        portalCrudService.initWith(List.of(portal));
+
+        var output = useCase.execute(new GetPortalUseCase.Input(AUDIT_INFO, portal.getId()));
+
+        assertThat(output.portal()).isEqualTo(portal);
+    }
+
+    @Test
+    void should_throw_when_missing() {
+        var unknownId = PortalId.of("00000000-0000-0000-0000-0000000000ff");
+        var throwable = catchThrowable(() -> useCase.execute(new GetPortalUseCase.Input(AUDIT_INFO, unknownId)));
+
+        assertThat(throwable).isInstanceOf(PortalNotFoundException.class).hasMessage("Portal [ " + unknownId + " ] not found");
+    }
+
+    @Test
+    void should_throw_when_id_exists_in_different_environment() {
+        var portal = PortalFixtures.aPortal();
+        portalCrudService.initWith(List.of(portal));
+
+        var otherEnvAudit = AuditInfo.builder()
+            .organizationId("organization-id")
+            .environmentId("other-env")
+            .actor(AuditActor.builder().userId("user-id").build())
+            .build();
+
+        var throwable = catchThrowable(() -> useCase.execute(new GetPortalUseCase.Input(otherEnvAudit, portal.getId())));
+
+        assertThat(throwable).isInstanceOf(PortalNotFoundException.class);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/crud_service/portal/PortalCrudServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/crud_service/portal/PortalCrudServiceImplTest.java
@@ -1,0 +1,201 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.infra.crud_service.portal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import fixtures.core.model.PortalFixtures;
+import io.gravitee.apim.core.exception.TechnicalDomainException;
+import io.gravitee.apim.core.portal.model.Portal;
+import io.gravitee.apim.core.portal.model.PortalId;
+import io.gravitee.apim.infra.adapter.PortalAdapter;
+import io.gravitee.repository.exceptions.TechnicalException;
+import io.gravitee.repository.management.api.PortalRepository;
+import java.util.Optional;
+import lombok.SneakyThrows;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+class PortalCrudServiceImplTest {
+
+    PortalRepository repository;
+    PortalCrudServiceImpl service;
+
+    @BeforeEach
+    void setUp() {
+        repository = mock(PortalRepository.class);
+        service = new PortalCrudServiceImpl(repository);
+    }
+
+    @Nested
+    class Create {
+
+        @Test
+        @SneakyThrows
+        void should_create_a_portal() {
+            var portal = PortalFixtures.aPortal();
+            when(repository.create(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+            var result = service.create(portal);
+
+            SoftAssertions.assertSoftly(soft -> {
+                soft.assertThat(result.getId()).isEqualTo(portal.getId());
+                soft.assertThat(result.getEnvironmentId()).isEqualTo(portal.getEnvironmentId());
+                soft.assertThat(result.getOrganizationId()).isEqualTo(portal.getOrganizationId());
+                soft.assertThat(result.getName()).isEqualTo(portal.getName());
+            });
+        }
+
+        @Test
+        @SneakyThrows
+        void should_throw_when_technical_exception_occurs() {
+            var portal = PortalFixtures.aPortal();
+            when(repository.create(any())).thenThrow(TechnicalException.class);
+
+            var throwable = catchThrowable(() -> service.create(portal));
+
+            assertThat(throwable)
+                .isInstanceOf(TechnicalDomainException.class)
+                .hasMessage("An error occurred while trying to create a Portal with id: " + portal.getId());
+        }
+    }
+
+    @Nested
+    class FindByIdAndEnvironmentId {
+
+        @Test
+        @SneakyThrows
+        void should_return_portal_and_adapt_it() {
+            var portalId = PortalFixtures.PORTAL_ID;
+            var environmentId = "environment-id";
+            when(repository.findByIdAndEnvironmentId(portalId.toString(), environmentId)).thenReturn(
+                Optional.of(
+                    io.gravitee.repository.management.model.Portal.builder()
+                        .id(portalId.toString())
+                        .environmentId(environmentId)
+                        .organizationId("organization-id")
+                        .name("Default Portal")
+                        .build()
+                )
+            );
+
+            var result = service.findByIdAndEnvironmentId(portalId, environmentId);
+
+            assertThat(result).isPresent();
+            SoftAssertions.assertSoftly(soft -> {
+                soft.assertThat(result.get().getId()).isEqualTo(portalId);
+                soft.assertThat(result.get().getEnvironmentId()).isEqualTo(environmentId);
+                soft.assertThat(result.get().getName()).isEqualTo("Default Portal");
+            });
+        }
+
+        @Test
+        @SneakyThrows
+        void should_return_empty_when_not_found() {
+            when(repository.findByIdAndEnvironmentId(any(), any())).thenReturn(Optional.empty());
+
+            assertThat(service.findByIdAndEnvironmentId(PortalFixtures.PORTAL_ID, "environment-id")).isEmpty();
+        }
+
+        @Test
+        @SneakyThrows
+        void should_throw_when_technical_exception_occurs() {
+            when(repository.findByIdAndEnvironmentId(any(), any())).thenThrow(TechnicalException.class);
+
+            var portalId = PortalFixtures.PORTAL_ID;
+            var throwable = catchThrowable(() -> service.findByIdAndEnvironmentId(portalId, "environment-id"));
+
+            assertThat(throwable)
+                .isInstanceOf(TechnicalDomainException.class)
+                .hasMessage("An error occurred while trying to find a Portal with id (" + portalId + ") in environment (environment-id)");
+        }
+    }
+
+    @Nested
+    class Update {
+
+        @Test
+        @SneakyThrows
+        void should_update_existing_portal() {
+            Portal portal = PortalFixtures.aPortal().toBuilder().name("Renamed").build();
+            when(repository.update(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+            service.update(portal);
+
+            var captor = ArgumentCaptor.forClass(io.gravitee.repository.management.model.Portal.class);
+            verify(repository).update(captor.capture());
+            assertThat(captor.getValue()).isEqualTo(PortalAdapter.INSTANCE.toRepository(portal));
+            assertThat(captor.getValue().getName()).isEqualTo("Renamed");
+        }
+
+        @Test
+        @SneakyThrows
+        void should_return_the_updated_portal() {
+            when(repository.update(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+            var toUpdate = PortalFixtures.aPortal();
+            var result = service.update(toUpdate);
+
+            assertThat(result).isEqualTo(toUpdate);
+        }
+
+        @Test
+        void should_throw_when_technical_exception_occurs() throws TechnicalException {
+            when(repository.update(any())).thenThrow(TechnicalException.class);
+
+            var portal = PortalFixtures.aPortal();
+            var throwable = catchThrowable(() -> service.update(portal));
+
+            assertThat(throwable)
+                .isInstanceOf(TechnicalDomainException.class)
+                .hasMessage("An error occurred while trying to update a Portal with id: " + portal.getId());
+        }
+    }
+
+    @Nested
+    class Delete {
+
+        @Test
+        void should_delete_portal() throws TechnicalException {
+            var portalId = PortalFixtures.PORTAL_ID;
+
+            service.delete(portalId);
+
+            verify(repository).delete(portalId.toString());
+        }
+
+        @Test
+        void should_throw_when_technical_exception_occurs() throws TechnicalException {
+            var portalId = PortalFixtures.PORTAL_ID;
+            doThrow(new TechnicalException("boom")).when(repository).delete(portalId.toString());
+
+            assertThatThrownBy(() -> service.delete(portalId))
+                .isInstanceOf(TechnicalDomainException.class)
+                .hasMessage("An error occurred while trying to delete the Portal with id: " + portalId);
+            verify(repository).delete(portalId.toString());
+        }
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/cockpit/command/handler/EnvironmentCommandHandlerTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/cockpit/command/handler/EnvironmentCommandHandlerTest.java
@@ -25,6 +25,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.gravitee.apim.core.access_point.crud_service.AccessPointCrudService;
+import io.gravitee.apim.core.portal.use_case.CreateDefaultPortalUseCase;
 import io.gravitee.apim.core.portal_page.use_case.CreateDefaultPortalNavigationItemsUseCase;
 import io.gravitee.cockpit.api.command.model.accesspoint.AccessPoint;
 import io.gravitee.cockpit.api.command.v1.CockpitCommandType;
@@ -62,11 +63,19 @@ public class EnvironmentCommandHandlerTest {
     @Mock
     private CreateDefaultPortalNavigationItemsUseCase createDefaultPortalNavigationItemsUseCase;
 
+    @Mock
+    private CreateDefaultPortalUseCase createDefaultPortalUseCase;
+
     public EnvironmentCommandHandler cut;
 
     @Before
     public void before() {
-        cut = new EnvironmentCommandHandler(environmentService, accessPointService, createDefaultPortalNavigationItemsUseCase);
+        cut = new EnvironmentCommandHandler(
+            environmentService,
+            accessPointService,
+            createDefaultPortalNavigationItemsUseCase,
+            createDefaultPortalUseCase
+        );
     }
 
     @Test
@@ -213,6 +222,71 @@ public class EnvironmentCommandHandlerTest {
         obs.assertValue(reply -> reply.getCommandId().equals(command.getId()) && reply.getCommandStatus().equals(CommandStatus.SUCCEEDED));
 
         verify(createDefaultPortalNavigationItemsUseCase).execute(orgId, envId);
+    }
+
+    @Test
+    @SneakyThrows
+    public void environmentCreationCreatesDefaultPortal() {
+        String envId = "env#1";
+        String orgId = "orga#1";
+        EnvironmentCommandPayload environmentPayload = EnvironmentCommandPayload.builder()
+            .id(envId)
+            .cockpitId("env#cockpit-1")
+            .hrids(Collections.singletonList("env-1"))
+            .organizationId(orgId)
+            .description("Environment description")
+            .name("Environment name")
+            .build();
+        EnvironmentCommand command = new EnvironmentCommand(environmentPayload);
+
+        when(environmentService.findByCockpitId(any())).thenThrow(new EnvironmentNotFoundException("Env not found"));
+        when(environmentService.createOrUpdate(eq(orgId), eq(envId), any(UpdateEnvironmentEntity.class))).thenReturn(
+            EnvironmentEntity.builder().id(envId).organizationId(orgId).build()
+        );
+
+        TestObserver<EnvironmentReply> obs = cut.handle(command).test();
+
+        obs.await();
+        obs.assertValue(reply -> reply.getCommandId().equals(command.getId()) && reply.getCommandStatus().equals(CommandStatus.SUCCEEDED));
+
+        verify(createDefaultPortalUseCase).execute(orgId, envId);
+    }
+
+    @Test
+    public void environmentUpdateDoesNotCreateDefaultPortal() throws InterruptedException {
+        EnvironmentCommandPayload environmentPayload = EnvironmentCommandPayload.builder()
+            .id("env#1")
+            .cockpitId("env#cockpit-1")
+            .hrids(Collections.singletonList("env-1"))
+            .organizationId("orga#1")
+            .description("Environment description")
+            .name("Environment name")
+            .build();
+        EnvironmentCommand command = new EnvironmentCommand(environmentPayload);
+        EnvironmentEntity existingEnvironment = mock(EnvironmentEntity.class);
+        when(existingEnvironment.getId()).thenReturn("DEFAULT");
+        when(existingEnvironment.getOrganizationId()).thenReturn("DEFAULT");
+        when(environmentService.findByCockpitId(any())).thenReturn(existingEnvironment);
+        when(
+            environmentService.createOrUpdate(
+                eq("DEFAULT"),
+                eq("DEFAULT"),
+                argThat(
+                    newEnvironment ->
+                        newEnvironment.getCockpitId().equals(environmentPayload.cockpitId()) &&
+                        newEnvironment.getHrids().equals(environmentPayload.hrids()) &&
+                        newEnvironment.getDescription().equals(environmentPayload.description()) &&
+                        newEnvironment.getName().equals(environmentPayload.name())
+                )
+            )
+        ).thenReturn(new EnvironmentEntity());
+
+        TestObserver<EnvironmentReply> obs = cut.handle(command).test();
+
+        obs.await();
+        obs.assertValue(reply -> reply.getCommandId().equals(command.getId()) && reply.getCommandStatus().equals(CommandStatus.SUCCEEDED));
+
+        verify(createDefaultPortalUseCase, never()).execute(any(), any());
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/EnvironmentsDefaultPortalUpgraderTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/EnvironmentsDefaultPortalUpgraderTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.impl.upgrade.upgrader;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertThrows;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.apim.core.portal.use_case.CreateDefaultPortalUseCase;
+import io.gravitee.node.api.upgrader.UpgraderException;
+import io.gravitee.repository.exceptions.TechnicalException;
+import io.gravitee.repository.management.api.EnvironmentRepository;
+import io.gravitee.repository.management.model.Environment;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import lombok.SneakyThrows;
+import org.junit.function.ThrowingRunnable;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+public class EnvironmentsDefaultPortalUpgraderTest {
+
+    private static final Environment ANOTHER_ENVIRONMENT = Environment.builder()
+        .id("ANOTHER_ENVIRONMENT")
+        .hrids(List.of("another environment"))
+        .name("another environment")
+        .organizationId("ANOTHER_ORG")
+        .build();
+
+    @Mock
+    EnvironmentRepository environmentRepository;
+
+    @Mock
+    CreateDefaultPortalUseCase createDefaultPortalUseCase;
+
+    private EnvironmentsDefaultPortalUpgrader upgrader;
+
+    @BeforeEach
+    public void setUp() {
+        upgrader = new EnvironmentsDefaultPortalUpgrader(environmentRepository, createDefaultPortalUseCase);
+    }
+
+    @Test
+    @SneakyThrows
+    void should_do_nothing_when_there_is_no_environment() {
+        when(environmentRepository.findAll()).thenReturn(Collections.emptySet());
+        assertThat(upgrader.upgrade()).isTrue();
+        verifyNoInteractions(createDefaultPortalUseCase);
+    }
+
+    @Test
+    @SneakyThrows
+    void should_return_false_when_something_wrong_happens() {
+        when(environmentRepository.findAll()).thenThrow(new TechnicalException("this is a test exception"));
+
+        final ThrowingRunnable throwing = () -> upgrader.upgrade();
+
+        Exception exception = assertThrows(UpgraderException.class, throwing);
+        assertThat(exception.getMessage()).contains("this is a test exception");
+    }
+
+    @Test
+    @SneakyThrows
+    void should_create_default_portal_for_both_environments() {
+        when(environmentRepository.findAll()).thenReturn(Set.of(Environment.DEFAULT, ANOTHER_ENVIRONMENT));
+
+        assertThat(upgrader.upgrade()).isTrue();
+
+        ArgumentCaptor<String> captorOrgId = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<String> captorEnvId = ArgumentCaptor.forClass(String.class);
+
+        verify(createDefaultPortalUseCase, times(2)).execute(captorOrgId.capture(), captorEnvId.capture());
+        assertThat(captorOrgId.getAllValues()).containsExactlyInAnyOrder("DEFAULT", "ANOTHER_ORG");
+        assertThat(captorEnvId.getAllValues()).containsExactlyInAnyOrder("DEFAULT", "ANOTHER_ENVIRONMENT");
+    }
+}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/EXT-134

## Description

First vertical slice of next-gen portal automation.

Adds the **Portal** resource (`PUT`/`GET`/`DELETE` on `/portals[/{hrid}]`) for GKO and the Terraform provider — foundation for upcoming Listing / Documentation / API-navigation slices.

  - New `Portal` entity + persistence (Mongo, JDBC, Liquibase, repository TCK).
  - Core domain (`PortalCrudService` + 3 use cases) and automation REST resources.
  - New `ENVIRONMENT_PORTAL` permission.
  - Deterministic id from `(orgId, hrid, envId)` via `HRIDToUUID.portal()` — HRID not persisted, per PRD.

  ## Test plan

  Verified end-to-end against the local MongoDB Docker Compose stack:                                                                                              

  ```bash
  curl -i -u admin:admin -X PUT -H 'Content-Type: application/json' -d '{"hrid":"default-portal","name":"Default Portal"}' 'http://localhost:8083/automation/organizations/DEFAULT/environments/DEFAULT/portals'

  curl -i -u admin:admin 'http://localhost:8083/automation/organizations/DEFAULT/environments/DEFAULT/portals/default-portal'

  curl -i -u admin:admin -X DELETE 'http://localhost:8083/automation/organizations/DEFAULT/environments/DEFAULT/portals/default-portal'

  200 → 200 (idempotent) → 204.
```

To be confirmed
  
- [ ] No GET /portals listing - kept consistent with every other automation collection (/apis, /applications, /groups, …): only PUT on the collection, GET/DELETE per HRID.
- [ ] Should we support DELETE or remove it temporarily?
- [ ] Should we support createOrUpdate or just update assuming that portal instances are currently populated from seed?
- [ ] Multiple Portal rows vs. the single next-gen portal instance - how should >1 Portal map to the one rendered portal today (dedicated name like "default-portal")?
