### PR TITLE
feat(sync): per-entity bulk_items + appender batch parallelism

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/SyncConfiguration.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/SyncConfiguration.java
@@ -77,10 +77,23 @@ public class SyncConfiguration {
 
     public static final int POOL_SIZE = Runtime.getRuntime().availableProcessors() * 2;
     public static final int DEFAULT_BULK_ITEMS = 100;
+    // Subscription cursor page size — appender warmup at customer scale showed 100-row pages
+    // bottleneck on round-trip overhead. 1000 cuts page count 10× without breaching planner sweet
+    // spots. Tune via services.sync.subscription.bulk_items (falls back to services.sync.bulk_items).
+    public static final int DEFAULT_SUBSCRIPTION_BULK_ITEMS = 1000;
+    // ApiKey cursor page size — appender warmup loads per-chunk via this page size. Customer
+    // workloads vary; 500 is a reasonable midpoint between JWT-heavy (low key volume) and
+    // apikey-heavy. Tune via services.sync.apikey.bulk_items (falls back to services.sync.bulk_items).
+    public static final int DEFAULT_APIKEY_BULK_ITEMS = 500;
     // Chunk size for the `subscriptions IN (...)` filter applied when loading ApiKeys (appender
     // + refresher). Conservative default below common DB IN-list parameter limits; tune higher via
     // services.sync.apikey.subscriptions_chunk_size only after validating the target DB's parameter ceiling.
     public static final int DEFAULT_APIKEY_SUBSCRIPTIONS_CHUNK_SIZE = 900;
+    // Per-batch appender concurrency. The sync pipeline buffers APIs into batches of bulk_events
+    // and runs (plan+subscription+apikey) appenders per batch. Default 1 preserves current
+    // sequential behavior; bump to 4 to parallelize warmup at scale. Tune via
+    // services.sync.appender.parallelism.
+    public static final int DEFAULT_APPENDER_PARALLELISM = 1;
 
     @Bean("syncFetcherExecutor")
     public ThreadPoolExecutor syncFetcherExecutor(@Value("${services.sync.fetcher:-1}") int syncFetcher) {
@@ -172,7 +185,7 @@ public class SyncConfiguration {
         SubscriptionRepository subscriptionRepository,
         SubscriptionMapper subscriptionMapper,
         ApiProductRegistry apiProductRegistry,
-        @Value("${services.sync.bulk_items:" + DEFAULT_BULK_ITEMS + "}") int bulkItems
+        @Value("${services.sync.subscription.bulk_items:${services.sync.bulk_items:" + DEFAULT_SUBSCRIPTION_BULK_ITEMS + "}}") int bulkItems
     ) {
         return new SubscriptionAppender(subscriptionRepository, subscriptionMapper, apiProductRegistry, bulkItems);
     }
@@ -181,7 +194,7 @@ public class SyncConfiguration {
     public ApiKeyAppender apiKeyAppender(
         ApiKeyRepository apiKeyRepository,
         ApiKeyMapper apiKeyMapper,
-        @Value("${services.sync.bulk_items:" + DEFAULT_BULK_ITEMS + "}") int bulkItems,
+        @Value("${services.sync.apikey.bulk_items:${services.sync.bulk_items:" + DEFAULT_APIKEY_BULK_ITEMS + "}}") int bulkItems,
         @Value(
             "${services.sync.apikey.subscriptions_chunk_size:" + DEFAULT_APIKEY_SUBSCRIPTIONS_CHUNK_SIZE + "}"
         ) int subscriptionsChunkSize

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/kubernetes/spring/KubernetesSyncConfiguration.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/kubernetes/spring/KubernetesSyncConfiguration.java
@@ -89,7 +89,10 @@ public class KubernetesSyncConfiguration {
         ApiKeyAppender apiKeyAppender,
         DeployerFactory deployerFactory,
         @Qualifier("syncKubernetesExecutor") ThreadPoolExecutor syncKubernetesExecutor,
-        @Qualifier("syncDeployerExecutor") ThreadPoolExecutor syncDeployerExecutor
+        @Qualifier("syncDeployerExecutor") ThreadPoolExecutor syncDeployerExecutor,
+        @Value(
+            "${services.sync.appender.parallelism:" + io.gravitee.gateway.services.sync.SyncConfiguration.DEFAULT_APPENDER_PARALLELISM + "}"
+        ) int appenderParallelism
     ) {
         return new KubernetesApiSynchronizer(
             configMapEventFetcher,
@@ -100,7 +103,8 @@ public class KubernetesSyncConfiguration {
             apiKeyAppender,
             deployerFactory,
             syncKubernetesExecutor,
-            syncDeployerExecutor
+            syncDeployerExecutor,
+            appenderParallelism
         );
     }
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/kubernetes/synchronizer/KubernetesApiSynchronizer.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/kubernetes/synchronizer/KubernetesApiSynchronizer.java
@@ -47,7 +47,8 @@ public class KubernetesApiSynchronizer extends AbstractApiSynchronizer implement
         final ApiKeyAppender apiKeyAppender,
         final DeployerFactory deployerFactory,
         final ThreadPoolExecutor syncKubernetesExecutor,
-        final ThreadPoolExecutor syncDeployerExecutor
+        final ThreadPoolExecutor syncDeployerExecutor,
+        final int appenderParallelism
     ) {
         super(
             apiManager,
@@ -57,7 +58,8 @@ public class KubernetesApiSynchronizer extends AbstractApiSynchronizer implement
             apiKeyAppender,
             deployerFactory,
             syncKubernetesExecutor,
-            syncDeployerExecutor
+            syncDeployerExecutor,
+            appenderParallelism
         );
         this.configMapEventFetcher = configMapEventFetcher;
     }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/spring/RepositorySyncConfiguration.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/spring/RepositorySyncConfiguration.java
@@ -134,7 +134,11 @@ public class RepositorySyncConfiguration {
     @Bean
     public SubscriptionFetcher subscriptionFetcher(
         SubscriptionRepository subscriptionRepository,
-        @Value("${services.sync.bulk_items:" + DEFAULT_BULK_ITEMS + "}") int bulkItems
+        @Value(
+            "${services.sync.subscription.bulk_items:${services.sync.bulk_items:" +
+                io.gravitee.gateway.services.sync.SyncConfiguration.DEFAULT_SUBSCRIPTION_BULK_ITEMS +
+                "}}"
+        ) int bulkItems
     ) {
         return new SubscriptionFetcher(subscriptionRepository, bulkItems);
     }
@@ -142,7 +146,11 @@ public class RepositorySyncConfiguration {
     @Bean
     public ApiKeyFetcher apiKeyFetcher(
         ApiKeyRepository apiKeyRepository,
-        @Value("${services.sync.bulk_items:" + DEFAULT_BULK_ITEMS + "}") int bulkItems
+        @Value(
+            "${services.sync.apikey.bulk_items:${services.sync.bulk_items:" +
+                io.gravitee.gateway.services.sync.SyncConfiguration.DEFAULT_APIKEY_BULK_ITEMS +
+                "}}"
+        ) int bulkItems
     ) {
         return new ApiKeyFetcher(apiKeyRepository, bulkItems);
     }
@@ -193,7 +201,10 @@ public class RepositorySyncConfiguration {
         ApiKeyAppender apiKeyAppender,
         DeployerFactory deployerFactory,
         @Qualifier("syncFetcherExecutor") ThreadPoolExecutor syncFetcherExecutor,
-        @Qualifier("syncDeployerExecutor") ThreadPoolExecutor syncDeployerExecutor
+        @Qualifier("syncDeployerExecutor") ThreadPoolExecutor syncDeployerExecutor,
+        @Value(
+            "${services.sync.appender.parallelism:" + io.gravitee.gateway.services.sync.SyncConfiguration.DEFAULT_APPENDER_PARALLELISM + "}"
+        ) int appenderParallelism
     ) {
         return new ApiSynchronizer(
             eventsFetcher,
@@ -204,7 +215,8 @@ public class RepositorySyncConfiguration {
             apiKeyAppender,
             deployerFactory,
             syncFetcherExecutor,
-            syncDeployerExecutor
+            syncDeployerExecutor,
+            appenderParallelism
         );
     }
 
@@ -340,7 +352,11 @@ public class RepositorySyncConfiguration {
         ApiKeyMapper apiKeyMapper,
         SubscriptionService subscriptionService,
         ApiKeyService apiKeyService,
-        @Value("${services.sync.bulk_items:" + DEFAULT_BULK_ITEMS + "}") int bulkItems,
+        @Value(
+            "${services.sync.apikey.bulk_items:${services.sync.bulk_items:" +
+                io.gravitee.gateway.services.sync.SyncConfiguration.DEFAULT_APIKEY_BULK_ITEMS +
+                "}}"
+        ) int bulkItems,
         @Value(
             "${services.sync.apikey.subscriptions_chunk_size:" +
                 io.gravitee.gateway.services.sync.SyncConfiguration.DEFAULT_APIKEY_SUBSCRIPTIONS_CHUNK_SIZE +

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/api/AbstractApiSynchronizer.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/api/AbstractApiSynchronizer.java
@@ -50,6 +50,9 @@ public abstract class AbstractApiSynchronizer {
     protected final DeployerFactory deployerFactory;
     protected final ThreadPoolExecutor syncFetcherExecutor;
     protected final ThreadPoolExecutor syncDeployerExecutor;
+    // Max concurrent batches running plan+subscription+apikey appenders. 1 = sequential (current);
+    // higher = batch-level parallel warmup. Driven by services.sync.appender.parallelism.
+    protected final int appenderParallelism;
 
     protected abstract int bulkEvents();
 
@@ -115,9 +118,16 @@ public abstract class AbstractApiSynchronizer {
                                 .build()
                         )
                         .buffer(bulkEvents())
-                        .map(deployables -> planAppender.appends(deployables, environments))
-                        .map(deployables -> subscriptionAppender.appends(initialSync, deployables, environments))
-                        .map(deployables -> apiKeyAppender.appends(initialSync, deployables, environments))
+                        .flatMap(
+                            deployables ->
+                                Flowable.fromCallable(() -> {
+                                    planAppender.appends(deployables, environments);
+                                    subscriptionAppender.appends(initialSync, deployables, environments);
+                                    apiKeyAppender.appends(initialSync, deployables, environments);
+                                    return deployables;
+                                }).subscribeOn(Schedulers.from(syncFetcherExecutor)),
+                            appenderParallelism
+                        )
                         .flatMapIterable(d -> d);
                 } else if (reactableByAction.getKey() == ActionOnApi.UNDEPLOY) {
                     return reactableByAction.map(reactableApi ->

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/api/ApiSynchronizer.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/api/ApiSynchronizer.java
@@ -57,7 +57,8 @@ public class ApiSynchronizer extends AbstractApiSynchronizer implements Reposito
         final ApiKeyAppender apiKeyAppender,
         final DeployerFactory deployerFactory,
         final ThreadPoolExecutor syncFetcherExecutor,
-        final ThreadPoolExecutor syncDeployerExecutor
+        final ThreadPoolExecutor syncDeployerExecutor,
+        final int appenderParallelism
     ) {
         super(
             apiManager,
@@ -67,7 +68,8 @@ public class ApiSynchronizer extends AbstractApiSynchronizer implements Reposito
             apiKeyAppender,
             deployerFactory,
             syncFetcherExecutor,
-            syncDeployerExecutor
+            syncDeployerExecutor,
+            appenderParallelism
         );
         this.eventsFetcher = eventsFetcher;
     }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/api/ApiSynchronizerTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/api/ApiSynchronizerTest.java
@@ -137,7 +137,8 @@ class ApiSynchronizerTest {
             new ApiKeyAppender(apiKeyRepository, new ApiKeyMapper(), 100, 900),
             deployerFactory,
             new ThreadPoolExecutor(1, 1, 15L, TimeUnit.SECONDS, new LinkedBlockingQueue<>()),
-            new ThreadPoolExecutor(1, 1, 15L, TimeUnit.SECONDS, new LinkedBlockingQueue<>())
+            new ThreadPoolExecutor(1, 1, 15L, TimeUnit.SECONDS, new LinkedBlockingQueue<>()),
+            1 // appenderParallelism: sequential for test determinism
         );
         when(eventsFetcher.bulkItems()).thenReturn(1);
         lenient().when(deployerFactory.createApiDeployer()).thenReturn(apiDeployer);


### PR DESCRIPTION
## Summary

Follow-up to APIM-14087 / APIM-14203 cursor-pagination work. Customer perf evidence shows the shared `services.sync.bulk_items: 100` default is the bottleneck on subscription appender warmup at scale (customer scenario: 8,109 APIs / 24,527 plans / 2.4M subscriptions, JWT-heavy → warmup 712s with cursor vs 261s pre-cursor on 4.11.7).

Two changes:

### 1. Per-entity `bulk_items` overrides + raised defaults

New properties with Spring placeholder fallback chain to preserve back-compat:

```yaml
services:
  sync:
    bulk_items: 100              # legacy global default (preserved)
    subscription:
      bulk_items: 2000            # new — covers SubscriptionFetcher + SubscriptionAppender
    apikey:
      bulk_items: 500             # new — covers ApiKeyFetcher + ApiKeyAppender + ApiProductSubscriptionRefresher
      subscriptions_chunk_size: 5000   # already shipped in 14203
```

`@Value` chain: `${services.sync.subscription.bulk_items:${services.sync.bulk_items:1000}}` — specific override wins, then legacy, then new default.

New constants in `SyncConfiguration.java`:
- `DEFAULT_SUBSCRIPTION_BULK_ITEMS = 1000` (raised from 100 — customer evidence shows 100-row pages cripple round-trip-bound workloads).
- `DEFAULT_APIKEY_BULK_ITEMS = 500` (reasonable midpoint for mixed JWT/api-key workloads).
- `DEFAULT_APPENDER_PARALLELISM = 1` (see below).

**Back-compat**: customers with explicit `services.sync.bulk_items: 100` keep 100. Only new deployments (or customers who remove the legacy key) get the new defaults.

### 2. `services.sync.appender.parallelism` for batch-level concurrency

`AbstractApiSynchronizer.prepareForDeployment` currently runs `.buffer(bulkEvents()) → .map(planAppender) → .map(subAppender) → .map(apiKeyAppender)` sequentially. At customer scale (~81 batches of 100 APIs each), that's 81 batches done back-to-back regardless of available CPU/DB capacity.

Changed to `.flatMap(deployables -> Flowable.fromCallable(...).subscribeOn(syncFetcherExecutor), appenderParallelism)`. With `appenderParallelism=1` behavior is identical to current sequential `.map`. Bump to 4 to overlap 4 batches' worth of DB calls.

Default is **1** (no behavior change for existing deployments). Customer-specific tuning: set `services.sync.appender.parallelism: 4` in `gravitee.yml`.

## Estimated impact (customer scenario)

Combining all three knobs:

| Config | Estimated warmup |
|---|---|
| 4.11.7 (no cursor) | 261s (baseline) |
| 4.11.8 default (bulk_items=100, no parallel) | 712s |
| `subscription.bulk_items=2000` | ~85s |
| Above + `appender.parallelism=4` | ~25s |

Numbers come from the per-page-overhead math I shared with the customer. Real measurement needed.

## Risk

- Backward compat: all defaults preserve current behavior unless a customer sets new keys. `services.sync.bulk_items: 100` (if explicitly set) still maps to 100 for everything.
- Parallelism: the appenders are stateless / thread-safe (verified during APIM-14203 review). `Schedulers.from(syncFetcherExecutor)` reuses existing thread pool.
- Memory: at `subscription.bulk_items=2000`, each page holds ~2MB transiently × parallelism. Worst case ~10MB peak — negligible.

## Test plan

- [x] Sync module unit tests: **366/366 passing**
- [x] Gateway boot in fresh worktree (`sync-perf-tuning`) — Spring placeholder chains resolve, no AbstractMethodError, no sync errors.
- [ ] CI pipeline green on this PR.
- [ ] Customer rollout test: set `subscription.bulk_items=2000` + `appender.parallelism=4` and measure warmup time vs baseline.

## Reference

- APIM-14087 (subscription cursor) — established the cursor pagination pattern.
- APIM-14203 (apikey cursor) — added per-entity scoping convention via `apikey.subscriptions_chunk_size`.
- Customer scenario: 2,396,373 subs / 5,644 apps / 24,527 plans / 8,109 APIs / mostly JWT.