### PR TITLE
fix(GKO-2908): undeploy dynamic dictionary when automation sets deployed false

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/dictionary/DictionaryAutomationDomainServiceLegacyWrapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/dictionary/DictionaryAutomationDomainServiceLegacyWrapper.java
@@ -75,7 +75,8 @@ public class DictionaryAutomationDomainServiceLegacyWrapper implements Dictionar
             if (deploy && !isStarted(dictionary)) {
                 return dictionaryService.start(executionContext, dictionary.getId());
             } else if (!deploy && isStarted(dictionary)) {
-                return dictionaryService.stop(executionContext, dictionary.getId());
+                dictionaryService.stop(executionContext, dictionary.getId());
+                return dictionaryService.undeploy(executionContext, dictionary.getId());
             }
         }
         return dictionary;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/configuration/dictionary/DictionaryServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/configuration/dictionary/DictionaryServiceImpl.java
@@ -337,13 +337,17 @@ public class DictionaryServiceImpl extends AbstractService implements Dictionary
     @Override
     public DictionaryEntity updateProperties(final String id, final Map<String, String> properties) {
         try {
-            log.debug("Update dictionary properties {}", id);
+            log.debug("Update dynamic dictionary properties {}", id);
 
             Optional<Dictionary> optDictionary = dictionaryRepository.findById(id);
             if (optDictionary.isEmpty()) {
                 throw new DictionaryNotFoundException(id);
             }
             Dictionary dictionary = optDictionary.get();
+            if (dictionary.getState() != LifecycleState.STARTED) {
+                log.warn("Update dictionary {} properties not applied: dictionary is {}", id, dictionary.getState());
+                return convert(dictionary);
+            }
             dictionary.setProperties(properties);
             dictionary.setUpdatedAt(new Date());
             dictionary.setDeployedAt(dictionary.getUpdatedAt());

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/dictionary/DictionaryAutomationDomainServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/dictionary/DictionaryAutomationDomainServiceTest.java
@@ -195,7 +195,7 @@ class DictionaryAutomationDomainServiceTest {
         }
 
         @Test
-        void should_stop_when_deploy_is_false_and_started() {
+        void should_stop_and_undeploy_when_deploy_is_false_and_started() {
             var dictionary = DictionaryEntity.builder()
                 .id("dict-id")
                 .type(io.gravitee.rest.api.model.configuration.dictionary.DictionaryType.DYNAMIC)
@@ -206,12 +206,19 @@ class DictionaryAutomationDomainServiceTest {
                 .type(io.gravitee.rest.api.model.configuration.dictionary.DictionaryType.DYNAMIC)
                 .state(Lifecycle.State.STOPPED)
                 .build();
+            var undeployed = DictionaryEntity.builder()
+                .id("dict-id")
+                .type(io.gravitee.rest.api.model.configuration.dictionary.DictionaryType.DYNAMIC)
+                .state(Lifecycle.State.STOPPED)
+                .build();
             when(dictionaryService.stop(executionContext, "dict-id")).thenReturn(stopped);
+            when(dictionaryService.undeploy(executionContext, "dict-id")).thenReturn(undeployed);
 
             var result = domainService.handleDeployment(executionContext, dictionary, false);
 
-            assertThat(result).isSameAs(stopped);
+            assertThat(result).isSameAs(undeployed);
             verify(dictionaryService).stop(executionContext, "dict-id");
+            verify(dictionaryService).undeploy(executionContext, "dict-id");
         }
 
         @Test


### PR DESCRIPTION
## Issue
https://gravitee.atlassian.net/browse/GKO-2908

## Summary

- When the Automation API sets `deployed: false` on a DYNAMIC dictionary, call `undeploy()` after `stop()` so gateways receive `UNPUBLISH_DICTIONARY` and stop resolving `${dictionaries[...]}` values.
- Previously only `stop()` ran (`STOP_DICTIONARY`), which stops management-side polling but leaves the last `PUBLISH_DICTIONARY` snapshot on gateways (GKO-2908).

## Test plan

- [x] `DictionaryAutomationDomainServiceTest.should_stop_and_undeploy_when_deploy_is_false_and_started`
- [x] GKO E2E: un-`test.fixme` `dictionary-dynamic-lifecycle.test.ts` — `Setting deployed=false on a dynamic dictionary stops gateway resolution` (https://github.com/gravitee-io/gravitee-kubernetes-operator/pull/1682)
- [x] Manual: apply DYNAMIC dictionary CR with `deployed: true`, confirm gateway resolves; flip to `deployed: false`; confirm gateway stops within ~2 trigger cycles

