### PR TITLE
feat(portal): expose automation REST endpoints and wire @UseCase

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/java/io/gravitee/apim/rest/api/automation/GraviteeAutomationApplication.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/java/io/gravitee/apim/rest/api/automation/GraviteeAutomationApplication.java
@@ -28,6 +28,8 @@ import io.gravitee.apim.rest.api.automation.resource.GroupResource;
 import io.gravitee.apim.rest.api.automation.resource.GroupsResource;
 import io.gravitee.apim.rest.api.automation.resource.OpenAPIResource;
 import io.gravitee.apim.rest.api.automation.resource.OrganizationResource;
+import io.gravitee.apim.rest.api.automation.resource.PortalResource;
+import io.gravitee.apim.rest.api.automation.resource.PortalsResource;
 import io.gravitee.apim.rest.api.automation.resource.SharedPolicyGroupsResource;
 import io.gravitee.apim.rest.api.automation.spring.PermissionsFilter;
 import io.gravitee.rest.api.management.v2.rest.exceptionmapper.BadRequestExceptionMapper;
@@ -61,6 +63,8 @@ public class GraviteeAutomationApplication extends ResourceConfig {
         register(SharedPolicyGroupsResource.class);
         register(DictionariesResource.class);
         register(DictionaryResource.class);
+        register(PortalsResource.class);
+        register(PortalResource.class);
 
         register(ValidationDomainMapper.class);
         register(HRIDNotFoundMapper.class);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/java/io/gravitee/apim/rest/api/automation/mapper/PortalMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/java/io/gravitee/apim/rest/api/automation/mapper/PortalMapper.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.rest.api.automation.mapper;
+
+import io.gravitee.apim.core.portal.model.Portal;
+import io.gravitee.apim.rest.api.automation.model.PortalState;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.MappingTarget;
+import org.mapstruct.factory.Mappers;
+
+/**
+ * @author GraviteeSource Team
+ */
+@Mapper
+public interface PortalMapper {
+    PortalMapper INSTANCE = Mappers.getMapper(PortalMapper.class);
+
+    default PortalState toPortalState(Portal portal, String hrid) {
+        var state = new PortalState(
+            portal.getId() != null ? portal.getId().toString() : null,
+            portal.getEnvironmentId(),
+            portal.getOrganizationId(),
+            null
+        );
+        state.setHrid(hrid);
+        mapPortalToState(portal, state);
+        return state;
+    }
+
+    @Mapping(target = "id", ignore = true)
+    @Mapping(target = "environmentId", ignore = true)
+    @Mapping(target = "organizationId", ignore = true)
+    @Mapping(target = "errors", ignore = true)
+    @Mapping(target = "hrid", ignore = true)
+    @Mapping(target = "navigation", ignore = true)
+    void mapPortalToState(Portal portal, @MappingTarget PortalState state);
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/java/io/gravitee/apim/rest/api/automation/resource/EnvironmentResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/java/io/gravitee/apim/rest/api/automation/resource/EnvironmentResource.java
@@ -52,4 +52,9 @@ public class EnvironmentResource {
     public DictionariesResource getDictionariesResource() {
         return resourceContext.getResource(DictionariesResource.class);
     }
+
+    @Path("/portals")
+    public PortalsResource getPortalsResource() {
+        return resourceContext.getResource(PortalsResource.class);
+    }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/java/io/gravitee/apim/rest/api/automation/resource/PortalResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/java/io/gravitee/apim/rest/api/automation/resource/PortalResource.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.rest.api.automation.resource;
+
+import io.gravitee.apim.core.portal.exception.PortalNotFoundException;
+import io.gravitee.apim.core.portal.model.PortalId;
+import io.gravitee.apim.core.portal.use_case.DeletePortalUseCase;
+import io.gravitee.apim.core.portal.use_case.GetPortalUseCase;
+import io.gravitee.apim.rest.api.automation.exception.HRIDNotFoundException;
+import io.gravitee.apim.rest.api.automation.mapper.PortalMapper;
+import io.gravitee.common.http.MediaType;
+import io.gravitee.rest.api.model.permissions.RolePermission;
+import io.gravitee.rest.api.model.permissions.RolePermissionAction;
+import io.gravitee.rest.api.rest.annotation.Permission;
+import io.gravitee.rest.api.rest.annotation.Permissions;
+import io.gravitee.rest.api.service.common.HRIDToUUID;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.Response;
+
+/**
+ * @author GraviteeSource Team
+ */
+public class PortalResource extends AbstractResource {
+
+    @Inject
+    private GetPortalUseCase getPortalUseCase;
+
+    @Inject
+    private DeletePortalUseCase deletePortalUseCase;
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    @Permissions({ @Permission(value = RolePermission.ENVIRONMENT_PORTAL, acls = RolePermissionAction.READ) })
+    public Response getPortalByHRID(@PathParam("hrid") String hrid) {
+        var auditInfo = getAuditInfo();
+        PortalId id = PortalId.of(HRIDToUUID.portal().context(auditInfo).hrid(hrid).id());
+        try {
+            var output = getPortalUseCase.execute(new GetPortalUseCase.Input(auditInfo, id));
+            return Response.ok(PortalMapper.INSTANCE.toPortalState(output.portal(), hrid)).build();
+        } catch (PortalNotFoundException e) {
+            throw new HRIDNotFoundException(hrid);
+        }
+    }
+
+    @DELETE
+    @Permissions({ @Permission(value = RolePermission.ENVIRONMENT_PORTAL, acls = RolePermissionAction.DELETE) })
+    public Response deletePortalByHrid(@PathParam("hrid") String hrid) {
+        var auditInfo = getAuditInfo();
+        PortalId id = PortalId.of(HRIDToUUID.portal().context(auditInfo).hrid(hrid).id());
+        try {
+            deletePortalUseCase.execute(new DeletePortalUseCase.Input(auditInfo, id));
+        } catch (PortalNotFoundException e) {
+            throw new HRIDNotFoundException(hrid);
+        }
+        return Response.noContent().build();
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/java/io/gravitee/apim/rest/api/automation/resource/PortalsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/java/io/gravitee/apim/rest/api/automation/resource/PortalsResource.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.rest.api.automation.resource;
+
+import static io.gravitee.rest.api.model.permissions.RolePermissionAction.CREATE;
+import static io.gravitee.rest.api.model.permissions.RolePermissionAction.UPDATE;
+
+import io.gravitee.apim.core.portal.model.Portal;
+import io.gravitee.apim.core.portal.model.PortalId;
+import io.gravitee.apim.core.portal.use_case.CreateOrUpdatePortalUseCase;
+import io.gravitee.apim.rest.api.automation.mapper.PortalMapper;
+import io.gravitee.apim.rest.api.automation.model.PortalSpec;
+import io.gravitee.common.http.MediaType;
+import io.gravitee.rest.api.model.permissions.RolePermission;
+import io.gravitee.rest.api.rest.annotation.Permission;
+import io.gravitee.rest.api.rest.annotation.Permissions;
+import io.gravitee.rest.api.service.common.HRIDToUUID;
+import jakarta.inject.Inject;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.PUT;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.container.ResourceContext;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.Response;
+
+/**
+ * @author GraviteeSource Team
+ */
+public class PortalsResource extends AbstractResource {
+
+    @Context
+    private ResourceContext resourceContext;
+
+    @Inject
+    private CreateOrUpdatePortalUseCase createOrUpdatePortalUseCase;
+
+    @Path("/{hrid}")
+    public PortalResource getPortalResource() {
+        return resourceContext.getResource(PortalResource.class);
+    }
+
+    @PUT
+    @Produces(MediaType.APPLICATION_JSON)
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Permissions({ @Permission(value = RolePermission.ENVIRONMENT_PORTAL, acls = { CREATE, UPDATE }) })
+    public Response createOrUpdate(@Valid @NotNull PortalSpec spec, @QueryParam("dryRun") boolean dryRun) {
+        var auditInfo = getAuditInfo();
+        var portal = Portal.of(
+            PortalId.of(HRIDToUUID.portal().context(auditInfo).hrid(spec.getHrid()).id()),
+            auditInfo.environmentId(),
+            auditInfo.organizationId(),
+            spec.getName()
+        );
+
+        if (dryRun) {
+            return Response.ok(PortalMapper.INSTANCE.toPortalState(portal, spec.getHrid())).build();
+        }
+
+        var output = createOrUpdatePortalUseCase.execute(new CreateOrUpdatePortalUseCase.Input(auditInfo, portal));
+
+        return Response.ok(PortalMapper.INSTANCE.toPortalState(output.portal(), spec.getHrid())).build();
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/resource/PortalResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/resource/PortalResourceTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.rest.api.automation.resource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.apim.core.portal.exception.PortalNotFoundException;
+import io.gravitee.apim.core.portal.model.Portal;
+import io.gravitee.apim.core.portal.model.PortalId;
+import io.gravitee.apim.core.portal.use_case.DeletePortalUseCase;
+import io.gravitee.apim.core.portal.use_case.GetPortalUseCase;
+import io.gravitee.apim.rest.api.automation.model.PortalState;
+import io.gravitee.apim.rest.api.automation.resource.base.AbstractResourceTest;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.core.MediaType;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class PortalResourceTest extends AbstractResourceTest {
+
+    private static final String HRID = "default-portal";
+    private static final PortalId PORTAL_ID = PortalId.of("00000000-0000-0000-0000-0000000000a1");
+
+    @Inject
+    private GetPortalUseCase getPortalUseCase;
+
+    @Inject
+    private DeletePortalUseCase deletePortalUseCase;
+
+    @AfterEach
+    void tearDown() {
+        reset(getPortalUseCase, deletePortalUseCase);
+    }
+
+    @Override
+    protected String contextPath() {
+        return "/organizations/" + ORGANIZATION + "/environments/" + ENVIRONMENT + "/portals";
+    }
+
+    @Nested
+    class Get {
+
+        @Test
+        void should_return_portal_by_hrid() {
+            var persisted = Portal.of(PORTAL_ID, ENVIRONMENT, ORGANIZATION, "Default Portal");
+            when(getPortalUseCase.execute(any())).thenReturn(new GetPortalUseCase.Output(persisted));
+
+            try (var response = rootTarget(HRID).request().accept(MediaType.APPLICATION_JSON_TYPE).get()) {
+                assertThat(response.getStatus()).isEqualTo(200);
+                verify(getPortalUseCase).execute(any(GetPortalUseCase.Input.class));
+
+                var state = response.readEntity(PortalState.class);
+                SoftAssertions.assertSoftly(soft -> {
+                    soft.assertThat(state.getId()).isEqualTo(PORTAL_ID.toString());
+                    soft.assertThat(state.getHrid()).isEqualTo(HRID);
+                    soft.assertThat(state.getName()).isEqualTo("Default Portal");
+                });
+            }
+        }
+
+        @Test
+        void should_return_404_when_missing() {
+            when(getPortalUseCase.execute(any())).thenThrow(new PortalNotFoundException(PORTAL_ID.toString()));
+
+            try (var response = rootTarget(HRID).request().accept(MediaType.APPLICATION_JSON_TYPE).get()) {
+                assertThat(response.getStatus()).isEqualTo(404);
+            }
+        }
+    }
+
+    @Nested
+    class Delete {
+
+        @Test
+        void should_delete_portal_by_hrid() {
+            try (var response = rootTarget(HRID).request().delete()) {
+                assertThat(response.getStatus()).isEqualTo(204);
+                verify(deletePortalUseCase).execute(any(DeletePortalUseCase.Input.class));
+            }
+        }
+
+        @Test
+        void should_return_404_on_delete_missing() {
+            org.mockito.Mockito.doThrow(new PortalNotFoundException(PORTAL_ID.toString()))
+                .when(deletePortalUseCase)
+                .execute(any(DeletePortalUseCase.Input.class));
+
+            try (var response = rootTarget(HRID).request().delete()) {
+                assertThat(response.getStatus()).isEqualTo(404);
+            }
+        }
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/resource/PortalsResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/resource/PortalsResourceTest.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.rest.api.automation.resource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.apim.core.portal.model.Portal;
+import io.gravitee.apim.core.portal.model.PortalId;
+import io.gravitee.apim.core.portal.use_case.CreateOrUpdatePortalUseCase;
+import io.gravitee.apim.rest.api.automation.model.PortalState;
+import io.gravitee.apim.rest.api.automation.resource.base.AbstractResourceTest;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.client.Entity;
+import jakarta.ws.rs.core.MediaType;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class PortalsResourceTest extends AbstractResourceTest {
+
+    @Inject
+    private CreateOrUpdatePortalUseCase createOrUpdatePortalUseCase;
+
+    @AfterEach
+    void tearDown() {
+        reset(createOrUpdatePortalUseCase);
+    }
+
+    @Override
+    protected String contextPath() {
+        return "/organizations/" + ORGANIZATION + "/environments/" + ENVIRONMENT + "/portals";
+    }
+
+    @Nested
+    class DryRun {
+
+        @Test
+        void should_return_populated_state_without_calling_use_case() {
+            try (
+                var response = rootTarget()
+                    .queryParam("dryRun", true)
+                    .request()
+                    .accept(MediaType.APPLICATION_JSON_TYPE)
+                    .put(Entity.json(readJSON("portal.json")))
+            ) {
+                assertThat(response.getStatus()).isEqualTo(200);
+                verifyNoInteractions(createOrUpdatePortalUseCase);
+
+                var state = response.readEntity(PortalState.class);
+                SoftAssertions.assertSoftly(soft -> {
+                    soft.assertThat(state.getHrid()).isEqualTo("default-portal");
+                    soft.assertThat(state.getName()).isEqualTo("Default Portal");
+                    soft.assertThat(state.getEnvironmentId()).isEqualTo(ENVIRONMENT);
+                    soft.assertThat(state.getOrganizationId()).isEqualTo(ORGANIZATION);
+                    soft.assertThat(state.getId()).isNotBlank();
+                });
+            }
+        }
+
+        @Test
+        void should_return_400_when_hrid_is_missing() {
+            try (
+                var response = rootTarget()
+                    .queryParam("dryRun", true)
+                    .request()
+                    .accept(MediaType.APPLICATION_JSON_TYPE)
+                    .put(Entity.json(readJSON("invalid-portal.json")))
+            ) {
+                assertThat(response.getStatus()).isEqualTo(400);
+                verifyNoInteractions(createOrUpdatePortalUseCase);
+            }
+        }
+    }
+
+    @Nested
+    class Run {
+
+        @Test
+        void should_create_or_update_portal() {
+            var persisted = Portal.of(PortalId.of("00000000-0000-0000-0000-0000000000a1"), ENVIRONMENT, ORGANIZATION, "Default Portal");
+            when(createOrUpdatePortalUseCase.execute(any())).thenReturn(new CreateOrUpdatePortalUseCase.Output(persisted));
+
+            try (var response = rootTarget().request().accept(MediaType.APPLICATION_JSON_TYPE).put(Entity.json(readJSON("portal.json")))) {
+                assertThat(response.getStatus()).isEqualTo(200);
+                verify(createOrUpdatePortalUseCase).execute(any(CreateOrUpdatePortalUseCase.Input.class));
+
+                var state = response.readEntity(PortalState.class);
+                SoftAssertions.assertSoftly(soft -> {
+                    soft.assertThat(state.getId()).isEqualTo("00000000-0000-0000-0000-0000000000a1");
+                    soft.assertThat(state.getHrid()).isEqualTo("default-portal");
+                    soft.assertThat(state.getEnvironmentId()).isEqualTo(ENVIRONMENT);
+                    soft.assertThat(state.getOrganizationId()).isEqualTo(ORGANIZATION);
+                    soft.assertThat(state.getName()).isEqualTo("Default Portal");
+                });
+            }
+        }
+
+        @Test
+        void should_silently_ignore_navigation_field() {
+            var persisted = Portal.of(PortalId.of("00000000-0000-0000-0000-0000000000a1"), ENVIRONMENT, ORGANIZATION, "Default Portal");
+            when(createOrUpdatePortalUseCase.execute(any())).thenReturn(new CreateOrUpdatePortalUseCase.Output(persisted));
+
+            try (
+                var response = rootTarget()
+                    .request()
+                    .accept(MediaType.APPLICATION_JSON_TYPE)
+                    .put(Entity.json(readJSON("portal-with-navigation.json")))
+            ) {
+                assertThat(response.getStatus()).isEqualTo(200);
+                verify(createOrUpdatePortalUseCase).execute(any(CreateOrUpdatePortalUseCase.Input.class));
+
+                var state = response.readEntity(PortalState.class);
+                assertThat(state.getNavigation()).isNullOrEmpty();
+            }
+        }
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/spring/ResourceContextConfiguration.java
@@ -140,6 +140,9 @@ import io.gravitee.apim.core.plan.query_service.PlanSearchQueryService;
 import io.gravitee.apim.core.plugin.crud_service.PolicyPluginCrudService;
 import io.gravitee.apim.core.plugin.domain_service.EndpointConnectorPluginDomainService;
 import io.gravitee.apim.core.policy.domain_service.PolicyValidationDomainService;
+import io.gravitee.apim.core.portal.use_case.CreateOrUpdatePortalUseCase;
+import io.gravitee.apim.core.portal.use_case.DeletePortalUseCase;
+import io.gravitee.apim.core.portal.use_case.GetPortalUseCase;
 import io.gravitee.apim.core.portal_page.crud_service.PortalNavigationItemCrudService;
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemDomainService;
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemValidatorService;
@@ -1254,5 +1257,20 @@ public class ResourceContextConfiguration {
     @Bean
     public io.gravitee.apim.core.log.crud_service.NativeApiLogCrudService nativeApiLogCrudService() {
         return mock(io.gravitee.apim.core.log.crud_service.NativeApiLogCrudService.class);
+    }
+
+    @Bean
+    public CreateOrUpdatePortalUseCase createOrUpdatePortalUseCase() {
+        return mock(CreateOrUpdatePortalUseCase.class);
+    }
+
+    @Bean
+    public GetPortalUseCase getPortalUseCase() {
+        return mock(GetPortalUseCase.class);
+    }
+
+    @Bean
+    public DeletePortalUseCase deletePortalUseCase() {
+        return mock(DeletePortalUseCase.class);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/resources/io/gravitee/apim/rest/api/automation/resource/invalid-portal.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/resources/io/gravitee/apim/rest/api/automation/resource/invalid-portal.json
@@ -1,0 +1,3 @@
+{
+  "name": "Missing HRID Portal"
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/resources/io/gravitee/apim/rest/api/automation/resource/portal-with-navigation.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/resources/io/gravitee/apim/rest/api/automation/resource/portal-with-navigation.json
@@ -1,0 +1,8 @@
+{
+  "hrid": "default-portal",
+  "name": "Default Portal",
+  "navigation": [
+    { "path": "/projects/alpha", "displayName": "Alpha" },
+    { "path": "/projects/alpha/docs" }
+  ]
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/resources/io/gravitee/apim/rest/api/automation/resource/portal.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/resources/io/gravitee/apim/rest/api/automation/resource/portal.json
@@ -1,0 +1,4 @@
+{
+  "hrid": "default-portal",
+  "name": "Default Portal"
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal/use_case/CreateOrUpdatePortalUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal/use_case/CreateOrUpdatePortalUseCase.java
@@ -15,11 +15,13 @@
  */
 package io.gravitee.apim.core.portal.use_case;
 
+import io.gravitee.apim.core.UseCase;
 import io.gravitee.apim.core.audit.model.AuditInfo;
 import io.gravitee.apim.core.portal.crud_service.PortalCrudService;
 import io.gravitee.apim.core.portal.model.Portal;
 import lombok.RequiredArgsConstructor;
 
+@UseCase
 @RequiredArgsConstructor
 public class CreateOrUpdatePortalUseCase {
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal/use_case/DeletePortalUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal/use_case/DeletePortalUseCase.java
@@ -15,12 +15,14 @@
  */
 package io.gravitee.apim.core.portal.use_case;
 
+import io.gravitee.apim.core.UseCase;
 import io.gravitee.apim.core.audit.model.AuditInfo;
 import io.gravitee.apim.core.portal.crud_service.PortalCrudService;
 import io.gravitee.apim.core.portal.exception.PortalNotFoundException;
 import io.gravitee.apim.core.portal.model.PortalId;
 import lombok.RequiredArgsConstructor;
 
+@UseCase
 @RequiredArgsConstructor
 public class DeletePortalUseCase {
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal/use_case/GetPortalUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal/use_case/GetPortalUseCase.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.apim.core.portal.use_case;
 
+import io.gravitee.apim.core.UseCase;
 import io.gravitee.apim.core.audit.model.AuditInfo;
 import io.gravitee.apim.core.portal.crud_service.PortalCrudService;
 import io.gravitee.apim.core.portal.exception.PortalNotFoundException;
@@ -22,6 +23,7 @@ import io.gravitee.apim.core.portal.model.Portal;
 import io.gravitee.apim.core.portal.model.PortalId;
 import lombok.RequiredArgsConstructor;
 
+@UseCase
 @RequiredArgsConstructor
 public class GetPortalUseCase {
 


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/EXT-134

## Description

Context: Final slice of the Portal feature — exposes the resource through the Automation API so external clients can create, read, update, and delete portals, completing the end-to-end flow.

Scope:
  - Adds the Automation REST resources, mapper, and resource-context wiring backed by tests + JSON fixtures.
  - Re-enables the create-or-update, get, and delete use cases as Spring beans so the resources can invoke them.
  - After this PR merges, the feature is live: the upgrader seeds a default portal per environment, automation pushes update that same portal idempotently
  via the HRID-derived id, and Cockpit-registered environments get their default portal automatically.


