### PR TITLE
fix(ci): detect gamma-only changes for frontend CI jobs

### DIFF
--- a/.circleci/ci/src/config.ts
+++ b/.circleci/ci/src/config.ts
@@ -54,6 +54,7 @@ const components = {
   gamma: {
     project: 'gravitee-gamma-control-plane-webui',
     workdir: 'gravitee-gamma/gravitee-gamma-control-plane-webui',
+    rootDir: 'gravitee-gamma',
     image: 'gamma-ui',
   },
 };

--- a/.circleci/ci/src/pipelines/tests/pipeline-pull-requests.spec.ts
+++ b/.circleci/ci/src/pipelines/tests/pipeline-pull-requests.spec.ts
@@ -18,25 +18,25 @@ import { generatePullRequestsConfig } from '../pipeline-pull-requests';
 
 describe('Pull requests workflow tests', () => {
   it.each`
-    baseBranch  | branch                          | changedFiles                                             | expectedFileName
-    ${'master'} | ${'master'}                     | ${['pom.xml']}                                           | ${'pull-requests-master.yml'}
-    ${'4.1.x'}  | ${'4.1.x'}                      | ${['pom.xml']}                                           | ${'pull-requests-4-1-x.yml'}
-    ${'4.0.x'}  | ${'mergify/bp/4.0.x/pr-1234'}   | ${['pom.xml']}                                           | ${'pull-requests-mergify.yml'}
-    ${'master'} | ${'APIM-1234-run-e2e'}          | ${['pom.xml']}                                           | ${'pull-requests-run-e2e.yml'}
-    ${'master'} | ${'APIM-1234-my-custom-branch'} | ${['pom.xml']}                                           | ${'pull-requests-custom-branch.yml'}
-    ${'master'} | ${'APIM-1234-my-custom-branch'} | ${['helm']}                                              | ${'pull-requests-custom-branch-helm-only.yml'}
-    ${'master'} | ${'APIM-1234-my-custom-branch'} | ${['gravitee-apim-console-webui']}                       | ${'pull-requests-custom-branch-console-only.yml'}
-    ${'master'} | ${'APIM-1234-my-custom-branch'} | ${['gravitee-gamma/gravitee-gamma-control-plane-webui']} | ${'pull-requests-custom-branch-gamma-console-only.yml'}
-    ${'master'} | ${'APIM-1234-my-custom-branch'} | ${['gravitee-apim-portal-webui']}                        | ${'pull-requests-custom-branch-portal-only.yml'}
-    ${'master'} | ${'APIM-1234-my-custom-branch'} | ${['gravitee-apim-portal-webui-next']}                   | ${'pull-requests-custom-branch-portal-next-only.yml'}
-    ${'master'} | ${'APIM-1234-my-custom-branch'} | ${['gravitee-apim-definition']}                          | ${'pull-requests-custom-branch-backend-only.yml'}
-    ${'master'} | ${'APIM-1234-my-custom-branch'} | ${['gravitee-apim-distribution']}                        | ${'pull-requests-custom-branch-backend-distribution-only.yml'}
-    ${'master'} | ${'APIM-1234-my-custom-branch'} | ${['gravitee-apim-gateway']}                             | ${'pull-requests-custom-branch-backend-gateway-only.yml'}
-    ${'master'} | ${'APIM-1234-my-custom-branch'} | ${['gravitee-apim-integration-tests']}                   | ${'pull-requests-custom-branch-backend-integration-tests-only.yml'}
-    ${'master'} | ${'APIM-1234-my-custom-branch'} | ${['gravitee-apim-plugin']}                              | ${'pull-requests-custom-branch-backend-plugin-only.yml'}
-    ${'master'} | ${'APIM-1234-my-custom-branch'} | ${['gravitee-apim-reporter']}                            | ${'pull-requests-custom-branch-backend-reporter-only.yml'}
-    ${'master'} | ${'APIM-1234-my-custom-branch'} | ${['gravitee-apim-repository']}                          | ${'pull-requests-custom-branch-backend-only.yml'}
-    ${'master'} | ${'APIM-1234-my-custom-branch'} | ${['gravitee-apim-rest-api']}                            | ${'pull-requests-custom-branch-backend-rest-api-only.yml'}
+    baseBranch  | branch                          | changedFiles                           | expectedFileName
+    ${'master'} | ${'master'}                     | ${['pom.xml']}                         | ${'pull-requests-master.yml'}
+    ${'4.1.x'}  | ${'4.1.x'}                      | ${['pom.xml']}                         | ${'pull-requests-4-1-x.yml'}
+    ${'4.0.x'}  | ${'mergify/bp/4.0.x/pr-1234'}   | ${['pom.xml']}                         | ${'pull-requests-mergify.yml'}
+    ${'master'} | ${'APIM-1234-run-e2e'}          | ${['pom.xml']}                         | ${'pull-requests-run-e2e.yml'}
+    ${'master'} | ${'APIM-1234-my-custom-branch'} | ${['pom.xml']}                         | ${'pull-requests-custom-branch.yml'}
+    ${'master'} | ${'APIM-1234-my-custom-branch'} | ${['helm']}                            | ${'pull-requests-custom-branch-helm-only.yml'}
+    ${'master'} | ${'APIM-1234-my-custom-branch'} | ${['gravitee-apim-console-webui']}     | ${'pull-requests-custom-branch-console-only.yml'}
+    ${'master'} | ${'APIM-1234-my-custom-branch'} | ${['gravitee-gamma']}                  | ${'pull-requests-custom-branch-gamma-console-only.yml'}
+    ${'master'} | ${'APIM-1234-my-custom-branch'} | ${['gravitee-apim-portal-webui']}      | ${'pull-requests-custom-branch-portal-only.yml'}
+    ${'master'} | ${'APIM-1234-my-custom-branch'} | ${['gravitee-apim-portal-webui-next']} | ${'pull-requests-custom-branch-portal-next-only.yml'}
+    ${'master'} | ${'APIM-1234-my-custom-branch'} | ${['gravitee-apim-definition']}        | ${'pull-requests-custom-branch-backend-only.yml'}
+    ${'master'} | ${'APIM-1234-my-custom-branch'} | ${['gravitee-apim-distribution']}      | ${'pull-requests-custom-branch-backend-distribution-only.yml'}
+    ${'master'} | ${'APIM-1234-my-custom-branch'} | ${['gravitee-apim-gateway']}           | ${'pull-requests-custom-branch-backend-gateway-only.yml'}
+    ${'master'} | ${'APIM-1234-my-custom-branch'} | ${['gravitee-apim-integration-tests']} | ${'pull-requests-custom-branch-backend-integration-tests-only.yml'}
+    ${'master'} | ${'APIM-1234-my-custom-branch'} | ${['gravitee-apim-plugin']}            | ${'pull-requests-custom-branch-backend-plugin-only.yml'}
+    ${'master'} | ${'APIM-1234-my-custom-branch'} | ${['gravitee-apim-reporter']}          | ${'pull-requests-custom-branch-backend-reporter-only.yml'}
+    ${'master'} | ${'APIM-1234-my-custom-branch'} | ${['gravitee-apim-repository']}        | ${'pull-requests-custom-branch-backend-only.yml'}
+    ${'master'} | ${'APIM-1234-my-custom-branch'} | ${['gravitee-apim-rest-api']}          | ${'pull-requests-custom-branch-backend-rest-api-only.yml'}
   `(
     'should generate pull-requests config for branch $branchName with changedFiles $changedFiles',
     ({ baseBranch, branch, changedFiles, expectedFileName }) => {

--- a/.circleci/ci/src/workflows/workflow-pull-requests.ts
+++ b/.circleci/ci/src/workflows/workflow-pull-requests.ts
@@ -779,7 +779,7 @@ function shouldBuildPortal(changedFiles: string[]): boolean {
 }
 
 function shouldBuildGammaUI(changedFiles: string[]): boolean {
-  return shouldBuildAllFront(changedFiles) || changedFiles.some((file) => file.includes(config.components.gamma.workdir));
+  return shouldBuildAllFront(changedFiles) || changedFiles.some((file) => file.includes(config.components.gamma.rootDir));
 }
 
 function shouldBuildBackend(changedFiles: string[]): boolean {


### PR DESCRIPTION
## Summary

- The CI `changedFiles` utility (`git.ts`) truncates file paths to the first directory segment (e.g. `gravitee-gamma/gravitee-gamma-control-plane-webui/src/...` becomes `gravitee-gamma`)
- `shouldBuildGammaUI` compared against the full nested path `gravitee-gamma/gravitee-gamma-control-plane-webui`, which never matched the truncated input
- This caused frontend lint, test, and build jobs to be silently skipped for any gamma-only branch that didn't also touch root-level files like `package.json` or `yarn.lock`
- Fix: match on `gravitee-gamma` instead of the full nested workdir path
- Updated the test to use realistic truncated input (`gravitee-gamma` instead of `gravitee-gamma/gravitee-gamma-control-plane-webui`); all 100 CI tests pass

## Test plan

- [x] All 100 existing CI config generation tests pass locally
- [ ] Verify CI runs frontend jobs on a gamma-only branch after merge