### PR TITLE
feat(apim-console): enable remote source URL for v4 OpenAPI import

### DIFF
--- a/gravitee-apim-console-webui/src/entities/management-api-v2/api/v4/importSwaggerDescriptor.ts
+++ b/gravitee-apim-console-webui/src/entities/management-api-v2/api/v4/importSwaggerDescriptor.ts
@@ -14,7 +14,10 @@
  * limitations under the License.
  */
 export interface ImportSwaggerDescriptor {
+  /** The raw OpenAPI/Swagger content (INLINE) or the URL to fetch it from (URL). */
   payload: string;
+  /** Whether the payload is an inline OpenAPI string or a remote URL. Defaults to INLINE. */
+  type?: 'INLINE' | 'URL';
   withDocumentation?: boolean;
   withOASValidationPolicy?: boolean;
 }

--- a/gravitee-apim-console-webui/src/management/api/import-v4/api-import-v4-form/api-import-v4-form.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/import-v4/api-import-v4-form/api-import-v4-form.component.spec.ts
@@ -161,6 +161,7 @@ describe('ApiImportV4FormComponent', () => {
     expect(req.request.body).toEqual(
       expect.objectContaining({
         payload: yaml,
+        type: 'INLINE',
         withDocumentation: true,
         withOASValidationPolicy: false,
       }),
@@ -264,6 +265,7 @@ describe('ApiImportV4FormComponent', () => {
     expect(apiV2.importSwaggerApi).toHaveBeenCalledWith(
       expect.objectContaining({
         payload: 'https://example.com/openapi.yaml',
+        type: 'URL',
         withDocumentation: true,
         withOASValidationPolicy: false,
       }),
@@ -291,6 +293,7 @@ describe('ApiImportV4FormComponent', () => {
       'same-api',
       expect.objectContaining({
         payload: 'https://example.com/openapi.yaml',
+        type: 'URL',
         withDocumentation: true,
         withOASValidationPolicy: false,
       }),
@@ -422,6 +425,56 @@ describe('ApiImportV4FormComponent', () => {
       expect(req.request.body).toBe('https://cdn.example/def.json');
       expect(req.request.headers.get('Content-Type')).toBe('text/plain');
       req.flush(fakeApiV4({ id: 'existing-api' }));
+      httpMock.verify();
+    });
+
+    it('should PUT to _import/swagger with type URL for remote OpenAPI in update mode', async () => {
+      const httpMock = TestBed.inject(HttpTestingController);
+
+      await harness.selectFormat('openapi');
+      fixture.detectChanges();
+      await harness.clickNext();
+      await harness.selectSource('remote');
+      await harness.setRemoteUrl('https://example.com/openapi.yaml');
+      fixture.detectChanges();
+      await harness.clickNext();
+      await harness.clickNext();
+      await harness.clickImport();
+
+      const req = httpMock.expectOne(
+        r => r.method === 'PUT' && r.url === `${CONSTANTS_TESTING.env.v2BaseURL}/apis/existing-api/_import/swagger`,
+      );
+      expect(req.request.body).toEqual(
+        expect.objectContaining({
+          payload: 'https://example.com/openapi.yaml',
+          type: 'URL',
+        }),
+      );
+      req.flush(fakeApiV4({ id: 'existing-api' }));
+      httpMock.verify();
+    });
+
+    it('should surface the backend message when the swagger update endpoint returns an error', async () => {
+      const snackBarService = TestBed.inject(SnackBarService);
+      const snackBarErrorSpy = jest.spyOn(snackBarService, 'error');
+      const httpMock = TestBed.inject(HttpTestingController);
+
+      await harness.selectFormat('openapi');
+      fixture.detectChanges();
+      await harness.clickNext();
+      await harness.selectSource('remote');
+      await harness.setRemoteUrl('https://example.com/broken.yaml');
+      fixture.detectChanges();
+      await harness.clickNext();
+      await harness.clickNext();
+      await harness.clickImport();
+
+      const req = httpMock.expectOne(
+        r => r.method === 'PUT' && r.url === `${CONSTANTS_TESTING.env.v2BaseURL}/apis/existing-api/_import/swagger`,
+      );
+      req.flush({ message: 'Unable to fetch the OpenAPI descriptor from the provided URL' }, { status: 400, statusText: 'error' });
+
+      expect(snackBarErrorSpy).toHaveBeenCalledWith('Unable to fetch the OpenAPI descriptor from the provided URL');
       httpMock.verify();
     });
   });

--- a/gravitee-apim-console-webui/src/management/api/import-v4/api-import-v4-form/api-import-v4-form.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/import-v4/api-import-v4-form/api-import-v4-form.component.ts
@@ -494,8 +494,8 @@ export class ApiImportV4FormComponent {
         : this.apiV2Service.importWsdlApi(this.buildImportWsdlDescriptor(url, 'URL'));
     }
     return updateId
-      ? this.apiV2Service.updateApiFromSwagger(updateId, this.buildImportSwaggerDescriptor(url))
-      : this.apiV2Service.importSwaggerApi(this.buildImportSwaggerDescriptor(url));
+      ? this.apiV2Service.updateApiFromSwagger(updateId, this.buildImportSwaggerDescriptor(url, 'URL'))
+      : this.apiV2Service.importSwaggerApi(this.buildImportSwaggerDescriptor(url, 'URL'));
   }
 
   private resolveFileImport$(): Observable<ApiV4> | null {
@@ -511,8 +511,8 @@ export class ApiImportV4FormComponent {
     }
     if (format === 'openapi' && pickedType === 'SWAGGER') {
       return updateId
-        ? this.apiV2Service.updateApiFromSwagger(updateId, this.buildImportSwaggerDescriptor(fileContent))
-        : this.apiV2Service.importSwaggerApi(this.buildImportSwaggerDescriptor(fileContent));
+        ? this.apiV2Service.updateApiFromSwagger(updateId, this.buildImportSwaggerDescriptor(fileContent, 'INLINE'))
+        : this.apiV2Service.importSwaggerApi(this.buildImportSwaggerDescriptor(fileContent, 'INLINE'));
     }
     if (format === 'wsdl' && pickedType === 'WSDL') {
       return updateId
@@ -523,10 +523,11 @@ export class ApiImportV4FormComponent {
   }
 
   /** Builds the OpenAPI/Swagger import descriptor sent to the Management API. */
-  private buildImportSwaggerDescriptor(payload: string): ImportSwaggerDescriptor {
+  private buildImportSwaggerDescriptor(payload: string, type: 'INLINE' | 'URL'): ImportSwaggerDescriptor {
     const rawOptions = this.optionsForm.getRawValue();
     return {
       payload,
+      type,
       withDocumentation: rawOptions.withDocumentation,
       withOASValidationPolicy: rawOptions.withOASValidationPolicy,
     };


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-12143
https://gravitee.atlassian.net/browse/APIM-12144

## Description
- importSwaggerDescriptor.ts — type?: 'INLINE' | 'URL'
- api-import-v4-form.component.ts — builder sets type; remote→URL, file→INLINE (create and update paths)
- api-import-v4-form.component.spec.ts — create assertions + 2 new update-mode tests:
- HTTP-level PUT …/apis/{id}/_import/swagger carries type: 'URL'
- error-state: backend message surfaced in snackbar on a failed update fetch
- 3 files, +62 / −5 · 44/44 tests green


https://github.com/user-attachments/assets/f7d0841e-b924-49df-8e26-534beb5f2c87


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

