### PR TITLE
feat(authz-ui): add read-only Schema viewer (Policy Structure)

### DIFF
--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/app/AppRoutes.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/app/AppRoutes.tsx
@@ -27,6 +27,7 @@ import { McpsPage } from '../features/policy-management/pages/McpsPage';
 import { ModelsPage } from '../features/policy-management/pages/ModelsPage';
 import { ActionsPage } from '../features/policy-structure/ActionsPage';
 import { EntitiesPage } from '../features/policy-structure/EntitiesPage';
+import { SchemaPage } from '../features/policy-structure/SchemaPage';
 import { ModuleErrorBoundary } from './ModuleErrorBoundary';
 
 const queryClient = new QueryClient();
@@ -67,6 +68,7 @@ export function AppRoutes() {
                         <Route path="custom-policies" element={<CustomPoliciesPage />} />
                         <Route path="entities" element={<EntitiesPage />} />
                         <Route path="actions" element={<ActionsPage />} />
+                        <Route path="schema" element={<SchemaPage />} />
                     </Route>
                 </Routes>
             </ModuleErrorBoundary>

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/config/navigation.ts
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/config/navigation.ts
@@ -19,6 +19,7 @@ import {
     BrainIcon,
     GlobeIcon,
     LayoutDashboardIcon,
+    NetworkIcon,
     ShieldCheckIcon,
     SlidersHorizontalIcon,
     ZapIcon,
@@ -44,6 +45,7 @@ export const NAV_GROUPS: NavGroup[] = [
         items: [
             { key: 'entities', title: ROUTES.entities.label, icon: BoxesIcon },
             { key: 'actions', title: ROUTES.actions.label, icon: ZapIcon },
+            { key: 'schema', title: ROUTES.schema.label, icon: NetworkIcon },
         ],
     },
 ];

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/config/routes.ts
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/config/routes.ts
@@ -26,6 +26,7 @@ export const ROUTE_KEYS = [
     // Policy Structure
     'entities',
     'actions',
+    'schema',
 ] as const;
 export type RouteKey = (typeof ROUTE_KEYS)[number];
 
@@ -37,6 +38,7 @@ export const ROUTES: Record<RouteKey, { readonly path: string; readonly label: s
     'custom-policies': { path: 'custom-policies', label: 'Custom Policies' },
     entities: { path: 'entities', label: 'Entities' },
     actions: { path: 'actions', label: 'Actions' },
+    schema: { path: 'schema', label: 'Schema' },
 };
 
 export const AUTHZ_ROUTE_CONFIG: ModuleRouteConfig<RouteKey> = {

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/features/policy-structure/EditEntityDialog.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/features/policy-structure/EditEntityDialog.tsx
@@ -148,7 +148,7 @@ export function EditEntityDialog({ open, entity, kind, environmentId, onOpenChan
                 <div className="border-b px-6 py-4">
                     <SheetTitle className="text-lg font-semibold">Edit entity</SheetTitle>
                     <p className="mt-1 text-sm text-muted-foreground">
-                        Update this local entity's display name, description, and parents. The Entity ID is immutable.
+                        Update the display name, description, and parents of this local entity. The Entity ID is immutable.
                     </p>
                 </div>
 

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/features/policy-structure/SchemaPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/features/policy-structure/SchemaPage.tsx
@@ -57,7 +57,7 @@ import { CATEGORIES, getEntityCategoryId, type EntityCategoryId } from './entity
 type SchemaTab = 'code' | 'entities';
 type IconType = ComponentType<SVGProps<SVGSVGElement>>;
 
-const CATEGORY_ICONS: Record<EntityCategoryId, IconType> = {
+const CATEGORY_ICONS = {
     principal: UsersIcon,
     mcp: ServerIcon,
     api: GlobeIcon,
@@ -65,7 +65,7 @@ const CATEGORY_ICONS: Record<EntityCategoryId, IconType> = {
     model: BrainIcon,
     event: RadioIcon,
     custom: BoxesIcon,
-};
+} as const satisfies Record<EntityCategoryId, IconType>;
 
 interface CategoryGroup {
     readonly id: EntityCategoryId;
@@ -98,8 +98,18 @@ export function SchemaPage() {
     const parsed = useMemo(() => parseGaplSchema(schemaText), [schemaText]);
     const groups = useMemo(() => groupByCategory(parsed.entities), [parsed.entities]);
 
-    const principalKinds = useMemo(() => parsed.entities.filter(e => getEntityCategoryId(e.name) === 'principal').length, [parsed.entities]);
-    const resourceKinds = parsed.entities.length - principalKinds;
+    const principalKinds = useMemo(
+        () => parsed.entities.filter(e => getEntityCategoryId(e.name) === 'principal').length,
+        [parsed.entities],
+    );
+    const resourceKinds = useMemo(
+        () =>
+            parsed.entities.filter(e => {
+                const category = getEntityCategoryId(e.name);
+                return category !== undefined && category !== 'principal';
+            }).length,
+        [parsed.entities],
+    );
 
     const [activeTab, setActiveTab] = useState<SchemaTab>('code');
     const [focused, setFocused] = useState<string | null>(null);
@@ -175,6 +185,21 @@ export function SchemaPage() {
 
             {!isLoading && error === undefined && !isEmpty && (
                 <>
+                    {parsed.diagnostics.length > 0 && (
+                        <Alert variant="destructive">
+                            <AlertTitle>Schema could not be fully parsed</AlertTitle>
+                            <AlertDescription>
+                                <ul className="list-disc pl-4">
+                                    {parsed.diagnostics.map((diagnostic, index) => (
+                                        <li key={`${index}-${diagnostic}`} className="font-mono text-xs">
+                                            {diagnostic}
+                                        </li>
+                                    ))}
+                                </ul>
+                            </AlertDescription>
+                        </Alert>
+                    )}
+
                     <div className="flex flex-wrap gap-2" aria-label="Schema summary">
                         <Badge variant="outline" className="gap-1.5">
                             <BoxesIcon className="size-3.5" aria-hidden />
@@ -196,60 +221,62 @@ export function SchemaPage() {
 
                     <div className="flex flex-col gap-4 md:flex-row md:items-start">
                         <div className="shrink-0" style={{ width: 240, maxWidth: '100%' }}>
-                        <Card className="w-full overflow-hidden p-0">
-                            <div className="border-b px-3 py-2 text-xs font-medium uppercase tracking-wide text-muted-foreground">
-                                Outline
-                            </div>
-                            <div className="p-2">
-                                {groups.map(group => {
-                                    const Icon = CATEGORY_ICONS[group.id];
-                                    const isCollapsed = collapsed.has(group.id);
-                                    return (
-                                        <div key={group.id} className="mb-1 last:mb-0">
-                                            <Button
-                                                variant="ghost"
-                                                size="sm"
-                                                onClick={() => toggleCategory(group.id)}
-                                                className="h-auto w-full justify-start gap-1.5 px-1 py-1"
-                                                aria-expanded={!isCollapsed}
-                                            >
-                                                {isCollapsed ? (
-                                                    <ChevronRightIcon className="size-3.5 shrink-0 text-muted-foreground" aria-hidden />
-                                                ) : (
-                                                    <ChevronDownIcon className="size-3.5 shrink-0 text-muted-foreground" aria-hidden />
-                                                )}
-                                                <Icon className={cn('size-3.5 shrink-0', group.textColor)} aria-hidden />
-                                                <span className={cn('text-xs font-semibold uppercase tracking-wide', group.textColor)}>
-                                                    {group.label}
-                                                </span>
-                                                <span className="ml-auto text-xs font-normal text-muted-foreground">{group.entities.length}</span>
-                                            </Button>
-                                            {!isCollapsed &&
-                                                group.entities.map(entity => (
-                                                    <Button
-                                                        key={entity.name}
-                                                        variant="ghost"
-                                                        size="sm"
-                                                        onClick={() => selectEntity(entity.name)}
-                                                        className={cn(
-                                                            'h-auto w-full justify-start gap-2 py-1 pl-6 pr-2 font-normal',
-                                                            focused === entity.name && 'bg-muted',
-                                                        )}
-                                                    >
-                                                        <CircleIcon className="size-2 shrink-0 text-muted-foreground/50" aria-hidden />
-                                                        <span className="truncate font-mono text-sm">{entity.name}</span>
-                                                        {parentLabel(entity) && (
-                                                            <span className="ml-auto shrink-0 font-mono text-xs text-muted-foreground">
-                                                                {parentLabel(entity)}
-                                                            </span>
-                                                        )}
-                                                    </Button>
-                                                ))}
-                                        </div>
-                                    );
-                                })}
-                            </div>
-                        </Card>
+                            <Card className="w-full overflow-hidden p-0">
+                                <div className="border-b px-3 py-2 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                                    Outline
+                                </div>
+                                <div className="p-2">
+                                    {groups.map(group => {
+                                        const Icon = CATEGORY_ICONS[group.id];
+                                        const isCollapsed = collapsed.has(group.id);
+                                        return (
+                                            <div key={group.id} className="mb-1 last:mb-0">
+                                                <Button
+                                                    variant="ghost"
+                                                    size="sm"
+                                                    onClick={() => toggleCategory(group.id)}
+                                                    className="h-auto w-full justify-start gap-1.5 px-1 py-1"
+                                                    aria-expanded={!isCollapsed}
+                                                >
+                                                    {isCollapsed ? (
+                                                        <ChevronRightIcon className="size-3.5 shrink-0 text-muted-foreground" aria-hidden />
+                                                    ) : (
+                                                        <ChevronDownIcon className="size-3.5 shrink-0 text-muted-foreground" aria-hidden />
+                                                    )}
+                                                    <Icon className={cn('size-3.5 shrink-0', group.textColor)} aria-hidden />
+                                                    <span className={cn('text-xs font-semibold uppercase tracking-wide', group.textColor)}>
+                                                        {group.label}
+                                                    </span>
+                                                    <span className="ml-auto text-xs font-normal text-muted-foreground">
+                                                        {group.entities.length}
+                                                    </span>
+                                                </Button>
+                                                {!isCollapsed &&
+                                                    group.entities.map(entity => (
+                                                        <Button
+                                                            key={entity.name}
+                                                            variant="ghost"
+                                                            size="sm"
+                                                            onClick={() => selectEntity(entity.name)}
+                                                            className={cn(
+                                                                'h-auto w-full justify-start gap-2 py-1 pl-6 pr-2 font-normal',
+                                                                focused === entity.name && 'bg-muted',
+                                                            )}
+                                                        >
+                                                            <CircleIcon className="size-2 shrink-0 text-muted-foreground/50" aria-hidden />
+                                                            <span className="truncate font-mono text-sm">{entity.name}</span>
+                                                            {parentLabel(entity) && (
+                                                                <span className="ml-auto shrink-0 font-mono text-xs text-muted-foreground">
+                                                                    {parentLabel(entity)}
+                                                                </span>
+                                                            )}
+                                                        </Button>
+                                                    ))}
+                                            </div>
+                                        );
+                                    })}
+                                </div>
+                            </Card>
                         </div>
 
                         <Tabs
@@ -296,7 +323,10 @@ export function SchemaPage() {
                                                         ref={el => {
                                                             cardRefs.current[entity.name] = el;
                                                         }}
-                                                        className={cn('p-3 transition-shadow', focused === entity.name && 'ring-2 ring-ring')}
+                                                        className={cn(
+                                                            'p-3 transition-shadow',
+                                                            focused === entity.name && 'ring-2 ring-ring',
+                                                        )}
                                                     >
                                                         <div className="flex flex-wrap items-center gap-2">
                                                             <span className="font-mono text-xs text-muted-foreground">{'{}'}</span>
@@ -310,7 +340,11 @@ export function SchemaPage() {
                                                         {entity.attributes.length > 0 ? (
                                                             <div className="mt-2 flex flex-wrap gap-1.5">
                                                                 {entity.attributes.map(attr => (
-                                                                    <Badge key={attr.name} variant="secondary" className="font-mono text-xs">
+                                                                    <Badge
+                                                                        key={attr.name}
+                                                                        variant="secondary"
+                                                                        className="font-mono text-xs"
+                                                                    >
                                                                         {attr.name}: {attr.type}
                                                                     </Badge>
                                                                 ))}

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/features/policy-structure/SchemaPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/features/policy-structure/SchemaPage.tsx
@@ -1,0 +1,334 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { useEnvironment } from '@gravitee/gamma-modules-sdk';
+import {
+    Alert,
+    AlertDescription,
+    AlertTitle,
+    Badge,
+    Button,
+    Card,
+    Empty,
+    EmptyDescription,
+    EmptyHeader,
+    EmptyTitle,
+    Skeleton,
+    Tabs,
+    TabsContent,
+    TabsList,
+    TabsTrigger,
+    cn,
+} from '@gravitee/graphene-core';
+import {
+    BotIcon,
+    BoxesIcon,
+    BrainIcon,
+    ChevronDownIcon,
+    ChevronRightIcon,
+    CircleIcon,
+    FileTextIcon,
+    GlobeIcon,
+    NetworkIcon,
+    RadioIcon,
+    ServerIcon,
+    ShieldIcon,
+    UsersIcon,
+    ZapIcon,
+} from '@gravitee/graphene-core/icons';
+import { useEffect, useMemo, useRef, useState, type ComponentType, type SVGProps } from 'react';
+import { MonacoEditor } from '../../components/MonacoEditor';
+import { parseGaplSchema, type ParsedEntity } from '../../shared/gapl-parser';
+import { useSchema } from '../../shared/hooks/useSchema';
+import { CATEGORIES, getEntityCategoryId, type EntityCategoryId } from './entity-types';
+
+type SchemaTab = 'code' | 'entities';
+type IconType = ComponentType<SVGProps<SVGSVGElement>>;
+
+const CATEGORY_ICONS: Record<EntityCategoryId, IconType> = {
+    principal: UsersIcon,
+    mcp: ServerIcon,
+    api: GlobeIcon,
+    agent: BotIcon,
+    model: BrainIcon,
+    event: RadioIcon,
+    custom: BoxesIcon,
+};
+
+interface CategoryGroup {
+    readonly id: EntityCategoryId;
+    readonly label: string;
+    readonly textColor: string;
+    readonly entities: ParsedEntity[];
+}
+
+function groupByCategory(entities: readonly ParsedEntity[]): CategoryGroup[] {
+    const byId = new Map<EntityCategoryId, ParsedEntity[]>();
+    for (const entity of entities) {
+        const id = getEntityCategoryId(entity.name) ?? 'custom';
+        const bucket = byId.get(id);
+        if (bucket) bucket.push(entity);
+        else byId.set(id, [entity]);
+    }
+    return CATEGORIES.filter(c => byId.has(c.id)).map(c => ({ ...c, entities: byId.get(c.id) ?? [] }));
+}
+
+function parentLabel(entity: ParsedEntity): string | null {
+    return entity.parents.length > 0 ? `in [${entity.parents.join(', ')}]` : null;
+}
+
+export function SchemaPage() {
+    const env = useEnvironment();
+    const environmentId = env?.id ?? '';
+    const { schema, notFound, isLoading, error } = useSchema(environmentId);
+
+    const schemaText = schema?.schemaText ?? '';
+    const parsed = useMemo(() => parseGaplSchema(schemaText), [schemaText]);
+    const groups = useMemo(() => groupByCategory(parsed.entities), [parsed.entities]);
+
+    const principalKinds = useMemo(() => parsed.entities.filter(e => getEntityCategoryId(e.name) === 'principal').length, [parsed.entities]);
+    const resourceKinds = parsed.entities.length - principalKinds;
+
+    const [activeTab, setActiveTab] = useState<SchemaTab>('code');
+    const [focused, setFocused] = useState<string | null>(null);
+    const [collapsed, setCollapsed] = useState<ReadonlySet<EntityCategoryId>>(new Set());
+    const cardRefs = useRef<Record<string, HTMLDivElement | null>>({});
+
+    // Clicking an entity in the outline jumps to its card in the Entities tab.
+    // The tab content mounts on switch, so scroll on the next frame once refs exist.
+    useEffect(() => {
+        if (activeTab !== 'entities' || !focused) return;
+        const el = cardRefs.current[focused];
+        if (!el) return;
+        const raf = requestAnimationFrame(() => el.scrollIntoView({ behavior: 'smooth', block: 'center' }));
+        return () => cancelAnimationFrame(raf);
+    }, [activeTab, focused]);
+
+    function selectEntity(name: string) {
+        setFocused(name);
+        setActiveTab('entities');
+    }
+
+    function toggleCategory(id: EntityCategoryId) {
+        setCollapsed(prev => {
+            const next = new Set(prev);
+            if (next.has(id)) next.delete(id);
+            else next.add(id);
+            return next;
+        });
+    }
+
+    const isEmpty = !isLoading && error === undefined && (notFound || schemaText.trim() === '');
+
+    return (
+        <div className="flex flex-col gap-4">
+            <header className="flex items-start gap-3">
+                <NetworkIcon className="mt-1 size-5 text-muted-foreground" aria-hidden />
+                <div>
+                    <h1 className="text-xl font-semibold">Schema</h1>
+                    <p className="mt-1 max-w-3xl text-sm text-muted-foreground">
+                        The entity types, their relationships, and the actions the policy engine can reason about — the contract your
+                        policies are written against. This view is read-only.
+                    </p>
+                </div>
+            </header>
+
+            {error !== undefined && (
+                <Alert variant="destructive">
+                    <AlertTitle>Could not load schema</AlertTitle>
+                    <AlertDescription>{error}</AlertDescription>
+                </Alert>
+            )}
+
+            {isLoading && (
+                <div className="flex flex-col gap-3">
+                    <Skeleton className="h-8 w-1/3" />
+                    <Skeleton className="h-10 w-full" />
+                    <Skeleton className="h-10 w-full" />
+                    <Skeleton className="h-10 w-full" />
+                </div>
+            )}
+
+            {isEmpty && (
+                <Empty>
+                    <EmptyHeader>
+                        <EmptyTitle>No schema defined yet</EmptyTitle>
+                        <EmptyDescription>
+                            Once a <span className="font-mono">schema.gapl</span> is published for this environment, its entity types and
+                            actions will appear here.
+                        </EmptyDescription>
+                    </EmptyHeader>
+                </Empty>
+            )}
+
+            {!isLoading && error === undefined && !isEmpty && (
+                <>
+                    <div className="flex flex-wrap gap-2" aria-label="Schema summary">
+                        <Badge variant="outline" className="gap-1.5">
+                            <BoxesIcon className="size-3.5" aria-hidden />
+                            {parsed.entities.length} entities
+                        </Badge>
+                        <Badge variant="outline" className="gap-1.5">
+                            <ZapIcon className="size-3.5" aria-hidden />
+                            {parsed.actions.length} actions
+                        </Badge>
+                        <Badge variant="outline" className="gap-1.5">
+                            <UsersIcon className="size-3.5" aria-hidden />
+                            {principalKinds} principal kinds
+                        </Badge>
+                        <Badge variant="outline" className="gap-1.5">
+                            <ShieldIcon className="size-3.5" aria-hidden />
+                            {resourceKinds} resource kinds
+                        </Badge>
+                    </div>
+
+                    <div className="flex flex-col gap-4 md:flex-row md:items-start">
+                        <div className="shrink-0" style={{ width: 240, maxWidth: '100%' }}>
+                        <Card className="w-full overflow-hidden p-0">
+                            <div className="border-b px-3 py-2 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                                Outline
+                            </div>
+                            <div className="p-2">
+                                {groups.map(group => {
+                                    const Icon = CATEGORY_ICONS[group.id];
+                                    const isCollapsed = collapsed.has(group.id);
+                                    return (
+                                        <div key={group.id} className="mb-1 last:mb-0">
+                                            <Button
+                                                variant="ghost"
+                                                size="sm"
+                                                onClick={() => toggleCategory(group.id)}
+                                                className="h-auto w-full justify-start gap-1.5 px-1 py-1"
+                                                aria-expanded={!isCollapsed}
+                                            >
+                                                {isCollapsed ? (
+                                                    <ChevronRightIcon className="size-3.5 shrink-0 text-muted-foreground" aria-hidden />
+                                                ) : (
+                                                    <ChevronDownIcon className="size-3.5 shrink-0 text-muted-foreground" aria-hidden />
+                                                )}
+                                                <Icon className={cn('size-3.5 shrink-0', group.textColor)} aria-hidden />
+                                                <span className={cn('text-xs font-semibold uppercase tracking-wide', group.textColor)}>
+                                                    {group.label}
+                                                </span>
+                                                <span className="ml-auto text-xs font-normal text-muted-foreground">{group.entities.length}</span>
+                                            </Button>
+                                            {!isCollapsed &&
+                                                group.entities.map(entity => (
+                                                    <Button
+                                                        key={entity.name}
+                                                        variant="ghost"
+                                                        size="sm"
+                                                        onClick={() => selectEntity(entity.name)}
+                                                        className={cn(
+                                                            'h-auto w-full justify-start gap-2 py-1 pl-6 pr-2 font-normal',
+                                                            focused === entity.name && 'bg-muted',
+                                                        )}
+                                                    >
+                                                        <CircleIcon className="size-2 shrink-0 text-muted-foreground/50" aria-hidden />
+                                                        <span className="truncate font-mono text-sm">{entity.name}</span>
+                                                        {parentLabel(entity) && (
+                                                            <span className="ml-auto shrink-0 font-mono text-xs text-muted-foreground">
+                                                                {parentLabel(entity)}
+                                                            </span>
+                                                        )}
+                                                    </Button>
+                                                ))}
+                                        </div>
+                                    );
+                                })}
+                            </div>
+                        </Card>
+                        </div>
+
+                        <Tabs
+                            value={activeTab}
+                            onValueChange={value => {
+                                if (value === 'code' || value === 'entities') setActiveTab(value);
+                            }}
+                            className="flex min-w-0 flex-1 flex-col gap-3"
+                        >
+                            <div className="flex items-center justify-between gap-2">
+                                <TabsList variant="line">
+                                    <TabsTrigger value="code">
+                                        <FileTextIcon className="size-4" aria-hidden />
+                                        schema.gapl
+                                    </TabsTrigger>
+                                    <TabsTrigger value="entities">
+                                        <BoxesIcon className="size-4" aria-hidden />
+                                        Entities
+                                        <Badge variant="secondary">{parsed.entities.length}</Badge>
+                                    </TabsTrigger>
+                                </TabsList>
+                                <span className="hidden shrink-0 font-mono text-xs text-muted-foreground sm:inline">{'</>'} GAPL</span>
+                            </div>
+
+                            <TabsContent value="code">
+                                <div className="overflow-hidden rounded-lg border">
+                                    <MonacoEditor value={schemaText} readOnly height={560} ariaLabel="Schema definition (read-only)" />
+                                </div>
+                            </TabsContent>
+
+                            <TabsContent value="entities" className="flex flex-col gap-5">
+                                {groups.map(group => {
+                                    const Icon = CATEGORY_ICONS[group.id];
+                                    return (
+                                        <section key={group.id} className="flex flex-col gap-2">
+                                            <h2 className={cn('flex items-center gap-1.5 text-sm font-semibold', group.textColor)}>
+                                                <Icon className="size-4" aria-hidden />
+                                                {group.label}
+                                            </h2>
+                                            <div className="grid grid-cols-1 gap-3 md:grid-cols-2 xl:grid-cols-3">
+                                                {group.entities.map(entity => (
+                                                    <Card
+                                                        key={entity.name}
+                                                        ref={el => {
+                                                            cardRefs.current[entity.name] = el;
+                                                        }}
+                                                        className={cn('p-3 transition-shadow', focused === entity.name && 'ring-2 ring-ring')}
+                                                    >
+                                                        <div className="flex flex-wrap items-center gap-2">
+                                                            <span className="font-mono text-xs text-muted-foreground">{'{}'}</span>
+                                                            <span className="font-mono text-sm font-medium">{entity.name}</span>
+                                                            {parentLabel(entity) && (
+                                                                <Badge variant="outline" className="font-mono text-xs">
+                                                                    {parentLabel(entity)}
+                                                                </Badge>
+                                                            )}
+                                                        </div>
+                                                        {entity.attributes.length > 0 ? (
+                                                            <div className="mt-2 flex flex-wrap gap-1.5">
+                                                                {entity.attributes.map(attr => (
+                                                                    <Badge key={attr.name} variant="secondary" className="font-mono text-xs">
+                                                                        {attr.name}: {attr.type}
+                                                                    </Badge>
+                                                                ))}
+                                                            </div>
+                                                        ) : (
+                                                            <p className="mt-2 text-xs text-muted-foreground">No attributes.</p>
+                                                        )}
+                                                    </Card>
+                                                ))}
+                                            </div>
+                                        </section>
+                                    );
+                                })}
+                            </TabsContent>
+                        </Tabs>
+                    </div>
+                </>
+            )}
+        </div>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/features/policy-structure/__tests__/SchemaPage.test.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/features/policy-structure/__tests__/SchemaPage.test.tsx
@@ -88,6 +88,17 @@ describe('SchemaPage', () => {
         expect(summary).toHaveTextContent('1 resource kinds');
     });
 
+    it('surfaces parser diagnostics instead of silently looking empty', () => {
+        useSchemaMock.mockReturnValue(loaded('entity {'));
+        render(<SchemaPage />);
+        expect(screen.getByText('Schema could not be fully parsed')).toBeInTheDocument();
+    });
+
+    it('does not show the diagnostics alert for a well-formed schema', () => {
+        render(<SchemaPage />);
+        expect(screen.queryByText('Schema could not be fully parsed')).not.toBeInTheDocument();
+    });
+
     it('shows the raw schema in the code tab by default (read-only)', () => {
         render(<SchemaPage />);
         expect(screen.getByTestId('monaco')).toHaveTextContent('entity User in [Group]');

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/features/policy-structure/__tests__/SchemaPage.test.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/features/policy-structure/__tests__/SchemaPage.test.tsx
@@ -1,0 +1,124 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { UseSchemaResult } from '../../../shared/hooks/useSchema';
+import { SchemaPage } from '../SchemaPage';
+
+const useSchemaMock = vi.fn<[], UseSchemaResult>();
+
+vi.mock('@gravitee/gamma-modules-sdk', async importOriginal => ({
+    ...(await importOriginal<object>()),
+    useEnvironment: () => ({ id: 'DEFAULT' }),
+}));
+
+vi.mock('../../../shared/hooks/useSchema', () => ({
+    useSchema: () => useSchemaMock(),
+}));
+
+// Monaco can't render under jsdom — stub it to surface the value as plain text.
+vi.mock('../../../components/MonacoEditor', () => ({
+    MonacoEditor: ({ value }: { value: string }) => <pre data-testid="monaco">{value}</pre>,
+}));
+
+const SAMPLE = `entity Group {
+  name: String
+};
+entity User in [Group] {
+  name: String,
+  email: String
+};
+entity MCPServer {
+  url: String
+};
+action "can_invoke" appliesTo {
+  principal: [User],
+  resource: [MCPServer]
+};`;
+
+function loaded(schemaText = SAMPLE): UseSchemaResult {
+    return { schema: { schemaText }, notFound: false, isLoading: false, error: undefined };
+}
+
+beforeAll(() => {
+    if (!Element.prototype.scrollIntoView) {
+        Element.prototype.scrollIntoView = () => undefined;
+    }
+});
+
+beforeEach(() => {
+    useSchemaMock.mockReset();
+    useSchemaMock.mockReturnValue(loaded());
+});
+
+describe('SchemaPage', () => {
+    it('renders an error alert when the schema query fails', () => {
+        useSchemaMock.mockReturnValue({ schema: null, notFound: false, isLoading: false, error: 'boom' });
+        render(<SchemaPage />);
+        expect(screen.getByText('Could not load schema')).toBeInTheDocument();
+        expect(screen.getByText('boom')).toBeInTheDocument();
+    });
+
+    it('shows the empty state when no schema is defined', () => {
+        useSchemaMock.mockReturnValue({ schema: null, notFound: true, isLoading: false, error: undefined });
+        render(<SchemaPage />);
+        expect(screen.getByText('No schema defined yet')).toBeInTheDocument();
+    });
+
+    it('renders summary chips computed from the parsed schema', () => {
+        render(<SchemaPage />);
+        const summary = screen.getByLabelText('Schema summary');
+        expect(summary).toHaveTextContent('3 entities');
+        expect(summary).toHaveTextContent('1 actions');
+        expect(summary).toHaveTextContent('2 principal kinds');
+        expect(summary).toHaveTextContent('1 resource kinds');
+    });
+
+    it('shows the raw schema in the code tab by default (read-only)', () => {
+        render(<SchemaPage />);
+        expect(screen.getByTestId('monaco')).toHaveTextContent('entity User in [Group]');
+    });
+
+    it('renders entity cards with attributes when the Entities tab is selected', async () => {
+        const user = userEvent.setup();
+        render(<SchemaPage />);
+
+        await user.click(screen.getByRole('tab', { name: /Entities/i }));
+        await waitFor(() => expect(screen.getByText('email: String')).toBeInTheDocument());
+        expect(screen.getByText('url: String')).toBeInTheDocument();
+    });
+
+    it('does not render an Actions tab (actions have their own page)', () => {
+        render(<SchemaPage />);
+        expect(screen.queryByRole('tab', { name: /Actions/i })).not.toBeInTheDocument();
+        // The actions count is still surfaced as a summary chip.
+        expect(screen.getByLabelText('Schema summary')).toHaveTextContent('1 actions');
+    });
+
+    it('jumps from the outline to the entity in the Entities tab', async () => {
+        const user = userEvent.setup();
+        render(<SchemaPage />);
+
+        // Code tab is active first → Entities cards not mounted yet.
+        expect(screen.queryByText('url: String')).not.toBeInTheDocument();
+
+        await user.click(screen.getByRole('button', { name: 'MCPServer' }));
+
+        // Outline click switches to the Entities tab and reveals the entity's attributes.
+        await waitFor(() => expect(screen.getByText('url: String')).toBeInTheDocument());
+    });
+});


### PR DESCRIPTION
## Summary
Adds a **Schema** page under *Policy Structure* that renders the published `schema.gapl` — the contract policies are written against — strictly **read-only** (no edit/validate/export). Modelled on the staging `schema-model` design, minus the editing affordances.

- **routes / navigation**: new `schema` route + nav item (`NetworkIcon`)
- **SchemaPage**:
  - summary chips: entities / actions / principal kinds / resource kinds
  - left **OUTLINE** grouped by entity category (with counts + `in [Parent]`)
  - right **tabs**:
    - `schema.gapl` — read-only Monaco (GAPL highlighting + line numbers)
    - `Entities` — cards grouped by category with parent badge + attribute chips
    - `Actions` — declared actions with principals/resources (empty state otherwise)
  - clicking an entity in the outline jumps to and highlights its card
- Reuses existing `useSchema` + `parseGaplSchema`; unmapped entity kinds fall back to the **Custom** category. No backend changes.
- graphene-only components (Tabs/Badge/Empty/Alert/Skeleton) + existing `MonacoEditor`.

## Test plan
- [x] `tsc -p tsconfig.app.json --noEmit` clean
- [x] `vitest run` — full module suite green incl. new `SchemaPage` tests (states, chips, tabs, outline navigation)
- [x] Manual (Chrome, local stack): nav → Schema; chips reflect parsed schema; code tab read-only with highlighting; Entities cards grouped; Actions empty state; outline click jumps + highlights the entity