### PR TITLE
feat(authz-ui): add Actions submenu under Policy Structure

### DIFF
--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/app/AppRoutes.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/app/AppRoutes.tsx
@@ -25,6 +25,7 @@ import { ApisPage } from '../features/policy-management/pages/ApisPage';
 import { CustomPoliciesPage } from '../features/policy-management/pages/CustomPoliciesPage';
 import { ModelsPage } from '../features/policy-management/pages/ModelsPage';
 import { McpsPage } from '../features/policy-management/pages/McpsPage';
+import { ActionsPage } from '../features/policy-structure/ActionsPage';
 import { EntitiesPage } from '../features/policy-structure/EntitiesPage';
 import { ModuleErrorBoundary } from './ModuleErrorBoundary';
 
@@ -65,6 +66,7 @@ export function AppRoutes() {
                         <Route path="apis" element={<ApisPage />} />
                         <Route path="custom-policies" element={<CustomPoliciesPage />} />
                         <Route path="entities" element={<EntitiesPage />} />
+                        <Route path="actions" element={<ActionsPage />} />
                     </Route>
                 </Routes>
             </ModuleErrorBoundary>

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/config/navigation.ts
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/config/navigation.ts
@@ -21,6 +21,7 @@ import {
     LayoutDashboardIcon,
     ShieldCheckIcon,
     SlidersHorizontalIcon,
+    ZapIcon,
 } from '@gravitee/graphene-core/icons';
 import { ROUTES } from './routes';
 
@@ -40,6 +41,9 @@ export const NAV_GROUPS: NavGroup[] = [
     },
     {
         label: 'Policy Structure',
-        items: [{ key: 'entities', title: ROUTES.entities.label, icon: BoxesIcon }],
+        items: [
+            { key: 'entities', title: ROUTES.entities.label, icon: BoxesIcon },
+            { key: 'actions', title: ROUTES.actions.label, icon: ZapIcon },
+        ],
     },
 ];

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/config/routes.ts
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/config/routes.ts
@@ -25,6 +25,7 @@ export const ROUTE_KEYS = [
     'custom-policies',
     // Policy Structure
     'entities',
+    'actions',
 ] as const;
 export type RouteKey = (typeof ROUTE_KEYS)[number];
 
@@ -35,6 +36,7 @@ export const ROUTES: Record<RouteKey, { readonly path: string; readonly label: s
     apis: { path: 'apis', label: 'APIs' },
     'custom-policies': { path: 'custom-policies', label: 'Custom Policies' },
     entities: { path: 'entities', label: 'Entities' },
+    actions: { path: 'actions', label: 'Actions' },
 };
 
 export const AUTHZ_ROUTE_CONFIG: ModuleRouteConfig<RouteKey> = {

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/features/policy-structure/ActionsPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/features/policy-structure/ActionsPage.tsx
@@ -1,0 +1,307 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useEnvironment } from '@gravitee/gamma-modules-sdk';
+import {
+    Alert,
+    AlertDescription,
+    AlertTitle,
+    Badge,
+    Button,
+    DataTable,
+    DataTablePagination,
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+    Empty,
+    EmptyDescription,
+    EmptyHeader,
+    EmptyTitle,
+    Input,
+    toast,
+} from '@gravitee/graphene-core';
+import { PlusIcon, Trash2Icon, ZapIcon } from '@gravitee/graphene-core/icons';
+import { useQueryClient } from '@tanstack/react-query';
+import type { ColumnDef } from '@tanstack/react-table';
+import { useDeferredValue, useMemo, useState } from 'react';
+import { KpiTile } from '../../components/KpiTile';
+import { authzApiService } from '../../shared/api/authz-api.service';
+import { authzQueryKeys } from '../../shared/api/query-keys';
+import { formatEntityUid, fromBackend } from '../../shared/entity-adapter';
+import type { EntityInstance } from '../../shared/entity.types';
+import { useEntities } from '../../shared/hooks/useEntities';
+import { CreateActionDialog } from './CreateActionDialog';
+
+const ACTION_PREFIX = 'action.';
+const PAGE_SIZE_OPTIONS = [10, 25, 50, 100];
+
+const ACTIONS_HELP =
+    'Actions are the verbs the policy engine authorizes (e.g. call_tool, invoke, read). Reference them in the action clause of a policy. They live under the reserved action. Entity ID prefix.';
+
+function displayNameOf(entity: EntityInstance): string {
+    if (entity.displayName) return entity.displayName;
+    const name = entity.attrs.name;
+    if (typeof name === 'string' && name) return name;
+    const displayName = entity.attrs.displayName;
+    if (typeof displayName === 'string' && displayName) return displayName;
+    return entity.uid.id;
+}
+
+function descriptionOf(entity: EntityInstance): string {
+    const description = entity.attrs.description;
+    return typeof description === 'string' ? description : '';
+}
+
+function sourceLabelOf(entity: EntityInstance): string {
+    if (entity.source === 'apim') return 'APIM';
+    if (entity.source === 'gravitee-catalog') return 'Gravitee Catalog';
+    return 'Local';
+}
+
+function actionName(entity: EntityInstance): string {
+    return entity.uid.id;
+}
+
+function applyFilter(actions: readonly EntityInstance[], search: string): EntityInstance[] {
+    const needle = search.trim().toLowerCase();
+    if (!needle) return [...actions];
+    return actions.filter(
+        a =>
+            actionName(a).toLowerCase().includes(needle) ||
+            formatEntityUid(a.uid).toLowerCase().includes(needle) ||
+            displayNameOf(a).toLowerCase().includes(needle) ||
+            descriptionOf(a).toLowerCase().includes(needle),
+    );
+}
+
+export function ActionsPage() {
+    const env = useEnvironment();
+    const environmentId = env?.id ?? '';
+    const queryClient = useQueryClient();
+    const actionsQuery = useEntities(environmentId, undefined, { kind: 'RESOURCE', entityIdPrefix: ACTION_PREFIX });
+
+    const [search, setSearch] = useState('');
+    const [addOpen, setAddOpen] = useState(false);
+    const [pendingDelete, setPendingDelete] = useState<EntityInstance | null>(null);
+    const [deletingEntityId, setDeletingEntityId] = useState<string | undefined>();
+
+    const deferredSearch = useDeferredValue(search);
+
+    const actions = useMemo(() => (actionsQuery.data ? actionsQuery.data.data.map(fromBackend) : []), [actionsQuery.data]);
+    const total = actionsQuery.data?.total ?? 0;
+    const filtered = useMemo(() => applyFilter(actions, deferredSearch), [actions, deferredSearch]);
+
+    const pendingDeleteUid = pendingDelete ? formatEntityUid(pendingDelete.uid) : '';
+    const pendingDeleteName = pendingDelete ? displayNameOf(pendingDelete) : '';
+
+    function handleChanged() {
+        void queryClient.invalidateQueries({ queryKey: authzQueryKeys.entities.all(environmentId) });
+    }
+
+    async function confirmDelete() {
+        if (!pendingDelete) return;
+        const uid = formatEntityUid(pendingDelete.uid);
+        const friendly = displayNameOf(pendingDelete);
+        setDeletingEntityId(uid);
+        try {
+            await authzApiService.deleteEntity(environmentId, uid);
+            toast.success(`Removed ${friendly}`);
+            setDeletingEntityId(undefined);
+            setPendingDelete(null);
+            handleChanged();
+        } catch (err) {
+            toast.error(`Failed to remove: ${err instanceof Error ? err.message : String(err)}`);
+            setDeletingEntityId(undefined);
+        }
+    }
+
+    const columns = useMemo<ColumnDef<EntityInstance>[]>(
+        () => [
+            {
+                id: 'name',
+                header: 'Action',
+                size: 220,
+                cell: ({ row }) => <span className="block truncate font-medium">{displayNameOf(row.original)}</span>,
+            },
+            {
+                id: 'entityId',
+                header: 'Entity ID',
+                size: 280,
+                cell: ({ row }) => <span className="font-mono text-xs text-foreground">{formatEntityUid(row.original.uid)}</span>,
+            },
+            {
+                id: 'description',
+                header: 'Description',
+                size: 320,
+                cell: ({ row }) => {
+                    const description = descriptionOf(row.original);
+                    return description ? (
+                        <span className="block truncate text-sm text-muted-foreground">{description}</span>
+                    ) : (
+                        <span className="text-sm text-muted-foreground/60">—</span>
+                    );
+                },
+            },
+            {
+                id: 'source',
+                header: 'Source',
+                size: 120,
+                cell: ({ row }) => <Badge variant="secondary">{sourceLabelOf(row.original)}</Badge>,
+            },
+            {
+                id: 'actions',
+                header: '',
+                size: 60,
+                cell: ({ row }) => {
+                    const uid = formatEntityUid(row.original.uid);
+                    const isLocal = row.original.source === 'local';
+                    if (!isLocal) return null;
+                    return (
+                        <Button
+                            variant="ghost"
+                            size="sm"
+                            onClick={() => setPendingDelete(row.original)}
+                            disabled={deletingEntityId === uid}
+                            aria-label={`Delete ${uid}`}
+                            title="Remove from Authorization"
+                        >
+                            <Trash2Icon className="size-4 text-muted-foreground" aria-hidden />
+                        </Button>
+                    );
+                },
+            },
+        ],
+        [deletingEntityId],
+    );
+
+    return (
+        <div className="flex flex-col gap-4">
+            <header className="flex items-start gap-3">
+                <ZapIcon className="mt-1 size-5 text-muted-foreground" aria-hidden />
+                <div>
+                    <h1 className="text-xl font-semibold">Actions</h1>
+                    <p className="mt-1 max-w-3xl text-sm text-muted-foreground">
+                        The action vocabulary the policy engine evaluates. Define the verbs your policies grant or forbid.
+                    </p>
+                </div>
+            </header>
+
+            <div className="grid grid-cols-2 gap-3 md:grid-cols-4" aria-label="Key metrics">
+                <KpiTile label="Total actions" value={total} loading={actionsQuery.isLoading} />
+            </div>
+
+            {actionsQuery.error !== undefined && (
+                <Alert variant="destructive">
+                    <AlertTitle>Could not load actions</AlertTitle>
+                    <AlertDescription>{actionsQuery.error}</AlertDescription>
+                </Alert>
+            )}
+
+            <Alert>
+                <AlertDescription>{ACTIONS_HELP}</AlertDescription>
+            </Alert>
+
+            <div className="flex flex-wrap items-center gap-2">
+                <Input
+                    value={search}
+                    onChange={e => setSearch(e.target.value)}
+                    placeholder="Search by name, Entity ID, or description…"
+                    className="max-w-sm"
+                    aria-label="Search actions"
+                />
+                <div className="ml-auto">
+                    <Button onClick={() => setAddOpen(true)}>
+                        <PlusIcon className="mr-2 size-4" aria-hidden />
+                        Add action
+                    </Button>
+                </div>
+            </div>
+
+            {!actionsQuery.isLoading && filtered.length === 0 ? (
+                <Empty>
+                    <EmptyHeader>
+                        <EmptyTitle>No actions yet</EmptyTitle>
+                        <EmptyDescription>
+                            {deferredSearch
+                                ? 'No matches for the current search.'
+                                : 'Add an action to start authorizing it in your policies.'}
+                        </EmptyDescription>
+                    </EmptyHeader>
+                </Empty>
+            ) : (
+                <>
+                    <DataTable<EntityInstance>
+                        columns={columns}
+                        data={filtered}
+                        serverSide
+                        enableColumnResizing
+                        loading={actionsQuery.isLoading}
+                        skeletonCount={actionsQuery.perPage}
+                    />
+                    <DataTablePagination
+                        page={actionsQuery.page}
+                        pageSize={actionsQuery.perPage}
+                        totalCount={total}
+                        pageSizeOptions={PAGE_SIZE_OPTIONS}
+                        onPageChange={actionsQuery.setPage}
+                        onPageSizeChange={actionsQuery.setPerPage}
+                    />
+                </>
+            )}
+
+            <CreateActionDialog
+                open={addOpen}
+                environmentId={environmentId}
+                onOpenChange={setAddOpen}
+                onCreated={handleChanged}
+            />
+
+            <Dialog
+                open={pendingDelete !== null}
+                onOpenChange={open => {
+                    if (!open && !deletingEntityId) setPendingDelete(null);
+                }}
+            >
+                <DialogContent>
+                    <DialogHeader>
+                        <DialogTitle>Remove action from Authorization?</DialogTitle>
+                        <DialogDescription>
+                            {pendingDelete
+                                ? `"${pendingDeleteName}" (${pendingDeleteUid}) will be removed. Policies that reference this action will no longer match it.`
+                                : ''}
+                        </DialogDescription>
+                    </DialogHeader>
+                    <DialogFooter>
+                        <Button type="button" variant="outline" onClick={() => setPendingDelete(null)} disabled={deletingEntityId !== undefined}>
+                            Cancel
+                        </Button>
+                        <Button
+                            type="button"
+                            variant="destructive"
+                            onClick={confirmDelete}
+                            disabled={deletingEntityId !== undefined}
+                            aria-label={pendingDelete ? `Confirm remove ${pendingDeleteName}` : 'Confirm remove'}
+                        >
+                            {deletingEntityId !== undefined ? 'Removing…' : 'Remove'}
+                        </Button>
+                    </DialogFooter>
+                </DialogContent>
+            </Dialog>
+        </div>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/features/policy-structure/CreateActionDialog.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/features/policy-structure/CreateActionDialog.tsx
@@ -1,0 +1,227 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+    Alert,
+    AlertDescription,
+    Button,
+    Input,
+    Label,
+    Sheet,
+    SheetContent,
+    SheetTitle,
+    Spinner,
+    Textarea,
+    cn,
+    toast,
+} from '@gravitee/graphene-core';
+import { PlusIcon } from '@gravitee/graphene-core/icons';
+import { useQueryClient } from '@tanstack/react-query';
+import { useEffect, useState } from 'react';
+import { authzApiService } from '../../shared/api/authz-api.service';
+import { authzQueryKeys } from '../../shared/api/query-keys';
+
+/** Backend limit; see AuthzEntityIdConstants.MAX_ENTITY_ID_LENGTH. */
+const MAX_ENTITY_ID_LENGTH = 255;
+
+/** Action id segment: same charset the backend accepts between dots. */
+const SEGMENT_REGEX = /^[a-z0-9_-]+$/;
+
+/** Actions are RESOURCE entities under the reserved `action.` prefix. */
+const ACTION_PREFIX = 'action';
+
+function slugify(value: string): string {
+    return value
+        .normalize('NFD')
+        .replace(/[̀-ͯ]/g, '')
+        .toLowerCase()
+        .replace(/[^a-z0-9_-]+/g, '-')
+        .replace(/^-+|-+$/g, '');
+}
+
+export interface CreateActionDialogProps {
+    readonly open: boolean;
+    readonly environmentId: string;
+    readonly onOpenChange: (open: boolean) => void;
+    readonly onCreated: () => void;
+}
+
+export function CreateActionDialog({ open, environmentId, onOpenChange, onCreated }: CreateActionDialogProps) {
+    const queryClient = useQueryClient();
+
+    const [displayName, setDisplayName] = useState('');
+    const [slug, setSlug] = useState('');
+    const [slugTouched, setSlugTouched] = useState(false);
+    const [description, setDescription] = useState('');
+    const [submitting, setSubmitting] = useState(false);
+    const [submitError, setSubmitError] = useState<string | null>(null);
+
+    useEffect(() => {
+        if (!open) {
+            setDisplayName('');
+            setSlug('');
+            setSlugTouched(false);
+            setDescription('');
+            setSubmitting(false);
+            setSubmitError(null);
+        }
+    }, [open]);
+
+    // Auto-derive the action id from the display name until the user edits it.
+    useEffect(() => {
+        if (!slugTouched) setSlug(slugify(displayName));
+    }, [displayName, slugTouched]);
+
+    const entityId = slug ? `${ACTION_PREFIX}.${slug}` : '';
+    const slugError = slug.length > 0 && !SEGMENT_REGEX.test(slug) ? 'Action ID must match [a-z0-9_-]+ (no dots, no spaces).' : null;
+    const lengthError = entityId.length > MAX_ENTITY_ID_LENGTH ? `Entity ID must be at most ${MAX_ENTITY_ID_LENGTH} characters.` : null;
+
+    const canSubmit = !submitting && slug.length > 0 && displayName.trim().length > 0 && !slugError && !lengthError;
+
+    async function handleSubmit(event: React.FormEvent) {
+        event.preventDefault();
+        if (!canSubmit) return;
+        setSubmitting(true);
+        setSubmitError(null);
+        const trimmedDescription = description.trim();
+        const attributes: Record<string, unknown> = { _displayName: displayName.trim() };
+        if (trimmedDescription) attributes.description = trimmedDescription;
+        try {
+            await authzApiService.createEntity(environmentId, {
+                entityId,
+                kind: 'RESOURCE',
+                attributes,
+                parents: [],
+                source: 'local',
+            });
+            toast.success(`Created ${displayName.trim()}`);
+            void queryClient.invalidateQueries({ queryKey: authzQueryKeys.entities.all(environmentId) });
+            onCreated();
+            onOpenChange(false);
+        } catch (err) {
+            const message = err instanceof Error ? err.message : String(err);
+            if (/already exists|duplicate|conflict/i.test(message) || /409/.test(message)) {
+                setSubmitError(`An action with ID "${entityId}" already exists.`);
+            } else {
+                setSubmitError(message);
+            }
+        } finally {
+            setSubmitting(false);
+        }
+    }
+
+    return (
+        <Sheet open={open} onOpenChange={onOpenChange}>
+            <SheetContent
+                side="right"
+                showCloseButton={false}
+                aria-label="Add Action"
+                style={{ width: 'min(560px, 100vw)', maxWidth: 'min(560px, 100vw)' }}
+                className="flex h-full flex-col gap-0 p-0"
+            >
+                <div className="border-b px-6 py-4">
+                    <SheetTitle className="text-lg font-semibold">Add Action</SheetTitle>
+                    <p className="mt-1 text-sm text-muted-foreground">
+                        Declare an action the policy engine can authorize (e.g. <code className="font-mono">call_tool</code>,{' '}
+                        <code className="font-mono">invoke</code>). Actions are referenced in the action clause of a policy.
+                    </p>
+                </div>
+
+                <form className="flex min-h-0 flex-1 flex-col overflow-y-auto" onSubmit={handleSubmit}>
+                    <div className="flex flex-col gap-4 px-6 py-4">
+                        {submitError && (
+                            <Alert variant="destructive">
+                                <AlertDescription>{submitError}</AlertDescription>
+                            </Alert>
+                        )}
+
+                        <div className="flex flex-col gap-1.5">
+                            <Label htmlFor="create-action-display-name">Display name</Label>
+                            <Input
+                                id="create-action-display-name"
+                                value={displayName}
+                                onChange={e => setDisplayName(e.target.value)}
+                                placeholder="e.g. Call Tool"
+                                required
+                            />
+                        </div>
+
+                        <div className="flex flex-col gap-1.5">
+                            <Label htmlFor="create-action-slug">Action ID</Label>
+                            <Input
+                                id="create-action-slug"
+                                value={slug}
+                                onChange={e => {
+                                    setSlug(e.target.value);
+                                    setSlugTouched(true);
+                                }}
+                                onFocus={e => {
+                                    if (!slugTouched) e.currentTarget.select();
+                                }}
+                                placeholder="e.g. call_tool"
+                                aria-invalid={slugError !== null}
+                                aria-describedby={slugError ? 'create-action-slug-error' : undefined}
+                                required
+                            />
+                            {slugError && (
+                                <p id="create-action-slug-error" className="text-xs text-destructive">
+                                    {slugError}
+                                </p>
+                            )}
+                        </div>
+
+                        <div className="flex flex-col gap-1.5">
+                            <Label htmlFor="create-action-id-preview">Entity ID</Label>
+                            <code
+                                id="create-action-id-preview"
+                                aria-live="polite"
+                                className={cn(
+                                    'rounded-md border bg-muted/40 px-3 py-2 font-mono text-sm',
+                                    lengthError ? 'border-destructive text-destructive' : 'text-foreground',
+                                )}
+                            >
+                                {entityId || <span className="text-muted-foreground">{`${ACTION_PREFIX}.<id>`}</span>}
+                            </code>
+                            {lengthError && <p className="text-xs text-destructive">{lengthError}</p>}
+                        </div>
+
+                        <div className="flex flex-col gap-1.5">
+                            <Label htmlFor="create-action-description">
+                                Description <span className="text-xs text-muted-foreground">(optional)</span>
+                            </Label>
+                            <Textarea
+                                id="create-action-description"
+                                value={description}
+                                onChange={e => setDescription(e.target.value)}
+                                placeholder="Short note about what this action represents."
+                                rows={3}
+                            />
+                        </div>
+                    </div>
+                </form>
+
+                <div className="flex flex-none items-center justify-end gap-2 border-t bg-muted/40 px-6 py-3.5">
+                    <Button type="button" variant="outline" onClick={() => onOpenChange(false)} disabled={submitting}>
+                        Cancel
+                    </Button>
+                    <Button type="button" onClick={handleSubmit as unknown as () => void} disabled={!canSubmit}>
+                        {submitting ? <Spinner className="mr-2 size-4" aria-hidden /> : <PlusIcon className="mr-2 size-4" aria-hidden />}
+                        Create Action
+                    </Button>
+                </div>
+            </SheetContent>
+        </Sheet>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/features/policy-structure/__tests__/ActionsPage.test.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/features/policy-structure/__tests__/ActionsPage.test.tsx
@@ -1,0 +1,189 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { ReactNode } from 'react';
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { EntityResponse } from '../../../shared/api/authz-api.types';
+import { ActionsPage } from '../ActionsPage';
+
+const toastSuccessSpy = vi.fn();
+const toastErrorSpy = vi.fn();
+
+vi.mock('@gravitee/graphene-core', async importOriginal => {
+    const actual = await importOriginal<Record<string, unknown>>();
+    return {
+        ...actual,
+        toast: { success: (msg: string) => toastSuccessSpy(msg), error: (msg: string) => toastErrorSpy(msg) },
+    };
+});
+
+// The add dialog is unit-tested separately; stub it so the page test stays focused.
+vi.mock('../CreateActionDialog', () => ({
+    CreateActionDialog: ({ open }: { open: boolean }) => (open ? <div data-testid="create-action-dialog-stub" /> : null),
+}));
+
+beforeAll(() => {
+    if (!Element.prototype.scrollIntoView) {
+        Element.prototype.scrollIntoView = () => undefined;
+    }
+});
+
+interface ListEntitiesParams {
+    readonly kind?: 'PRINCIPAL' | 'RESOURCE';
+    readonly entityIdPrefix?: string;
+}
+
+const listEntitiesSpy = vi.fn();
+const deleteEntitySpy = vi.fn();
+
+vi.mock('@gravitee/gamma-modules-sdk', async importOriginal => ({
+    ...(await importOriginal<object>()),
+    useEnvironment: () => ({ id: 'DEFAULT' }),
+}));
+
+vi.mock('../../../shared/api/authz-api.service', () => ({
+    DEFAULT_PER_PAGE: 10,
+    authzApiService: {
+        listEntities: (env: string, params?: ListEntitiesParams) => listEntitiesSpy(env, params),
+        deleteEntity: (env: string, entityId: string) => deleteEntitySpy(env, entityId),
+    },
+}));
+
+function makeAction(id: string, overrides: Partial<EntityResponse> = {}): EntityResponse {
+    return {
+        id: `ent-${id}`,
+        environmentId: 'DEFAULT',
+        uid: `action.${id}`,
+        attributes: { _displayName: id },
+        parents: [],
+        createdAt: '2026-04-27T10:00:00.000Z',
+        updatedAt: '2026-04-27T10:00:00.000Z',
+        ...overrides,
+    };
+}
+
+function mockActions(actions: readonly EntityResponse[]) {
+    listEntitiesSpy.mockImplementation((_env: string, params?: ListEntitiesParams) => {
+        if (params?.kind === 'RESOURCE' && params?.entityIdPrefix === 'action.') {
+            return Promise.resolve({ data: actions, total: actions.length, page: 1, perPage: 10 });
+        }
+        return Promise.resolve({ data: [], total: 0, page: 1, perPage: 10 });
+    });
+}
+
+function renderPage() {
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const wrapper = ({ children }: { children: ReactNode }) => <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+    return render(<ActionsPage />, { wrapper });
+}
+
+beforeEach(() => {
+    listEntitiesSpy.mockReset();
+    deleteEntitySpy.mockReset();
+    toastSuccessSpy.mockReset();
+    toastErrorSpy.mockReset();
+});
+
+describe('ActionsPage', () => {
+    it('queries RESOURCE entities under the action. prefix', async () => {
+        mockActions([]);
+        renderPage();
+
+        await waitFor(() => expect(listEntitiesSpy).toHaveBeenCalled());
+        expect(listEntitiesSpy).toHaveBeenCalledWith('DEFAULT', expect.objectContaining({ kind: 'RESOURCE', entityIdPrefix: 'action.' }));
+    });
+
+    it('shows the empty state when there are no actions', async () => {
+        mockActions([]);
+        renderPage();
+        await waitFor(() => expect(screen.getByText('No actions yet')).toBeInTheDocument());
+    });
+
+    it('lists action entities by Entity ID', async () => {
+        mockActions([makeAction('call_tool'), makeAction('invoke')]);
+        renderPage();
+
+        await waitFor(() => expect(screen.getByText('action.call_tool')).toBeInTheDocument());
+        expect(screen.getByText('action.invoke')).toBeInTheDocument();
+    });
+
+    it('filters actions by the search input', async () => {
+        mockActions([makeAction('call_tool'), makeAction('invoke')]);
+        renderPage();
+
+        await waitFor(() => expect(screen.getByText('action.call_tool')).toBeInTheDocument());
+        fireEvent.change(screen.getByLabelText('Search actions'), { target: { value: 'invoke' } });
+
+        await waitFor(() => {
+            expect(screen.queryByText('action.call_tool')).not.toBeInTheDocument();
+            expect(screen.getByText('action.invoke')).toBeInTheDocument();
+        });
+    });
+
+    it('opens the add-action dialog stub on "Add action"', async () => {
+        mockActions([]);
+        renderPage();
+
+        const user = userEvent.setup();
+        await waitFor(() => expect(screen.getByRole('button', { name: /Add action/i })).toBeInTheDocument());
+        expect(screen.queryByTestId('create-action-dialog-stub')).not.toBeInTheDocument();
+        await user.click(screen.getByRole('button', { name: /Add action/i }));
+        expect(screen.getByTestId('create-action-dialog-stub')).toBeInTheDocument();
+    });
+
+    it('hides the Remove action for non-local (read-only) actions', async () => {
+        mockActions([makeAction('read', { attributes: { _displayName: 'read', _source: 'gravitee-catalog' } })]);
+        renderPage();
+
+        await waitFor(() => expect(screen.getByText('action.read')).toBeInTheDocument());
+        expect(screen.queryByLabelText('Delete action.read')).not.toBeInTheDocument();
+    });
+
+    it('removes a local action through the confirmation dialog', async () => {
+        mockActions([makeAction('call_tool')]);
+        deleteEntitySpy.mockResolvedValue(undefined);
+        renderPage();
+
+        const user = userEvent.setup();
+        await waitFor(() => expect(screen.getByLabelText('Delete action.call_tool')).toBeInTheDocument());
+        await user.click(screen.getByLabelText('Delete action.call_tool'));
+
+        const dialog = await screen.findByRole('dialog');
+        expect(within(dialog).getByText('Remove action from Authorization?')).toBeInTheDocument();
+        await user.click(within(dialog).getByRole('button', { name: /Confirm remove/i }));
+
+        await waitFor(() => expect(deleteEntitySpy).toHaveBeenCalledWith('DEFAULT', 'action.call_tool'));
+        await waitFor(() => expect(toastSuccessSpy).toHaveBeenCalled());
+        await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
+    });
+
+    it('does not call deleteEntity when the remove dialog is cancelled', async () => {
+        mockActions([makeAction('call_tool')]);
+        renderPage();
+
+        const user = userEvent.setup();
+        await waitFor(() => expect(screen.getByLabelText('Delete action.call_tool')).toBeInTheDocument());
+        await user.click(screen.getByLabelText('Delete action.call_tool'));
+
+        const dialog = await screen.findByRole('dialog');
+        await user.click(within(dialog).getByRole('button', { name: /^Cancel$/i }));
+
+        await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
+        expect(deleteEntitySpy).not.toHaveBeenCalled();
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/features/policy-structure/__tests__/CreateActionDialog.test.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/features/policy-structure/__tests__/CreateActionDialog.test.tsx
@@ -1,0 +1,158 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { ReactNode } from 'react';
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { CreateActionDialog } from '../CreateActionDialog';
+
+beforeAll(() => {
+    if (!Element.prototype.scrollIntoView) {
+        Element.prototype.scrollIntoView = () => undefined;
+    }
+});
+
+const createEntitySpy = vi.fn();
+const toastSuccessSpy = vi.fn();
+
+vi.mock('../../../shared/api/authz-api.service', () => ({
+    DEFAULT_PER_PAGE: 10,
+    authzApiService: {
+        createEntity: (env: string, req: unknown) => createEntitySpy(env, req),
+    },
+}));
+
+vi.mock('@gravitee/graphene-core', async importOriginal => {
+    const actual = await importOriginal<Record<string, unknown>>();
+    return {
+        ...actual,
+        toast: { success: (msg: string) => toastSuccessSpy(msg), error: vi.fn() },
+    };
+});
+
+function wrapper({ children }: { children: ReactNode }) {
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    return <QueryClientProvider client={qc}>{children}</QueryClientProvider>;
+}
+
+beforeEach(() => {
+    createEntitySpy.mockReset();
+    toastSuccessSpy.mockReset();
+    createEntitySpy.mockResolvedValue({
+        id: 'new-1',
+        environmentId: 'DEFAULT',
+        uid: 'action.call_tool',
+        attributes: { _displayName: 'Call Tool' },
+        parents: [],
+        createdAt: '2026-05-27T11:00:00.000Z',
+        updatedAt: '2026-05-27T11:00:00.000Z',
+    });
+});
+
+function renderDialog(props: Partial<Parameters<typeof CreateActionDialog>[0]> = {}) {
+    const onOpenChange = vi.fn();
+    const onCreated = vi.fn();
+    render(<CreateActionDialog open environmentId="DEFAULT" onOpenChange={onOpenChange} onCreated={onCreated} {...props} />, { wrapper });
+    return { onOpenChange, onCreated };
+}
+
+describe('CreateActionDialog', () => {
+    it('renders the Add Action sheet', () => {
+        renderDialog();
+        expect(screen.getByRole('heading', { name: /Add Action/i })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: /Create Action/i })).toBeInTheDocument();
+    });
+
+    it('auto-derives the action id from the display name and previews the action. Entity ID', async () => {
+        const user = userEvent.setup();
+        renderDialog();
+
+        await user.type(screen.getByLabelText(/Display name/i), 'Call Tool');
+        const slug = screen.getByLabelText('Action ID') as HTMLInputElement;
+        await waitFor(() => expect(slug.value).toBe('call-tool'));
+        expect(screen.getByText(/^action\.call-tool$/)).toBeInTheDocument();
+    });
+
+    it('stops auto-deriving once the action id is edited manually', async () => {
+        const user = userEvent.setup();
+        renderDialog();
+
+        await user.type(screen.getByLabelText(/Display name/i), 'Call Tool');
+        const slug = screen.getByLabelText('Action ID') as HTMLInputElement;
+        await waitFor(() => expect(slug.value).toBe('call-tool'));
+
+        await user.clear(slug);
+        await user.type(slug, 'call_tool');
+        await user.type(screen.getByLabelText(/Display name/i), ' Now');
+        expect(slug.value).toBe('call_tool');
+    });
+
+    it('disables Create until name + id are valid and flags a bad id', async () => {
+        const user = userEvent.setup();
+        renderDialog();
+        const create = screen.getByRole('button', { name: /Create Action/i });
+        expect(create).toBeDisabled();
+
+        await user.type(screen.getByLabelText(/Display name/i), 'Call Tool');
+        await waitFor(() => expect(create).toBeEnabled());
+
+        const slug = screen.getByLabelText('Action ID') as HTMLInputElement;
+        await user.clear(slug);
+        await user.type(slug, 'Bad Id!');
+        expect(create).toBeDisabled();
+        expect(screen.getByText(/Action ID must match/i)).toBeInTheDocument();
+    });
+
+    it('creates a RESOURCE entity under the action. prefix with the right payload', async () => {
+        const user = userEvent.setup();
+        const { onOpenChange, onCreated } = renderDialog();
+
+        await user.type(screen.getByLabelText(/Display name/i), 'Call Tool');
+        const slug = screen.getByLabelText('Action ID') as HTMLInputElement;
+        await user.clear(slug);
+        await user.type(slug, 'call_tool');
+        await user.type(screen.getByLabelText(/Description/i), 'Invoke an MCP tool');
+        await user.click(screen.getByRole('button', { name: /Create Action/i }));
+
+        await waitFor(() => expect(createEntitySpy).toHaveBeenCalledTimes(1));
+        const [env, req] = createEntitySpy.mock.calls[0];
+        expect(env).toBe('DEFAULT');
+        expect(req).toMatchObject({ entityId: 'action.call_tool', kind: 'RESOURCE', source: 'local', parents: [] });
+        expect((req as { attributes: Record<string, unknown> }).attributes).toMatchObject({
+            _displayName: 'Call Tool',
+            description: 'Invoke an MCP tool',
+        });
+        await waitFor(() => expect(toastSuccessSpy).toHaveBeenCalledWith('Created Call Tool'));
+        await waitFor(() => expect(onCreated).toHaveBeenCalledTimes(1));
+        expect(onOpenChange).toHaveBeenCalledWith(false);
+    });
+
+    it('surfaces a duplicate-id message on 409 and keeps the dialog open', async () => {
+        const user = userEvent.setup();
+        createEntitySpy.mockRejectedValueOnce(new Error('HTTP 409 entity already exists'));
+        const { onOpenChange } = renderDialog();
+
+        await user.type(screen.getByLabelText(/Display name/i), 'Call Tool');
+        const slug = screen.getByLabelText('Action ID') as HTMLInputElement;
+        await user.clear(slug);
+        await user.type(slug, 'call_tool');
+        await user.click(screen.getByRole('button', { name: /Create Action/i }));
+
+        await waitFor(() => expect(screen.getByText(/An action with ID "action\.call_tool" already exists/i)).toBeInTheDocument());
+        expect(onOpenChange).not.toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION
## Summary
Adds a dedicated **Actions** page under *Policy Structure*, listing the action vocabulary the policy engine authorizes (RESOURCE entities under the reserved `action.` prefix). This resolves the existing in-product pointer ("Add some under Policy Structure → Actions") referenced from the per-service policy editor — that destination now exists.

- **routes / navigation**: new `actions` route + nav item under Policy Structure (`ZapIcon`)
- **ActionsPage**: list + client-side search, "Total actions" KPI, remove with confirmation; read-only (catalog/APIM-sourced) actions are not removable
- **CreateActionDialog**: Display name → auto-derived `action.<id>` (select-on-first-focus so typing replaces), Entity ID preview, validation, duplicate-id handling
- tests for both components

## Test plan
- [x] `tsc -p tsconfig.app.json --noEmit` clean
- [x] `vitest run` — full module suite green incl. new ActionsPage / CreateActionDialog tests
- [x] Manual (Chrome, local stack): nav item appears; list renders seeded actions; search filters (`prompt` → `list_prompts`); add `action.qa-smoke-action` → count 10→11; remove via confirmation → 11→10, DB clean