### PR TITLE
chore(deps): bump gravitee-apim-repository-bridge 8.3.0 → 8.4.0 (APIM-14087)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -314,7 +314,7 @@
         <gravitee-resource-ai-vector-store-aws-s3.version>1.0.0</gravitee-resource-ai-vector-store-aws-s3.version>
         <gravitee-resource-ai-model-text-embedding.version>1.0.0</gravitee-resource-ai-model-text-embedding.version>
         <gravitee-policy-ai-semantic-caching.version>1.1.0</gravitee-policy-ai-semantic-caching.version>
-        <gravitee-apim-repository-bridge.version>8.3.0</gravitee-apim-repository-bridge.version>
+        <gravitee-apim-repository-bridge.version>8.4.0</gravitee-apim-repository-bridge.version>
         <gravitee-secretprovider-hc-vault.version>2.1.0</gravitee-secretprovider-hc-vault.version>
         <gravitee-secretprovider-aws.version>2.0.0</gravitee-secretprovider-aws.version>
         <gravitee-service-secrets.version>3.0.1</gravitee-service-secrets.version>


### PR DESCRIPTION
Bumps `gravitee-apim-repository-bridge.version` from `8.3.0` to `8.4.0`.

8.4.0 brings the bridge side of the `(plan, id)` subscription warmup cursor (gravitee-io/gravitee-apim-repository-bridge#136), completing the over-the-bridge propagation for APIM-14087.

Changes 8.3.0 → 8.4.0:
- feat(subscriptions): propagate (plan,id) warmup cursor over the bridge (APIM-14087) — bridge #136

JIRA: APIM-14087