### PR TITLE
fix(authz-ui): QA findings — duplicate guard, full-set filtering, canonical targets

### DIFF
--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/features/policy-structure/CreateEntityDialog.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/features/policy-structure/CreateEntityDialog.tsx
@@ -187,6 +187,14 @@ export function CreateEntityDialog({ open, kind, environmentId, onOpenChange, on
         };
         if (trimmedDescription) attributes.description = trimmedDescription;
         try {
+            // The backend "save" is create-or-replace (upsert), shared with the
+            // import/sync flows. The Add dialog means *create*, so guard against
+            // silently overwriting an existing entity with the same Entity ID.
+            const existing = await authzApiService.getEntity(environmentId, entityId);
+            if (existing) {
+                setSubmitError(`An entity with ID "${entityId}" already exists. Pick a different slug or prefix.`);
+                return;
+            }
             await authzApiService.createEntity(environmentId, {
                 entityId,
                 kind,
@@ -303,6 +311,11 @@ export function CreateEntityDialog({ open, kind, environmentId, onOpenChange, on
                                 onChange={e => {
                                     setSlug(e.target.value);
                                     setSlugTouched(true);
+                                }}
+                                onFocus={e => {
+                                    // First focus on an auto-derived slug selects it, so typing
+                                    // replaces the suggestion instead of appending to it.
+                                    if (!slugTouched) e.currentTarget.select();
                                 }}
                                 placeholder="e.g. alice"
                                 aria-invalid={slugError !== null}

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/features/policy-structure/EntitiesPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/features/policy-structure/EntitiesPage.tsx
@@ -47,12 +47,12 @@ import {
 import { BoxesIcon, DownloadIcon, PlusIcon, ShieldIcon, Trash2Icon, UsersIcon } from '@gravitee/graphene-core/icons';
 import { useQueryClient } from '@tanstack/react-query';
 import type { ColumnDef } from '@tanstack/react-table';
-import { useDeferredValue, useMemo, useState } from 'react';
+import { useDeferredValue, useEffect, useMemo, useState } from 'react';
 import { KpiTile } from '../../components/KpiTile';
-import { authzApiService } from '../../shared/api/authz-api.service';
+import { authzApiService, DEFAULT_PER_PAGE } from '../../shared/api/authz-api.service';
 import { authzQueryKeys } from '../../shared/api/query-keys';
 import { formatEntityUid, fromBackend } from '../../shared/entity-adapter';
-import { useEntities, type UseEntitiesResult } from '../../shared/hooks/useEntities';
+import { useAllEntities } from '../../shared/hooks/useAllEntities';
 import { CreateEntityDialog } from './CreateEntityDialog';
 import { CATEGORIES, getEntityCategoryId, type EntityInstance } from './entity-types';
 import { ImportFromCatalogDialog } from './ImportFromCatalogDialog';
@@ -297,24 +297,28 @@ function distinctSorted<T extends string>(values: Iterable<T>): T[] {
     return Array.from(new Set(values)).sort();
 }
 
-function pageEntities(query: UseEntitiesResult): readonly EntityInstance[] {
-    if (!query.data) return [];
-    return query.data.data.map(fromBackend);
+function paginate<T>(items: readonly T[], page: number, perPage: number): T[] {
+    const start = (page - 1) * perPage;
+    return items.slice(start, start + perPage);
 }
 
 export function EntitiesPage() {
     const env = useEnvironment();
     const environmentId = env?.id ?? '';
     const queryClient = useQueryClient();
-    const principalsQuery = useEntities(environmentId, undefined, { kind: 'PRINCIPAL' });
-    const resourcesQuery = useEntities(environmentId, undefined, { kind: 'RESOURCE', excludeEntityIdPrefix: ACTION_PREFIX });
+    const principalsQuery = useAllEntities(environmentId, { kind: 'PRINCIPAL' });
+    const resourcesQuery = useAllEntities(environmentId, { kind: 'RESOURCE', excludeEntityIdPrefix: ACTION_PREFIX });
 
     const [principalSearch, setPrincipalSearch] = useState('');
     const [principalTypeFilter, setPrincipalTypeFilter] = useState<TypeFilter>('all');
     const [principalSourceFilter, setPrincipalSourceFilter] = useState<SourceFilter>('all');
+    const [principalPage, setPrincipalPage] = useState(1);
+    const [principalPerPage, setPrincipalPerPage] = useState(DEFAULT_PER_PAGE);
     const [resourceSearch, setResourceSearch] = useState('');
     const [resourceTypeFilter, setResourceTypeFilter] = useState<TypeFilter>('all');
     const [resourceSourceFilter, setResourceSourceFilter] = useState<SourceFilter>('all');
+    const [resourcePage, setResourcePage] = useState(1);
+    const [resourcePerPage, setResourcePerPage] = useState(DEFAULT_PER_PAGE);
     const [importOpen, setImportOpen] = useState(false);
     const [addingKind, setAddingKind] = useState<AddingKind | null>(null);
     const [pendingDelete, setPendingDelete] = useState<EntityInstance | null>(null);
@@ -348,19 +352,19 @@ export function EntitiesPage() {
     const deferredPrincipalSearch = useDeferredValue(principalSearch);
     const deferredResourceSearch = useDeferredValue(resourceSearch);
 
-    const principals = useMemo(() => pageEntities(principalsQuery), [principalsQuery]);
-    const resources = useMemo(() => pageEntities(resourcesQuery), [resourcesQuery]);
+    // Full sets (every page) so search/filter/paginate operate over all entities,
+    // not just one server page.
+    const principals = useMemo(() => principalsQuery.data.map(fromBackend), [principalsQuery.data]);
+    const resources = useMemo(() => resourcesQuery.data.map(fromBackend), [resourcesQuery.data]);
 
-    const principalTotal = principalsQuery.data?.total ?? 0;
-    const resourceTotal = resourcesQuery.data?.total ?? 0;
+    const principalTotal = principalsQuery.total;
+    const resourceTotal = resourcesQuery.total;
 
     const principalTypes = useMemo(() => distinctSorted(principals.map(e => e.uid.type)), [principals]);
     const resourceTypes = useMemo(() => distinctSorted(resources.map(e => e.uid.type)), [resources]);
     const principalSources = useMemo(() => distinctSorted(principals.map(sourceLabelOf)), [principals]);
     const resourceSources = useMemo(() => distinctSorted(resources.map(sourceLabelOf)), [resources]);
 
-    // TODO(authz-ui): server-side filters for search/type/source — these stay
-    // client-side and operate on the currently visible page only.
     const filteredPrincipals = useMemo(
         () => applyFilters(principals, deferredPrincipalSearch, principalTypeFilter, principalSourceFilter),
         [principals, deferredPrincipalSearch, principalTypeFilter, principalSourceFilter],
@@ -370,13 +374,35 @@ export function EntitiesPage() {
         [resources, deferredResourceSearch, resourceTypeFilter, resourceSourceFilter],
     );
 
+    // Reset to page 1 whenever the filtered result set changes shape, so we never
+    // sit on a now-empty page after filtering, resizing, or deleting.
+    useEffect(() => {
+        setPrincipalPage(1);
+    }, [deferredPrincipalSearch, principalTypeFilter, principalSourceFilter, principalPerPage]);
+    useEffect(() => {
+        setResourcePage(1);
+    }, [deferredResourceSearch, resourceTypeFilter, resourceSourceFilter, resourcePerPage]);
+
+    const principalPageCount = Math.max(1, Math.ceil(filteredPrincipals.length / principalPerPage));
+    const resourcePageCount = Math.max(1, Math.ceil(filteredResources.length / resourcePerPage));
+    const safePrincipalPage = Math.min(principalPage, principalPageCount);
+    const safeResourcePage = Math.min(resourcePage, resourcePageCount);
+    const pagedPrincipals = useMemo(
+        () => paginate(filteredPrincipals, safePrincipalPage, principalPerPage),
+        [filteredPrincipals, safePrincipalPage, principalPerPage],
+    );
+    const pagedResources = useMemo(
+        () => paginate(filteredResources, safeResourcePage, resourcePerPage),
+        [filteredResources, safeResourcePage, resourcePerPage],
+    );
+
     const kpis = useMemo(() => {
-        const visibleTypes = new Set<string>();
-        principals.forEach(e => visibleTypes.add(e.uid.type));
-        resources.forEach(e => visibleTypes.add(e.uid.type));
+        const types = new Set<string>();
+        principals.forEach(e => types.add(e.uid.type));
+        resources.forEach(e => types.add(e.uid.type));
         return {
             total: principalTotal + resourceTotal,
-            types: visibleTypes.size,
+            types: types.size,
             principals: principalTotal,
             resources: resourceTotal,
         };
@@ -400,7 +426,7 @@ export function EntitiesPage() {
 
             <div className="grid grid-cols-2 gap-3 md:grid-cols-4" aria-label="Key metrics">
                 <KpiTile label="Total entities" value={kpis.total} loading={isLoading} />
-                <KpiTile label="Types (this page)" value={kpis.types} loading={isLoading} />
+                <KpiTile label="Types" value={kpis.types} loading={isLoading} />
                 <KpiTile label="Principals" value={kpis.principals} loading={isLoading} />
                 <KpiTile label="Resources" value={kpis.resources} loading={isLoading} />
             </div>
@@ -451,14 +477,14 @@ export function EntitiesPage() {
                     </div>
                     <EntitiesTable
                         tab="principals"
-                        entities={filteredPrincipals}
+                        entities={pagedPrincipals}
                         searchValue={deferredPrincipalSearch}
                         isLoading={principalsQuery.isLoading}
-                        page={principalsQuery.page}
-                        perPage={principalsQuery.perPage}
-                        totalCount={principalTotal}
-                        onPageChange={principalsQuery.setPage}
-                        onPerPageChange={principalsQuery.setPerPage}
+                        page={safePrincipalPage}
+                        perPage={principalPerPage}
+                        totalCount={filteredPrincipals.length}
+                        onPageChange={setPrincipalPage}
+                        onPerPageChange={setPrincipalPerPage}
                     />
                 </TabsContent>
 
@@ -491,14 +517,14 @@ export function EntitiesPage() {
                     </div>
                     <EntitiesTable
                         tab="resources"
-                        entities={filteredResources}
+                        entities={pagedResources}
                         searchValue={deferredResourceSearch}
                         isLoading={resourcesQuery.isLoading}
-                        page={resourcesQuery.page}
-                        perPage={resourcesQuery.perPage}
-                        totalCount={resourceTotal}
-                        onPageChange={resourcesQuery.setPage}
-                        onPerPageChange={resourcesQuery.setPerPage}
+                        page={safeResourcePage}
+                        perPage={resourcePerPage}
+                        totalCount={filteredResources.length}
+                        onPageChange={setResourcePage}
+                        onPerPageChange={setResourcePerPage}
                         onDelete={setPendingDelete}
                         deletingEntityId={deletingEntityId}
                     />

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/features/policy-structure/__tests__/CreateEntityDialog.test.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/features/policy-structure/__tests__/CreateEntityDialog.test.tsx
@@ -27,6 +27,7 @@ beforeAll(() => {
 });
 
 const listEntitiesSpy = vi.fn();
+const getEntitySpy = vi.fn();
 const createEntitySpy = vi.fn();
 const toastSuccessSpy = vi.fn();
 
@@ -34,6 +35,7 @@ vi.mock('../../../shared/api/authz-api.service', () => ({
     DEFAULT_PER_PAGE: 200,
     authzApiService: {
         listEntities: (env: string, params?: unknown) => listEntitiesSpy(env, params),
+        getEntity: (env: string, id: string) => getEntitySpy(env, id),
         createEntity: (env: string, req: unknown) => createEntitySpy(env, req),
     },
 }));
@@ -73,9 +75,11 @@ function seedParents(uids: readonly string[]) {
 
 beforeEach(() => {
     listEntitiesSpy.mockReset();
+    getEntitySpy.mockReset();
     createEntitySpy.mockReset();
     toastSuccessSpy.mockReset();
     seedParents([]);
+    getEntitySpy.mockResolvedValue(null);
     createEntitySpy.mockResolvedValue({
         id: 'new-1',
         environmentId: 'DEFAULT',
@@ -199,8 +203,35 @@ describe('CreateEntityDialog', () => {
         expect(attrs.description).toBeUndefined();
     });
 
-    it('renders the duplicate-id message on 409 and keeps the dialog open', async () => {
+    it('blocks the create when an entity with the same Entity ID already exists', async () => {
         const user = userEvent.setup();
+        // Pre-check finds an existing entity → must not call the upsert endpoint,
+        // which would silently overwrite it (data loss).
+        getEntitySpy.mockResolvedValue({
+            id: 'existing-1',
+            environmentId: 'DEFAULT',
+            uid: 'user.alice',
+            attributes: { _displayName: 'Original Alice', department: 'engineering' },
+            parents: [],
+            createdAt: '2026-01-01T00:00:00.000Z',
+            updatedAt: '2026-01-01T00:00:00.000Z',
+        });
+        const { onOpenChange } = renderDialog({ kind: 'PRINCIPAL' });
+
+        await user.type(screen.getByLabelText(/Display name/i), 'Alice');
+        await user.click(screen.getByRole('button', { name: /Create Principal/i }));
+
+        await waitFor(() => expect(getEntitySpy).toHaveBeenCalledWith('DEFAULT', 'user.alice'));
+        await waitFor(() => expect(screen.getByText(/An entity with ID "user\.alice" already exists/i)).toBeInTheDocument());
+        expect(createEntitySpy).not.toHaveBeenCalled();
+        // Dialog stays open; onOpenChange is only called by the caller closing it.
+        expect(onOpenChange).not.toHaveBeenCalled();
+    });
+
+    it('still maps a backend 409 (race) to the duplicate-id message', async () => {
+        const user = userEvent.setup();
+        // Pre-check passes (null) but a concurrent create lands first → backend 409.
+        getEntitySpy.mockResolvedValue(null);
         createEntitySpy.mockRejectedValueOnce(new Error('HTTP 409 entity already exists'));
         const { onOpenChange } = renderDialog({ kind: 'PRINCIPAL' });
 
@@ -208,7 +239,6 @@ describe('CreateEntityDialog', () => {
         await user.click(screen.getByRole('button', { name: /Create Principal/i }));
 
         await waitFor(() => expect(screen.getByText(/An entity with ID "user\.alice" already exists/i)).toBeInTheDocument());
-        // Dialog stays open; onOpenChange called only by the caller closing it, not by the error path.
         expect(onOpenChange).not.toHaveBeenCalled();
     });
 

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/features/policy-structure/__tests__/EntitiesPage.test.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/features/policy-structure/__tests__/EntitiesPage.test.tsx
@@ -70,6 +70,7 @@ vi.mock('@gravitee/gamma-modules-sdk', async importOriginal => ({
 
 vi.mock('../../../shared/api/authz-api.service', () => ({
     DEFAULT_PER_PAGE: 10,
+    MAX_PER_PAGE: 100,
     authzApiService: {
         listEntities: (env: string, params?: ListEntitiesParams) => listEntitiesSpy(env, params),
         deleteEntity: (env: string, entityId: string) => deleteEntitySpy(env, entityId),

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/shared/__tests__/policy-entity-refs.test.ts
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/shared/__tests__/policy-entity-refs.test.ts
@@ -191,8 +191,19 @@ describe('deriveTargetEntityId', () => {
     });
 
     it('binds LLM and API resources to their service entity', () => {
-        expect(deriveTargetEntityId('permit ( principal, action, resource == LLM::"gpt-4o" );')).toBe('llm.gpt-4o');
+        // `LLM` is an alias of the `model` kind — the derived id is canonicalised.
+        expect(deriveTargetEntityId('permit ( principal, action, resource == LLM::"gpt-4o" );')).toBe('model.gpt-4o');
         expect(deriveTargetEntityId('forbid ( principal, action, resource == API::"orders.items" );')).toBe('api.orders');
+    });
+
+    it('canonicalises UI-type and alias tokens to the canonical kind', () => {
+        // The visual builder emits the UI type (`MCPServer`); code authors may use
+        // the kind or an alias. All must reduce to the same canonical entityId so
+        // the target matches the resource entity (`mcp.bookings`), not `mcpserver.*`.
+        expect(deriveTargetEntityId('permit ( principal, action, resource == MCPServer::"bookings" );')).toBe('mcp.bookings');
+        expect(deriveTargetEntityId('permit ( principal, action, resource == mcpserver::"bookings" );')).toBe('mcp.bookings');
+        expect(deriveTargetEntityId('permit ( principal, action, resource == Model::"gpt-4o" );')).toBe('model.gpt-4o');
+        expect(deriveTargetEntityId('permit ( principal, action, resource == AgentIdentity::"svc" );')).toBe('agent-identity.svc');
     });
 
     it('returns null for generic/custom resources (stays GLOBAL → Custom)', () => {

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/shared/api/authz-api.service.ts
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/shared/api/authz-api.service.ts
@@ -15,7 +15,7 @@
  */
 import { deriveServiceType } from '../entity-kind-registry';
 import { deriveTargetEntityId } from '../policy-entity-refs';
-import { authzCoreApiClient } from './authz-api-client';
+import { ApiError, authzCoreApiClient } from './authz-api-client';
 import type {
     EntityResponse,
     PagedResponse,
@@ -286,6 +286,18 @@ export const authzApiService = {
             page: response.page,
             perPage: response.perPage,
         };
+    },
+
+    getEntity: async (environmentId: string, entityId: string): Promise<EntityResponse | null> => {
+        try {
+            const entity = await authzCoreApiClient.get<CanonicalEntity>(
+                corePath(environmentId, `/entities/${encodeURIComponent(entityId)}`),
+            );
+            return adaptEntityResponse(entity);
+        } catch (err) {
+            if (err instanceof ApiError && err.status === 404) return null;
+            throw err;
+        }
     },
 
     createEntity: async (environmentId: string, request: CreateEntityRequest): Promise<EntityResponse> => {

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/shared/api/query-keys.ts
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/shared/api/query-keys.ts
@@ -17,6 +17,8 @@ export const authzQueryKeys = {
     all: ['authz'] as const,
     entities: {
         all: (environmentId: string) => ['authz', 'entities', environmentId] as const,
+        list: (environmentId: string, kind?: string, entityIdPrefix?: string, excludeEntityIdPrefix?: string) =>
+            ['authz', 'entities', environmentId, 'list', kind, entityIdPrefix, excludeEntityIdPrefix] as const,
         page: (
             environmentId: string,
             page: number,

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/shared/entity-kind-registry.ts
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/shared/entity-kind-registry.ts
@@ -55,6 +55,19 @@ export function uiTypeToKind(type: string): string {
     return BY_UI_TYPE.get(type.toLowerCase())?.canonical ?? type.toLowerCase();
 }
 
+/**
+ * Resolve a GAPL/Cedar type token to its canonical lowercase kind, accepting
+ * either a UI type (`MCPServer`), the canonical kind (`mcp`), or any alias
+ * (`mcpserver`, `llm`). Falls back to the lowercased token when unknown.
+ *
+ * Use this — not a raw `toLowerCase()` — when deriving a canonical entityId
+ * from policy text so `MCPServer::"x"` and `mcp.x` resolve to the same id.
+ */
+export function canonicalKindOf(token: string): string {
+    const lower = token.toLowerCase();
+    return BY_KIND.get(lower)?.canonical ?? BY_UI_TYPE.get(lower)?.canonical ?? lower;
+}
+
 /** EntityId (`<kind>.<id>`) → policy type. Anything without a registered policy
  *  type — including null/undefined entityIds — falls back to `CUSTOM`. */
 export function deriveServiceType(entityId: string | null | undefined): PolicyType {

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/shared/hooks/__tests__/useAllEntities.test.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/shared/hooks/__tests__/useAllEntities.test.tsx
@@ -1,0 +1,154 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { EntityResponse } from '../../api/authz-api.types';
+import { useAllEntities } from '../useAllEntities';
+
+const listSpy = vi.fn();
+
+vi.mock('../../api/authz-api.service', () => ({
+    MAX_PER_PAGE: 100,
+    authzApiService: {
+        listEntities: (env: string, params?: unknown) => listSpy(env, params),
+    },
+}));
+
+function makeWrapper() {
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    return ({ children }: { children: ReactNode }) => <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+}
+
+function Probe({ env }: { env: string }) {
+    const { data, total, truncated, isLoading, error } = useAllEntities(env, { kind: 'RESOURCE', excludeEntityIdPrefix: 'action.' });
+    return (
+        <div>
+            <span data-testid="loading">{String(isLoading)}</span>
+            <span data-testid="error">{error ?? 'none'}</span>
+            <span data-testid="fetched">{data.length}</span>
+            <span data-testid="total">{total}</span>
+            <span data-testid="truncated">{String(truncated)}</span>
+        </div>
+    );
+}
+
+function makeEntity(id: string): EntityResponse {
+    return {
+        id,
+        environmentId: 'DEFAULT',
+        uid: `mcp.${id}`,
+        attributes: {},
+        parents: [],
+        createdAt: '2026-05-27T10:00:00.000Z',
+        updatedAt: '2026-05-27T10:00:00.000Z',
+    };
+}
+
+beforeEach(() => listSpy.mockReset());
+
+describe('useAllEntities', () => {
+    it('does not fire the query when environmentId is empty', async () => {
+        listSpy.mockResolvedValue({ data: [], total: 0, page: 1, perPage: 100 });
+        render(<Probe env="" />, { wrapper: makeWrapper() });
+
+        await Promise.resolve();
+        await Promise.resolve();
+        expect(listSpy).not.toHaveBeenCalled();
+    });
+
+    it('passes the kind + excludeEntityIdPrefix filter through and fetches one page when it covers the total', async () => {
+        listSpy.mockResolvedValue({
+            data: [makeEntity('a'), makeEntity('b')],
+            total: 2,
+            page: 1,
+            perPage: 100,
+        });
+
+        const { getByTestId } = render(<Probe env="env-1" />, { wrapper: makeWrapper() });
+
+        await waitFor(() => expect(getByTestId('fetched').textContent).toBe('2'));
+        expect(getByTestId('truncated').textContent).toBe('false');
+        expect(listSpy).toHaveBeenCalledTimes(1);
+        expect(listSpy).toHaveBeenCalledWith(
+            'env-1',
+            expect.objectContaining({ kind: 'RESOURCE', excludeEntityIdPrefix: 'action.', page: 1, perPage: 100 }),
+        );
+    });
+
+    it('walks every page until the accumulated set covers the reported total', async () => {
+        listSpy
+            .mockResolvedValueOnce({ data: Array.from({ length: 100 }, (_, i) => makeEntity(`p1-${i}`)), total: 250, page: 1, perPage: 100 })
+            .mockResolvedValueOnce({ data: Array.from({ length: 100 }, (_, i) => makeEntity(`p2-${i}`)), total: 250, page: 2, perPage: 100 })
+            .mockResolvedValueOnce({ data: Array.from({ length: 50 }, (_, i) => makeEntity(`p3-${i}`)), total: 250, page: 3, perPage: 100 });
+
+        const { getByTestId } = render(<Probe env="env-1" />, { wrapper: makeWrapper() });
+
+        await waitFor(() => expect(getByTestId('fetched').textContent).toBe('250'));
+        expect(getByTestId('truncated').textContent).toBe('false');
+        expect(listSpy).toHaveBeenCalledTimes(3);
+        expect(listSpy.mock.calls.map(c => (c[1] as { page: number }).page)).toEqual([1, 2, 3]);
+    });
+
+    it('stops early when the server returns an empty page (defensive against inconsistent total)', async () => {
+        listSpy
+            .mockResolvedValueOnce({ data: [makeEntity('a')], total: 999, page: 1, perPage: 100 })
+            .mockResolvedValueOnce({ data: [], total: 999, page: 2, perPage: 100 });
+
+        const { getByTestId } = render(<Probe env="env-1" />, { wrapper: makeWrapper() });
+
+        await waitFor(() => expect(getByTestId('fetched').textContent).toBe('1'));
+        expect(listSpy).toHaveBeenCalledTimes(2);
+    });
+
+    it('reports truncated=true when the MAX_PAGES safety cap is hit before all rows are fetched', async () => {
+        // MAX_PAGES = 50, perPage = 100 → fetch 5000 of a larger total.
+        listSpy.mockImplementation((_env: string, params?: { page: number }) =>
+            Promise.resolve({
+                data: Array.from({ length: 100 }, (_, i) => makeEntity(`p${params?.page}-${i}`)),
+                total: 100000,
+                page: params?.page ?? 1,
+                perPage: 100,
+            }),
+        );
+
+        const { getByTestId } = render(<Probe env="env-1" />, { wrapper: makeWrapper() });
+
+        await waitFor(() => expect(getByTestId('truncated').textContent).toBe('true'));
+        expect(listSpy).toHaveBeenCalledTimes(50);
+        expect(getByTestId('fetched').textContent).toBe('5000');
+    });
+
+    it('coalesces a nullish data slice to an empty page instead of crashing', async () => {
+        listSpy.mockResolvedValue({ data: undefined, total: 3, page: 1, perPage: 100 });
+
+        const { getByTestId } = render(<Probe env="env-1" />, { wrapper: makeWrapper() });
+
+        await waitFor(() => expect(getByTestId('loading').textContent).toBe('false'));
+        expect(getByTestId('error').textContent).toBe('none');
+        expect(getByTestId('fetched').textContent).toBe('0');
+        expect(listSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('exposes an error string when the query rejects', async () => {
+        listSpy.mockRejectedValueOnce(new Error('listEntities down'));
+
+        const { getByTestId } = render(<Probe env="env-1" />, { wrapper: makeWrapper() });
+
+        await waitFor(() => expect(getByTestId('error').textContent).toBe('listEntities down'));
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/shared/hooks/useAllEntities.ts
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/shared/hooks/useAllEntities.ts
@@ -1,0 +1,86 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { useCallback } from 'react';
+import { authzApiService, MAX_PER_PAGE, type EntityKindFilter } from '../api/authz-api.service';
+import type { EntityResponse } from '../api/authz-api.types';
+import { authzQueryKeys } from '../api/query-keys';
+
+/** Safety cap: MAX_PER_PAGE * MAX_PAGES rows before we stop and report truncation. */
+const MAX_PAGES = 50;
+
+export interface UseAllEntitiesFilter {
+    readonly kind?: EntityKindFilter;
+    readonly entityIdPrefix?: string;
+    readonly excludeEntityIdPrefix?: string;
+}
+
+export interface UseAllEntitiesResult {
+    readonly data: readonly EntityResponse[];
+    readonly total: number;
+    readonly truncated: boolean;
+    readonly isLoading: boolean;
+    readonly error: string | undefined;
+    readonly reload: () => void;
+}
+
+/**
+ * Fetch the full entity set for a kind by walking every page (capped), so the
+ * page can filter/search/paginate client-side over the complete dataset rather
+ * than a single server page. Mirrors the listPolicies fetch-all approach.
+ */
+export function useAllEntities(environmentId: string, filter: UseAllEntitiesFilter = {}): UseAllEntitiesResult {
+    const { kind, entityIdPrefix, excludeEntityIdPrefix } = filter;
+    const queryClient = useQueryClient();
+
+    const query = useQuery({
+        queryKey: authzQueryKeys.entities.list(environmentId, kind, entityIdPrefix, excludeEntityIdPrefix),
+        queryFn: async () => {
+            const acc: EntityResponse[] = [];
+            let total = 0;
+            for (let page = 1; page <= MAX_PAGES; page++) {
+                const res = await authzApiService.listEntities(environmentId, {
+                    page,
+                    perPage: MAX_PER_PAGE,
+                    kind,
+                    entityIdPrefix,
+                    excludeEntityIdPrefix,
+                });
+                total = res.total;
+                const slice = res.data ?? [];
+                acc.push(...slice);
+                if (slice.length === 0 || acc.length >= total) break;
+            }
+            return { data: acc, total, truncated: acc.length < total };
+        },
+        enabled: Boolean(environmentId),
+        staleTime: 30_000,
+    });
+
+    const reload = useCallback(
+        () => void queryClient.invalidateQueries({ queryKey: authzQueryKeys.entities.all(environmentId) }),
+        [environmentId, queryClient],
+    );
+
+    return {
+        data: query.data?.data ?? [],
+        total: query.data?.total ?? 0,
+        truncated: query.data?.truncated ?? false,
+        isLoading: query.isLoading,
+        error: query.error instanceof Error ? query.error.message : query.error ? String(query.error) : undefined,
+        reload,
+    };
+}

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/shared/policy-entity-refs.ts
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/shared/policy-entity-refs.ts
@@ -15,7 +15,7 @@
  */
 import type { PolicyResponse } from './api/authz-api.types';
 import { formatEntityUid } from './entity-adapter';
-import { deriveServiceType } from './entity-kind-registry';
+import { canonicalKindOf, deriveServiceType } from './entity-kind-registry';
 import type { EntityInstance } from './entity.types';
 
 export type PolicyClause = 'principal' | 'action' | 'resource';
@@ -85,7 +85,7 @@ export function deriveTargetEntityId(policyText: string | null | undefined): str
     if (!policyText) return null;
     for (const ref of extractEntityRefsFromPolicyText(policyText)) {
         if (ref.clause !== 'resource') continue;
-        const entityId = `${ref.type.toLowerCase()}.${ref.id}`;
+        const entityId = `${canonicalKindOf(ref.type)}.${ref.id}`;
         if (deriveServiceType(entityId) === 'CUSTOM') continue;
         // entityId always carries the kind prefix + a literal dot, so split
         // yields at least [kind, server] — reduce to the owning service entity.


### PR DESCRIPTION
## Summary
Fixes found during a manual QA pass over the authz Gamma module (Entities + policy placement).

- **Duplicate entity = data loss (critical):** the Add Principal/Resource dialog called the backend's create-or-replace (upsert) `save`, silently overwriting an existing entity with the same Entity ID. The dialog now pre-checks the Entity ID (`GET /entities/{id}`, new `getEntity` returning `null` on 404) and blocks the create with an "already exists" error. The backend upsert (shared with import/sync) is unchanged; the 409 fallback mapping is kept for races.
- **Filters/search only saw one page:** the Entities page fetched a single server page then filtered client-side, so search/type/source missed rows on other pages and the type/source dropdowns + "Types" KPI were per-page. New `useAllEntities` hook fetches the full set per kind (paged loop with a safety cap, same pattern as `listPolicies`); the page now filters/searches/paginates client-side over the whole dataset.
- **Derived policy target used an alias prefix:** `deriveTargetEntityId` lowercased the GAPL type token (`MCPServer` → `mcpserver.x`) instead of the resource's canonical Entity ID. It now canonicalises via the kind registry (`MCPServer`/`LLM` → `mcp`/`model`) so the target matches the resource entity.
- **Slug auto-suggestion appended:** the slug field now selects its auto-derived value on first focus, so typing replaces rather than appends.

Note: the deep-link → `/home` redirect observed in QA is a host (gamma-console) routing concern, not in this module — out of scope here.

## Test plan
- [x] `tsc -p tsconfig.app.json --noEmit` clean
- [x] `vitest run` — full module suite green (372 tests), incl. new `useAllEntities` multi-page/truncation/error tests, duplicate-guard tests, and canonicalisation tests
- [x] Manual: add a principal with an existing slug → blocked with error; Resources tab search/type/source span all pages; create an MCP policy via editor → lands on MCP page with canonical `mcp.*` target