### PR TITLE
fix(authz-ui): self-host Monaco and lazy-load the Schema viewer

### DIFF
--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/app/AppRoutes.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/app/AppRoutes.tsx
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 import { useModuleRouting } from '@gravitee/gamma-modules-sdk/routing';
-import { SidebarNavigation, buildLinearBreadcrumbs, useLayoutConfig } from '@gravitee/graphene-core';
+import { SidebarNavigation, Skeleton, buildLinearBreadcrumbs, useLayoutConfig } from '@gravitee/graphene-core';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { useMemo } from 'react';
+import { Suspense, lazy, useMemo } from 'react';
 import { Navigate, Outlet, Route, Routes, useNavigate } from 'react-router-dom';
 import { NAV_GROUPS } from '../config/navigation';
 import { AUTHZ_ROUTE_CONFIG, ROUTES, type RouteKey } from '../config/routes';
@@ -27,8 +27,10 @@ import { McpsPage } from '../features/policy-management/pages/McpsPage';
 import { ModelsPage } from '../features/policy-management/pages/ModelsPage';
 import { ActionsPage } from '../features/policy-structure/ActionsPage';
 import { EntitiesPage } from '../features/policy-structure/EntitiesPage';
-import { SchemaPage } from '../features/policy-structure/SchemaPage';
 import { ModuleErrorBoundary } from './ModuleErrorBoundary';
+
+// Lazy-loaded so the ~600KB (gzip) Monaco bundle only ships when the read-only Schema viewer is opened.
+const SchemaPage = lazy(() => import('../features/policy-structure/SchemaPage').then(m => ({ default: m.SchemaPage })));
 
 const queryClient = new QueryClient();
 
@@ -68,7 +70,14 @@ export function AppRoutes() {
                         <Route path="custom-policies" element={<CustomPoliciesPage />} />
                         <Route path="entities" element={<EntitiesPage />} />
                         <Route path="actions" element={<ActionsPage />} />
-                        <Route path="schema" element={<SchemaPage />} />
+                        <Route
+                            path="schema"
+                            element={
+                                <Suspense fallback={<Skeleton className="h-[560px] w-full" />}>
+                                    <SchemaPage />
+                                </Suspense>
+                            }
+                        />
                     </Route>
                 </Routes>
             </ModuleErrorBoundary>

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/components/MonacoEditor.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/components/MonacoEditor.tsx
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import './monaco-setup';
 import Editor, { type EditorProps, type OnMount } from '@monaco-editor/react';
 import type * as monacoNs from 'monaco-editor';
 import { useEffect, useState } from 'react';

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/components/__tests__/MonacoEditor.test.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/components/__tests__/MonacoEditor.test.tsx
@@ -29,6 +29,8 @@ const capturedTheme: { current: string | null } = {
     current: null,
 };
 
+vi.mock('../monaco-setup', () => ({}));
+
 vi.mock('@monaco-editor/react', () => ({
     __esModule: true,
     default: (props: { onMount?: (editor: unknown, monaco: unknown) => void; options?: Record<string, unknown>; theme?: string }) => {

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/components/monaco-setup.ts
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/components/monaco-setup.ts
@@ -1,0 +1,25 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { loader } from '@monaco-editor/react';
+import * as monaco from 'monaco-editor/esm/vs/editor/editor.api';
+
+// Self-host Monaco from the bundled package instead of @monaco-editor/react's default jsDelivr CDN,
+// which is unreachable in firewalled/air-gapped deployments and flaky under CDN outages.
+self.MonacoEnvironment = {
+    getWorker: () => new Worker(new URL('monaco-editor/esm/vs/editor/editor.worker.js', import.meta.url)),
+};
+
+loader.config({ monaco });


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-XXX <!-- TODO: link the ticket -->

## Description

The read-only Schema viewer was stuck on "Loading..." in firewalled deployments. This PR fixes it and trims the bundle cost:

- **Self-host Monaco** — `@monaco-editor/react` defaults to fetching the Monaco runtime from the jsDelivr CDN, which is unreachable in firewalled/air-gapped environments and was returning 503s. The editor now loads from the locally bundled `monaco-editor` via `loader.config({ monaco })`, and the editor worker is served from the module's own `publicPath` instead of the CDN.
- **Lazy-load the Schema viewer** — `SchemaPage` is the only Monaco consumer and is read-only, yet a static import pulled its ~600KB (gzip) bundle into the eager module graph for *every* authz page. It now loads via `React.lazy`/`Suspense`, so Monaco ships only when the Schema route is opened.

## Additional context

**Verification**
- `vitest`: 412/412 passing.
- Rspack production build succeeds (exit 0).
- Build output confirms the Monaco chunk is no longer in the eager graph (`App` expose / `main` / `remoteEntry`) and is loaded asynchronously only via the Schema route chunk. No jsDelivr references in the emitted worker chunk.

**Reproduction / test steps**
- Open the Schema viewer in a firewalled/CDN-blocked environment and confirm it renders (no eternal "Loading...").
- Confirm Monaco network requests hit the app origin, not `cdn.jsdelivr.net`.
- Navigate to other authz pages (Dashboard, APIs, Entities) and confirm the Monaco chunk is not requested.

**Note**
- `MonacoEditor.tsx` already carries `TODO(GMA-384)` to replace Monaco with the Graphene editor component; this PR is the interim unblock, not a rework.