### PR TITLE
chore(deps): bump gravitee-policy-authz-pep to 1.0.0-alpha.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -342,7 +342,7 @@
 
         <!-- Authz plugins -->
         <gravitee-service-authz-pdp.version>1.0.0-alpha.1</gravitee-service-authz-pdp.version>
-        <gravitee-policy-authz-pep.version>1.0.0-alpha.1</gravitee-policy-authz-pep.version>
+        <gravitee-policy-authz-pep.version>1.0.0-alpha.3</gravitee-policy-authz-pep.version>
     </properties>
 
     <scm>


### PR DESCRIPTION
## Issue

N/A — dependency bump for the Gamma Authz PEP plugin.

## Description

Bump `gravitee-policy-authz-pep` from `1.0.0-alpha.1` to `1.0.0-alpha.3` (single property in root `pom.xml`; both distribution poms resolve via `${gravitee-policy-authz-pep.version}`).

Picks up two customer-facing fixes:

- **`1.0.0-alpha.2`** — cold-start no-snapshot policy (`DENY` / `RETRY_THEN_DENY` / `PERMIT`): the PEP can now tell apart a PDP that hasn't loaded its first snapshot yet from a permanently dead PDP, instead of hard-503-ing every request during the boot window.
- **`1.0.0-alpha.3`** — preserve the configured `denyStatus` on a PDP DENY. Previously every non-PERMIT decision raised an `InterruptionFailureException` that was caught and re-mapped through `handleFailure`, clobbering the intended `403` to `500` and emitting a misleading `Authz PDP eval failed` ERROR with a full stacktrace — even though the PDP responded correctly. Also defaults `evalTimeoutMs` to `1000ms` so configs created via the UI without an explicit value no longer fail with `PEP sendTimeout must be >= 1`.

## Additional context

- Artifact verified resolvable from `gravitee-artifactory-releases` (groupId `com.graviteesource.gamma`), `mvn dependency:get` → BUILD SUCCESS.
- Upstream PRs: gravitee-io/gravitee-policy-authz-pep#2 (alpha.2) and #3 (alpha.3).