### PR TITLE
fix(console): refresh UI after API detach from automation source

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/general-info/api-general-info-danger-zone/api-general-info-danger-zone.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/general-info/api-general-info-danger-zone/api-general-info-danger-zone.component.spec.ts
@@ -290,6 +290,22 @@ describe('ApiGeneralInfoDangerZoneComponent', () => {
     expect(component.reloadDetails.emit).toHaveBeenCalled();
   });
 
+  it('should hide detach action when api origin context is updated', async () => {
+    const api = fakeApiV2({
+      id: API_ID,
+      originContext: { origin: 'KUBERNETES' },
+    });
+    createComponent(api);
+
+    expect(await loader.getAllHarnesses(MatButtonHarness.with({ text: 'Detach the API' }))).toHaveLength(1);
+
+    component.api = fakeApiV2({ id: API_ID, originContext: { origin: 'MANAGEMENT' } });
+    component.ngOnChanges({ api: new SimpleChange(api, component.api, false) });
+    fixture.detectChanges();
+
+    expect(await loader.getAllHarnesses(MatButtonHarness.with({ text: 'Detach the API' }))).toHaveLength(0);
+  });
+
   it('should show detach action', async () => {
     const api = fakeApiV2({
       id: API_ID,

--- a/gravitee-apim-console-webui/src/management/api/general-info/api-general-info-danger-zone/api-general-info-danger-zone.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/general-info/api-general-info-danger-zone/api-general-info-danger-zone.component.ts
@@ -87,8 +87,7 @@ export class ApiGeneralInfoDangerZoneComponent implements OnChanges, OnDestroy, 
   ) {}
 
   ngOnInit(): void {
-    this.isReadOnly = this.api.definitionVersion === 'V1' || this.api.originContext?.origin === 'KUBERNETES';
-    this.canDetach = this.api.originContext?.origin === 'KUBERNETES';
+    this.updateOriginContextState();
     this.license$ = this.licenseService.getLicense$();
     this.isOEM$ = this.licenseService.isOEM$();
 
@@ -104,6 +103,7 @@ export class ApiGeneralInfoDangerZoneComponent implements OnChanges, OnDestroy, 
 
   ngOnChanges(changes: SimpleChanges): void {
     if (changes.api) {
+      this.updateOriginContextState();
       this.dangerActions = {
         canAskForReview:
           this.constants.env?.settings?.apiReview?.enabled &&
@@ -336,6 +336,11 @@ export class ApiGeneralInfoDangerZoneComponent implements OnChanges, OnDestroy, 
         takeUntil(this.unsubscribe$),
       )
       .subscribe();
+  }
+
+  private updateOriginContextState(): void {
+    this.isReadOnly = this.api?.definitionVersion === 'V1' || this.api?.originContext?.origin === 'KUBERNETES';
+    this.canDetach = this.api?.originContext?.origin === 'KUBERNETES';
   }
 
   private canChangeApiLifecycle(api: Api): boolean {

--- a/gravitee-apim-console-webui/src/management/api/general-info/api-general-info.component.html
+++ b/gravitee-apim-console-webui/src/management/api/general-info/api-general-info.component.html
@@ -201,7 +201,7 @@
     <api-general-info-quality class="api-quality" [apiId]="apiId" />
   }
 
-  <api-general-info-danger-zone class="danger-zone" [api]="api" (reloadDetails)="ngOnInit()" />
+  <api-general-info-danger-zone class="danger-zone" [api]="api" (reloadDetails)="reloadDetails()" />
 
   <gio-save-bar
     [form]="parentForm"

--- a/gravitee-apim-console-webui/src/management/api/general-info/api-general-info.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/general-info/api-general-info.component.ts
@@ -112,6 +112,10 @@ export class ApiGeneralInfoComponent implements OnInit, OnDestroy {
 
   private refresh$ = new Subject<void>();
 
+  reloadDetails(): void {
+    this.refresh$.next();
+  }
+
   ngOnInit(): void {
     this.labelsAutocompleteOptions = this.constants.env?.settings?.api?.labelsDictionary ?? [];
 

--- a/gravitee-apim-console-webui/src/services-ngx/api-v2.service.spec.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/api-v2.service.spec.ts
@@ -168,6 +168,31 @@ describe('ApiV2Service', () => {
     });
   });
 
+  describe('detach', () => {
+    it('should call the API and refresh the last api fetch', (done) => {
+      const fakeApi = fakeApiV4();
+
+      apiV2Service.get(fakeApi.id).subscribe();
+      httpTestingController.expectOne({ url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${fakeApi.id}`, method: 'GET' }).flush(fakeApi);
+
+      apiV2Service.detach(fakeApi.id).subscribe(() => {
+        done();
+      });
+
+      const detachReq = httpTestingController.expectOne({
+        url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${fakeApi.id}/_detach`,
+        method: 'POST',
+      });
+      detachReq.flush(null);
+
+      const refreshReq = httpTestingController.expectOne({
+        url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${fakeApi.id}`,
+        method: 'GET',
+      });
+      refreshReq.flush({ ...fakeApi, originContext: { origin: 'MANAGEMENT' } });
+    });
+  });
+
   describe('deploy', () => {
     it('should call the API', (done) => {
       const fakeApi = fakeApiV4();

--- a/gravitee-apim-console-webui/src/services-ngx/api-v2.service.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/api-v2.service.ts
@@ -88,7 +88,10 @@ export class ApiV2Service {
   }
 
   detach(apiId: string): Observable<void> {
-    return this.http.post<void>(`${this.constants.env.v2BaseURL}/apis/${apiId}/_detach`, {});
+    return this.http.post<void>(`${this.constants.env.v2BaseURL}/apis/${apiId}/_detach`, {}).pipe(
+      switchMap(() => this.refreshLastApiFetch()),
+      map(() => void 0),
+    );
   }
 
   start(apiId: string): Observable<void> {


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-13877

## Description

Reload General Info via refresh$ instead of re-running ngOnInit, refresh lastApiFetch after detach, and update danger zone detach/read-only state when originContext changes.

## Additional context

**api-general-info:** Replace (reloadDetails)="ngOnInit()" with reloadDetails() that triggers the existing refresh$ subject, so the API is refetched without stacking duplicate subscriptions.
**ApiV2Service.detach():** Chain refreshLastApiFetch() after _detach (same pattern as deploy) so getLastApiFetch() consumers (e.g. API navigation) receive the updated originContext.
**api-general-info-danger-zone:** Move canDetach / isReadOnly into updateOriginContextState() and call it from ngOnChanges when the [api] input changes, so the Detach action hides after reload.

https://github.com/user-attachments/assets/08fc6b75-a86a-4107-b5e7-58f1abf2228d
