### PR TITLE
fix(portal): refine ownership transfer dialog UX

### DIFF
--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-members/application-tab-members.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-members/application-tab-members.component.spec.ts
@@ -569,6 +569,7 @@ describe('ApplicationTabMembersComponent', () => {
       );
 
       await harness.clickTransferOwnershipButton();
+      fixture.detectChanges();
       await fixture.whenStable();
       fixture.detectChanges();
 
@@ -581,6 +582,7 @@ describe('ApplicationTabMembersComponent', () => {
       const harness = await flush(fakeMembersResponse([fakeMember()]));
 
       await harness.clickTransferOwnershipButton();
+      fixture.detectChanges();
       await fixture.whenStable();
       fixture.detectChanges();
 

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-members/application-tab-members.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-members/application-tab-members.component.ts
@@ -43,7 +43,6 @@ import {
 import {
   ApplicationTransferOwnershipDialogComponent,
   ApplicationTransferOwnershipDialogData,
-  ApplicationTransferOwnershipMemberOption,
 } from '../application-transfer-ownership-dialog/application-transfer-ownership-dialog.component';
 
 interface MemberTableRow {
@@ -213,9 +212,6 @@ export class ApplicationTabMembersComponent {
           data: {
             applicationId: this.applicationId(),
             currentOwnerId: this.application()?.owner?.id,
-            members: this.rows()
-              .filter(row => !!row.id)
-              .map(row => this.toTransferOwnershipMemberOption(row)),
           },
           disableClose: true,
         },
@@ -291,17 +287,6 @@ export class ApplicationTabMembersComponent {
       isCurrentUser: !!user?.id && user.id === this.currentUserService.user()?.id,
       role: member.role ?? '',
       isPrimaryOwner: member.role === APPLICATION_PRIMARY_OWNER_ROLE_NAME,
-    };
-  }
-
-  private toTransferOwnershipMemberOption(member: MemberTableRow): ApplicationTransferOwnershipMemberOption {
-    return {
-      id: member.id,
-      reference: member.reference,
-      displayName: member.user.displayName,
-      email: member.user.email,
-      avatarUrl: member.user.avatarUrl,
-      initials: member.user.initials,
     };
   }
 

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-transfer-ownership-dialog/application-transfer-ownership-dialog.component.harness.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-transfer-ownership-dialog/application-transfer-ownership-dialog.component.harness.ts
@@ -38,6 +38,10 @@ export class ApplicationTransferOwnershipDialogHarness extends ComponentHarness 
     MatButtonHarness.with({ selector: '[data-testid="transfer-ownership-submit-button"]' }),
   );
   private readonly locateSearchError = this.locatorForOptional('[data-testid="transfer-ownership-user-search-error"]');
+  private readonly locateApplicationMemberSearchError = this.locatorForOptional(
+    '[data-testid="transfer-ownership-application-member-search-error"]',
+  );
+  private readonly locateSelectedTarget = this.locatorForOptional('[data-testid="transfer-ownership-selected-target"]');
   private readonly locateSubmitError = this.locatorForOptional('[data-testid="transfer-ownership-submit-error"]');
   private readonly locateRolesError = this.locatorForOptional('[data-testid="transfer-ownership-roles-error"]');
 
@@ -120,6 +124,16 @@ export class ApplicationTransferOwnershipDialogHarness extends ComponentHarness 
 
   async getSearchErrorText(): Promise<string | null> {
     const element = await this.locateSearchError();
+    return element ? element.text() : null;
+  }
+
+  async getApplicationMemberSearchErrorText(): Promise<string | null> {
+    const element = await this.locateApplicationMemberSearchError();
+    return element ? element.text() : null;
+  }
+
+  async getSelectedTargetText(): Promise<string | null> {
+    const element = await this.locateSelectedTarget();
     return element ? element.text() : null;
   }
 

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-transfer-ownership-dialog/application-transfer-ownership-dialog.component.html
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-transfer-ownership-dialog/application-transfer-ownership-dialog.component.html
@@ -28,12 +28,14 @@
     </p>
     <app-button-toggle-group [value]="transferMethod()" (valueChange)="onTransferMethodChange($event)">
       <app-button-toggle-option
+        class="application-transfer-ownership-dialog__method-option"
         value="APPLICATION_MEMBER"
-        icon="groups"
+        icon="person"
         label="Application member"
         i18n-label="@@transferApplicationOwnershipApplicationMemberMethod"
       />
       <app-button-toggle-option
+        class="application-transfer-ownership-dialog__method-option"
         value="OTHER_USER"
         icon="person_search"
         label="Other user"
@@ -59,6 +61,14 @@
           i18n-placeholder="@@transferApplicationOwnershipMemberPlaceholder"
         />
         <mat-autocomplete #applicationMemberAutocomplete="matAutocomplete">
+          @if (applicationMembersResource.isLoading()) {
+            <mat-option disabled data-testid="transfer-ownership-application-member-search-loading">
+              <div class="application-transfer-ownership-dialog__option">
+                <mat-progress-spinner diameter="20" mode="indeterminate" />
+                <span class="next-gen-small" i18n="@@transferApplicationOwnershipMemberSearchLoading">Searching members...</span>
+              </div>
+            </mat-option>
+          }
           @for (option of applicationMemberOptions(); track option.id) {
             <mat-option [value]="applicationMemberSearchQuery()" (onSelectionChange)="$event.isUserInput && onTargetSelected(option)">
               <app-user-cell [user]="option.vm" />
@@ -71,6 +81,17 @@
           }
         </mat-autocomplete>
       </mat-form-field>
+
+      @if (applicationMembersResource.error()) {
+        <p
+          class="application-transfer-ownership-dialog__error next-gen-small"
+          data-testid="transfer-ownership-application-member-search-error"
+          role="alert"
+          i18n
+        >
+          An error occurred while searching application members. Please try again.
+        </p>
+      }
     } @else {
       <mat-form-field appearance="outline" class="application-transfer-ownership-dialog__field">
         <mat-label i18n="@@transferApplicationOwnershipOtherUserLabel">Search user</mat-label>
@@ -135,6 +156,12 @@
         </p>
       }
     }
+
+    @if (selectedTarget(); as target) {
+      <div class="application-transfer-ownership-dialog__selected-target" data-testid="transfer-ownership-selected-target">
+        <app-user-cell [user]="target.vm" />
+      </div>
+    }
   </section>
 
   <section class="application-transfer-ownership-dialog__section">
@@ -154,11 +181,11 @@
       </p>
     } @else {
       <mat-form-field appearance="outline" class="application-transfer-ownership-dialog__field">
-        <mat-label i18n="@@transferApplicationOwnershipCurrentOwnerRoleLabel">Current owner new role</mat-label>
+        <mat-label i18n="@@transferApplicationOwnershipCurrentOwnerRoleLabel">New Role for Current Primary Owner</mat-label>
         <mat-select
           [formControl]="roleControl"
           data-testid="transfer-ownership-role-select"
-          aria-label="Current owner new role"
+          aria-label="New Role for Current Primary Owner"
           i18n-aria-label="@@transferApplicationOwnershipCurrentOwnerRoleAriaLabel"
         >
           @for (role of assignableRoles(); track role.name) {

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-transfer-ownership-dialog/application-transfer-ownership-dialog.component.scss
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-transfer-ownership-dialog/application-transfer-ownership-dialog.component.scss
@@ -39,6 +39,10 @@
     width: 100%;
   }
 
+  &__selected-target {
+    display: flex;
+  }
+
   &__loading {
     display: flex;
     align-items: center;

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-transfer-ownership-dialog/application-transfer-ownership-dialog.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-transfer-ownership-dialog/application-transfer-ownership-dialog.component.spec.ts
@@ -26,6 +26,8 @@ import {
 } from './application-transfer-ownership-dialog.component';
 import { ApplicationTransferOwnershipDialogHarness } from './application-transfer-ownership-dialog.component.harness';
 import { APPLICATION_PRIMARY_OWNER_ROLE_NAME, ApplicationRole } from '../../../../entities/application/application';
+import { MembersResponse } from '../../../../entities/member/member';
+import { fakeMember, fakeMembersResponse } from '../../../../entities/member/member.fixtures';
 import { User, UsersResponse } from '../../../../entities/user/user';
 import { fakeUser, fakeUsersResponse } from '../../../../entities/user/user.fixtures';
 import { ConfigService } from '../../../../services/config.service';
@@ -35,27 +37,25 @@ const APPLICATION_ID = 'app-1';
 const OWNER_ID = 'owner-1';
 const ROLES_URL = `${TESTING_BASE_URL}/configuration/applications/roles`;
 const TRANSFER_URL = `${TESTING_BASE_URL}/applications/${APPLICATION_ID}/members/_transfer_ownership`;
+const MEMBERS_SEARCH_URL = `${TESTING_BASE_URL}/applications/${APPLICATION_ID}/members/_search`;
 const USERS_SEARCH_URL = `${TESTING_BASE_URL}/users/_search`;
 
 const DIALOG_DATA: ApplicationTransferOwnershipDialogData = {
   applicationId: APPLICATION_ID,
   currentOwnerId: OWNER_ID,
-  members: [
-    {
-      id: OWNER_ID,
-      displayName: 'Current Owner',
-      email: 'owner@example.com',
-      initials: 'CO',
-    },
-    {
-      id: 'member-1',
-      reference: 'member-reference',
-      displayName: 'Alice Smith',
-      email: 'alice@example.com',
-      initials: 'AS',
-    },
-  ],
 };
+
+const APPLICATION_MEMBERS_RESPONSE = fakeMembersResponse([
+  fakeMember({
+    id: OWNER_ID,
+    role: APPLICATION_PRIMARY_OWNER_ROLE_NAME,
+    user: { id: OWNER_ID, display_name: 'Current Owner', _links: {} },
+  }),
+  fakeMember({
+    id: 'member-1',
+    user: { id: 'member-1', reference: 'member-reference', display_name: 'Alice Smith', email: 'alice@example.com', _links: {} },
+  }),
+]);
 
 const APPLICATION_ROLES: ApplicationRole[] = [
   { id: APPLICATION_PRIMARY_OWNER_ROLE_NAME, name: APPLICATION_PRIMARY_OWNER_ROLE_NAME, default: false, system: true },
@@ -74,6 +74,7 @@ describe('ApplicationTransferOwnershipDialogComponent', () => {
   async function init(
     data: ApplicationTransferOwnershipDialogData = DIALOG_DATA,
     roles: ApplicationRole[] | null = APPLICATION_ROLES,
+    applicationMembers: MembersResponse | null = null,
     createHarness = true,
   ): Promise<void> {
     jest.useRealTimers();
@@ -97,6 +98,11 @@ describe('ApplicationTransferOwnershipDialogComponent', () => {
     fixture.detectChanges();
     if (roles) {
       flushRoles(roles);
+    }
+    if (applicationMembers) {
+      flushApplicationMembers(applicationMembers);
+    }
+    if (roles || applicationMembers) {
       await fixture.whenStable();
       fixture.detectChanges();
     }
@@ -109,6 +115,30 @@ describe('ApplicationTransferOwnershipDialogComponent', () => {
     const req = httpTestingController.expectOne(ROLES_URL);
     expect(req.request.method).toBe('GET');
     req.flush({ data: roles });
+  }
+
+  function flushApplicationMembers(response: MembersResponse = APPLICATION_MEMBERS_RESPONSE, query = ''): void {
+    const req = httpTestingController.expectOne(req => req.url === MEMBERS_SEARCH_URL);
+    expect(req.request.method).toBe('POST');
+    expect(req.request.params.get('page')).toBe('1');
+    expect(req.request.params.get('size')).toBe('20');
+    expect(req.request.body).toEqual({
+      filters: {
+        displayName: query,
+      },
+    });
+    req.flush(response);
+  }
+
+  async function searchApplicationMember(query: string, response: MembersResponse): Promise<void> {
+    await harness.searchApplicationMember(query);
+    fixture.detectChanges();
+    await new Promise(resolve => setTimeout(resolve, 350));
+    fixture.detectChanges();
+
+    flushApplicationMembers(response, query);
+    await fixture.whenStable();
+    fixture.detectChanges();
   }
 
   async function searchOtherUser(query: string, response: UsersResponse): Promise<void> {
@@ -148,6 +178,12 @@ describe('ApplicationTransferOwnershipDialogComponent', () => {
     expect(methodTexts.some(text => text.includes('Primary owner group'))).toBe(false);
   });
 
+  it('should not search application members before query is entered', async () => {
+    await init();
+
+    httpTestingController.expectNone(req => req.url === MEMBERS_SEARCH_URL);
+  });
+
   it('should offer only assignable roles for the current owner new role', async () => {
     await init();
 
@@ -157,7 +193,7 @@ describe('ApplicationTransferOwnershipDialogComponent', () => {
   it('should keep transfer disabled until target and role are selected', async () => {
     await init();
 
-    await harness.searchApplicationMember('Alice');
+    await searchApplicationMember('Alice', fakeMembersResponse([aliceMember()]));
     await harness.selectApplicationMember(/Alice Smith/);
     fixture.detectChanges();
 
@@ -171,7 +207,7 @@ describe('ApplicationTransferOwnershipDialogComponent', () => {
   it('should transfer ownership to an application member', async () => {
     await init();
 
-    await harness.searchApplicationMember('Alice');
+    await searchApplicationMember('Alice', fakeMembersResponse([aliceMember()]));
     expect(await harness.getApplicationMemberOptionTexts()).toEqual([expect.stringContaining('Alice Smith')]);
     await harness.selectApplicationMember(/Alice Smith/);
     await harness.selectRole('OWNER');
@@ -189,6 +225,48 @@ describe('ApplicationTransferOwnershipDialogComponent', () => {
     await fixture.whenStable();
 
     expect(dialogRef.close).toHaveBeenCalledWith(true);
+  });
+
+  it('should show the selected application member email after selection', async () => {
+    await init();
+
+    await searchApplicationMember('Alice', fakeMembersResponse([aliceMember()]));
+    await harness.selectApplicationMember(/Alice Smith/);
+    fixture.detectChanges();
+
+    expect(await harness.getSelectedTargetText()).toContain('alice@example.com');
+  });
+
+  it('should search application members independently from the members table page', async () => {
+    await init();
+
+    await searchApplicationMember(
+      'Page Two',
+      fakeMembersResponse([
+        fakeMember({
+          id: 'page-2-member',
+          user: {
+            id: 'page-2-member',
+            reference: 'page-2-reference',
+            display_name: 'Page Two Member',
+            email: 'page.two@example.com',
+            _links: {},
+          },
+        }),
+      ]),
+    );
+    await harness.selectApplicationMember(/Page Two Member/);
+    await harness.selectRole('OWNER');
+    await harness.clickSubmit();
+    fixture.detectChanges();
+
+    const req = httpTestingController.expectOne(TRANSFER_URL);
+    expect(req.request.body).toEqual({
+      new_primary_owner_id: 'page-2-member',
+      new_primary_owner_reference: 'page-2-reference',
+      primary_owner_newrole: 'OWNER',
+    });
+    req.flush(null, { status: 204, statusText: 'No Content' });
   });
 
   it('should transfer ownership to another registered user', async () => {
@@ -228,7 +306,7 @@ describe('ApplicationTransferOwnershipDialogComponent', () => {
   it('should keep dialog open and show inline error when transfer fails', async () => {
     await init();
 
-    await harness.searchApplicationMember('Alice');
+    await searchApplicationMember('Alice', fakeMembersResponse([aliceMember()]));
     await harness.selectApplicationMember(/Alice Smith/);
     await harness.selectRole('OWNER');
     await harness.clickSubmit();
@@ -253,7 +331,7 @@ describe('ApplicationTransferOwnershipDialogComponent', () => {
   });
 
   it('should show recoverable roles loading error', async () => {
-    await init(DIALOG_DATA, null, false);
+    await init(DIALOG_DATA, null, null, false);
 
     httpTestingController.expectOne(ROLES_URL).flush({ message: 'Server error' }, { status: 500, statusText: 'Error' });
     await fixture.whenStable();
@@ -271,5 +349,12 @@ function usersResponse(users: User[], applicationMembership: Record<string, bool
       data: { total: users.length },
       applicationMembership,
     },
+  });
+}
+
+function aliceMember() {
+  return fakeMember({
+    id: 'member-1',
+    user: { id: 'member-1', reference: 'member-reference', display_name: 'Alice Smith', email: 'alice@example.com', _links: {} },
   });
 }

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-transfer-ownership-dialog/application-transfer-ownership-dialog.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-transfer-ownership-dialog/application-transfer-ownership-dialog.component.ts
@@ -30,6 +30,7 @@ import { ButtonToggleGroupComponent } from '../../../../components/button-toggle
 import { ButtonToggleOptionComponent } from '../../../../components/button-toggle-group/button-toggle-option.component';
 import { UserCellComponent, UserCellVM } from '../../../../components/user-cell/user-cell.component';
 import { isAssignableApplicationRole } from '../../../../entities/application/application';
+import { Member, MembersResponse } from '../../../../entities/member/member';
 import { User, UsersResponse } from '../../../../entities/user/user';
 import { ApplicationService } from '../../../../services/application.service';
 import { MembershipService } from '../../../../services/membership.service';
@@ -37,10 +38,11 @@ import { UsersService } from '../../../../services/users.service';
 
 const APPLICATION_MEMBER_METHOD = 'APPLICATION_MEMBER';
 const OTHER_USER_METHOD = 'OTHER_USER';
+const APPLICATION_MEMBER_SEARCH_PAGE_SIZE = 20;
 
 type TransferOwnershipMethod = typeof APPLICATION_MEMBER_METHOD | typeof OTHER_USER_METHOD;
 
-export interface ApplicationTransferOwnershipMemberOption {
+interface ApplicationTransferOwnershipMemberOption {
   id: string;
   reference?: string;
   displayName: string;
@@ -52,7 +54,6 @@ export interface ApplicationTransferOwnershipMemberOption {
 export interface ApplicationTransferOwnershipDialogData {
   applicationId: string;
   currentOwnerId?: string;
-  members: ApplicationTransferOwnershipMemberOption[];
 }
 
 interface TransferOwnershipTarget extends ApplicationTransferOwnershipMemberOption {
@@ -98,7 +99,11 @@ export class ApplicationTransferOwnershipDialogComponent {
   readonly selectedTarget = signal<TransferOwnershipTarget | null>(null);
 
   private readonly applicationMemberSearchValue = toSignal(
-    this.applicationMemberControl.valueChanges.pipe(startWith(this.applicationMemberControl.value)),
+    this.applicationMemberControl.valueChanges.pipe(
+      debounceTime(300),
+      distinctUntilChanged(),
+      startWith(this.applicationMemberControl.value),
+    ),
     {
       initialValue: this.applicationMemberControl.value,
     },
@@ -119,10 +124,24 @@ export class ApplicationTransferOwnershipDialogComponent {
   readonly isOtherUserMethod = computed(() => this.transferMethod() === OTHER_USER_METHOD);
   readonly applicationMemberSearchQuery = computed(() => this.applicationMemberSearchValue().trim());
   readonly otherUserSearchQuery = computed(() => this.otherUserSearchValue().trim());
+  readonly applicationMemberSearchRequest = computed(() => {
+    const query = this.applicationMemberSearchQuery();
+    return this.isApplicationMemberMethod() && query.length > 0 ? query : null;
+  });
   readonly otherUserSearchRequest = computed(() => (this.isOtherUserMethod() ? this.otherUserSearchQuery() : ''));
 
   protected readonly rolesResource = rxResource({
     stream: () => this.applicationService.getApplicationRoles(),
+  });
+
+  protected readonly applicationMembersResource = rxResource<MembersResponse | undefined, string | null>({
+    params: this.applicationMemberSearchRequest,
+    stream: ({ params }) =>
+      params === null
+        ? of(undefined)
+        : this.membershipService.searchApplicationMembers(this.data.applicationId, 1, APPLICATION_MEMBER_SEARCH_PAGE_SIZE, {
+            displayName: params,
+          }),
   });
 
   protected readonly usersResource = rxResource<UsersResponse | undefined, string>({
@@ -131,13 +150,19 @@ export class ApplicationTransferOwnershipDialogComponent {
       params.length > 0 ? this.usersService.searchUsersForApplicationMembership(this.data.applicationId, params) : of(undefined),
   });
 
-  readonly assignableRoles = computed(() => (this.rolesResource.value() ?? []).filter(isAssignableApplicationRole));
+  readonly assignableRoles = computed(() =>
+    this.rolesResource.error() ? [] : (this.rolesResource.value() ?? []).filter(isAssignableApplicationRole),
+  );
 
   readonly applicationMemberOptions = computed<TransferOwnershipTarget[]>(() => {
+    if (this.applicationMembersResource.error()) {
+      return [];
+    }
+
     const query = this.applicationMemberSearchQuery().toLowerCase();
-    return this.data.members
-      .filter(member => member.id !== this.data.currentOwnerId)
+    return (this.applicationMembersResource.value()?.data ?? [])
       .map(member => this.toMemberTarget(member))
+      .filter(target => !target.isDisabled)
       .filter(target => this.targetMatchesQuery(target, query));
   });
 
@@ -160,7 +185,11 @@ export class ApplicationTransferOwnershipDialogComponent {
   });
 
   readonly noApplicationMembersFound = computed(
-    () => this.applicationMemberSearchQuery() !== '' && this.applicationMemberOptions().length === 0,
+    () =>
+      this.applicationMemberSearchQuery() !== '' &&
+      !this.applicationMembersResource.isLoading() &&
+      !this.applicationMembersResource.error() &&
+      this.applicationMemberOptions().length === 0,
   );
 
   readonly noUsersFound = computed(
@@ -263,17 +292,20 @@ export class ApplicationTransferOwnershipDialogComponent {
     this.roleControl.enable(options);
   }
 
-  private toMemberTarget(member: ApplicationTransferOwnershipMemberOption): TransferOwnershipTarget {
+  private toMemberTarget(member: Member): TransferOwnershipTarget {
+    const id = member.id ?? member.user?.id ?? '';
+    const userCell = this.toMemberUserCell(member);
+
     return {
-      ...member,
-      vm: {
-        displayName: member.displayName,
-        email: member.email,
-        avatarUrl: member.avatarUrl,
-        initials: member.initials,
-      },
+      id,
+      reference: member.user?.reference,
+      displayName: userCell.displayName,
+      email: userCell.email,
+      avatarUrl: userCell.avatarUrl,
+      initials: userCell.initials,
+      vm: userCell,
       isAlreadyMember: true,
-      isDisabled: false,
+      isDisabled: !id || id === this.data.currentOwnerId,
     };
   }
 
@@ -301,6 +333,20 @@ export class ApplicationTransferOwnershipDialogComponent {
       displayName,
       email: user.email,
       avatarUrl: user._links?.avatar,
+      initials: this.getInitialsFromDisplayName(displayName),
+    };
+  }
+
+  private toMemberUserCell(member: Member): UserCellVM {
+    const user = member.user;
+    const displayName =
+      user?.display_name ??
+      (user?.first_name || user?.last_name ? `${user?.first_name ?? ''} ${user?.last_name ?? ''}`.trim() : (user?.id ?? member.id ?? ''));
+
+    return {
+      displayName,
+      email: user?.email,
+      avatarUrl: user?._links?.avatar,
       initials: this.getInitialsFromDisplayName(displayName),
     };
   }


### PR DESCRIPTION


## Issue

https://gravitee.atlassian.net/browse/APIM-14242

## Description

Addresses the ownership transfer dialog review comments:

1. Added spacing between the transfer method icon and label.
2. Updated the role field label to “New Role for Current Primary Owner”.

<img width="621" height="513" alt="Zrzut ekranu 2026-06-1 o 16 30 06" src="https://github.com/user-attachments/assets/9b9541c3-10b9-4984-9e6c-2d87ae9450be" />


4. Display the selected target using the user cell, so the email is visible when provided by the backend response.
<img width="713" height="626" alt="Zrzut ekranu 2026-06-1 o 16 30 47" src="https://github.com/user-attachments/assets/0eed6099-0cd1-41fb-854a-51eadc7f1c82" />


5. The dialog now searches application members independently instead of using the currently visible members table rows, so results are no longer limited by table pagination.

