### PR TITLE
fix(portal): normalize OAS 3.1 type arrays before passing spec to Swgger UI to fix required-field validation error

### DIFF
--- a/gravitee-apim-portal-webui-next/src/components/page/page-swagger/page-swagger.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/components/page/page-swagger/page-swagger.component.spec.ts
@@ -19,6 +19,10 @@ import { PageSwaggerComponent } from './page-swagger.component';
 import { fakePage } from '../../../entities/page/page.fixtures';
 import { AppTestingModule } from '../../../testing/app-testing.module';
 
+jest.mock('swagger-ui', () => jest.fn(() => ({ initOAuth: jest.fn() })));
+
+type WithNormalizeTypeArrays = { normalizeTypeArrays: (obj: unknown) => unknown };
+
 describe('PageSwaggerComponent', () => {
   let component: PageSwaggerComponent;
   let fixture: ComponentFixture<PageSwaggerComponent>;
@@ -36,5 +40,93 @@ describe('PageSwaggerComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should normalize OAS 3.1 type arrays in the spec before passing it to Swagger UI (JSON)', () => {
+    const spec = {
+      openapi: '3.1.0',
+      paths: {
+        '/test': {
+          get: {
+            parameters: [{ name: 'id', in: 'query', schema: { type: ['integer', 'string'] } }],
+          },
+        },
+      },
+    };
+    component.page = fakePage({ type: 'SWAGGER', content: JSON.stringify(spec) });
+    component.ngOnChanges();
+    expect(component).toBeTruthy();
+  });
+
+  it('should normalize OAS 3.1 type arrays in the spec before passing it to Swagger UI (YAML)', () => {
+    const yaml = `openapi: "3.1.0"\npaths:\n  /test:\n    get:\n      parameters:\n        - name: id\n          in: query\n          schema:\n            type:\n              - integer\n              - string\n`;
+    component.page = fakePage({ type: 'SWAGGER', content: yaml });
+    component.ngOnChanges();
+    expect(component).toBeTruthy();
+  });
+
+  it('should handle missing page content gracefully', () => {
+    component.page = fakePage({ type: 'SWAGGER', content: undefined });
+    component.ngOnChanges();
+    expect(component).toBeTruthy();
+  });
+
+  describe('normalizeTypeArrays', () => {
+    it('should flatten a single-element type array to that type', () => {
+      expect((component as unknown as WithNormalizeTypeArrays).normalizeTypeArrays({ type: ['integer'] })).toEqual({ type: 'integer' });
+    });
+
+    it('should pick the most permissive OAS type when multiple non-null types are present', () => {
+      expect((component as unknown as WithNormalizeTypeArrays).normalizeTypeArrays({ type: ['integer', 'string'] })).toEqual({
+        type: 'string',
+      });
+    });
+
+    it('should pick "number" over "integer" when both are present', () => {
+      expect((component as unknown as WithNormalizeTypeArrays).normalizeTypeArrays({ type: ['integer', 'number'] })).toEqual({
+        type: 'number',
+      });
+    });
+
+    it('should leave a non-OAS type array (e.g. extension values) untouched', () => {
+      expect((component as unknown as WithNormalizeTypeArrays).normalizeTypeArrays({ type: ['compact', 'expanded'] })).toEqual({
+        type: ['compact', 'expanded'],
+      });
+    });
+
+    it('should strip null and add nullable:true for a nullable type', () => {
+      expect((component as unknown as WithNormalizeTypeArrays).normalizeTypeArrays({ type: ['string', 'null'] })).toEqual({
+        type: 'string',
+        nullable: true,
+      });
+    });
+
+    it('should fall back to "string" and add nullable:true when the type array contains only "null"', () => {
+      expect((component as unknown as WithNormalizeTypeArrays).normalizeTypeArrays({ type: ['null'] })).toEqual({
+        type: 'string',
+        nullable: true,
+      });
+    });
+
+    it('should leave a plain string type untouched', () => {
+      expect((component as unknown as WithNormalizeTypeArrays).normalizeTypeArrays({ type: 'number' })).toEqual({ type: 'number' });
+    });
+
+    it('should recurse into nested schema objects', () => {
+      const input = { properties: { id: { type: ['integer', 'string'] } } };
+      expect((component as unknown as WithNormalizeTypeArrays).normalizeTypeArrays(input)).toEqual({
+        properties: { id: { type: 'string' } },
+      });
+    });
+
+    it('should recurse into arrays', () => {
+      expect((component as unknown as WithNormalizeTypeArrays).normalizeTypeArrays([{ type: ['integer'] }])).toEqual([{ type: 'integer' }]);
+    });
+
+    it('should return primitives and null unchanged', () => {
+      expect((component as unknown as WithNormalizeTypeArrays).normalizeTypeArrays(null)).toBeNull();
+      expect((component as unknown as WithNormalizeTypeArrays).normalizeTypeArrays('string')).toBe('string');
+      expect((component as unknown as WithNormalizeTypeArrays).normalizeTypeArrays(42)).toBe(42);
+    });
   });
 });

--- a/gravitee-apim-portal-webui-next/src/components/page/page-swagger/page-swagger.component.ts
+++ b/gravitee-apim-portal-webui-next/src/components/page/page-swagger/page-swagger.component.ts
@@ -21,6 +21,10 @@ import { readYaml } from '../../../app/helpers/yaml-parser';
 import { Page } from '../../../entities/page/page';
 import { CurrentUserService } from '../../../services/current-user.service';
 
+const OAS_SCHEMA_TYPES = new Set(['null', 'boolean', 'object', 'array', 'number', 'string', 'integer']);
+// Priority order: most permissive first, so we pick the least-restrictive type from the array
+const OAS_TYPE_PRIORITY = ['string', 'number', 'integer', 'boolean', 'array', 'object'];
+
 @Component({
   selector: 'app-page-swagger',
   standalone: true,
@@ -94,10 +98,40 @@ export class PageSwaggerComponent implements OnChanges {
       return undefined;
     }
     try {
-      return JSON.parse(content);
+      return this.normalizeTypeArrays(JSON.parse(content));
     } catch (_) {
-      return readYaml(content);
+      return this.normalizeTypeArrays(readYaml(content));
     }
+  }
+
+  /**
+   * Recursively normalizes OAS 3.1 type arrays (e.g. `"type": ["integer", "string"]`) to a single
+   * string type that Swagger UI can validate correctly. Without this, Swagger UI's form validator
+   * fails to match entered values against an array type and incorrectly reports required fields as
+   * missing. See APIM-14231.
+   */
+  private normalizeTypeArrays(obj: unknown): unknown {
+    if (obj === null || typeof obj !== 'object') {
+      return obj;
+    }
+    if (Array.isArray(obj)) {
+      return obj.map(item => this.normalizeTypeArrays(item));
+    }
+    const record = obj as Record<string, unknown>;
+    const result: Record<string, unknown> = {};
+    for (const key of Object.keys(record)) {
+      if (key === 'type' && Array.isArray(record[key]) && (record[key] as string[]).every(t => OAS_SCHEMA_TYPES.has(t))) {
+        const typeArray = record[key] as string[];
+        const nonNullTypes = typeArray.filter(t => t !== 'null');
+        result[key] = nonNullTypes.length === 1 ? nonNullTypes[0] : (OAS_TYPE_PRIORITY.find(t => nonNullTypes.includes(t)) ?? 'string');
+        if (typeArray.includes('null')) {
+          result['nullable'] = true;
+        }
+      } else {
+        result[key] = this.normalizeTypeArrays(record[key]);
+      }
+    }
+    return result;
   }
 
   private disabledTryItOutPlugin() {

--- a/gravitee-apim-portal-webui/src/app/components/gv-page-swaggerui/gv-page-swaggerui.component.spec.ts
+++ b/gravitee-apim-portal-webui/src/app/components/gv-page-swaggerui/gv-page-swaggerui.component.spec.ts
@@ -37,4 +37,49 @@ describe('GvPageSwaggerUIComponent', () => {
   it('should create', () => {
     expect(component).toBeTruthy();
   });
+
+  describe('normalizeTypeArrays', () => {
+    it('should flatten a single-element type array to that type', () => {
+      expect(component['normalizeTypeArrays']({ type: ['integer'] })).toEqual({ type: 'integer' });
+    });
+
+    it('should pick the most permissive OAS type when multiple non-null types are present', () => {
+      expect(component['normalizeTypeArrays']({ type: ['integer', 'string'] })).toEqual({ type: 'string' });
+    });
+
+    it('should pick "number" over "integer" when both are present', () => {
+      expect(component['normalizeTypeArrays']({ type: ['integer', 'number'] })).toEqual({ type: 'number' });
+    });
+
+    it('should leave a non-OAS type array (e.g. extension values) untouched', () => {
+      expect(component['normalizeTypeArrays']({ type: ['compact', 'expanded'] })).toEqual({ type: ['compact', 'expanded'] });
+    });
+
+    it('should strip null and add nullable:true for a nullable type', () => {
+      expect(component['normalizeTypeArrays']({ type: ['string', 'null'] })).toEqual({ type: 'string', nullable: true });
+    });
+
+    it('should fall back to "string" and add nullable:true when the type array contains only "null"', () => {
+      expect(component['normalizeTypeArrays']({ type: ['null'] })).toEqual({ type: 'string', nullable: true });
+    });
+
+    it('should leave a plain string type untouched', () => {
+      expect(component['normalizeTypeArrays']({ type: 'number' })).toEqual({ type: 'number' });
+    });
+
+    it('should recurse into nested schema objects', () => {
+      const input = { properties: { id: { type: ['integer', 'string'] } } };
+      expect(component['normalizeTypeArrays'](input)).toEqual({ properties: { id: { type: 'string' } } });
+    });
+
+    it('should recurse into arrays', () => {
+      expect(component['normalizeTypeArrays']([{ type: ['integer'] }])).toEqual([{ type: 'integer' }]);
+    });
+
+    it('should return primitives and null unchanged', () => {
+      expect(component['normalizeTypeArrays'](null)).toBeNull();
+      expect(component['normalizeTypeArrays']('string')).toBe('string');
+      expect(component['normalizeTypeArrays'](42)).toBe(42);
+    });
+  });
 });

--- a/gravitee-apim-portal-webui/src/app/components/gv-page-swaggerui/gv-page-swaggerui.component.ts
+++ b/gravitee-apim-portal-webui/src/app/components/gv-page-swaggerui/gv-page-swaggerui.component.ts
@@ -22,6 +22,10 @@ import { CurrentUserService } from '../../services/current-user.service';
 import { PageService } from '../../services/page.service';
 import { readYaml } from '../../utils/yaml-parser';
 
+const OAS_SCHEMA_TYPES = new Set(['null', 'boolean', 'object', 'array', 'number', 'string', 'integer']);
+// Priority order: most permissive first, so we pick the least-restrictive type from the array
+const OAS_TYPE_PRIORITY = ['string', 'number', 'integer', 'boolean', 'array', 'object'];
+
 type docExpansion = 'list' | 'full' | 'none';
 
 @Component({
@@ -110,10 +114,38 @@ export class GvPageSwaggerUIComponent implements OnInit, OnDestroy {
 
   private readSpec(page: Page): { [propName: string]: any } | undefined {
     try {
-      return JSON.parse(page.content);
+      return this.normalizeTypeArrays(JSON.parse(page.content));
     } catch (_) {
-      return readYaml(page.content);
+      return this.normalizeTypeArrays(readYaml(page.content));
     }
+  }
+
+  /**
+   * Recursively normalizes OAS 3.1 type arrays (e.g. `"type": ["integer", "string"]`) to a single
+   * string type that Swagger UI can validate correctly. Without this, Swagger UI's form validator
+   * fails to match entered values against an array type and incorrectly reports required fields as
+   * missing. See APIM-14231.
+   */
+  private normalizeTypeArrays(obj: any): any {
+    if (obj === null || typeof obj !== 'object') {
+      return obj;
+    }
+    if (Array.isArray(obj)) {
+      return obj.map((item: any) => this.normalizeTypeArrays(item));
+    }
+    const result: any = {};
+    for (const key of Object.keys(obj)) {
+      if (key === 'type' && Array.isArray(obj[key]) && (obj[key] as string[]).every((t: string) => OAS_SCHEMA_TYPES.has(t))) {
+        const nonNullTypes = (obj[key] as string[]).filter((t: string) => t !== 'null');
+        result[key] = nonNullTypes.length === 1 ? nonNullTypes[0] : (OAS_TYPE_PRIORITY.find(t => nonNullTypes.includes(t)) ?? 'string');
+        if ((obj[key] as string[]).includes('null')) {
+          result['nullable'] = true;
+        }
+      } else {
+        result[key] = this.normalizeTypeArrays(obj[key]);
+      }
+    }
+    return result;
   }
 
   buildPlugins(page: Page): SwaggerUIPlugin[] {


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-14231

## Description

Swagger UI's form validator expects type to be a string (OAS 3.0 style). When it encounters an OAS 3.1 type array (e.g. "type": ["integer", "string"]), it cannot resolve the parameter type and incorrectly raises "Required field is not provided", blocking the request.                                                                                                                                                                                                                                                         

Added a normalizeTypeArrays pre-processing step in both portal Swagger components that recursively walks the parsed spec before handing it to Swagger UI:

## Additional context

**Before Fix:**


https://github.com/user-attachments/assets/63ef93a5-45b3-4b98-a0b3-62fe827f0d02


**After  Fix:**


https://github.com/user-attachments/assets/dac9c131-6955-41c8-9e54-ec9be5a7dcf8


<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

