### PR TITLE
feat(authz-ui): inline-define policy-only principals and resources

### DIFF
--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/features/policy-management/PolicyBuilder.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/features/policy-management/PolicyBuilder.tsx
@@ -17,6 +17,7 @@ import { Button } from '@gravitee/graphene-core';
 import { PlusIcon, SparklesIcon } from '@gravitee/graphene-core/icons';
 import type { ChipOption } from '../../shared/chip-option';
 import { PolicyStatementCard } from './PolicyStatementCard';
+import type { InlineCreateConfig } from './inline-entity-create';
 import { createEmptyStatement, makeStatementId, type PolicyEffect, type PolicyStatement } from './statement-to-gapl';
 
 export interface PolicyBuilderProps {
@@ -30,6 +31,8 @@ export interface PolicyBuilderProps {
     readonly emptyPrincipalsHint?: string;
     readonly emptyActionsHint?: string;
     readonly emptyResourcesHint?: string;
+    readonly principalCreate?: InlineCreateConfig;
+    readonly resourceCreate?: InlineCreateConfig;
 }
 
 export function PolicyBuilder({
@@ -43,6 +46,8 @@ export function PolicyBuilder({
     emptyPrincipalsHint,
     emptyActionsHint,
     emptyResourcesHint,
+    principalCreate,
+    resourceCreate,
 }: PolicyBuilderProps) {
     const addStatement = (effect: PolicyEffect) => onChange([...statements, createEmptyStatement(effect)]);
 
@@ -102,6 +107,8 @@ export function PolicyBuilder({
                     emptyPrincipalsHint={emptyPrincipalsHint}
                     emptyActionsHint={emptyActionsHint}
                     emptyResourcesHint={emptyResourcesHint}
+                    principalCreate={principalCreate}
+                    resourceCreate={resourceCreate}
                 />
             ))}
             <div className="flex flex-col items-start gap-1.5 pt-1">

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/features/policy-management/PolicyEditorSheet.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/features/policy-management/PolicyEditorSheet.tsx
@@ -27,6 +27,7 @@ import { parseGaplToStatements } from '../../shared/gapl-policy-parser';
 import { PolicyBuilder } from './PolicyBuilder';
 import { relativeTime } from './PolicyListTable';
 import type { CatalogEntry, ServicePageConfig } from './ServicePolicyPage';
+import type { InlineCreateConfig } from './inline-entity-create';
 import { createEmptyStatement, statementsToGapl, type PolicyStatement } from './statement-to-gapl';
 
 export interface PolicyEditorSheetProps {
@@ -42,6 +43,8 @@ export interface PolicyEditorSheetProps {
     readonly emptyPrincipalsHint?: string;
     readonly emptyActionsHint?: string;
     readonly emptyResourcesHint?: string;
+    readonly principalCreate?: InlineCreateConfig;
+    readonly resourceCreate?: InlineCreateConfig;
 }
 
 const TEMPLATE = 'permit (principal, action, resource);';
@@ -61,6 +64,8 @@ export function PolicyEditorSheet({
     emptyPrincipalsHint,
     emptyActionsHint,
     emptyResourcesHint,
+    principalCreate,
+    resourceCreate,
 }: PolicyEditorSheetProps) {
     const [name, setName] = useState('');
     const [description, setDescription] = useState('');
@@ -326,6 +331,8 @@ export function PolicyEditorSheet({
                             emptyPrincipalsHint={emptyPrincipalsHint}
                             emptyActionsHint={emptyActionsHint}
                             emptyResourcesHint={emptyResourcesHint}
+                            principalCreate={principalCreate}
+                            resourceCreate={resourceCreate}
                         />
                     ) : (
                         <CodePane

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/features/policy-management/PolicyStatementCard.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/features/policy-management/PolicyStatementCard.tsx
@@ -440,10 +440,13 @@ function InlineCreatePanel({ createConfig, query, existingLabels, onCreated }: I
     if (displayName === '' || exactMatch) return null;
 
     const slugInvalid = !slug || !SLUG_REGEX.test(slug);
+    const candidate = slugInvalid ? null : createConfig.create({ canonicalPrefix: canonical, slug, displayName });
+    const idExists = candidate !== null && existingLabels.some(o => o.id === candidate.id);
+    const disabled = slugInvalid || idExists;
 
     const runCreate = () => {
-        if (slugInvalid) return;
-        onCreated(createConfig.create({ canonicalPrefix: canonical, slug, displayName }));
+        if (disabled || candidate === null) return;
+        onCreated(candidate);
     };
 
     return (
@@ -473,12 +476,15 @@ function InlineCreatePanel({ createConfig, query, existingLabels, onCreated }: I
                 size="xs"
                 onMouseDown={e => e.preventDefault()}
                 onClick={runCreate}
-                disabled={slugInvalid}
+                disabled={disabled}
                 className="mt-1.5 w-full justify-start"
             >
                 <PlusIcon className="mr-1 size-3" aria-hidden />
                 <span className="truncate">
-                    Add <span className="font-mono">{canonical}.{slug || '…'}</span>
+                    {idExists ? 'Already in list: ' : 'Add '}
+                    <span className="font-mono">
+                        {canonical}.{slug || '…'}
+                    </span>
                 </span>
             </Button>
         </div>

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/features/policy-management/PolicyStatementCard.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/features/policy-management/PolicyStatementCard.tsx
@@ -29,12 +29,17 @@ import {
     Textarea,
     ToggleGroup,
     ToggleGroupItem,
+    Tooltip,
+    TooltipContent,
+    TooltipProvider,
+    TooltipTrigger,
     cn,
     useComboboxAnchor,
 } from '@gravitee/graphene-core';
-import { ChevronDownIcon, ChevronUpIcon, CopyIcon, Trash2Icon, TriangleAlertIcon } from '@gravitee/graphene-core/icons';
+import { ChevronDownIcon, ChevronUpIcon, CopyIcon, PlusIcon, Trash2Icon, TriangleAlertIcon } from '@gravitee/graphene-core/icons';
 import { useMemo, useState } from 'react';
 import type { ChipOption } from '../../shared/chip-option';
+import { SLUG_REGEX, slugify, type InlineCreateConfig } from './inline-entity-create';
 import type { ActionRef, PolicyEffect, PolicyStatement, PrincipalRef, ResourceRef } from './statement-to-gapl';
 
 const GAPL_UID_PATTERN = /^([^:]+)::"(.+)"$/;
@@ -57,6 +62,8 @@ export interface PolicyStatementCardProps {
     readonly emptyPrincipalsHint?: string;
     readonly emptyActionsHint?: string;
     readonly emptyResourcesHint?: string;
+    readonly principalCreate?: InlineCreateConfig;
+    readonly resourceCreate?: InlineCreateConfig;
 }
 
 const DEFAULT_CONDITION_SNIPPETS: readonly { label: string; snippet: string }[] = [
@@ -84,6 +91,8 @@ export function PolicyStatementCard({
     emptyPrincipalsHint,
     emptyActionsHint,
     emptyResourcesHint,
+    principalCreate,
+    resourceCreate,
 }: PolicyStatementCardProps) {
     const [conditionOpen, setConditionOpen] = useState(Boolean((statement.condition ?? '').trim()));
 
@@ -137,6 +146,7 @@ export function PolicyStatementCard({
     const snippets = conditionSnippets ?? DEFAULT_CONDITION_SNIPPETS;
 
     return (
+        <TooltipProvider>
         <div className={cn('rounded-lg border bg-card p-3 shadow-sm', effectBorderClass)}>
             <div className="flex items-center justify-between gap-2">
                 <div className="flex items-center gap-2">
@@ -206,6 +216,7 @@ export function PolicyStatementCard({
                         onChange={syncPrincipals}
                         groupOrder={['User', 'Group', 'ServiceAccount', 'AgentIdentity']}
                         emptyHint={emptyPrincipalsHint}
+                        createConfig={principalCreate}
                     />
                 </ChipField>
 
@@ -228,6 +239,7 @@ export function PolicyStatementCard({
                         onChange={syncResources}
                         groupOrder={resourceGroups.map(g => g.key)}
                         emptyHint={emptyResourcesHint}
+                        createConfig={resourceCreate}
                     />
                 </ChipField>
             </div>
@@ -271,6 +283,7 @@ export function PolicyStatementCard({
                 ) : null}
             </div>
         </div>
+        </TooltipProvider>
     );
 }
 
@@ -290,9 +303,10 @@ interface ChipMultiComboboxProps {
     readonly onChange: (ids: string[]) => void;
     readonly groupOrder?: readonly string[];
     readonly emptyHint?: string;
+    readonly createConfig?: InlineCreateConfig;
 }
 
-function ChipMultiCombobox({ placeholder, options, selectedIds, onChange, groupOrder, emptyHint }: ChipMultiComboboxProps) {
+function ChipMultiCombobox({ placeholder, options, selectedIds, onChange, groupOrder, emptyHint, createConfig }: ChipMultiComboboxProps) {
     const anchorRef = useComboboxAnchor();
     const [query, setQuery] = useState('');
 
@@ -350,7 +364,7 @@ function ChipMultiCombobox({ placeholder, options, selectedIds, onChange, groupO
             <ComboboxChips ref={anchorRef}>
                 {values.map(id => {
                     const { label, ghost } = labelOf(id);
-                    return (
+                    const chip = (
                         <ComboboxChip
                             key={id}
                             removeAriaLabel={`Remove ${label}`}
@@ -360,10 +374,17 @@ function ChipMultiCombobox({ placeholder, options, selectedIds, onChange, groupO
                             {label}
                         </ComboboxChip>
                     );
+                    if (!ghost) return chip;
+                    return (
+                        <Tooltip key={id}>
+                            <TooltipTrigger asChild>{chip}</TooltipTrigger>
+                            <TooltipContent>Defined only in this policy. Add it under Entities to reuse it.</TooltipContent>
+                        </Tooltip>
+                    );
                 })}
                 <ComboboxChipsInput placeholder={values.length === 0 ? placeholder : 'Type to filter…'} aria-label={placeholder} />
             </ComboboxChips>
-            <ComboboxContent anchor={anchorRef} className="max-h-64 min-w-60" style={{ pointerEvents: 'auto' }}>
+            <ComboboxContent anchor={anchorRef} className="max-h-72 min-w-60" style={{ pointerEvents: 'auto' }}>
                 <ComboboxList>
                     {!hasVisibleItems && (
                         <ComboboxEmpty>
@@ -386,7 +407,80 @@ function ChipMultiCombobox({ placeholder, options, selectedIds, onChange, groupO
                         </ComboboxGroup>
                     ))}
                 </ComboboxList>
+                {createConfig ? (
+                    <InlineCreatePanel
+                        createConfig={createConfig}
+                        query={query}
+                        existingLabels={options}
+                        onCreated={opt => {
+                            if (!values.includes(opt.id)) onChange([...values, opt.id]);
+                            setQuery('');
+                        }}
+                    />
+                ) : null}
             </ComboboxContent>
         </Combobox>
+    );
+}
+
+interface InlineCreatePanelProps {
+    readonly createConfig: InlineCreateConfig;
+    readonly query: string;
+    readonly existingLabels: readonly ChipOption[];
+    readonly onCreated: (option: ChipOption) => void;
+}
+
+function InlineCreatePanel({ createConfig, query, existingLabels, onCreated }: InlineCreatePanelProps) {
+    const [canonical, setCanonical] = useState(createConfig.defaultCanonical);
+
+    const displayName = query.trim();
+    const slug = slugify(displayName);
+    const exactMatch = displayName !== '' && existingLabels.some(o => o.label.toLowerCase() === displayName.toLowerCase());
+
+    if (displayName === '' || exactMatch) return null;
+
+    const slugInvalid = !slug || !SLUG_REGEX.test(slug);
+
+    const runCreate = () => {
+        if (slugInvalid) return;
+        onCreated(createConfig.create({ canonicalPrefix: canonical, slug, displayName }));
+    };
+
+    return (
+        <div className="border-t px-2 py-2">
+            <p className="px-1 pb-1 text-xs font-medium text-muted-foreground">Add to this policy only</p>
+            <div className="flex flex-wrap gap-1 px-1">
+                {createConfig.presets.map(preset => (
+                    <button
+                        key={preset.canonical}
+                        type="button"
+                        onMouseDown={e => e.preventDefault()}
+                        onClick={() => setCanonical(preset.canonical)}
+                        className={cn(
+                            'rounded border px-1.5 py-0.5 text-xs',
+                            canonical === preset.canonical
+                                ? 'border-primary bg-primary/10 text-primary'
+                                : 'border-dashed text-muted-foreground hover:border-foreground/40 hover:text-foreground',
+                        )}
+                    >
+                        {preset.label}
+                    </button>
+                ))}
+            </div>
+            <Button
+                type="button"
+                variant="outline"
+                size="xs"
+                onMouseDown={e => e.preventDefault()}
+                onClick={runCreate}
+                disabled={slugInvalid}
+                className="mt-1.5 w-full justify-start"
+            >
+                <PlusIcon className="mr-1 size-3" aria-hidden />
+                <span className="truncate">
+                    Add <span className="font-mono">{canonical}.{slug || '…'}</span>
+                </span>
+            </Button>
+        </div>
     );
 }

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/features/policy-management/ServicePolicyPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/features/policy-management/ServicePolicyPage.tsx
@@ -49,6 +49,13 @@ import { usePolicies } from '../../shared/hooks/usePolicies';
 import { useSchema } from '../../shared/hooks/useSchema';
 import { PolicyEditorSheet } from './PolicyEditorSheet';
 import { PolicyListTable } from './PolicyListTable';
+import {
+    defaultResourceCanonical,
+    makeInlineEntityCreator,
+    PRINCIPAL_INLINE_PRESETS,
+    RESOURCE_INLINE_PRESETS,
+    type InlineCreateConfig,
+} from './inline-entity-create';
 
 export type CatalogEntryType = 'MCP' | 'AGENT' | 'MODEL' | 'API' | 'EVENT';
 
@@ -240,6 +247,26 @@ export function ServicePolicyPage({ config }: { readonly config: ServicePageConf
         return items;
     }, [config.hasTarget, config.type, catalogEntities.data]);
 
+    const principalCreate = useMemo<InlineCreateConfig>(
+        () => ({
+            kind: 'PRINCIPAL',
+            presets: PRINCIPAL_INLINE_PRESETS,
+            defaultCanonical: 'user',
+            create: makeInlineEntityCreator('PRINCIPAL'),
+        }),
+        [],
+    );
+
+    const resourceCreate = useMemo<InlineCreateConfig>(
+        () => ({
+            kind: 'RESOURCE',
+            presets: RESOURCE_INLINE_PRESETS,
+            defaultCanonical: defaultResourceCanonical(config.type),
+            create: makeInlineEntityCreator('RESOURCE'),
+        }),
+        [config.type],
+    );
+
     const effectiveConfig = useMemo<ServicePageConfig>(
         () => ({
             ...config,
@@ -425,6 +452,8 @@ export function ServicePolicyPage({ config }: { readonly config: ServicePageConf
                 actionOptions={actionOptions}
                 emptyPrincipalsHint={emptyPrincipalsHint}
                 emptyActionsHint={emptyActionsHint}
+                principalCreate={principalCreate}
+                resourceCreate={resourceCreate}
                 onOpenChange={o => {
                     if (!o) {
                         setSheet({ kind: 'closed' });

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/features/policy-management/__tests__/PolicyStatementCard.test.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/features/policy-management/__tests__/PolicyStatementCard.test.tsx
@@ -202,6 +202,30 @@ describe('PolicyStatementCard', () => {
         );
     });
 
+    it('disables the inline-create button when the typed name resolves to an existing option id', async () => {
+        render(
+            <PolicyStatementCard
+                index={0}
+                statement={baseStatement}
+                principalOptions={[{ id: 'User::"alice-doe"', label: 'Alice Doe', group: 'User' }]}
+                actionOptions={actionOptions}
+                resourceOptions={resourceOptions}
+                resourceGroups={[{ key: 'MCPTool', label: 'Tools' }]}
+                onChange={vi.fn()}
+                onDuplicate={vi.fn()}
+                onDelete={vi.fn()}
+                principalCreate={principalCreate}
+            />,
+        );
+
+        await userEvent.click(screen.getByRole('combobox', { name: /add principal/i }));
+        await userEvent.type(screen.getByRole('combobox', { name: /add principal/i }), 'alice---doe');
+
+        const addButton = screen.getByRole('button', { name: /already in list/i });
+        expect(addButton).toBeDisabled();
+        expect(addButton).toHaveTextContent('user.alice-doe');
+    });
+
     it('renders an unregistered selected principal as a ghost chip with a warning tooltip', async () => {
         const stmt: PolicyStatement = {
             ...baseStatement,

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/features/policy-management/__tests__/PolicyStatementCard.test.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/features/policy-management/__tests__/PolicyStatementCard.test.tsx
@@ -17,7 +17,15 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi } from 'vitest';
 import { PolicyStatementCard } from '../PolicyStatementCard';
+import { makeInlineEntityCreator, PRINCIPAL_INLINE_PRESETS, type InlineCreateConfig } from '../inline-entity-create';
 import type { PolicyStatement } from '../statement-to-gapl';
+
+const principalCreate: InlineCreateConfig = {
+    kind: 'PRINCIPAL',
+    presets: PRINCIPAL_INLINE_PRESETS,
+    defaultCanonical: 'user',
+    create: makeInlineEntityCreator('PRINCIPAL'),
+};
 
 const baseStatement: PolicyStatement = {
     id: 'stmt-1',
@@ -165,6 +173,60 @@ describe('PolicyStatementCard', () => {
         expect(screen.getByRole('combobox', { name: /add principal/i })).toBeInTheDocument();
         expect(screen.getByRole('combobox', { name: /add action/i })).toBeInTheDocument();
         expect(screen.getByRole('combobox', { name: /add resource/i })).toBeInTheDocument();
+    });
+
+    it('adds a typed-but-unregistered principal to the policy as a ghost id', async () => {
+        const onChange = vi.fn();
+
+        render(
+            <PolicyStatementCard
+                index={0}
+                statement={baseStatement}
+                principalOptions={principalOptions}
+                actionOptions={actionOptions}
+                resourceOptions={resourceOptions}
+                resourceGroups={[{ key: 'MCPTool', label: 'Tools' }]}
+                onChange={onChange}
+                onDuplicate={vi.fn()}
+                onDelete={vi.fn()}
+                principalCreate={principalCreate}
+            />,
+        );
+
+        await userEvent.click(screen.getByRole('combobox', { name: /add principal/i }));
+        await userEvent.type(screen.getByRole('combobox', { name: /add principal/i }), 'alice123');
+        await userEvent.click(screen.getByRole('button', { name: /add user\.alice123/i }));
+
+        expect(onChange).toHaveBeenCalledWith(
+            expect.objectContaining({ principals: [{ id: 'User::"alice123"', kind: 'User', label: 'alice123' }] }),
+        );
+    });
+
+    it('renders an unregistered selected principal as a ghost chip with a warning tooltip', async () => {
+        const stmt: PolicyStatement = {
+            ...baseStatement,
+            principals: [{ id: 'User::"ghost"', kind: 'User', label: 'ghost' }],
+        };
+
+        render(
+            <PolicyStatementCard
+                index={0}
+                statement={stmt}
+                principalOptions={principalOptions}
+                actionOptions={actionOptions}
+                resourceOptions={resourceOptions}
+                resourceGroups={[{ key: 'MCPTool', label: 'Tools' }]}
+                onChange={vi.fn()}
+                onDuplicate={vi.fn()}
+                onDelete={vi.fn()}
+                principalCreate={principalCreate}
+            />,
+        );
+
+        const chip = screen.getByText('ghost').closest('.border-dashed');
+        expect(chip).not.toBeNull();
+        expect(chip).toHaveClass('border-warning');
+        expect(chip).toHaveTextContent('ghost');
     });
 
     it('shows existing condition text when statement has a condition', () => {

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/features/policy-management/__tests__/inline-entity-create.test.ts
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/features/policy-management/__tests__/inline-entity-create.test.ts
@@ -1,0 +1,81 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, expect, it } from 'vitest';
+import { defaultResourceCanonical, makeInlineEntityCreator, slugify } from '../inline-entity-create';
+
+describe('slugify', () => {
+    it('kebab-cases and strips accents', () => {
+        expect(slugify('Alice Doe')).toBe('alice-doe');
+        expect(slugify('Crème Brûlée')).toBe('creme-brulee');
+    });
+
+    it('trims leading/trailing separators', () => {
+        expect(slugify('  --Flight API--  ')).toBe('flight-api');
+    });
+});
+
+describe('defaultResourceCanonical', () => {
+    it('maps policy types to their canonical resource prefix', () => {
+        expect(defaultResourceCanonical('MCP')).toBe('mcp');
+        expect(defaultResourceCanonical('MODEL')).toBe('model');
+        expect(defaultResourceCanonical('AGENT')).toBe('agent');
+        expect(defaultResourceCanonical('API')).toBe('api');
+        expect(defaultResourceCanonical('EVENT')).toBe('event');
+    });
+
+    it('falls back to "resource" for custom/unknown types', () => {
+        expect(defaultResourceCanonical('CUSTOM')).toBe('resource');
+    });
+});
+
+describe('makeInlineEntityCreator — PRINCIPAL', () => {
+    it('builds a chip option in the principal option id format without persisting', () => {
+        const create = makeInlineEntityCreator('PRINCIPAL');
+        const option = create({ canonicalPrefix: 'user', slug: 'alice-doe', displayName: 'Alice Doe' });
+
+        // id must match useEntityOptions.toChipOption (`UiType::"slug"`) so a known option reuses it
+        // and an unknown one renders as a ghost chip via the same GAPL uid pattern.
+        expect(option).toEqual({ id: 'User::"alice-doe"', label: 'alice-doe', group: 'User' });
+    });
+
+    it('maps the agent-identity canonical prefix to the AgentIdentity ui type', () => {
+        const create = makeInlineEntityCreator('PRINCIPAL');
+        const option = create({ canonicalPrefix: 'agent-identity', slug: 'bot', displayName: 'Bot' });
+
+        expect(option.id).toBe('AgentIdentity::"bot"');
+        expect(option.group).toBe('AgentIdentity');
+    });
+});
+
+describe('makeInlineEntityCreator — RESOURCE', () => {
+    it('builds a chip option in the service resource option id format', () => {
+        const create = makeInlineEntityCreator('RESOURCE');
+        const option = create({ canonicalPrefix: 'mcp', slug: 'flight-api', displayName: 'Flight API' });
+
+        // id must match ServicePolicyPage.serviceResourceOptions (`Group::"slug"`); label keeps the display name.
+        expect(option).toEqual({ id: 'MCP::"flight-api"', label: 'Flight API', group: 'MCP' });
+    });
+
+    it('maps model/agent/api/unknown prefixes to their resource groups', () => {
+        const create = makeInlineEntityCreator('RESOURCE');
+        const groupFor = (canonicalPrefix: string) => create({ canonicalPrefix, slug: 's', displayName: 'S' }).group;
+
+        expect(groupFor('model')).toBe('Model');
+        expect(groupFor('agent')).toBe('Agent');
+        expect(groupFor('api')).toBe('API');
+        expect(groupFor('webhook')).toBe('Resource');
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/features/policy-management/inline-entity-create.ts
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/features/policy-management/inline-entity-create.ts
@@ -1,0 +1,114 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import type { PolicyType } from '../../shared/api/authz-api.types';
+import type { ChipOption } from '../../shared/chip-option';
+import { kindToUiType } from '../../shared/entity-kind-registry';
+
+export type InlineEntityKind = 'PRINCIPAL' | 'RESOURCE';
+
+export interface InlineCreatePreset {
+    readonly canonical: string;
+    readonly label: string;
+}
+
+export interface InlineCreateInput {
+    readonly canonicalPrefix: string;
+    readonly slug: string;
+    readonly displayName: string;
+}
+
+export interface InlineCreateConfig {
+    readonly kind: InlineEntityKind;
+    readonly presets: readonly InlineCreatePreset[];
+    readonly defaultCanonical: string;
+    readonly create: (input: InlineCreateInput) => ChipOption;
+}
+
+export const PRINCIPAL_INLINE_PRESETS: readonly InlineCreatePreset[] = [
+    { canonical: 'user', label: 'User' },
+    { canonical: 'group', label: 'Group' },
+    { canonical: 'serviceaccount', label: 'Service Account' },
+    { canonical: 'agent-identity', label: 'Agent Identity' },
+];
+
+export const RESOURCE_INLINE_PRESETS: readonly InlineCreatePreset[] = [
+    { canonical: 'mcp', label: 'MCP' },
+    { canonical: 'model', label: 'Model' },
+    { canonical: 'agent', label: 'Agent' },
+    { canonical: 'api', label: 'API' },
+    { canonical: 'event', label: 'Event' },
+    { canonical: 'resource', label: 'Resource' },
+];
+
+/** Single entityId segment, mirroring the backend regex between dots. */
+export const SLUG_REGEX = /^[a-z0-9_-]+$/;
+
+export function slugify(value: string): string {
+    return value
+        .normalize('NFD')
+        .replace(/[̀-ͯ]/g, '')
+        .toLowerCase()
+        .replace(/[^a-z0-9_-]+/g, '-')
+        .replace(/^-+|-+$/g, '');
+}
+
+/** Mirror of ServicePolicyPage.serviceResourceOptions group derivation so an
+ *  optimistically-created resource chip matches the canonical option id. */
+function resourceGroupOf(canonicalPrefix: string): string {
+    switch (canonicalPrefix) {
+        case 'mcp':
+            return 'MCP';
+        case 'model':
+        case 'llm':
+            return 'Model';
+        case 'agent':
+            return 'Agent';
+        case 'api':
+            return 'API';
+        default:
+            return 'Resource';
+    }
+}
+
+function capitalize(value: string): string {
+    return value.length === 0 ? value : value[0]!.toUpperCase() + value.slice(1);
+}
+
+function toChipOption(kind: InlineEntityKind, input: InlineCreateInput): ChipOption {
+    const { canonicalPrefix, slug, displayName } = input;
+    if (kind === 'PRINCIPAL') {
+        const uiType = kindToUiType(canonicalPrefix) ?? capitalize(canonicalPrefix);
+        return { id: `${uiType}::"${slug}"`, label: slug, group: uiType };
+    }
+    const group = resourceGroupOf(canonicalPrefix);
+    return { id: `${group}::"${slug}"`, label: displayName || slug, group };
+}
+
+const POLICY_TYPE_TO_CANONICAL: Partial<Record<PolicyType, string>> = {
+    MCP: 'mcp',
+    MODEL: 'model',
+    AGENT: 'agent',
+    API: 'api',
+    EVENT: 'event',
+};
+
+export function defaultResourceCanonical(type: PolicyType): string {
+    return POLICY_TYPE_TO_CANONICAL[type] ?? 'resource';
+}
+
+export function makeInlineEntityCreator(kind: InlineEntityKind): (input: InlineCreateInput) => ChipOption {
+    return (input: InlineCreateInput): ChipOption => toChipOption(kind, input);
+}

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/features/policy-management/inline-entity-create.ts
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/features/policy-management/inline-entity-create.ts
@@ -59,9 +59,10 @@ export const SLUG_REGEX = /^[a-z0-9_-]+$/;
 export function slugify(value: string): string {
     return value
         .normalize('NFD')
-        .replace(/[̀-ͯ]/g, '')
+        .replace(/[\u0300-\u036f]/g, '')
         .toLowerCase()
         .replace(/[^a-z0-9_-]+/g, '-')
+        .replace(/-+/g, '-')
         .replace(/^-+|-+$/g, '');
 }
 


### PR DESCRIPTION
## Issue

N/A

## Description

Lets users add a principal or resource that is **not** registered in the schema, directly from the policy editor combobox.

When you type a name with no match, an **"Add to this policy only"** panel appears with a kind selector (User / Group / Service Account / Agent Identity for principals; resource group for resources). The created entity is emitted into the policy GAPL as a ghost uid (e.g. `User::"alice123"`) and is **never persisted to the entity store** — it lives only inside the policy.

Ghost entities are rendered as **dashed warning (yellow) chips** with a warning icon and a tooltip: *"Defined only in this policy. Add it under Entities to reuse it."* Action chips are intentionally excluded from inline creation.

### Changes
- `inline-entity-create.ts` (new): synchronous factory building a `ChipOption` with the correct `Type::"slug"` uid; no DB persistence.
- `PolicyStatementCard.tsx`: inline-create panel, ghost-chip rendering + graphene `Tooltip`, self-contained `TooltipProvider`.
- `ServicePolicyPage.tsx` / `PolicyBuilder.tsx` / `PolicyEditorSheet.tsx`: wire principal/resource create configs through the editor chain.
- Tests: `inline-entity-create.test.ts` (new) + extended `PolicyStatementCard.test.tsx`.

## Additional context

- Verified manually in the standalone authz dev module (`:3003`): inline-create panel → yellow ghost chip → tooltip → Code view shows `principal == User::"alice123"`.
- **Follow-up (separate repo):** the dropdown scrollbar fix removes `no-scrollbar` from `Combobox` in `gravitee-ui-graphene` and needs its own PR there.

## Test plan
- [ ] `npx vitest run` for the authz UI module (policy-management tests green — 17/17 locally)
- [ ] In the editor, type an unregistered principal → "Add to this policy only" appears
- [ ] Adding it produces a yellow dashed ghost chip with a warning tooltip
- [ ] Code view emits the ghost uid; no new entity created in the store