### PR TITLE
feat(authz-ui): edit local entities (name, description, parents)

### DIFF
--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/features/policy-structure/EditEntityDialog.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/features/policy-structure/EditEntityDialog.tsx
@@ -1,0 +1,246 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+    Alert,
+    AlertDescription,
+    Badge,
+    Button,
+    Combobox,
+    ComboboxChip,
+    ComboboxChips,
+    ComboboxChipsInput,
+    ComboboxContent,
+    ComboboxEmpty,
+    ComboboxItem,
+    ComboboxList,
+    Input,
+    Label,
+    Sheet,
+    SheetContent,
+    SheetTitle,
+    Spinner,
+    Textarea,
+    toast,
+    useComboboxAnchor,
+} from '@gravitee/graphene-core';
+import { CheckIcon } from '@gravitee/graphene-core/icons';
+import { useQueryClient } from '@tanstack/react-query';
+import { useEffect, useMemo, useState } from 'react';
+import { authzApiService } from '../../shared/api/authz-api.service';
+import { authzQueryKeys } from '../../shared/api/query-keys';
+import { formatEntityUid, fromBackend, toBackend } from '../../shared/entity-adapter';
+import type { EntityInstance } from '../../shared/entity.types';
+import { useEntities } from '../../shared/hooks/useEntities';
+
+type EntityKind = 'PRINCIPAL' | 'RESOURCE';
+
+export interface EditEntityDialogProps {
+    readonly open: boolean;
+    readonly entity: EntityInstance | null;
+    readonly kind: EntityKind;
+    readonly environmentId: string;
+    readonly onOpenChange: (open: boolean) => void;
+    readonly onUpdated: () => void;
+}
+
+function displayNameOf(entity: EntityInstance): string {
+    if (entity.displayName) return entity.displayName;
+    const name = entity.attrs.name;
+    return typeof name === 'string' ? name : entity.uid.id;
+}
+
+function descriptionOf(entity: EntityInstance): string {
+    const description = entity.attrs.description;
+    return typeof description === 'string' ? description : '';
+}
+
+export function EditEntityDialog({ open, entity, kind, environmentId, onOpenChange, onUpdated }: EditEntityDialogProps) {
+    const queryClient = useQueryClient();
+
+    const [displayName, setDisplayName] = useState('');
+    const [description, setDescription] = useState('');
+    const [parentIds, setParentIds] = useState<string[]>([]);
+    const [submitting, setSubmitting] = useState(false);
+    const [submitError, setSubmitError] = useState<string | null>(null);
+
+    // Re-seed the form whenever a different entity is opened for editing.
+    useEffect(() => {
+        if (open && entity) {
+            setDisplayName(displayNameOf(entity));
+            setDescription(descriptionOf(entity));
+            setParentIds(entity.parents.map(formatEntityUid));
+            setSubmitError(null);
+            setSubmitting(false);
+        }
+    }, [open, entity]);
+
+    const entityUid = entity ? formatEntityUid(entity.uid) : '';
+    const displayNameError = displayName.trim().length === 0 ? 'Display name is required.' : null;
+    const canSubmit = !submitting && entity !== null && displayName.trim().length > 0 && !displayNameError;
+
+    // Parents come from the same kind, mirroring the create flow.
+    const parentsQuery = useEntities(environmentId, 200, { kind });
+    const parentOptions = useMemo(() => {
+        const all = parentsQuery.data?.data ?? [];
+        return all
+            .map(fromBackend)
+            .filter(e => !entity || formatEntityUid(e.uid) !== entityUid) // an entity can't parent itself
+            .map(e => {
+                const uid = formatEntityUid(e.uid);
+                const label =
+                    (typeof e.attrs._displayName === 'string' && (e.attrs._displayName as string)) ||
+                    (typeof e.attrs.name === 'string' && (e.attrs.name as string)) ||
+                    e.uid.id;
+                return { uid, label, type: e.uid.type };
+            });
+    }, [parentsQuery.data, entity, entityUid]);
+
+    const parentAnchorRef = useComboboxAnchor();
+
+    async function handleSubmit(event: React.FormEvent) {
+        event.preventDefault();
+        if (!canSubmit || !entity) return;
+        setSubmitting(true);
+        setSubmitError(null);
+        // Full replace: start from the entity's complete attribute map so unknown
+        // attributes (department, email, _kind, _source, …) are preserved, then
+        // override only the edited fields.
+        const attributes: Record<string, unknown> = { ...toBackend(entity).attributes };
+        attributes._displayName = displayName.trim();
+        const trimmedDescription = description.trim();
+        if (trimmedDescription) attributes.description = trimmedDescription;
+        else delete attributes.description;
+        try {
+            await authzApiService.updateEntity(environmentId, entityUid, { attributes, parents: parentIds });
+            toast.success(`Updated ${displayName.trim()}`);
+            void queryClient.invalidateQueries({ queryKey: authzQueryKeys.entities.all(environmentId) });
+            onUpdated();
+            onOpenChange(false);
+        } catch (err) {
+            setSubmitError(err instanceof Error ? err.message : String(err));
+        } finally {
+            setSubmitting(false);
+        }
+    }
+
+    return (
+        <Sheet open={open} onOpenChange={onOpenChange}>
+            <SheetContent
+                side="right"
+                showCloseButton={false}
+                aria-label="Edit entity"
+                style={{ width: 'min(640px, 100vw)', maxWidth: 'min(640px, 100vw)' }}
+                className="flex h-full flex-col gap-0 p-0"
+            >
+                <div className="border-b px-6 py-4">
+                    <SheetTitle className="text-lg font-semibold">Edit entity</SheetTitle>
+                    <p className="mt-1 text-sm text-muted-foreground">
+                        Update this local entity's display name, description, and parents. The Entity ID is immutable.
+                    </p>
+                </div>
+
+                <form className="flex min-h-0 flex-1 flex-col overflow-y-auto" onSubmit={handleSubmit}>
+                    <div className="flex flex-col gap-4 px-6 py-4">
+                        {submitError && (
+                            <Alert variant="destructive">
+                                <AlertDescription>{submitError}</AlertDescription>
+                            </Alert>
+                        )}
+
+                        <div className="flex flex-col gap-1.5">
+                            <Label htmlFor="edit-entity-id">Entity ID</Label>
+                            <code id="edit-entity-id" className="rounded-md border bg-muted/40 px-3 py-2 font-mono text-sm text-muted-foreground">
+                                {entityUid || '—'}
+                            </code>
+                        </div>
+
+                        <div className="flex flex-col gap-1.5">
+                            <Label htmlFor="edit-entity-display-name">Display name</Label>
+                            <Input
+                                id="edit-entity-display-name"
+                                value={displayName}
+                                onChange={e => setDisplayName(e.target.value)}
+                                placeholder="e.g. Alice"
+                                aria-invalid={displayName.length > 0 && displayNameError !== null}
+                                required
+                            />
+                        </div>
+
+                        <div className="flex flex-col gap-1.5">
+                            <Label htmlFor="edit-entity-description">
+                                Description <span className="text-xs text-muted-foreground">(optional)</span>
+                            </Label>
+                            <Textarea
+                                id="edit-entity-description"
+                                value={description}
+                                onChange={e => setDescription(e.target.value)}
+                                placeholder="Short note about what this entity represents."
+                                rows={3}
+                            />
+                        </div>
+
+                        <div className="flex flex-col gap-1.5">
+                            <Label>
+                                Parents <span className="text-xs text-muted-foreground">(optional)</span>
+                            </Label>
+                            <Combobox multiple value={parentIds} onValueChange={next => setParentIds(next as string[])} autoComplete="list">
+                                <ComboboxChips ref={parentAnchorRef}>
+                                    {parentIds.map(pid => {
+                                        const opt = parentOptions.find(o => o.uid === pid);
+                                        return (
+                                            <ComboboxChip key={pid} removeAriaLabel={`Remove ${opt?.label ?? pid}`}>
+                                                {opt?.label ?? pid}
+                                            </ComboboxChip>
+                                        );
+                                    })}
+                                    <ComboboxChipsInput
+                                        placeholder={parentIds.length === 0 ? 'Search existing entities…' : ''}
+                                        aria-label="Add parent"
+                                    />
+                                </ComboboxChips>
+                                <ComboboxContent anchor={parentAnchorRef} className="max-h-64 min-w-60" style={{ pointerEvents: 'auto' }}>
+                                    <ComboboxList>
+                                        <ComboboxEmpty>No matches.</ComboboxEmpty>
+                                        {parentOptions.map(opt => (
+                                            <ComboboxItem key={opt.uid} value={opt.uid}>
+                                                <div className="flex min-w-0 flex-1 items-center gap-2">
+                                                    <span className="truncate">{opt.label}</span>
+                                                    <Badge variant="outline" className="shrink-0 font-mono text-xs">
+                                                        {opt.type}
+                                                    </Badge>
+                                                </div>
+                                            </ComboboxItem>
+                                        ))}
+                                    </ComboboxList>
+                                </ComboboxContent>
+                            </Combobox>
+                        </div>
+                    </div>
+                </form>
+
+                <div className="flex flex-none items-center justify-end gap-2 border-t bg-muted/40 px-6 py-3.5">
+                    <Button type="button" variant="outline" onClick={() => onOpenChange(false)} disabled={submitting}>
+                        Cancel
+                    </Button>
+                    <Button type="button" onClick={handleSubmit as unknown as () => void} disabled={!canSubmit}>
+                        {submitting ? <Spinner className="mr-2 size-4" aria-hidden /> : <CheckIcon className="mr-2 size-4" aria-hidden />}
+                        Save changes
+                    </Button>
+                </div>
+            </SheetContent>
+        </Sheet>
+    );
+}

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/features/policy-structure/EditEntityDialog.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/features/policy-structure/EditEntityDialog.tsx
@@ -152,7 +152,7 @@ export function EditEntityDialog({ open, entity, kind, environmentId, onOpenChan
                     </p>
                 </div>
 
-                <form className="flex min-h-0 flex-1 flex-col overflow-y-auto" onSubmit={handleSubmit}>
+                <form id="edit-entity-form" className="flex min-h-0 flex-1 flex-col overflow-y-auto" onSubmit={handleSubmit}>
                     <div className="flex flex-col gap-4 px-6 py-4">
                         {submitError && (
                             <Alert variant="destructive">
@@ -162,7 +162,10 @@ export function EditEntityDialog({ open, entity, kind, environmentId, onOpenChan
 
                         <div className="flex flex-col gap-1.5">
                             <Label htmlFor="edit-entity-id">Entity ID</Label>
-                            <code id="edit-entity-id" className="rounded-md border bg-muted/40 px-3 py-2 font-mono text-sm text-muted-foreground">
+                            <code
+                                id="edit-entity-id"
+                                className="rounded-md border bg-muted/40 px-3 py-2 font-mono text-sm text-muted-foreground"
+                            >
                                 {entityUid || '—'}
                             </code>
                         </div>
@@ -235,7 +238,7 @@ export function EditEntityDialog({ open, entity, kind, environmentId, onOpenChan
                     <Button type="button" variant="outline" onClick={() => onOpenChange(false)} disabled={submitting}>
                         Cancel
                     </Button>
-                    <Button type="button" onClick={handleSubmit as unknown as () => void} disabled={!canSubmit}>
+                    <Button type="submit" form="edit-entity-form" disabled={!canSubmit}>
                         {submitting ? <Spinner className="mr-2 size-4" aria-hidden /> : <CheckIcon className="mr-2 size-4" aria-hidden />}
                         Save changes
                     </Button>

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/features/policy-structure/EntitiesPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/features/policy-structure/EntitiesPage.tsx
@@ -44,7 +44,7 @@ import {
     TabsTrigger,
     toast,
 } from '@gravitee/graphene-core';
-import { BoxesIcon, DownloadIcon, PlusIcon, ShieldIcon, Trash2Icon, UsersIcon } from '@gravitee/graphene-core/icons';
+import { BoxesIcon, DownloadIcon, PencilIcon, PlusIcon, ShieldIcon, Trash2Icon, UsersIcon } from '@gravitee/graphene-core/icons';
 import { useQueryClient } from '@tanstack/react-query';
 import type { ColumnDef } from '@tanstack/react-table';
 import { useDeferredValue, useEffect, useMemo, useState } from 'react';
@@ -54,6 +54,7 @@ import { authzQueryKeys } from '../../shared/api/query-keys';
 import { formatEntityUid, fromBackend } from '../../shared/entity-adapter';
 import { useAllEntities } from '../../shared/hooks/useAllEntities';
 import { CreateEntityDialog } from './CreateEntityDialog';
+import { EditEntityDialog } from './EditEntityDialog';
 import { ImportFromCatalogDialog } from './ImportFromCatalogDialog';
 import { CATEGORIES, getEntityCategoryId, type EntityInstance } from './entity-types';
 
@@ -102,6 +103,7 @@ interface EntitiesTableProps {
     readonly totalCount: number;
     readonly onPageChange: (page: number) => void;
     readonly onPerPageChange: (perPage: number) => void;
+    readonly onEdit?: (entity: EntityInstance) => void;
     readonly onDelete?: (entity: EntityInstance) => void;
     readonly deletingEntityId?: string;
 }
@@ -116,6 +118,7 @@ function EntitiesTable({
     totalCount,
     onPageChange,
     onPerPageChange,
+    onEdit,
     onDelete,
     deletingEntityId,
 }: EntitiesTableProps) {
@@ -153,31 +156,48 @@ function EntitiesTable({
                 cell: ({ row }) => <Badge variant="secondary">{sourceLabelOf(row.original)}</Badge>,
             },
         ];
-        if (onDelete) {
+        if (onEdit || onDelete) {
             baseColumns.push({
                 id: 'actions',
                 header: '',
-                size: 60,
+                size: 96,
                 cell: ({ row }) => {
                     const uid = formatEntityUid(row.original.uid);
                     const isDeleting = deletingEntityId === uid;
+                    // Only local entities are editable; catalog/APIM-sourced are read-only.
+                    const canEdit = onEdit && row.original.source === 'local';
                     return (
-                        <Button
-                            variant="ghost"
-                            size="sm"
-                            onClick={() => onDelete(row.original)}
-                            disabled={isDeleting}
-                            aria-label={`Delete ${uid}`}
-                            title="Remove from Authorization"
-                        >
-                            <Trash2Icon className="size-4 text-muted-foreground" aria-hidden />
-                        </Button>
+                        <div className="flex items-center justify-end gap-1">
+                            {canEdit && (
+                                <Button
+                                    variant="ghost"
+                                    size="sm"
+                                    onClick={() => onEdit(row.original)}
+                                    aria-label={`Edit ${uid}`}
+                                    title="Edit"
+                                >
+                                    <PencilIcon className="size-4 text-muted-foreground" aria-hidden />
+                                </Button>
+                            )}
+                            {onDelete && (
+                                <Button
+                                    variant="ghost"
+                                    size="sm"
+                                    onClick={() => onDelete(row.original)}
+                                    disabled={isDeleting}
+                                    aria-label={`Delete ${uid}`}
+                                    title="Remove from Authorization"
+                                >
+                                    <Trash2Icon className="size-4 text-muted-foreground" aria-hidden />
+                                </Button>
+                            )}
+                        </div>
                     );
                 },
             });
         }
         return baseColumns;
-    }, [onDelete, deletingEntityId]);
+    }, [onEdit, onDelete, deletingEntityId]);
 
     if (!isLoading && entities.length === 0) {
         return (
@@ -321,6 +341,7 @@ export function EntitiesPage() {
     const [resourcePerPage, setResourcePerPage] = useState(DEFAULT_PER_PAGE);
     const [importOpen, setImportOpen] = useState(false);
     const [addingKind, setAddingKind] = useState<AddingKind | null>(null);
+    const [editing, setEditing] = useState<{ entity: EntityInstance; kind: AddingKind } | null>(null);
     const [pendingDelete, setPendingDelete] = useState<EntityInstance | null>(null);
     const [deletingEntityId, setDeletingEntityId] = useState<string | undefined>();
 
@@ -485,6 +506,7 @@ export function EntitiesPage() {
                         totalCount={filteredPrincipals.length}
                         onPageChange={setPrincipalPage}
                         onPerPageChange={setPrincipalPerPage}
+                        onEdit={entity => setEditing({ entity, kind: 'PRINCIPAL' })}
                     />
                 </TabsContent>
 
@@ -525,6 +547,7 @@ export function EntitiesPage() {
                         totalCount={filteredResources.length}
                         onPageChange={setResourcePage}
                         onPerPageChange={setResourcePerPage}
+                        onEdit={entity => setEditing({ entity, kind: 'RESOURCE' })}
                         onDelete={setPendingDelete}
                         deletingEntityId={deletingEntityId}
                     />
@@ -546,6 +569,17 @@ export function EntitiesPage() {
                     if (!open) setAddingKind(null);
                 }}
                 onCreated={handleImported}
+            />
+
+            <EditEntityDialog
+                open={editing !== null}
+                entity={editing?.entity ?? null}
+                kind={editing?.kind ?? 'PRINCIPAL'}
+                environmentId={environmentId}
+                onOpenChange={open => {
+                    if (!open) setEditing(null);
+                }}
+                onUpdated={handleImported}
             />
 
             <Dialog

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/features/policy-structure/EntitiesPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/features/policy-structure/EntitiesPage.tsx
@@ -68,7 +68,7 @@ const PAGE_SIZE_OPTIONS = [10, 25, 50, 100];
 const ACTION_PREFIX = 'action.';
 
 const PRINCIPALS_HELP =
-    'Principals (users, groups, service accounts, agent identities) live in this environment. Edit and import flows are in a follow-up PR.';
+    'Principals (users, groups, service accounts, agent identities) live in this environment. Local principals can be edited or removed; synced ones are read-only.';
 const RESOURCES_HELP =
     'Resources are imported from the Context Catalog — MCP servers, AI models, and agents keep the same Entity ID in Authorization. Catalog-sourced entries are read-only; you can remove imported instances but cannot edit them here.';
 
@@ -105,6 +105,7 @@ interface EntitiesTableProps {
     readonly onPerPageChange: (perPage: number) => void;
     readonly onEdit?: (entity: EntityInstance) => void;
     readonly onDelete?: (entity: EntityInstance) => void;
+    readonly canDelete?: (entity: EntityInstance) => boolean;
     readonly deletingEntityId?: string;
 }
 
@@ -120,6 +121,7 @@ function EntitiesTable({
     onPerPageChange,
     onEdit,
     onDelete,
+    canDelete,
     deletingEntityId,
 }: EntitiesTableProps) {
     const columns = useMemo<ColumnDef<EntityInstance>[]>(() => {
@@ -166,6 +168,7 @@ function EntitiesTable({
                     const isDeleting = deletingEntityId === uid;
                     // Only local entities are editable; catalog/APIM-sourced are read-only.
                     const canEdit = onEdit && row.original.source === 'local';
+                    const showDelete = onDelete && (!canDelete || canDelete(row.original));
                     return (
                         <div className="flex items-center justify-end gap-1">
                             {canEdit && (
@@ -179,7 +182,7 @@ function EntitiesTable({
                                     <PencilIcon className="size-4 text-muted-foreground" aria-hidden />
                                 </Button>
                             )}
-                            {onDelete && (
+                            {showDelete && (
                                 <Button
                                     variant="ghost"
                                     size="sm"
@@ -197,7 +200,7 @@ function EntitiesTable({
             });
         }
         return baseColumns;
-    }, [onEdit, onDelete, deletingEntityId]);
+    }, [onEdit, onDelete, canDelete, deletingEntityId]);
 
     if (!isLoading && entities.length === 0) {
         return (
@@ -347,8 +350,9 @@ export function EntitiesPage() {
 
     const pendingDeleteUid = pendingDelete ? formatEntityUid(pendingDelete.uid) : '';
     const pendingDeleteName = pendingDelete ? displayNameOf(pendingDelete) : '';
+    const pendingDeleteIsLocal = pendingDelete?.source === 'local';
 
-    async function confirmDeleteResource() {
+    async function confirmDelete() {
         if (!pendingDelete) return;
         const uid = formatEntityUid(pendingDelete.uid);
         const friendly = displayNameOf(pendingDelete);
@@ -507,6 +511,9 @@ export function EntitiesPage() {
                         onPageChange={setPrincipalPage}
                         onPerPageChange={setPrincipalPerPage}
                         onEdit={entity => setEditing({ entity, kind: 'PRINCIPAL' })}
+                        onDelete={setPendingDelete}
+                        canDelete={entity => entity.source === 'local'}
+                        deletingEntityId={deletingEntityId}
                     />
                 </TabsContent>
 
@@ -592,9 +599,11 @@ export function EntitiesPage() {
                     <DialogHeader>
                         <DialogTitle>Remove entity from Authorization?</DialogTitle>
                         <DialogDescription>
-                            {pendingDelete
-                                ? `"${pendingDeleteName}" (${pendingDeleteUid}) will be removed from Authorization. This won't delete it from the Context Catalog — you can re-import it later.`
-                                : ''}
+                            {!pendingDelete
+                                ? ''
+                                : pendingDeleteIsLocal
+                                  ? `"${pendingDeleteName}" (${pendingDeleteUid}) will be permanently removed from Authorization. This can't be undone.`
+                                  : `"${pendingDeleteName}" (${pendingDeleteUid}) will be removed from Authorization. This won't delete it from the Context Catalog — you can re-import it later.`}
                         </DialogDescription>
                     </DialogHeader>
                     <DialogFooter>
@@ -609,7 +618,7 @@ export function EntitiesPage() {
                         <Button
                             type="button"
                             variant="destructive"
-                            onClick={confirmDeleteResource}
+                            onClick={confirmDelete}
                             disabled={deletingEntityId !== undefined}
                             aria-label={pendingDelete ? `Confirm remove ${pendingDeleteName}` : 'Confirm remove'}
                         >

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/features/policy-structure/__tests__/EditEntityDialog.test.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/features/policy-structure/__tests__/EditEntityDialog.test.tsx
@@ -68,7 +68,14 @@ function renderDialog(entity: EntityInstance | null = aliceEntity()) {
     const onOpenChange = vi.fn();
     const onUpdated = vi.fn();
     render(
-        <EditEntityDialog open entity={entity} kind="PRINCIPAL" environmentId="DEFAULT" onOpenChange={onOpenChange} onUpdated={onUpdated} />,
+        <EditEntityDialog
+            open
+            entity={entity}
+            kind="PRINCIPAL"
+            environmentId="DEFAULT"
+            onOpenChange={onOpenChange}
+            onUpdated={onUpdated}
+        />,
         { wrapper },
     );
     return { onOpenChange, onUpdated };
@@ -150,5 +157,49 @@ describe('EditEntityDialog', () => {
 
         await waitFor(() => expect(screen.getByText('entity not found')).toBeInTheDocument());
         expect(onOpenChange).not.toHaveBeenCalled();
+    });
+
+    it('disables Save while the update is in flight', async () => {
+        const user = userEvent.setup();
+        let resolveUpdate: (value: unknown) => void = () => undefined;
+        updateEntitySpy.mockReturnValue(new Promise(resolve => (resolveUpdate = resolve)));
+        renderDialog();
+
+        const save = screen.getByRole('button', { name: /Save changes/i });
+        await user.click(save);
+
+        await waitFor(() => expect(save).toBeDisabled());
+        resolveUpdate({}); // settle the pending request
+    });
+
+    it('re-seeds name, description, and Entity ID when reopened with a different entity', async () => {
+        const { rerender } = render(
+            <EditEntityDialog
+                open
+                entity={aliceEntity()}
+                kind="PRINCIPAL"
+                environmentId="DEFAULT"
+                onOpenChange={vi.fn()}
+                onUpdated={vi.fn()}
+            />,
+            { wrapper },
+        );
+        expect((screen.getByLabelText(/Display name/i) as HTMLInputElement).value).toBe('Alice');
+        expect(screen.getByText('user.alice')).toBeInTheDocument();
+
+        const bob: EntityInstance = {
+            uid: { type: 'User', id: 'bob' },
+            displayName: 'Bob',
+            attrs: { description: 'QA pipeline owner' },
+            parents: [],
+            source: 'local',
+        };
+        rerender(
+            <EditEntityDialog open entity={bob} kind="PRINCIPAL" environmentId="DEFAULT" onOpenChange={vi.fn()} onUpdated={vi.fn()} />,
+        );
+
+        await waitFor(() => expect((screen.getByLabelText(/Display name/i) as HTMLInputElement).value).toBe('Bob'));
+        expect((screen.getByLabelText(/Description/i) as HTMLTextAreaElement).value).toBe('QA pipeline owner');
+        expect(screen.getByText('user.bob')).toBeInTheDocument();
     });
 });

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/features/policy-structure/__tests__/EditEntityDialog.test.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/features/policy-structure/__tests__/EditEntityDialog.test.tsx
@@ -1,0 +1,154 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { ReactNode } from 'react';
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { EntityInstance } from '../../../shared/entity.types';
+import { EditEntityDialog } from '../EditEntityDialog';
+
+beforeAll(() => {
+    if (!Element.prototype.scrollIntoView) {
+        Element.prototype.scrollIntoView = () => undefined;
+    }
+});
+
+const updateEntitySpy = vi.fn();
+const toastSuccessSpy = vi.fn();
+
+vi.mock('../../../shared/api/authz-api.service', () => ({
+    DEFAULT_PER_PAGE: 10,
+    authzApiService: {
+        updateEntity: (env: string, id: string, req: unknown) => updateEntitySpy(env, id, req),
+    },
+}));
+
+// Parents picker source — keep it empty so the test stays focused on the payload.
+vi.mock('../../../shared/hooks/useEntities', () => ({
+    useEntities: () => ({ data: { data: [], total: 0, page: 1, perPage: 200 }, isLoading: false, error: undefined }),
+}));
+
+vi.mock('@gravitee/graphene-core', async importOriginal => {
+    const actual = await importOriginal<Record<string, unknown>>();
+    return { ...actual, toast: { success: (m: string) => toastSuccessSpy(m), error: vi.fn() } };
+});
+
+function wrapper({ children }: { children: ReactNode }) {
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    return <QueryClientProvider client={qc}>{children}</QueryClientProvider>;
+}
+
+function aliceEntity(): EntityInstance {
+    return {
+        uid: { type: 'User', id: 'alice' },
+        displayName: 'Alice',
+        attrs: { department: 'engineering', email: 'alice@example.io', description: 'Eng lead' },
+        parents: [{ type: 'Group', id: 'developers' }],
+        source: 'local',
+        createdAt: '2026-01-01T00:00:00.000Z',
+        updatedAt: '2026-01-02T00:00:00.000Z',
+    };
+}
+
+function renderDialog(entity: EntityInstance | null = aliceEntity()) {
+    const onOpenChange = vi.fn();
+    const onUpdated = vi.fn();
+    render(
+        <EditEntityDialog open entity={entity} kind="PRINCIPAL" environmentId="DEFAULT" onOpenChange={onOpenChange} onUpdated={onUpdated} />,
+        { wrapper },
+    );
+    return { onOpenChange, onUpdated };
+}
+
+beforeEach(() => {
+    updateEntitySpy.mockReset();
+    toastSuccessSpy.mockReset();
+    updateEntitySpy.mockResolvedValue({});
+});
+
+describe('EditEntityDialog', () => {
+    it('prefills display name + description and shows the Entity ID read-only', () => {
+        renderDialog();
+        expect((screen.getByLabelText(/Display name/i) as HTMLInputElement).value).toBe('Alice');
+        expect((screen.getByLabelText(/Description/i) as HTMLTextAreaElement).value).toBe('Eng lead');
+        // Entity ID is rendered, not as an editable input.
+        expect(screen.getByText('user.alice')).toBeInTheDocument();
+        expect(screen.queryByRole('textbox', { name: /Entity ID/i })).not.toBeInTheDocument();
+    });
+
+    it('disables Save when the display name is cleared', async () => {
+        const user = userEvent.setup();
+        renderDialog();
+        const save = screen.getByRole('button', { name: /Save changes/i });
+        expect(save).toBeEnabled();
+        await user.clear(screen.getByLabelText(/Display name/i));
+        expect(save).toBeDisabled();
+    });
+
+    it('sends the full attribute map (preserving unknown attrs) with only edited fields changed', async () => {
+        const user = userEvent.setup();
+        const { onUpdated, onOpenChange } = renderDialog();
+
+        const name = screen.getByLabelText(/Display name/i);
+        await user.clear(name);
+        await user.type(name, 'Alice Smith');
+        await user.click(screen.getByRole('button', { name: /Save changes/i }));
+
+        await waitFor(() => expect(updateEntitySpy).toHaveBeenCalledTimes(1));
+        const [env, id, req] = updateEntitySpy.mock.calls[0];
+        expect(env).toBe('DEFAULT');
+        expect(id).toBe('user.alice');
+        const attrs = (req as { attributes: Record<string, unknown> }).attributes;
+        // edited
+        expect(attrs._displayName).toBe('Alice Smith');
+        expect(attrs.description).toBe('Eng lead');
+        // preserved (would be wiped by a partial patch)
+        expect(attrs.department).toBe('engineering');
+        expect(attrs.email).toBe('alice@example.io');
+        expect(attrs._kind).toBe('user');
+        // parents round-tripped to canonical entityIds
+        expect((req as { parents: string[] }).parents).toEqual(['group.developers']);
+
+        await waitFor(() => expect(toastSuccessSpy).toHaveBeenCalledWith('Updated Alice Smith'));
+        await waitFor(() => expect(onUpdated).toHaveBeenCalledTimes(1));
+        expect(onOpenChange).toHaveBeenCalledWith(false);
+    });
+
+    it('drops the description attribute when the field is cleared', async () => {
+        const user = userEvent.setup();
+        renderDialog();
+
+        await user.clear(screen.getByLabelText(/Description/i));
+        await user.click(screen.getByRole('button', { name: /Save changes/i }));
+
+        await waitFor(() => expect(updateEntitySpy).toHaveBeenCalledTimes(1));
+        const attrs = (updateEntitySpy.mock.calls[0][2] as { attributes: Record<string, unknown> }).attributes;
+        expect('description' in attrs).toBe(false);
+        expect(attrs._displayName).toBe('Alice');
+    });
+
+    it('surfaces a backend error and keeps the dialog open', async () => {
+        const user = userEvent.setup();
+        updateEntitySpy.mockRejectedValueOnce(new Error('entity not found'));
+        const { onOpenChange } = renderDialog();
+
+        await user.click(screen.getByRole('button', { name: /Save changes/i }));
+
+        await waitFor(() => expect(screen.getByText('entity not found')).toBeInTheDocument());
+        expect(onOpenChange).not.toHaveBeenCalled();
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/features/policy-structure/__tests__/EditEntityDialog.test.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/features/policy-structure/__tests__/EditEntityDialog.test.tsx
@@ -135,6 +135,18 @@ describe('EditEntityDialog', () => {
         expect(onOpenChange).toHaveBeenCalledWith(false);
     });
 
+    it('sends parents=[] after the existing parent chip is removed', async () => {
+        const user = userEvent.setup();
+        renderDialog();
+
+        // Alice starts parented to group.developers; remove that chip.
+        await user.click(screen.getByRole('button', { name: /Remove group\.developers/i }));
+        await user.click(screen.getByRole('button', { name: /Save changes/i }));
+
+        await waitFor(() => expect(updateEntitySpy).toHaveBeenCalledTimes(1));
+        expect((updateEntitySpy.mock.calls[0][2] as { parents: string[] }).parents).toEqual([]);
+    });
+
     it('drops the description attribute when the field is cleared', async () => {
         const user = userEvent.setup();
         renderDialog();

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/features/policy-structure/__tests__/EntitiesPage.test.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/features/policy-structure/__tests__/EntitiesPage.test.tsx
@@ -313,21 +313,48 @@ describe('EntitiesPage', () => {
         expect(stub).toHaveAttribute('data-entity', 'flight');
     });
 
-    it('shows the row-level Remove action only on the Resources tab', async () => {
+    it('shows the Remove action on local principal rows but not on synced ones', async () => {
         mockByKind({
-            principals: [makeEntity({ id: 'p1', uid: 'user.alice' })],
-            resources: [makeEntity({ id: 'r1', uid: 'mcp.flight' })],
+            principals: [
+                makeEntity({ id: 'p1', uid: 'user.alice' }),
+                makeEntity({ id: 'p2', uid: 'user.bob', attributes: { _source: 'apim' } }),
+            ],
         });
         renderPage();
 
-        await waitFor(() => expect(screen.getAllByText('alice').length).toBeGreaterThan(0));
-        // Principal rows have no Delete button.
-        expect(screen.queryByLabelText('Delete user.alice')).not.toBeInTheDocument();
+        await waitFor(() => expect(screen.getByLabelText('Delete user.alice')).toBeInTheDocument());
+        // Synced (APIM-sourced) principals are read-only — no remove.
+        expect(screen.queryByLabelText('Delete user.bob')).not.toBeInTheDocument();
+    });
+
+    it('warns about permanent removal when deleting a local principal', async () => {
+        mockByKind({
+            principals: [makeEntity({ id: 'p1', uid: 'user.alice', attributes: { _displayName: 'Alice' } })],
+        });
+        renderPage();
 
         const user = userEvent.setup();
-        await user.click(screen.getByRole('tab', { name: /Resources/i }));
+        await waitFor(() => expect(screen.getByLabelText('Delete user.alice')).toBeInTheDocument());
+        await user.click(screen.getByLabelText('Delete user.alice'));
 
-        await waitFor(() => expect(screen.getByLabelText('Delete mcp.flight')).toBeInTheDocument());
+        const dialog = await screen.findByRole('dialog');
+        expect(within(dialog).getByText(/permanently removed/i)).toBeInTheDocument();
+    });
+
+    it('deletes a local principal on confirm', async () => {
+        mockByKind({ principals: [makeEntity({ id: 'p1', uid: 'user.alice' })] });
+        deleteEntitySpy.mockResolvedValue(undefined);
+        renderPage();
+
+        const user = userEvent.setup();
+        await waitFor(() => expect(screen.getByLabelText('Delete user.alice')).toBeInTheDocument());
+        await user.click(screen.getByLabelText('Delete user.alice'));
+
+        const dialog = await screen.findByRole('dialog');
+        await user.click(within(dialog).getByRole('button', { name: /Confirm remove/i }));
+
+        await waitFor(() => expect(deleteEntitySpy).toHaveBeenCalledWith('DEFAULT', 'user.alice'));
+        await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
     });
 
     it('opens the Remove confirmation dialog when the trash icon is clicked', async () => {

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/features/policy-structure/__tests__/EntitiesPage.test.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/features/policy-structure/__tests__/EntitiesPage.test.tsx
@@ -42,6 +42,11 @@ vi.mock('../CreateEntityDialog', () => ({
         open ? <div data-testid="create-entity-dialog-stub" data-kind={kind} /> : null,
 }));
 
+vi.mock('../EditEntityDialog', () => ({
+    EditEntityDialog: ({ open, kind, entity }: { open: boolean; kind: string; entity: { uid: { id: string } } | null }) =>
+        open ? <div data-testid="edit-entity-dialog-stub" data-kind={kind} data-entity={entity?.uid.id ?? ''} /> : null,
+}));
+
 vi.mock('../ImportFromCatalogDialog', () => ({
     ImportFromCatalogDialog: ({ open }: { open: boolean }) => (open ? <div data-testid="import-dialog-stub" /> : null),
 }));
@@ -266,6 +271,46 @@ describe('EntitiesPage', () => {
 
         const stub = screen.getByTestId('create-entity-dialog-stub');
         expect(stub).toHaveAttribute('data-kind', 'RESOURCE');
+    });
+
+    it('opens the edit dialog (kind=PRINCIPAL) for a local principal row', async () => {
+        mockByKind({ principals: [makeEntity({ id: 'p1', uid: 'user.alice' })] });
+        renderPage();
+
+        const user = userEvent.setup();
+        await waitFor(() => expect(screen.getByLabelText('Edit user.alice')).toBeInTheDocument());
+        expect(screen.queryByTestId('edit-entity-dialog-stub')).not.toBeInTheDocument();
+        await user.click(screen.getByLabelText('Edit user.alice'));
+
+        const stub = screen.getByTestId('edit-entity-dialog-stub');
+        expect(stub).toHaveAttribute('data-kind', 'PRINCIPAL');
+        expect(stub).toHaveAttribute('data-entity', 'alice');
+    });
+
+    it('hides the edit action for non-local (read-only) entities', async () => {
+        mockByKind({ resources: [makeEntity({ id: 'r1', uid: 'mcp.flight', attributes: { _source: 'gravitee-catalog' } })] });
+        renderPage();
+
+        const user = userEvent.setup();
+        await user.click(screen.getByRole('tab', { name: /Resources/i }));
+        await waitFor(() => expect(screen.getByText('mcp.flight')).toBeInTheDocument());
+        // Catalog-sourced → no edit, but still removable.
+        expect(screen.queryByLabelText('Edit mcp.flight')).not.toBeInTheDocument();
+        expect(screen.getByLabelText('Delete mcp.flight')).toBeInTheDocument();
+    });
+
+    it('opens the edit dialog (kind=RESOURCE) for a local resource row', async () => {
+        mockByKind({ resources: [makeEntity({ id: 'r1', uid: 'mcp.flight' })] });
+        renderPage();
+
+        const user = userEvent.setup();
+        await user.click(screen.getByRole('tab', { name: /Resources/i }));
+        await waitFor(() => expect(screen.getByLabelText('Edit mcp.flight')).toBeInTheDocument());
+        await user.click(screen.getByLabelText('Edit mcp.flight'));
+
+        const stub = screen.getByTestId('edit-entity-dialog-stub');
+        expect(stub).toHaveAttribute('data-kind', 'RESOURCE');
+        expect(stub).toHaveAttribute('data-entity', 'flight');
     });
 
     it('shows the row-level Remove action only on the Resources tab', async () => {

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/shared/api/__tests__/authz-api.service.test.ts
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/shared/api/__tests__/authz-api.service.test.ts
@@ -17,11 +17,12 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { authzApiService } from '../authz-api.service';
 
 const get = vi.fn();
+const put = vi.fn();
 vi.mock('../authz-api-client', () => ({
     authzCoreApiClient: {
         get: (path: string) => get(path),
         post: vi.fn(),
-        put: vi.fn(),
+        put: (path: string, body: unknown) => put(path, body),
         delete: vi.fn(),
     },
     ApiError: class ApiError extends Error {},
@@ -83,5 +84,49 @@ describe('authzApiService.listPolicies — type filtering across pages', () => {
         expect(res.total).toBe(42);
         expect(res.page).toBe(3);
         expect(res.data.map(p => p.name)).toEqual(['p']);
+    });
+});
+
+function canonicalEntity(overrides: Record<string, unknown> = {}) {
+    return {
+        id: 'e1',
+        environmentId: 'DEFAULT',
+        entityId: 'user.alice',
+        attributes: { _displayName: 'Alice', department: 'engineering' },
+        parents: ['group.developers'],
+        source: 'local',
+        createdAt: '2026-01-01T00:00:00Z',
+        updatedAt: '2026-01-02T00:00:00Z',
+        ...overrides,
+    };
+}
+
+describe('authzApiService.updateEntity', () => {
+    beforeEach(() => put.mockReset());
+
+    it('PUTs attributes + parents to the entity path and returns the adapted entity', async () => {
+        put.mockResolvedValue(canonicalEntity({ attributes: { _displayName: 'Alice Smith', department: 'engineering' } }));
+
+        const body = { attributes: { _displayName: 'Alice Smith', department: 'engineering' }, parents: ['group.developers'] };
+        const res = await authzApiService.updateEntity('DEFAULT', 'user.alice', body);
+
+        expect(put).toHaveBeenCalledTimes(1);
+        const [path, sentBody] = put.mock.calls[0];
+        expect(path).toContain('/environments/DEFAULT/modules/authz/entities/user.alice');
+        expect(sentBody).toEqual(body);
+        // Adapted shape: canonical entityId → uid, source surfaced as _source.
+        expect(res.uid).toBe('user.alice');
+        expect(res.attributes._displayName).toBe('Alice Smith');
+        expect(res.attributes.department).toBe('engineering');
+        expect(res.attributes._source).toBe('local');
+        expect(res.parents).toEqual(['group.developers']);
+    });
+
+    it('url-encodes the entityId in the path', async () => {
+        put.mockResolvedValue(canonicalEntity({ entityId: 'custom prefix.id' }));
+
+        await authzApiService.updateEntity('DEFAULT', 'custom prefix.id', { attributes: {}, parents: [] });
+
+        expect(put.mock.calls[0][0]).toContain('/entities/custom%20prefix.id');
     });
 });

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/shared/api/__tests__/authz-api.service.test.ts
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/shared/api/__tests__/authz-api.service.test.ts
@@ -18,12 +18,13 @@ import { authzApiService } from '../authz-api.service';
 
 const get = vi.fn();
 const put = vi.fn();
+const del = vi.fn();
 vi.mock('../authz-api-client', () => ({
     authzCoreApiClient: {
         get: (path: string) => get(path),
         post: vi.fn(),
         put: (path: string, body: unknown) => put(path, body),
-        delete: vi.fn(),
+        delete: (path: string) => del(path),
     },
     ApiError: class ApiError extends Error {},
 }));
@@ -128,5 +129,26 @@ describe('authzApiService.updateEntity', () => {
         await authzApiService.updateEntity('DEFAULT', 'custom prefix.id', { attributes: {}, parents: [] });
 
         expect(put.mock.calls[0][0]).toContain('/entities/custom%20prefix.id');
+    });
+});
+
+describe('authzApiService.deleteEntity', () => {
+    beforeEach(() => del.mockReset());
+
+    it('DELETEs the url-encoded entity path', async () => {
+        del.mockResolvedValue(undefined);
+
+        await authzApiService.deleteEntity('DEFAULT', 'user.alice');
+
+        expect(del).toHaveBeenCalledTimes(1);
+        expect(del.mock.calls[0][0]).toContain('/environments/DEFAULT/modules/authz/entities/user.alice');
+    });
+
+    it('url-encodes the entityId in the path', async () => {
+        del.mockResolvedValue(undefined);
+
+        await authzApiService.deleteEntity('DEFAULT', 'custom prefix.id');
+
+        expect(del.mock.calls[0][0]).toContain('/entities/custom%20prefix.id');
     });
 });

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/shared/api/authz-api.service.ts
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/shared/api/authz-api.service.ts
@@ -305,6 +305,16 @@ export const authzApiService = {
         return adaptEntityResponse(created);
     },
 
+    // Update is a full replace of attributes + parents (entityId/kind/source are immutable).
+    // Callers must send the complete attributes map, not a partial patch.
+    updateEntity: async (environmentId: string, entityId: string, request: UpdateEntityRequest): Promise<EntityResponse> => {
+        const updated = await authzCoreApiClient.put<CanonicalEntity>(
+            corePath(environmentId, `/entities/${encodeURIComponent(entityId)}`),
+            request,
+        );
+        return adaptEntityResponse(updated);
+    },
+
     deleteEntity: (environmentId: string, entityId: string): Promise<void> =>
         authzCoreApiClient.delete<void>(corePath(environmentId, `/entities/${encodeURIComponent(entityId)}`)),
 };
@@ -315,4 +325,9 @@ export interface CreateEntityRequest {
     readonly attributes: Record<string, unknown>;
     readonly parents: readonly string[];
     readonly source: string;
+}
+
+export interface UpdateEntityRequest {
+    readonly attributes: Record<string, unknown>;
+    readonly parents: readonly string[];
 }

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/shared/hooks/__tests__/useAllEntities.test.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/shared/hooks/__tests__/useAllEntities.test.tsx
@@ -92,9 +92,24 @@ describe('useAllEntities', () => {
 
     it('walks every page until the accumulated set covers the reported total', async () => {
         listSpy
-            .mockResolvedValueOnce({ data: Array.from({ length: 100 }, (_, i) => makeEntity(`p1-${i}`)), total: 250, page: 1, perPage: 100 })
-            .mockResolvedValueOnce({ data: Array.from({ length: 100 }, (_, i) => makeEntity(`p2-${i}`)), total: 250, page: 2, perPage: 100 })
-            .mockResolvedValueOnce({ data: Array.from({ length: 50 }, (_, i) => makeEntity(`p3-${i}`)), total: 250, page: 3, perPage: 100 });
+            .mockResolvedValueOnce({
+                data: Array.from({ length: 100 }, (_, i) => makeEntity(`p1-${i}`)),
+                total: 250,
+                page: 1,
+                perPage: 100,
+            })
+            .mockResolvedValueOnce({
+                data: Array.from({ length: 100 }, (_, i) => makeEntity(`p2-${i}`)),
+                total: 250,
+                page: 2,
+                perPage: 100,
+            })
+            .mockResolvedValueOnce({
+                data: Array.from({ length: 50 }, (_, i) => makeEntity(`p3-${i}`)),
+                total: 250,
+                page: 3,
+                perPage: 100,
+            });
 
         const { getByTestId } = render(<Probe env="env-1" />, { wrapper: makeWrapper() });
 


### PR DESCRIPTION
## Summary
Wires the existing backend `PUT /entities/{entityId}` into the UI so **local** entities can be edited in place (the previously-promised "Edit … in a follow-up PR").

- **service:** `updateEntity(env, entityId, { attributes, parents })` + `UpdateEntityRequest`.
- **EditEntityDialog:** prefilled right-side sheet — **Entity ID is read-only** (immutable key); edits **display name**, **description**, **parents**. Submits the **complete attribute map** (rebuilt via `toBackend`) so unrelated attributes (e.g. `department`, `email`, `_kind`) are preserved — the backend update is a *full replace*, not a patch, so a partial payload would wipe them.
- **EntitiesPage:** row-level **Edit (pencil)** on both Principals and Resources, shown **only for `source=local`** (catalog/APIM-sourced stay read-only); opens the dialog with the right kind and invalidates the list on success.
- **tests:** EditEntityDialog (prefill, read-only id, attribute preservation, drop-description, validation, error) + EntitiesPage edit wiring (local-only).

## Test plan
- [x] `tsc -p tsconfig.app.json --noEmit` clean
- [x] `vitest run` — full module suite green (384 tests) incl. new edit tests
- [x] Manual (Chrome, local stack): Principals/Resources show Edit for local rows only; editing `user.bob` → "Bob Edited" persists, Entity ID unchanged, entity counts stable (no duplicate/data-loss); catalog-sourced rows have no Edit