### PR TITLE
fix: xss via markdown page import

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/PageServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/PageServiceImpl.java
@@ -2579,12 +2579,12 @@ public class PageServiceImpl extends AbstractService implements PageService, App
 
             if (markdownSanitize && MARKDOWN.name().equals(pageType)) {
                 this.transformWithTemplate(executionContext, pageEntity, apiId);
-                if (!CollectionUtils.isEmpty(pageEntity.getMessages())) {
-                    return asList(pageEntity.getMessages().toString());
-                }
                 HtmlSanitizer.SanitizeInfos sanitizeInfos = this.htmlSanitizer.isSafe(pageEntity.getContent());
                 if (!sanitizeInfos.isSafe()) {
                     throw new PageContentUnsafeException(sanitizeInfos.getRejectedMessage());
+                }
+                if (!CollectionUtils.isEmpty(pageEntity.getMessages())) {
+                    return asList(pageEntity.getMessages().toString());
                 }
             } else if (swaggerValidateSafeContent && SWAGGER.name().equals(pageEntity.getType()) && pageEntity.getContent() != null) {
                 OAIDescriptor openApiDescriptor = new OAIParser().parse(pageEntity.getContent());

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/PageService_CreateTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/PageService_CreateTest.java
@@ -601,6 +601,7 @@ public class PageService_CreateTest {
         when(
             this.notificationTemplateService.resolveInlineTemplateWithParam(anyString(), anyString(), eq(content), any(), anyBoolean())
         ).thenThrow(new TemplateProcessingException(new TemplateException(null)));
+        when(htmlSanitizer.isSafe(anyString())).thenReturn(new HtmlSanitizer.SanitizeInfos(true, null));
         this.pageService.createPage(GraviteeContext.getExecutionContext(), API_ID, newPage);
 
         verify(pageRepository).create(any());

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/PageService_UpdateTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/PageService_UpdateTest.java
@@ -18,6 +18,7 @@ package io.gravitee.rest.api.service.impl;
 import static java.util.Arrays.asList;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 import static org.springframework.test.util.ReflectionTestUtils.setField;
 
@@ -522,7 +523,7 @@ public class PageService_UpdateTest {
         verify(pageRepository, never()).update(any());
     }
 
-    @Test
+    @Test(expected = PageContentUnsafeException.class)
     public void shouldNotUpdateBecausePageContentTemplatingException() throws TechnicalException, TemplateException {
         setField(pageService, "markdownSanitize", true);
 
@@ -533,15 +534,35 @@ public class PageService_UpdateTest {
         when(page1.getReferenceId()).thenReturn(API_ID);
         when(pageRepository.findById(PAGE_ID)).thenReturn(Optional.of(page1));
 
-        when(pageRepository.update(any())).thenReturn(page1);
+        when(
+            this.notificationTemplateService.resolveInlineTemplateWithParam(anyString(), anyString(), eq(content), any(), anyBoolean())
+        ).thenThrow(new TemplateProcessingException(new TemplateException(null)));
+        when(htmlSanitizer.isSafe(anyString())).thenReturn(new HtmlSanitizer.SanitizeInfos(false, "Tag not allowed: script"));
+
+        pageService.update(GraviteeContext.getExecutionContext(), PAGE_ID, existingPage);
+
+        verify(pageRepository, never()).update(any());
+    }
+
+    @Test(expected = PageContentUnsafeException.class)
+    public void shouldNotUpdateWhenXssPayloadBypassesTemplateError() throws TechnicalException, TemplateException {
+        setField(pageService, "markdownSanitize", true);
+
+        String content = "<img src=x onerror=\"alert('XSS')\">\n${";
+        when(existingPage.getContent()).thenReturn(content);
+        when(page1.getType()).thenReturn(PageType.MARKDOWN.name());
+        when(page1.getReferenceType()).thenReturn(PageReferenceType.API);
+        when(page1.getReferenceId()).thenReturn(API_ID);
+        when(pageRepository.findById(PAGE_ID)).thenReturn(Optional.of(page1));
 
         when(
             this.notificationTemplateService.resolveInlineTemplateWithParam(anyString(), anyString(), eq(content), any(), anyBoolean())
         ).thenThrow(new TemplateProcessingException(new TemplateException(null)));
+        when(htmlSanitizer.isSafe(anyString())).thenReturn(new HtmlSanitizer.SanitizeInfos(false, "Attribute not allowed: onerror"));
 
         pageService.update(GraviteeContext.getExecutionContext(), PAGE_ID, existingPage);
 
-        verify(pageRepository).update(any());
+        verify(pageRepository, never()).update(any());
     }
 
     @Test


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/PEN-97

## Description

 The vulnerability existed because the sanitization guard and the early-return-on-messages were in the wrong order — a control-flow ordering bug. The fix restores the correct invariant: content must be sanitized before it can be persisted, with no exception path that bypasses it. No new abstraction or bandage is added.


Before:
<img width="1504" height="738" alt="image" src="https://github.com/user-attachments/assets/62d6fe54-cf6e-4d35-b972-6b9fda79dc2b" />

After:
<img width="1504" height="738" alt="image" src="https://github.com/user-attachments/assets/3b40a04a-6951-45f1-8f80-84fd08d0ee14" />

<img width="1504" height="738" alt="image" src="https://github.com/user-attachments/assets/390ed65c-52c0-4cbd-8a34-58b67393e648" />
