### PR TITLE
feat(gateway): add specific connection-error classification keys (APIM-12769)

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-http/src/main/java/io/gravitee/gateway/reactive/http/vertx/VertxHttpServerRequest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-http/src/main/java/io/gravitee/gateway/reactive/http/vertx/VertxHttpServerRequest.java
@@ -45,6 +45,17 @@ import javax.net.ssl.SSLSession;
 public class VertxHttpServerRequest extends AbstractRequest {
 
     public static final String NETTY_ATTR_CONNECTION_TIME = "connectionTime";
+
+    /**
+     * Netty channel attribute carrying the in-flight {@code MutableExecutionContext} so the
+     * Vert.x connection-level exception handler can lazily populate {@code metrics.errorKey} /
+     * {@code metrics.errorMessage} with the classified client-close reason before the dispose
+     * chain reaches the endpoint connector. The {@code Metrics} object on the context is set by
+     * the {@code MetricsProcessor} pre-processor, which runs after dispatch starts — so we stash
+     * the context (not the metrics directly) and read its current metrics at exception time.
+     * <p>Used by {@code HttpProtocolVerticle.configureConnectionHandlers}.</p>
+     */
+    public static final String NETTY_ATTR_REQUEST_CONTEXT = "requestContext";
     protected final HttpServerRequest nativeRequest;
     private Boolean isWebSocket = null;
     private Boolean isStreaming = null;

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactive/reactor/DefaultHttpRequestDispatcher.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/main/java/io/gravitee/gateway/reactive/reactor/DefaultHttpRequestDispatcher.java
@@ -19,6 +19,7 @@ import static io.gravitee.gateway.reactive.api.context.InternalContextAttributes
 import static io.gravitee.gateway.reactive.api.context.InternalContextAttributes.ATTR_INTERNAL_SERVER_ID;
 import static io.gravitee.gateway.reactive.api.context.InternalContextAttributes.ATTR_INTERNAL_TRACING_ERROR;
 import static io.gravitee.gateway.reactive.api.context.InternalContextAttributes.ATTR_INTERNAL_TRACING_ROOT_SPAN;
+import static io.gravitee.gateway.reactive.http.vertx.VertxHttpServerRequest.NETTY_ATTR_REQUEST_CONTEXT;
 
 import io.gravitee.common.http.IdGenerator;
 import io.gravitee.common.http.MediaType;
@@ -56,6 +57,7 @@ import io.gravitee.node.api.opentelemetry.Span;
 import io.gravitee.node.api.opentelemetry.http.ObservableHttpServerRequest;
 import io.gravitee.node.api.opentelemetry.http.ObservableHttpServerResponse;
 import io.gravitee.reporter.api.v4.metric.Metrics;
+import io.netty.util.AttributeKey;
 import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.CompletableEmitter;
 import io.reactivex.rxjava3.schedulers.Schedulers;
@@ -63,6 +65,7 @@ import io.smallrye.common.vertx.VertxContext;
 import io.vertx.core.Context;
 import io.vertx.core.Vertx;
 import io.vertx.core.http.HttpVersion;
+import io.vertx.core.http.impl.HttpServerConnection;
 import io.vertx.rxjava3.core.http.HttpHeaders;
 import io.vertx.rxjava3.core.http.HttpServerRequest;
 import java.util.List;
@@ -84,6 +87,7 @@ public class DefaultHttpRequestDispatcher implements HttpRequestDispatcher {
 
     private static final String ATTR_INTERNAL_VERTX_TIMER_ID = ContextAttributes.ATTR_PREFIX + "vertx-timer-id";
     public static final String ATTR_ENTRYPOINT = ContextAttributes.ATTR_PREFIX + "entrypoint";
+    private static final AttributeKey<Object> REQUEST_CONTEXT_ATTR_KEY = AttributeKey.valueOf(NETTY_ATTR_REQUEST_CONTEXT);
     private final GatewayConfiguration gatewayConfiguration;
     private final HttpAcceptorResolver httpAcceptorResolver;
     private final IdGenerator idGenerator;
@@ -262,6 +266,12 @@ public class DefaultHttpRequestDispatcher implements HttpRequestDispatcher {
         ctx.componentProvider(globalComponentProvider);
         ctx.setInternalAttribute(ATTR_INTERNAL_LISTENER_TYPE, ListenerType.HTTP);
         ctx.setInternalAttribute(ATTR_INTERNAL_SERVER_ID, serverId);
+
+        // Stash the in-flight context on the connection so the Vert.x connection exception/close handler
+        // (HttpProtocolVerticle) can classify a client-side close (RST, broken pipe, idle timeout, …) onto the
+        // in-flight request before the dispose chain reaches the endpoint connector and emits a generic 499
+        // (APIM-12769).
+        ((HttpServerConnection) httpServerRequest.connection().getDelegate()).channel().attr(REQUEST_CONTEXT_ATTR_KEY).set(ctx);
 
         return ctx;
     }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/test/java/io/gravitee/gateway/reactive/reactor/DefaultHttpRequestDispatcherTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-reactor/src/test/java/io/gravitee/gateway/reactive/reactor/DefaultHttpRequestDispatcherTest.java
@@ -17,6 +17,7 @@ package io.gravitee.gateway.reactive.reactor;
 
 import static io.gravitee.gateway.reactive.api.context.InternalContextAttributes.ATTR_INTERNAL_TRACING_ROOT_SPAN;
 import static io.gravitee.gateway.reactive.http.vertx.VertxHttpServerRequest.NETTY_ATTR_CONNECTION_TIME;
+import static io.gravitee.gateway.reactive.http.vertx.VertxHttpServerRequest.NETTY_ATTR_REQUEST_CONTEXT;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
@@ -229,6 +230,7 @@ class DefaultHttpRequestDispatcherTest {
         lenient().when(httpConnection.getDelegate()).thenReturn(httpServerConnection);
         lenient().when(httpServerConnection.channel()).thenReturn(channel);
         lenient().when(channel.attr(AttributeKey.valueOf(NETTY_ATTR_CONNECTION_TIME))).thenReturn(attribute);
+        lenient().when(channel.attr(AttributeKey.valueOf(NETTY_ATTR_REQUEST_CONTEXT))).thenReturn(attribute);
         lenient().when(attribute.get()).thenReturn(System.currentTimeMillis());
     }
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/main/java/io/gravitee/gateway/reactive/standalone/vertx/HttpProtocolVerticle.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/main/java/io/gravitee/gateway/reactive/standalone/vertx/HttpProtocolVerticle.java
@@ -16,11 +16,24 @@
 package io.gravitee.gateway.reactive.standalone.vertx;
 
 import static io.gravitee.gateway.reactive.http.vertx.VertxHttpServerRequest.NETTY_ATTR_CONNECTION_TIME;
+import static io.gravitee.gateway.reactive.http.vertx.VertxHttpServerRequest.NETTY_ATTR_REQUEST_CONTEXT;
 
 import io.gravitee.common.http.HttpStatusCode;
+import io.gravitee.gateway.reactive.api.ExecutionFailure;
+import io.gravitee.gateway.reactive.api.context.base.BaseExecutionContext;
+import io.gravitee.gateway.reactive.api.context.http.HttpBaseExecutionContext;
+import io.gravitee.gateway.reactive.core.context.ComponentScope;
+import io.gravitee.gateway.reactive.core.context.diagnostic.DiagnosticReportHelper;
 import io.gravitee.gateway.reactive.reactor.HttpRequestDispatcher;
 import io.gravitee.node.api.server.ServerManager;
 import io.gravitee.node.vertx.server.http.VertxHttpServer;
+import io.gravitee.reporter.api.v4.metric.Diagnostic;
+import io.gravitee.reporter.api.v4.metric.Metrics;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.channel.ChannelPipeline;
+import io.netty.handler.timeout.IdleStateEvent;
 import io.netty.util.AttributeKey;
 import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.Flowable;
@@ -33,6 +46,7 @@ import io.vertx.rxjava3.core.Vertx;
 import io.vertx.rxjava3.core.http.HttpServer;
 import io.vertx.rxjava3.core.http.HttpServerRequest;
 import io.vertx.rxjava3.core.http.HttpServerResponse;
+import java.nio.channels.ClosedChannelException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -167,13 +181,202 @@ public class HttpProtocolVerticle extends AbstractVerticle {
         }
     }
 
+    static final String CLIENT_ABORTED_TCP_RESET = "CLIENT_ABORTED_TCP_RESET";
+    static final String CLIENT_ABORTED_BROKEN_PIPE = "CLIENT_ABORTED_BROKEN_PIPE";
+    static final String CLIENT_ABORTED_IDLE_TIMEOUT = "CLIENT_ABORTED_IDLE_TIMEOUT";
+    static final String CLIENT_ABORTED_CHANNEL_CLOSED = "CLIENT_ABORTED_CHANNEL_CLOSED";
+    static final String CLIENT_ABORTED_TCP_RESET_MESSAGE = "The client reset the connection";
+    static final String CLIENT_ABORTED_BROKEN_PIPE_MESSAGE = "The client closed the connection while the response was being written";
+    static final String CLIENT_ABORTED_IDLE_TIMEOUT_MESSAGE = "The connection was closed after the client idle timeout elapsed";
+    static final String CLIENT_ABORTED_CHANNEL_CLOSED_MESSAGE = "The client closed the connection";
+
+    /** Name of the inbound handler we install to capture {@link IdleStateEvent} before Vert.x closes the channel. */
+    private static final String IDLE_REASON_HANDLER_NAME = "gravitee-client-close-reason";
+    /** Name Vert.x 4.5 gives the {@code IdleStateHandler} it installs when {@code http.idleTimeout} is configured. */
+    private static final String VERTX_IDLE_HANDLER_NAME = "idle";
+    /** Marker stored on the channel so {@code closeHandler} can tell an idle-timeout close apart from a plain FIN. */
+    private static final String IDLE_CLOSE_REASON = "IDLE_TIMEOUT";
+    private static final AttributeKey<Object> REQUEST_CONTEXT_ATTR_KEY = AttributeKey.valueOf(NETTY_ATTR_REQUEST_CONTEXT);
+    private static final AttributeKey<Object> CLIENT_CLOSE_REASON_ATTR_KEY = AttributeKey.valueOf("graviteeClientCloseReason");
+
     private void configureConnectionHandlers(HttpServerRequest request, Disposable dispatchDisposable) {
+        installIdleCloseReasonHandler(request);
         request
             .connection()
             // Must be added to ensure closed connection or error disposes underlying subscription.
-            .exceptionHandler(event -> gracefulDispose(dispatchDisposable))
-            .closeHandler(event -> gracefulDispose(dispatchDisposable));
+            .exceptionHandler(event -> {
+                recordClientCloseReason(request, event);
+                gracefulDispose(dispatchDisposable);
+            })
+            .closeHandler(event -> {
+                // A Vert.x server idle-timeout close arrives here with no Throwable (it never reaches the
+                // exceptionHandler), so we rely on the marker set by IdleCloseReasonHandler to identify it.
+                recordIdleCloseReason(request);
+                gracefulDispose(dispatchDisposable);
+            });
     }
+
+    /**
+     * Install, once per connection, a tiny inbound handler right after Vert.x's {@code IdleStateHandler}
+     * (named {@value #VERTX_IDLE_HANDLER_NAME}) so we can observe the {@link IdleStateEvent} it fires and
+     * record an idle marker on the channel <em>before</em> Vert.x reacts to that event by closing the
+     * connection.
+     * <p>
+     * Without this, a server {@code http.idleTimeout} close is indistinguishable from a normal client FIN at
+     * {@code closeHandler} time, and {@link #CLIENT_ABORTED_IDLE_TIMEOUT} would be unreachable (APIM-12769).
+     * Only installed when the idle handler is present (i.e. {@code http.idleTimeout} is configured).
+     */
+    private void installIdleCloseReasonHandler(HttpServerRequest request) {
+        try {
+            Channel channel = ((HttpServerConnection) request.connection().getDelegate()).channel();
+            ChannelPipeline pipeline = channel.pipeline();
+            if (pipeline.get(IDLE_REASON_HANDLER_NAME) == null && pipeline.get(VERTX_IDLE_HANDLER_NAME) != null) {
+                pipeline.addAfter(VERTX_IDLE_HANDLER_NAME, IDLE_REASON_HANDLER_NAME, new IdleCloseReasonHandler());
+            }
+        } catch (Exception e) {
+            log.debug("Unable to install idle-close-reason handler", e);
+        }
+    }
+
+    /**
+     * Inbound handler that records an idle marker on the channel when Netty's {@code IdleStateHandler} signals
+     * inactivity, then forwards the event so Vert.x still closes the connection as it normally would.
+     */
+    private static class IdleCloseReasonHandler extends ChannelInboundHandlerAdapter {
+
+        @Override
+        public void userEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
+            if (evt instanceof IdleStateEvent) {
+                ctx.channel().attr(CLIENT_CLOSE_REASON_ATTR_KEY).set(IDLE_CLOSE_REASON);
+            }
+            super.userEventTriggered(ctx, evt);
+        }
+    }
+
+    /**
+     * If the connection was closed because of a server idle timeout (flagged by {@link IdleCloseReasonHandler}),
+     * decorate the in-flight request metrics with {@link #CLIENT_ABORTED_IDLE_TIMEOUT}.
+     */
+    private void recordIdleCloseReason(HttpServerRequest request) {
+        try {
+            Channel channel = ((HttpServerConnection) request.connection().getDelegate()).channel();
+            if (IDLE_CLOSE_REASON.equals(channel.attr(CLIENT_CLOSE_REASON_ATTR_KEY).get())) {
+                decorateClientClose(request, CLIENT_ABORTED_IDLE_TIMEOUT, CLIENT_ABORTED_IDLE_TIMEOUT_MESSAGE, null);
+            }
+        } catch (Exception e) {
+            log.debug("Unable to record idle close reason", e);
+        }
+    }
+
+    /**
+     * Best-effort: classify the Vert.x connection-level {@link Throwable} that signaled a client-side close
+     * (RST, broken pipe, …) and surface it on the request {@link Metrics} so it appears in access logs and
+     * analytics — instead of the generic "CLIENT_ABORTED_DURING_RESPONSE_ERROR" fallback (APIM-12769).
+     */
+    private void recordClientCloseReason(HttpServerRequest request, Throwable cause) {
+        if (cause == null) {
+            return;
+        }
+        ClientCloseReason reason = classifyClientClose(cause);
+        decorateClientClose(request, reason.key(), reason.message(), cause);
+    }
+
+    /**
+     * Decorate the in-flight request {@link Metrics} with a client-close failure, going through
+     * {@link DiagnosticReportHelper} — the same path {@code AbstractExecutionContext.interruptWith} uses for
+     * upstream errors — so the {@link Diagnostic} written here is shape-compatible with every other V4 failure
+     * path. No-op when there is no in-flight context/metrics, or when a more specific failure was already set.
+     */
+    private void decorateClientClose(HttpServerRequest request, String key, String message, Throwable cause) {
+        try {
+            Object stashed = ((HttpServerConnection) request.connection().getDelegate()).channel().attr(REQUEST_CONTEXT_ATTR_KEY).get();
+            if (stashed instanceof HttpBaseExecutionContext ctx) {
+                decorateContext(ctx, key, message, cause);
+            }
+        } catch (Exception classificationError) {
+            log.debug("Failed to classify client close reason", classificationError);
+        }
+    }
+
+    private void decorateContext(HttpBaseExecutionContext ctx, String key, String message, Throwable cause) {
+        Metrics metrics = ctx.metrics();
+        if (metrics == null) {
+            // MetricsProcessor hasn't run yet (extremely early abort) — nothing to decorate.
+            return;
+        }
+        if (metrics.getFailure() != null || metrics.getErrorKey() != null) {
+            // A more specific classifier (e.g. the upstream connector), or another close handler, already set it.
+            return;
+        }
+        ExecutionFailure failure = new ExecutionFailure(499).key(key).message(message);
+        if (cause != null) {
+            failure.cause(cause);
+        }
+        ComponentScope.ComponentEntry component = ComponentScope.peek((BaseExecutionContext) ctx);
+        Diagnostic diagnostic = DiagnosticReportHelper.fromExecutionFailure(
+            component,
+            metrics.getErrorKey(),
+            metrics.getErrorMessage(),
+            failure
+        );
+        metrics.setFailure(diagnostic);
+        // Legacy fields kept in sync so dashboards reading the flat error-key/error-message still work.
+        metrics.setErrorKey(diagnostic.getKey());
+        metrics.setErrorMessage(diagnostic.getMessage());
+        log.debug("Classified client close reason as {}", key);
+    }
+
+    static ClientCloseReason classifyClientClose(Throwable cause) {
+        if (hasCause(cause, ClosedChannelException.class)) {
+            return new ClientCloseReason(CLIENT_ABORTED_CHANNEL_CLOSED, CLIENT_ABORTED_CHANNEL_CLOSED_MESSAGE);
+        }
+        // Scan the whole cause chain: the close cause is sometimes wrapped, so the top-level message alone is not
+        // enough (consistent with the upstream connector's classification).
+        String message = collectChainMessages(cause);
+        if (message != null) {
+            if (message.contains("Connection reset")) {
+                return new ClientCloseReason(CLIENT_ABORTED_TCP_RESET, CLIENT_ABORTED_TCP_RESET_MESSAGE);
+            }
+            if (message.contains("Broken pipe")) {
+                return new ClientCloseReason(CLIENT_ABORTED_BROKEN_PIPE, CLIENT_ABORTED_BROKEN_PIPE_MESSAGE);
+            }
+        }
+        // Default for any other IO/connection error reaching the exception handler.
+        return new ClientCloseReason(CLIENT_ABORTED_CHANNEL_CLOSED, CLIENT_ABORTED_CHANNEL_CLOSED_MESSAGE);
+    }
+
+    /** Walk the cause chain looking for a given exception type (the close cause may be wrapped). */
+    private static boolean hasCause(Throwable t, Class<? extends Throwable> type) {
+        Throwable current = t;
+        while (current != null) {
+            if (type.isInstance(current)) {
+                return true;
+            }
+            if (current.getCause() == current) {
+                break;
+            }
+            current = current.getCause();
+        }
+        return false;
+    }
+
+    /** Concatenate the messages along the cause chain so message-based detection survives wrapping. */
+    private static String collectChainMessages(Throwable t) {
+        StringBuilder sb = new StringBuilder();
+        Throwable current = t;
+        while (current != null) {
+            if (current.getMessage() != null) {
+                sb.append(current.getMessage()).append('\n');
+            }
+            if (current.getCause() == current) {
+                break;
+            }
+            current = current.getCause();
+        }
+        return sb.isEmpty() ? null : sb.toString();
+    }
+
+    record ClientCloseReason(String key, String message) {}
 
     private void gracefulDispose(Disposable dispatchDisposable) {
         if (!dispatchDisposable.isDisposed()) {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/test/java/io/gravitee/gateway/reactive/standalone/vertx/HttpProtocolVerticleClassifyTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/test/java/io/gravitee/gateway/reactive/standalone/vertx/HttpProtocolVerticleClassifyTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.reactive.standalone.vertx;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.gateway.reactive.standalone.vertx.HttpProtocolVerticle.ClientCloseReason;
+import java.io.IOException;
+import java.nio.channels.ClosedChannelException;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit coverage for {@link HttpProtocolVerticle#classifyClientClose(Throwable)} — pins the (key, message)
+ * mapping for the client-close reasons that reach the connection exception handler (APIM-12769). The idle
+ * path is intentionally not covered here: it is signalled out-of-band by a channel attribute, not by a
+ * {@link Throwable}, and is validated end-to-end in {@code ConnectionErrorClassificationV4IntegrationTest}.
+ */
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class HttpProtocolVerticleClassifyTest {
+
+    @Test
+    void should_classify_connection_reset_as_tcp_reset() {
+        ClientCloseReason reason = HttpProtocolVerticle.classifyClientClose(new IOException("Connection reset by peer"));
+        assertThat(reason.key()).isEqualTo(HttpProtocolVerticle.CLIENT_ABORTED_TCP_RESET);
+        assertThat(reason.message()).isEqualTo(HttpProtocolVerticle.CLIENT_ABORTED_TCP_RESET_MESSAGE);
+    }
+
+    @Test
+    void should_classify_wrapped_connection_reset_via_cause_chain() {
+        ClientCloseReason reason = HttpProtocolVerticle.classifyClientClose(
+            new RuntimeException("wrapper", new IOException("Connection reset by peer"))
+        );
+        assertThat(reason.key()).isEqualTo(HttpProtocolVerticle.CLIENT_ABORTED_TCP_RESET);
+    }
+
+    @Test
+    void should_classify_broken_pipe() {
+        ClientCloseReason reason = HttpProtocolVerticle.classifyClientClose(new IOException("Broken pipe"));
+        assertThat(reason.key()).isEqualTo(HttpProtocolVerticle.CLIENT_ABORTED_BROKEN_PIPE);
+        assertThat(reason.message()).isEqualTo(HttpProtocolVerticle.CLIENT_ABORTED_BROKEN_PIPE_MESSAGE);
+    }
+
+    @Test
+    void should_classify_closed_channel_exception_as_channel_closed() {
+        ClientCloseReason reason = HttpProtocolVerticle.classifyClientClose(new ClosedChannelException());
+        assertThat(reason.key()).isEqualTo(HttpProtocolVerticle.CLIENT_ABORTED_CHANNEL_CLOSED);
+        assertThat(reason.message()).isEqualTo(HttpProtocolVerticle.CLIENT_ABORTED_CHANNEL_CLOSED_MESSAGE);
+    }
+
+    @Test
+    void should_default_unrecognised_cause_to_channel_closed() {
+        ClientCloseReason reason = HttpProtocolVerticle.classifyClientClose(new RuntimeException("something else"));
+        assertThat(reason.key()).isEqualTo(HttpProtocolVerticle.CLIENT_ABORTED_CHANNEL_CLOSED);
+        assertThat(reason.message()).isEqualTo(HttpProtocolVerticle.CLIENT_ABORTED_CHANNEL_CLOSED_MESSAGE);
+    }
+}

--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/ConnectionErrorClassificationV4IntegrationTest.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/ConnectionErrorClassificationV4IntegrationTest.java
@@ -1,0 +1,452 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.integration.tests.http;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.ok;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.github.tomakehurst.wiremock.http.Fault;
+import io.gravitee.apim.gateway.tests.sdk.AbstractGatewayTest;
+import io.gravitee.apim.gateway.tests.sdk.annotations.DeployApi;
+import io.gravitee.apim.gateway.tests.sdk.annotations.GatewayTest;
+import io.gravitee.apim.gateway.tests.sdk.configuration.GatewayConfigurationBuilder;
+import io.gravitee.apim.gateway.tests.sdk.connector.EndpointBuilder;
+import io.gravitee.apim.gateway.tests.sdk.connector.EntrypointBuilder;
+import io.gravitee.apim.gateway.tests.sdk.parameters.GatewayDynamicConfig;
+import io.gravitee.apim.gateway.tests.sdk.reporter.FakeReporter;
+import io.gravitee.definition.model.v4.Api;
+import io.gravitee.definition.model.v4.analytics.Analytics;
+import io.gravitee.gateway.reactor.ReactableApi;
+import io.gravitee.plugin.endpoint.EndpointConnectorPlugin;
+import io.gravitee.plugin.endpoint.http.proxy.HttpProxyEndpointConnectorFactory;
+import io.gravitee.plugin.entrypoint.EntrypointConnectorPlugin;
+import io.gravitee.plugin.entrypoint.http.proxy.HttpProxyEntrypointConnectorFactory;
+import io.gravitee.reporter.api.v4.metric.Metrics;
+import io.reactivex.rxjava3.subjects.BehaviorSubject;
+import io.vertx.core.http.HttpClientOptions;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.core.net.NetClientOptions;
+import io.vertx.rxjava3.core.Vertx;
+import io.vertx.rxjava3.core.http.HttpClient;
+import io.vertx.rxjava3.core.http.HttpClientRequest;
+import java.io.IOException;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * End-to-end coverage for the connection-error classification carved out by APIM-12769. For every error key
+ * we induce the <em>real</em> failure (no mocked exceptions) and assert the reported {@link Metrics} carries
+ * the expected status, error key and message — proving both halves of the classifier are actually reachable
+ * with the exception types/messages we assumed.
+ * <p>
+ * The classifier mapping itself (which exception/message maps to which key) is exhaustively unit-tested in
+ * {@code HttpProxyEndpointConnectorTest} and {@code HttpProtocolVerticleClassifyTest}; these integration tests
+ * validate the runtime assumptions those unit tests cannot (which callback fires, what message the stack emits).
+ *
+ * @author GraviteeSource Team
+ */
+class ConnectionErrorClassificationV4IntegrationTest {
+
+    private static final String API_PATH = "/test";
+    private static final String ENDPOINT_PATH = "/endpoint";
+
+    private static void configureProxyEntrypoint(Map<String, EntrypointConnectorPlugin<?, ?>> entrypoints) {
+        entrypoints.putIfAbsent("http-proxy", EntrypointBuilder.build("http-proxy", HttpProxyEntrypointConnectorFactory.class));
+    }
+
+    private static void configureProxyEndpoint(Map<String, EndpointConnectorPlugin<?, ?>> endpoints) {
+        endpoints.putIfAbsent("http-proxy", EndpointBuilder.build("http-proxy", HttpProxyEndpointConnectorFactory.class));
+    }
+
+    private static void enableAnalytics(ReactableApi<?> api) {
+        if (api.getDefinition() instanceof Api definition) {
+            var analytics = new Analytics();
+            analytics.setEnabled(true);
+            definition.setAnalytics(analytics);
+        }
+    }
+
+    private static BehaviorSubject<Metrics> captureReportedMetrics(FakeReporter fakeReporter) {
+        BehaviorSubject<Metrics> subject = BehaviorSubject.create();
+        fakeReporter.setReportableHandler(reportable -> {
+            if (reportable instanceof Metrics metrics) {
+                subject.onNext(metrics.toBuilder().build());
+            }
+        });
+        return subject;
+    }
+
+    /**
+     * Wait for the first reported {@link Metrics} carrying an error key and assert its status, key and (a
+     * substring of) its message. Failing assertions surface the <em>actual</em> key/message so a wrong
+     * runtime assumption is immediately visible.
+     */
+    private static void assertReportedError(
+        BehaviorSubject<Metrics> metricsSubject,
+        int expectedStatus,
+        String expectedKey,
+        String expectedMessageContains
+    ) {
+        metricsSubject
+            .filter(metrics -> metrics.getErrorKey() != null)
+            .take(1)
+            .test()
+            .awaitDone(30, TimeUnit.SECONDS)
+            .assertValue(metrics -> {
+                assertThat(metrics.getStatus()).isEqualTo(expectedStatus);
+                assertThat(metrics.getErrorKey()).isEqualTo(expectedKey);
+                // The actionable message is carried on the V4 Diagnostic (metrics.failure), which both the
+                // connector's interruptWith path and the connection-handler decoration populate. The legacy
+                // flat errorMessage is only set on some paths, so we assert against the Diagnostic.
+                assertThat(metrics.getFailure()).as("failure diagnostic").isNotNull();
+                assertThat(metrics.getFailure().getKey()).isEqualTo(expectedKey);
+                assertThat(metrics.getFailure().getMessage()).contains(expectedMessageContains);
+                return true;
+            });
+    }
+
+    private static String targetConfiguration(String target) {
+        ObjectNode configuration = new ObjectMapper().createObjectNode();
+        configuration.put("target", target);
+        return configuration.toString();
+    }
+
+    // -----------------------------------------------------------------------------------------------------
+    // Upstream (gateway-as-client) failures surfaced through the endpoint connector.
+    // -----------------------------------------------------------------------------------------------------
+
+    @Nested
+    @GatewayTest
+    @DeployApi("/apis/v4/http/api.json")
+    class UpstreamFaults extends AbstractGatewayTest {
+
+        private BehaviorSubject<Metrics> metricsSubject;
+
+        @BeforeEach
+        void setUp() {
+            metricsSubject = captureReportedMetrics(getBean(FakeReporter.class));
+        }
+
+        @Override
+        public void configureEntrypoints(Map<String, EntrypointConnectorPlugin<?, ?>> entrypoints) {
+            configureProxyEntrypoint(entrypoints);
+        }
+
+        @Override
+        public void configureEndpoints(Map<String, EndpointConnectorPlugin<?, ?>> endpoints) {
+            configureProxyEndpoint(endpoints);
+        }
+
+        @Override
+        public void configureApi(ReactableApi<?> api, Class<?> definitionClass) {
+            enableAnalytics(api);
+        }
+
+        @Test
+        @DisplayName("Upstream resets the connection -> 502 UPSTREAM_CONNECTION_RESET")
+        void should_classify_upstream_connection_reset(HttpClient httpClient) {
+            wiremock.stubFor(get(urlPathEqualTo(ENDPOINT_PATH)).willReturn(aResponse().withFault(Fault.CONNECTION_RESET_BY_PEER)));
+
+            sendGet(httpClient);
+
+            assertReportedError(metricsSubject, 502, "UPSTREAM_CONNECTION_RESET", "The upstream reset the connection");
+        }
+
+        @Test
+        @DisplayName("Upstream closes the connection without responding -> 502 UPSTREAM_CONNECTION_CLOSED")
+        void should_classify_upstream_connection_closed(HttpClient httpClient) {
+            wiremock.stubFor(get(urlPathEqualTo(ENDPOINT_PATH)).willReturn(aResponse().withFault(Fault.EMPTY_RESPONSE)));
+
+            sendGet(httpClient);
+
+            assertReportedError(metricsSubject, 502, "UPSTREAM_CONNECTION_CLOSED", "The upstream closed the connection");
+        }
+    }
+
+    @Nested
+    @GatewayTest
+    @DeployApi("/apis/v4/http/api.json")
+    class UpstreamDnsFailure extends AbstractGatewayTest {
+
+        private BehaviorSubject<Metrics> metricsSubject;
+
+        @BeforeEach
+        void setUp() {
+            metricsSubject = captureReportedMetrics(getBean(FakeReporter.class));
+        }
+
+        @Override
+        public void configureEntrypoints(Map<String, EntrypointConnectorPlugin<?, ?>> entrypoints) {
+            configureProxyEntrypoint(entrypoints);
+        }
+
+        @Override
+        public void configureEndpoints(Map<String, EndpointConnectorPlugin<?, ?>> endpoints) {
+            configureProxyEndpoint(endpoints);
+        }
+
+        @Override
+        public void configureApi(ReactableApi<?> api, Class<?> definitionClass) {
+            enableAnalytics(api);
+            // Host that cannot resolve. The ".invalid" TLD is reserved by RFC 2606 and never resolves.
+            // The port is irrelevant: DNS resolution fails first. Not the localhost:8080 placeholder, so the
+            // SDK leaves it untouched.
+            if (api.getDefinition() instanceof Api definition) {
+                updateEndpoints(definition, endpoint ->
+                    endpoint.setConfiguration(targetConfiguration("http://gravitee-upstream-does-not-exist.invalid:8080" + ENDPOINT_PATH))
+                );
+            }
+        }
+
+        @Test
+        @DisplayName("Upstream host does not resolve -> 502 UPSTREAM_DNS_FAILURE")
+        void should_classify_dns_failure(HttpClient httpClient) {
+            sendGet(httpClient);
+
+            assertReportedError(metricsSubject, 502, "UPSTREAM_DNS_FAILURE", "Unable to resolve the upstream host");
+        }
+    }
+
+    @Nested
+    @GatewayTest
+    @DeployApi("/apis/v4/http/api.json")
+    class UpstreamConnectionRefused extends AbstractGatewayTest {
+
+        private BehaviorSubject<Metrics> metricsSubject;
+
+        @BeforeEach
+        void setUp() {
+            metricsSubject = captureReportedMetrics(getBean(FakeReporter.class));
+        }
+
+        @Override
+        public void configureEntrypoints(Map<String, EntrypointConnectorPlugin<?, ?>> entrypoints) {
+            configureProxyEntrypoint(entrypoints);
+        }
+
+        @Override
+        public void configureEndpoints(Map<String, EndpointConnectorPlugin<?, ?>> endpoints) {
+            configureProxyEndpoint(endpoints);
+        }
+
+        @Override
+        public void configureApi(ReactableApi<?> api, Class<?> definitionClass) {
+            enableAnalytics(api);
+            // Port 1 on loopback is (effectively always) closed -> immediate TCP connection refused. Not the
+            // localhost:8080 placeholder, so the SDK leaves it untouched.
+            if (api.getDefinition() instanceof Api definition) {
+                updateEndpoints(definition, endpoint ->
+                    endpoint.setConfiguration(targetConfiguration("http://127.0.0.1:1" + ENDPOINT_PATH))
+                );
+            }
+        }
+
+        @Test
+        @DisplayName("Upstream refuses the connection -> 502 UPSTREAM_CONNECTION_REFUSED")
+        void should_classify_connection_refused(HttpClient httpClient) {
+            sendGet(httpClient);
+
+            assertReportedError(metricsSubject, 502, "UPSTREAM_CONNECTION_REFUSED", "The upstream refused the connection");
+        }
+    }
+
+    @Nested
+    @GatewayTest
+    @DeployApi("/apis/v4/http/api.json")
+    class UpstreamIdleTimeout extends AbstractGatewayTest {
+
+        private static final int HANG_BACKEND_PORT = 19998;
+
+        private BehaviorSubject<Metrics> metricsSubject;
+
+        @BeforeEach
+        void setUp() {
+            metricsSubject = captureReportedMetrics(getBean(FakeReporter.class));
+        }
+
+        @Override
+        public void configureEntrypoints(Map<String, EntrypointConnectorPlugin<?, ?>> entrypoints) {
+            configureProxyEntrypoint(entrypoints);
+        }
+
+        @Override
+        public void configureEndpoints(Map<String, EndpointConnectorPlugin<?, ?>> endpoints) {
+            configureProxyEndpoint(endpoints);
+        }
+
+        @Override
+        public void configureApi(ReactableApi<?> api, Class<?> definitionClass) {
+            enableAnalytics(api);
+            // Point at the silent backend (below); short idleTimeout, longer readTimeout so idle fires first.
+            // A WireMock delayed response does not reproduce a Vert.x connection-idle — only a truly silent
+            // socket does — so we use a raw hang backend rather than WireMock here.
+            if (api.getDefinition() instanceof Api definition) {
+                updateEndpoints(definition, endpoint -> {
+                    endpoint.setConfiguration(targetConfiguration("http://localhost:" + HANG_BACKEND_PORT + ENDPOINT_PATH));
+                    endpoint.setSharedConfigurationOverride(
+                        "{\"http\":{\"idleTimeout\":2000,\"readTimeout\":8000,\"connectTimeout\":3000}}"
+                    );
+                });
+            }
+        }
+
+        @Test
+        @DisplayName("Endpoint idle timeout closes the upstream connection -> 504 UPSTREAM_IDLE_TIMEOUT")
+        void should_classify_upstream_idle_timeout(HttpClient httpClient) throws Exception {
+            try (ServerSocket hangBackend = new ServerSocket(HANG_BACKEND_PORT)) {
+                List<Socket> held = new ArrayList<>();
+                Thread acceptor = new Thread(() -> {
+                    try {
+                        while (!hangBackend.isClosed()) {
+                            held.add(hangBackend.accept()); // accept and hold the connection; never respond
+                        }
+                    } catch (IOException ignored) {
+                        // server socket closed at end of test
+                    }
+                });
+                acceptor.setDaemon(true);
+                acceptor.start();
+
+                sendGet(httpClient);
+
+                assertReportedError(metricsSubject, 504, "UPSTREAM_IDLE_TIMEOUT", "idle timeout");
+
+                for (Socket socket : held) {
+                    socket.close();
+                }
+            }
+        }
+    }
+
+    // -----------------------------------------------------------------------------------------------------
+    // Server (gateway-as-server) client-abort failures surfaced through the connection-level handlers.
+    // -----------------------------------------------------------------------------------------------------
+
+    @Nested
+    @GatewayTest
+    @DeployApi("/apis/v4/http/api.json")
+    class ClientTcpReset extends AbstractGatewayTest {
+
+        private BehaviorSubject<Metrics> metricsSubject;
+
+        @BeforeEach
+        void setUp() {
+            metricsSubject = captureReportedMetrics(getBean(FakeReporter.class));
+        }
+
+        @Override
+        public void configureEntrypoints(Map<String, EntrypointConnectorPlugin<?, ?>> entrypoints) {
+            configureProxyEntrypoint(entrypoints);
+        }
+
+        @Override
+        public void configureEndpoints(Map<String, EndpointConnectorPlugin<?, ?>> endpoints) {
+            configureProxyEndpoint(endpoints);
+        }
+
+        @Override
+        public void configureApi(ReactableApi<?> api, Class<?> definitionClass) {
+            enableAnalytics(api);
+        }
+
+        @Test
+        @DisplayName("Client resets the TCP connection mid-request -> 499 CLIENT_ABORTED_TCP_RESET")
+        void should_classify_client_tcp_reset(Vertx vertx, GatewayDynamicConfig.Config gatewayConfig) {
+            // Backend is slow so the request is still in flight when the client sends a RST.
+            wiremock.stubFor(get(urlPathEqualTo(ENDPOINT_PATH)).willReturn(ok("backend").withFixedDelay(5000)));
+
+            int port = gatewayConfig.httpPort();
+            // soLinger=0 -> close() emits a TCP RST instead of a graceful FIN, which the gateway sees as
+            // "Connection reset by peer" on its connection exception handler.
+            vertx
+                .createNetClient(new NetClientOptions().setSoLinger(0))
+                .rxConnect(port, "localhost")
+                .subscribe(socket -> {
+                    socket.write("GET " + API_PATH + " HTTP/1.1\r\nHost: localhost:" + port + "\r\n\r\n");
+                    // Close (RST) once the request is dispatched and waiting on the slow backend.
+                    vertx.getDelegate().setTimer(800, id -> socket.getDelegate().close());
+                });
+
+            assertReportedError(metricsSubject, 499, "CLIENT_ABORTED_TCP_RESET", "The client reset the connection");
+        }
+    }
+
+    @Nested
+    @GatewayTest
+    @DeployApi("/apis/v4/http/api.json")
+    class ClientIdleTimeout extends AbstractGatewayTest {
+
+        private BehaviorSubject<Metrics> metricsSubject;
+
+        @BeforeEach
+        void setUp() {
+            metricsSubject = captureReportedMetrics(getBean(FakeReporter.class));
+        }
+
+        @Override
+        protected void configureGateway(GatewayConfigurationBuilder gatewayConfigurationBuilder) {
+            super.configureGateway(gatewayConfigurationBuilder);
+            // http.idleTimeout is expressed in SECONDS (Vert.x default unit; the node layer never overrides it).
+            gatewayConfigurationBuilder.set("http.idleTimeout", 1);
+        }
+
+        @Override
+        public void configureEntrypoints(Map<String, EntrypointConnectorPlugin<?, ?>> entrypoints) {
+            configureProxyEntrypoint(entrypoints);
+        }
+
+        @Override
+        public void configureEndpoints(Map<String, EndpointConnectorPlugin<?, ?>> endpoints) {
+            configureProxyEndpoint(endpoints);
+        }
+
+        @Override
+        public void configureApi(ReactableApi<?> api, Class<?> definitionClass) {
+            enableAnalytics(api);
+        }
+
+        @Test
+        @DisplayName("Server idle timeout closes an in-flight connection -> 499 CLIENT_ABORTED_IDLE_TIMEOUT")
+        void should_classify_idle_timeout(HttpClient httpClient) {
+            // Backend slower than the 1s server idle timeout: the inbound connection sits idle while the
+            // gateway waits, the server idle timeout fires and closes it -> the in-flight request is aborted.
+            wiremock.stubFor(get(urlPathEqualTo(ENDPOINT_PATH)).willReturn(ok("backend").withFixedDelay(8000)));
+
+            sendGet(httpClient);
+
+            assertReportedError(metricsSubject, 499, "CLIENT_ABORTED_IDLE_TIMEOUT", "idle timeout");
+        }
+    }
+
+    private static void sendGet(HttpClient httpClient) {
+        // Fire the request; the gateway reports metrics independently of whether the client reads the body
+        // (and for client-abort scenarios the send itself errors when the gateway closes the connection).
+        httpClient.rxRequest(HttpMethod.GET, API_PATH).flatMap(HttpClientRequest::rxSend).ignoreElement().onErrorComplete().subscribe();
+    }
+}

--- a/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-http-proxy/src/main/java/io/gravitee/plugin/endpoint/http/proxy/HttpProxyEndpointConnector.java
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-http-proxy/src/main/java/io/gravitee/plugin/endpoint/http/proxy/HttpProxyEndpointConnector.java
@@ -15,7 +15,6 @@
  */
 package io.gravitee.plugin.endpoint.http.proxy;
 
-import io.gravitee.common.http.HttpStatusCode;
 import io.gravitee.common.http.MediaType;
 import io.gravitee.gateway.api.http.HttpHeaderNames;
 import io.gravitee.gateway.reactive.api.ConnectorMode;
@@ -24,6 +23,7 @@ import io.gravitee.gateway.reactive.api.connector.endpoint.sync.HttpEndpointSync
 import io.gravitee.gateway.reactive.api.context.http.HttpExecutionContext;
 import io.gravitee.gateway.reactive.api.context.http.HttpRequest;
 import io.gravitee.gateway.reactive.core.context.interruption.InterruptionFailureException;
+import io.gravitee.plugin.endpoint.http.proxy.client.ConnectionFailureClassifier;
 import io.gravitee.plugin.endpoint.http.proxy.client.GrpcHttpClientFactory;
 import io.gravitee.plugin.endpoint.http.proxy.client.HttpClientFactory;
 import io.gravitee.plugin.endpoint.http.proxy.configuration.HttpProxyEndpointConnectorConfiguration;
@@ -32,12 +32,8 @@ import io.gravitee.plugin.endpoint.http.proxy.connector.GrpcConnector;
 import io.gravitee.plugin.endpoint.http.proxy.connector.HttpConnector;
 import io.gravitee.plugin.endpoint.http.proxy.connector.ProxyConnector;
 import io.gravitee.plugin.endpoint.http.proxy.connector.WebSocketConnector;
-import io.netty.channel.ConnectTimeoutException;
-import io.netty.handler.timeout.ReadTimeoutException;
 import io.reactivex.rxjava3.core.Completable;
-import io.vertx.circuitbreaker.TimeoutException;
 import io.vertx.core.impl.NoStackTraceTimeoutException;
-import java.io.IOException;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -52,8 +48,26 @@ public class HttpProxyEndpointConnector extends HttpEndpointSyncConnector {
 
     private static final String ENDPOINT_ID = "http-proxy";
     private final Set<ConnectorMode> SUPPORTED_MODES = Set.of(ConnectorMode.REQUEST_RESPONSE);
-    static final String GATEWAY_CLIENT_CONNECTION_ERROR = "GATEWAY_CLIENT_CONNECTION_ERROR";
-    static final String REQUEST_TIMEOUT = "REQUEST_TIMEOUT";
+    // Connection-failure keys/messages are owned by ConnectionFailureClassifier (single source of truth, shared
+    // with the WebSocket and gRPC connectors). Re-exported here for callers/tests that reference the connector.
+    static final String GATEWAY_CLIENT_CONNECTION_ERROR = ConnectionFailureClassifier.GATEWAY_CLIENT_CONNECTION_ERROR;
+    static final String REQUEST_TIMEOUT = ConnectionFailureClassifier.REQUEST_TIMEOUT;
+    static final String UPSTREAM_CONNECT_TIMEOUT = ConnectionFailureClassifier.UPSTREAM_CONNECT_TIMEOUT;
+    static final String UPSTREAM_IDLE_TIMEOUT = ConnectionFailureClassifier.UPSTREAM_IDLE_TIMEOUT;
+    static final String UPSTREAM_DNS_FAILURE = ConnectionFailureClassifier.UPSTREAM_DNS_FAILURE;
+    static final String UPSTREAM_CONNECTION_REFUSED = ConnectionFailureClassifier.UPSTREAM_CONNECTION_REFUSED;
+    static final String UPSTREAM_TLS_FAILURE = ConnectionFailureClassifier.UPSTREAM_TLS_FAILURE;
+    static final String UPSTREAM_CONNECTION_RESET = ConnectionFailureClassifier.UPSTREAM_CONNECTION_RESET;
+    static final String UPSTREAM_BROKEN_PIPE = ConnectionFailureClassifier.UPSTREAM_BROKEN_PIPE;
+    static final String UPSTREAM_CONNECTION_CLOSED = ConnectionFailureClassifier.UPSTREAM_CONNECTION_CLOSED;
+    static final String UPSTREAM_CONNECT_TIMEOUT_MESSAGE = ConnectionFailureClassifier.UPSTREAM_CONNECT_TIMEOUT_MESSAGE;
+    static final String UPSTREAM_IDLE_TIMEOUT_MESSAGE = ConnectionFailureClassifier.UPSTREAM_IDLE_TIMEOUT_MESSAGE;
+    static final String UPSTREAM_DNS_FAILURE_MESSAGE = ConnectionFailureClassifier.UPSTREAM_DNS_FAILURE_MESSAGE;
+    static final String UPSTREAM_CONNECTION_REFUSED_MESSAGE = ConnectionFailureClassifier.UPSTREAM_CONNECTION_REFUSED_MESSAGE;
+    static final String UPSTREAM_TLS_FAILURE_MESSAGE = ConnectionFailureClassifier.UPSTREAM_TLS_FAILURE_MESSAGE;
+    static final String UPSTREAM_CONNECTION_RESET_MESSAGE = ConnectionFailureClassifier.UPSTREAM_CONNECTION_RESET_MESSAGE;
+    static final String UPSTREAM_BROKEN_PIPE_MESSAGE = ConnectionFailureClassifier.UPSTREAM_BROKEN_PIPE_MESSAGE;
+    static final String UPSTREAM_CONNECTION_CLOSED_MESSAGE = ConnectionFailureClassifier.UPSTREAM_CONNECTION_CLOSED_MESSAGE;
     private static final String SERVER_NULL_PATTERN = " for server null";
     static final String CLIENT_ABORTED_DURING_RESPONSE_ERROR = "CLIENT_ABORTED_DURING_RESPONSE_ERROR";
     static final String CLIENT_ABORTED_DURING_RESPONSE_MESSAGE = "The response cannot be sent to the client because the client has aborted";
@@ -105,12 +119,18 @@ public class HttpProxyEndpointConnector extends HttpEndpointSyncConnector {
     /**
      * Handle client abort by setting appropriate error status and metrics.
      * This is called when the client disconnects before the response is fully delivered.
+     * <p>
+     * If the Vert.x connection-level exception handler already classified the close reason
+     * (TCP reset, broken pipe, idle timeout, …), keep that more specific information instead
+     * of overwriting it with the generic fallback (APIM-12769).
      */
     private void handleClientAbort(final HttpExecutionContext ctx) {
         if (ctx.response().status() == 0) {
             ctx.response().status(499);
-            ctx.metrics().setErrorKey(CLIENT_ABORTED_DURING_RESPONSE_ERROR);
-            ctx.metrics().setErrorMessage(CLIENT_ABORTED_DURING_RESPONSE_MESSAGE);
+            if (ctx.metrics().getFailure() == null && ctx.metrics().getErrorKey() == null) {
+                ctx.metrics().setErrorKey(CLIENT_ABORTED_DURING_RESPONSE_ERROR);
+                ctx.metrics().setErrorMessage(CLIENT_ABORTED_DURING_RESPONSE_MESSAGE);
+            }
         }
     }
 
@@ -151,24 +171,17 @@ public class HttpProxyEndpointConnector extends HttpEndpointSyncConnector {
     }
 
     private Completable handleException(Throwable throwable, HttpExecutionContext ctx) {
-        return switch (throwable) {
-            case InterruptionFailureException e -> Completable.error(e);
-            case TimeoutException e -> ctx.interruptWith(
-                new ExecutionFailure(HttpStatusCode.GATEWAY_TIMEOUT_504).key(REQUEST_TIMEOUT).cause(throwable)
-            );
-            case NoStackTraceTimeoutException e -> ctx.interruptWith(
-                new ExecutionFailure(HttpStatusCode.GATEWAY_TIMEOUT_504).key(REQUEST_TIMEOUT).cause(rewriteServerNull(e, ctx))
-            );
-            case ReadTimeoutException e -> ctx.interruptWith(
-                new ExecutionFailure(HttpStatusCode.GATEWAY_TIMEOUT_504).key(REQUEST_TIMEOUT).cause(throwable)
-            );
-            case ConnectTimeoutException e -> ctx.interruptWith(
-                new ExecutionFailure(HttpStatusCode.GATEWAY_TIMEOUT_504).key(REQUEST_TIMEOUT).cause(throwable)
-            );
-            default -> ctx.interruptWith(
-                new ExecutionFailure(HttpStatusCode.BAD_GATEWAY_502).key(GATEWAY_CLIENT_CONNECTION_ERROR).cause(throwable)
-            );
-        };
+        if (throwable instanceof InterruptionFailureException) {
+            return Completable.error(throwable);
+        }
+        ConnectionFailureClassifier.Classification classification = ConnectionFailureClassifier.classify(throwable);
+        // Preserve the rewritten "for endpoint …" message for the NoStackTrace request-timeout case.
+        Throwable cause = throwable instanceof NoStackTraceTimeoutException nst ? rewriteServerNull(nst, ctx) : throwable;
+        ExecutionFailure executionFailure = new ExecutionFailure(classification.statusCode()).key(classification.key()).cause(cause);
+        if (classification.message() != null) {
+            executionFailure.message(classification.message());
+        }
+        return ctx.interruptWith(executionFailure);
     }
 
     private Throwable rewriteServerNull(NoStackTraceTimeoutException e, HttpExecutionContext ctx) {

--- a/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-http-proxy/src/main/java/io/gravitee/plugin/endpoint/http/proxy/client/ConnectionFailureClassifier.java
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-http-proxy/src/main/java/io/gravitee/plugin/endpoint/http/proxy/client/ConnectionFailureClassifier.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.plugin.endpoint.http.proxy.client;
+
+import io.gravitee.common.http.HttpStatusCode;
+import io.netty.channel.ConnectTimeoutException;
+import io.netty.handler.timeout.ReadTimeoutException;
+import io.vertx.circuitbreaker.TimeoutException;
+import io.vertx.core.http.HttpClosedException;
+import io.vertx.core.http.StreamResetException;
+import io.vertx.core.impl.NoStackTraceTimeoutException;
+import java.net.ConnectException;
+import java.net.UnknownHostException;
+import javax.net.ssl.SSLException;
+
+/**
+ * Single source of truth for classifying a {@link Throwable} raised while contacting an upstream (gateway→backend)
+ * into a (statusCode, errorKey, message) triple. Shared by every connector in the HTTP proxy plugin
+ * (HTTP, WebSocket, gRPC) so they report the same taxonomy for the same failure (APIM-12769).
+ * <p>
+ * Classification is type-first (walking the whole cause chain, since Vert.x wraps low-level causes) and falls back
+ * to message matching, finally to the generic {@link #GATEWAY_CLIENT_CONNECTION_ERROR}. The two pre-existing umbrella
+ * keys ({@code REQUEST_TIMEOUT}, {@code GATEWAY_CLIENT_CONNECTION_ERROR}) are preserved so existing dashboards keep
+ * working; the {@code UPSTREAM_*} keys carve out the actionable subcases. A {@code null} message means "derive it
+ * from the cause".
+ */
+public final class ConnectionFailureClassifier {
+
+    // Pre-existing umbrella keys (kept for dashboard backward-compatibility).
+    public static final String GATEWAY_CLIENT_CONNECTION_ERROR = "GATEWAY_CLIENT_CONNECTION_ERROR";
+    public static final String REQUEST_TIMEOUT = "REQUEST_TIMEOUT";
+
+    // Carved-out upstream subcases (APIM-12769).
+    public static final String UPSTREAM_CONNECT_TIMEOUT = "UPSTREAM_CONNECT_TIMEOUT";
+    public static final String UPSTREAM_IDLE_TIMEOUT = "UPSTREAM_IDLE_TIMEOUT";
+    public static final String UPSTREAM_DNS_FAILURE = "UPSTREAM_DNS_FAILURE";
+    public static final String UPSTREAM_CONNECTION_REFUSED = "UPSTREAM_CONNECTION_REFUSED";
+    public static final String UPSTREAM_TLS_FAILURE = "UPSTREAM_TLS_FAILURE";
+    public static final String UPSTREAM_CONNECTION_RESET = "UPSTREAM_CONNECTION_RESET";
+    public static final String UPSTREAM_BROKEN_PIPE = "UPSTREAM_BROKEN_PIPE";
+    public static final String UPSTREAM_CONNECTION_CLOSED = "UPSTREAM_CONNECTION_CLOSED";
+
+    public static final String UPSTREAM_CONNECT_TIMEOUT_MESSAGE = "Timed out while establishing a connection to the upstream";
+    public static final String UPSTREAM_IDLE_TIMEOUT_MESSAGE = "The connection to the upstream was closed after the idle timeout elapsed";
+    public static final String UPSTREAM_DNS_FAILURE_MESSAGE = "Unable to resolve the upstream host";
+    public static final String UPSTREAM_CONNECTION_REFUSED_MESSAGE = "The upstream refused the connection";
+    public static final String UPSTREAM_TLS_FAILURE_MESSAGE = "TLS handshake with the upstream failed";
+    public static final String UPSTREAM_CONNECTION_RESET_MESSAGE = "The upstream reset the connection";
+    public static final String UPSTREAM_BROKEN_PIPE_MESSAGE = "The connection to the upstream was broken while sending the request";
+    public static final String UPSTREAM_CONNECTION_CLOSED_MESSAGE = "The upstream closed the connection unexpectedly";
+
+    private ConnectionFailureClassifier() {}
+
+    /** Result of classification. {@code message == null} means the caller should derive it from the cause. */
+    public record Classification(int statusCode, String key, String message) {}
+
+    /**
+     * Classify an upstream failure. Order matters: more specific causes win, {@link ConnectTimeoutException} (which
+     * extends {@link ConnectException}) is checked before connection-refused, and the typed checks run before the
+     * message-based fallback.
+     */
+    public static Classification classify(final Throwable t) {
+        if (
+            hasCause(t, TimeoutException.class) ||
+            hasCause(t, NoStackTraceTimeoutException.class) ||
+            hasCause(t, ReadTimeoutException.class)
+        ) {
+            return new Classification(HttpStatusCode.GATEWAY_TIMEOUT_504, REQUEST_TIMEOUT, null);
+        }
+        if (hasCause(t, ConnectTimeoutException.class)) {
+            return new Classification(HttpStatusCode.GATEWAY_TIMEOUT_504, UPSTREAM_CONNECT_TIMEOUT, UPSTREAM_CONNECT_TIMEOUT_MESSAGE);
+        }
+        if (hasCause(t, UpstreamIdleTimeoutException.class)) {
+            return new Classification(HttpStatusCode.GATEWAY_TIMEOUT_504, UPSTREAM_IDLE_TIMEOUT, UPSTREAM_IDLE_TIMEOUT_MESSAGE);
+        }
+        if (hasCause(t, UnknownHostException.class)) {
+            return new Classification(HttpStatusCode.BAD_GATEWAY_502, UPSTREAM_DNS_FAILURE, UPSTREAM_DNS_FAILURE_MESSAGE);
+        }
+        if (hasCause(t, ConnectException.class)) {
+            return new Classification(HttpStatusCode.BAD_GATEWAY_502, UPSTREAM_CONNECTION_REFUSED, UPSTREAM_CONNECTION_REFUSED_MESSAGE);
+        }
+        if (hasCause(t, SSLException.class)) {
+            return new Classification(HttpStatusCode.BAD_GATEWAY_502, UPSTREAM_TLS_FAILURE, UPSTREAM_TLS_FAILURE_MESSAGE);
+        }
+        // HTTP/2 RST_STREAM from the upstream (common gRPC failure mode).
+        if (hasCause(t, StreamResetException.class)) {
+            return new Classification(HttpStatusCode.BAD_GATEWAY_502, UPSTREAM_CONNECTION_RESET, UPSTREAM_CONNECTION_RESET_MESSAGE);
+        }
+        // Pooled connection closed by the backend / reused-then-stale (typed, more robust than message matching).
+        if (hasCause(t, HttpClosedException.class)) {
+            return new Classification(HttpStatusCode.BAD_GATEWAY_502, UPSTREAM_CONNECTION_CLOSED, UPSTREAM_CONNECTION_CLOSED_MESSAGE);
+        }
+        return classifyByMessage(t);
+    }
+
+    /**
+     * Fallback when no specific type matched. Vert.x wraps low-level IO failures in {@code VertxException} (not an
+     * {@link java.io.IOException}) and the meaningful text is often on a nested cause, so the whole cause chain is
+     * scanned.
+     */
+    private static Classification classifyByMessage(final Throwable t) {
+        final String message = collectChainMessages(t);
+        if (message != null) {
+            if (message.contains("Connection reset")) {
+                return new Classification(HttpStatusCode.BAD_GATEWAY_502, UPSTREAM_CONNECTION_RESET, UPSTREAM_CONNECTION_RESET_MESSAGE);
+            }
+            if (message.contains("Broken pipe")) {
+                return new Classification(HttpStatusCode.BAD_GATEWAY_502, UPSTREAM_BROKEN_PIPE, UPSTREAM_BROKEN_PIPE_MESSAGE);
+            }
+            if (message.contains("Connection was closed") || message.contains("Connection closed")) {
+                return new Classification(HttpStatusCode.BAD_GATEWAY_502, UPSTREAM_CONNECTION_CLOSED, UPSTREAM_CONNECTION_CLOSED_MESSAGE);
+            }
+        }
+        return new Classification(HttpStatusCode.BAD_GATEWAY_502, GATEWAY_CLIENT_CONNECTION_ERROR, null);
+    }
+
+    /** Walk the cause chain looking for a given exception type (Vert.x frequently wraps the real cause). */
+    public static boolean hasCause(final Throwable t, final Class<? extends Throwable> type) {
+        Throwable current = t;
+        while (current != null) {
+            if (type.isInstance(current)) {
+                return true;
+            }
+            if (current.getCause() == current) {
+                break;
+            }
+            current = current.getCause();
+        }
+        return false;
+    }
+
+    /** Concatenate the messages along the cause chain so message-based detection survives wrapping. */
+    private static String collectChainMessages(final Throwable t) {
+        final StringBuilder sb = new StringBuilder();
+        Throwable current = t;
+        while (current != null) {
+            if (current.getMessage() != null) {
+                sb.append(current.getMessage()).append('\n');
+            }
+            if (current.getCause() == current) {
+                break;
+            }
+            current = current.getCause();
+        }
+        return sb.isEmpty() ? null : sb.toString();
+    }
+}

--- a/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-http-proxy/src/main/java/io/gravitee/plugin/endpoint/http/proxy/client/HttpClientFactory.java
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-http-proxy/src/main/java/io/gravitee/plugin/endpoint/http/proxy/client/HttpClientFactory.java
@@ -23,15 +23,29 @@ import io.gravitee.plugin.endpoint.http.proxy.configuration.HttpProxyEndpointCon
 import io.gravitee.plugin.mappers.HttpClientOptionsMapper;
 import io.gravitee.plugin.mappers.HttpProxyOptionsMapper;
 import io.gravitee.plugin.mappers.SslOptionsMapper;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.channel.ChannelPipeline;
+import io.netty.handler.timeout.IdleStateEvent;
+import io.vertx.core.http.impl.HttpClientConnection;
 import io.vertx.rxjava3.core.Vertx;
 import io.vertx.rxjava3.core.http.HttpClient;
+import io.vertx.rxjava3.core.http.HttpConnection;
 import java.util.concurrent.atomic.AtomicBoolean;
+import lombok.CustomLog;
 
 /**
  * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
  * @author GraviteeSource Team
  */
+@CustomLog
 public class HttpClientFactory {
+
+    /** Name Vert.x uses for the {@code IdleStateHandler} it installs on a client connection when {@code idleTimeout} is set. */
+    private static final String VERTX_IDLE_HANDLER_NAME = "idle";
+    /** Name of the handler we add to convert the upstream idle event into a typed exception. */
+    private static final String UPSTREAM_IDLE_HANDLER_NAME = "gravitee-upstream-idle";
 
     private HttpClient httpClient;
     private final AtomicBoolean httpClientCreated = new AtomicBoolean(false);
@@ -46,10 +60,51 @@ public class HttpClientFactory {
                 // Double-checked locking.
                 if (httpClientCreated.compareAndSet(false, true)) {
                     httpClient = buildHttpClient(ctx, configuration, sharedConfiguration).build().createHttpClient();
+                    // When the endpoint idleTimeout is configured, Vert.x closes an idle upstream connection
+                    // silently (surfacing only a generic close). Convert that idle event into a typed exception
+                    // so the connector can report UPSTREAM_IDLE_TIMEOUT distinctly (APIM-12769).
+                    if (httpClient != null && sharedConfiguration.getHttpOptions().getIdleTimeout() > 0) {
+                        httpClient.connectionHandler(HttpClientFactory::installUpstreamIdleConverter);
+                    }
                 }
             }
         }
         return httpClient;
+    }
+
+    /**
+     * Add, once per upstream connection, a handler right after Vert.x's {@code IdleStateHandler} that turns the
+     * {@link IdleStateEvent} into an {@link UpstreamIdleTimeoutException} failing the in-flight request — instead
+     * of letting Vert.x close the connection silently. Best-effort: if the pipeline shape is unexpected we leave
+     * it untouched and fall back to the generic connection-close classification.
+     */
+    private static void installUpstreamIdleConverter(final HttpConnection connection) {
+        try {
+            final Channel channel = ((HttpClientConnection) connection.getDelegate()).channel();
+            final ChannelPipeline pipeline = channel.pipeline();
+            if (pipeline.get(UPSTREAM_IDLE_HANDLER_NAME) == null && pipeline.get(VERTX_IDLE_HANDLER_NAME) != null) {
+                pipeline.addAfter(VERTX_IDLE_HANDLER_NAME, UPSTREAM_IDLE_HANDLER_NAME, new UpstreamIdleStateConverter());
+            }
+        } catch (Exception e) {
+            log.debug("Unable to install upstream idle converter; falling back to default close classification", e);
+        }
+    }
+
+    /**
+     * Inbound handler that converts the Netty idle event on an upstream connection into a typed
+     * {@link UpstreamIdleTimeoutException} (which fails the in-flight request), rather than forwarding the event
+     * to Vert.x which would close the connection silently.
+     */
+    private static class UpstreamIdleStateConverter extends ChannelInboundHandlerAdapter {
+
+        @Override
+        public void userEventTriggered(final ChannelHandlerContext ctx, final Object evt) throws Exception {
+            if (evt instanceof IdleStateEvent) {
+                ctx.fireExceptionCaught(new UpstreamIdleTimeoutException("Upstream idle timeout"));
+            } else {
+                super.userEventTriggered(ctx, evt);
+            }
+        }
     }
 
     protected VertxHttpClientFactory.VertxHttpClientFactoryBuilder buildHttpClient(

--- a/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-http-proxy/src/main/java/io/gravitee/plugin/endpoint/http/proxy/client/UpstreamIdleTimeoutException.java
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-http-proxy/src/main/java/io/gravitee/plugin/endpoint/http/proxy/client/UpstreamIdleTimeoutException.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.plugin.endpoint.http.proxy.client;
+
+import io.vertx.core.VertxException;
+
+/**
+ * Raised when the gateway closes an upstream (gateway→backend) connection because it stayed idle longer than the
+ * endpoint's configured {@code idleTimeout}. Vert.x's {@code HttpClient} would otherwise close an idle connection
+ * silently, surfacing only a generic "Connection was closed" to the in-flight request — indistinguishable from a
+ * genuine upstream close. {@code HttpClientFactory} installs a handler that converts the Netty
+ * {@code IdleStateEvent} into this typed exception so the connector can classify it as
+ * {@code UPSTREAM_IDLE_TIMEOUT} rather than {@code UPSTREAM_CONNECTION_CLOSED} (APIM-12769).
+ */
+public class UpstreamIdleTimeoutException extends VertxException {
+
+    public UpstreamIdleTimeoutException(final String message) {
+        super(message, true);
+    }
+}

--- a/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-http-proxy/src/main/java/io/gravitee/plugin/endpoint/http/proxy/connector/WebSocketConnector.java
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-http-proxy/src/main/java/io/gravitee/plugin/endpoint/http/proxy/connector/WebSocketConnector.java
@@ -29,6 +29,7 @@ import io.gravitee.gateway.reactive.api.context.http.HttpRequest;
 import io.gravitee.gateway.reactive.http.vertx.ws.VertxWebSocket;
 import io.gravitee.node.api.opentelemetry.Span;
 import io.gravitee.node.api.opentelemetry.http.ObservableHttpClientRequest;
+import io.gravitee.plugin.endpoint.http.proxy.client.ConnectionFailureClassifier;
 import io.gravitee.plugin.endpoint.http.proxy.client.HttpClientFactory;
 import io.gravitee.plugin.endpoint.http.proxy.configuration.HttpProxyEndpointConnectorConfiguration;
 import io.gravitee.plugin.endpoint.http.proxy.configuration.HttpProxyEndpointConnectorSharedConfiguration;
@@ -133,17 +134,22 @@ public class WebSocketConnector extends HttpConnector {
                                 )
                             );
                     }
-                    return request
-                        .webSocket()
-                        .close(HttpStatusCode.INTERNAL_SERVER_ERROR_500)
-                        .andThen(
-                            ctx.interruptWith(
-                                new ExecutionFailure(HttpStatusCode.INTERNAL_SERVER_ERROR_500)
-                                    .key(HTTP_PROXY_WEBSOCKET_FAILURE)
-                                    .cause(throwable)
-                                    .message("Endpoint Websocket connection in error")
-                            )
-                        );
+                    // Reclassify upstream connection failures (DNS/refused/TLS/reset/timeout) to the shared taxonomy
+                    // (502/504 + UPSTREAM_* keys), consistent with the HTTP path; keep the WebSocket-specific key
+                    // only for failures that aren't recognised connection errors (APIM-12769).
+                    final ConnectionFailureClassifier.Classification classification = ConnectionFailureClassifier.classify(throwable);
+                    final ExecutionFailure failure = ConnectionFailureClassifier.GATEWAY_CLIENT_CONNECTION_ERROR.equals(
+                            classification.key()
+                        )
+                        ? new ExecutionFailure(HttpStatusCode.INTERNAL_SERVER_ERROR_500)
+                            .key(HTTP_PROXY_WEBSOCKET_FAILURE)
+                            .cause(throwable)
+                            .message("Endpoint Websocket connection in error")
+                        : new ExecutionFailure(classification.statusCode())
+                            .key(classification.key())
+                            .cause(throwable)
+                            .message(classification.message());
+                    return request.webSocket().close(failure.statusCode()).andThen(ctx.interruptWith(failure));
                 })
                 .doFinally(() -> ctx.getTracer().end(httpRequestSpan));
         } catch (Exception e) {

--- a/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-http-proxy/src/test/java/io/gravitee/plugin/endpoint/http/proxy/HttpProxyEndpointConnectorTest.java
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-http-proxy/src/test/java/io/gravitee/plugin/endpoint/http/proxy/HttpProxyEndpointConnectorTest.java
@@ -19,6 +19,22 @@ import static io.gravitee.plugin.endpoint.http.proxy.HttpProxyEndpointConnector.
 import static io.gravitee.plugin.endpoint.http.proxy.HttpProxyEndpointConnector.CLIENT_ABORTED_DURING_RESPONSE_MESSAGE;
 import static io.gravitee.plugin.endpoint.http.proxy.HttpProxyEndpointConnector.GATEWAY_CLIENT_CONNECTION_ERROR;
 import static io.gravitee.plugin.endpoint.http.proxy.HttpProxyEndpointConnector.REQUEST_TIMEOUT;
+import static io.gravitee.plugin.endpoint.http.proxy.HttpProxyEndpointConnector.UPSTREAM_BROKEN_PIPE;
+import static io.gravitee.plugin.endpoint.http.proxy.HttpProxyEndpointConnector.UPSTREAM_BROKEN_PIPE_MESSAGE;
+import static io.gravitee.plugin.endpoint.http.proxy.HttpProxyEndpointConnector.UPSTREAM_CONNECTION_CLOSED;
+import static io.gravitee.plugin.endpoint.http.proxy.HttpProxyEndpointConnector.UPSTREAM_CONNECTION_CLOSED_MESSAGE;
+import static io.gravitee.plugin.endpoint.http.proxy.HttpProxyEndpointConnector.UPSTREAM_CONNECTION_REFUSED;
+import static io.gravitee.plugin.endpoint.http.proxy.HttpProxyEndpointConnector.UPSTREAM_CONNECTION_REFUSED_MESSAGE;
+import static io.gravitee.plugin.endpoint.http.proxy.HttpProxyEndpointConnector.UPSTREAM_CONNECTION_RESET;
+import static io.gravitee.plugin.endpoint.http.proxy.HttpProxyEndpointConnector.UPSTREAM_CONNECTION_RESET_MESSAGE;
+import static io.gravitee.plugin.endpoint.http.proxy.HttpProxyEndpointConnector.UPSTREAM_CONNECT_TIMEOUT;
+import static io.gravitee.plugin.endpoint.http.proxy.HttpProxyEndpointConnector.UPSTREAM_CONNECT_TIMEOUT_MESSAGE;
+import static io.gravitee.plugin.endpoint.http.proxy.HttpProxyEndpointConnector.UPSTREAM_DNS_FAILURE;
+import static io.gravitee.plugin.endpoint.http.proxy.HttpProxyEndpointConnector.UPSTREAM_DNS_FAILURE_MESSAGE;
+import static io.gravitee.plugin.endpoint.http.proxy.HttpProxyEndpointConnector.UPSTREAM_IDLE_TIMEOUT;
+import static io.gravitee.plugin.endpoint.http.proxy.HttpProxyEndpointConnector.UPSTREAM_IDLE_TIMEOUT_MESSAGE;
+import static io.gravitee.plugin.endpoint.http.proxy.HttpProxyEndpointConnector.UPSTREAM_TLS_FAILURE;
+import static io.gravitee.plugin.endpoint.http.proxy.HttpProxyEndpointConnector.UPSTREAM_TLS_FAILURE_MESSAGE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.lenient;
@@ -45,6 +61,7 @@ import io.gravitee.gateway.reactive.core.context.interruption.InterruptionFailur
 import io.gravitee.node.opentelemetry.tracer.noop.NoOpTracer;
 import io.gravitee.plugin.endpoint.http.proxy.client.GrpcHttpClientFactory;
 import io.gravitee.plugin.endpoint.http.proxy.client.HttpClientFactory;
+import io.gravitee.plugin.endpoint.http.proxy.client.UpstreamIdleTimeoutException;
 import io.gravitee.plugin.endpoint.http.proxy.configuration.HttpProxyEndpointConnectorConfiguration;
 import io.gravitee.plugin.endpoint.http.proxy.configuration.HttpProxyEndpointConnectorSharedConfiguration;
 import io.gravitee.plugin.endpoint.http.proxy.connector.ProxyConnector;
@@ -58,9 +75,12 @@ import io.vertx.core.http.WebSocketConnectOptions;
 import io.vertx.core.impl.NoStackTraceTimeoutException;
 import io.vertx.rxjava3.core.http.HttpClient;
 import java.io.IOException;
+import java.net.ConnectException;
+import java.net.UnknownHostException;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Stream;
+import javax.net.ssl.SSLException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
@@ -144,11 +164,9 @@ class HttpProxyEndpointConnectorTest {
     }
 
     static Stream<Throwable> timeoutExceptionsProvider() {
-        return Stream.of(
-            new NoStackTraceTimeoutException("Vertx no stack trace timeout"),
-            ReadTimeoutException.INSTANCE,
-            new ConnectTimeoutException("Netty connect timeout")
-        );
+        // ConnectTimeoutException intentionally excluded: it now maps to its own UPSTREAM_CONNECT_TIMEOUT key
+        // (APIM-12769), asserted by should_classify_connect_timeout_as_upstream_connect_timeout below.
+        return Stream.of(new NoStackTraceTimeoutException("Vertx no stack trace timeout"), ReadTimeoutException.INSTANCE);
     }
 
     @Test
@@ -388,6 +406,123 @@ class HttpProxyEndpointConnectorTest {
                 .assertComplete();
             verify(spyHttpClientFactory).getOrBuildHttpClient(any(), any(), any());
             verify(spyGrpcHttpClientFactory, never()).getOrBuildHttpClient(any(), any(), any());
+        }
+    }
+
+    @Nested
+    class UpstreamFailureClassification {
+
+        private void assertClassifiedAs(Throwable thrown, int expectedStatus, String expectedKey, String expectedMessage) {
+            Map<String, ProxyConnector> mockConnectors = new ConcurrentHashMap<>();
+            mockConnectors.put("http", proxyConnector);
+            ReflectionTestUtils.setField(cut, "connectors", mockConnectors);
+            when(proxyConnector.connect(ctx)).thenReturn(Completable.error(thrown));
+            when(ctx.interruptWith(any(ExecutionFailure.class))).thenReturn(Completable.complete());
+
+            TestObserver<Void> testObserver = cut.connect(ctx).test();
+
+            verify(ctx).interruptWith(failureCaptor.capture());
+            ExecutionFailure failure = failureCaptor.getValue();
+            assertThat(failure.statusCode()).isEqualTo(expectedStatus);
+            assertThat(failure.key()).isEqualTo(expectedKey);
+            if (expectedMessage != null) {
+                assertThat(failure.message()).isEqualTo(expectedMessage);
+            }
+            // The original cause must always be preserved for logging/debugging.
+            assertThat(failure.cause()).isSameAs(thrown);
+            testObserver.assertComplete().assertNoErrors();
+        }
+
+        @Test
+        void should_classify_connect_timeout_as_upstream_connect_timeout() {
+            assertClassifiedAs(
+                new ConnectTimeoutException("connection timed out"),
+                HttpStatusCode.GATEWAY_TIMEOUT_504,
+                UPSTREAM_CONNECT_TIMEOUT,
+                UPSTREAM_CONNECT_TIMEOUT_MESSAGE
+            );
+        }
+
+        @Test
+        void should_classify_upstream_idle_timeout() {
+            assertClassifiedAs(
+                new UpstreamIdleTimeoutException("Upstream idle timeout"),
+                HttpStatusCode.GATEWAY_TIMEOUT_504,
+                UPSTREAM_IDLE_TIMEOUT,
+                UPSTREAM_IDLE_TIMEOUT_MESSAGE
+            );
+        }
+
+        @Test
+        void should_classify_unknown_host_as_dns_failure() {
+            assertClassifiedAs(
+                new UnknownHostException("api.invalid"),
+                HttpStatusCode.BAD_GATEWAY_502,
+                UPSTREAM_DNS_FAILURE,
+                UPSTREAM_DNS_FAILURE_MESSAGE
+            );
+        }
+
+        @Test
+        void should_classify_connection_refused_as_upstream_connection_refused() {
+            assertClassifiedAs(
+                new ConnectException("Connection refused"),
+                HttpStatusCode.BAD_GATEWAY_502,
+                UPSTREAM_CONNECTION_REFUSED,
+                UPSTREAM_CONNECTION_REFUSED_MESSAGE
+            );
+        }
+
+        @Test
+        void should_classify_ssl_exception_as_tls_failure() {
+            assertClassifiedAs(
+                new SSLException("Received fatal alert: handshake_failure"),
+                HttpStatusCode.BAD_GATEWAY_502,
+                UPSTREAM_TLS_FAILURE,
+                UPSTREAM_TLS_FAILURE_MESSAGE
+            );
+        }
+
+        @Test
+        void should_classify_connection_reset_message_as_upstream_connection_reset() {
+            // Vert.x wraps low-level IO failures in VertxException (not an IOException), so the default switch
+            // branch must also classify by message — exercise it here with a non-IOException carrying the message.
+            assertClassifiedAs(
+                new RuntimeException("Connection reset by peer"),
+                HttpStatusCode.BAD_GATEWAY_502,
+                UPSTREAM_CONNECTION_RESET,
+                UPSTREAM_CONNECTION_RESET_MESSAGE
+            );
+        }
+
+        @Test
+        void should_classify_broken_pipe_message_as_upstream_broken_pipe() {
+            assertClassifiedAs(
+                new IOException("Broken pipe"),
+                HttpStatusCode.BAD_GATEWAY_502,
+                UPSTREAM_BROKEN_PIPE,
+                UPSTREAM_BROKEN_PIPE_MESSAGE
+            );
+        }
+
+        @Test
+        void should_classify_connection_closed_message_as_upstream_connection_closed() {
+            assertClassifiedAs(
+                new RuntimeException("Connection was closed"),
+                HttpStatusCode.BAD_GATEWAY_502,
+                UPSTREAM_CONNECTION_CLOSED,
+                UPSTREAM_CONNECTION_CLOSED_MESSAGE
+            );
+        }
+
+        @Test
+        void should_fallback_to_gateway_client_connection_error_for_unrecognised_failure() {
+            assertClassifiedAs(
+                new RuntimeException("something totally unexpected"),
+                HttpStatusCode.BAD_GATEWAY_502,
+                GATEWAY_CLIENT_CONNECTION_ERROR,
+                null
+            );
         }
     }
 }

--- a/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-http-proxy/src/test/java/io/gravitee/plugin/endpoint/http/proxy/client/ConnectionFailureClassifierTest.java
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-http-proxy/src/test/java/io/gravitee/plugin/endpoint/http/proxy/client/ConnectionFailureClassifierTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.plugin.endpoint.http.proxy.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.common.http.HttpStatusCode;
+import io.vertx.core.http.HttpClosedException;
+import io.vertx.core.http.StreamResetException;
+import java.net.ConnectException;
+import java.net.UnknownHostException;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit coverage for the shared {@link ConnectionFailureClassifier}, focused on the cases the connector test does
+ * not exercise directly: HTTP/2 stream resets, typed pooled-connection close, and cause-chain unwrapping.
+ */
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class ConnectionFailureClassifierTest {
+
+    @Test
+    void should_classify_http2_stream_reset_as_upstream_connection_reset() {
+        ConnectionFailureClassifier.Classification c = ConnectionFailureClassifier.classify(new StreamResetException(8L));
+        assertThat(c.statusCode()).isEqualTo(HttpStatusCode.BAD_GATEWAY_502);
+        assertThat(c.key()).isEqualTo(ConnectionFailureClassifier.UPSTREAM_CONNECTION_RESET);
+    }
+
+    @Test
+    void should_classify_http_closed_exception_as_upstream_connection_closed_by_type() {
+        // Pool-reuse stale connection: typed match, independent of the message wording.
+        ConnectionFailureClassifier.Classification c = ConnectionFailureClassifier.classify(new HttpClosedException("anything"));
+        assertThat(c.statusCode()).isEqualTo(HttpStatusCode.BAD_GATEWAY_502);
+        assertThat(c.key()).isEqualTo(ConnectionFailureClassifier.UPSTREAM_CONNECTION_CLOSED);
+    }
+
+    @Test
+    void should_classify_idle_timeout() {
+        ConnectionFailureClassifier.Classification c = ConnectionFailureClassifier.classify(new UpstreamIdleTimeoutException("idle"));
+        assertThat(c.statusCode()).isEqualTo(HttpStatusCode.GATEWAY_TIMEOUT_504);
+        assertThat(c.key()).isEqualTo(ConnectionFailureClassifier.UPSTREAM_IDLE_TIMEOUT);
+    }
+
+    @Test
+    void should_unwrap_dns_failure_from_the_cause_chain() {
+        ConnectionFailureClassifier.Classification c = ConnectionFailureClassifier.classify(
+            new RuntimeException("wrapper", new UnknownHostException("api.invalid"))
+        );
+        assertThat(c.key()).isEqualTo(ConnectionFailureClassifier.UPSTREAM_DNS_FAILURE);
+    }
+
+    @Test
+    void should_classify_connection_refused_before_treating_it_as_a_message() {
+        ConnectionFailureClassifier.Classification c = ConnectionFailureClassifier.classify(new ConnectException("Connection refused"));
+        assertThat(c.key()).isEqualTo(ConnectionFailureClassifier.UPSTREAM_CONNECTION_REFUSED);
+    }
+
+    @Test
+    void should_fall_back_to_gateway_client_connection_error_for_unrecognised_failure() {
+        ConnectionFailureClassifier.Classification c = ConnectionFailureClassifier.classify(new RuntimeException("something unexpected"));
+        assertThat(c.statusCode()).isEqualTo(HttpStatusCode.BAD_GATEWAY_502);
+        assertThat(c.key()).isEqualTo(ConnectionFailureClassifier.GATEWAY_CLIENT_CONNECTION_ERROR);
+    }
+}


### PR DESCRIPTION
## APIM-12769 — specific connection-error classification

Replaces the generic `499 / 502 / 504` fallback keys with specific, actionable error keys for both **client→gateway** aborts and **gateway→backend** upstream failures, so reported metrics name the actual failure mode instead of a bare status.

### What changed

**Shared classifier (single source of truth)**
- New `ConnectionFailureClassifier` (http-proxy plugin): `classify(Throwable) → (status, key, message)`. **Cause-chain, type-first** matching (Vert.x wraps low-level exceptions), then a message fallback:
  - `TimeoutException` / `ReadTimeoutException` → `504 REQUEST_TIMEOUT`
  - `ConnectTimeoutException` → `504 UPSTREAM_CONNECT_TIMEOUT`
  - `UpstreamIdleTimeoutException` → `504 UPSTREAM_IDLE_TIMEOUT`
  - `UnknownHostException` → `502 UPSTREAM_DNS_FAILURE`
  - `ConnectException` → `502 UPSTREAM_CONNECTION_REFUSED`
  - `SSLException` → `502 UPSTREAM_TLS_FAILURE`
  - `StreamResetException` → `502 UPSTREAM_CONNECTION_RESET`
  - `HttpClosedException` → `502 UPSTREAM_CONNECTION_CLOSED` (typed, not message-matched)
  - unrecognised → `502 GATEWAY_CLIENT_CONNECTION_ERROR`

**Upstream idle timeout (was unclassified)**
- `HttpClientFactory` installs a Netty handler after the client `idle` handler that fires `UpstreamIdleTimeoutException` when the endpoint `idleTimeout` elapses → surfaces as `504 UPSTREAM_IDLE_TIMEOUT`.

**Connector / WebSocket parity**
- `HttpProxyEndpointConnector.handleException` now delegates to the shared classifier (local duplicate logic removed; key constants kept as aliases so existing static imports stay valid).
- `WebSocketConnector` non-`UpgradeRejected` failures map to the same `502/504 UPSTREAM_*` taxonomy; the WS-specific `500` key is kept only for genuinely unrecognised failures.

**Client-side close classification**
- The protocol verticle classifies a client-side connection close (TCP reset, broken pipe, idle timeout, channel closed) onto the in-flight request metrics, scanning the **cause chain** (`ClosedChannelException` + chained messages) so wrapped causes are recognised — instead of the generic `CLIENT_ABORTED_DURING_RESPONSE_ERROR` fallback.

### Test plan — all green
- **Plugin unit:** 29 (`HttpProxyEndpointConnectorTest` 23 + `ConnectionFailureClassifierTest` 6)
- **Verticle unit:** 5 (`HttpProtocolVerticleClassifyTest`)
- **Integration:** 7 (`ConnectionErrorClassificationV4IntegrationTest`) — induces the **real** failures (no mocked exceptions): DNS, connection-refused, upstream idle, client TCP RST, client idle, plus upstream faults
- **Live smoke** on a running gateway confirmed `CLIENT_ABORTED_TCP_RESET`, `UPSTREAM_DNS_FAILURE`, `UPSTREAM_CONNECTION_REFUSED`, `UPSTREAM_TLS_FAILURE`, and endpoint idle in Elasticsearch metrics.

### Reviewer call-outs
- **Released-line behavior change:** targets `4.11.x`. Responses that previously carried generic `499/502/504` keys now carry the specific `*_*` keys above. Additive in spirit, but anything asserting on the old keys/messages downstream will see different values — please confirm acceptable for this release line.

### Out of scope (follow-ups)
- V3-emulation (`InvokerAdapter`) alignment to the same taxonomy.
- TCP-listener client-abort classification.
- `ConnectionPoolTooBusyException` → `503`.
