### PR TITLE
feat(apim-rest-api): Guard v4 OpenAPI URL import against SSRF (v2 parity)

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/api/OAIDomainServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/api/OAIDomainServiceImpl.java
@@ -40,6 +40,8 @@ import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
 import io.gravitee.rest.api.service.impl.swagger.parser.OAIParser;
 import io.gravitee.rest.api.service.impl.swagger.policy.PolicyOperationVisitorManager;
 import io.gravitee.rest.api.service.impl.swagger.visitor.v3.OAIOperationVisitor;
+import io.gravitee.rest.api.service.sanitizer.UrlSanitizerUtils;
+import io.gravitee.rest.api.service.spring.ImportConfiguration;
 import io.gravitee.rest.api.service.swagger.OAIDescriptor;
 import io.swagger.v3.parser.core.models.ParseOptions;
 import java.util.Collection;
@@ -62,6 +64,7 @@ public class OAIDomainServiceImpl implements OAIDomainService {
     private final TagQueryService tagsQueryService;
     private final EndpointConnectorPluginDomainService endpointConnectorPluginService;
     private final PolicyPluginCrudService policyPluginCrudService;
+    private final ImportConfiguration importConfiguration;
 
     @Override
     public ImportDefinition convert(
@@ -72,6 +75,15 @@ public class OAIDomainServiceImpl implements OAIDomainService {
         boolean withOASValidationPolicy
     ) {
         var payload = importSwaggerDescriptor.getPayload();
+        // When the payload is a URL, the swagger parser fetches it server-side. Guard that fetch against SSRF
+        // (import whitelist + private-address blocking), consistent with the v2 swagger import (SwaggerServiceImpl).
+        if (UrlSanitizerUtils.isUrl(payload)) {
+            UrlSanitizerUtils.checkAllowed(
+                payload,
+                importConfiguration.getImportWhitelist(),
+                importConfiguration.isAllowImportFromPrivate()
+            );
+        }
         var descriptor = toOAIDescriptor(payload);
         var visitors = getVisitors(importSwaggerDescriptor);
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/OAIToImportApiUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/OAIToImportApiUseCaseTest.java
@@ -49,6 +49,7 @@ import io.gravitee.rest.api.model.ImportSwaggerDescriptorEntity;
 import io.gravitee.rest.api.model.parameters.Key;
 import io.gravitee.rest.api.model.settings.ApiPrimaryOwnerMode;
 import io.gravitee.rest.api.service.impl.swagger.policy.impl.PolicyOperationVisitorManagerImpl;
+import io.gravitee.rest.api.service.spring.ImportConfiguration;
 import java.util.List;
 import lombok.SneakyThrows;
 import org.junit.jupiter.api.BeforeEach;
@@ -118,13 +119,18 @@ class OAIToImportApiUseCaseTest {
             )
         ).thenAnswer(invocation -> invocation.getArgument(0));
 
+        var importConfiguration = mock(ImportConfiguration.class);
+        when(importConfiguration.isAllowImportFromPrivate()).thenReturn(true);
+        when(importConfiguration.getImportWhitelist()).thenReturn(List.of());
+
         useCase = new OAIToImportApiUseCase(
             new OAIDomainServiceImpl(
                 policyOperationVisitorManager,
                 groupQueryService,
                 tagQueryService,
                 endpointConnectorPluginService,
-                policyPluginCrudService
+                policyPluginCrudService,
+                importConfiguration
             ),
             importDefinitionCreateDomainServiceTestInitializer.initialize()
         );
@@ -188,6 +194,23 @@ class OAIToImportApiUseCaseTest {
             .hasSize(1)
             .extracting(EndpointGroup::getSharedConfiguration)
             .containsExactly(SHARED_CONFIGURATION);
+    }
+
+    @Test
+    @SneakyThrows
+    void should_import_when_payload_is_a_remote_url() {
+        // Given a payload that is a remote location (a file: URL the parser fetches) — import-from-private is allowed in this test
+        var importSwaggerDescriptor = new ImportSwaggerDescriptorEntity();
+        var resourceUrl = Resources.getResource("io/gravitee/rest/api/management/service/openapi-withExtensions.json").toString();
+        importSwaggerDescriptor.setPayload(resourceUrl);
+
+        // When
+        var output = useCase.execute(new OAIToImportApiUseCase.Input(importSwaggerDescriptor, AUDIT_INFO));
+
+        // Then the spec is fetched from the URL and imported
+        assertThat(output).isNotNull();
+        assertThat(output.apiWithFlows()).isNotNull();
+        assertThat(output.apiWithFlows().getTags()).containsExactly("tag1");
     }
 
     @Nested

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/WsdlToImportApiUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/WsdlToImportApiUseCaseTest.java
@@ -114,7 +114,8 @@ class WsdlToImportApiUseCaseTest {
                 new GroupQueryServiceInMemory(),
                 new TagQueryServiceInMemory(),
                 endpointConnectorPluginService,
-                policyPluginCrudService
+                policyPluginCrudService,
+                importConfiguration
             ),
             importDefinitionCreateDomainServiceTestInitializer.initialize()
         );

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/WsdlToUpdateApiUseCaseIntegrationTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/WsdlToUpdateApiUseCaseIntegrationTest.java
@@ -103,7 +103,8 @@ class WsdlToUpdateApiUseCaseIntegrationTest {
             new GroupQueryServiceInMemory(),
             new TagQueryServiceInMemory(),
             endpointConnectorPluginService,
-            policyPluginCrudService
+            policyPluginCrudService,
+            importConfiguration
         );
 
         var updateApiDefinitionUseCase = new UpdateApiDefinitionFromImportUseCase(

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/cockpit/DeployModelToApiCreateUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/cockpit/DeployModelToApiCreateUseCaseTest.java
@@ -60,6 +60,7 @@ import io.gravitee.rest.api.service.common.ExecutionContext;
 import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.common.UuidString;
 import io.gravitee.rest.api.service.impl.swagger.policy.impl.PolicyOperationVisitorManagerImpl;
+import io.gravitee.rest.api.service.spring.ImportConfiguration;
 import io.gravitee.rest.api.service.v4.ApiService;
 import java.io.IOException;
 import java.net.URL;
@@ -205,7 +206,8 @@ public class DeployModelToApiCreateUseCaseTest {
             groupQueryService,
             tagQueryService,
             endpointConnectorPluginService,
-            policyPluginCrudService
+            policyPluginCrudService,
+            mock(ImportConfiguration.class)
         );
         final var importDefinitionCreateDomainService = importDefinitionCreateDomainServiceTestInitializer.initialize();
         final var updateApiDomainService = new UpdateApiDomainServiceImpl(delegateApiService, apiCrudService);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/cockpit/DeployModelToApiUpdateUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/cockpit/DeployModelToApiUpdateUseCaseTest.java
@@ -58,6 +58,7 @@ import io.gravitee.rest.api.service.common.ExecutionContext;
 import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.common.UuidString;
 import io.gravitee.rest.api.service.impl.swagger.policy.impl.PolicyOperationVisitorManagerImpl;
+import io.gravitee.rest.api.service.spring.ImportConfiguration;
 import io.gravitee.rest.api.service.v4.ApiService;
 import java.io.IOException;
 import java.net.URL;
@@ -172,7 +173,8 @@ public class DeployModelToApiUpdateUseCaseTest {
             groupQueryService,
             tagQueryService,
             endpointConnectorPluginService,
-            policyPluginCrudService
+            policyPluginCrudService,
+            mock(ImportConfiguration.class)
         );
 
         final var updateApiDomainService = new UpdateApiDomainServiceImpl(delegateApiService, apiCrudService);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/api/OAIDomainServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/api/OAIDomainServiceImplTest.java
@@ -29,7 +29,9 @@ import io.gravitee.apim.core.plugin.model.PolicyPlugin;
 import io.gravitee.definition.model.v4.flow.Flow;
 import io.gravitee.rest.api.model.ImportSwaggerDescriptorEntity;
 import io.gravitee.rest.api.service.exceptions.SwaggerDescriptorException;
+import io.gravitee.rest.api.service.exceptions.UrlForbiddenException;
 import io.gravitee.rest.api.service.impl.swagger.policy.impl.PolicyOperationVisitorManagerImpl;
+import io.gravitee.rest.api.service.spring.ImportConfiguration;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
@@ -48,10 +50,26 @@ class OAIDomainServiceImplTest {
 
     private OAIDomainServiceImpl oaiDomainService;
     private final PolicyOperationVisitorManagerImpl policyOperationVisitorManager = new PolicyOperationVisitorManagerImpl();
+    private ImportConfiguration importConfiguration;
 
     @BeforeEach
     void setUp() {
-        oaiDomainService = new OAIDomainServiceImpl(policyOperationVisitorManager, null, null, null, null);
+        importConfiguration = mock(ImportConfiguration.class);
+        when(importConfiguration.getImportWhitelist()).thenReturn(List.of());
+        when(importConfiguration.isAllowImportFromPrivate()).thenReturn(false);
+        oaiDomainService = new OAIDomainServiceImpl(policyOperationVisitorManager, null, null, null, null, importConfiguration);
+    }
+
+    @Test
+    void should_throw_when_remote_url_payload_targets_a_private_address() {
+        // Given a payload that is a URL resolving to a private/link-local address (SSRF attempt)
+        var importSwaggerDescriptor = new ImportSwaggerDescriptorEntity();
+        importSwaggerDescriptor.setPayload("http://169.254.169.254/latest/meta-data/");
+
+        // When / Then the URL is rejected before any fetch happens
+        assertThatThrownBy(() ->
+            oaiDomainService.convert(ORGANIZATION_ID, ENVIRONMENT_ID, importSwaggerDescriptor, false, false)
+        ).isInstanceOf(UrlForbiddenException.class);
     }
 
     @ParameterizedTest
@@ -112,7 +130,8 @@ class OAIDomainServiceImplTest {
                 new GroupQueryServiceInMemory(),
                 new TagQueryServiceInMemory(),
                 endpointConnectorPluginService,
-                policyPluginCrudService
+                policyPluginCrudService,
+                mock(ImportConfiguration.class)
             );
         }
 


### PR DESCRIPTION


## Issue

https://gravitee.atlassian.net/browse/APIM-14246
## Description

The v4 OpenAPI import fetches remote URL payloads server-side via the swagger parser, but — unlike the v2 path (SwaggerServiceImpl) — never validated the URL. This adds UrlSanitizerUtils.checkAllowed (import whitelist + private-address blocking) in OAIDomainServiceImpl when the payload is a URL, matching v2. No new endpoint, no API change; the type field stays a frontend/entity-shape detail (APIM-13658) and the backend sniffs the payload as before.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

