### PR TITLE
fix(gamma): resolve AuthzEntity NoClassDefFoundError in gamma-rest-api

### DIFF
--- a/gravitee-gamma/gravitee-gamma-rest-api/pom.xml
+++ b/gravitee-gamma/gravitee-gamma-rest-api/pom.xml
@@ -42,6 +42,12 @@
             <version>${project.version}</version>
             <scope>provided</scope>
         </dependency>
+        <!-- compile scope so plugins resolve AuthzPolicy/AuthzEntity via parent classloader -->
+        <dependency>
+            <groupId>io.gravitee.gamma.definition</groupId>
+            <artifactId>gravitee-gamma-definition-model</artifactId>
+            <version>${project.version}</version>
+        </dependency>
         <dependency>
             <groupId>io.gravitee.apim.rest.api.management</groupId>
             <artifactId>gravitee-apim-rest-api-management-rest</artifactId>


### PR DESCRIPTION
## Summary
- `EventRepositoryAuthzEventPublisher.publishEntityUpserted` throws `NoClassDefFoundError: io/gravitee/gamma/definition/authz/AuthzEntity` during scheduled API sync on master.
- Root cause: `gravitee-gamma-definition-model` (where `AuthzEntity` lives) was not on the `gravitee-gamma-rest-api` runtime classpath, so the class was unavailable to the parent classloader that Gamma plugins resolve against.
- Fix: add `io.gravitee.gamma.definition:gravitee-gamma-definition-model` in compile scope to `gravitee-gamma-rest-api`.

## Test plan
- [ ] Build `gravitee-gamma-rest-api` and confirm `gravitee-gamma-definition-model` is on the runtime classpath.
- [ ] Run rest-api, trigger scheduled API sync, confirm no `NoClassDefFoundError` and authz entity upsert events publish.