### PR TITLE
feat(portal): add HTTP_STATUS filter to analytics details

### DIFF
--- a/gravitee-apim-portal-webui-next/src/app/dashboard/analytics/analytics-details/analytics-details.component.scss
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/analytics/analytics-details/analytics-details.component.scss
@@ -21,15 +21,22 @@
 .analytics-details__toolbar {
   display: flex;
   flex-direction: column;
-  gap: 8px;
-  margin-right: 32px;
+  gap: 16px;
+  padding-top: 8px;
 }
 
 .analytics-details__timeframe {
   display: flex;
   justify-content: flex-end;
+  margin-left: 32px;
+  margin-right: 32px;
 }
 
 .analytics-details__filters {
-  display: flex;
+  box-sizing: border-box;
+  margin-left: 32px;
+  margin-right: 32px;
+  padding: 10px 12px;
+  border: 1px solid var(--mat-form-field-outlined-outline-color);
+  border-radius: 4px;
 }

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/analytics/analytics-details/portal-analytics-filters.service.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/analytics/analytics-details/portal-analytics-filters.service.spec.ts
@@ -48,12 +48,16 @@ describe('PortalAnalyticsFiltersService', () => {
       expect(definitions).toHaveLength(4);
       expect(definitions.map(d => d.name)).toEqual(['API', 'APPLICATION', 'HTTP_STATUS_CODE_GROUP', 'HTTP_STATUS']);
       expect(definitions[0].type).toBe('KEYWORD');
+      expect(definitions[0].apiTypes).toEqual(['HTTP_PROXY', 'MESSAGE', 'LLM', 'MCP', 'NATIVE', 'EDGE']);
       expect(definitions[1].type).toBe('KEYWORD');
+      expect(definitions[1].apiTypes).toEqual(['HTTP_PROXY', 'MESSAGE', 'LLM', 'MCP', 'NATIVE', 'EDGE']);
       expect(definitions[2].type).toBe('ENUM');
       expect(definitions[2].values).toEqual(['1XX', '2XX', '3XX', '4XX', '5XX']);
+      expect(definitions[2].apiTypes).toEqual(['HTTP_PROXY', 'MESSAGE', 'LLM', 'MCP']);
       expect(definitions[3].type).toBe('NUMBER');
       expect(definitions[3].range).toEqual({ min: 100, max: 599 });
       expect(definitions[3].operators).toEqual(['EQ', 'LTE', 'GTE']);
+      expect(definitions[3].apiTypes).toEqual(['HTTP_PROXY', 'MESSAGE', 'LLM', 'MCP']);
       done();
     });
   });

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/analytics/analytics-details/portal-analytics-filters.service.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/analytics/analytics-details/portal-analytics-filters.service.spec.ts
@@ -43,14 +43,17 @@ describe('PortalAnalyticsFiltersService', () => {
     httpTestingController.verify();
   });
 
-  it('should_return_three_filter_definitions', done => {
+  it('should_return_four_filter_definitions', done => {
     service.getDefinitions().subscribe(definitions => {
-      expect(definitions).toHaveLength(3);
-      expect(definitions.map(d => d.name)).toEqual(['API', 'APPLICATION', 'HTTP_STATUS_CODE_GROUP']);
+      expect(definitions).toHaveLength(4);
+      expect(definitions.map(d => d.name)).toEqual(['API', 'APPLICATION', 'HTTP_STATUS_CODE_GROUP', 'HTTP_STATUS']);
       expect(definitions[0].type).toBe('KEYWORD');
       expect(definitions[1].type).toBe('KEYWORD');
       expect(definitions[2].type).toBe('ENUM');
-      expect(definitions[2].values).toEqual(['2xx', '4xx', '5xx']);
+      expect(definitions[2].values).toEqual(['1XX', '2XX', '3XX', '4XX', '5XX']);
+      expect(definitions[3].type).toBe('NUMBER');
+      expect(definitions[3].range).toEqual({ min: 100, max: 599 });
+      expect(definitions[3].operators).toEqual(['EQ', 'LTE', 'GTE']);
       done();
     });
   });
@@ -91,13 +94,10 @@ describe('PortalAnalyticsFiltersService', () => {
       });
   });
 
-  it('should_return_static_status_code_groups', done => {
+  it('should_return_empty_for_enum_status_code_group_filter', done => {
+    // ENUM filters source their options from the definition's `values`, not getValues().
     service.getValues({ filterName: 'HTTP_STATUS_CODE_GROUP', page: 1, perPage: 10 }).subscribe(result => {
-      expect(result.data).toEqual([
-        { value: '2xx', label: '2xx' },
-        { value: '4xx', label: '4xx' },
-        { value: '5xx', label: '5xx' },
-      ]);
+      expect(result.data).toEqual([]);
       expect(result.hasNextPage).toBe(false);
       done();
     });

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/analytics/analytics-details/portal-analytics-filters.service.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/analytics/analytics-details/portal-analytics-filters.service.ts
@@ -39,10 +39,17 @@ export class PortalAnalyticsFiltersService implements FilterDefinitionProvider, 
       { name: 'APPLICATION', label: $localize`:@@analyticsFilterApplication:Application`, type: 'KEYWORD', operators: ['EQ', 'IN'] },
       {
         name: 'HTTP_STATUS_CODE_GROUP',
-        label: $localize`:@@analyticsFilterStatusCode:Status Code`,
+        label: $localize`:@@analyticsFilterStatusCodeGroup:Status Code Group`,
         type: 'ENUM',
         operators: ['EQ', 'IN'],
-        values: ['2xx', '4xx', '5xx'],
+        values: ['1XX', '2XX', '3XX', '4XX', '5XX'],
+      },
+      {
+        name: 'HTTP_STATUS',
+        label: $localize`:@@analyticsFilterStatusCode:Status Code`,
+        type: 'NUMBER',
+        range: { min: 100, max: 599 },
+        operators: ['EQ', 'LTE', 'GTE'],
       },
     ]);
   }
@@ -63,15 +70,6 @@ export class PortalAnalyticsFiltersService implements FilterDefinitionProvider, 
             hasNextPage: (response.metadata?.pagination?.current_page ?? 1) < (response.metadata?.pagination?.total_pages ?? 1),
           })),
         );
-      case 'HTTP_STATUS_CODE_GROUP':
-        return of({
-          data: [
-            { value: '2xx', label: '2xx' },
-            { value: '4xx', label: '4xx' },
-            { value: '5xx', label: '5xx' },
-          ],
-          hasNextPage: false,
-        });
       default:
         return of({ data: [], hasNextPage: false });
     }

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/analytics/analytics-details/portal-analytics-filters.service.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/analytics/analytics-details/portal-analytics-filters.service.ts
@@ -35,14 +35,27 @@ export class PortalAnalyticsFiltersService implements FilterDefinitionProvider, 
 
   getDefinitions(): Observable<FilterDefinition[]> {
     return of([
-      { name: 'API', label: $localize`:@@analyticsFilterApi:API`, type: 'KEYWORD', operators: ['EQ', 'IN'] },
-      { name: 'APPLICATION', label: $localize`:@@analyticsFilterApplication:Application`, type: 'KEYWORD', operators: ['EQ', 'IN'] },
+      {
+        name: 'API',
+        label: $localize`:@@analyticsFilterApi:API`,
+        type: 'KEYWORD',
+        operators: ['EQ', 'IN'],
+        apiTypes: ['HTTP_PROXY', 'MESSAGE', 'LLM', 'MCP', 'NATIVE', 'EDGE'],
+      },
+      {
+        name: 'APPLICATION',
+        label: $localize`:@@analyticsFilterApplication:Application`,
+        type: 'KEYWORD',
+        operators: ['EQ', 'IN'],
+        apiTypes: ['HTTP_PROXY', 'MESSAGE', 'LLM', 'MCP', 'NATIVE', 'EDGE'],
+      },
       {
         name: 'HTTP_STATUS_CODE_GROUP',
         label: $localize`:@@analyticsFilterStatusCodeGroup:Status Code Group`,
         type: 'ENUM',
         operators: ['EQ', 'IN'],
         values: ['1XX', '2XX', '3XX', '4XX', '5XX'],
+        apiTypes: ['HTTP_PROXY', 'MESSAGE', 'LLM', 'MCP'],
       },
       {
         name: 'HTTP_STATUS',
@@ -50,6 +63,7 @@ export class PortalAnalyticsFiltersService implements FilterDefinitionProvider, 
         type: 'NUMBER',
         range: { min: 100, max: 599 },
         operators: ['EQ', 'LTE', 'GTE'],
+        apiTypes: ['HTTP_PROXY', 'MESSAGE', 'LLM', 'MCP'],
       },
     ]);
   }

--- a/gravitee-apim-portal-webui-next/src/components/sidenav-layout/sidenav-layout.component.scss
+++ b/gravitee-apim-portal-webui-next/src/components/sidenav-layout/sidenav-layout.component.scss
@@ -121,6 +121,7 @@ $transition-base: 300ms cubic-bezier(0.4, 0, 0.2, 1);
 
     &__content {
       overflow: auto;
+      scrollbar-gutter: stable;
       height: 100%;
 
       display: flex;

--- a/gravitee-apim-webui-libs/gravitee-dashboard/src/lib/components/filter/add-filter-dialog/add-filter-dialog.component.scss
+++ b/gravitee-apim-webui-libs/gravitee-dashboard/src/lib/components/filter/add-filter-dialog/add-filter-dialog.component.scss
@@ -28,6 +28,7 @@
   width: min(560px, calc(100vw - 32px));
   max-width: 100%;
   font-family: inherit;
+  overflow-y: auto;
 }
 
 :host > h2[mat-dialog-title] {
@@ -44,11 +45,7 @@
   width: 100%;
   max-width: 100%;
   font-family: inherit;
-  overflow-x: hidden;
-  overflow-y: auto;
-  -webkit-overflow-scrolling: touch;
-  // Extra top padding so outline floating labels are not clipped at the scroll edge.
-  padding-top: 12px;
+  overflow: visible;
   padding-bottom: 4px;
   box-sizing: border-box;
   // Let the host flex chain own vertical bounds; Material’s default max-height on


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-12834
https://gravitee.atlassian.net/browse/APIM-13657

## Description

- Adds API-type badges (HTTP Proxy, Message, LLM, MCP, NATIVE, EDGE) to the analytics
  filters, like the console.
- Adds the Status Code (HTTP_STATUS) filter.
- Aligns the timeframe/filter toolbar with the dashboard grid (32px gutters + scrollbar-gutter: stable to stop the width shifting when the scrollbar toggles).

## Additional context

<img width="1064" height="669" alt="Capture d’écran 2026-06-01 à 10 07 42" src="https://github.com/user-attachments/assets/39e30a64-7b8d-4ae3-b18b-08777b22f674" />