### PR TITLE
feat(mcp): seed default Overview pages for MCP proxy APIs

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/use_case/SeedDefaultPagesForApiNavigationItemsUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/use_case/SeedDefaultPagesForApiNavigationItemsUseCase.java
@@ -16,6 +16,7 @@
 package io.gravitee.apim.core.portal_page.use_case;
 
 import io.gravitee.apim.core.UseCase;
+import io.gravitee.apim.core.api.crud_service.ApiCrudService;
 import io.gravitee.apim.core.portal_page.crud_service.PortalPageContentCrudService;
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemDomainService;
 import io.gravitee.apim.core.portal_page.model.CreatePortalNavigationItem;
@@ -27,6 +28,7 @@ import io.gravitee.apim.core.portal_page.model.PortalNavigationItemType;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationPage;
 import io.gravitee.apim.core.portal_page.model.PortalPageContentType;
 import io.gravitee.apim.core.portal_page.query_service.PortalNavigationItemsQueryService;
+import io.gravitee.definition.model.v4.ApiType;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.CustomLog;
@@ -39,10 +41,12 @@ public class SeedDefaultPagesForApiNavigationItemsUseCase {
 
     private static final String DEFAULT_PAGE_TITLE = "Overview";
     private static final String DEFAULT_OVERVIEW_TEMPLATE = "api-overview-page-content.md";
+    private static final String MCP_PROXY_OVERVIEW_TEMPLATE = "api-overview-mcp-proxy-page-content.md";
 
     private final PortalNavigationItemsQueryService portalNavigationItemsQueryService;
     private final PortalNavigationItemDomainService portalNavigationItemDomainService;
     private final PortalPageContentCrudService portalPageContentCrudService;
+    private final ApiCrudService apiCrudService;
 
     public Output execute(Input input) {
         var seededNavigationItemIds = new ArrayList<PortalNavigationItemId>();
@@ -79,8 +83,14 @@ public class SeedDefaultPagesForApiNavigationItemsUseCase {
             return false;
         }
 
+        var templatePath = apiCrudService
+            .findById(apiNavigationItem.getApiId())
+            .filter(api -> ApiType.MCP_PROXY == api.getType())
+            .map(api -> MCP_PROXY_OVERVIEW_TEMPLATE)
+            .orElse(DEFAULT_OVERVIEW_TEMPLATE);
+
         var content = portalPageContentCrudService.create(
-            GraviteeMarkdownPageContent.create(organizationId, environmentId, loadContent(DEFAULT_OVERVIEW_TEMPLATE))
+            GraviteeMarkdownPageContent.create(organizationId, environmentId, loadContent(templatePath))
         );
 
         portalNavigationItemDomainService.create(

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/resources/templates/api-overview-mcp-proxy-page-content.md
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/resources/templates/api-overview-mcp-proxy-page-content.md
@@ -1,0 +1,18 @@
+# ${api.name}
+
+Welcome to the documentation for **${api.name}**.
+
+<#if api.description?? && api.description?has_content>
+${api.description}
+
+</#if>
+## API information
+
+- Version: `${api.version!""}`
+- Type: `${api.type!""}`
+- Visibility: `${api.visibility!""}`
+- Identifier: `${api.id}`
+
+## Install this MCP server
+
+<gmd-install-mcp name="${api.name}" transport="http" url="<#if api.entrypoints?? && (api.entrypoints?size > 0)>${api.entrypoints[0]}</#if><#if api.mcp?? && api.mcp.mcpPath??>${api.mcp.mcpPath}</#if>" />

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/SeedDefaultPagesForApiNavigationItemsUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/SeedDefaultPagesForApiNavigationItemsUseCaseTest.java
@@ -46,6 +46,7 @@ import org.junit.jupiter.api.Test;
 class SeedDefaultPagesForApiNavigationItemsUseCaseTest {
 
     private SeedDefaultPagesForApiNavigationItemsUseCase useCase;
+    private ApiCrudServiceInMemory apiCrudService;
     private PortalNavigationItemsCrudServiceInMemory portalNavigationItemsCrudService;
     private PortalNavigationItemsQueryServiceInMemory portalNavigationItemsQueryService;
     private PortalPageContentCrudServiceInMemory portalPageContentCrudService;
@@ -57,7 +58,7 @@ class SeedDefaultPagesForApiNavigationItemsUseCaseTest {
         portalNavigationItemsQueryService = new PortalNavigationItemsQueryServiceInMemory(storage);
         portalPageContentCrudService = new PortalPageContentCrudServiceInMemory();
 
-        var apiCrudService = new ApiCrudServiceInMemory();
+        apiCrudService = new ApiCrudServiceInMemory();
         apiCrudService.initWith(List.of(Api.builder().id("api-1").name("API 1").version("1.0.0").type(ApiType.PROXY).build()));
 
         portalNavigationItemsQueryService.initWith(PortalNavigationItemFixtures.sampleNavigationItems());
@@ -70,7 +71,8 @@ class SeedDefaultPagesForApiNavigationItemsUseCaseTest {
                 portalPageContentCrudService,
                 apiCrudService
             ),
-            portalPageContentCrudService
+            portalPageContentCrudService,
+            apiCrudService
         );
     }
 
@@ -116,6 +118,22 @@ class SeedDefaultPagesForApiNavigationItemsUseCaseTest {
 
         assertThat(output.seededNavigationItemIds()).isEmpty();
         assertThat(portalPageContentCrudService.storage()).isEmpty();
+    }
+
+    @Test
+    void should_seed_mcp_proxy_overview_page_for_mcp_proxy_api() {
+        apiCrudService.initWith(List.of(Api.builder().id("api-1").name("MCP API").version("1.0.0").type(ApiType.MCP_PROXY).build()));
+
+        var output = useCase.execute(
+            new SeedDefaultPagesForApiNavigationItemsUseCase.Input(ORG_ID, ENV_ID, List.of(PortalNavigationItemId.of(API1_ID)))
+        );
+
+        assertThat(output.seededNavigationItemIds()).containsExactly(PortalNavigationItemId.of(API1_ID));
+        assertThat(portalPageContentCrudService.storage())
+            .singleElement()
+            .isInstanceOfSatisfying(GraviteeMarkdownPageContent.class, content ->
+                assertThat(content.getContent().value()).isEqualTo(loadTemplate("api-overview-mcp-proxy-page-content.md"))
+            );
     }
 
     @Test


### PR DESCRIPTION
Add logic to generate specific "Overview" pages for MCP proxy APIs using a dedicated template. Update tests and integrate with existing seeding mechanisms.

## Issue

https://gravitee.atlassian.net/browse/APIM-14225

Summary

Adds MCP Proxy default Overview template with install widget and API metadata.
Selects template in SeedDefaultPagesForApiNavigationItemsUseCase based on linked API type (MCP_PROXY vs default).
Adds unit test for MCP Proxy seeding.

POST /portal-navigation-items/_default-pages
  → SeedDefaultPagesForApiNavigationItemsUseCase
      → for each API nav item (no existing child page):
          → apiCrudService.findById(apiId)
          → type == MCP_PROXY ? mcp template : generic template
          → create Gravitee Markdown content + unpublished "Overview" page


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

