### PR TITLE
feat(portal): add core domain, use cases and HRID-to-UUID factory

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal/crud_service/PortalCrudService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal/crud_service/PortalCrudService.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal.crud_service;
+
+import io.gravitee.apim.core.portal.model.Portal;
+import io.gravitee.apim.core.portal.model.PortalId;
+import java.util.Optional;
+
+public interface PortalCrudService {
+    Portal create(Portal portal);
+
+    Portal update(Portal portal);
+
+    Optional<Portal> findByIdAndEnvironmentId(PortalId portalId, String environmentId);
+
+    void delete(PortalId portalId);
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal/exception/PortalNotFoundException.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal/exception/PortalNotFoundException.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal.exception;
+
+import io.gravitee.apim.core.exception.NotFoundDomainException;
+
+/**
+ * @author GraviteeSource Team
+ */
+public class PortalNotFoundException extends NotFoundDomainException {
+
+    public PortalNotFoundException(String portalId) {
+        super("Portal [ " + portalId + " ] not found", portalId);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal/model/Portal.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal/model/Portal.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal.model;
+
+import jakarta.annotation.Nonnull;
+import lombok.Getter;
+
+@Getter
+public class Portal {
+
+    @Nonnull
+    private final PortalId id;
+
+    @Nonnull
+    private final String environmentId;
+
+    @Nonnull
+    private final String organizationId;
+
+    @Nonnull
+    private final String name;
+
+    private Portal(PortalId id, String environmentId, String organizationId, String name) {
+        this.id = id;
+        this.environmentId = environmentId;
+        this.organizationId = organizationId;
+        this.name = name;
+    }
+
+    /** New portal with a random id. */
+    public static Portal create(String environmentId, String organizationId, String name) {
+        return new Portal(PortalId.random(), environmentId, organizationId, name);
+    }
+
+    /** Reconstitute a portal from a known id (HRID-derived, persistence, etc.). */
+    public static Portal of(PortalId id, String environmentId, String organizationId, String name) {
+        return new Portal(id, environmentId, organizationId, name);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Portal that = (Portal) o;
+        return id.equals(that.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return id.hashCode();
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal/model/PortalId.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal/model/PortalId.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal.model;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+import jakarta.annotation.Nonnull;
+import java.util.UUID;
+
+public record PortalId(@Nonnull UUID id) {
+    public static PortalId random() {
+        return new PortalId(UUID.randomUUID());
+    }
+
+    public static PortalId of(String value) {
+        return new PortalId(UUID.fromString(value));
+    }
+
+    @JsonValue
+    @Override
+    public String toString() {
+        return id.toString();
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal/use_case/CreateDefaultPortalUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal/use_case/CreateDefaultPortalUseCase.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal.use_case;
+
+import io.gravitee.apim.core.portal.crud_service.PortalCrudService;
+import io.gravitee.apim.core.portal.model.Portal;
+import io.gravitee.apim.core.portal.model.PortalId;
+import io.gravitee.rest.api.service.common.ExecutionContext;
+import io.gravitee.rest.api.service.common.HRIDToUUID;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class CreateDefaultPortalUseCase {
+
+    static final String DEFAULT_PORTAL_HRID = "default-portal";
+    static final String DEFAULT_PORTAL_NAME = "Default Portal";
+
+    private final PortalCrudService portalCrudService;
+
+    public void execute(String organizationId, String environmentId) {
+        var portalId = PortalId.of(
+            HRIDToUUID.portal().context(new ExecutionContext(organizationId, environmentId)).hrid(DEFAULT_PORTAL_HRID).id()
+        );
+        if (portalCrudService.findByIdAndEnvironmentId(portalId, environmentId).isPresent()) {
+            return;
+        }
+        portalCrudService.create(Portal.of(portalId, environmentId, organizationId, DEFAULT_PORTAL_NAME));
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal/use_case/CreateOrUpdatePortalUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal/use_case/CreateOrUpdatePortalUseCase.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal.use_case;
+
+import io.gravitee.apim.core.audit.model.AuditInfo;
+import io.gravitee.apim.core.portal.crud_service.PortalCrudService;
+import io.gravitee.apim.core.portal.model.Portal;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class CreateOrUpdatePortalUseCase {
+
+    private final PortalCrudService portalCrudService;
+
+    public record Input(AuditInfo auditInfo, Portal portal) {}
+
+    public record Output(Portal portal) {}
+
+    public Output execute(Input input) {
+        var portal = input.portal();
+        var existing = portalCrudService.findByIdAndEnvironmentId(portal.getId(), input.auditInfo().environmentId());
+        var saved = existing.isPresent() ? portalCrudService.update(portal) : portalCrudService.create(portal);
+        return new Output(saved);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal/use_case/DeletePortalUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal/use_case/DeletePortalUseCase.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal.use_case;
+
+import io.gravitee.apim.core.audit.model.AuditInfo;
+import io.gravitee.apim.core.portal.crud_service.PortalCrudService;
+import io.gravitee.apim.core.portal.exception.PortalNotFoundException;
+import io.gravitee.apim.core.portal.model.PortalId;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class DeletePortalUseCase {
+
+    private final PortalCrudService portalCrudService;
+
+    public record Input(AuditInfo auditInfo, PortalId portalId) {}
+
+    public void execute(Input input) {
+        portalCrudService
+            .findByIdAndEnvironmentId(input.portalId(), input.auditInfo().environmentId())
+            .orElseThrow(() -> new PortalNotFoundException(input.portalId().toString()));
+        portalCrudService.delete(input.portalId());
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal/use_case/GetPortalUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal/use_case/GetPortalUseCase.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal.use_case;
+
+import io.gravitee.apim.core.audit.model.AuditInfo;
+import io.gravitee.apim.core.portal.crud_service.PortalCrudService;
+import io.gravitee.apim.core.portal.exception.PortalNotFoundException;
+import io.gravitee.apim.core.portal.model.Portal;
+import io.gravitee.apim.core.portal.model.PortalId;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class GetPortalUseCase {
+
+    private final PortalCrudService portalCrudService;
+
+    public record Input(AuditInfo auditInfo, PortalId portalId) {}
+
+    public record Output(Portal portal) {}
+
+    public Output execute(Input input) {
+        var portal = portalCrudService
+            .findByIdAndEnvironmentId(input.portalId(), input.auditInfo().environmentId())
+            .orElseThrow(() -> new PortalNotFoundException(input.portalId().toString()));
+        return new Output(portal);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/common/HRIDToUUID.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/common/HRIDToUUID.java
@@ -56,6 +56,10 @@ public final class HRIDToUUID {
         return new TopLevelBuilder();
     }
 
+    public static TopLevelBuilder portal() {
+        return new TopLevelBuilder();
+    }
+
     public static SubResourceBuilder plan() {
         return new SubResourceBuilder();
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/fixtures/core/model/PortalFixtures.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/fixtures/core/model/PortalFixtures.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package fixtures.core.model;
+
+import io.gravitee.apim.core.portal.model.Portal;
+import io.gravitee.apim.core.portal.model.PortalId;
+
+public class PortalFixtures {
+
+    private PortalFixtures() {}
+
+    public static final PortalId PORTAL_ID = PortalId.of("00000000-0000-0000-0000-0000000000a1");
+
+    public static Portal aPortal() {
+        return Portal.of(PORTAL_ID, "environment-id", "organization-id", "Default Portal");
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/PortalCrudServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/PortalCrudServiceInMemory.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package inmemory;
+
+import io.gravitee.apim.core.portal.crud_service.PortalCrudService;
+import io.gravitee.apim.core.portal.exception.PortalNotFoundException;
+import io.gravitee.apim.core.portal.model.Portal;
+import io.gravitee.apim.core.portal.model.PortalId;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.OptionalInt;
+
+public class PortalCrudServiceInMemory implements PortalCrudService, InMemoryAlternative<Portal> {
+
+    final ArrayList<Portal> storage = new ArrayList<>();
+
+    @Override
+    public Portal create(Portal portal) {
+        storage.add(portal);
+        return portal;
+    }
+
+    @Override
+    public Portal update(Portal portal) {
+        OptionalInt index = this.findIndex(this.storage, p -> p.getId().equals(portal.getId()));
+        if (index.isPresent()) {
+            storage.set(index.getAsInt(), portal);
+            return portal;
+        }
+        throw new PortalNotFoundException(portal.getId().toString());
+    }
+
+    @Override
+    public Optional<Portal> findByIdAndEnvironmentId(PortalId portalId, String environmentId) {
+        return storage
+            .stream()
+            .filter(p -> portalId.equals(p.getId()) && environmentId.equals(p.getEnvironmentId()))
+            .findFirst();
+    }
+
+    @Override
+    public void delete(PortalId portalId) {
+        storage.removeIf(p -> portalId.equals(p.getId()));
+    }
+
+    @Override
+    public void initWith(List<Portal> items) {
+        storage.clear();
+        storage.addAll(items);
+    }
+
+    @Override
+    public void reset() {
+        storage.clear();
+    }
+
+    @Override
+    public List<Portal> storage() {
+        return Collections.unmodifiableList(storage);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal/use_case/CreateDefaultPortalUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal/use_case/CreateDefaultPortalUseCaseTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal.use_case;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import inmemory.PortalCrudServiceInMemory;
+import io.gravitee.apim.core.portal.model.Portal;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class CreateDefaultPortalUseCaseTest {
+
+    private static final String ORGANIZATION_ID = "organization-id";
+    private static final String ENVIRONMENT_ID = "environment-id";
+
+    private final PortalCrudServiceInMemory portalCrudService = new PortalCrudServiceInMemory();
+    private CreateDefaultPortalUseCase useCase;
+
+    @BeforeEach
+    void setUp() {
+        useCase = new CreateDefaultPortalUseCase(portalCrudService);
+    }
+
+    @AfterEach
+    void tearDown() {
+        portalCrudService.reset();
+    }
+
+    @Test
+    void should_create_default_portal_when_absent() {
+        useCase.execute(ORGANIZATION_ID, ENVIRONMENT_ID);
+
+        assertThat(portalCrudService.storage()).hasSize(1);
+        Portal seeded = portalCrudService.storage().get(0);
+        assertThat(seeded.getEnvironmentId()).isEqualTo(ENVIRONMENT_ID);
+        assertThat(seeded.getOrganizationId()).isEqualTo(ORGANIZATION_ID);
+        assertThat(seeded.getName()).isEqualTo(CreateDefaultPortalUseCase.DEFAULT_PORTAL_NAME);
+        assertThat(seeded.getId()).isNotNull();
+    }
+
+    @Test
+    void should_be_idempotent_when_already_seeded() {
+        useCase.execute(ORGANIZATION_ID, ENVIRONMENT_ID);
+        useCase.execute(ORGANIZATION_ID, ENVIRONMENT_ID);
+
+        assertThat(portalCrudService.storage()).hasSize(1);
+    }
+
+    @Test
+    void should_derive_a_stable_id_per_environment() {
+        useCase.execute(ORGANIZATION_ID, ENVIRONMENT_ID);
+        var firstId = portalCrudService.storage().get(0).getId();
+        portalCrudService.reset();
+
+        useCase.execute(ORGANIZATION_ID, ENVIRONMENT_ID);
+        var secondId = portalCrudService.storage().get(0).getId();
+
+        assertThat(firstId).isEqualTo(secondId);
+    }
+
+    @Test
+    void should_derive_different_ids_for_different_environments() {
+        useCase.execute(ORGANIZATION_ID, ENVIRONMENT_ID);
+        useCase.execute(ORGANIZATION_ID, "other-env");
+
+        assertThat(portalCrudService.storage()).hasSize(2);
+        assertThat(portalCrudService.storage().get(0).getId()).isNotEqualTo(portalCrudService.storage().get(1).getId());
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal/use_case/CreateOrUpdatePortalUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal/use_case/CreateOrUpdatePortalUseCaseTest.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal.use_case;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import fixtures.core.model.PortalFixtures;
+import inmemory.PortalCrudServiceInMemory;
+import io.gravitee.apim.core.audit.model.AuditActor;
+import io.gravitee.apim.core.audit.model.AuditInfo;
+import io.gravitee.apim.core.portal.model.Portal;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class CreateOrUpdatePortalUseCaseTest {
+
+    private static final AuditInfo AUDIT_INFO = AuditInfo.builder()
+        .organizationId("organization-id")
+        .environmentId("environment-id")
+        .actor(AuditActor.builder().userId("user-id").build())
+        .build();
+
+    private final PortalCrudServiceInMemory portalCrudService = new PortalCrudServiceInMemory();
+    private CreateOrUpdatePortalUseCase useCase;
+
+    @BeforeEach
+    void setUp() {
+        useCase = new CreateOrUpdatePortalUseCase(portalCrudService);
+    }
+
+    @AfterEach
+    void tearDown() {
+        portalCrudService.reset();
+    }
+
+    @Test
+    void should_create_when_not_existing() {
+        var portal = PortalFixtures.aPortal();
+
+        var output = useCase.execute(new CreateOrUpdatePortalUseCase.Input(AUDIT_INFO, portal));
+
+        assertThat(output.portal()).isEqualTo(portal);
+        assertThat(portalCrudService.storage()).containsExactly(portal);
+    }
+
+    @Test
+    void should_update_when_existing() {
+        var existing = PortalFixtures.aPortal();
+        portalCrudService.initWith(java.util.List.of(existing));
+        var renamed = Portal.of(existing.getId(), existing.getEnvironmentId(), existing.getOrganizationId(), "Renamed Portal");
+
+        var output = useCase.execute(new CreateOrUpdatePortalUseCase.Input(AUDIT_INFO, renamed));
+
+        assertThat(output.portal().getName()).isEqualTo("Renamed Portal");
+        assertThat(portalCrudService.storage()).hasSize(1).containsExactly(renamed);
+    }
+
+    @Test
+    void should_be_idempotent_when_put_twice() {
+        var portal = PortalFixtures.aPortal();
+
+        var first = useCase.execute(new CreateOrUpdatePortalUseCase.Input(AUDIT_INFO, portal));
+        var second = useCase.execute(new CreateOrUpdatePortalUseCase.Input(AUDIT_INFO, portal));
+
+        assertThat(first.portal()).isEqualTo(second.portal());
+        assertThat(portalCrudService.storage()).hasSize(1).containsExactly(portal);
+    }
+
+    @Test
+    void should_not_consider_an_id_match_in_a_different_environment_as_existing() {
+        var existing = PortalFixtures.aPortal();
+        portalCrudService.initWith(java.util.List.of(existing));
+
+        var otherEnvAudit = AuditInfo.builder()
+            .organizationId("organization-id")
+            .environmentId("other-env")
+            .actor(AuditActor.builder().userId("user-id").build())
+            .build();
+        var inOtherEnv = Portal.of(existing.getId(), "other-env", "organization-id", "Other Env Portal");
+
+        var output = useCase.execute(new CreateOrUpdatePortalUseCase.Input(otherEnvAudit, inOtherEnv));
+
+        assertThat(output.portal()).isEqualTo(inOtherEnv);
+        assertThat(portalCrudService.storage()).hasSize(2);
+        assertThat(portalCrudService.storage().stream().map(Portal::getEnvironmentId).toList()).containsExactlyInAnyOrder(
+            "environment-id",
+            "other-env"
+        );
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal/use_case/DeletePortalUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal/use_case/DeletePortalUseCaseTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal.use_case;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+
+import fixtures.core.model.PortalFixtures;
+import inmemory.PortalCrudServiceInMemory;
+import io.gravitee.apim.core.audit.model.AuditActor;
+import io.gravitee.apim.core.audit.model.AuditInfo;
+import io.gravitee.apim.core.portal.exception.PortalNotFoundException;
+import io.gravitee.apim.core.portal.model.PortalId;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class DeletePortalUseCaseTest {
+
+    private static final AuditInfo AUDIT_INFO = AuditInfo.builder()
+        .organizationId("organization-id")
+        .environmentId("environment-id")
+        .actor(AuditActor.builder().userId("user-id").build())
+        .build();
+
+    private final PortalCrudServiceInMemory portalCrudService = new PortalCrudServiceInMemory();
+    private DeletePortalUseCase useCase;
+
+    @BeforeEach
+    void setUp() {
+        useCase = new DeletePortalUseCase(portalCrudService);
+    }
+
+    @AfterEach
+    void tearDown() {
+        portalCrudService.reset();
+    }
+
+    @Test
+    void should_delete() {
+        var portal = PortalFixtures.aPortal();
+        portalCrudService.initWith(List.of(portal));
+
+        useCase.execute(new DeletePortalUseCase.Input(AUDIT_INFO, portal.getId()));
+
+        assertThat(portalCrudService.storage()).isEmpty();
+    }
+
+    @Test
+    void should_throw_when_missing() {
+        var unknownId = PortalId.of("00000000-0000-0000-0000-0000000000ff");
+        var throwable = catchThrowable(() -> useCase.execute(new DeletePortalUseCase.Input(AUDIT_INFO, unknownId)));
+
+        assertThat(throwable).isInstanceOf(PortalNotFoundException.class).hasMessage("Portal [ " + unknownId + " ] not found");
+    }
+
+    @Test
+    void should_throw_when_id_exists_in_different_environment() {
+        var portal = PortalFixtures.aPortal();
+        portalCrudService.initWith(List.of(portal));
+
+        var otherEnvAudit = AuditInfo.builder()
+            .organizationId("organization-id")
+            .environmentId("other-env")
+            .actor(AuditActor.builder().userId("user-id").build())
+            .build();
+
+        var throwable = catchThrowable(() -> useCase.execute(new DeletePortalUseCase.Input(otherEnvAudit, portal.getId())));
+
+        assertThat(throwable).isInstanceOf(PortalNotFoundException.class);
+        assertThat(portalCrudService.storage()).containsExactly(portal);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal/use_case/GetPortalUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal/use_case/GetPortalUseCaseTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal.use_case;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+
+import fixtures.core.model.PortalFixtures;
+import inmemory.PortalCrudServiceInMemory;
+import io.gravitee.apim.core.audit.model.AuditActor;
+import io.gravitee.apim.core.audit.model.AuditInfo;
+import io.gravitee.apim.core.portal.exception.PortalNotFoundException;
+import io.gravitee.apim.core.portal.model.PortalId;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class GetPortalUseCaseTest {
+
+    private static final AuditInfo AUDIT_INFO = AuditInfo.builder()
+        .organizationId("organization-id")
+        .environmentId("environment-id")
+        .actor(AuditActor.builder().userId("user-id").build())
+        .build();
+
+    private final PortalCrudServiceInMemory portalCrudService = new PortalCrudServiceInMemory();
+    private GetPortalUseCase useCase;
+
+    @BeforeEach
+    void setUp() {
+        useCase = new GetPortalUseCase(portalCrudService);
+    }
+
+    @AfterEach
+    void tearDown() {
+        portalCrudService.reset();
+    }
+
+    @Test
+    void should_return_portal() {
+        var portal = PortalFixtures.aPortal();
+        portalCrudService.initWith(List.of(portal));
+
+        var output = useCase.execute(new GetPortalUseCase.Input(AUDIT_INFO, portal.getId()));
+
+        assertThat(output.portal()).isEqualTo(portal);
+    }
+
+    @Test
+    void should_throw_when_missing() {
+        var unknownId = PortalId.of("00000000-0000-0000-0000-0000000000ff");
+        var throwable = catchThrowable(() -> useCase.execute(new GetPortalUseCase.Input(AUDIT_INFO, unknownId)));
+
+        assertThat(throwable).isInstanceOf(PortalNotFoundException.class).hasMessage("Portal [ " + unknownId + " ] not found");
+    }
+
+    @Test
+    void should_throw_when_id_exists_in_different_environment() {
+        var portal = PortalFixtures.aPortal();
+        portalCrudService.initWith(List.of(portal));
+
+        var otherEnvAudit = AuditInfo.builder()
+            .organizationId("organization-id")
+            .environmentId("other-env")
+            .actor(AuditActor.builder().userId("user-id").build())
+            .build();
+
+        var throwable = catchThrowable(() -> useCase.execute(new GetPortalUseCase.Input(otherEnvAudit, portal.getId())));
+
+        assertThat(throwable).isInstanceOf(PortalNotFoundException.class);
+    }
+}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/EXT-134

## Description

Context: First slice of the next-gen Portal feature for the Automation API — introduces the domain layer of the Portal resource so reviewers can absorb the model, contracts, and use cases in isolation before persistence or REST wiring lands.

Scope:
  - Adds the Portal core model (entity + value-object id + not-found exception) and its CRUD service interface.
  - Introduces four use cases covering create-or-update, get, delete, and default-portal seeding, fully covered by unit tests backed by an in-memory CRUD
  service.
  - Extends the HRID-to-UUID factory with a deterministic portal() derivation used by the seed.
  - No Spring wiring yet — the use cases ship without the framework annotation so the module boots green until persistence arrives in PR 2.

