### PR TITLE
Feature/ext 109 kafka namespace policy

### DIFF
--- a/docker/quick-setup/native-kafka/README.md
+++ b/docker/quick-setup/native-kafka/README.md
@@ -100,6 +100,23 @@ docker exec -it gio_apim_kafka-client bash -c "/opt/kafka/bin/kafka-console-prod
 docker exec -it gio_apim_kafka-client bash -c "/opt/kafka/bin/kafka-console-consumer.sh --bootstrap-server foo.kafka.local:9092 --consumer.config config/kafka-keyless-plan-ssl.properties --topic client-topic-1"`
 ```
 
+**In current 4.12.0 SNAPSHOT the command above does not work. Basically the consumer is not able to pull messages.**
+Most probably the issue is something like this: the gateway correctly rewrites broker addresses in METADATA_RESPONSE (kafka:9091 → broker-0-foo.kafka.local:9092), but FIND_COORDINATOR_RESPONSE is not rewritten — the client receives the raw broker address kafka:9091, tries to open a TCP connection directly to the broker, fails
+(the kafka-client container is on the gateway network, not the kafka network), and loops. That's the endless METADATA → FIND_COORDINATOR cycle visible in the gateway logs without any JOIN_GROUP ever happening.
+The issue will be somewhere in kafka reactor native component.
+
+As a workaround, the one below works fine:  --partition + --offset, the consumer uses static partition assignment and skips FIND_COORDINATOR / JOIN_GROUP / SYNC_GROUP entirely — it goes straight to FETCH.
+
+```bash
+docker exec -it gio_apim_kafka-client bash -c \
+    "/opt/kafka/bin/kafka-console-consumer.sh \
+      --bootstrap-server foo.kafka.local:9092 \
+      --consumer.config config/kafka-keyless-plan-ssl.properties \
+      --topic test.client-topic-1 \
+      --partition 0 --offset 0 \
+      --max-messages 10"
+```
+
 ### See the API in the portal (next)
 
 Activate the new portal in the environment settings (Settings > Settings > Enable the New Developer Portal)

--- a/docker/quick-setup/native-kafka/docker-compose.yml
+++ b/docker/quick-setup/native-kafka/docker-compose.yml
@@ -14,8 +14,6 @@
 # limitations under the License.
 #
 
-version: '3.8'
-
 networks:
     frontend:
         name: frontend
@@ -33,6 +31,11 @@ volumes:
     data-elasticsearch:
     data-mongo:
     data-kafka:
+    apim-mongodb-logs:
+    apim-gateway-logs:
+    apim-management-api-logs:
+    apim-management-ui-logs:
+    apim-portal-ui-logs:
 
 services:
     mongodb:
@@ -41,7 +44,7 @@ services:
         restart: always
         volumes:
             - data-mongo:/data/db
-            - ./.logs/apim-mongodb:/var/log/mongodb
+            - apim-mongodb-logs:/var/log/mongodb
         healthcheck:
             test: mongosh --eval 'db.runCommand({serverStatus:1}).ok' --quiet | grep 1
             interval: 5s
@@ -80,12 +83,15 @@ services:
             - storage
 
     kibana:
-        image: docker.elastic.co/kibana/kibana:8.8.1-arm64
+        image: docker.elastic.co/kibana/kibana:${ELASTIC_VERSION:-8.17.2}
         container_name: kibana
         environment:
             - ELASTICSEARCH_HOSTS=http://elasticsearch:9200
         ports:
             - '5601:5601'
+        depends_on:
+            elasticsearch:
+                condition: service_healthy
         networks:
             - storage
 
@@ -102,7 +108,7 @@ services:
             elasticsearch:
                 condition: service_healthy
         volumes:
-            - ./.logs/apim-gateway:/opt/graviteeio-gateway/logs
+            - apim-gateway-logs:/opt/graviteeio-gateway/logs
             - ./.license:/opt/graviteeio-gateway/license
             - ./.ssl:/opt/graviteeio-gateway/ssl
             #      - ./.hosts:/etc/hosts
@@ -117,6 +123,7 @@ services:
             - gravitee_kafka_ssl_keystore_path=$${gravitee.home}/ssl/server.keystore.jks
             - gravitee_kafka_ssl_keystore_type=jks
             - 'gravitee_kafka_routingHostMode_defaultDomain=kafka.local'
+            - 'license.key=${LICENSE_KEY}'
         networks:
             storage:
             frontend:
@@ -146,7 +153,7 @@ services:
             elasticsearch:
                 condition: service_healthy
         volumes:
-            - ./.logs/apim-management-api:/opt/graviteeio-management-api/logs
+            - apim-management-api-logs:/opt/graviteeio-management-api/logs
             - ./.license:/opt/graviteeio-management-api/license
         environment:
             - gravitee_management_mongodb_uri=mongodb://mongodb:27017/gravitee?serverSelectionTimeoutMS=5000&connectTimeoutMS=5000&socketTimeoutMS=5000
@@ -156,6 +163,7 @@ services:
             - gravitee_email_port=1025
             - gravitee_email_subject="TEST"
             - gravitee_email_from="user@my.domain"
+            - 'license.key=${LICENSE_KEY}'
         networks:
             - storage
             - frontend
@@ -172,7 +180,7 @@ services:
         environment:
             - MGMT_API_URL=http://localhost:8083/management/
         volumes:
-            - ./.logs/apim-management-ui:/var/log/nginx
+            - apim-management-ui-logs:/var/log/nginx
         networks:
             - frontend
 
@@ -187,7 +195,7 @@ services:
         environment:
             - PORTAL_API_URL=http://localhost:8083/portal
         volumes:
-            - ./.logs/apim-portal-ui:/var/log/nginx
+            - apim-portal-ui-logs:/var/log/nginx
         networks:
             - frontend
 
@@ -247,6 +255,13 @@ services:
 
         command: >
             /opt/kafka/bin/kafka-server-start.sh /opt/kafka/config/kraft/server.properties
+
+        healthcheck:
+            test: ['CMD', '/opt/kafka/bin/kafka-broker-api-versions.sh', '--bootstrap-server', 'localhost:9091']
+            interval: 10s
+            timeout: 5s
+            retries: 10
+            start_period: 30s
 
     kafka-ui:
         container_name: gio_apim_kafka-ui

--- a/gravitee-apim-distribution/pom.xml
+++ b/gravitee-apim-distribution/pom.xml
@@ -1872,6 +1872,19 @@
                 </dependency>
                 <dependency>
                     <groupId>com.graviteesource.policy</groupId>
+                    <artifactId>gravitee-policy-kafka-namespace</artifactId>
+                    <version>${gravitee-policy-kafka-namespace.version}</version>
+                    <type>zip</type>
+                    <scope>runtime</scope>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>*</groupId>
+                            <artifactId>*</artifactId>
+                        </exclusion>
+                    </exclusions>
+                </dependency>
+                <dependency>
+                    <groupId>com.graviteesource.policy</groupId>
                     <artifactId>gravitee-policy-kafka-fetch-rules</artifactId>
                     <version>${gravitee-policy-kafka-rules.version}</version>
                     <type>zip</type>

--- a/pom.xml
+++ b/pom.xml
@@ -309,7 +309,7 @@
         <gravitee-resource-schema-registry-embedded.version>1.0.0-alpha.1</gravitee-resource-schema-registry-embedded.version>
         <gravitee-resource-storage-azure-blob.version>1.1.0</gravitee-resource-storage-azure-blob.version>
         <gravitee-reactor-message.version>11.0.0-alpha.3</gravitee-reactor-message.version>
-        <gravitee-reactor-native-kafka.version>7.0.0-alpha.14</gravitee-reactor-native-kafka.version>
+        <gravitee-reactor-native-kafka.version>7.0.0-alpha.18</gravitee-reactor-native-kafka.version>
         <gravitee-reactor-mcp-proxy.version>1.1.2</gravitee-reactor-mcp-proxy.version>
         <gravitee-reactor-llm-proxy.version>3.0.0-alpha.1</gravitee-reactor-llm-proxy.version>
         <gravitee-reactor-a2a-proxy.version>1.0.0</gravitee-reactor-a2a-proxy.version>
@@ -326,6 +326,7 @@
         <gravitee-policy-kafka-quota.version>1.2.1</gravitee-policy-kafka-quota.version>
         <gravitee-policy-kafka-topic-mapping.version>2.0.0</gravitee-policy-kafka-topic-mapping.version>
         <gravitee-policy-kafka-acl.version>3.0.1</gravitee-policy-kafka-acl.version>
+        <gravitee-policy-kafka-namespace.version>1.0.0</gravitee-policy-kafka-namespace.version>
         <gravitee-policy-kafka-transform-key.version>1.0.0</gravitee-policy-kafka-transform-key.version>
         <gravitee-policy-kafka-message-filtering.version>1.0.0</gravitee-policy-kafka-message-filtering.version>
         <gravitee-policy-kafka-message-encryption-decryption.version>1.0.0</gravitee-policy-kafka-message-encryption-decryption.version>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/EXT-109

## Description

* adds new Kafka namespace policu
* fixes native kafka docker compose

## Additional context

Report from AI agents (using SKILL.md):
# Rules Compliance — Last 2 Commits

**Commits**: `b7d89af30f` feat: add gravitee-policy-kafka-namespace to distribution bundle → `8699c6da9c` fix: make native-kafka docker compose working fine
**Files changed**: 4
**Rules loaded**: root `AGENTS.md` + `.agent-rules/java.md` + `gravitee-apim-distribution/AGENTS.md`

## Violations

No violations found.

## Notes

- **`docker/quick-setup/native-kafka/README.md`** and **`docker/quick-setup/native-kafka/docker-compose.yml`** fall outside all module roots listed in root `AGENTS.md`. No module-specific rules apply; conventional commit prefixes are correct (`fix:`, `feat:`).
- **`pom.xml`** and **`gravitee-apim-distribution/pom.xml`** changes are pure Maven XML (version properties and dependency declarations). No Java logic was modified, so `.agent-rules/java.md` coding standards (logging, exception handling, test naming) do not apply. The new `gravitee-policy-kafka-namespace` dependency follows the same `zip`/`runtime`/wildcard-exclusion pattern used by all other Kafka policy entries in `gravitee-apim-distribution/pom.xml`.
- **`gravitee-apim-distribution/AGENTS.md`** is empty — no module-specific rules to check.
- The README addition correctly documents a known limitation in the 4.12.0 SNAPSHOT (FIND_COORDINATOR_RESPONSE rewrite missing in the native Kafka reactor) and provides a valid workaround. This is informational; no rule governs documentation wording.
