### PR TITLE
fix(authz): show bare-id principals in policy pickers

### DIFF
--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/features/policy-management/PolicyStatementCard.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/features/policy-management/PolicyStatementCard.tsx
@@ -204,7 +204,7 @@ export function PolicyStatementCard({
                         options={principalOptions}
                         selectedIds={statement.principals.map(p => p.id)}
                         onChange={syncPrincipals}
-                        groupOrder={['User', 'Group', 'ServiceAccount', 'AgentIdentity']}
+                        groupOrder={['User', 'Group', 'ServiceAccount', 'AgentIdentity', 'Principal']}
                         emptyHint={emptyPrincipalsHint}
                     />
                 </ChipField>

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/features/policy-management/ServicePolicyPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/features/policy-management/ServicePolicyPage.tsx
@@ -92,6 +92,11 @@ const DEFAULT_RESOURCE_GROUPS: readonly { key: string; label: string }[] = [
     { key: 'Resource', label: 'Resource' },
 ];
 
+// Custom policies cover everything not already routed to a dedicated page
+// (API / MCP / Model) and never the Action picker. Resources carrying these
+// prefixes are excluded from the custom resource picker.
+const CUSTOM_RESOURCE_EXCLUDED_PREFIXES = new Set(['api', 'mcp', 'model', 'llm', 'action']);
+
 export function ServicePolicyPage({ config }: { readonly config: ServicePageConfig }) {
     const env = useEnvironment();
     const [statusFilter, setStatusFilter] = useState<StatusFilter>('ALL');
@@ -113,7 +118,7 @@ export function ServicePolicyPage({ config }: { readonly config: ServicePageConf
     // service prefix instead of "fetch all" so envs with 10k+ entities still load fast.
     const catalogEntities = useEntities(envId, 200, {
         kind: 'RESOURCE',
-        entityIdPrefix: `${config.type.toLowerCase()}.`,
+        ...(config.hasTarget ? { entityIdPrefix: `${config.type.toLowerCase()}.` } : {}),
     });
     // Action chip options. Separate scoped fetch so it never bloats with catalog rows.
     const actionEntities = useEntities(envId, 200, { kind: 'RESOURCE', entityIdPrefix: 'action.' });
@@ -191,7 +196,7 @@ export function ServicePolicyPage({ config }: { readonly config: ServicePageConf
     }, [schema.schema, actionEntities.data]);
 
     const { options: principalOptions } = useEntityOptions(envId, {
-        typeFilter: config.hasTarget ? ['User', 'Group', 'ServiceAccount', 'AgentIdentity'] : undefined,
+        typeFilter: ['User', 'Group', 'ServiceAccount', 'AgentIdentity'],
     });
 
     const emptyActionsHint = useMemo<string | undefined>(() => {
@@ -214,6 +219,7 @@ export function ServicePolicyPage({ config }: { readonly config: ServicePageConf
             const attrs = e.attributes ?? {};
             const firstSeg = e.uid.includes('.') ? e.uid.slice(0, e.uid.indexOf('.')).toLowerCase() : '';
             if (config.hasTarget && firstSeg !== typePrefix) continue;
+            if (!config.hasTarget && CUSTOM_RESOURCE_EXCLUDED_PREFIXES.has(firstSeg)) continue;
             const label =
                 typeof attrs.displayName === 'string' && attrs.displayName
                     ? (attrs.displayName as string)

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/features/policy-management/ServicePolicyPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/features/policy-management/ServicePolicyPage.tsx
@@ -40,7 +40,7 @@ import { PlusIcon, RefreshCwIcon } from '@gravitee/graphene-core/icons';
 import { useCallback, useDeferredValue, useMemo, useState } from 'react';
 import { KpiTile } from '../../components/KpiTile';
 import { ValidationErrorAlert } from '../../components/ValidationErrorAlert';
-import type { PolicyRequest, PolicyResponse, PolicyStatus, PolicyType } from '../../shared/api/authz-api.types';
+import type { EntityResponse, PolicyRequest, PolicyResponse, PolicyStatus, PolicyType } from '../../shared/api/authz-api.types';
 import type { ChipOption } from '../../shared/chip-option';
 import { parseGaplSchema } from '../../shared/gapl-parser';
 import { useEntities } from '../../shared/hooks/useEntities';
@@ -96,6 +96,41 @@ const DEFAULT_RESOURCE_GROUPS: readonly { key: string; label: string }[] = [
 // (API / MCP / Model) and never the Action picker. Resources carrying these
 // prefixes are excluded from the custom resource picker.
 const CUSTOM_RESOURCE_EXCLUDED_PREFIXES = new Set(['api', 'mcp', 'model', 'llm', 'action']);
+
+export function buildServiceResourceOptions(
+    entities: readonly EntityResponse[],
+    config: { readonly hasTarget: boolean; readonly type: PolicyType },
+): readonly ChipOption[] {
+    const items: ChipOption[] = [];
+    const typePrefix = config.type.toLowerCase();
+    for (const e of entities) {
+        const attrs = e.attributes ?? {};
+        const firstSeg = e.uid.includes('.') ? e.uid.slice(0, e.uid.indexOf('.')).toLowerCase() : '';
+        if (config.hasTarget && firstSeg !== typePrefix) continue;
+        if (!config.hasTarget && CUSTOM_RESOURCE_EXCLUDED_PREFIXES.has(firstSeg)) continue;
+        const labelForUid = e.uid.includes('.') ? e.uid.slice(e.uid.indexOf('.') + 1) : e.uid;
+        const label =
+            typeof attrs.displayName === 'string' && attrs.displayName
+                ? (attrs.displayName as string)
+                : typeof attrs.name === 'string' && attrs.name
+                  ? (attrs.name as string)
+                  : labelForUid;
+        const group =
+            firstSeg === 'mcp'
+                ? 'MCP'
+                : firstSeg === 'model' || firstSeg === 'llm'
+                  ? 'Model'
+                  : firstSeg === 'agent'
+                    ? 'Agent'
+                    : firstSeg === 'api'
+                      ? 'API'
+                      : 'Resource';
+        const description = typeof attrs.description === 'string' ? (attrs.description as string) : undefined;
+        items.push({ id: `${group}::"${labelForUid}"`, label, group, description });
+    }
+    items.sort((a, b) => (a.group === b.group ? a.label.localeCompare(b.label) : a.group.localeCompare(b.group)));
+    return items;
+}
 
 export function ServicePolicyPage({ config }: { readonly config: ServicePageConfig }) {
     const env = useEnvironment();
@@ -209,42 +244,10 @@ export function ServicePolicyPage({ config }: { readonly config: ServicePageConf
         return 'No principals available. Add Users, Groups, Service Accounts or Agent Identities under Policy Structure → Entities.';
     }, [principalOptions.length]);
 
-    const serviceResourceOptions = useMemo((): readonly ChipOption[] => {
-        // catalogEntities is already scoped server-side to this service prefix
-        // (kind=RESOURCE + entityIdPrefix=<type>.) — no need to re-filter out
-        // principals or other service types here.
-        const items: ChipOption[] = [];
-        const typePrefix = config.type.toLowerCase();
-        for (const e of catalogEntities.data?.data ?? []) {
-            const attrs = e.attributes ?? {};
-            const firstSeg = e.uid.includes('.') ? e.uid.slice(0, e.uid.indexOf('.')).toLowerCase() : '';
-            if (config.hasTarget && firstSeg !== typePrefix) continue;
-            if (!config.hasTarget && CUSTOM_RESOURCE_EXCLUDED_PREFIXES.has(firstSeg)) continue;
-            const label =
-                typeof attrs.displayName === 'string' && attrs.displayName
-                    ? (attrs.displayName as string)
-                    : typeof attrs.name === 'string' && attrs.name
-                      ? (attrs.name as string)
-                      : e.uid.includes('.')
-                        ? e.uid.slice(e.uid.indexOf('.') + 1)
-                        : e.uid;
-            const group =
-                firstSeg === 'mcp'
-                    ? 'MCP'
-                    : firstSeg === 'model' || firstSeg === 'llm'
-                      ? 'Model'
-                      : firstSeg === 'agent'
-                        ? 'Agent'
-                        : firstSeg === 'api'
-                          ? 'API'
-                          : 'Resource';
-            const description = typeof attrs.description === 'string' ? (attrs.description as string) : undefined;
-            const labelForUid = e.uid.includes('.') ? e.uid.slice(e.uid.indexOf('.') + 1) : e.uid;
-            items.push({ id: `${group}::"${labelForUid}"`, label, group, description });
-        }
-        items.sort((a, b) => (a.group === b.group ? a.label.localeCompare(b.label) : a.group.localeCompare(b.group)));
-        return items;
-    }, [config.hasTarget, config.type, catalogEntities.data]);
+    const serviceResourceOptions = useMemo(
+        () => buildServiceResourceOptions(catalogEntities.data?.data ?? [], { hasTarget: config.hasTarget, type: config.type }),
+        [config.hasTarget, config.type, catalogEntities.data],
+    );
 
     const effectiveConfig = useMemo<ServicePageConfig>(
         () => ({

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/features/policy-management/__tests__/ServicePolicyPage.test.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/features/policy-management/__tests__/ServicePolicyPage.test.tsx
@@ -17,8 +17,8 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, fireEvent, screen, waitFor, within } from '@testing-library/react';
 import type { ReactNode } from 'react';
 import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
-import type { PolicyResponse, PolicyStatus } from '../../../shared/api/authz-api.types';
-import { ServicePolicyPage, type ServicePageConfig } from '../ServicePolicyPage';
+import type { EntityResponse, PolicyResponse, PolicyStatus } from '../../../shared/api/authz-api.types';
+import { buildServiceResourceOptions, ServicePolicyPage, type ServicePageConfig } from '../ServicePolicyPage';
 
 // jsdom doesn't implement scrollIntoView; Radix Select calls it on item activation.
 beforeAll(() => {
@@ -157,5 +157,60 @@ describe('ServicePolicyPage', () => {
 
         await waitFor(() => expect(listPoliciesSpy).toHaveBeenCalled());
         expect(screen.queryByLabelText('Unique targets')).not.toBeInTheDocument();
+    });
+});
+
+function resourceEntity(uid: string, attributes: Record<string, unknown> = {}): EntityResponse {
+    return {
+        id: `id-${uid}`,
+        environmentId: 'DEFAULT',
+        uid,
+        attributes,
+        parents: [],
+        createdAt: new Date(0).toISOString(),
+        updatedAt: new Date(0).toISOString(),
+    };
+}
+
+describe('buildServiceResourceOptions', () => {
+    it('excludes api/mcp/model/llm/action prefixes for custom policies', () => {
+        const entities = [
+            resourceEntity('api.orders'),
+            resourceEntity('mcp.files'),
+            resourceEntity('model.gpt'),
+            resourceEntity('llm.claude'),
+            resourceEntity('action.read'),
+            resourceEntity('document.contract'),
+        ];
+
+        const options = buildServiceResourceOptions(entities, { hasTarget: false, type: 'CUSTOM' });
+
+        expect(options.map(o => o.id)).toEqual(['Resource::"contract"']);
+        expect(options[0].group).toBe('Resource');
+        expect(options[0].label).toBe('contract');
+    });
+
+    it('keeps bare-id resources for custom policies', () => {
+        const entities = [resourceEntity('inventory'), resourceEntity('api.orders')];
+
+        const options = buildServiceResourceOptions(entities, { hasTarget: false, type: 'CUSTOM' });
+
+        expect(options).toHaveLength(1);
+        expect(options[0].id).toBe('Resource::"inventory"');
+        expect(options[0].group).toBe('Resource');
+    });
+
+    it('scopes to the service prefix and groups by segment for targeted policies', () => {
+        const entities = [
+            resourceEntity('mcp.files', { displayName: 'Files MCP' }),
+            resourceEntity('mcp.search'),
+            resourceEntity('api.orders'),
+        ];
+
+        const options = buildServiceResourceOptions(entities, { hasTarget: true, type: 'MCP' });
+
+        expect(options.map(o => o.id)).toEqual(['MCP::"files"', 'MCP::"search"']);
+        expect(options.every(o => o.group === 'MCP')).toBe(true);
+        expect(options[0].label).toBe('Files MCP');
     });
 });

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/shared/hooks/__tests__/useEntityOptions.test.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/shared/hooks/__tests__/useEntityOptions.test.tsx
@@ -138,6 +138,27 @@ describe('useEntityOptions', () => {
         expect(listEntitiesSpy).toHaveBeenCalledWith('env-1', { page: 1, perPage: 200, kind: 'PRINCIPAL' });
     });
 
+    it('keeps bare-id principals under the kind umbrella group when typeFilter is a principal subset', async () => {
+        listEntitiesSpy.mockImplementation((_env: string, params: { kind?: string } = {}) => {
+            if (params.kind === 'PRINCIPAL') {
+                return Promise.resolve(paged([entity('alice'), entity('api-gateway')]));
+            }
+            return Promise.resolve(paged([]));
+        });
+
+        const { getByTestId } = render(<Probe env="env-1" opts={{ typeFilter: ['User', 'ServiceAccount'] }} />, {
+            wrapper: makeWrapper(),
+        });
+
+        await waitFor(() => expect(getByTestId('count').textContent).toBe('2'));
+        const items = getByTestId('options').querySelectorAll('li');
+        expect(items[0].getAttribute('data-group')).toBe('Principal');
+        expect(items[0].getAttribute('data-label')).toBe('alice');
+        expect(items[0].textContent).toBe('Principal::"alice"');
+        expect(items[1].getAttribute('data-group')).toBe('Principal');
+        expect(items[1].textContent).toBe('Principal::"api-gateway"');
+    });
+
     it('sets error when total exceeds page size and still returns the loaded slice', async () => {
         const data = Array.from({ length: 200 }, (_, i) => entity(`User::"u${i}"`));
         listEntitiesSpy.mockResolvedValue(paged(data, 503));

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/shared/hooks/__tests__/useEntityOptions.test.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/shared/hooks/__tests__/useEntityOptions.test.tsx
@@ -159,6 +159,26 @@ describe('useEntityOptions', () => {
         expect(items[1].textContent).toBe('Principal::"api-gateway"');
     });
 
+    it('recovers the specific type for bare-id principals from the _kind hint', async () => {
+        listEntitiesSpy.mockImplementation((_env: string, params: { kind?: string } = {}) => {
+            if (params.kind === 'PRINCIPAL') {
+                return Promise.resolve(paged([entity('bob', { _kind: 'user' }), entity('ci', { _kind: 'serviceaccount' })]));
+            }
+            return Promise.resolve(paged([]));
+        });
+
+        const { getByTestId } = render(<Probe env="env-1" opts={{ typeFilter: ['User', 'ServiceAccount'] }} />, {
+            wrapper: makeWrapper(),
+        });
+
+        await waitFor(() => expect(getByTestId('count').textContent).toBe('2'));
+        const items = getByTestId('options').querySelectorAll('li');
+        expect(items[0].getAttribute('data-group')).toBe('User');
+        expect(items[0].textContent).toBe('User::"bob"');
+        expect(items[1].getAttribute('data-group')).toBe('ServiceAccount');
+        expect(items[1].textContent).toBe('ServiceAccount::"ci"');
+    });
+
     it('sets error when total exceeds page size and still returns the loaded slice', async () => {
         const data = Array.from({ length: 200 }, (_, i) => entity(`User::"u${i}"`));
         listEntitiesSpy.mockResolvedValue(paged(data, 503));

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/shared/hooks/useEntityOptions.ts
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/shared/hooks/useEntityOptions.ts
@@ -39,6 +39,12 @@ const PER_PAGE = 200;
 // under that kind, so we don't need N kind-scoped requests.
 const PRINCIPAL_UI_TYPES = new Set(['User', 'Group', 'ServiceAccount', 'AgentIdentity']);
 
+// Umbrella group for entities the server already scoped by kind but whose uid
+// carries no recognizable `<kind>.<id>` prefix (e.g. parity-imported principals
+// stored as bare ids like `alice`). Maps to the canonical GAPL entity type so
+// the emitted token (`Principal::"alice"`) stays schema-valid.
+const KIND_FALLBACK_GROUP: Record<EntityKindFilter, string> = { PRINCIPAL: 'Principal', RESOURCE: 'Resource' };
+
 function resolveKind(typeFilter: readonly string[] | undefined): EntityKindFilter | undefined {
     if (!typeFilter || typeFilter.length === 0) return undefined;
     const allPrincipals = typeFilter.every(t => PRINCIPAL_UI_TYPES.has(t));
@@ -58,12 +64,13 @@ function summarizeAttributes(attrs: Record<string, unknown>): string | undefined
     return parts.join(', ');
 }
 
-function toChipOption(entity: EntityResponse): ChipOption {
+function toChipOption(entity: EntityResponse, fallbackGroup?: string): ChipOption {
     const { type, id } = parseEntityUid(entity.uid);
+    const group = type === 'Unknown' && fallbackGroup ? fallbackGroup : type;
     return {
-        id: `${type}::"${id}"`,
+        id: `${group}::"${id}"`,
         label: id,
-        group: type,
+        group,
         description: summarizeAttributes(entity.attributes),
     };
 }
@@ -84,14 +91,16 @@ export function useEntityOptions(environmentId: string, opts?: UseEntityOptionsO
         staleTime: 30_000,
     });
 
-    const allOptions = useMemo(() => query.data?.data.map(toChipOption) ?? [], [query.data]);
+    const fallbackGroup = kind ? KIND_FALLBACK_GROUP[kind] : undefined;
+
+    const allOptions = useMemo(() => query.data?.data.map(e => toChipOption(e, fallbackGroup)) ?? [], [query.data, fallbackGroup]);
 
     const allowedTypes = useMemo(() => (typeFilterKey ? new Set(typeFilterKey.split('\0')) : null), [typeFilterKey]);
 
     const options = useMemo<readonly ChipOption[]>(() => {
         if (!allowedTypes) return allOptions;
-        return allOptions.filter(o => allowedTypes.has(o.group));
-    }, [allOptions, allowedTypes]);
+        return allOptions.filter(o => allowedTypes.has(o.group) || (fallbackGroup !== undefined && o.group === fallbackGroup));
+    }, [allOptions, allowedTypes, fallbackGroup]);
 
     const tooMany = (query.data?.total ?? 0) > (query.data?.data.length ?? 0);
     const networkError = query.error instanceof Error ? query.error.message : query.error ? String(query.error) : undefined;

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/shared/hooks/useEntityOptions.ts
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/shared/hooks/useEntityOptions.ts
@@ -20,6 +20,7 @@ import type { EntityResponse } from '../api/authz-api.types';
 import { authzQueryKeys } from '../api/query-keys';
 import type { ChipOption } from '../chip-option';
 import { parseEntityUid } from '../entity-adapter';
+import { kindToUiType } from '../entity-kind-registry';
 
 export interface UseEntityOptionsResult {
     readonly options: readonly ChipOption[];
@@ -40,9 +41,10 @@ const PER_PAGE = 200;
 const PRINCIPAL_UI_TYPES = new Set(['User', 'Group', 'ServiceAccount', 'AgentIdentity']);
 
 // Umbrella group for entities the server already scoped by kind but whose uid
-// carries no recognizable `<kind>.<id>` prefix (e.g. parity-imported principals
-// stored as bare ids like `alice`). Maps to the canonical GAPL entity type so
-// the emitted token (`Principal::"alice"`) stays schema-valid.
+// carries no recognizable `<kind>.<id>` prefix and no `_kind` hint (e.g.
+// parity-imported principals stored as bare ids like `alice`). Maps to the
+// canonical GAPL entity type so the emitted token (`Principal::"alice"`) stays
+// schema-valid.
 const KIND_FALLBACK_GROUP: Record<EntityKindFilter, string> = { PRINCIPAL: 'Principal', RESOURCE: 'Resource' };
 
 function resolveKind(typeFilter: readonly string[] | undefined): EntityKindFilter | undefined {
@@ -66,7 +68,9 @@ function summarizeAttributes(attrs: Record<string, unknown>): string | undefined
 
 function toChipOption(entity: EntityResponse, fallbackGroup?: string): ChipOption {
     const { type, id } = parseEntityUid(entity.uid);
-    const group = type === 'Unknown' && fallbackGroup ? fallbackGroup : type;
+    // Bare ids parse to `Unknown`; recover the specific type from the `_kind`
+    // hint (as fromBackend does) before dropping to the kind umbrella group.
+    const group = type !== 'Unknown' ? type : (kindToUiType(entity.attributes['_kind']) ?? fallbackGroup ?? type);
     return {
         id: `${group}::"${id}"`,
         label: id,


### PR DESCRIPTION
## Summary
- Parity-imported principals are stored with bare entityIds (e.g. `alice` instead of `user.alice`). These parsed to type `Unknown` and were filtered out of the PRINCIPAL picker, so defined users never showed up in the dropdown.
- `useEntityOptions` now falls back to the kind umbrella group (`Principal`/`Resource`) when a kind-scoped entity has no recognizable `<kind>.<id>` prefix, keeping the emitted GAPL token (e.g. `Principal::"alice"`) schema-valid.
- `toChipOption` consults the `_kind` attribute before dropping to the umbrella group, so a bare-id principal carrying `_kind=user` is grouped under **User** (token `User::"alice"`) — matching `fromBackend` behaviour.
- Custom policies: the principal picker is always scoped to `kind=PRINCIPAL`, and the resource picker is restricted to genuine resources (excludes `api`/`mcp`/`model`/`llm`/`action`, which have their own dedicated pickers).
- Extracted the custom resource filtering into a pure, unit-tested helper `buildServiceResourceOptions`.

## Test plan
- [x] `useEntityOptions` unit test: bare-id principals (`alice`, `api-gateway`) land under the `Principal` umbrella group with token `Principal::"alice"`.
- [x] `useEntityOptions` unit test: bare-id principals with `_kind` (`bob`/`ci`) recover their specific type (`User::"bob"`, `ServiceAccount::"ci"`).
- [x] `buildServiceResourceOptions` unit tests: custom policies exclude `api`/`mcp`/`model`/`llm`/`action`, keep bare-id resources, and targeted policies scope+group by service prefix.
- [x] Full suite green: 18/18 vitest tests across both files.
- [x] Verified live in gamma-console (Custom Policy editor): PRINCIPAL dropdown shows `alice123` under **User** and `alice`/`api-gateway` under **Principal**; RESOURCE picker excludes api/mcp/model/action entities.