### PR TITLE
feat(authz-ui): align KPI tiles with dashboard style across policy screens

### DIFF
--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/components/KpiTile.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/components/KpiTile.tsx
@@ -35,7 +35,9 @@ export function KpiTile({ label, value, loading = false, tone = 'default', Icon,
     return (
         <Card className="flex flex-col gap-3 p-5" aria-label={label}>
             {Icon && (
-                <div className={cn('flex size-10 items-center justify-center rounded-lg', iconClassName ?? 'bg-muted text-muted-foreground')}>
+                <div
+                    className={cn('flex size-10 items-center justify-center rounded-lg', iconClassName ?? 'bg-muted text-muted-foreground')}
+                >
                     <Icon className="size-5" aria-hidden />
                 </div>
             )}

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/components/KpiTile.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/components/KpiTile.tsx
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 import { Card, Skeleton, cn } from '@gravitee/graphene-core';
+import type { ComponentType, SVGProps } from 'react';
 
 const TONE_CLASS = {
     default: '',
@@ -26,13 +27,26 @@ export interface KpiTileProps {
     readonly value: number | string;
     readonly loading?: boolean;
     readonly tone?: keyof typeof TONE_CLASS;
+    readonly Icon?: ComponentType<SVGProps<SVGSVGElement>>;
+    readonly iconClassName?: string;
 }
 
-export function KpiTile({ label, value, loading = false, tone = 'default' }: KpiTileProps) {
+export function KpiTile({ label, value, loading = false, tone = 'default', Icon, iconClassName }: KpiTileProps) {
     return (
-        <Card className="p-4" aria-label={label}>
-            {loading ? <Skeleton className="h-8 w-12" /> : <div className={cn('text-2xl', TONE_CLASS[tone])}>{value}</div>}
-            <p className="text-xs text-muted-foreground">{label}</p>
+        <Card className="flex flex-col gap-3 p-5" aria-label={label}>
+            {Icon && (
+                <div className={cn('flex size-10 items-center justify-center rounded-lg', iconClassName ?? 'bg-muted text-muted-foreground')}>
+                    <Icon className="size-5" aria-hidden />
+                </div>
+            )}
+            <div className="flex flex-col gap-0.5">
+                {loading ? (
+                    <Skeleton className="h-8 w-12" />
+                ) : (
+                    <div className={cn('text-3xl font-semibold leading-none', TONE_CLASS[tone])}>{value}</div>
+                )}
+                <p className="text-sm font-medium">{label}</p>
+            </div>
         </Card>
     );
 }

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/features/dashboard/DashboardPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/features/dashboard/DashboardPage.tsx
@@ -120,7 +120,7 @@ export function DashboardPage() {
                 </p>
             </header>
 
-            <div className="grid gap-4" style={{ gridTemplateColumns: 'repeat(auto-fit, minmax(240px, 1fr))' }}>
+            <div className="grid grid-cols-4 gap-4">
                 {KPI_CARDS.map(kpi => {
                     const count = counts[kpi.label as keyof typeof counts];
                     return (

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/features/policy-management/ServicePolicyPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/features/policy-management/ServicePolicyPage.tsx
@@ -296,7 +296,7 @@ export function ServicePolicyPage({ config }: { readonly config: ServicePageConf
                 </div>
             </header>
 
-            <div className="grid gap-4" style={{ gridTemplateColumns: 'repeat(auto-fit, minmax(240px, 1fr))' }} aria-label="Key metrics">
+            <div className="grid grid-cols-4 gap-4" aria-label="Key metrics">
                 <KpiTile
                     label="Policies"
                     value={kpis.total}

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/features/policy-management/ServicePolicyPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/features/policy-management/ServicePolicyPage.tsx
@@ -36,7 +36,7 @@ import {
     SelectTrigger,
     SelectValue,
 } from '@gravitee/graphene-core';
-import { PlusIcon, RefreshCwIcon } from '@gravitee/graphene-core/icons';
+import { NetworkIcon, PencilIcon, PlusIcon, RefreshCwIcon, RocketIcon, ShieldCheckIcon } from '@gravitee/graphene-core/icons';
 import { useCallback, useDeferredValue, useMemo, useState } from 'react';
 import { KpiTile } from '../../components/KpiTile';
 import { ValidationErrorAlert } from '../../components/ValidationErrorAlert';
@@ -296,12 +296,38 @@ export function ServicePolicyPage({ config }: { readonly config: ServicePageConf
                 </div>
             </header>
 
-            <div className="grid grid-cols-2 gap-3 md:grid-cols-4" aria-label="Key metrics">
-                <KpiTile label="Policies" value={kpis.total} loading={policies.isLoading} />
-                <KpiTile label={`Deployed${pageSuffix}`} value={kpis.deployed} loading={policies.isLoading} tone="success" />
-                <KpiTile label={`Draft${pageSuffix}`} value={kpis.draft} loading={policies.isLoading} tone="muted" />
+            <div className="grid gap-4" style={{ gridTemplateColumns: 'repeat(auto-fit, minmax(240px, 1fr))' }} aria-label="Key metrics">
+                <KpiTile
+                    label="Policies"
+                    value={kpis.total}
+                    loading={policies.isLoading}
+                    Icon={ShieldCheckIcon}
+                    iconClassName="bg-primary/10 text-primary"
+                />
+                <KpiTile
+                    label={`Deployed${pageSuffix}`}
+                    value={kpis.deployed}
+                    loading={policies.isLoading}
+                    tone="success"
+                    Icon={RocketIcon}
+                    iconClassName="bg-success/10 text-success"
+                />
+                <KpiTile
+                    label={`Draft${pageSuffix}`}
+                    value={kpis.draft}
+                    loading={policies.isLoading}
+                    tone="muted"
+                    Icon={PencilIcon}
+                    iconClassName="bg-muted text-muted-foreground"
+                />
                 {config.hasTarget ? (
-                    <KpiTile label={`Unique targets${pageSuffix}`} value={kpis.uniqueTargets} loading={policies.isLoading} />
+                    <KpiTile
+                        label={`Unique targets${pageSuffix}`}
+                        value={kpis.uniqueTargets}
+                        loading={policies.isLoading}
+                        Icon={NetworkIcon}
+                        iconClassName="bg-highlight/10 text-highlight"
+                    />
                 ) : null}
             </div>
 

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/features/policy-structure/ActionsPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/features/policy-structure/ActionsPage.tsx
@@ -201,7 +201,7 @@ export function ActionsPage() {
                 </div>
             </header>
 
-            <div className="grid grid-cols-2 gap-3 md:grid-cols-4" aria-label="Key metrics">
+            <div className="grid gap-4" style={{ gridTemplateColumns: 'repeat(auto-fit, minmax(240px, 1fr))' }} aria-label="Key metrics">
                 <KpiTile label="Total actions" value={total} loading={actionsQuery.isLoading} Icon={ZapIcon} iconClassName="bg-warning/10 text-warning" />
             </div>
 

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/features/policy-structure/ActionsPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/features/policy-structure/ActionsPage.tsx
@@ -201,7 +201,7 @@ export function ActionsPage() {
                 </div>
             </header>
 
-            <div className="grid gap-4" style={{ gridTemplateColumns: 'repeat(auto-fit, minmax(240px, 1fr))' }} aria-label="Key metrics">
+            <div className="grid grid-cols-4 gap-4" aria-label="Key metrics">
                 <KpiTile
                     label="Total actions"
                     value={total}

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/features/policy-structure/ActionsPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/features/policy-structure/ActionsPage.tsx
@@ -202,7 +202,7 @@ export function ActionsPage() {
             </header>
 
             <div className="grid grid-cols-2 gap-3 md:grid-cols-4" aria-label="Key metrics">
-                <KpiTile label="Total actions" value={total} loading={actionsQuery.isLoading} />
+                <KpiTile label="Total actions" value={total} loading={actionsQuery.isLoading} Icon={ZapIcon} iconClassName="bg-warning/10 text-warning" />
             </div>
 
             {actionsQuery.error !== undefined && (

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/features/policy-structure/ActionsPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/features/policy-structure/ActionsPage.tsx
@@ -202,7 +202,13 @@ export function ActionsPage() {
             </header>
 
             <div className="grid gap-4" style={{ gridTemplateColumns: 'repeat(auto-fit, minmax(240px, 1fr))' }} aria-label="Key metrics">
-                <KpiTile label="Total actions" value={total} loading={actionsQuery.isLoading} Icon={ZapIcon} iconClassName="bg-warning/10 text-warning" />
+                <KpiTile
+                    label="Total actions"
+                    value={total}
+                    loading={actionsQuery.isLoading}
+                    Icon={ZapIcon}
+                    iconClassName="bg-warning/10 text-warning"
+                />
             </div>
 
             {actionsQuery.error !== undefined && (

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/features/policy-structure/EntitiesPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/features/policy-structure/EntitiesPage.tsx
@@ -54,8 +54,10 @@ import {
     DownloadIcon,
     PencilIcon,
     PlusIcon,
+    PuzzleIcon,
     RefreshCwIcon,
     SettingsIcon,
+    ShieldCheckIcon,
     ShieldIcon,
     Trash2Icon,
     UsersIcon,
@@ -601,12 +603,18 @@ export function EntitiesPage() {
                 </DropdownMenu>
             </header>
 
-            <div className="grid grid-cols-2 gap-3 md:grid-cols-5" aria-label="Key metrics">
-                <KpiTile label="Total entities" value={kpis.total} loading={isLoading} />
-                <KpiTile label="Types" value={kpis.types} loading={isLoading} />
-                <KpiTile label="Principals" value={kpis.principals} loading={isLoading} />
-                <KpiTile label="Resources" value={kpis.resources} loading={isLoading} />
-                <KpiTile label="Policy-Linked" value={policyLinkedCount} loading={isLoading} />
+            <div className="grid gap-4" style={{ gridTemplateColumns: 'repeat(auto-fit, minmax(240px, 1fr))' }} aria-label="Key metrics">
+                <KpiTile label="Total entities" value={kpis.total} loading={isLoading} Icon={BoxesIcon} iconClassName="bg-primary/10 text-primary" />
+                <KpiTile label="Types" value={kpis.types} loading={isLoading} Icon={PuzzleIcon} iconClassName="bg-highlight/10 text-highlight" />
+                <KpiTile label="Principals" value={kpis.principals} loading={isLoading} Icon={UsersIcon} iconClassName="bg-success/10 text-success" />
+                <KpiTile label="Resources" value={kpis.resources} loading={isLoading} Icon={ShieldIcon} iconClassName="bg-warning/10 text-warning" />
+                <KpiTile
+                    label="Policy-Linked"
+                    value={policyLinkedCount}
+                    loading={isLoading}
+                    Icon={ShieldCheckIcon}
+                    iconClassName="bg-highlight/10 text-highlight"
+                />
             </div>
 
             {error !== undefined && (

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/features/policy-structure/EntitiesPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/features/policy-structure/EntitiesPage.tsx
@@ -603,11 +603,35 @@ export function EntitiesPage() {
                 </DropdownMenu>
             </header>
 
-            <div className="grid gap-4" style={{ gridTemplateColumns: 'repeat(auto-fit, minmax(240px, 1fr))' }} aria-label="Key metrics">
-                <KpiTile label="Total entities" value={kpis.total} loading={isLoading} Icon={BoxesIcon} iconClassName="bg-primary/10 text-primary" />
-                <KpiTile label="Types" value={kpis.types} loading={isLoading} Icon={PuzzleIcon} iconClassName="bg-highlight/10 text-highlight" />
-                <KpiTile label="Principals" value={kpis.principals} loading={isLoading} Icon={UsersIcon} iconClassName="bg-success/10 text-success" />
-                <KpiTile label="Resources" value={kpis.resources} loading={isLoading} Icon={ShieldIcon} iconClassName="bg-warning/10 text-warning" />
+            <div className="grid grid-cols-5 gap-4" aria-label="Key metrics">
+                <KpiTile
+                    label="Total entities"
+                    value={kpis.total}
+                    loading={isLoading}
+                    Icon={BoxesIcon}
+                    iconClassName="bg-primary/10 text-primary"
+                />
+                <KpiTile
+                    label="Types"
+                    value={kpis.types}
+                    loading={isLoading}
+                    Icon={PuzzleIcon}
+                    iconClassName="bg-highlight/10 text-highlight"
+                />
+                <KpiTile
+                    label="Principals"
+                    value={kpis.principals}
+                    loading={isLoading}
+                    Icon={UsersIcon}
+                    iconClassName="bg-success/10 text-success"
+                />
+                <KpiTile
+                    label="Resources"
+                    value={kpis.resources}
+                    loading={isLoading}
+                    Icon={ShieldIcon}
+                    iconClassName="bg-warning/10 text-warning"
+                />
                 <KpiTile
                     label="Policy-Linked"
                     value={policyLinkedCount}

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/features/policy-structure/SchemaPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/features/policy-structure/SchemaPage.tsx
@@ -201,11 +201,7 @@ export function SchemaPage() {
                         </Alert>
                     )}
 
-                    <div
-                        className="grid gap-4"
-                        style={{ gridTemplateColumns: 'repeat(auto-fit, minmax(240px, 1fr))' }}
-                        aria-label="Schema summary"
-                    >
+                    <div className="grid grid-cols-4 gap-4" aria-label="Schema summary">
                         <KpiTile
                             label="Entities"
                             value={parsed.entities.length}

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/features/policy-structure/SchemaPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/features/policy-structure/SchemaPage.tsx
@@ -49,6 +49,7 @@ import {
     ZapIcon,
 } from '@gravitee/graphene-core/icons';
 import { useEffect, useMemo, useRef, useState, type ComponentType, type SVGProps } from 'react';
+import { KpiTile } from '../../components/KpiTile';
 import { MonacoEditor } from '../../components/MonacoEditor';
 import { parseGaplSchema, type ParsedEntity } from '../../shared/gapl-parser';
 import { useSchema } from '../../shared/hooks/useSchema';
@@ -200,23 +201,21 @@ export function SchemaPage() {
                         </Alert>
                     )}
 
-                    <div className="flex flex-wrap gap-2" aria-label="Schema summary">
-                        <Badge variant="outline" className="gap-1.5">
-                            <BoxesIcon className="size-3.5" aria-hidden />
-                            {parsed.entities.length} entities
-                        </Badge>
-                        <Badge variant="outline" className="gap-1.5">
-                            <ZapIcon className="size-3.5" aria-hidden />
-                            {parsed.actions.length} actions
-                        </Badge>
-                        <Badge variant="outline" className="gap-1.5">
-                            <UsersIcon className="size-3.5" aria-hidden />
-                            {principalKinds} principal kinds
-                        </Badge>
-                        <Badge variant="outline" className="gap-1.5">
-                            <ShieldIcon className="size-3.5" aria-hidden />
-                            {resourceKinds} resource kinds
-                        </Badge>
+                    <div className="grid gap-4" style={{ gridTemplateColumns: 'repeat(auto-fit, minmax(240px, 1fr))' }} aria-label="Schema summary">
+                        <KpiTile label="Entities" value={parsed.entities.length} Icon={BoxesIcon} iconClassName="bg-primary/10 text-primary" />
+                        <KpiTile label="Actions" value={parsed.actions.length} Icon={ZapIcon} iconClassName="bg-warning/10 text-warning" />
+                        <KpiTile
+                            label="Principal kinds"
+                            value={principalKinds}
+                            Icon={UsersIcon}
+                            iconClassName="bg-success/10 text-success"
+                        />
+                        <KpiTile
+                            label="Resource kinds"
+                            value={resourceKinds}
+                            Icon={ShieldIcon}
+                            iconClassName="bg-highlight/10 text-highlight"
+                        />
                     </div>
 
                     <div className="flex flex-col gap-4 md:flex-row md:items-start">

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/features/policy-structure/SchemaPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/features/policy-structure/SchemaPage.tsx
@@ -201,8 +201,17 @@ export function SchemaPage() {
                         </Alert>
                     )}
 
-                    <div className="grid gap-4" style={{ gridTemplateColumns: 'repeat(auto-fit, minmax(240px, 1fr))' }} aria-label="Schema summary">
-                        <KpiTile label="Entities" value={parsed.entities.length} Icon={BoxesIcon} iconClassName="bg-primary/10 text-primary" />
+                    <div
+                        className="grid gap-4"
+                        style={{ gridTemplateColumns: 'repeat(auto-fit, minmax(240px, 1fr))' }}
+                        aria-label="Schema summary"
+                    >
+                        <KpiTile
+                            label="Entities"
+                            value={parsed.entities.length}
+                            Icon={BoxesIcon}
+                            iconClassName="bg-primary/10 text-primary"
+                        />
                         <KpiTile label="Actions" value={parsed.actions.length} Icon={ZapIcon} iconClassName="bg-warning/10 text-warning" />
                         <KpiTile
                             label="Principal kinds"


### PR DESCRIPTION
## Issue

_No associated Jira ticket — small UI consistency follow-up._

## Description

Unifies the KPI tiles across the Authorization module so every screen matches the Dashboard look.

- `KpiTile` gains an optional icon badge (`Icon` + `iconClassName`) rendered as a tinted rounded square, with a larger value and label — same anatomy as the Dashboard cards.
- Entities, Actions, Schema summary, and the policy-management screens (MCPs / AI Models / APIs / Custom Policies) now use the Dashboard's `auto-fit` grid (`repeat(auto-fit, minmax(240px, 1fr))`) instead of `grid-cols-2 md:grid-cols-4`, so metric tiles render in a single row.
- Schema's summary block switches from outline badges to `KpiTile`s for consistency.

No behavioural changes — purely presentational.

## Additional context

<img width="1481" height="812" alt="image" src="https://github.com/user-attachments/assets/ef7d88bd-dc79-4816-8d29-0d78ebf2de8c" />


- `tsc --noEmit` and `eslint` both pass.
- Verified visually on the standalone dev harness: tiles render in one row and share the Dashboard styling.