### PR TITLE
feat(portal): add persistence, CRUD impl, default-portal seed and Coc…

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/PortalRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/PortalRepository.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.management.api;
+
+import io.gravitee.repository.exceptions.TechnicalException;
+import io.gravitee.repository.management.model.Portal;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * @author GraviteeSource Team
+ */
+public interface PortalRepository extends CrudRepository<Portal, String> {
+    Optional<Portal> findByIdAndEnvironmentId(final String portalId, final String environmentId) throws TechnicalException;
+    List<Portal> findByEnvironmentId(final String environmentId) throws TechnicalException;
+    void deleteByEnvironmentId(final String environmentId) throws TechnicalException;
+    void deleteByOrganizationId(final String organizationId) throws TechnicalException;
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/Portal.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/Portal.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.management.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+/**
+ * @author GraviteeSource Team
+ */
+@Data
+@EqualsAndHashCode(of = "id")
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Portal {
+
+    private String id;
+    private String environmentId;
+    private String organizationId;
+    private String name;
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcPortalRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcPortalRepository.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.jdbc.management;
+
+import io.gravitee.repository.exceptions.TechnicalException;
+import io.gravitee.repository.jdbc.orm.JdbcObjectMapper;
+import io.gravitee.repository.management.api.PortalRepository;
+import io.gravitee.repository.management.model.Portal;
+import java.sql.Types;
+import java.util.List;
+import java.util.Optional;
+import lombok.CustomLog;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Repository;
+
+/**
+ * @author GraviteeSource Team
+ */
+@CustomLog
+@Repository
+public class JdbcPortalRepository extends JdbcAbstractCrudRepository<Portal, String> implements PortalRepository {
+
+    JdbcPortalRepository(@Value("${management.jdbc.prefix:}") String tablePrefix) {
+        super(tablePrefix, "portals");
+    }
+
+    @Override
+    protected JdbcObjectMapper<Portal> buildOrm() {
+        return JdbcObjectMapper.builder(Portal.class, this.tableName, "id")
+            .addColumn("id", Types.NVARCHAR, String.class)
+            .addColumn("environment_id", Types.NVARCHAR, String.class)
+            .addColumn("organization_id", Types.NVARCHAR, String.class)
+            .addColumn("name", Types.NVARCHAR, String.class)
+            .build();
+    }
+
+    @Override
+    protected String getId(final Portal item) {
+        return item.getId();
+    }
+
+    @Override
+    public Optional<Portal> findByIdAndEnvironmentId(String portalId, String environmentId) throws TechnicalException {
+        log.debug("JdbcPortalRepository.findByIdAndEnvironmentId({}, {})", portalId, environmentId);
+        try {
+            return jdbcTemplate
+                .query(
+                    getOrm().getSelectAllSql() + " WHERE id = ? and environment_id = ?",
+                    getOrm().getRowMapper(),
+                    portalId,
+                    environmentId
+                )
+                .stream()
+                .findFirst();
+        } catch (final Exception ex) {
+            final String error = String.format("Failed to find portal by id (%s) and environment id (%s)", portalId, environmentId);
+            log.error(error, ex);
+            throw new TechnicalException(error, ex);
+        }
+    }
+
+    @Override
+    public List<Portal> findByEnvironmentId(String environmentId) throws TechnicalException {
+        log.debug("JdbcPortalRepository.findByEnvironmentId({})", environmentId);
+        try {
+            return jdbcTemplate.query(getOrm().getSelectAllSql() + " WHERE environment_id = ?", getOrm().getRowMapper(), environmentId);
+        } catch (final Exception ex) {
+            final String error = "Failed to find portals by environment id: " + environmentId;
+            log.error(error, ex);
+            throw new TechnicalException(error, ex);
+        }
+    }
+
+    @Override
+    public void deleteByEnvironmentId(String environmentId) throws TechnicalException {
+        log.debug("JdbcPortalRepository.deleteByEnvironmentId({})", environmentId);
+        try {
+            jdbcTemplate.update("delete from " + this.tableName + " where environment_id = ?", environmentId);
+        } catch (final Exception ex) {
+            final String error = "Failed to delete portals by environment id: " + environmentId;
+            log.error(error, ex);
+            throw new TechnicalException(error, ex);
+        }
+    }
+
+    @Override
+    public void deleteByOrganizationId(String organizationId) throws TechnicalException {
+        log.debug("JdbcPortalRepository.deleteByOrganizationId({})", organizationId);
+        try {
+            jdbcTemplate.update("delete from " + this.tableName + " where organization_id = ?", organizationId);
+        } catch (final Exception ex) {
+            final String error = "Failed to delete portals by organization id: " + organizationId;
+            log.error(error, ex);
+            throw new TechnicalException(error, ex);
+        }
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_12_0/11_add_portals_table.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_12_0/11_add_portals_table.yml
@@ -1,0 +1,28 @@
+databaseChangeLog:
+  - changeSet:
+      id: 4.12.0_add_portals
+      author: GraviteeSource Team
+      changes:
+        - createTable:
+            tableName: ${gravitee_prefix}portals
+            columns:
+              - column: {name: id, type: nvarchar(64), constraints: { nullable: false, primaryKey: true, primaryKeyName: pk_portals } }
+              - column: {name: environment_id, type: nvarchar(64), constraints: { nullable: false } }
+              - column: {name: organization_id, type: nvarchar(64), constraints: { nullable: false } }
+              - column: {name: name, type: nvarchar(256), constraints: { nullable: false } }
+
+        - createIndex:
+            indexName: idx_${gravitee_prefix}portals_environment_id
+            columns:
+              - column:
+                  name: environment_id
+                  type: nvarchar(64)
+            tableName: ${gravitee_prefix}portals
+
+        - createIndex:
+            indexName: idx_${gravitee_prefix}portals_organization_id
+            columns:
+              - column:
+                  name: organization_id
+                  type: nvarchar(64)
+            tableName: ${gravitee_prefix}portals

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/master.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/master.yml
@@ -363,3 +363,5 @@ databaseChangeLog:
         - file: liquibase/changelogs/v4_12_0/09_add_kafka_port_ranges_table.yml
     - include:
         - file: liquibase/changelogs/v4_12_0/10_add_am_connections_table.yml
+    - include:
+        - file: liquibase/changelogs/v4_12_0/11_add_portals_table.yml

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/test/java/io/gravitee/repository/jdbc/JdbcTestRepositoryInitializer.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/test/java/io/gravitee/repository/jdbc/JdbcTestRepositoryInitializer.java
@@ -163,7 +163,8 @@ public class JdbcTestRepositoryInitializer implements TestRepositoryInitializer 
         "portal_navigation_items",
         "subscription_forms",
         "kafka_port_ranges",
-        "am_connections"
+        "am_connections",
+        "portals"
     );
     private static final List<String> tablesToDrop = concatenate(tablesToTruncate, List.of("databasechangelog", "databasechangeloglock"));
     private final DataSource dataSource;

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoPortalRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoPortalRepository.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.mongodb.management;
+
+import io.gravitee.repository.exceptions.TechnicalException;
+import io.gravitee.repository.management.api.PortalRepository;
+import io.gravitee.repository.management.model.Portal;
+import io.gravitee.repository.mongodb.management.internal.model.PortalMongo;
+import io.gravitee.repository.mongodb.management.internal.portal.PortalMongoRepository;
+import io.gravitee.repository.mongodb.management.mapper.GraviteeMapper;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import lombok.CustomLog;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+/**
+ * @author GraviteeSource Team
+ */
+@CustomLog
+@Component
+public class MongoPortalRepository implements PortalRepository {
+
+    @Autowired
+    private PortalMongoRepository internalPortalRepo;
+
+    @Autowired
+    private GraviteeMapper mapper;
+
+    @Override
+    public Optional<Portal> findByIdAndEnvironmentId(String portalId, String environmentId) throws TechnicalException {
+        log.debug("Find portal by ID [{}] and environment [{}]", portalId, environmentId);
+        PortalMongo portal = internalPortalRepo.findByIdAndEnvironmentId(portalId, environmentId).orElse(null);
+        return Optional.ofNullable(mapper.map(portal));
+    }
+
+    @Override
+    public List<Portal> findByEnvironmentId(String environmentId) throws TechnicalException {
+        return mapper.mapPortals(internalPortalRepo.findByEnvironmentId(environmentId));
+    }
+
+    @Override
+    public void deleteByEnvironmentId(String environmentId) throws TechnicalException {
+        try {
+            internalPortalRepo.deleteByEnvironmentId(environmentId);
+        } catch (Exception e) {
+            log.error("An error occurred when deleting portals by environment [{}]", environmentId, e);
+            throw new TechnicalException("An error occurred when deleting portals by environment");
+        }
+    }
+
+    @Override
+    public void deleteByOrganizationId(String organizationId) throws TechnicalException {
+        try {
+            internalPortalRepo.deleteByOrganizationId(organizationId);
+        } catch (Exception e) {
+            log.error("An error occurred when deleting portals by organization [{}]", organizationId, e);
+            throw new TechnicalException("An error occurred when deleting portals by organization");
+        }
+    }
+
+    @Override
+    public Optional<Portal> findById(String portalId) throws TechnicalException {
+        log.debug("Find portal by ID [{}]", portalId);
+        PortalMongo portal = internalPortalRepo.findById(portalId).orElse(null);
+        return Optional.ofNullable(mapper.map(portal));
+    }
+
+    @Override
+    public Portal create(Portal portal) throws TechnicalException {
+        log.debug("Create portal [{}]", portal.getName());
+        PortalMongo portalMongo = mapper.map(portal);
+        PortalMongo created = internalPortalRepo.insert(portalMongo);
+        return mapper.map(created);
+    }
+
+    @Override
+    public Portal update(Portal portal) throws TechnicalException {
+        if (portal == null) {
+            throw new IllegalStateException("Portal must not be null");
+        }
+
+        PortalMongo existing = internalPortalRepo.findById(portal.getId()).orElse(null);
+        if (existing == null) {
+            throw new IllegalStateException(String.format("No portal found with id [%s]", portal.getId()));
+        }
+
+        try {
+            PortalMongo updated = internalPortalRepo.save(mapper.map(portal));
+            return mapper.map(updated);
+        } catch (Exception e) {
+            log.error("An error occurred when updating portal [{}]", portal.getId(), e);
+            throw new TechnicalException("An error occurred when updating portal");
+        }
+    }
+
+    @Override
+    public void delete(String portalId) throws TechnicalException {
+        try {
+            internalPortalRepo.deleteById(portalId);
+        } catch (Exception e) {
+            log.error("An error occurred when deleting portal [{}]", portalId, e);
+            throw new TechnicalException("An error occurred when deleting portal");
+        }
+    }
+
+    @Override
+    public Set<Portal> findAll() throws TechnicalException {
+        return internalPortalRepo.findAll().stream().map(mapper::map).collect(Collectors.toSet());
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/model/PortalMongo.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/model/PortalMongo.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.mongodb.management.internal.model;
+
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+/**
+ * @author GraviteeSource Team
+ */
+@Document(collection = "#{@environment.getProperty('management.mongodb.prefix')}portals")
+@Data
+@EqualsAndHashCode(of = "id")
+public class PortalMongo {
+
+    @Id
+    private String id;
+
+    private String environmentId;
+    private String organizationId;
+    private String name;
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/portal/PortalMongoRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/portal/PortalMongoRepository.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.mongodb.management.internal.portal;
+
+import io.gravitee.repository.mongodb.management.internal.model.PortalMongo;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.data.mongodb.repository.Query;
+import org.springframework.stereotype.Repository;
+
+/**
+ * @author GraviteeSource Team
+ */
+@Repository
+public interface PortalMongoRepository extends MongoRepository<PortalMongo, String> {
+    @Query("{ '_id': ?0, 'environmentId': ?1 }")
+    Optional<PortalMongo> findByIdAndEnvironmentId(String portalId, String environmentId);
+
+    @Query("{ 'environmentId': ?0 }")
+    List<PortalMongo> findByEnvironmentId(String environmentId);
+
+    @Query(value = "{ 'environmentId': ?0 }", delete = true)
+    void deleteByEnvironmentId(String environmentId);
+
+    @Query(value = "{ 'organizationId': ?0 }", delete = true)
+    void deleteByOrganizationId(String organizationId);
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/mapper/GraviteeMapper.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/mapper/GraviteeMapper.java
@@ -260,6 +260,11 @@ public interface GraviteeMapper {
 
     PlanMongo map(Plan toMap);
 
+    // Portal mapping
+    Portal map(PortalMongo toMap);
+    PortalMongo map(Portal toMap);
+    List<Portal> mapPortals(Collection<PortalMongo> toMap);
+
     // Portal menu links mapping
     PortalMenuLink map(PortalMenuLinkMongo toMap);
     PortalMenuLinkMongo map(PortalMenuLink toMap);

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/index/portals/EnvironmentIdIndexUpgrader.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/index/portals/EnvironmentIdIndexUpgrader.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.mongodb.management.upgrade.upgrader.index.portals;
+
+import io.gravitee.repository.mongodb.management.upgrade.upgrader.index.Index;
+import io.gravitee.repository.mongodb.management.upgrade.upgrader.index.IndexUpgrader;
+import org.springframework.stereotype.Component;
+
+/**
+ * Mirrors the JDBC {@code idx_portals_environment_id} index on the {@code portals} collection.
+ * Lookups by environment scope (find/delete by environmentId) would otherwise fall back to a
+ * collection scan.
+ */
+@Component("PortalsEnvironmentIdIndexUpgrader")
+public class EnvironmentIdIndexUpgrader extends IndexUpgrader {
+
+    @Override
+    protected Index buildIndex() {
+        return Index.builder()
+            .collection("portals")
+            .name("ei1")
+            .key("environmentId", ascending())
+            .build();
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/index/portals/OrganizationIdIndexUpgrader.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/index/portals/OrganizationIdIndexUpgrader.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.mongodb.management.upgrade.upgrader.index.portals;
+
+import io.gravitee.repository.mongodb.management.upgrade.upgrader.index.Index;
+import io.gravitee.repository.mongodb.management.upgrade.upgrader.index.IndexUpgrader;
+import org.springframework.stereotype.Component;
+
+/**
+ * Mirrors the JDBC {@code idx_portals_organization_id} index on the {@code portals} collection.
+ * Used by {@code deleteByOrganizationId}; without this index MongoDB falls back to a
+ * collection scan.
+ */
+@Component("PortalsOrganizationIdIndexUpgrader")
+public class OrganizationIdIndexUpgrader extends IndexUpgrader {
+
+    @Override
+    protected Index buildIndex() {
+        return Index.builder()
+            .collection("portals")
+            .name("oi1")
+            .key("organizationId", ascending())
+            .build();
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/AbstractManagementRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/AbstractManagementRepositoryTest.java
@@ -231,6 +231,9 @@ public abstract class AbstractManagementRepositoryTest extends AbstractRepositor
     protected PortalMenuLinkRepository portalMenuLinkRepository;
 
     @Inject
+    protected PortalRepository portalRepository;
+
+    @Inject
     protected ClusterRepository clusterRepository;
 
     @Inject
@@ -331,6 +334,7 @@ public abstract class AbstractManagementRepositoryTest extends AbstractRepositor
             case ApiCategoryOrder apiCategoryOrder -> apiCategoryOrderRepository.create(apiCategoryOrder);
             case SharedPolicyGroup sharedPolicyGroup -> sharedPolicyGroupRepository.create(sharedPolicyGroup);
             case PortalMenuLink portalMenuLink -> portalMenuLinkRepository.create(portalMenuLink);
+            case Portal portal -> portalRepository.create(portal);
             case Cluster cluster -> clusterRepository.create(cluster);
             case PortalPage portalPage -> portalPageRepository.create(portalPage);
             case PortalPageContext portalPageContext -> portalPageContextRepository.create(portalPageContext);

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/PortalRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/PortalRepositoryTest.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.management;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.repository.management.model.Portal;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author GraviteeSource Team
+ */
+public class PortalRepositoryTest extends AbstractManagementRepositoryTest {
+
+    @Override
+    protected String getTestCasesPath() {
+        return "/data/portal-tests/";
+    }
+
+    @Test
+    public void should_find_by_id_and_environment() throws Exception {
+        Optional<Portal> portal = portalRepository.findByIdAndEnvironmentId("portal1", "environment1");
+
+        assertThat(portal).isPresent();
+        assertThat(portal.get().getName()).isEqualTo("Default Portal");
+        assertThat(portal.get().getOrganizationId()).isEqualTo("organization1");
+    }
+
+    @Test
+    public void should_not_find_by_id_when_environment_differs() throws Exception {
+        Optional<Portal> portal = portalRepository.findByIdAndEnvironmentId("portal1", "environment2");
+
+        assertThat(portal).isNotPresent();
+    }
+
+    @Test
+    public void should_find_by_environment() throws Exception {
+        List<Portal> portals = portalRepository.findByEnvironmentId("environment1");
+
+        assertThat(portals).extracting(Portal::getId).containsExactlyInAnyOrder("portal1", "portal2");
+    }
+
+    @Test
+    public void should_find_nothing_when_environment_unknown() throws Exception {
+        List<Portal> portals = portalRepository.findByEnvironmentId("unknown-env");
+
+        assertThat(portals).isEmpty();
+    }
+
+    @Test
+    public void should_create() throws Exception {
+        Portal toCreate = Portal.builder()
+            .id("new-portal")
+            .environmentId("environment1")
+            .organizationId("organization1")
+            .name("Created Portal")
+            .build();
+
+        Portal created = portalRepository.create(toCreate);
+
+        assertThat(created).isEqualTo(toCreate);
+        assertThat(portalRepository.findById("new-portal")).hasValue(toCreate);
+    }
+
+    @Test
+    public void should_update() throws Exception {
+        Portal toUpdate = Portal.builder()
+            .id("portal1")
+            .environmentId("environment1")
+            .organizationId("organization1")
+            .name("Renamed Portal")
+            .build();
+
+        Portal updated = portalRepository.update(toUpdate);
+
+        assertThat(updated.getName()).isEqualTo("Renamed Portal");
+        assertThat(portalRepository.findById("portal1")).hasValue(toUpdate);
+    }
+
+    @Test
+    public void should_delete() throws Exception {
+        portalRepository.delete("portal1");
+
+        assertThat(portalRepository.findById("portal1")).isNotPresent();
+    }
+
+    @Test
+    public void should_delete_by_environment() throws Exception {
+        portalRepository.deleteByEnvironmentId("environment1");
+
+        Set<Portal> remaining = portalRepository.findAll();
+        assertThat(remaining).extracting(Portal::getId).containsExactlyInAnyOrder("portal3", "portal4");
+    }
+
+    @Test
+    public void should_delete_by_organization() throws Exception {
+        portalRepository.deleteByOrganizationId("organization1");
+
+        Set<Portal> remaining = portalRepository.findAll();
+        assertThat(remaining).extracting(Portal::getId).containsExactly("portal4");
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/resources/data/portal-tests/portals.json
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/resources/data/portal-tests/portals.json
@@ -1,0 +1,26 @@
+[
+  {
+    "id": "portal1",
+    "environmentId": "environment1",
+    "organizationId": "organization1",
+    "name": "Default Portal"
+  },
+  {
+    "id": "portal2",
+    "environmentId": "environment1",
+    "organizationId": "organization1",
+    "name": "Secondary Portal"
+  },
+  {
+    "id": "portal3",
+    "environmentId": "environment2",
+    "organizationId": "organization1",
+    "name": "Env2 Portal"
+  },
+  {
+    "id": "portal4",
+    "environmentId": "environment3",
+    "organizationId": "organization2",
+    "name": "Org2 Portal"
+  }
+]

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/organization/RoleScopesResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/organization/RoleScopesResourceTest.java
@@ -71,6 +71,7 @@ public class RoleScopesResourceTest extends AbstractResourceTest {
             "METADATA",
             "NOTIFICATION",
             "PLATFORM",
+            "PORTAL",
             "QUALITY_RULE",
             "SETTINGS",
             "SHARED_POLICY_GROUP",

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/permissions/EnvironmentPermission.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/permissions/EnvironmentPermission.java
@@ -51,7 +51,8 @@ public enum EnvironmentPermission implements Permission {
     SHARED_POLICY_GROUP("SHARED_POLICY_GROUP", 3900),
     CLUSTER("CLUSTER", 4000),
     API_PRODUCT("API_PRODUCT", 4100),
-    AUTHORIZATION("AUTHORIZATION", 4200);
+    AUTHORIZATION("AUTHORIZATION", 4200),
+    PORTAL("PORTAL", 4300);
 
     String name;
     int mask;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/permissions/RolePermission.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/permissions/RolePermission.java
@@ -92,6 +92,7 @@ public enum RolePermission {
     ENVIRONMENT_CLUSTER(RoleScope.ENVIRONMENT, EnvironmentPermission.CLUSTER),
     ENVIRONMENT_API_PRODUCT(RoleScope.ENVIRONMENT, EnvironmentPermission.API_PRODUCT),
     ENVIRONMENT_AUTHORIZATION(RoleScope.ENVIRONMENT, EnvironmentPermission.AUTHORIZATION),
+    ENVIRONMENT_PORTAL(RoleScope.ENVIRONMENT, EnvironmentPermission.PORTAL),
 
     ORGANIZATION_USERS(RoleScope.ORGANIZATION, OrganizationPermission.USER),
     ORGANIZATION_USERS_TOKEN(RoleScope.ORGANIZATION, OrganizationPermission.USER_TOKEN),

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal/use_case/CreateDefaultPortalUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal/use_case/CreateDefaultPortalUseCase.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.apim.core.portal.use_case;
 
+import io.gravitee.apim.core.UseCase;
 import io.gravitee.apim.core.portal.crud_service.PortalCrudService;
 import io.gravitee.apim.core.portal.model.Portal;
 import io.gravitee.apim.core.portal.model.PortalId;
@@ -22,6 +23,7 @@ import io.gravitee.rest.api.service.common.ExecutionContext;
 import io.gravitee.rest.api.service.common.HRIDToUUID;
 import lombok.RequiredArgsConstructor;
 
+@UseCase
 @RequiredArgsConstructor
 public class CreateDefaultPortalUseCase {
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/PortalAdapter.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/PortalAdapter.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.infra.adapter;
+
+import io.gravitee.apim.core.portal.model.Portal;
+import io.gravitee.apim.core.portal.model.PortalId;
+import org.mapstruct.Mapper;
+import org.mapstruct.factory.Mappers;
+
+@Mapper
+public interface PortalAdapter {
+    PortalAdapter INSTANCE = Mappers.getMapper(PortalAdapter.class);
+
+    default Portal toEntity(io.gravitee.repository.management.model.Portal portal) {
+        if (portal == null) {
+            return null;
+        }
+        return Portal.of(PortalId.of(portal.getId()), portal.getEnvironmentId(), portal.getOrganizationId(), portal.getName());
+    }
+
+    io.gravitee.repository.management.model.Portal toRepository(Portal portal);
+
+    default String mapPortalId(PortalId id) {
+        return id.toString();
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/crud_service/portal/PortalCrudServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/crud_service/portal/PortalCrudServiceImpl.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.infra.crud_service.portal;
+
+import io.gravitee.apim.core.exception.TechnicalDomainException;
+import io.gravitee.apim.core.portal.crud_service.PortalCrudService;
+import io.gravitee.apim.core.portal.model.Portal;
+import io.gravitee.apim.core.portal.model.PortalId;
+import io.gravitee.apim.infra.adapter.PortalAdapter;
+import io.gravitee.repository.exceptions.TechnicalException;
+import io.gravitee.repository.management.api.PortalRepository;
+import java.util.Optional;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.stereotype.Component;
+
+@Component
+public class PortalCrudServiceImpl implements PortalCrudService {
+
+    private final PortalRepository portalRepository;
+    private static final PortalAdapter portalAdapter = PortalAdapter.INSTANCE;
+
+    public PortalCrudServiceImpl(@Lazy PortalRepository portalRepository) {
+        this.portalRepository = portalRepository;
+    }
+
+    @Override
+    public Portal create(Portal portal) {
+        try {
+            var result = portalRepository.create(portalAdapter.toRepository(portal));
+            return portalAdapter.toEntity(result);
+        } catch (TechnicalException e) {
+            throw new TechnicalDomainException(
+                String.format("An error occurred while trying to create a Portal with id: %s", portal.getId()),
+                e
+            );
+        }
+    }
+
+    @Override
+    public Portal update(Portal portal) {
+        try {
+            var result = portalRepository.update(portalAdapter.toRepository(portal));
+            return portalAdapter.toEntity(result);
+        } catch (TechnicalException e) {
+            throw new TechnicalDomainException(
+                String.format("An error occurred while trying to update a Portal with id: %s", portal.getId()),
+                e
+            );
+        }
+    }
+
+    @Override
+    public Optional<Portal> findByIdAndEnvironmentId(PortalId portalId, String environmentId) {
+        try {
+            return portalRepository.findByIdAndEnvironmentId(portalId.toString(), environmentId).map(portalAdapter::toEntity);
+        } catch (TechnicalException e) {
+            throw new TechnicalDomainException(
+                String.format("An error occurred while trying to find a Portal with id (%s) in environment (%s)", portalId, environmentId),
+                e
+            );
+        }
+    }
+
+    @Override
+    public void delete(PortalId portalId) {
+        try {
+            portalRepository.delete(portalId.toString());
+        } catch (TechnicalException e) {
+            throw new TechnicalDomainException(
+                String.format("An error occurred while trying to delete the Portal with id: %s", portalId),
+                e
+            );
+        }
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/cockpit/command/handler/DeleteEnvironmentCommandHandler.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/cockpit/command/handler/DeleteEnvironmentCommandHandler.java
@@ -63,6 +63,7 @@ import io.gravitee.repository.management.api.PortalNotificationConfigRepository;
 import io.gravitee.repository.management.api.PortalPageContentRepository;
 import io.gravitee.repository.management.api.PortalPageContextRepository;
 import io.gravitee.repository.management.api.PortalPageRepository;
+import io.gravitee.repository.management.api.PortalRepository;
 import io.gravitee.repository.management.api.PromotionRepository;
 import io.gravitee.repository.management.api.QualityRuleRepository;
 import io.gravitee.repository.management.api.RatingAnswerRepository;
@@ -169,6 +170,7 @@ public class DeleteEnvironmentCommandHandler implements CommandHandler<DeleteEnv
     private final PortalPageContextRepository portalPageContextRepository;
     private final PortalNavigationItemRepository portalNavigationItemRepository;
     private final PortalPageContentRepository portalPageContentRepository;
+    private final PortalRepository portalRepository;
     private final PromotionRepository promotionRepository;
     private final QualityRuleRepository qualityRuleRepository;
     private final RatingAnswerRepository ratingAnswerRepository;
@@ -227,6 +229,7 @@ public class DeleteEnvironmentCommandHandler implements CommandHandler<DeleteEnv
         @Lazy PortalPageContextRepository portalPageContextRepository,
         @Lazy PortalNavigationItemRepository portalNavigationItemRepository,
         @Lazy PortalPageContentRepository portalPageContentRepository,
+        @Lazy PortalRepository portalRepository,
         @Lazy PromotionRepository promotionRepository,
         @Lazy QualityRuleRepository qualityRuleRepository,
         @Lazy RatingAnswerRepository ratingAnswerRepository,
@@ -298,6 +301,7 @@ public class DeleteEnvironmentCommandHandler implements CommandHandler<DeleteEnv
         this.portalPageContextRepository = portalPageContextRepository;
         this.portalNavigationItemRepository = portalNavigationItemRepository;
         this.portalPageContentRepository = portalPageContentRepository;
+        this.portalRepository = portalRepository;
         this.promotionRepository = promotionRepository;
         this.qualityRuleRepository = qualityRuleRepository;
         this.ratingAnswerRepository = ratingAnswerRepository;
@@ -404,6 +408,7 @@ public class DeleteEnvironmentCommandHandler implements CommandHandler<DeleteEnv
         portalPageRepository.deleteByEnvironmentId(environment.getId());
         deletePortalNavigationItems(environment);
         portalNavigationItemRepository.deleteByEnvironmentId(environment.getId());
+        portalRepository.deleteByEnvironmentId(environment.getId());
         customUserFieldsRepository.deleteByReferenceIdAndReferenceType(environment.getId(), CustomUserFieldReferenceType.ENVIRONMENT);
         groupRepository
             .deleteByEnvironmentId(environment.getId())

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/cockpit/command/handler/EnvironmentCommandHandler.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/cockpit/command/handler/EnvironmentCommandHandler.java
@@ -16,6 +16,7 @@
 package io.gravitee.rest.api.service.cockpit.command.handler;
 
 import io.gravitee.apim.core.access_point.crud_service.AccessPointCrudService;
+import io.gravitee.apim.core.portal.use_case.CreateDefaultPortalUseCase;
 import io.gravitee.apim.core.portal_page.use_case.CreateDefaultPortalNavigationItemsUseCase;
 import io.gravitee.cockpit.api.command.v1.CockpitCommandType;
 import io.gravitee.cockpit.api.command.v1.environment.EnvironmentCommand;
@@ -45,6 +46,7 @@ public class EnvironmentCommandHandler implements CommandHandler<EnvironmentComm
     private final EnvironmentService environmentService;
     private final AccessPointCrudService accessPointService;
     private final CreateDefaultPortalNavigationItemsUseCase createDefaultPortalNavigationItemsUseCase;
+    private final CreateDefaultPortalUseCase createDefaultPortalUseCase;
 
     @Override
     public String supportType() {
@@ -96,8 +98,9 @@ public class EnvironmentCommandHandler implements CommandHandler<EnvironmentComm
                 accessPointsToCreate
             );
 
-            // Seed default portal navigation items only when Cockpit registers this environment for the first time
+            // Seed default portal + navigation items only when Cockpit registers this environment for the first time
             if (existingEnvironment == null) {
+                createDefaultPortalUseCase.execute(environment.getOrganizationId(), environment.getId());
                 createDefaultPortalNavigationItemsUseCase.execute(environment.getOrganizationId(), environment.getId());
             }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/EnvironmentsDefaultPortalUpgrader.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/EnvironmentsDefaultPortalUpgrader.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.impl.upgrade.upgrader;
+
+import static io.gravitee.rest.api.service.impl.upgrade.upgrader.UpgraderOrder.ENVIRONMENTS_DEFAULT_PORTAL_UPGRADER;
+
+import io.gravitee.apim.core.portal.use_case.CreateDefaultPortalUseCase;
+import io.gravitee.node.api.upgrader.Upgrader;
+import io.gravitee.node.api.upgrader.UpgraderException;
+import io.gravitee.repository.exceptions.TechnicalException;
+import io.gravitee.repository.management.api.EnvironmentRepository;
+import lombok.CustomLog;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.stereotype.Component;
+
+@Component
+@CustomLog
+public class EnvironmentsDefaultPortalUpgrader implements Upgrader {
+
+    private final EnvironmentRepository environmentRepository;
+    private final CreateDefaultPortalUseCase createDefaultPortalUseCase;
+
+    public EnvironmentsDefaultPortalUpgrader(
+        @Lazy EnvironmentRepository environmentRepository,
+        CreateDefaultPortalUseCase createDefaultPortalUseCase
+    ) {
+        this.environmentRepository = environmentRepository;
+        this.createDefaultPortalUseCase = createDefaultPortalUseCase;
+    }
+
+    @Override
+    public int getOrder() {
+        return ENVIRONMENTS_DEFAULT_PORTAL_UPGRADER;
+    }
+
+    @Override
+    public boolean upgrade() throws UpgraderException {
+        return this.wrapException(this::applyUpgrade);
+    }
+
+    private boolean applyUpgrade() throws TechnicalException {
+        for (final var environment : environmentRepository.findAll()) {
+            createDefaultPortalUseCase.execute(environment.getOrganizationId(), environment.getId());
+        }
+        return true;
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/UpgraderOrder.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/UpgraderOrder.java
@@ -65,6 +65,7 @@ public class UpgraderOrder {
     public static final int TAG_KEY_UPGRADER = 716;
     public static final int TENANT_KEY_UPGRADER = 717;
     public static final int SUBSCRIPTION_FORM_CONSTRAINTS_UPGRADER = 718;
+    public static final int ENVIRONMENTS_DEFAULT_PORTAL_UPGRADER = 719;
     public static final int CLUSTER_ROLES_UPGRADER = 900;
     public static final int CLUSTER_CROSS_ID_UPGRADER = 901;
     public static final int API_ENDPOINT_WEIGHT_UPGRADER = 560;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/spring/InMemoryConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/spring/InMemoryConfiguration.java
@@ -554,6 +554,11 @@ public class InMemoryConfiguration {
     }
 
     @Bean
+    public PortalCrudServiceInMemory portalCrudService() {
+        return new PortalCrudServiceInMemory();
+    }
+
+    @Bean
     public ApiProductCrudServiceInMemory apiProductCrudService() {
         return new ApiProductCrudServiceInMemory();
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/crud_service/portal/PortalCrudServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/crud_service/portal/PortalCrudServiceImplTest.java
@@ -1,0 +1,202 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.infra.crud_service.portal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import fixtures.core.model.PortalFixtures;
+import io.gravitee.apim.core.exception.TechnicalDomainException;
+import io.gravitee.apim.core.portal.model.Portal;
+import io.gravitee.apim.core.portal.model.PortalId;
+import io.gravitee.apim.infra.adapter.PortalAdapter;
+import io.gravitee.repository.exceptions.TechnicalException;
+import io.gravitee.repository.management.api.PortalRepository;
+import java.util.Optional;
+import lombok.SneakyThrows;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+class PortalCrudServiceImplTest {
+
+    PortalRepository repository;
+    PortalCrudServiceImpl service;
+
+    @BeforeEach
+    void setUp() {
+        repository = mock(PortalRepository.class);
+        service = new PortalCrudServiceImpl(repository);
+    }
+
+    @Nested
+    class Create {
+
+        @Test
+        @SneakyThrows
+        void should_create_a_portal() {
+            var portal = PortalFixtures.aPortal();
+            when(repository.create(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+            var result = service.create(portal);
+
+            SoftAssertions.assertSoftly(soft -> {
+                soft.assertThat(result.getId()).isEqualTo(portal.getId());
+                soft.assertThat(result.getEnvironmentId()).isEqualTo(portal.getEnvironmentId());
+                soft.assertThat(result.getOrganizationId()).isEqualTo(portal.getOrganizationId());
+                soft.assertThat(result.getName()).isEqualTo(portal.getName());
+            });
+        }
+
+        @Test
+        @SneakyThrows
+        void should_throw_when_technical_exception_occurs() {
+            var portal = PortalFixtures.aPortal();
+            when(repository.create(any())).thenThrow(TechnicalException.class);
+
+            var throwable = catchThrowable(() -> service.create(portal));
+
+            assertThat(throwable)
+                .isInstanceOf(TechnicalDomainException.class)
+                .hasMessage("An error occurred while trying to create a Portal with id: " + portal.getId());
+        }
+    }
+
+    @Nested
+    class FindByIdAndEnvironmentId {
+
+        @Test
+        @SneakyThrows
+        void should_return_portal_and_adapt_it() {
+            var portalId = PortalFixtures.PORTAL_ID;
+            var environmentId = "environment-id";
+            when(repository.findByIdAndEnvironmentId(portalId.toString(), environmentId)).thenReturn(
+                Optional.of(
+                    io.gravitee.repository.management.model.Portal.builder()
+                        .id(portalId.toString())
+                        .environmentId(environmentId)
+                        .organizationId("organization-id")
+                        .name("Default Portal")
+                        .build()
+                )
+            );
+
+            var result = service.findByIdAndEnvironmentId(portalId, environmentId);
+
+            assertThat(result).isPresent();
+            SoftAssertions.assertSoftly(soft -> {
+                soft.assertThat(result.get().getId()).isEqualTo(portalId);
+                soft.assertThat(result.get().getEnvironmentId()).isEqualTo(environmentId);
+                soft.assertThat(result.get().getName()).isEqualTo("Default Portal");
+            });
+        }
+
+        @Test
+        @SneakyThrows
+        void should_return_empty_when_not_found() {
+            when(repository.findByIdAndEnvironmentId(any(), any())).thenReturn(Optional.empty());
+
+            assertThat(service.findByIdAndEnvironmentId(PortalFixtures.PORTAL_ID, "environment-id")).isEmpty();
+        }
+
+        @Test
+        @SneakyThrows
+        void should_throw_when_technical_exception_occurs() {
+            when(repository.findByIdAndEnvironmentId(any(), any())).thenThrow(TechnicalException.class);
+
+            var portalId = PortalFixtures.PORTAL_ID;
+            var throwable = catchThrowable(() -> service.findByIdAndEnvironmentId(portalId, "environment-id"));
+
+            assertThat(throwable)
+                .isInstanceOf(TechnicalDomainException.class)
+                .hasMessage("An error occurred while trying to find a Portal with id (" + portalId + ") in environment (environment-id)");
+        }
+    }
+
+    @Nested
+    class Update {
+
+        @Test
+        @SneakyThrows
+        void should_update_existing_portal() {
+            Portal base = PortalFixtures.aPortal();
+            Portal portal = Portal.of(base.getId(), base.getEnvironmentId(), base.getOrganizationId(), "Renamed");
+            when(repository.update(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+            service.update(portal);
+
+            var captor = ArgumentCaptor.forClass(io.gravitee.repository.management.model.Portal.class);
+            verify(repository).update(captor.capture());
+            assertThat(captor.getValue()).isEqualTo(PortalAdapter.INSTANCE.toRepository(portal));
+            assertThat(captor.getValue().getName()).isEqualTo("Renamed");
+        }
+
+        @Test
+        @SneakyThrows
+        void should_return_the_updated_portal() {
+            when(repository.update(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+            var toUpdate = PortalFixtures.aPortal();
+            var result = service.update(toUpdate);
+
+            assertThat(result).isEqualTo(toUpdate);
+        }
+
+        @Test
+        void should_throw_when_technical_exception_occurs() throws TechnicalException {
+            when(repository.update(any())).thenThrow(TechnicalException.class);
+
+            var portal = PortalFixtures.aPortal();
+            var throwable = catchThrowable(() -> service.update(portal));
+
+            assertThat(throwable)
+                .isInstanceOf(TechnicalDomainException.class)
+                .hasMessage("An error occurred while trying to update a Portal with id: " + portal.getId());
+        }
+    }
+
+    @Nested
+    class Delete {
+
+        @Test
+        void should_delete_portal() throws TechnicalException {
+            var portalId = PortalFixtures.PORTAL_ID;
+
+            service.delete(portalId);
+
+            verify(repository).delete(portalId.toString());
+        }
+
+        @Test
+        void should_throw_when_technical_exception_occurs() throws TechnicalException {
+            var portalId = PortalFixtures.PORTAL_ID;
+            doThrow(new TechnicalException("boom")).when(repository).delete(portalId.toString());
+
+            assertThatThrownBy(() -> service.delete(portalId))
+                .isInstanceOf(TechnicalDomainException.class)
+                .hasMessage("An error occurred while trying to delete the Portal with id: " + portalId);
+            verify(repository).delete(portalId.toString());
+        }
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/cockpit/command/handler/DeleteEnvironmentCommandHandlerTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/cockpit/command/handler/DeleteEnvironmentCommandHandlerTest.java
@@ -67,6 +67,7 @@ import io.gravitee.repository.management.api.PortalNotificationConfigRepository;
 import io.gravitee.repository.management.api.PortalPageContentRepository;
 import io.gravitee.repository.management.api.PortalPageContextRepository;
 import io.gravitee.repository.management.api.PortalPageRepository;
+import io.gravitee.repository.management.api.PortalRepository;
 import io.gravitee.repository.management.api.PromotionRepository;
 import io.gravitee.repository.management.api.QualityRuleRepository;
 import io.gravitee.repository.management.api.RatingAnswerRepository;
@@ -315,6 +316,9 @@ public class DeleteEnvironmentCommandHandlerTest {
     private PortalNavigationItemRepository portalNavigationItemRepository;
 
     @Mock
+    private PortalRepository portalRepository;
+
+    @Mock
     private PromotionRepository promotionRepository;
 
     @Mock
@@ -471,6 +475,7 @@ public class DeleteEnvironmentCommandHandlerTest {
             portalPageContextRepository,
             portalNavigationItemRepository,
             portalPageContentRepository,
+            portalRepository,
             promotionRepository,
             qualityRuleRepository,
             ratingAnswerRepository,

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/cockpit/command/handler/EnvironmentCommandHandlerTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/cockpit/command/handler/EnvironmentCommandHandlerTest.java
@@ -25,6 +25,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.gravitee.apim.core.access_point.crud_service.AccessPointCrudService;
+import io.gravitee.apim.core.portal.use_case.CreateDefaultPortalUseCase;
 import io.gravitee.apim.core.portal_page.use_case.CreateDefaultPortalNavigationItemsUseCase;
 import io.gravitee.cockpit.api.command.model.accesspoint.AccessPoint;
 import io.gravitee.cockpit.api.command.v1.CockpitCommandType;
@@ -65,11 +66,19 @@ public class EnvironmentCommandHandlerTest {
     @Mock
     private CreateDefaultPortalNavigationItemsUseCase createDefaultPortalNavigationItemsUseCase;
 
+    @Mock
+    private CreateDefaultPortalUseCase createDefaultPortalUseCase;
+
     public EnvironmentCommandHandler cut;
 
     @BeforeEach
     public void before() {
-        cut = new EnvironmentCommandHandler(environmentService, accessPointService, createDefaultPortalNavigationItemsUseCase);
+        cut = new EnvironmentCommandHandler(
+            environmentService,
+            accessPointService,
+            createDefaultPortalNavigationItemsUseCase,
+            createDefaultPortalUseCase
+        );
     }
 
     @Test
@@ -216,6 +225,71 @@ public class EnvironmentCommandHandlerTest {
         obs.assertValue(reply -> reply.getCommandId().equals(command.getId()) && reply.getCommandStatus().equals(CommandStatus.SUCCEEDED));
 
         verify(createDefaultPortalNavigationItemsUseCase).execute(orgId, envId);
+    }
+
+    @Test
+    @SneakyThrows
+    public void environmentCreationCreatesDefaultPortal() {
+        String envId = "env#1";
+        String orgId = "orga#1";
+        EnvironmentCommandPayload environmentPayload = EnvironmentCommandPayload.builder()
+            .id(envId)
+            .cockpitId("env#cockpit-1")
+            .hrids(Collections.singletonList("env-1"))
+            .organizationId(orgId)
+            .description("Environment description")
+            .name("Environment name")
+            .build();
+        EnvironmentCommand command = new EnvironmentCommand(environmentPayload);
+
+        when(environmentService.findByCockpitId(any())).thenThrow(new EnvironmentNotFoundException("Env not found"));
+        when(environmentService.createOrUpdate(eq(orgId), eq(envId), any(UpdateEnvironmentEntity.class))).thenReturn(
+            EnvironmentEntity.builder().id(envId).organizationId(orgId).build()
+        );
+
+        TestObserver<EnvironmentReply> obs = cut.handle(command).test();
+
+        obs.await();
+        obs.assertValue(reply -> reply.getCommandId().equals(command.getId()) && reply.getCommandStatus().equals(CommandStatus.SUCCEEDED));
+
+        verify(createDefaultPortalUseCase).execute(orgId, envId);
+    }
+
+    @Test
+    public void environmentUpdateDoesNotCreateDefaultPortal() throws InterruptedException {
+        EnvironmentCommandPayload environmentPayload = EnvironmentCommandPayload.builder()
+            .id("env#1")
+            .cockpitId("env#cockpit-1")
+            .hrids(Collections.singletonList("env-1"))
+            .organizationId("orga#1")
+            .description("Environment description")
+            .name("Environment name")
+            .build();
+        EnvironmentCommand command = new EnvironmentCommand(environmentPayload);
+        EnvironmentEntity existingEnvironment = mock(EnvironmentEntity.class);
+        when(existingEnvironment.getId()).thenReturn("DEFAULT");
+        when(existingEnvironment.getOrganizationId()).thenReturn("DEFAULT");
+        when(environmentService.findByCockpitId(any())).thenReturn(existingEnvironment);
+        when(
+            environmentService.createOrUpdate(
+                eq("DEFAULT"),
+                eq("DEFAULT"),
+                argThat(
+                    newEnvironment ->
+                        newEnvironment.getCockpitId().equals(environmentPayload.cockpitId()) &&
+                        newEnvironment.getHrids().equals(environmentPayload.hrids()) &&
+                        newEnvironment.getDescription().equals(environmentPayload.description()) &&
+                        newEnvironment.getName().equals(environmentPayload.name())
+                )
+            )
+        ).thenReturn(new EnvironmentEntity());
+
+        TestObserver<EnvironmentReply> obs = cut.handle(command).test();
+
+        obs.await();
+        obs.assertValue(reply -> reply.getCommandId().equals(command.getId()) && reply.getCommandStatus().equals(CommandStatus.SUCCEEDED));
+
+        verify(createDefaultPortalUseCase, never()).execute(any(), any());
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/EnvironmentsDefaultPortalUpgraderTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/EnvironmentsDefaultPortalUpgraderTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.impl.upgrade.upgrader;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.apim.core.portal.use_case.CreateDefaultPortalUseCase;
+import io.gravitee.node.api.upgrader.UpgraderException;
+import io.gravitee.repository.exceptions.TechnicalException;
+import io.gravitee.repository.management.api.EnvironmentRepository;
+import io.gravitee.repository.management.model.Environment;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import lombok.SneakyThrows;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.function.Executable;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+public class EnvironmentsDefaultPortalUpgraderTest {
+
+    private static final Environment ANOTHER_ENVIRONMENT = Environment.builder()
+        .id("ANOTHER_ENVIRONMENT")
+        .hrids(List.of("another environment"))
+        .name("another environment")
+        .organizationId("ANOTHER_ORG")
+        .build();
+
+    @Mock
+    EnvironmentRepository environmentRepository;
+
+    @Mock
+    CreateDefaultPortalUseCase createDefaultPortalUseCase;
+
+    private EnvironmentsDefaultPortalUpgrader upgrader;
+
+    @BeforeEach
+    public void setUp() {
+        upgrader = new EnvironmentsDefaultPortalUpgrader(environmentRepository, createDefaultPortalUseCase);
+    }
+
+    @Test
+    @SneakyThrows
+    void should_do_nothing_when_there_is_no_environment() {
+        when(environmentRepository.findAll()).thenReturn(Collections.emptySet());
+        assertThat(upgrader.upgrade()).isTrue();
+        verifyNoInteractions(createDefaultPortalUseCase);
+    }
+
+    @Test
+    @SneakyThrows
+    void should_return_false_when_something_wrong_happens() {
+        when(environmentRepository.findAll()).thenThrow(new TechnicalException("this is a test exception"));
+
+        final Executable throwing = () -> upgrader.upgrade();
+
+        Exception exception = assertThrows(UpgraderException.class, throwing);
+        assertThat(exception.getMessage()).contains("this is a test exception");
+    }
+
+    @Test
+    @SneakyThrows
+    void should_create_default_portal_for_both_environments() {
+        when(environmentRepository.findAll()).thenReturn(Set.of(Environment.DEFAULT, ANOTHER_ENVIRONMENT));
+
+        assertThat(upgrader.upgrade()).isTrue();
+
+        ArgumentCaptor<String> captorOrgId = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<String> captorEnvId = ArgumentCaptor.forClass(String.class);
+
+        verify(createDefaultPortalUseCase, times(2)).execute(captorOrgId.capture(), captorEnvId.capture());
+        assertThat(captorOrgId.getAllValues()).containsExactlyInAnyOrder("DEFAULT", "ANOTHER_ORG");
+        assertThat(captorEnvId.getAllValues()).containsExactlyInAnyOrder("DEFAULT", "ANOTHER_ENVIRONMENT");
+    }
+}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/EXT-134

## Description

Context: Second slice of the Portal feature — adds the persistence layer, the runtime implementation of the CRUD service, and the seeding mechanism so that every environment (existing or newly registered via Cockpit) gets a default Portal automatically.

Scope:
  - Adds the Portal repository entity, JDBC + Mongo implementations, the Liquibase migration, and repository integration tests.
  - Implements the CRUD service against the repository and wires the new ENVIRONMENT_PORTAL permission in the security model.
  - Introduces the default-portal upgrader (one-time per installation) and the matching hook in the Cockpit environment-creation handler, both delegating to
   the seed use case.
  - Promotes the seed use case to a Spring-managed bean — the other three use cases remain dormant until PR 3.

