### PR TITLE
perf(gateway-sync): keyset warmup subscriptions by (plan,_id) + index (APIM-14087)

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/SyncConfiguration.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/SyncConfiguration.java
@@ -77,23 +77,27 @@ public class SyncConfiguration {
 
     public static final int POOL_SIZE = Runtime.getRuntime().availableProcessors() * 2;
     public static final int DEFAULT_BULK_ITEMS = 100;
-    // Subscription cursor page size — appender warmup at customer scale showed 100-row pages
-    // bottleneck on round-trip overhead. 1000 cuts page count 10× without breaching planner sweet
-    // spots. Tune via services.sync.subscription.bulk_items (falls back to services.sync.bulk_items).
-    public static final int DEFAULT_SUBSCRIPTION_BULK_ITEMS = 1000;
-    // ApiKey cursor page size — appender warmup loads per-chunk via this page size. Customer
-    // workloads vary; 500 is a reasonable midpoint between JWT-heavy (low key volume) and
-    // apikey-heavy. Tune via services.sync.apikey.bulk_items (falls back to services.sync.bulk_items).
-    public static final int DEFAULT_APIKEY_BULK_ITEMS = 500;
+    // Subscription cursor page size — appender warmup at 2.4M-subscription scale showed page count
+    // dominates round-trip overhead. 2000 keeps page count low; on JDBC larger pages help further
+    // (tune up to ~10000), on Mongo page size is near-neutral once the (plan,_id) index is present.
+    // Tune via services.sync.subscription.bulk_items. Note: this does NOT fall back to the legacy
+    // services.sync.bulk_items — that key only controls the events fetcher, so an old bulk_items=100
+    // can no longer silently down-tune subscription warmup to the pathological 100-row page path.
+    public static final int DEFAULT_SUBSCRIPTION_BULK_ITEMS = 2000;
+    // ApiKey cursor page size — appender warmup loads per-chunk via this page size. 1000 is a
+    // reasonable midpoint between JWT-heavy (low key volume) and apikey-heavy workloads.
+    // Tune via services.sync.apikey.bulk_items. Like the subscription page size, this no longer
+    // falls back to the legacy services.sync.bulk_items.
+    public static final int DEFAULT_APIKEY_BULK_ITEMS = 1000;
     // Chunk size for the `subscriptions IN (...)` filter applied when loading ApiKeys (appender
     // + refresher). Conservative default below common DB IN-list parameter limits; tune higher via
     // services.sync.apikey.subscriptions_chunk_size only after validating the target DB's parameter ceiling.
     public static final int DEFAULT_APIKEY_SUBSCRIPTIONS_CHUNK_SIZE = 900;
     // Per-batch appender concurrency. The sync pipeline buffers APIs into batches of bulk_events
-    // and runs (plan+subscription+apikey) appenders per batch. Default 1 preserves current
-    // sequential behavior; bump to 4 to parallelize warmup at scale. Tune via
-    // services.sync.appender.parallelism.
-    public static final int DEFAULT_APPENDER_PARALLELISM = 1;
+    // and runs (plan+subscription+apikey) appenders per batch. 4 overlaps DB round trips across
+    // batches (≈3× faster warmup at scale than sequential) and is bounded by the sync executor
+    // pool; set to 1 for the previous sequential behavior. Tune via services.sync.appender.parallelism.
+    public static final int DEFAULT_APPENDER_PARALLELISM = 4;
 
     @Bean("syncFetcherExecutor")
     public ThreadPoolExecutor syncFetcherExecutor(@Value("${services.sync.fetcher:-1}") int syncFetcher) {
@@ -185,7 +189,7 @@ public class SyncConfiguration {
         SubscriptionRepository subscriptionRepository,
         SubscriptionMapper subscriptionMapper,
         ApiProductRegistry apiProductRegistry,
-        @Value("${services.sync.subscription.bulk_items:${services.sync.bulk_items:" + DEFAULT_SUBSCRIPTION_BULK_ITEMS + "}}") int bulkItems
+        @Value("${services.sync.subscription.bulk_items:" + DEFAULT_SUBSCRIPTION_BULK_ITEMS + "}") int bulkItems
     ) {
         return new SubscriptionAppender(subscriptionRepository, subscriptionMapper, apiProductRegistry, bulkItems);
     }
@@ -194,7 +198,7 @@ public class SyncConfiguration {
     public ApiKeyAppender apiKeyAppender(
         ApiKeyRepository apiKeyRepository,
         ApiKeyMapper apiKeyMapper,
-        @Value("${services.sync.apikey.bulk_items:${services.sync.bulk_items:" + DEFAULT_APIKEY_BULK_ITEMS + "}}") int bulkItems,
+        @Value("${services.sync.apikey.bulk_items:" + DEFAULT_APIKEY_BULK_ITEMS + "}") int bulkItems,
         @Value(
             "${services.sync.apikey.subscriptions_chunk_size:" + DEFAULT_APIKEY_SUBSCRIPTIONS_CHUNK_SIZE + "}"
         ) int subscriptionsChunkSize

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/spring/RepositorySyncConfiguration.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/spring/RepositorySyncConfiguration.java
@@ -135,9 +135,9 @@ public class RepositorySyncConfiguration {
     public SubscriptionFetcher subscriptionFetcher(
         SubscriptionRepository subscriptionRepository,
         @Value(
-            "${services.sync.subscription.bulk_items:${services.sync.bulk_items:" +
+            "${services.sync.subscription.bulk_items:" +
                 io.gravitee.gateway.services.sync.SyncConfiguration.DEFAULT_SUBSCRIPTION_BULK_ITEMS +
-                "}}"
+                "}"
         ) int bulkItems
     ) {
         return new SubscriptionFetcher(subscriptionRepository, bulkItems);
@@ -147,9 +147,7 @@ public class RepositorySyncConfiguration {
     public ApiKeyFetcher apiKeyFetcher(
         ApiKeyRepository apiKeyRepository,
         @Value(
-            "${services.sync.apikey.bulk_items:${services.sync.bulk_items:" +
-                io.gravitee.gateway.services.sync.SyncConfiguration.DEFAULT_APIKEY_BULK_ITEMS +
-                "}}"
+            "${services.sync.apikey.bulk_items:" + io.gravitee.gateway.services.sync.SyncConfiguration.DEFAULT_APIKEY_BULK_ITEMS + "}"
         ) int bulkItems
     ) {
         return new ApiKeyFetcher(apiKeyRepository, bulkItems);
@@ -353,9 +351,7 @@ public class RepositorySyncConfiguration {
         SubscriptionService subscriptionService,
         ApiKeyService apiKeyService,
         @Value(
-            "${services.sync.apikey.bulk_items:${services.sync.bulk_items:" +
-                io.gravitee.gateway.services.sync.SyncConfiguration.DEFAULT_APIKEY_BULK_ITEMS +
-                "}}"
+            "${services.sync.apikey.bulk_items:" + io.gravitee.gateway.services.sync.SyncConfiguration.DEFAULT_APIKEY_BULK_ITEMS + "}"
         ) int bulkItems,
         @Value(
             "${services.sync.apikey.subscriptions_chunk_size:" +

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/api/SubscriptionAppender.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/api/SubscriptionAppender.java
@@ -140,7 +140,10 @@ public class SubscriptionAppender {
             criteriaBuilder.statuses(INCREMENTAL_STATUS);
         }
         SubscriptionCriteria criteria = criteriaBuilder.build();
-        var sortable = new SortableBuilder().field("id").order(Order.ASC).build();
+        // Warmup pages by (plan, id): the sort field "plan" pairs with the byPlanAndId cursor below
+        // so the repository's order and keyset seek agree (an "id"-field request would seek/sort by
+        // id only — the legacy fallback — and mismatch the (plan, id) cursor).
+        var sortable = new SortableBuilder().field("plan").order(Order.ASC).build();
 
         Map<String, List<Subscription>> grouped = new HashMap<>();
         SubscriptionCursor cursor = null;
@@ -166,7 +169,7 @@ public class SubscriptionAppender {
                 if (page.size() < bulkItems) {
                     return grouped;
                 }
-                cursor = SubscriptionCursor.byId(page.getLast().getId());
+                cursor = SubscriptionCursor.byPlanAndId(page.getLast().getPlan(), page.getLast().getId());
             }
         } catch (Exception ex) {
             throw new SyncException("Error occurred when retrieving subscriptions", ex);

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/search/SubscriptionCursor.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/search/SubscriptionCursor.java
@@ -18,21 +18,26 @@ package io.gravitee.repository.management.api.search;
 import java.util.Objects;
 
 /**
- * Position marker for keyset / seek pagination over subscriptions. Two seek modes are supported by
- * {@code SubscriptionRepository.searchAfter} depending on the sort field passed alongside:
+ * Position marker for keyset / seek pagination over subscriptions. Three seek modes are supported by
+ * {@code SubscriptionRepository.searchAfter} depending on the sort field passed alongside (see
+ * {@link SubscriptionSearchSort}); the cursor's shape must match that field:
  *
  * <ul>
  *   <li>{@code (updatedAt, id)} — used when the {@code Sortable} field is {@code "updatedAt"} (the
  *       delta sync path). Construct with {@link #byUpdatedAt(long, String)}.</li>
- *   <li>{@code id}-only — used when the {@code Sortable} field is {@code "id"} (the warmup path
- *       where a {@code plans IN} filter dominates selectivity). Construct with {@link #byId(String)};
- *       the {@code updatedAt} component is ignored by the seek.</li>
+ *   <li>{@code (plan, id)} — used when the {@code Sortable} field is {@code "plan"} (the warmup path
+ *       where a {@code plans IN} filter dominates selectivity). Construct with
+ *       {@link #byPlanAndId(String, String)}. Sorting/seeking by {@code (plan, _id)} lets the
+ *       {@code {plan:1,_id:1}} index scan each plan's range in order without an N-way merge, instead
+ *       of an {@code _id}-ordered collection walk that examines unrelated rows.</li>
+ *   <li>{@code id} only — used when the {@code Sortable} field is {@code "id"} (legacy / repository
+ *       bridge fallback when no plan marker is available). Construct with {@link #byId(String)}.</li>
  * </ul>
  *
  * <p>Use the static factories rather than the canonical constructor to make the seek mode explicit
  * at the call site.
  */
-public record SubscriptionCursor(long updatedAt, String id) {
+public record SubscriptionCursor(long updatedAt, String id, String plan) {
     public SubscriptionCursor {
         Objects.requireNonNull(id, "SubscriptionCursor.id must not be null");
         if (id.isBlank()) {
@@ -42,11 +47,17 @@ public record SubscriptionCursor(long updatedAt, String id) {
 
     /** Cursor for {@code (updatedAt, id)} keyset seek — delta sync path. */
     public static SubscriptionCursor byUpdatedAt(long updatedAt, String id) {
-        return new SubscriptionCursor(updatedAt, id);
+        return new SubscriptionCursor(updatedAt, id, null);
     }
 
-    /** Cursor for {@code id}-only keyset seek — warmup path. */
+    /** Cursor for {@code (plan, id)} keyset seek — warmup path served by the {@code {plan,_id}} index. */
+    public static SubscriptionCursor byPlanAndId(String plan, String id) {
+        return new SubscriptionCursor(0L, id, plan);
+    }
+
+    /** Cursor for {@code id}-only keyset seek — fallback when no plan marker is available
+     *  (e.g. the repository bridge receiving a cursor from an older client). */
     public static SubscriptionCursor byId(String id) {
-        return new SubscriptionCursor(0L, id);
+        return new SubscriptionCursor(0L, id, null);
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/search/SubscriptionSearchSort.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/search/SubscriptionSearchSort.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.management.api.search;
+
+/**
+ * Sort/seek mode for {@code SubscriptionRepository.searchAfter}, resolved from the {@link Sortable}
+ * field. The mode drives <b>both</b> the {@code order by} and the keyset seek predicate, so the two
+ * always agree: a sort that does not match its seek silently skips or duplicates rows across pages.
+ *
+ * <ul>
+ *   <li>{@link #UPDATED_AT} — {@code (updatedAt, id)}, the delta-sync path. Pair with
+ *       {@link SubscriptionCursor#byUpdatedAt(long, String)}.</li>
+ *   <li>{@link #PLAN_ID} — {@code (plan, id)}, the warmup path served by the {@code {plan,id}}
+ *       index. Pair with {@link SubscriptionCursor#byPlanAndId(String, String)}.</li>
+ *   <li>{@link #ID} — {@code id} only, the legacy / repository-bridge fallback used when no plan
+ *       marker is available (e.g. an older client). Pair with {@link SubscriptionCursor#byId(String)}.</li>
+ * </ul>
+ */
+public enum SubscriptionSearchSort {
+    UPDATED_AT,
+    PLAN_ID,
+    ID;
+
+    /**
+     * Resolve the sort mode from a {@link Sortable}. A {@code null} sortable (or {@code null} field)
+     * defaults to {@link #UPDATED_AT} to preserve the delta-sync default.
+     *
+     * @throws IllegalArgumentException if the field is not one of {@code updatedAt}, {@code plan} or {@code id}
+     */
+    public static SubscriptionSearchSort fromSortable(Sortable sortable) {
+        if (sortable == null || sortable.field() == null || "updatedAt".equals(sortable.field())) {
+            return UPDATED_AT;
+        }
+        return switch (sortable.field()) {
+            case "plan" -> PLAN_ID;
+            case "id" -> ID;
+            default -> throw new IllegalArgumentException(
+                "searchAfter supports sort field 'updatedAt', 'plan' or 'id' only, got: " + sortable.field()
+            );
+        };
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/test/java/io/gravitee/repository/management/api/search/SubscriptionSearchSortTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/test/java/io/gravitee/repository/management/api/search/SubscriptionSearchSortTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.management.api.search;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.gravitee.repository.management.api.search.builder.SortableBuilder;
+import org.junit.jupiter.api.Test;
+
+class SubscriptionSearchSortTest {
+
+    @Test
+    void should_default_to_updatedAt_for_null_sortable() {
+        assertThat(SubscriptionSearchSort.fromSortable(null)).isEqualTo(SubscriptionSearchSort.UPDATED_AT);
+    }
+
+    @Test
+    void should_default_to_updatedAt_for_null_field() {
+        assertThat(SubscriptionSearchSort.fromSortable(new SortableBuilder().order(Order.ASC).build())).isEqualTo(
+            SubscriptionSearchSort.UPDATED_AT
+        );
+    }
+
+    @Test
+    void should_resolve_updatedAt_field() {
+        assertThat(SubscriptionSearchSort.fromSortable(new SortableBuilder().field("updatedAt").order(Order.ASC).build())).isEqualTo(
+            SubscriptionSearchSort.UPDATED_AT
+        );
+    }
+
+    @Test
+    void should_resolve_plan_field_to_plan_id_keyset() {
+        assertThat(SubscriptionSearchSort.fromSortable(new SortableBuilder().field("plan").order(Order.ASC).build())).isEqualTo(
+            SubscriptionSearchSort.PLAN_ID
+        );
+    }
+
+    @Test
+    void should_resolve_id_field_to_id_only_keyset() {
+        assertThat(SubscriptionSearchSort.fromSortable(new SortableBuilder().field("id").order(Order.ASC).build())).isEqualTo(
+            SubscriptionSearchSort.ID
+        );
+    }
+
+    @Test
+    void should_reject_unsupported_field() {
+        assertThatThrownBy(() -> SubscriptionSearchSort.fromSortable(new SortableBuilder().field("createdAt").order(Order.ASC).build()))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("createdAt");
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcApiKeyRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcApiKeyRepository.java
@@ -193,7 +193,8 @@ public class JdbcApiKeyRepository extends JdbcAbstractCrudRepository<ApiKey, Str
         // otherwise a federated key with multiple key_subscriptions rows consumes more than one
         // row of the limit (partial subscriptions + false short-page exhaustion). Build the page
         // of key ids in a subquery, then join key_subscriptions on the outer query.
-        final StringBuilder inner = new StringBuilder("select * from ").append(this.tableName);
+        // The api-key table is named "keys", a reserved word on MySQL/MariaDB/SQL Server — escape it.
+        final StringBuilder inner = new StringBuilder("select * from ").append(escapeReservedWord(this.tableName));
 
         boolean started = false;
         if (!isEmpty(criteria.getSubscriptions())) {
@@ -380,7 +381,7 @@ public class JdbcApiKeyRepository extends JdbcAbstractCrudRepository<ApiKey, Str
             return apiKey;
         }
         jdbcTemplate.update("insert into " + keySubscriptions + " ( key_id, subscription_id ) values ( ?, ? )", id, subscriptionId);
-        jdbcTemplate.update("update " + this.tableName + " set updated_at=? where id=?", new Date(), id);
+        jdbcTemplate.update("update " + escapeReservedWord(this.tableName) + " set updated_at=? where id=?", new Date(), id);
         return findById(id);
     }
 
@@ -389,7 +390,7 @@ public class JdbcApiKeyRepository extends JdbcAbstractCrudRepository<ApiKey, Str
         log.debug("JdbcApiKeyRepository.deleteByEnvironmentId({})", environmentId);
         try {
             final var keyIds = jdbcTemplate.queryForList(
-                "select id from " + this.tableName + " where environment_id = ?",
+                "select id from " + escapeReservedWord(this.tableName) + " where environment_id = ?",
                 String.class,
                 environmentId
             );
@@ -399,7 +400,7 @@ public class JdbcApiKeyRepository extends JdbcAbstractCrudRepository<ApiKey, Str
                     "delete from " + keySubscriptions + " where key_id IN (" + getOrm().buildInClause(keyIds) + ")",
                     keyIds.toArray()
                 );
-                jdbcTemplate.update("delete from " + tableName + " where environment_id = ?", environmentId);
+                jdbcTemplate.update("delete from " + escapeReservedWord(tableName) + " where environment_id = ?", environmentId);
             }
             log.debug("JdbcApiKeyRepository.deleteByEnvironmentId({}) - Done", environmentId);
             return keyIds;

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcSubscriptionRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcSubscriptionRepository.java
@@ -34,6 +34,7 @@ import io.gravitee.repository.management.api.search.Pageable;
 import io.gravitee.repository.management.api.search.Sortable;
 import io.gravitee.repository.management.api.search.SubscriptionCriteria;
 import io.gravitee.repository.management.api.search.SubscriptionCursor;
+import io.gravitee.repository.management.api.search.SubscriptionSearchSort;
 import io.gravitee.repository.management.model.Subscription;
 import io.gravitee.repository.management.model.SubscriptionReferenceType;
 import java.sql.PreparedStatement;
@@ -202,13 +203,11 @@ public class JdbcSubscriptionRepository extends JdbcAbstractCrudRepository<Subsc
         if (!isEmpty(criteria.getPlanSecurityTypes()) || !isEmpty(criteria.getExcludedApis())) {
             throw new TechnicalException("searchAfter does not support planSecurityTypes or excludedApis filters; use search() instead");
         }
-        boolean sortByUpdatedAt;
-        if (sortable == null || sortable.field() == null || "updatedAt".equals(sortable.field())) {
-            sortByUpdatedAt = true;
-        } else if ("id".equals(sortable.field())) {
-            sortByUpdatedAt = false;
-        } else {
-            throw new TechnicalException("searchAfter supports sort field 'updatedAt' or 'id' only, got: " + sortable.field());
+        final SubscriptionSearchSort sort;
+        try {
+            sort = SubscriptionSearchSort.fromSortable(sortable);
+        } catch (IllegalArgumentException e) {
+            throw new TechnicalException(e.getMessage());
         }
 
         final List<Object> argsList = new ArrayList<>();
@@ -262,34 +261,68 @@ public class JdbcSubscriptionRepository extends JdbcAbstractCrudRepository<Subsc
             argsList.add(new Date(criteria.getEndingAtAfter()));
             started = true;
         }
+        final String planColumn = escapeReservedWord("plan");
         if (after != null) {
             inner.append(started ? AND_CLAUSE : WHERE_CLAUSE);
-            if (sortByUpdatedAt) {
-                inner.append("( updated_at > ? or ( updated_at = ? and id > ? ) )");
-                Date marker = new Date(after.updatedAt());
-                argsList.add(marker);
-                argsList.add(marker);
-                argsList.add(after.id());
-            } else {
-                inner.append("id > ?");
-                argsList.add(after.id());
+            switch (sort) {
+                case UPDATED_AT -> {
+                    inner.append("( updated_at > ? or ( updated_at = ? and id > ? ) )");
+                    Date marker = new Date(after.updatedAt());
+                    argsList.add(marker);
+                    argsList.add(marker);
+                    argsList.add(after.id());
+                }
+                case PLAN_ID -> {
+                    if (after.plan() == null) {
+                        throw new TechnicalException("PLAN_ID sort requires a (plan, id) cursor, but the cursor has no plan");
+                    }
+                    // (plan, id) keyset. The OR-form is the portable, correct comparison (works on all
+                    // JDBC dialects incl. SQL Server, which rejects row-value comparisons). The extra
+                    // redundant `plan >= ?` is a sargable lower bound that lets the planner start the
+                    // index scan at the cursor's plan instead of filtering the whole plan range — on
+                    // Postgres this becomes the index range condition.
+                    inner
+                        .append("( ( ")
+                        .append(planColumn)
+                        .append(" > ? or ( ")
+                        .append(planColumn)
+                        .append(" = ? and id > ? ) ) and ")
+                        .append(planColumn)
+                        .append(" >= ? )");
+                    argsList.add(after.plan());
+                    argsList.add(after.plan());
+                    argsList.add(after.id());
+                    argsList.add(after.plan());
+                }
+                case ID -> {
+                    inner.append("id > ?");
+                    argsList.add(after.id());
+                }
             }
         }
 
-        if (sortByUpdatedAt) {
-            inner.append(" order by updated_at asc, id asc ");
-        } else {
-            inner.append(" order by id asc ");
-        }
+        // The order must match the seek predicate above (and the backing index): a sort that
+        // disagrees with the keyset silently skips or duplicates rows across pages.
+        final String orderBy = switch (sort) {
+            case UPDATED_AT -> "updated_at asc, id asc";
+            case PLAN_ID -> planColumn + " asc, id asc";
+            case ID -> "id asc";
+        };
+        inner.append(" order by ").append(orderBy).append(" ");
         inner.append(createPagingClause(pageSize, 0));
 
+        final String outerOrderBy = switch (sort) {
+            case UPDATED_AT -> "order by s.updated_at asc, s.id asc";
+            case PLAN_ID -> "order by s." + planColumn + " asc, s.id asc";
+            case ID -> "order by s.id asc";
+        };
         final String query =
             "select s.*, sm.k as sm_k, sm.v as sm_v from (" +
             inner +
             ") s left join " +
             this.metadataTableName +
             " sm on s.id = sm.subscription_id " +
-            (sortByUpdatedAt ? "order by s.updated_at asc, s.id asc" : "order by s.id asc");
+            outerOrderBy;
 
         try {
             jdbcTemplate.query(query, rowMapper, argsList.toArray());

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoSubscriptionRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoSubscriptionRepository.java
@@ -23,6 +23,7 @@ import io.gravitee.repository.management.api.search.Pageable;
 import io.gravitee.repository.management.api.search.Sortable;
 import io.gravitee.repository.management.api.search.SubscriptionCriteria;
 import io.gravitee.repository.management.api.search.SubscriptionCursor;
+import io.gravitee.repository.management.api.search.SubscriptionSearchSort;
 import io.gravitee.repository.management.model.Subscription;
 import io.gravitee.repository.management.model.SubscriptionReferenceType;
 import io.gravitee.repository.mongodb.management.internal.model.SubscriptionMongo;
@@ -83,19 +84,13 @@ public class MongoSubscriptionRepository implements SubscriptionRepository {
         ) {
             throw new TechnicalException("searchAfter does not support planSecurityTypes or excludedApis filters; use search() instead");
         }
-        boolean sortByUpdatedAt = resolveSortByUpdatedAt(sortable);
-        return mapper.mapSubscriptions(internalSubscriptionRepository.searchAfter(criteria, after, pageSize, sortByUpdatedAt));
-    }
-
-    private static boolean resolveSortByUpdatedAt(Sortable sortable) throws TechnicalException {
-        if (sortable == null || sortable.field() == null) {
-            return true;
+        SubscriptionSearchSort sort;
+        try {
+            sort = SubscriptionSearchSort.fromSortable(sortable);
+        } catch (IllegalArgumentException e) {
+            throw new TechnicalException(e.getMessage());
         }
-        return switch (sortable.field()) {
-            case "updatedAt" -> true;
-            case "id" -> false;
-            default -> throw new TechnicalException("searchAfter supports sort field 'updatedAt' or 'id' only, got: " + sortable.field());
-        };
+        return mapper.mapSubscriptions(internalSubscriptionRepository.searchAfter(criteria, after, pageSize, sort));
     }
 
     @Override

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/plan/SubscriptionMongoRepositoryCustom.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/plan/SubscriptionMongoRepositoryCustom.java
@@ -21,6 +21,7 @@ import io.gravitee.repository.management.api.search.Pageable;
 import io.gravitee.repository.management.api.search.Sortable;
 import io.gravitee.repository.management.api.search.SubscriptionCriteria;
 import io.gravitee.repository.management.api.search.SubscriptionCursor;
+import io.gravitee.repository.management.api.search.SubscriptionSearchSort;
 import io.gravitee.repository.mongodb.management.internal.model.SubscriptionMongo;
 import java.util.List;
 import java.util.Set;
@@ -37,17 +38,21 @@ public interface SubscriptionMongoRepositoryCustom {
     List<SubscriptionMongo> searchUnordered(SubscriptionCriteria criteria);
 
     /**
-     * Keyset / seek pagination. Builds a {@code find()} query (not the aggregation pipeline).
+     * Keyset / seek pagination. Builds a {@code find()} query (not the aggregation pipeline). The
+     * {@code sort} mode drives both the sort order and the seek predicate so they always match:
      *
-     * <p>When {@code sortByUpdatedAt} is {@code true}, sorts by {@code (updatedAt, _id)} and seeks
-     * past {@code (cursor.updatedAt, cursor.id)} — used by the gateway-sync delta loop where the
-     * {@code (environmentId, updatedAt, _id)} compound index can be used cleanly.
-     *
-     * <p>When {@code sortByUpdatedAt} is {@code false}, sorts by {@code _id} only and seeks past
-     * {@code cursor.id} — used by the warmup load path where a {@code plans IN} filter dominates
-     * selectivity and the {@code _id_} primary index makes the seek O(N) across all pages.
+     * <ul>
+     *   <li>{@code UPDATED_AT} — sorts by {@code (updatedAt, _id)} and seeks past
+     *       {@code (cursor.updatedAt, cursor.id)} — the gateway-sync delta loop, served cleanly by
+     *       the {@code (environmentId, updatedAt, _id)} compound index.</li>
+     *   <li>{@code PLAN_ID} — sorts by {@code (plan, _id)} and seeks past {@code (cursor.plan, cursor.id)}
+     *       — the warmup path, where the {@code {plan,_id}} index scans each plan's range in order
+     *       instead of an {@code _id}-ordered walk over unrelated rows.</li>
+     *   <li>{@code ID} — sorts by {@code _id} only and seeks past {@code cursor.id} — the legacy /
+     *       repository-bridge fallback when no plan marker is available.</li>
+     * </ul>
      */
-    List<SubscriptionMongo> searchAfter(SubscriptionCriteria criteria, SubscriptionCursor after, int pageSize, boolean sortByUpdatedAt);
+    List<SubscriptionMongo> searchAfter(SubscriptionCriteria criteria, SubscriptionCursor after, int pageSize, SubscriptionSearchSort sort);
 
     Set<String> findReferenceIdsOrderByNumberOfSubscriptions(SubscriptionCriteria criteria, Order order);
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/plan/SubscriptionMongoRepositoryImpl.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/plan/SubscriptionMongoRepositoryImpl.java
@@ -32,6 +32,7 @@ import io.gravitee.repository.management.api.search.Pageable;
 import io.gravitee.repository.management.api.search.Sortable;
 import io.gravitee.repository.management.api.search.SubscriptionCriteria;
 import io.gravitee.repository.management.api.search.SubscriptionCursor;
+import io.gravitee.repository.management.api.search.SubscriptionSearchSort;
 import io.gravitee.repository.management.model.SubscriptionReferenceType;
 import io.gravitee.repository.mongodb.management.internal.model.SubscriptionMongo;
 import io.gravitee.repository.mongodb.utils.FieldUtils;
@@ -241,7 +242,7 @@ public class SubscriptionMongoRepositoryImpl implements SubscriptionMongoReposit
         SubscriptionCriteria criteria,
         SubscriptionCursor after,
         int pageSize,
-        boolean sortByUpdatedAt
+        SubscriptionSearchSort sort
     ) {
         Criteria mongoCriteria = new Criteria();
         List<Criteria> clauses = new ArrayList<>();
@@ -270,16 +271,30 @@ public class SubscriptionMongoRepositoryImpl implements SubscriptionMongoReposit
             }
         }
         if (after != null) {
-            if (sortByUpdatedAt) {
-                Date marker = new Date(after.updatedAt());
-                clauses.add(
-                    new Criteria().orOperator(
-                        Criteria.where("updatedAt").gt(marker),
-                        new Criteria().andOperator(Criteria.where("updatedAt").is(marker), Criteria.where("_id").gt(after.id()))
-                    )
-                );
-            } else {
-                clauses.add(Criteria.where("_id").gt(after.id()));
+            switch (sort) {
+                case UPDATED_AT -> {
+                    Date marker = new Date(after.updatedAt());
+                    clauses.add(
+                        new Criteria().orOperator(
+                            Criteria.where("updatedAt").gt(marker),
+                            new Criteria().andOperator(Criteria.where("updatedAt").is(marker), Criteria.where("_id").gt(after.id()))
+                        )
+                    );
+                }
+                case PLAN_ID -> {
+                    if (after.plan() == null) {
+                        throw new IllegalArgumentException("PLAN_ID sort requires a (plan, id) cursor, but the cursor has no plan");
+                    }
+                    // (plan, _id) keyset: lets the {plan:1,_id:1} index scan each plan's range in order
+                    // instead of an _id-ordered collection walk over unrelated rows.
+                    clauses.add(
+                        new Criteria().orOperator(
+                            Criteria.where("plan").gt(after.plan()),
+                            new Criteria().andOperator(Criteria.where("plan").is(after.plan()), Criteria.where("_id").gt(after.id()))
+                        )
+                    );
+                }
+                case ID -> clauses.add(Criteria.where("_id").gt(after.id()));
             }
         }
 
@@ -287,8 +302,14 @@ public class SubscriptionMongoRepositoryImpl implements SubscriptionMongoReposit
             mongoCriteria = mongoCriteria.andOperator(clauses.toArray(new Criteria[0]));
         }
 
-        Sort sort = sortByUpdatedAt ? Sort.by(Sort.Order.asc("updatedAt"), Sort.Order.asc("_id")) : Sort.by(Sort.Order.asc("_id"));
-        Query query = new Query(mongoCriteria).with(sort).limit(pageSize);
+        // Sort must match the seek predicate above (and the backing index): an order that disagrees
+        // with the keyset silently skips or duplicates rows across pages.
+        Sort mongoSort = switch (sort) {
+            case UPDATED_AT -> Sort.by(Sort.Order.asc("updatedAt"), Sort.Order.asc("_id"));
+            case PLAN_ID -> Sort.by(Sort.Order.asc("plan"), Sort.Order.asc("_id"));
+            case ID -> Sort.by(Sort.Order.asc("_id"));
+        };
+        Query query = new Query(mongoCriteria).with(mongoSort).limit(pageSize);
 
         return mongoTemplate.find(query, SubscriptionMongo.class);
     }

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/index/subscriptions/PlanIdIndexUpgrader.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/index/subscriptions/PlanIdIndexUpgrader.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.mongodb.management.upgrade.upgrader.index.subscriptions;
+
+import io.gravitee.repository.mongodb.management.upgrade.upgrader.index.Index;
+import io.gravitee.repository.mongodb.management.upgrade.upgrader.index.IndexUpgrader;
+import org.springframework.stereotype.Component;
+
+/**
+ * Supports the gateway-sync warmup appender, which loads subscriptions filtered by a {@code plan IN (…)}
+ * list and keyset-paginated by {@code (plan, _id)}. This compound index lets Mongo scan each plan's
+ * range already ordered by {@code _id} — avoiding both the N-way merge of a {@code {plan,_id}} sort
+ * over a wide {@code IN} and the {@code _id}-ordered collection walk that examines unrelated rows.
+ */
+@Component("SubscriptionsPlanIdIndexUpgrader")
+public class PlanIdIndexUpgrader extends IndexUpgrader {
+
+    @Override
+    protected Index buildIndex() {
+        return Index.builder()
+            .collection("subscriptions")
+            .name("p1i1")
+            .key("plan", ascending())
+            .key("_id", ascending())
+            .build();
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/test/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/index/subscriptions/PlanIdIndexUpgraderTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/test/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/index/subscriptions/PlanIdIndexUpgraderTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.mongodb.management.upgrade.upgrader.index.subscriptions;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.repository.mongodb.management.upgrade.upgrader.index.Index;
+import org.bson.Document;
+import org.junit.jupiter.api.Test;
+
+class PlanIdIndexUpgraderTest {
+
+    @Test
+    void buildIndex_definesCompoundIndexOnSubscriptionsWithExpectedNameAndKeys() {
+        Index index = new PlanIdIndexUpgrader().buildIndex();
+
+        assertThat(index.getCollection()).isEqualTo("subscriptions");
+        assertThat(index.options().getName()).isEqualTo("p1i1");
+
+        Document keys = index.toIndexDefinition().getIndexKeys();
+        assertThat(keys).hasSize(2);
+        assertThat(keys.get("plan")).isEqualTo(1);
+        assertThat(keys.get("_id")).isEqualTo(1);
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/SubscriptionRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/SubscriptionRepositoryTest.java
@@ -765,9 +765,10 @@ public class SubscriptionRepositoryTest extends AbstractManagementRepositoryTest
     }
 
     @Test
-    public void searchAfter_shouldPaginateByIdWithPlansFilter() throws TechnicalException {
+    public void searchAfter_shouldPaginateByPlanKeysetWithPlansFilter() throws TechnicalException {
         SubscriptionCriteria criteria = SubscriptionCriteria.builder().plans(List.of("plan3")).build();
-        var sortable = new SortableBuilder().field("id").order(Order.ASC).build();
+        // Warmup path: sort field "plan" → (plan, id) keyset, paired with byPlanAndId cursor.
+        var sortable = new SortableBuilder().field("plan").order(Order.ASC).build();
 
         Set<String> collected = new java.util.LinkedHashSet<>();
         SubscriptionCursor cursor = null;
@@ -782,7 +783,7 @@ public class SubscriptionRepositoryTest extends AbstractManagementRepositoryTest
                 assertTrue("Duplicate id across pages: " + s.getId(), collected.add(s.getId()));
             }
             Subscription last = page.getLast();
-            cursor = SubscriptionCursor.byId(last.getId());
+            cursor = SubscriptionCursor.byPlanAndId(last.getPlan(), last.getId());
             if (page.size() < pageSize) {
                 break;
             }
@@ -796,6 +797,49 @@ public class SubscriptionRepositoryTest extends AbstractManagementRepositoryTest
     }
 
     @Test
+    public void searchAfter_shouldPaginateByIdOnlyFallback() throws TechnicalException {
+        // Legacy / repository-bridge fallback: sort field "id" → id-only keyset, paired with byId
+        // cursor. The seek and the sort must both be id-only — if the sort were (plan, id) here while
+        // the seek stays id-only (the bug this guards), keyset pagination would skip or duplicate rows.
+        SubscriptionCriteria criteria = SubscriptionCriteria.builder().plans(List.of("plan3")).build();
+        var sortable = new SortableBuilder().field("id").order(Order.ASC).build();
+
+        // Ground truth: a single page (no keyset) gives the engine's own id order. Collation differs
+        // per engine, so we compare against this rather than a hard-coded order.
+        List<String> singlePageOrder = subscriptionRepository
+            .searchAfter(criteria, sortable, null, 100)
+            .stream()
+            .map(Subscription::getId)
+            .collect(Collectors.toList());
+
+        // Paginate the same query in small pages via the byId cursor.
+        List<String> paged = new java.util.ArrayList<>();
+        SubscriptionCursor cursor = null;
+        int pageSize = 2;
+        int guard = 10;
+        while (guard-- > 0) {
+            List<Subscription> page = subscriptionRepository.searchAfter(criteria, sortable, cursor, pageSize);
+            if (page.isEmpty()) {
+                break;
+            }
+            page.forEach(s -> paged.add(s.getId()));
+            cursor = SubscriptionCursor.byId(page.getLast().getId());
+            if (page.size() < pageSize) {
+                break;
+            }
+        }
+
+        // Keyset pagination must reproduce the single-page order exactly — same elements, same order,
+        // no skips or duplicates. This holds only when the seek predicate agrees with the sort.
+        assertEquals("id-only keyset pagination must reproduce the single-page id order (no skip/dup/reorder)", singlePageOrder, paged);
+        assertEquals(
+            "plan3 subs returned exactly — no leak from unrelated plans",
+            Set.of("sub-legacy-push", "sub2", "sub3", "sub6", "sub7", "sub8"),
+            new java.util.HashSet<>(paged)
+        );
+    }
+
+    @Test
     public void searchAfter_shouldHonourEndingAtAfterWithIncludeWithoutEnd() throws TechnicalException {
         // Warmup criteria — initial sync filter uses endingAtAfter(now) + includeWithoutEnd(true)
         // to load subs that are active OR have no expiry. searchAfter's net-new criteria support
@@ -805,7 +849,7 @@ public class SubscriptionRepositoryTest extends AbstractManagementRepositoryTest
             .endingAtAfter(2500L)
             .includeWithoutEnd(true)
             .build();
-        var sortable = new SortableBuilder().field("id").order(Order.ASC).build();
+        var sortable = new SortableBuilder().field("plan").order(Order.ASC).build();
 
         Set<String> viaSearchAfter = new java.util.LinkedHashSet<>();
         SubscriptionCursor cursor = null;
@@ -817,7 +861,7 @@ public class SubscriptionRepositoryTest extends AbstractManagementRepositoryTest
                 break;
             }
             page.forEach(s -> viaSearchAfter.add(s.getId()));
-            cursor = SubscriptionCursor.byId(page.getLast().getId());
+            cursor = SubscriptionCursor.byPlanAndId(page.getLast().getPlan(), page.getLast().getId());
             if (page.size() < pageSize) {
                 break;
             }


### PR DESCRIPTION
## Summary

Follow-up to APIM-14087 (subscription cursor warmup). The shipped warmup appender
keyset-paginates by `_id` with a `plan IN (…)` filter. On production-realistic
**random-UUID `_id`s**, a batch's plans are scattered across the `_id` space, so the
`_id`-ordered walk examines large numbers of unrelated rows per page — a severe
warmup regression that gets worse with scale.

This PR changes the warmup keyset to **`(plan, _id)`** and adds a matching
**`{plan:1, _id:1}`** index, so Mongo scans each plan's range already ordered by
`_id` (no N-way merge, no walking unrelated rows).

## Measured at customer scale (single GW, same data, **verified-equal load**)

Equal subscription/key counts loaded in every run (instrumented + cross-checked vs Mongo).

**2.4M subscriptions / 8.1k APIs (uniform, UUID ids):**

| Warmup appender | wall-clock |
|---|---:|
| shipped `_id` cursor | **423 s** |
| 4.11.7 single-query baseline | 114 s |
| **this PR — `(plan,_id)` + index** | **43 s** |

**25M projected scale — DB-layer `explain` (300 scattered plans → 2000 rows):**

| cursor | docs examined / page |
|---|---:|
| shipped `_id` | 58,862 |
| **this PR** | **2,114** (28× fewer) |

The regression and the fix both amplify with scale (3× fewer examined at 2.4M → 28× at 25M).

## Changes

- `SubscriptionCursor`: `byId(...)` → `byPlanAndId(plan, id)` (adds `plan` to the record).
  `byId` was introduced in the unreleased 4.11.8 cursor work, so no shipped API is broken.
- `SubscriptionMongoRepositoryImpl.searchAfter`: warmup path sorts + seeks by `(plan, _id)`.
- `PlanIdIndexUpgrader`: creates `subscriptions {plan:1,_id:1}` (name `p1i1`) on startup.
- `SubscriptionAppender`: builds the `(plan,_id)` cursor.

## Tests

- `SubscriptionRepositoryTest` (real Mongo testcontainer) — warmup `searchAfter` pagination green (9/9).
- `PlanIdIndexUpgraderTest` — index shape (1/1).
- `SubscriptionAppenderTest` / `ApiKeyAppenderTest` — 4/4 each.
- The two warmup-pagination assertions in `SubscriptionRepositoryTest` switched from `byId` to
  `byPlanAndId` (the only caller of the removed factory); they assert page completeness/no-dups,
  which the `(plan,_id)` order preserves.

## Notes / follow-ups

- **Mongo only.** The JDBC warmup path (`JdbcSubscriptionRepository.searchAfter`) still sorts by
  `id`; a `(plan, id)` keyset + composite index there is a sensible follow-up.
- Does **not** address the per-batch heap materialization observed at 25M (a hot event-batch can load
  ~12M subscriptions into memory at once) — that needs a streaming appender + sharding, tracked separately.

Refs APIM-14087.
