### PR TITLE
fix(GKO-2863): return 400 when primary owner is a group member

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/group/use_case/ImportGroupCRDUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/group/use_case/ImportGroupCRDUseCase.java
@@ -17,7 +17,7 @@ package io.gravitee.apim.core.group.use_case;
 
 import io.gravitee.apim.core.UseCase;
 import io.gravitee.apim.core.audit.model.AuditInfo;
-import io.gravitee.apim.core.exception.TechnicalDomainException;
+import io.gravitee.apim.core.exception.ValidationDomainException;
 import io.gravitee.apim.core.group.crud_service.GroupCrudService;
 import io.gravitee.apim.core.group.domain_service.ValidateGroupCRDDomainService;
 import io.gravitee.apim.core.group.model.crd.GroupCRDSpec;
@@ -65,11 +65,16 @@ public class ImportGroupCRDUseCase {
         validationResult
             .severe()
             .ifPresent(errors -> {
-                throw new TechnicalDomainException(errors.iterator().next().getMessage());
+                throw new ValidationDomainException(
+                    String.format(
+                        "Unable to import because of errors [%s]",
+                        String.join(",", errors.stream().map(Validator.Error::getMessage).toList())
+                    )
+                );
             });
 
         var warnings = validationResult.warning().orElseGet(List::of);
-        var sanitizedInput = validationResult.value().orElseThrow(() -> new TechnicalDomainException("Unable to sanitize CRD spec"));
+        var sanitizedInput = validationResult.value().orElseThrow(() -> new ValidationDomainException("Unable to sanitize CRD spec"));
 
         var status = queryService
             .findById(sanitizedInput.spec.getId())

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/group/use_case/ImportGroupCRDUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/group/use_case/ImportGroupCRDUseCaseTest.java
@@ -15,7 +15,10 @@
  */
 package io.gravitee.apim.core.group.use_case;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.SoftAssertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import fixtures.core.model.AuditInfoFixtures;
@@ -25,17 +28,25 @@ import inmemory.GroupQueryServiceInMemory;
 import inmemory.RoleQueryServiceInMemory;
 import inmemory.UserDomainServiceInMemory;
 import io.gravitee.apim.core.audit.model.AuditInfo;
+import io.gravitee.apim.core.exception.ValidationDomainException;
+import io.gravitee.apim.core.group.domain_service.ValidateGroupCRDDomainService;
 import io.gravitee.apim.core.group.model.crd.GroupCRDSpec;
 import io.gravitee.apim.core.member.domain_service.ValidateCRDMembersDomainService;
 import io.gravitee.apim.core.member.model.RoleScope;
+import io.gravitee.apim.core.membership.model.Role;
+import io.gravitee.apim.core.user.model.BaseUserEntity;
+import io.gravitee.apim.core.user.model.IdpSource;
+import io.gravitee.apim.core.validation.Validator;
 import io.gravitee.apim.infra.domain_service.group.ValidateGroupCRDDomainServiceImpl;
 import io.gravitee.rest.api.model.RoleEntity;
 import io.gravitee.rest.api.model.context.OriginContext;
 import io.gravitee.rest.api.service.RoleService;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
@@ -66,12 +77,42 @@ class ImportGroupCRDUseCaseTest {
 
     private final CRDMembersDomainServiceInMemory membersService = new CRDMembersDomainServiceInMemory();
 
-    private final RoleService roleService = Mockito.mock(RoleService.class);
+    private final RoleService roleService = mock(RoleService.class);
 
     private ImportGroupCRDUseCase cut;
 
     @BeforeEach
     void setUp() {
+        when(
+            roleService.findDefaultRoleByScopes(
+                ORGANIZATION_ID,
+                io.gravitee.rest.api.model.permissions.RoleScope.API,
+                io.gravitee.rest.api.model.permissions.RoleScope.APPLICATION,
+                io.gravitee.rest.api.model.permissions.RoleScope.INTEGRATION
+            )
+        ).thenReturn(
+            List.of(
+                RoleEntity.builder()
+                    .id(UUID.randomUUID().toString())
+                    .scope(io.gravitee.rest.api.model.permissions.RoleScope.API)
+                    .defaultRole(true)
+                    .name("USER")
+                    .build(),
+                RoleEntity.builder()
+                    .id(UUID.randomUUID().toString())
+                    .scope(io.gravitee.rest.api.model.permissions.RoleScope.APPLICATION)
+                    .defaultRole(true)
+                    .name("USER")
+                    .build(),
+                RoleEntity.builder()
+                    .id(UUID.randomUUID().toString())
+                    .scope(io.gravitee.rest.api.model.permissions.RoleScope.INTEGRATION)
+                    .defaultRole(true)
+                    .name("USER")
+                    .build()
+            )
+        );
+
         cut = new ImportGroupCRDUseCase(
             new ValidateGroupCRDDomainServiceImpl(new ValidateCRDMembersDomainService(userDomainService, roleQueryService), roleService),
             groupQueryService,
@@ -134,5 +175,66 @@ class ImportGroupCRDUseCaseTest {
             soft.assertThat(membersService.getGroupApplicationRole(GROUP_ID)).isEqualTo("USER");
             soft.assertThat(membersService.getGroupApiProductRole(GROUP_ID)).isEqualTo("USER");
         });
+    }
+
+    @Test
+    void should_reject_import_when_primary_owner_is_added_as_group_member() {
+        userDomainService.initWith(
+            List.of(
+                BaseUserEntity.builder()
+                    .organizationId(ORGANIZATION_ID)
+                    .id(ACTOR_USER_ID)
+                    .source(IdpSource.of("memory"))
+                    .sourceId("admin")
+                    .build()
+            )
+        );
+        roleQueryService.initWith(
+            List.of(
+                Role.builder()
+                    .name("USER")
+                    .referenceType(Role.ReferenceType.ORGANIZATION)
+                    .referenceId(ORGANIZATION_ID)
+                    .id(UUID.randomUUID().toString())
+                    .scope(Role.Scope.API)
+                    .build()
+            )
+        );
+
+        var spec = GroupCRDSpec.builder()
+            .id(GROUP_ID)
+            .name("kubernetes-spec")
+            .members(
+                new LinkedHashSet<>(
+                    Set.of(GroupCRDSpec.Member.builder().source("memory").sourceId("admin").roles(Map.of(RoleScope.API, "USER")).build())
+                )
+            );
+
+        ImportGroupCRDUseCase.Input input = new ImportGroupCRDUseCase.Input(AUDIT_INFO, spec.build());
+        assertThatThrownBy(() -> cut.execute(input))
+            .isInstanceOf(ValidationDomainException.class)
+            .hasMessageContaining("Unable to import because of errors")
+            .hasMessageContaining("can not change the role of primary owner [admin]");
+    }
+
+    @Test
+    void sanitize_guard_throws_ValidationDomainException_when_value_is_absent() {
+        var validationService = mock(ValidateGroupCRDDomainService.class);
+        when(validationService.validateAndSanitize(any())).thenReturn(Validator.Result.empty());
+
+        var useCase = new ImportGroupCRDUseCase(
+            validationService,
+            new GroupQueryServiceInMemory(),
+            new GroupCrudServiceInMemory(),
+            new CRDMembersDomainServiceInMemory()
+        );
+
+        var auditInfo = AuditInfoFixtures.anAuditInfo("org", "env", "user");
+        var spec = GroupCRDSpec.builder().id("group-id").name("test").build();
+
+        var input = new ImportGroupCRDUseCase.Input(auditInfo, spec);
+        assertThatThrownBy(() -> useCase.execute(input))
+            .isInstanceOf(ValidationDomainException.class)
+            .hasMessage("Unable to sanitize CRD spec");
     }
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/GKO-2863

## Summary

- `ImportGroupCRDUseCase` now throws `ValidationDomainException` on severe validation errors (same pattern as other CRD import use cases), so the Automation API returns **HTTP 400** instead of **500** when the org primary owner is listed as a group member.
- Added a regression test reproducing the `memory` / `admin` member case from the ticket.

## Test plan

- [x] `mvn -f gravitee-apim-rest-api/gravitee-apim-rest-api-service/pom.xml test -Dtest=ImportGroupCRDUseCaseTest`
- [x] `PUT /automation/organizations/DEFAULT/environments/DEFAULT/groups` with primary owner in `members` returns **400** and a message containing `can not change the role of primary owner`