### PR TITLE
chore(4.11.x): bump gravitee-apim-repository-bridge from 8.2.0 to 8.3.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -314,7 +314,7 @@
         <gravitee-resource-ai-vector-store-aws-s3.version>1.0.0</gravitee-resource-ai-vector-store-aws-s3.version>
         <gravitee-resource-ai-model-text-embedding.version>1.0.0</gravitee-resource-ai-model-text-embedding.version>
         <gravitee-policy-ai-semantic-caching.version>1.1.0</gravitee-policy-ai-semantic-caching.version>
-        <gravitee-apim-repository-bridge.version>8.2.0</gravitee-apim-repository-bridge.version>
+        <gravitee-apim-repository-bridge.version>8.3.0</gravitee-apim-repository-bridge.version>
         <gravitee-secretprovider-hc-vault.version>2.1.0</gravitee-secretprovider-hc-vault.version>
         <gravitee-secretprovider-aws.version>2.0.0</gravitee-secretprovider-aws.version>
         <gravitee-service-secrets.version>3.0.1</gravitee-service-secrets.version>


### PR DESCRIPTION
## Summary

Bumps **[gravitee-io/gravitee-apim-repository-bridge](https://github.com/gravitee-io/gravitee-apim-repository-bridge)** from `8.2.0` to `8.3.0` on branch `4.11.x`.

## Changelog

See the [releases](https://github.com/gravitee-io/gravitee-apim-repository-bridge/releases) page for details.

## Jira

[APIM-14203](https://gravitee.atlassian.net/browse/APIM-14203)

[APIM-14203]: https://gravitee.atlassian.net/browse/APIM-14203?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ