### PR TITLE
fix: reject null pathOperator in v4 flow HTTP selectors

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/domain_service/ValidateApiCRDDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/domain_service/ValidateApiCRDDomainService.java
@@ -21,6 +21,8 @@ import io.gravitee.apim.core.audit.model.AuditInfo;
 import io.gravitee.apim.core.category.domain_service.ValidateCategoryIdsDomainService;
 import io.gravitee.apim.core.documentation.domain_service.ValidatePagesDomainService;
 import io.gravitee.apim.core.documentation.model.factory.PageModelFactory;
+import io.gravitee.apim.core.flow.domain_service.FlowValidationDomainService;
+import io.gravitee.apim.core.flow.exception.InvalidFlowException;
 import io.gravitee.apim.core.group.domain_service.ValidateGroupsDomainService;
 import io.gravitee.apim.core.group.model.Group;
 import io.gravitee.apim.core.member.domain_service.ValidateCRDMembersDomainService;
@@ -29,6 +31,8 @@ import io.gravitee.apim.core.notification.domain_service.ValidatePortalNotificat
 import io.gravitee.apim.core.plan.domain_service.ValidatePlanDomainService;
 import io.gravitee.apim.core.resource.domain_service.ValidateResourceDomainService;
 import io.gravitee.apim.core.validation.Validator;
+import io.gravitee.definition.model.v4.flow.AbstractFlow;
+import io.gravitee.definition.model.v4.flow.Flow;
 import io.gravitee.definition.model.v4.listener.ListenerType;
 import io.gravitee.definition.model.v4.nativeapi.kafka.KafkaListener;
 import io.gravitee.rest.api.service.common.IdBuilder;
@@ -166,6 +170,28 @@ public class ValidateApiCRDDomainService implements Validator<ValidateApiCRDDoma
                 new VerifyApiPathDomainService.Input(input.auditInfo.environmentId(), input.spec.getId(), input.spec.getPaths())
             )
             .peek(sanitized -> sanitizedBuilder.paths(sanitized.paths()), errors::addAll);
+
+        checkApiFlowsPathOperator(input.spec.getFlows());
+    }
+
+    private void checkApiFlowsPathOperator(List<? extends AbstractFlow> flows) {
+        if (flows == null) {
+            return;
+        }
+        flows
+            .stream()
+            .filter(Flow.class::isInstance)
+            .map(Flow.class::cast)
+            .filter(flow -> flow.getSelectors() != null)
+            .forEach(flow -> {
+                boolean hasNullPathOperator = flow
+                    .getSelectors()
+                    .stream()
+                    .anyMatch(FlowValidationDomainService.HTTP_SELECTOR_WITH_NULL_PATH_OPERATOR);
+                if (hasNullPathOperator) {
+                    throw InvalidFlowException.missingPathOperator(flow.getName());
+                }
+            });
     }
 
     private void validateAndSanitizeNativeV4ForCreation(

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/flow/domain_service/FlowValidationDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/flow/domain_service/FlowValidationDomainService.java
@@ -41,6 +41,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
+import java.util.function.Predicate;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -62,6 +63,9 @@ public class FlowValidationDomainService {
         this.policyValidationDomainService = policyValidationDomainService;
         this.entrypointConnectorPluginService = entrypointConnectorPluginService;
     }
+
+    public static final Predicate<Selector> HTTP_SELECTOR_WITH_NULL_PATH_OPERATOR = selector ->
+        selector instanceof HttpSelector httpSelector && httpSelector.getPathOperator() == null;
 
     private static final Function<Flow, Optional<String>> HTTP_PATH_EXTRACTOR = flow ->
         flow
@@ -97,6 +101,9 @@ public class FlowValidationDomainService {
                 // Check selectors according to api type
                 checkSelectorsForType(apiType, flow);
 
+                // Check HTTP selectors carry a non-null pathOperator
+                checkHttpSelectorsPathOperator(flow);
+
                 // Validate policy
                 var steps = Stream.of(flow.getRequest(), flow.getResponse(), flow.getPublish(), flow.getSubscribe())
                     .filter(Objects::nonNull)
@@ -125,6 +132,15 @@ public class FlowValidationDomainService {
             });
         }
         return flows;
+    }
+
+    private void checkHttpSelectorsPathOperator(final Flow flow) {
+        if (flow.getSelectors() != null) {
+            boolean hasNullPathOperator = flow.getSelectors().stream().anyMatch(HTTP_SELECTOR_WITH_NULL_PATH_OPERATOR);
+            if (hasNullPathOperator) {
+                throw InvalidFlowException.missingPathOperator(flow.getName());
+            }
+        }
     }
 
     private void checkSelectorsForType(final ApiType apiType, final Flow flow) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/flow/exception/InvalidFlowException.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/flow/exception/InvalidFlowException.java
@@ -17,6 +17,7 @@ package io.gravitee.apim.core.flow.exception;
 
 import io.gravitee.apim.core.exception.ValidationDomainException;
 import io.gravitee.definition.model.v4.ApiType;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
@@ -29,21 +30,37 @@ public class InvalidFlowException extends ValidationDomainException {
     public static InvalidFlowException invalidEntrypoint(String flowName, Set<String> invalidEntrypoints) {
         return new InvalidFlowException(
             "The flow [" + flowName + "] contains channel selector with invalid entrypoints",
-            Map.of("flowName", flowName, "invalidEntrypoints", String.join(",", invalidEntrypoints))
+            withFlowName(flowName, Map.of("invalidEntrypoints", String.join(",", invalidEntrypoints)))
         );
     }
 
     public static InvalidFlowException invalidSelector(String flowName, ApiType apiType, Set<String> invalidSelectors) {
         return new InvalidFlowException(
             "The flow [" + flowName + "] contains selectors that couldn't apply to " + apiType.getLabel() + " API",
-            Map.of("flowName", flowName, "invalidSelectors", String.join(",", invalidSelectors))
+            withFlowName(flowName, Map.of("invalidSelectors", String.join(",", invalidSelectors)))
+        );
+    }
+
+    public static InvalidFlowException missingPathOperator(String flowName) {
+        return new InvalidFlowException(
+            "The flow [" + flowName + "] contains an HTTP selector with a missing pathOperator",
+            withFlowName(flowName, Map.of())
         );
     }
 
     public static InvalidFlowException duplicatedSelector(String flowName, Set<String> duplicatedSelectors) {
         return new InvalidFlowException(
             "The flow [" + flowName + "] contains duplicated selectors type",
-            Map.of("flowName", flowName, "duplicatedSelectors", String.join(",", duplicatedSelectors))
+            withFlowName(flowName, Map.of("duplicatedSelectors", String.join(",", duplicatedSelectors)))
         );
+    }
+
+    private static Map<String, String> withFlowName(String flowName, Map<String, String> parameters) {
+        if (flowName == null) {
+            return parameters;
+        }
+        var withName = new HashMap<>(parameters);
+        withName.put("flowName", flowName);
+        return withName;
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/validation/ApiValidationServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/validation/ApiValidationServiceImpl.java
@@ -201,7 +201,9 @@ public class ApiValidationServiceImpl extends TransactionalService implements Ap
             analyticsValidationService.validateAndSanitize(executionContext, updateApiEntity.getType(), updateApiEntity.getAnalytics())
         );
         // Validate and clean flow
-        updateApiEntity.setFlows(flowValidationService.validateAndSanitize(updateApiEntity.getType(), updateApiEntity.getFlows()));
+        updateApiEntity.setFlows(
+            flowValidationDomainService.validateAndSanitizeHttpV4(updateApiEntity.getType(), updateApiEntity.getFlows())
+        );
 
         // Validate and clean plans
         updateApiEntity.setPlans(planValidationService.validateAndSanitize(updateApiEntity.getType(), updateApiEntity.getPlans()));

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/mapper/FlowMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/mapper/FlowMapper.java
@@ -33,6 +33,7 @@ import io.gravitee.repository.management.model.flow.selector.FlowMcpSelector;
 import io.gravitee.repository.management.model.flow.selector.FlowOperator;
 import io.gravitee.repository.management.model.flow.selector.FlowSelector;
 import io.gravitee.rest.api.service.common.UuidString;
+import io.gravitee.rest.api.service.exceptions.InvalidDataException;
 import java.util.Date;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -151,6 +152,9 @@ public class FlowMapper {
             FlowHttpSelector repositoryFlowHttpSelector = new FlowHttpSelector();
             repositoryFlowHttpSelector.setMethods(definitionHttpSelector.getMethods());
             repositoryFlowHttpSelector.setPath(definitionHttpSelector.getPath());
+            if (definitionHttpSelector.getPathOperator() == null) {
+                throw new InvalidDataException("flows[].selectors[].pathOperator is required");
+            }
             repositoryFlowHttpSelector.setPathOperator(FlowOperator.valueOf(definitionHttpSelector.getPathOperator().name()));
             return repositoryFlowHttpSelector;
         } else if (definitionSelector instanceof ChannelSelector) {
@@ -189,7 +193,11 @@ public class FlowMapper {
             HttpSelector definitionHttpSelector = new HttpSelector();
             definitionHttpSelector.setMethods(repositoryFlowHttpSelector.getMethods());
             definitionHttpSelector.setPath(repositoryFlowHttpSelector.getPath());
-            definitionHttpSelector.setPathOperator(Operator.valueOf(repositoryFlowHttpSelector.getPathOperator().name()));
+            definitionHttpSelector.setPathOperator(
+                repositoryFlowHttpSelector.getPathOperator() == null
+                    ? Operator.STARTS_WITH
+                    : Operator.valueOf(repositoryFlowHttpSelector.getPathOperator().name())
+            );
             return definitionHttpSelector;
         } else if (repositoryFlowSelector instanceof FlowChannelSelector) {
             FlowChannelSelector repositoryFlowChannelSelector = (FlowChannelSelector) repositoryFlowSelector;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/domain_service/ValidateApiCRDDomainServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/domain_service/ValidateApiCRDDomainServiceTest.java
@@ -27,6 +27,7 @@ import fixtures.core.model.ApiCRDFixtures;
 import io.gravitee.apim.core.audit.model.AuditInfo;
 import io.gravitee.apim.core.category.domain_service.ValidateCategoryIdsDomainService;
 import io.gravitee.apim.core.documentation.domain_service.ValidatePagesDomainService;
+import io.gravitee.apim.core.flow.exception.InvalidFlowException;
 import io.gravitee.apim.core.group.domain_service.ValidateGroupsDomainService;
 import io.gravitee.apim.core.member.domain_service.ValidateCRDMembersDomainService;
 import io.gravitee.apim.core.member.model.MembershipReferenceType;
@@ -34,9 +35,12 @@ import io.gravitee.apim.core.notification.domain_service.ValidatePortalNotificat
 import io.gravitee.apim.core.plan.domain_service.ValidatePlanDomainService;
 import io.gravitee.apim.core.resource.domain_service.ValidateResourceDomainService;
 import io.gravitee.apim.core.validation.Validator;
+import io.gravitee.definition.model.v4.flow.Flow;
+import io.gravitee.definition.model.v4.flow.selector.HttpSelector;
 import io.gravitee.rest.api.model.notification.NotificationConfigType;
 import io.gravitee.rest.api.model.notification.PortalNotificationConfigEntity;
 import io.gravitee.rest.api.service.common.IdBuilder;
+import java.util.List;
 import java.util.Set;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -263,5 +267,22 @@ class ValidateApiCRDDomainServiceTest {
                 sanitized -> Assertions.assertThat(sanitized.spec()).isEqualTo(expected),
                 errors -> Assertions.assertThat(errors).isEmpty()
             );
+    }
+
+    @Test
+    void should_reject_api_flow_with_null_path_operator() {
+        var corruptFlow = Flow.builder()
+            .name("api-flow")
+            .selectors(List.of(HttpSelector.builder().path("/calls").pathOperator(null).build()))
+            .build();
+        var spec = ApiCRDFixtures.newBaseSpec().flows(List.of(corruptFlow)).build();
+        var input = new ValidateApiCRDDomainService.Input(AuditInfo.builder().environmentId(ENV_ID).build(), spec);
+
+        var throwable = Assertions.catchThrowable(() -> cut.validateAndSanitize(input));
+
+        Assertions.assertThat(throwable)
+            .isInstanceOf(InvalidFlowException.class)
+            .hasMessage("The flow [api-flow] contains an HTTP selector with a missing pathOperator");
+        Assertions.assertThat(((InvalidFlowException) throwable).getParameters()).containsEntry("flowName", "api-flow");
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/ImportApiCRDUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/ImportApiCRDUseCaseTest.java
@@ -114,6 +114,7 @@ import io.gravitee.apim.core.event.crud_service.EventCrudService;
 import io.gravitee.apim.core.event.crud_service.EventLatestCrudService;
 import io.gravitee.apim.core.exception.ValidationDomainException;
 import io.gravitee.apim.core.flow.domain_service.FlowValidationDomainService;
+import io.gravitee.apim.core.flow.exception.InvalidFlowException;
 import io.gravitee.apim.core.group.domain_service.ValidateGroupsDomainService;
 import io.gravitee.apim.core.group.model.Group;
 import io.gravitee.apim.core.member.domain_service.ValidateCRDMembersDomainService;
@@ -155,6 +156,7 @@ import io.gravitee.definition.model.v4.endpointgroup.Endpoint;
 import io.gravitee.definition.model.v4.endpointgroup.EndpointGroup;
 import io.gravitee.definition.model.v4.flow.AbstractFlow;
 import io.gravitee.definition.model.v4.flow.Flow;
+import io.gravitee.definition.model.v4.flow.selector.HttpSelector;
 import io.gravitee.definition.model.v4.listener.ListenerType;
 import io.gravitee.definition.model.v4.listener.entrypoint.Entrypoint;
 import io.gravitee.definition.model.v4.listener.http.HttpListener;
@@ -682,6 +684,54 @@ class ImportApiCRDUseCaseTest {
                 .extracting(Plan::getId, Plan::getName, Plan::getPublishedAt)
                 .containsExactly(tuple("keyless-id", "Keyless", INSTANT_NOW.atZone(ZoneId.systemDefault())));
             assertThat(flowCrudService.storage()).extracting(AbstractFlow::getName).containsExactly("plan-flow");
+        }
+
+        @Test
+        void should_reject_crd_import_when_plan_flow_has_null_path_operator() {
+            var corruptFlow = Flow.builder()
+                .name("plan-flow")
+                .selectors(List.of(HttpSelector.builder().path("/calls").pathOperator(null).build()))
+                .build();
+            var crd = aCRD()
+                .plans(
+                    Map.of(
+                        "keyless-key",
+                        PlanCRD.builder()
+                            .id("keyless-id")
+                            .name("Keyless")
+                            .security(PlanSecurity.builder().type("KEY_LESS").build())
+                            .mode(PlanMode.STANDARD)
+                            .validation(Plan.PlanValidationType.AUTO)
+                            .status(PlanStatus.PUBLISHED)
+                            .type(Plan.PlanType.API)
+                            .flows(List.of(corruptFlow))
+                            .build()
+                    )
+                )
+                .build();
+
+            var throwable = catchThrowable(() -> useCase.execute(new ImportApiCRDUseCase.Input(AUDIT_INFO, crd)));
+
+            SoftAssertions.assertSoftly(soft -> {
+                soft.assertThat(throwable).isInstanceOf(InvalidFlowException.class);
+                soft.assertThat(flowCrudService.storage()).extracting(AbstractFlow::getName).doesNotContain("plan-flow");
+            });
+        }
+
+        @Test
+        void should_reject_crd_import_when_api_flow_has_null_path_operator() {
+            var corruptFlow = Flow.builder()
+                .name("api-flow")
+                .selectors(List.of(HttpSelector.builder().path("/calls").pathOperator(null).build()))
+                .build();
+            var crd = aCRD().flows(List.of(corruptFlow)).build();
+
+            var throwable = catchThrowable(() -> useCase.execute(new ImportApiCRDUseCase.Input(AUDIT_INFO, crd)));
+
+            SoftAssertions.assertSoftly(soft -> {
+                soft.assertThat(throwable).isInstanceOf(InvalidFlowException.class);
+                soft.assertThat(flowCrudService.storage()).extracting(AbstractFlow::getName).doesNotContain("api-flow");
+            });
         }
 
         @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/flow/domain_service/FlowValidationDomainServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/flow/domain_service/FlowValidationDomainServiceTest.java
@@ -89,6 +89,30 @@ public class FlowValidationDomainServiceTest {
         }
 
         @Test
+        public void should_reject_http_selector_with_null_path_operator() {
+            HttpSelector selector = new HttpSelector();
+            selector.setPath("/calls");
+            selector.setPathOperator(null);
+            var flow = Flow.builder().name("plan-flow").selectors(List.of(selector)).build();
+
+            var throwable = catchThrowable(() -> service.validateAndSanitizeHttpV4(ApiType.PROXY, List.of(flow)));
+
+            assertThat(throwable).isInstanceOf(InvalidFlowException.class);
+        }
+
+        @Test
+        public void should_reject_http_selector_with_null_path_operator_when_flow_has_no_name() {
+            HttpSelector selector = new HttpSelector();
+            selector.setPath("/calls");
+            selector.setPathOperator(null);
+            var flow = Flow.builder().selectors(List.of(selector)).build();
+
+            var throwable = catchThrowable(() -> service.validateAndSanitizeHttpV4(ApiType.PROXY, List.of(flow)));
+
+            assertThat(throwable).isInstanceOf(InvalidFlowException.class);
+        }
+
+        @Test
         public void should_accept_flow_with_only_selectors() {
             var flow = Flow.builder()
                 .selectors(List.of(HttpSelector.builder().path("/").pathOperator(Operator.STARTS_WITH).build()))

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/flow/exception/InvalidFlowExceptionTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/flow/exception/InvalidFlowExceptionTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.flow.exception;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+
+import io.gravitee.definition.model.v4.ApiType;
+import java.util.Set;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class InvalidFlowExceptionTest {
+
+    @Test
+    void missingPathOperator_should_not_throw_when_flow_name_is_null() {
+        var throwable = catchThrowable(() -> InvalidFlowException.missingPathOperator(null));
+
+        assertThat(throwable).isNull();
+        assertThat(InvalidFlowException.missingPathOperator(null).getParameters()).doesNotContainKey("flowName");
+    }
+
+    @Test
+    void invalidEntrypoint_should_not_throw_when_flow_name_is_null() {
+        var throwable = catchThrowable(() -> InvalidFlowException.invalidEntrypoint(null, Set.of("sse")));
+
+        assertThat(throwable).isNull();
+        assertThat(InvalidFlowException.invalidEntrypoint(null, Set.of("sse")).getParameters())
+            .doesNotContainKey("flowName")
+            .containsEntry("invalidEntrypoints", "sse");
+    }
+
+    @Test
+    void invalidSelector_should_not_throw_when_flow_name_is_null() {
+        var throwable = catchThrowable(() -> InvalidFlowException.invalidSelector(null, ApiType.PROXY, Set.of("channel")));
+
+        assertThat(throwable).isNull();
+        assertThat(InvalidFlowException.invalidSelector(null, ApiType.PROXY, Set.of("channel")).getParameters())
+            .doesNotContainKey("flowName")
+            .containsEntry("invalidSelectors", "channel");
+    }
+
+    @Test
+    void duplicatedSelector_should_not_throw_when_flow_name_is_null() {
+        var throwable = catchThrowable(() -> InvalidFlowException.duplicatedSelector(null, Set.of("http")));
+
+        assertThat(throwable).isNull();
+        assertThat(InvalidFlowException.duplicatedSelector(null, Set.of("http")).getParameters())
+            .doesNotContainKey("flowName")
+            .containsEntry("duplicatedSelectors", "http");
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/validation/ApiValidationServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/validation/ApiValidationServiceImplTest.java
@@ -21,12 +21,14 @@ import static io.gravitee.rest.api.model.api.ApiLifecycleState.CREATED;
 import static io.gravitee.rest.api.model.api.ApiLifecycleState.DEPRECATED;
 import static io.gravitee.rest.api.model.api.ApiLifecycleState.PUBLISHED;
 import static io.gravitee.rest.api.model.api.ApiLifecycleState.UNPUBLISHED;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -35,8 +37,14 @@ import static org.mockito.Mockito.when;
 import io.gravitee.apim.core.api_product.model.ApiProduct;
 import io.gravitee.apim.core.api_product.query_service.ApiProductQueryService;
 import io.gravitee.apim.core.flow.domain_service.FlowValidationDomainService;
+import io.gravitee.apim.core.flow.exception.InvalidFlowException;
+import io.gravitee.apim.core.plugin.query_service.EntrypointPluginQueryService;
+import io.gravitee.apim.core.policy.domain_service.PolicyValidationDomainService;
 import io.gravitee.definition.model.DefinitionVersion;
 import io.gravitee.definition.model.v4.ApiType;
+import io.gravitee.definition.model.v4.flow.Flow;
+import io.gravitee.definition.model.v4.flow.selector.HttpSelector;
+import io.gravitee.definition.model.v4.flow.selector.Selector;
 import io.gravitee.definition.model.v4.plan.PlanStatus;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.rest.api.model.PrimaryOwnerEntity;
@@ -472,6 +480,54 @@ public class ApiValidationServiceImplTest {
         apiValidationService.validateAndSanitizeNewApi(GraviteeContext.getExecutionContext(), newApiEntity, primaryOwnerEntity);
 
         assertEquals("\"A Description\"", newApiEntity.getDescription());
+    }
+
+    @Test
+    public void shouldThrowWhenUpdateV4HttpFlowHasNullPathOperator() {
+        ApiValidationService apiValidationServiceWithRealFlowValidation = new ApiValidationServiceImpl(
+            tagsValidationService,
+            groupValidationService,
+            listenerValidationService,
+            endpointGroupsValidationService,
+            flowValidationService,
+            resourcesValidationService,
+            loggingValidationService,
+            planSearchService,
+            planValidationService,
+            apiServicePluginService,
+            new FlowValidationDomainService(mock(PolicyValidationDomainService.class), mock(EntrypointPluginQueryService.class)),
+            apiProductQueryService
+        );
+
+        HttpSelector httpSelector = new HttpSelector();
+        httpSelector.setPath("/");
+        httpSelector.setPathOperator(null);
+
+        Flow flow = new Flow();
+        flow.setName("my-flow");
+        flow.setSelectors(List.<Selector>of(httpSelector));
+
+        UpdateApiEntity updateApiEntity = new UpdateApiEntity();
+        updateApiEntity.setDefinitionVersion(DefinitionVersion.V4);
+        updateApiEntity.setType(ApiType.PROXY);
+        updateApiEntity.setLifecycleState(null);
+        updateApiEntity.setFlows(List.of(flow));
+
+        ApiEntity existingApiEntity = new ApiEntity();
+        existingApiEntity.setDefinitionVersion(DefinitionVersion.V4);
+        existingApiEntity.setType(ApiType.PROXY);
+        existingApiEntity.setLifecycleState(CREATED);
+
+        assertThatThrownBy(() ->
+            apiValidationServiceWithRealFlowValidation.validateAndSanitizeUpdateApi(
+                GraviteeContext.getExecutionContext(),
+                updateApiEntity,
+                new PrimaryOwnerEntity(),
+                existingApiEntity
+            )
+        )
+            .isInstanceOf(InvalidFlowException.class)
+            .hasMessageContaining("missing pathOperator");
     }
 
     private void assertUpdate(

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/mapper/FlowMapperTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/mapper/FlowMapperTest.java
@@ -18,6 +18,7 @@ package io.gravitee.rest.api.service.v4.mapper;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
 
 import io.gravitee.definition.model.flow.Operator;
 import io.gravitee.definition.model.v4.flow.Flow;
@@ -29,6 +30,7 @@ import io.gravitee.repository.management.model.flow.FlowReferenceType;
 import io.gravitee.repository.management.model.flow.selector.FlowHttpSelector;
 import io.gravitee.repository.management.model.flow.selector.FlowMcpSelector;
 import io.gravitee.repository.management.model.flow.selector.FlowOperator;
+import io.gravitee.rest.api.service.exceptions.InvalidDataException;
 import java.util.List;
 import java.util.Set;
 import org.junit.Test;
@@ -134,6 +136,36 @@ public class FlowMapperTest {
         assertEquals("ip-filtering", mappedStep.getPolicy());
         assertEquals(POLICY_CONDITION, mappedStep.getCondition());
         assertEquals("{\"blacklistIps\":[\"127.0.0.1\"]}", mappedStep.getConfiguration());
+    }
+
+    @Test
+    public void toRepositoryShouldRejectNullPathOperator() {
+        HttpSelector httpSelector = new HttpSelector();
+        httpSelector.setPath("/calls");
+        httpSelector.setPathOperator(null);
+
+        Flow flowDefinition = new Flow();
+        flowDefinition.setName("plan-flow");
+        flowDefinition.setSelectors(List.of(httpSelector));
+
+        assertThrows(InvalidDataException.class, () -> flowMapper.toRepository(flowDefinition, FlowReferenceType.PLAN, "plan-id", 0));
+    }
+
+    @Test
+    public void toDefinitionShouldDefaultNullPathOperatorToStartsWith() {
+        var flow = new io.gravitee.repository.management.model.flow.Flow();
+        FlowHttpSelector flowHttpSelector = new FlowHttpSelector();
+        flowHttpSelector.setPath("/calls");
+        flowHttpSelector.setPathOperator(null);
+        flow.setSelectors(List.of(flowHttpSelector));
+        flow.setTags(Set.of());
+
+        Flow flowDefinition = flowMapper.toDefinition(flow);
+
+        assertNotNull(flowDefinition.getSelectors());
+        assertEquals(1, flowDefinition.getSelectors().size());
+        HttpSelector mappedSelector = (HttpSelector) flowDefinition.getSelectors().get(0);
+        assertEquals(Operator.STARTS_WITH, mappedSelector.getPathOperator());
     }
 
     @Test


### PR DESCRIPTION
## Issue

[APIM-14252](https://gravitee.atlassian.net/browse/APIM-14252)

## Why

Creating or updating a v4 HTTP Proxy API with a flow whose HTTP selector has a null `pathOperator` returned a 500 NPE instead of a 400 validation error. Worse, the write path partially committed before crashing: on POST the API was persisted with an empty flow list, and on PUT an existing API had its name/listeners/endpoints overwritten and its flows wiped before the failure. Any record already stored with a null `pathOperator` then became unreadable, undeletable, and unupdatable because the read mapper also NPE-d. `path: null` was already correctly rejected by a `@NotNull` constraint; `pathOperator: null` had no equivalent guard.

## What changed

- **`FlowValidationDomainService`** — adds a pre-persist check that rejects any HTTP selector with a null `pathOperator`, throwing `InvalidFlowException` (400) on the management API create/update path for API-level and plan flows.
- **`ApiValidationServiceImpl`** — routes the v4 HTTP API **update** path through `FlowValidationDomainService` (it previously used the deprecated `FlowValidationServiceImpl`, which had no null-`pathOperator` guard), so a `PUT` with a null `pathOperator` is rejected before persistence instead of partially overwriting the existing API.
- **`ValidateApiCRDDomainService`** — applies the same null-`pathOperator` rejection on the automation/CRD import path.
- **`InvalidFlowException`** — new `missingPathOperator(flowName)` factory carrying the offending flow name.
- **`FlowMapper`** — write side now throws `InvalidDataException` (400) when mapping a null `pathOperator` to the repository model, as a defensive backstop; read side coerces a stored null to the model default `STARTS_WITH` so already-corrupt records load, delete, and self-heal on next save instead of returning 500.

## Affected endpoints

The fix touches both the **write/validation path** (now returns 400) and the **read path** (now self-heals corrupt records). The same code is reached from several endpoints, not just `POST /apis`:

```mermaid
flowchart LR
    subgraph WRITE["Write / validation — now 400 (was 500 + partial persist)"]
        direction TB
        POSTAPI["POST /management/v2/.../apis"]
        PUTAPI["PUT /management/v2/.../apis/{apiId}"]
        POSTPLAN["POST /management/v2/.../apis/{apiId}/plans"]
        PUTPLAN["PUT /management/v2/.../apis/{apiId}/plans/{planId}"]
        CRD["PUT /automation/.../apis  (CRD import)"]
    end

    subgraph READ["Read / export — now coerces null to STARTS_WITH (was 500)"]
        direction TB
        GETAPI["GET /management/v2/.../apis & /apis/{apiId}"]
        EXPORT["GET /management/v2/.../apis/{apiId}/_export/definition"]
        GETPLANS["GET /management/v2/.../apis/{apiId}/plans"]
        DELAPI["DELETE /management/v2/.../apis/{apiId}"]
        GETCRD["GET /automation/.../apis/{hrid}"]
    end

    FVDS["FlowValidationDomainService\n.checkHttpSelectorsPathOperator()"]
    VCRD["ValidateApiCRDDomainService\n.checkApiFlowsPathOperator()"]
    MAPW["FlowMapper.toRepository()\n(write — throws InvalidDataException)"]
    MAPR["FlowMapper.toDefinition()\n(read — defaults to STARTS_WITH)"]

    POSTAPI --> FVDS
    PUTAPI --> FVDS
    POSTPLAN --> FVDS
    PUTPLAN --> FVDS
    CRD --> VCRD
    FVDS --> MAPW
    VCRD --> MAPW

    GETAPI --> MAPR
    EXPORT --> MAPR
    GETPLANS --> MAPR
    DELAPI --> MAPR
    GETCRD --> MAPR
```

| Path | Endpoints | Effect after fix |
|------|-----------|------------------|
| `FlowValidationDomainService` | `POST`/`PUT` `/apis`, `POST`/`PUT` `/apis/{apiId}/plans` | Rejects null `pathOperator` with 400 |
| `ValidateApiCRDDomainService` | `PUT /automation/.../apis` (CRD import) | Rejects null `pathOperator` with 400 |
| `FlowMapper` write side | All create/update endpoints above | Defensive 400 backstop instead of NPE |
| `FlowMapper` read side | `GET`/`DELETE` `/apis`, `_export/definition`, `GET /apis/{apiId}/plans`, automation `GET` | Coerces stored null to `STARTS_WITH`; corrupt records load/delete/self-heal |

## User-facing impact

- **Behaviour change**: a v4 HTTP flow selector with a null `pathOperator` now returns `400` with a validation error instead of `500`, on the management API (create/update for both APIs and plans) and the automation/CRD endpoint. No more partial persistence of corrupt API records.
- **Recovery**: APIs already persisted with a null `pathOperator` are now readable, listable, exportable and deletable again (the operator defaults to `STARTS_WITH` on read) and self-heal on the next save.
- No API signature, config key, or default changes.

## How to test

The fix affects every endpoint in the diagram above — verify a representative write and read endpoint.

**Write path (validation):** create a v4 HTTP Proxy API with a flow HTTP selector that has `pathOperator: null`:

```
curl -s -w "\nHTTP_STATUS:%{http_code}" -X POST "http://localhost:8083/management/v2/environments/DEFAULT/apis" -H "Content-Type: application/json" -u "admin:admin" -d '{"name":"null-operator-test","apiVersion":"1.0","definitionVersion":"V4","type":"PROXY","flows":[{"name":"f1","enabled":true,"selectors":[{"type":"HTTP","path":"/","pathOperator":null,"methods":["GET"]}],"request":[],"response":[]}],"listeners":[{"type":"HTTP","paths":[{"path":"/null-operator-test"}],"entrypoints":[{"type":"http-proxy"}]}],"endpointGroups":[{"name":"default-group","type":"http-proxy","endpoints":[{"name":"default","type":"http-proxy","configuration":{"target":"https://httpbin.org"}}]}]}'
```

Expect a `400` with `flows[].selectors[].pathOperator is required`. Repeat with `PUT` against an existing API and with a plan create/update (`POST`/`PUT /apis/{apiId}/plans`) — same result, and the existing API/plan is left untouched. The automation `PUT /automation/.../apis` import returns 400 as well.

**Read path (self-heal):** for any API already persisted with a null `pathOperator` (e.g. created before this fix), `GET /apis/{apiId}`, `_export/definition`, and `DELETE` now succeed instead of returning 500; the selector reads back as `STARTS_WITH`.

## Known issues / follow-up

**CRD plan-flow null `pathOperator` is validated late, not up-front.** The up-front CRD guard (`ValidateApiCRDDomainService.checkApiFlowsPathOperator`) only inspects API-level `spec.flows`. A null `pathOperator` in a **plan** flow is caught downstream by `CreatePlanDomainService` at persistence time, which has two consequences specific to the CRD import endpoint (`PUT /apis/_import/crd`):

- **Real import (`dryRun=false`)** returns `400`, but the API document is committed *before* plan creation runs, so a flow-less **orphan API (no plans) is left behind** — i.e. rejected, but not "nothing persisted." The orphan is clean (no null is stored), reads/deletes normally, and the next reconcile with a corrected spec completes. This is the pre-existing non-transactional CRD partial-commit; this PR removes the 500/data-corruption, not the atomicity gap.
- **Dry-run (`dryRun=true`)** returns `200` (false-positive) for a plan-flow null, because dry-run runs only the up-front API-level check and skips the persistence-time plan validation. An API-level null is still correctly rejected at dry-run (`400`).

The plain management `POST`/`PUT /apis` and `POST`/`PUT /apis/{apiId}/plans` paths reject a null `pathOperator` with `400`, leave nothing persisted, and leave any existing API/plan untouched (verified). The gap above is specific to the CRD import/dry-run path and is tracked as follow-up.

[APIM-14022]: https://gravitee.atlassian.net/browse/APIM-14022?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


[APIM-14252]: https://gravitee.atlassian.net/browse/APIM-14252?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ