### PR TITLE
perf(jdbc): add (plan,id) composite index on subscriptions for warmup keyset (APIM-14087)

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_11_8/04_add_subscriptions_plan_id_index.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_11_8/04_add_subscriptions_plan_id_index.yml
@@ -1,0 +1,13 @@
+databaseChangeLog:
+  - changeSet:
+      id: 4.11.8_04_add_subscriptions_plan_id_index
+      author: GraviteeSource Team
+      changes:
+        - createIndex:
+            indexName: idx_${gravitee_prefix}subscriptions_plan_id
+            tableName: ${gravitee_prefix}subscriptions
+            columns:
+              - column:
+                  name: plan
+              - column:
+                  name: id

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/master.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/master.yml
@@ -338,3 +338,5 @@ databaseChangeLog:
         - file: liquibase/changelogs/v4_11_8/02_add_keys_environment_id_updated_at_id_index.yml
     - include:
         - file: liquibase/changelogs/v4_11_8/03_add_plans_cross_id_index.yml
+    - include:
+        - file: liquibase/changelogs/v4_11_8/04_add_subscriptions_plan_id_index.yml


### PR DESCRIPTION
## What
Adds a composite **`(plan, id)`** index on `subscriptions` for JDBC (Liquibase `v4_11_8/04_add_subscriptions_plan_id_index.yml`; additive — keeps the single-column `idx_subscriptions_plan`). JDBC counterpart of the Mongo `{plan:1,_id:1}` index in #17257.

## Why / measured impact (real Postgres 13, 2,396,373 subs / 2.28M ACCEPTED / 23.5k plans)
The warmup appender keyset-paginates `where plan in (…300…) order by plan, id limit 2000`. Full server-side keyset drain (82 batches, 1180 pages):

| warmup `order by` | full drain |
|---|---:|
| `id` (shipped base) | **303 s** (later pages walk ever-more of the id-space) |
| `plan, id` — only `idx_subscriptions_plan` (Incremental Sort) | **9.5 s** |
| `plan, id` — **with this `(plan,id)` index** | **9.0 s** |

- The dominant win is the **`order by plan,id` code change in #17257** (303 s → 9.5 s).
- On **Postgres** this composite index is a **minor** add-on (~5%): PG's *Incremental Sort* already serves `order by plan,id` cheaply off the plan-only index. Per page it does remove the sort (≈6 ms vs ≈33 ms), but that nets out small across the drain.
- Its real value is on engines **without incremental sort** — **MySQL / MariaDB / SQL Server** — where `order by plan,id` on a plan-only index forces a *full* per-page sort; the composite avoids that. Additive, harmless on PG.

## Notes
- Pairs with **#17257** (introduces the `(plan,id)` warmup keyset + the Mongo index). Should land together so JDBC's `order by plan,id` has a matching composite on the sort-less engines.
