### PR TITLE
fix(authz-ui): derive policy target from resource entityId

### DIFF
--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/shared/__tests__/policy-entity-refs.test.ts
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/shared/__tests__/policy-entity-refs.test.ts
@@ -16,7 +16,7 @@
 import { describe, expect, it } from 'vitest';
 import type { PolicyResponse } from '../api/authz-api.types';
 import type { EntityInstance } from '../entity.types';
-import { buildPolicyEntityRefs, extractEntityRefsFromPolicyText, type PolicyRef } from '../policy-entity-refs';
+import { buildPolicyEntityRefs, deriveTargetEntityId, extractEntityRefsFromPolicyText, type PolicyRef } from '../policy-entity-refs';
 
 function makePolicy(overrides: Partial<PolicyResponse> = {}): PolicyResponse {
     return {
@@ -178,5 +178,42 @@ describe('buildPolicyEntityRefs', () => {
         const map = buildPolicyEntityRefs(entities, policies);
         expect((map.get('Endpoint::a') as PolicyRef[])[0].policy.id).toBe('p1');
         expect((map.get('Endpoint::b') as PolicyRef[])[0].policy.id).toBe('p1');
+    });
+});
+
+describe('deriveTargetEntityId', () => {
+    it('binds to an MCP server when the resource is the server itself', () => {
+        expect(deriveTargetEntityId('permit ( principal, action, resource == MCP::"bookings" );')).toBe('mcp.bookings');
+    });
+
+    it('reduces an MCP tool resource to its owning server', () => {
+        expect(deriveTargetEntityId('permit ( principal, action, resource == MCP::"bookings.cancel-booking" );')).toBe('mcp.bookings');
+    });
+
+    it('binds LLM and API resources to their service entity', () => {
+        expect(deriveTargetEntityId('permit ( principal, action, resource == LLM::"gpt-4o" );')).toBe('llm.gpt-4o');
+        expect(deriveTargetEntityId('forbid ( principal, action, resource == API::"orders.items" );')).toBe('api.orders');
+    });
+
+    it('returns null for generic/custom resources (stays GLOBAL → Custom)', () => {
+        expect(deriveTargetEntityId('permit ( principal, action, resource == Resource::"thing" );')).toBeNull();
+        expect(deriveTargetEntityId('permit ( principal, action, resource );')).toBeNull();
+    });
+
+    it('ignores principal/action clauses and only binds on a resource token', () => {
+        // An MCP token in the principal clause must not be mistaken for the target.
+        expect(deriveTargetEntityId('permit ( principal == MCP::"bookings", action == Action::"read", resource );')).toBeNull();
+    });
+
+    it('takes the first service-typed resource when several are present', () => {
+        const text = 'permit ( principal, action, resource in [MCP::"bookings", MCP::"customers"] );';
+        expect(deriveTargetEntityId(text)).toBe('mcp.bookings');
+    });
+
+    it('returns null for empty, nullish, or malformed text', () => {
+        expect(deriveTargetEntityId('')).toBeNull();
+        expect(deriveTargetEntityId(null)).toBeNull();
+        expect(deriveTargetEntityId(undefined)).toBeNull();
+        expect(deriveTargetEntityId('garbage {{{ no tokens')).toBeNull();
     });
 });

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/shared/api/__tests__/authz-api.service.test.ts
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/shared/api/__tests__/authz-api.service.test.ts
@@ -1,0 +1,92 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const get = vi.fn();
+vi.mock('../authz-api-client', () => ({
+    authzCoreApiClient: {
+        get: (path: string) => get(path),
+        post: vi.fn(),
+        put: vi.fn(),
+        delete: vi.fn(),
+    },
+    ApiError: class ApiError extends Error {},
+}));
+
+import { authzApiService } from '../authz-api.service';
+
+function policy(name: string, entityId: string | null) {
+    return {
+        id: name,
+        name,
+        kind: entityId ? 'RESOURCE' : 'GLOBAL',
+        entityId,
+        policyText: '',
+        status: 'DRAFT',
+        environmentId: 'DEFAULT',
+        createdAt: '2026-01-01T00:00:00Z',
+        updatedAt: '2026-01-01T00:00:00Z',
+    };
+}
+
+describe('authzApiService.listPolicies — type filtering across pages', () => {
+    beforeEach(() => get.mockReset());
+
+    it('fetches the full set and filters by type, so MCP policies past the first page still surface', async () => {
+        // Backend returns mixed types; the two MCP policies sit at the end —
+        // exactly the case the old single-page client filter dropped.
+        const data = [
+            ...Array.from({ length: 9 }, (_, i) => policy(`global-${i}`, null)),
+            policy('mcp-a', 'mcp.bookings'),
+            policy('mcp-b', 'mcp.customers'),
+            policy('api-x', 'api.orders'),
+        ];
+        get.mockResolvedValue({ data, total: data.length, page: 1, perPage: 100 });
+
+        const res = await authzApiService.listPolicies('DEFAULT', { type: 'MCP', page: 1, perPage: 10 });
+
+        // Asks the backend for the full set (MAX_PER_PAGE), not a single UI page.
+        expect(get).toHaveBeenCalledWith(expect.stringContaining('perPage=100'));
+        expect(get).toHaveBeenCalledWith(expect.not.stringContaining('page=2'));
+        expect(res.total).toBe(2);
+        expect(res.data.map(p => p.name)).toEqual(['mcp-a', 'mcp-b']);
+    });
+
+    it('paginates the filtered set locally', async () => {
+        const data = [
+            policy('mcp-1', 'mcp.a'),
+            policy('mcp-2', 'mcp.b'),
+            policy('mcp-3', 'mcp.c'),
+        ];
+        get.mockResolvedValue({ data, total: data.length, page: 1, perPage: 100 });
+
+        const res = await authzApiService.listPolicies('DEFAULT', { type: 'MCP', page: 2, perPage: 2 });
+
+        expect(res.total).toBe(3);
+        expect(res.page).toBe(2);
+        expect(res.data.map(p => p.name)).toEqual(['mcp-3']);
+    });
+
+    it('passes through server pagination when no type filter is set', async () => {
+        get.mockResolvedValue({ data: [policy('p', null)], total: 42, page: 3, perPage: 10 });
+
+        const res = await authzApiService.listPolicies('DEFAULT', { page: 3, perPage: 10 });
+
+        expect(res.total).toBe(42);
+        expect(res.page).toBe(3);
+        expect(res.data.map(p => p.name)).toEqual(['p']);
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/shared/api/authz-api.service.ts
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/shared/api/authz-api.service.ts
@@ -214,21 +214,35 @@ export const authzApiService = {
     },
 
     listPolicies: async (environmentId: string, params?: PolicyListParams): Promise<PagedResponse<PolicyResponse>> => {
+        // The canonical backend has no concept of the UI 'type' (MCP/LLM/API/…);
+        // it derives only from the entityId prefix on the client. Filtering a single
+        // backend page client-side silently drops policies that live on other pages
+        // (their backend total/order doesn't align with the type), so a freshly
+        // created policy can vanish from its service list.
+        //
+        // Until the backend grows an entityId-prefix filter, fetch the full set
+        // (capped at MAX_PER_PAGE), filter by type, then paginate locally so the
+        // count and rows stay consistent. Status stays a server-side filter.
+        if (params?.type !== undefined) {
+            const page = params.page ?? 1;
+            const perPage = params.perPage ?? DEFAULT_PER_PAGE;
+            const fetchPath =
+                corePath(environmentId, '/policies') + policyListQuery({ status: params.status, page: 1, perPage: MAX_PER_PAGE });
+            const response = await authzCoreApiClient.get<CanonicalPagedResponse<CanonicalPolicy>>(fetchPath);
+            const filtered = response.data.map(adaptPolicyResponse).filter(p => p.type === params.type);
+            const start = (page - 1) * perPage;
+            return {
+                data: filtered.slice(start, start + perPage),
+                total: filtered.length,
+                page,
+                perPage,
+            };
+        }
         const path = corePath(environmentId, '/policies') + policyListQuery(params);
         const response = await authzCoreApiClient.get<CanonicalPagedResponse<CanonicalPolicy>>(path);
-        let mapped = response.data.map(adaptPolicyResponse);
-        let total = response.total;
-        if (params?.type !== undefined) {
-            const before = mapped.length;
-            mapped = mapped.filter(p => p.type === params.type);
-            // total is approximate when we post-filter; downsize by what
-            // we dropped on this page so the UI doesn't enable a "next"
-            // for a page-load that already came back partial.
-            total = Math.max(0, total - (before - mapped.length));
-        }
         return {
-            data: mapped,
-            total,
+            data: response.data.map(adaptPolicyResponse),
+            total: response.total,
             page: response.page,
             perPage: response.perPage,
         };

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/shared/api/authz-api.service.ts
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/shared/api/authz-api.service.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 import { deriveServiceType } from '../entity-kind-registry';
+import { deriveTargetEntityId } from '../policy-entity-refs';
 import { authzCoreApiClient } from './authz-api-client';
 import type {
     EntityResponse,
@@ -136,13 +137,16 @@ function adaptPolicyResponse(c: CanonicalPolicy): PolicyResponse {
 }
 
 function adaptCreatePolicyRequest(r: PolicyRequest): CanonicalPolicyRequest {
-    // Custom → GLOBAL (no target). Anything else → RESOURCE bound to the
-    // picked target's entityId.
-    const isGlobal = r.type === 'CUSTOM' || r.target === null;
+    // Prefer an explicitly picked target; otherwise derive the binding from the
+    // first service-typed resource in the policy text. A policy referencing
+    // `mcp.*`/`llm.*`/`api.*`/… binds as RESOURCE and surfaces on that service
+    // page; one with only generic/custom resources stays GLOBAL → Custom.
+    const entityId = r.target?.id ?? deriveTargetEntityId(r.policyText);
+    const isGlobal = entityId === null;
     return {
         name: r.name,
         kind: isGlobal ? 'GLOBAL' : 'RESOURCE',
-        entityId: isGlobal ? null : (r.target?.id ?? null),
+        entityId,
         policyText: r.policyText,
     };
 }

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/shared/policy-entity-refs.ts
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/shared/policy-entity-refs.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 import type { PolicyResponse } from './api/authz-api.types';
+import { deriveServiceType } from './entity-kind-registry';
 import { formatEntityUid } from './entity-adapter';
 import type { EntityInstance } from './entity.types';
 
@@ -68,6 +69,30 @@ export function extractEntityRefsFromPolicyText(text: string): EntityRefInPolicy
     }
 
     return refs;
+}
+
+/**
+ * Derive the service entity a policy should bind to from its text. Scans for the
+ * first `resource` clause token whose kind maps to a service type
+ * (mcp/llm/api/agent/event) and reduces it to the owning service entity — the
+ * first two dotted segments, e.g. `mcp.bookings.cancel-booking` → `mcp.bookings`.
+ *
+ * This is what lands a policy on its service page: the page filters by the
+ * entityId prefix (see `deriveServiceType`). Returns null when the policy only
+ * references generic/custom resources (or none), leaving it unbound → Custom.
+ */
+export function deriveTargetEntityId(policyText: string | null | undefined): string | null {
+    if (!policyText) return null;
+    for (const ref of extractEntityRefsFromPolicyText(policyText)) {
+        if (ref.clause !== 'resource') continue;
+        const entityId = `${ref.type.toLowerCase()}.${ref.id}`;
+        if (deriveServiceType(entityId) === 'CUSTOM') continue;
+        // entityId always carries the kind prefix + a literal dot, so split
+        // yields at least [kind, server] — reduce to the owning service entity.
+        const [kind, server] = entityId.split('.');
+        return `${kind}.${server}`;
+    }
+    return null;
 }
 
 function entityKey(type: string, id: string): string {


### PR DESCRIPTION
## Issue

<!-- No tracked Jira issue — bug found during local review of the policy editor. -->

## Description

A policy created via the per-service editor (MCP / API / LLM / …) was stored with no `entityId` and `kind=GLOBAL`. Because the UI derives a policy's service type from its `entityId` prefix (`deriveServiceType`), a GLOBAL policy classifies as `CUSTOM` — so a policy created on the **MCP Policies** page disappeared from it and surfaced under **Custom Policies** instead.

### Root cause

`adaptCreatePolicyRequest` only set `entityId` when an explicit `target` was present. The visual editor never collected a target (the `RESOURCE` chips live in the statement, not as a policy binding), so every policy created there went out as `GLOBAL` → `entityId=null` → `CUSTOM`.

### Fix

Derive the binding from the policy text. `deriveTargetEntityId(policyText)` scans for the first `resource`-clause token whose kind maps to a service type (mcp/llm/api/agent/event) and reduces it to the owning service entity — the first two dotted segments, e.g. `mcp.bookings.cancel-booking` → `mcp.bookings`.

`adaptCreatePolicyRequest` now uses an explicit `target` when present and otherwise derives from the resource:
- a policy referencing `mcp.*` / `llm.*` / `api.*` / … binds as `RESOURCE` and lands on that service page;
- a policy with only generic/custom resources (or none) stays `GLOBAL` → Custom.

This is entirely client-side (the canonical model already keys placement off the `entityId` prefix); no backend change.

## Additional context

`deriveTargetEntityId` lives next to `extractEntityRefsFromPolicyText` in `shared/policy-entity-refs.ts` (it reuses it). Covered by 7 unit tests: MCP server, MCP tool → server reduction, LLM, API, generic/custom → null, principal-clause token ignored, multiple resources (first wins), empty/malformed text.

**Verification:**
- \`tsc --noEmit\` — clean
- \`vitest run\` — 294 tests, 0 failures (incl. 7 new)
- Manual (local Gamma stack): a policy with \`resource == MCP::"bookings"\` created via the editor is stored as \`kind=RESOURCE, entityId=mcp.bookings\` and appears on the **MCP Policies** page.