### PR TITLE
feat(tracing): expose spanCount + status on the trace wire

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/tracing/model/Trace.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/tracing/model/Trace.java
@@ -23,7 +23,10 @@ import java.util.List;
  * Aggregated view of a distributed trace returned by a {@link io.gravitee.repository.tracing.api.TracingRepository}.
  * <p>
  * In list responses {@code spans} is empty (the backend only carries summary attributes); {@code spans} is populated when the
- * trace is fetched by id. {@code hasError} may be {@code null} when the backend cannot determine the error status.
+ * trace is fetched by id. {@code status} is the trace-level rollup in the same {@code UNSET / OK / ERROR} vocabulary as per-span
+ * status — any span reporting {@code ERROR} promotes the whole trace to {@code ERROR}; otherwise the root span's status is used.
+ * {@code spanCount} is the total span count for the trace (the aggregation doc_count in list responses; {@code spans.size()} in
+ * fetch-by-id), which the UI surfaces alongside the row.
  *
  * @author GraviteeSource Team
  */
@@ -33,7 +36,8 @@ public record Trace(
     long durationNanos,
     String rootService,
     String rootOperation,
-    Boolean hasError,
+    String status,
+    int spanCount,
     List<TraceSpan> spans
 ) {
     public Trace {

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/tracing/ElasticsearchTracingRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/tracing/ElasticsearchTracingRepository.java
@@ -339,9 +339,15 @@ public class ElasticsearchTracingRepository implements TracingRepository {
         String rootOperation = textOrNull(rootSource.get("name"));
         long durationNanos = rootSource.path("duration").asLong(0L);
 
-        boolean hasError = bucket.path("error_count").path("doc_count").asLong(0L) > 0L;
+        long errorCount = bucket.path("error_count").path("doc_count").asLong(0L);
+        // Trace-level rollup: any ERROR span wins; else fall back to the root span's normalized status (OK / UNSET).
+        // Missing status on the root → UNSET, mirroring the per-span fallback in normalizeStatusCode.
+        String status = errorCount > 0L ? "ERROR" : statusOrUnset(normalizeStatusCode(rootSource));
+        // doc_count on a terms-agg bucket equals the number of documents (= spans) for that trace_id within the search
+        // window. Exposed to the caller so a listing row can render "N spans" without a second round-trip.
+        int spanCount = (int) bucket.path("doc_count").asLong(0L);
 
-        return new Trace(traceId, traceStart, durationNanos, rootService, rootOperation, hasError, List.of());
+        return new Trace(traceId, traceStart, durationNanos, rootService, rootOperation, status, spanCount, List.of());
     }
 
     private static Trace parseGetTraceResponse(String traceId, SearchResponse response) {
@@ -352,7 +358,7 @@ public class ElasticsearchTracingRepository implements TracingRepository {
         }
 
         List<TraceSpan> spans = new ArrayList<>(response.getSearchHits().getHits().size());
-        boolean hasError = false;
+        boolean anyError = false;
         TraceSpan rootSpan = null;
         for (SearchHit hit : response.getSearchHits().getHits()) {
             JsonNode source = hit.getSource();
@@ -365,7 +371,7 @@ public class ElasticsearchTracingRepository implements TracingRepository {
                 rootSpan = span;
             }
             if ("ERROR".equals(span.attributes().get(OTEL_STATUS_CODE_ATTR))) {
-                hasError = true;
+                anyError = true;
             }
         }
 
@@ -381,8 +387,15 @@ public class ElasticsearchTracingRepository implements TracingRepository {
         long durationNanos = rootSpan != null ? rootSpan.durationNanos() : 0L;
         String rootService = rootSpan != null ? rootSpan.serviceName() : null;
         String rootOperation = rootSpan != null ? rootSpan.operationName() : null;
+        // Same trace-level rollup as the list path: any ERROR span wins; else root span's status drives OK / UNSET.
+        String rootStatus = rootSpan != null ? rootSpan.attributes().get(OTEL_STATUS_CODE_ATTR) : null;
+        String status = anyError ? "ERROR" : statusOrUnset(rootStatus);
 
-        return new Trace(traceId, traceStart, durationNanos, rootService, rootOperation, hasError, spans);
+        return new Trace(traceId, traceStart, durationNanos, rootService, rootOperation, status, spans.size(), spans);
+    }
+
+    private static String statusOrUnset(String raw) {
+        return (raw == null || raw.isEmpty()) ? "UNSET" : raw;
     }
 
     private static TraceSpan parseSpan(JsonNode source) {

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/tracing/ElasticsearchTracingRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/tracing/ElasticsearchTracingRepositoryTest.java
@@ -134,7 +134,11 @@ class ElasticsearchTracingRepositoryTest {
         assertThat(trace.rootService()).isEqualTo("test-service");
         assertThat(trace.rootOperation()).isEqualTo("GET /ok");
         assertThat(trace.durationNanos()).isEqualTo(5_000_000L);
-        assertThat(trace.hasError()).isFalse();
+        // Root span's status drives the trace-level rollup when no span errored — buildTracesAggregation seeds it
+        // with STATUS_CODE_OK so the bucket should resolve to OK (not UNSET).
+        assertThat(trace.status()).isEqualTo("OK");
+        // doc_count on the bucket = number of spans for that trace_id. Fixture sets it to 3.
+        assertThat(trace.spanCount()).isEqualTo(3);
         assertThat(trace.startTime()).isEqualTo(Instant.parse("2026-04-30T10:00:00Z"));
         assertThat(trace.spans()).isEmpty();
     }
@@ -175,7 +179,7 @@ class ElasticsearchTracingRepositoryTest {
     }
 
     @Test
-    void getTrace_should_mark_trace_has_error_when_any_span_has_error_short_form_status() {
+    void getTrace_should_promote_trace_status_to_ERROR_when_any_span_has_error_short_form_status() {
         // The OTel ES exporter (otel mapping mode, recent versions) writes status.code as the short form ("Error"),
         // not the proto-enum-suffix form ("STATUS_CODE_ERROR"). Both must work.
         SearchResponse response = new SearchResponse();
@@ -196,7 +200,10 @@ class ElasticsearchTracingRepositoryTest {
         Trace trace = repository.getTrace(QUERY_CONTEXT, "a1b2c3d4", Map.of()).blockingGet();
 
         assertThat(trace).isNotNull();
-        assertThat(trace.hasError()).isTrue();
+        // Trace-level status rolls up to ERROR because at least one span reported ERROR. Wire vocabulary matches
+        // per-span status (UNSET / OK / ERROR) so the UI can reuse the same lookup.
+        assertThat(trace.status()).isEqualTo("ERROR");
+        assertThat(trace.spanCount()).isEqualTo(1);
         assertThat(trace.spans().get(0).attributes()).containsEntry("otel.status_code", "ERROR");
     }
 
@@ -333,6 +340,9 @@ class ElasticsearchTracingRepositoryTest {
         Aggregation traces = new Aggregation();
         Map<String, Object> bucket = new HashMap<>();
         bucket.put("key", "a1b2c3d4");
+        // doc_count on a terms-agg bucket = number of docs (= spans) for this trace_id. Exposed to the caller via
+        // Trace.spanCount so the listing row can render "N spans".
+        bucket.put("doc_count", 3);
         Map<String, Object> traceStart = new HashMap<>();
         traceStart.put("value_as_string", "2026-04-30T10:00:00Z");
         bucket.put("trace_start", traceStart);
@@ -350,6 +360,11 @@ class ElasticsearchTracingRepositoryTest {
         resourceAttributes.put("service", resourceService);
         resource.put("attributes", resourceAttributes);
         rootSource.put("resource", resource);
+        // Root span status drives the trace-level rollup when no span errored — the impl runs the same
+        // normalizeStatusCode logic on the rootSpan top_hits as it does on per-span sources, so seed it the same way.
+        Map<String, Object> rootStatus = new HashMap<>();
+        rootStatus.put("code", "STATUS_CODE_OK");
+        rootSource.put("status", rootStatus);
         rootSpanHitsHits.put("_source", rootSource);
         rootSpanHits.put("hits", List.of(rootSpanHitsHits));
         rootSpan.put("hits", rootSpanHits);

--- a/gravitee-gamma/gravitee-gamma-rest-api/TRACING_API.md
+++ b/gravitee-gamma/gravitee-gamma-rest-api/TRACING_API.md
@@ -62,6 +62,8 @@ not assume the lib types match the wire field-for-field.
 | `FilterCondition.label / valueLabels`      | (omitted)                                       | lib synthesises from `TraceFilterSpec` for enums, raw value otherwise |
 | `TraceSpan.startTime / endTime / duration` | `startTimeEpochMs` + `durationNanos`            | lib adapter (renames; computes `endTime = start + duration/1e6`) |
 | `TraceSpan.attributes: AttributeValue`     | `attributes: Map<String,String>`                | lib adapter (lossy — typed attributes tracked as a follow-up)    |
+| `WireTraceSummary.status: 'unset'\|'ok'\|'error'` | `status` (same lowercase union)         | none — backend emits the lib's exact vocabulary                  |
+| `WireTraceSummary.spanCount: number`       | `spanCount: int`                                | none — backend emits the bucket `doc_count` (list) / `spans.length` (detail) |
 
 **`endTime` is intentionally not emitted** on the wire — it's purely derivable as
 `startTimeEpochMs + durationNanos / 1_000_000`. Emitting it would risk drift between stored and
@@ -124,7 +126,8 @@ interface TraceSummary {
   durationNanos: number;
   rootServiceName: string;
   rootOperationName: string;
-  hasError: boolean;
+  status: 'unset' | 'ok' | 'error';  // trace-level rollup; any ERROR span → 'error', else root's status
+  spanCount: number;                  // total spans for the trace in the search window
 }
 ```
 
@@ -153,7 +156,8 @@ Example response:
       "durationNanos": 1234000,
       "rootServiceName": "gateway",
       "rootOperationName": "GET /pets",
-      "hasError": true
+      "status": "error",
+      "spanCount": 12
     }
   ],
   "pagination": { "totalCount": 42, "page": 1, "pageCount": 3 }
@@ -329,7 +333,8 @@ interface TraceDetail {
   durationNanos: number;      // root span duration in ns
   rootServiceName: string;
   rootOperationName: string;
-  hasError: boolean;
+  status: 'unset' | 'ok' | 'error';  // same rollup as TraceSummary.status
+  spanCount: number;                  // equal to spans.length
   spans: Span[];
 }
 

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/tracing/model/Trace.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/tracing/model/Trace.java
@@ -19,8 +19,13 @@ import java.time.Instant;
 
 /**
  * Summary view of a trace — what the listing endpoint returns. Carries just enough to render a row
- * (trace id, root span operation / service, duration, error flag, start time) without paying for the
- * full span tree. The detail endpoint switches to {@link TraceDetail} for the timeline view.
+ * (trace id, root span operation / service, duration, status, span count, start time) without paying
+ * for the full span tree. The detail endpoint switches to {@link TraceDetail} for the timeline view.
+ *
+ * <p>{@code status} is the trace-level rollup using the same {@link SpanStatus} vocabulary as per-span
+ * status — any span reporting {@link SpanStatus#ERROR} promotes the trace to {@link SpanStatus#ERROR},
+ * otherwise the root span's status drives the outcome. {@code spanCount} is the total number of spans
+ * recorded for the trace within the search window.
  *
  * @author GraviteeSource Team
  */
@@ -30,5 +35,6 @@ public record Trace(
     long durationNanos,
     String rootServiceName,
     String rootOperationName,
-    boolean hasError
+    SpanStatus status,
+    int spanCount
 ) {}

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/tracing/model/TraceDetail.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/tracing/model/TraceDetail.java
@@ -30,6 +30,7 @@ public record TraceDetail(
     long durationNanos,
     String rootServiceName,
     String rootOperationName,
-    boolean hasError,
+    SpanStatus status,
+    int spanCount,
     List<Span> spans
 ) {}

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/tracing/use_case/GetTraceDetailUseCase.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/tracing/use_case/GetTraceDetailUseCase.java
@@ -96,15 +96,23 @@ public class GetTraceDetailUseCase {
         }
 
         Span rootSpan = pickRootSpan(stitchedSpans);
+        // Trace-level status uses the same UNSET/OK/ERROR vocabulary as a span: any ERROR wins; else fall back to
+        // the root span's own status. Keeps the wire status field useful for "is this trace healthy?" filtering
+        // without forcing the consumer to walk every span.
+        SpanStatus traceStatus;
+        if (stitchedSpans.stream().anyMatch(s -> s.status() == SpanStatus.ERROR)) {
+            traceStatus = SpanStatus.ERROR;
+        } else {
+            traceStatus = rootSpan != null ? rootSpan.status() : SpanStatus.UNSET;
+        }
         TraceDetail detail = new TraceDetail(
             input.traceId,
             rootSpan != null ? rootSpan.startTime() : null,
             rootSpan != null ? rootSpan.durationNanos() : 0L,
             rootSpan != null ? rootSpan.serviceName() : null,
             rootSpan != null ? rootSpan.operationName() : null,
-            // Trace-wide error is "any span reported ERROR" — now reads from the promoted status field
-            // instead of digging into attributes['otel.status_code'].
-            stitchedSpans.stream().anyMatch(s -> s.status() == SpanStatus.ERROR),
+            traceStatus,
+            stitchedSpans.size(),
             stitchedSpans
         );
         return new Output(Optional.of(detail));

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/infra/adapter/TracingPortAdapter.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/infra/adapter/TracingPortAdapter.java
@@ -94,7 +94,10 @@ public class TracingPortAdapter implements TracingPort {
             source.durationNanos(),
             source.rootService(),
             source.rootOperation(),
-            Boolean.TRUE.equals(source.hasError())
+            // The SPI emits status as a UNSET/OK/ERROR string (matches per-span normalizeStatusCode output); the
+            // core layer lifts it to the typed enum so the use case + DTO don't have to know the string vocabulary.
+            SpanStatus.fromAttribute(source.status()),
+            source.spanCount()
         );
     }
 

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/resources/tracing/dto/TraceDetailDto.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/resources/tracing/dto/TraceDetailDto.java
@@ -20,7 +20,7 @@ import java.util.List;
 
 /**
  * Full trace detail response — summary fields plus the assembled span tree. See {@link TraceSummaryDto}
- * for the ms-since-epoch timestamp rationale.
+ * for the ms-since-epoch timestamp rationale and the lowercase {@code status} vocabulary.
  */
 public record TraceDetailDto(
     String traceId,
@@ -28,7 +28,8 @@ public record TraceDetailDto(
     long durationNanos,
     String rootServiceName,
     String rootOperationName,
-    boolean hasError,
+    String status,
+    int spanCount,
     List<SpanDto> spans
 ) {
     public static TraceDetailDto from(TraceDetail detail) {
@@ -38,7 +39,8 @@ public record TraceDetailDto(
             detail.durationNanos(),
             detail.rootServiceName(),
             detail.rootOperationName(),
-            detail.hasError(),
+            detail.status().name().toLowerCase(),
+            detail.spanCount(),
             detail
                 .spans()
                 .stream()

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/resources/tracing/dto/TraceSummaryDto.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/resources/tracing/dto/TraceSummaryDto.java
@@ -26,6 +26,10 @@ import io.gravitee.gamma.rest.core.tracing.model.Trace;
  * Jackson's {@code Instant} handling entirely — the parent rest-api ObjectMapper has
  * {@code WRITE_DATES_AS_TIMESTAMPS} enabled, which would otherwise serialise Instant as a fractional
  * {@code <epoch_seconds>.<nanos>} value that JS code misinterprets as milliseconds.
+ *
+ * <p>{@code status} is emitted lowercase ({@code "unset" | "ok" | "error"}) to match the
+ * {@code @gravitee/gamma-lib-observability} {@code WireTraceSummary.status} contract — the lib renders
+ * a status badge per row from this exact vocabulary.
  */
 public record TraceSummaryDto(
     String traceId,
@@ -33,7 +37,8 @@ public record TraceSummaryDto(
     long durationNanos,
     String rootServiceName,
     String rootOperationName,
-    boolean hasError
+    String status,
+    int spanCount
 ) {
     public static TraceSummaryDto from(Trace trace) {
         return new TraceSummaryDto(
@@ -42,7 +47,8 @@ public record TraceSummaryDto(
             trace.durationNanos(),
             trace.rootServiceName(),
             trace.rootOperationName(),
-            trace.hasError()
+            trace.status().name().toLowerCase(),
+            trace.spanCount()
         );
     }
 }

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/resources/openapi/openapi-tracing.yaml
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/resources/openapi/openapi-tracing.yaml
@@ -440,7 +440,7 @@ components:
         TraceSummary:
             type: object
             description: Summary view of one trace returned by the list endpoint.
-            required: [traceId, startTimeEpochMs, durationNanos, rootServiceName, rootOperationName, hasError]
+            required: [traceId, startTimeEpochMs, durationNanos, rootServiceName, rootOperationName, status, spanCount]
             properties:
                 traceId:
                     type: string
@@ -466,15 +466,27 @@ components:
                     type: string
                     description: Operation name of the trace's root span.
                     example: GET /pets
-                hasError:
-                    type: boolean
-                    description: True iff any span in the trace has `status === "error"`. Precomputed server-side from `otel.status_code`.
-                    example: false
+                status:
+                    type: string
+                    enum: [unset, ok, error]
+                    description: |
+                        Trace-level status rollup using the same vocabulary as per-span `status`.
+                        Any span reporting `error` promotes the whole trace to `error`; otherwise the
+                        root span's status drives the outcome (`ok` or `unset`). Lowercase to match
+                        the lib's `WireTraceSummary.status` union.
+                    example: ok
+                spanCount:
+                    type: integer
+                    description: |
+                        Total span count for the trace within the search window. Computed
+                        server-side from the aggregation's `doc_count` per `trace_id` bucket — no
+                        extra round-trip needed to render "N spans" on a listing row.
+                    example: 12
 
         TraceDetail:
             type: object
             description: Full trace view returned by the detail endpoint — summary fields plus the assembled span tree.
-            required: [traceId, startTimeEpochMs, durationNanos, hasError, spans]
+            required: [traceId, startTimeEpochMs, durationNanos, status, spanCount, spans]
             properties:
                 traceId:
                     type: string
@@ -492,8 +504,13 @@ components:
                 rootOperationName:
                     type: string
                     nullable: true
-                hasError:
-                    type: boolean
+                status:
+                    type: string
+                    enum: [unset, ok, error]
+                    description: Same trace-level status rollup as `TraceSummary.status`.
+                spanCount:
+                    type: integer
+                    description: Equal to `spans.length` for the detail response. Sent on the envelope so the renderer doesn't need a `.length` walk before the array is rendered.
                 spans:
                     type: array
                     description: |

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/test/java/io/gravitee/gamma/rest/core/tracing/use_case/GetTraceDetailUseCaseTest.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/test/java/io/gravitee/gamma/rest/core/tracing/use_case/GetTraceDetailUseCaseTest.java
@@ -142,7 +142,7 @@ class GetTraceDetailUseCaseTest {
     }
 
     @Test
-    void should_flag_hasError_when_any_span_has_ERROR_status() {
+    void should_promote_trace_status_to_ERROR_when_any_span_has_ERROR_status() {
         Span ok = span("ok", null, "GET /pets", Instant.parse("2026-05-26T15:00:00Z"));
         Span failing = new Span(
             "failing",
@@ -161,16 +161,46 @@ class GetTraceDetailUseCaseTest {
 
         TraceDetail detail = useCase.execute(input()).trace().orElseThrow();
 
-        assertThat(detail.hasError()).isTrue();
+        assertThat(detail.status()).isEqualTo(SpanStatus.ERROR);
     }
 
     @Test
-    void should_not_flag_hasError_when_no_span_has_ERROR_status() {
-        givenTraceWithSpans(List.of(span("root", null, "GET /pets", Instant.parse("2026-05-26T15:00:00Z"))));
+    void should_fall_back_to_root_span_status_when_no_span_has_ERROR_status() {
+        // Root with explicit OK status — no spans errored, so the trace rolls up to the root's status (OK), not
+        // the default UNSET. Caller filters on "healthy traces" via status == OK can rely on this fallback.
+        Span root = new Span(
+            "root",
+            null,
+            "GET /pets",
+            "gateway",
+            Instant.parse("2026-05-26T15:00:00Z"),
+            1_000L,
+            SpanStatus.OK,
+            SpanKind.INTERNAL,
+            Map.of(),
+            List.of(),
+            List.of()
+        );
+        givenTraceWithSpans(List.of(root));
 
         TraceDetail detail = useCase.execute(input()).trace().orElseThrow();
 
-        assertThat(detail.hasError()).isFalse();
+        assertThat(detail.status()).isEqualTo(SpanStatus.OK);
+    }
+
+    @Test
+    void should_report_span_count_matching_the_assembled_span_list() {
+        givenTraceWithSpans(
+            List.of(
+                span("root", null, "GET /pets", Instant.parse("2026-05-26T15:00:00Z")),
+                span("child-1", "root", "policy-pre", Instant.parse("2026-05-26T15:00:01Z")),
+                span("child-2", "root", "policy-post", Instant.parse("2026-05-26T15:00:02Z"))
+            )
+        );
+
+        TraceDetail detail = useCase.execute(input()).trace().orElseThrow();
+
+        assertThat(detail.spanCount()).isEqualTo(3);
     }
 
     private Span span(String spanId, String parentSpanId, String op, Instant start) {
@@ -190,11 +220,14 @@ class GetTraceDetailUseCaseTest {
     }
 
     private void givenTraceWithSpans(List<Span> spans) {
+        // The summary Trace stamped onto the port is unused by GetTraceDetailUseCase (it builds TraceDetail from
+        // the spans list). Stub with UNSET / 0 so the fixture doesn't lie about the trace status — the use case
+        // computes status from the spans list, not from this seed.
         tracingPort.givenTrace(
             ORG,
             ENV,
             Map.of(TracingResourceFilters.ENV_ID_KEY, ENV, TracingResourceFilters.API_ID_KEY, API_ID),
-            new Trace(TRACE_ID, spans.get(0).startTime(), 1_000L, "gateway", spans.get(0).operationName(), false),
+            new Trace(TRACE_ID, spans.get(0).startTime(), 1_000L, "gateway", spans.get(0).operationName(), SpanStatus.UNSET, 0),
             spans
         );
     }

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/test/java/io/gravitee/gamma/rest/core/tracing/use_case/SearchTracesUseCaseTest.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/test/java/io/gravitee/gamma/rest/core/tracing/use_case/SearchTracesUseCaseTest.java
@@ -23,6 +23,7 @@ import io.gravitee.gamma.rest.core.tracing.exception.UnsupportedFilterException;
 import io.gravitee.gamma.rest.core.tracing.inmemory.InMemoryTracingPort;
 import io.gravitee.gamma.rest.core.tracing.model.FilterCondition;
 import io.gravitee.gamma.rest.core.tracing.model.FilterOperator;
+import io.gravitee.gamma.rest.core.tracing.model.SpanStatus;
 import io.gravitee.gamma.rest.core.tracing.model.Trace;
 import java.time.Duration;
 import java.time.Instant;
@@ -150,7 +151,7 @@ class SearchTracesUseCaseTest {
             ORG,
             ENV,
             Map.of(TracingResourceFilters.ENV_ID_KEY, ENV, TracingResourceFilters.API_ID_KEY, apiId),
-            new Trace(traceId, startTime, 1_000L, "gateway", "GET /pets", false),
+            new Trace(traceId, startTime, 1_000L, "gateway", "GET /pets", SpanStatus.OK, 1),
             null
         );
     }

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/test/java/io/gravitee/gamma/rest/resource/tracing/TracingResourceTest.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/test/java/io/gravitee/gamma/rest/resource/tracing/TracingResourceTest.java
@@ -125,7 +125,7 @@ class TracingResourceTest extends AbstractResourceTest {
 
         @Test
         void should_return_traces_with_logs_aligned_envelope_and_iso_8601_start_time() {
-            Trace trace = new Trace(TRACE_ID, SAMPLE_INSTANT, 1_234_000L, "gateway", "GET /pets", false);
+            Trace trace = new Trace(TRACE_ID, SAMPLE_INSTANT, 1_234_000L, "gateway", "GET /pets", SpanStatus.OK, 3);
             when(searchTracesUseCase.execute(any())).thenReturn(new SearchTracesUseCase.Output(new Page<>(List.of(trace), 0, 1, 1)));
 
             Response response = postSearch(Map.of("apiId", API_ID));
@@ -142,7 +142,10 @@ class TracingResourceTest extends AbstractResourceTest {
             assertThat(row.get("rootServiceName").asText()).isEqualTo("gateway");
             assertThat(row.get("rootOperationName").asText()).isEqualTo("GET /pets");
             assertThat(row.get("durationNanos").asLong()).isEqualTo(1_234_000L);
-            assertThat(row.get("hasError").asBoolean()).isFalse();
+            // status emitted lowercase to match the lib's WireTraceSummary.status union ('unset' | 'ok' | 'error');
+            // spanCount lets the listing row render "N spans" without a second round-trip.
+            assertThat(row.get("status").asText()).isEqualTo("ok");
+            assertThat(row.get("spanCount").asInt()).isEqualTo(3);
             // ms-since-epoch emission is load-bearing: see TraceSummaryDto's javadoc — the long
             // field type bypasses Jackson's Instant handling and the parent rest-api ObjectMapper's
             // WRITE_DATES_AS_TIMESTAMPS default that would otherwise emit <epoch_seconds>.<nanos>.
@@ -238,7 +241,16 @@ class TracingResourceTest extends AbstractResourceTest {
                 List.<SpanEvent>of(),
                 List.<PayloadLog>of()
             );
-            TraceDetail detail = new TraceDetail(TRACE_ID, SAMPLE_INSTANT, 1_234_000L, "gateway", "GET /pets", false, List.of(span));
+            TraceDetail detail = new TraceDetail(
+                TRACE_ID,
+                SAMPLE_INSTANT,
+                1_234_000L,
+                "gateway",
+                "GET /pets",
+                SpanStatus.OK,
+                1,
+                List.of(span)
+            );
             when(getTraceDetailUseCase.execute(any())).thenReturn(new GetTraceDetailUseCase.Output(Optional.of(detail)));
 
             Response response = detailRequest().request().get();
@@ -247,6 +259,9 @@ class TracingResourceTest extends AbstractResourceTest {
             JsonNode body = response.readEntity(JsonNode.class);
             assertThat(body.get("traceId").asText()).isEqualTo(TRACE_ID);
             assertThat(body.get("startTimeEpochMs").asLong()).isEqualTo(SAMPLE_INSTANT.toEpochMilli());
+            // status/spanCount mirror the lib's WireTraceDetail expectation — same vocabulary as the summary row.
+            assertThat(body.get("status").asText()).isEqualTo("ok");
+            assertThat(body.get("spanCount").asInt()).isEqualTo(1);
             assertThat(body.get("spans")).hasSize(1);
             JsonNode spanNode = body.get("spans").get(0);
             // traceId echoed on every span — matches OTel transports and lib's TraceSpan required field.


### PR DESCRIPTION
## Issue

N/A — follow-up to #17143 (slim trace explorer).

## Description

The gamma-lib-observability `WireTraceSummary` contract expects `spanCount: number` and `status: 'unset' | 'ok' | 'error'`; the slim PR emitted `hasError: boolean` instead and no count, so the lib reads both as `undefined` when consuming the gamma trace endpoints (status badge and "N spans" column both render blank).

This PR closes that gap end-to-end:

- **SPI `Trace` record** (`gravitee-apim-repository-api`): `Boolean hasError` → `String status` (`UNSET` / `OK` / `ERROR`), and a new `int spanCount`. Only consumers are the ES adapter, the noop, and the gamma adapter — all updated in this PR.
- **ES adapter** (`ElasticsearchTracingRepository`): list path derives `status` from the existing `error_count` sub-aggregation + the root span's `normalizeStatusCode` (`error_count > 0` → `ERROR`, else root's status, else `UNSET`), and `spanCount` from the terms-agg bucket's `doc_count`. Detail path uses the same rollup against the spans list with `spans.size()` for the count.
- **Gamma domain** (`gravitee-gamma-rest-api`): `Trace` / `TraceDetail` records carry `SpanStatus status` + `int spanCount`; `GetTraceDetailUseCase` re-derives the trace-level rollup from the stitched span list (any `ERROR` → `ERROR`, else root span's own status).
- **Wire**: `TraceSummaryDto` / `TraceDetailDto` emit the lib's exact vocabulary — lowercase `status` enum and integer `spanCount`. OpenAPI schema + `TRACING_API.md` updated; the Lib↔Wire mapping table now lists both fields as direct (no adapter translation needed on the lib side).

### Tests

All green:

- **ES adapter (12)** — `searchTraces_should_map_aggregation_buckets_to_traces` pins both new fields against a seeded `doc_count: 3` + `status.code: STATUS_CODE_OK`; the renamed `getTrace_should_promote_trace_status_to_ERROR_when_any_span_has_error_short_form_status` replaces the old `hasError` test.
- **Gamma domain (16)** — `GetTraceDetailUseCaseTest` gained `should_promote_trace_status_to_ERROR_when_any_span_has_ERROR_status`, `should_fall_back_to_root_span_status_when_no_span_has_ERROR_status`, and `should_report_span_count_matching_the_assembled_span_list`.
- **REST contract (16)** — `TracingResourceTest` asserts wire emission: `status: "ok"` (lowercase) + `spanCount: 3` on the list row, and `status: "ok"` + `spanCount: 1` on the detail envelope.

## Additional context

- **Companion to the lib v1.15.0 work in `gravitee-lib-observability`** — Sam already shipped `WireTraceSummary` / `WireTraceDetail` expecting these fields. The lib's adapter (`http-traces-source.ts:21`, `mapTraceSummary`) reads `wire.spanCount` and `wire.status` directly. No lib change needed once this lands.
- **Wire shape impact** — strictly additive for `spanCount` (new field); `hasError: boolean` replaced by `status: string` enum on both endpoints. No other consumers in the codebase, so no compat shim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)