### PR TITLE
feat(portal-nav): increase navigation panel default width from 350px …

### DIFF
--- a/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.scss
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.scss
@@ -95,7 +95,7 @@ $outline-color: mat.m2-get-color-from-palette(gio.$mat-space-palette, lighter80)
 
 .sections-panel {
   padding: 16px;
-  width: 350px;
+  width: 400px;
   min-width: 280px;
   max-width: 600px;
   resize: none;

--- a/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.spec.ts
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.spec.ts
@@ -1676,9 +1676,9 @@ describe('PortalNavigationItemsComponent', () => {
       await expectGetNavigationItems(fakePortalNavigationItemsResponse({ items: [] }));
     });
 
-    it('should have default panel width of 350px', () => {
+    it('should have default panel width of 400px', () => {
       const component = fixture.componentInstance;
-      expect(component.panelWidth()).toBe(350);
+      expect(component.panelWidth()).toBe(400);
     });
 
     it('should increase panel width when dragging right', () => {
@@ -1686,7 +1686,7 @@ describe('PortalNavigationItemsComponent', () => {
       const resizeHandle = fixture.nativeElement.querySelector('.resize-handle');
 
       const initialWidth = component.panelWidth();
-      expect(initialWidth).toBe(350);
+      expect(initialWidth).toBe(400);
 
       // Simulate mousedown
       const mousedownEvent = new MouseEvent('mousedown', {
@@ -1706,7 +1706,7 @@ describe('PortalNavigationItemsComponent', () => {
       document.dispatchEvent(mousemoveEvent);
       fixture.detectChanges();
 
-      expect(component.panelWidth()).toBe(400);
+      expect(component.panelWidth()).toBe(450);
 
       // Simulate mouseup
       const mouseupEvent = new MouseEvent('mouseup', {
@@ -1722,7 +1722,7 @@ describe('PortalNavigationItemsComponent', () => {
       const resizeHandle = fixture.nativeElement.querySelector('.resize-handle');
 
       const initialWidth = component.panelWidth();
-      expect(initialWidth).toBe(350);
+      expect(initialWidth).toBe(400);
 
       // Simulate mousedown
       const mousedownEvent = new MouseEvent('mousedown', {
@@ -1742,7 +1742,7 @@ describe('PortalNavigationItemsComponent', () => {
       document.dispatchEvent(mousemoveEvent);
       fixture.detectChanges();
 
-      expect(component.panelWidth()).toBe(300);
+      expect(component.panelWidth()).toBe(350);
 
       // Simulate mouseup
       const mouseupEvent = new MouseEvent('mouseup', {
@@ -1758,7 +1758,7 @@ describe('PortalNavigationItemsComponent', () => {
       const resizeHandle = fixture.nativeElement.querySelector('.resize-handle');
 
       const initialWidth = component.panelWidth();
-      expect(initialWidth).toBe(350);
+      expect(initialWidth).toBe(400);
 
       // Simulate mousedown
       const mousedownEvent = new MouseEvent('mousedown', {
@@ -1794,7 +1794,7 @@ describe('PortalNavigationItemsComponent', () => {
       const resizeHandle = fixture.nativeElement.querySelector('.resize-handle');
 
       const initialWidth = component.panelWidth();
-      expect(initialWidth).toBe(350);
+      expect(initialWidth).toBe(400);
 
       // Simulate mousedown
       const mousedownEvent = new MouseEvent('mousedown', {

--- a/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.ts
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.ts
@@ -192,7 +192,7 @@ export class PortalNavigationItemsComponent implements HasUnsavedChanges {
   private readonly ngZone = inject(NgZone);
   private readonly MIN_PANEL_WIDTH = 280;
   private readonly MAX_PANEL_WIDTH = 600;
-  panelWidth = signal(350);
+  panelWidth = signal(400);
   initialContent = signal('');
 
   readonly currentPageContentType = signal<PortalPageContentType | null>(null);


### PR DESCRIPTION
Increases the default width of the navigation tree panel from 350px to 400px. The extra 50px is taken equally from the editor and preview columns inside the markdown editor, giving the navigation tree more room without any other layout changes.

<img width="1716" height="869" alt="image" src="https://github.com/user-attachments/assets/eb16fc3d-4de5-4ad2-9fc2-cdbf395bfce3" />
