### PR TITLE
chore(authz-ui): rename entity action buttons

### DIFF
--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/features/policy-structure/EntitiesPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/features/policy-structure/EntitiesPage.tsx
@@ -533,7 +533,7 @@ export function EntitiesPage() {
                         <div className="ml-auto flex items-center gap-2">
                             <Button variant="outline" onClick={onSync} disabled={isSyncing}>
                                 <RefreshCwIcon className={`mr-2 size-4 ${isSyncing ? 'animate-spin' : ''}`} aria-hidden />
-                                {isSyncing ? 'Syncing from AM…' : 'Sync from AM'}
+                                {isSyncing ? 'Syncing from Gravitee Access Management…' : 'Sync From Gravitee Access Management'}
                             </Button>
                             <Button onClick={() => setAddingKind('PRINCIPAL')}>
                                 <PlusIcon className="mr-2 size-4" aria-hidden />
@@ -593,7 +593,7 @@ export function EntitiesPage() {
                             </Button>
                             <Button onClick={() => setImportOpen(true)}>
                                 <DownloadIcon className="mr-2 size-4" aria-hidden />
-                                Import from Context Catalog
+                                Import from AI Catalog
                             </Button>
                         </div>
                     </div>

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/features/policy-structure/ImportFromCatalogDialog.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/features/policy-structure/ImportFromCatalogDialog.tsx
@@ -297,7 +297,7 @@ export function ImportFromCatalogDialog({ open, environmentId, onOpenChange, onI
     const selectedCount = selected.size;
     const tabCount = (key: TabKey): number => queryByTab[key].data?.total ?? 0;
 
-    const ariaLabel = 'Import from Context Catalog';
+    const ariaLabel = 'Import from AI Catalog';
 
     function renderTabBody(tab: TabDef, query: UseAimCatalogItemsResult<CatalogItem>) {
         const items: readonly CatalogItem[] = query.data?.data ?? [];
@@ -434,7 +434,7 @@ export function ImportFromCatalogDialog({ open, environmentId, onOpenChange, onI
                 <SheetTitle className="sr-only">{ariaLabel}</SheetTitle>
 
                 <div className="border-b px-6 py-4">
-                    <h2 className="text-lg font-semibold">Import from Context Catalog</h2>
+                    <h2 className="text-lg font-semibold">Import from AI Catalog</h2>
                     <p className="mt-1 text-sm text-muted-foreground">
                         Select catalog entries to register as read-only resource entities in the Policy Engine. Imported entities keep the
                         same Entity ID as in the Catalog, so policies always refer to one canonical identifier.

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/features/policy-structure/__tests__/EntitiesPage.test.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/features/policy-structure/__tests__/EntitiesPage.test.tsx
@@ -229,12 +229,12 @@ describe('EntitiesPage', () => {
         renderPage();
 
         await waitFor(() => expect(screen.getAllByText('alice').length).toBeGreaterThan(0));
-        expect(screen.queryByRole('button', { name: /Import from Context Catalog/i })).not.toBeInTheDocument();
+        expect(screen.queryByRole('button', { name: /Import from AI Catalog/i })).not.toBeInTheDocument();
 
         const user = userEvent.setup();
         await user.click(screen.getByRole('tab', { name: /Resources/i }));
 
-        await waitFor(() => expect(screen.getByRole('button', { name: /Import from Context Catalog/i })).toBeInTheDocument());
+        await waitFor(() => expect(screen.getByRole('button', { name: /Import from AI Catalog/i })).toBeInTheDocument());
     });
 
     it('opens the import dialog stub when the button is clicked', async () => {
@@ -243,10 +243,10 @@ describe('EntitiesPage', () => {
 
         const user = userEvent.setup();
         await user.click(screen.getByRole('tab', { name: /Resources/i }));
-        await waitFor(() => expect(screen.getByRole('button', { name: /Import from Context Catalog/i })).toBeInTheDocument());
+        await waitFor(() => expect(screen.getByRole('button', { name: /Import from AI Catalog/i })).toBeInTheDocument());
 
         expect(screen.queryByTestId('import-dialog-stub')).not.toBeInTheDocument();
-        await user.click(screen.getByRole('button', { name: /Import from Context Catalog/i }));
+        await user.click(screen.getByRole('button', { name: /Import from AI Catalog/i }));
         expect(screen.getByTestId('import-dialog-stub')).toBeInTheDocument();
     });
 


### PR DESCRIPTION
## Summary
- Rename **"Sync from AM"** → **"Sync From Gravitee Access Management"** (and the in-progress label to match)
- Rename **"Import from Context Catalog"** → **"Import from AI Catalog"**, including the dialog `<h2>` title and the `sr-only` accessible name so they stay in sync

## Test plan
- [x] `nx lint gravitee-gamma-module-authz` — eslint + license check pass
- [x] `vitest run EntitiesPage` — 19/19 pass (button-label assertions updated)