### PR TITLE
feat(gamma-authz): import mcp tools from catalog and use them in policy builder

### DIFF
--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/java/io/gravitee/gamma/authorization/api/AuthzEntityRepository.java
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/java/io/gravitee/gamma/authorization/api/AuthzEntityRepository.java
@@ -60,6 +60,13 @@ public interface AuthzEntityRepository {
         return result;
     }
 
+    default List<AuthzEntity> findByParent(String environmentId, String parentEntityId) {
+        if (parentEntityId == null || parentEntityId.isBlank()) {
+            return List.of();
+        }
+        return findAll(environmentId).stream().filter(e -> e.parents().contains(parentEntityId)).toList();
+    }
+
     default List<AuthzEntity> findByAnyEntityIdPrefix(String environmentId, Collection<String> prefixes) {
         if (prefixes == null || prefixes.isEmpty()) {
             return List.of();

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/java/io/gravitee/gamma/authorization/infra/repository/MongoAuthzEntityRepository.java
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/java/io/gravitee/gamma/authorization/infra/repository/MongoAuthzEntityRepository.java
@@ -109,6 +109,15 @@ public class MongoAuthzEntityRepository implements AuthzEntityRepository {
     }
 
     @Override
+    public List<AuthzEntity> findByParent(String environmentId, String parentEntityId) {
+        if (parentEntityId == null || parentEntityId.isBlank()) {
+            return List.of();
+        }
+        var query = new Query(Criteria.where("environmentId").is(environmentId).and("parents").is(parentEntityId));
+        return mongo.find(query, AuthzEntityMongo.class).stream().map(AuthzEntityDocumentMapper::toDomain).toList();
+    }
+
+    @Override
     public List<AuthzEntity> findByAnyEntityIdPrefix(String environmentId, Collection<String> prefixes) {
         if (prefixes == null || prefixes.isEmpty()) {
             return List.of();

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/java/io/gravitee/gamma/authorization/service/AuthzEntityServiceImpl.java
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/java/io/gravitee/gamma/authorization/service/AuthzEntityServiceImpl.java
@@ -381,6 +381,9 @@ public class AuthzEntityServiceImpl implements AuthzEntityAdminApi {
         for (AuthzEntity e : entityRepository.findByAnyEntityIdPrefix(environmentId, prefixes)) {
             result.putIfAbsent(e.entityId(), e);
         }
+        for (AuthzEntity e : entityRepository.findByParent(environmentId, entityId)) {
+            result.putIfAbsent(e.entityId(), e);
+        }
         return result;
     }
 

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/features/policy-management/ServicePolicyPage.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/features/policy-management/ServicePolicyPage.tsx
@@ -42,13 +42,14 @@ import { KpiTile } from '../../components/KpiTile';
 import { ValidationErrorAlert } from '../../components/ValidationErrorAlert';
 import type { PolicyRequest, PolicyResponse, PolicyStatus, PolicyType } from '../../shared/api/authz-api.types';
 import type { ChipOption } from '../../shared/chip-option';
-import { parseGaplSchema } from '../../shared/gapl-parser';
 import { useEntities } from '../../shared/hooks/useEntities';
 import { useEntityOptions } from '../../shared/hooks/useEntityOptions';
 import { usePolicies } from '../../shared/hooks/usePolicies';
 import { useSchema } from '../../shared/hooks/useSchema';
 import { PolicyEditorSheet } from './PolicyEditorSheet';
 import { PolicyListTable } from './PolicyListTable';
+import { buildActionOptions } from './action-options';
+import { buildResourceOptions } from './resource-options';
 
 export type CatalogEntryType = 'MCP' | 'AGENT' | 'MODEL' | 'API' | 'EVENT';
 
@@ -117,6 +118,13 @@ export function ServicePolicyPage({ config }: { readonly config: ServicePageConf
     });
     // Action chip options. Separate scoped fetch so it never bloats with catalog rows.
     const actionEntities = useEntities(envId, 200, { kind: 'RESOURCE', entityIdPrefix: 'action.' });
+    // MCP tools surface as selectable actions on the MCP policy page only. Fetched
+    // env-wide (all tools, any server), not scoped to the selected target server.
+    const mcpToolEntities = useEntities(envId, 200, {
+        kind: 'RESOURCE',
+        entityIdPrefix: 'mcptool.',
+        enabled: config.type === 'MCP',
+    });
 
     const allPolicies = useMemo<readonly PolicyResponse[]>(() => policies.data?.data ?? [], [policies.data]);
 
@@ -165,30 +173,11 @@ export function ServicePolicyPage({ config }: { readonly config: ServicePageConf
         return { entries, isLoading: catalogEntities.isLoading, error: catalogEntities.error };
     }, [config.hasTarget, config.type, catalogEntities.data, catalogEntities.isLoading, catalogEntities.error]);
 
-    const actionOptions = useMemo((): readonly ChipOption[] => {
-        const seen = new Set<string>();
-        const merged: ChipOption[] = [];
-        if (schema.schema?.schemaText) {
-            const parsed = parseGaplSchema(schema.schema.schemaText);
-            for (const a of parsed.actions) {
-                const id = `Action::"${a.name}"`;
-                if (!seen.has(id)) {
-                    seen.add(id);
-                    merged.push({ id, label: a.name, group: 'Action' });
-                }
-            }
-        }
-        for (const e of actionEntities.data?.data ?? []) {
-            const name = (e.attributes?.name as string) || e.uid.replace(/^action\./, '');
-            if (!name) continue;
-            const id = `Action::"${name}"`;
-            if (seen.has(id)) continue;
-            seen.add(id);
-            const description = typeof e.attributes?.description === 'string' ? (e.attributes.description as string) : undefined;
-            merged.push({ id, label: name, group: 'Action', description });
-        }
-        return merged;
-    }, [schema.schema, actionEntities.data]);
+    const actionOptions = useMemo(
+        (): readonly ChipOption[] =>
+            buildActionOptions(schema.schema?.schemaText, actionEntities.data?.data ?? [], mcpToolEntities.data?.data ?? []),
+        [schema.schema, actionEntities.data, mcpToolEntities.data],
+    );
 
     const { options: principalOptions } = useEntityOptions(envId, {
         typeFilter: config.hasTarget ? ['User', 'Group', 'ServiceAccount', 'AgentIdentity'] : undefined,
@@ -204,41 +193,15 @@ export function ServicePolicyPage({ config }: { readonly config: ServicePageConf
         return 'No principals available. Add Users, Groups, Service Accounts or Agent Identities under Policy Structure → Entities.';
     }, [principalOptions.length]);
 
-    const serviceResourceOptions = useMemo((): readonly ChipOption[] => {
-        // catalogEntities is already scoped server-side to this service prefix
-        // (kind=RESOURCE + entityIdPrefix=<type>.) — no need to re-filter out
-        // principals or other service types here.
-        const items: ChipOption[] = [];
-        const typePrefix = config.type.toLowerCase();
-        for (const e of catalogEntities.data?.data ?? []) {
-            const attrs = e.attributes ?? {};
-            const firstSeg = e.uid.includes('.') ? e.uid.slice(0, e.uid.indexOf('.')).toLowerCase() : '';
-            if (config.hasTarget && firstSeg !== typePrefix) continue;
-            const label =
-                typeof attrs.displayName === 'string' && attrs.displayName
-                    ? (attrs.displayName as string)
-                    : typeof attrs.name === 'string' && attrs.name
-                      ? (attrs.name as string)
-                      : e.uid.includes('.')
-                        ? e.uid.slice(e.uid.indexOf('.') + 1)
-                        : e.uid;
-            const group =
-                firstSeg === 'mcp'
-                    ? 'MCP'
-                    : firstSeg === 'model' || firstSeg === 'llm'
-                      ? 'Model'
-                      : firstSeg === 'agent'
-                        ? 'Agent'
-                        : firstSeg === 'api'
-                          ? 'API'
-                          : 'Resource';
-            const description = typeof attrs.description === 'string' ? (attrs.description as string) : undefined;
-            const labelForUid = e.uid.includes('.') ? e.uid.slice(e.uid.indexOf('.') + 1) : e.uid;
-            items.push({ id: `${group}::"${labelForUid}"`, label, group, description });
-        }
-        items.sort((a, b) => (a.group === b.group ? a.label.localeCompare(b.label) : a.group.localeCompare(b.group)));
-        return items;
-    }, [config.hasTarget, config.type, catalogEntities.data]);
+    const serviceResourceOptions = useMemo(
+        (): readonly ChipOption[] =>
+            buildResourceOptions(
+                { type: config.type, hasTarget: config.hasTarget },
+                catalogEntities.data?.data ?? [],
+                mcpToolEntities.data?.data ?? [],
+            ),
+        [config.hasTarget, config.type, catalogEntities.data, mcpToolEntities.data],
+    );
 
     const effectiveConfig = useMemo<ServicePageConfig>(
         () => ({
@@ -301,7 +264,8 @@ export function ServicePolicyPage({ config }: { readonly config: ServicePageConf
         policies.reload();
         catalogEntities.reload();
         actionEntities.reload();
-    }, [policies, catalogEntities, actionEntities]);
+        mcpToolEntities.reload();
+    }, [policies, catalogEntities, actionEntities, mcpToolEntities]);
 
     const Icon = config.icon;
     const totalCount = policies.data?.total ?? 0;

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/features/policy-management/__tests__/action-options.test.ts
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/features/policy-management/__tests__/action-options.test.ts
@@ -1,0 +1,75 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, expect, it } from 'vitest';
+import type { EntityResponse } from '../../../shared/api/authz-api.types';
+import { buildActionOptions } from '../action-options';
+
+function entity(uid: string, attributes: Record<string, unknown> = {}): EntityResponse {
+    return { uid, attributes } as EntityResponse;
+}
+
+describe('buildActionOptions', () => {
+    it('merges schema actions and action.* entities into the Action group', () => {
+        const schema = 'action "read" appliesTo {}; action "write" appliesTo {};';
+        const result = buildActionOptions(schema, [entity('action.delete', { name: 'delete' })], []);
+
+        expect(result.map(o => o.label)).toEqual(['read', 'write', 'delete']);
+        expect(result.every(o => o.group === 'Action')).toBe(true);
+        expect(result.find(o => o.label === 'read')?.id).toBe('Action::"read"');
+    });
+
+    it('adds mcptool.* entities as a separate "MCP Tools" group, sorted by label', () => {
+        const tools = [
+            entity('mcptool.get_forecast', { _displayName: 'get_forecast', description: 'Forecast' }),
+            entity('mcptool.get_current_weather', { _displayName: 'get_current_weather' }),
+        ];
+        const result = buildActionOptions(undefined, [], tools);
+
+        expect(result.map(o => ({ label: o.label, group: o.group, id: o.id }))).toEqual([
+            { label: 'get_current_weather', group: 'MCP Tools', id: 'Action::"get_current_weather"' },
+            { label: 'get_forecast', group: 'MCP Tools', id: 'Action::"get_forecast"' },
+        ]);
+        expect(result[1].description).toBe('Forecast');
+    });
+
+    it('keeps actions first and tools after, as distinct groups', () => {
+        const result = buildActionOptions(
+            'action "read" appliesTo {};',
+            [],
+            [entity('mcptool.get_forecast', { _displayName: 'get_forecast' })],
+        );
+
+        expect(result.map(o => o.group)).toEqual(['Action', 'MCP Tools']);
+    });
+
+    it('falls back to the uid slug when a tool has no display name', () => {
+        const result = buildActionOptions(undefined, [], [entity('mcptool.search_locations')]);
+
+        expect(result[0].label).toBe('search_locations');
+        expect(result[0].id).toBe('Action::"search_locations"');
+    });
+
+    it('deduplicates by action id across schema, action.* and tools (first wins)', () => {
+        const result = buildActionOptions(
+            'action "read" appliesTo {};',
+            [entity('action.read', { name: 'read' })],
+            [entity('mcptool.read', { _displayName: 'read' })],
+        );
+
+        expect(result).toHaveLength(1);
+        expect(result[0].group).toBe('Action');
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/features/policy-management/__tests__/resource-options.test.ts
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/features/policy-management/__tests__/resource-options.test.ts
@@ -1,0 +1,75 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, expect, it } from 'vitest';
+import type { EntityResponse } from '../../../shared/api/authz-api.types';
+import { buildResourceOptions } from '../resource-options';
+
+function entity(uid: string, attributes: Record<string, unknown> = {}): EntityResponse {
+    return { uid, attributes } as EntityResponse;
+}
+
+describe('buildResourceOptions', () => {
+    it('maps mcp.* catalog rows to the MCP group with a canonical resource id', () => {
+        const result = buildResourceOptions({ type: 'MCP', hasTarget: true }, [entity('mcp.weather', { displayName: 'Weather MCP' })], []);
+
+        expect(result).toEqual([{ id: 'MCP::"weather"', label: 'Weather MCP', group: 'MCP', description: undefined }]);
+    });
+
+    it('adds mcptool.* rows as a separate "MCP Tools" group with MCPTool resource ids', () => {
+        const tools = [
+            entity('mcptool.get_forecast', { _displayName: 'get_forecast', description: 'Forecast' }),
+            entity('mcptool.get_current_weather', { _displayName: 'get_current_weather' }),
+        ];
+        const result = buildResourceOptions({ type: 'MCP', hasTarget: true }, [], tools);
+
+        expect(result.map(o => ({ id: o.id, label: o.label, group: o.group }))).toEqual([
+            { id: 'MCPTool::"get_current_weather"', label: 'get_current_weather', group: 'MCP Tools' },
+            { id: 'MCPTool::"get_forecast"', label: 'get_forecast', group: 'MCP Tools' },
+        ]);
+        expect(result.find(o => o.label === 'get_forecast')?.description).toBe('Forecast');
+    });
+
+    it('orders the MCP server group before the MCP Tools group', () => {
+        const result = buildResourceOptions(
+            { type: 'MCP', hasTarget: true },
+            [entity('mcp.weather', { displayName: 'Weather MCP' })],
+            [entity('mcptool.get_forecast', { _displayName: 'get_forecast' })],
+        );
+
+        expect(result.map(o => o.group)).toEqual(['MCP', 'MCP Tools']);
+    });
+
+    it('falls back to the uid slug when a tool has no display name', () => {
+        const result = buildResourceOptions({ type: 'MCP', hasTarget: true }, [], [entity('mcptool.search_locations')]);
+
+        expect(result[0]).toEqual({
+            id: 'MCPTool::"search_locations"',
+            label: 'search_locations',
+            group: 'MCP Tools',
+            description: undefined,
+        });
+    });
+
+    it('filters catalog rows whose prefix does not match the target service type', () => {
+        const result = buildResourceOptions(
+            { type: 'MCP', hasTarget: true },
+            [entity('mcp.weather', { displayName: 'Weather MCP' }), entity('model.gpt', { displayName: 'GPT' })],
+            [],
+        );
+
+        expect(result.map(o => o.id)).toEqual(['MCP::"weather"']);
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/features/policy-management/action-options.ts
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/features/policy-management/action-options.ts
@@ -1,0 +1,68 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import type { EntityResponse } from '../../shared/api/authz-api.types';
+import type { ChipOption } from '../../shared/chip-option';
+import { parseGaplSchema } from '../../shared/gapl-parser';
+
+function firstString(...values: unknown[]): string | undefined {
+    for (const v of values) {
+        if (typeof v === 'string' && v) return v;
+    }
+    return undefined;
+}
+
+export function buildActionOptions(
+    schemaText: string | undefined,
+    actionRows: readonly EntityResponse[],
+    mcpToolRows: readonly EntityResponse[],
+): readonly ChipOption[] {
+    const seen = new Set<string>();
+    const actions: ChipOption[] = [];
+
+    if (schemaText) {
+        for (const a of parseGaplSchema(schemaText).actions) {
+            const id = `Action::"${a.name}"`;
+            if (seen.has(id)) continue;
+            seen.add(id);
+            actions.push({ id, label: a.name, group: 'Action' });
+        }
+    }
+
+    for (const e of actionRows) {
+        const name = firstString(e.attributes?.name) ?? e.uid.replace(/^action\./, '');
+        if (!name) continue;
+        const id = `Action::"${name}"`;
+        if (seen.has(id)) continue;
+        seen.add(id);
+        const description = firstString(e.attributes?.description);
+        actions.push({ id, label: name, group: 'Action', description });
+    }
+
+    const tools: ChipOption[] = [];
+    for (const e of mcpToolRows) {
+        const attrs = e.attributes ?? {};
+        const name = firstString(attrs._displayName, attrs.displayName, attrs.name) ?? e.uid.replace(/^mcptool\./, '');
+        if (!name) continue;
+        const id = `Action::"${name}"`;
+        if (seen.has(id)) continue;
+        seen.add(id);
+        const description = firstString(attrs.description);
+        tools.push({ id, label: name, group: 'MCP Tools', description });
+    }
+    tools.sort((a, b) => a.label.localeCompare(b.label));
+
+    return [...actions, ...tools];
+}

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/features/policy-management/resource-options.ts
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/features/policy-management/resource-options.ts
@@ -1,0 +1,93 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import type { EntityResponse, PolicyType } from '../../shared/api/authz-api.types';
+import type { ChipOption } from '../../shared/chip-option';
+
+export interface ResourceOptionsConfig {
+    readonly type: PolicyType;
+    readonly hasTarget?: boolean;
+}
+
+function firstString(...values: unknown[]): string | undefined {
+    for (const v of values) {
+        if (typeof v === 'string' && v) return v;
+    }
+    return undefined;
+}
+
+function uidSlug(uid: string): string {
+    return uid.includes('.') ? uid.slice(uid.indexOf('.') + 1) : uid;
+}
+
+function groupForSegment(seg: string): string {
+    switch (seg) {
+        case 'mcp':
+            return 'MCP';
+        case 'model':
+        case 'llm':
+            return 'Model';
+        case 'agent':
+            return 'Agent';
+        case 'api':
+            return 'API';
+        default:
+            return 'Resource';
+    }
+}
+
+export function buildResourceOptions(
+    config: ResourceOptionsConfig,
+    catalogRows: readonly EntityResponse[],
+    mcpToolRows: readonly EntityResponse[],
+): readonly ChipOption[] {
+    const items: ChipOption[] = [];
+    const seen = new Set<string>();
+    const typePrefix = config.type.toLowerCase();
+
+    for (const e of catalogRows) {
+        const attrs = e.attributes ?? {};
+        const firstSeg = e.uid.includes('.') ? e.uid.slice(0, e.uid.indexOf('.')).toLowerCase() : '';
+        if (config.hasTarget && firstSeg !== typePrefix) continue;
+        const slug = uidSlug(e.uid);
+        const group = groupForSegment(firstSeg);
+        const id = `${group}::"${slug}"`;
+        if (seen.has(id)) continue;
+        seen.add(id);
+        items.push({
+            id,
+            label: firstString(attrs.displayName, attrs.name) ?? slug,
+            group,
+            description: firstString(attrs.description),
+        });
+    }
+
+    for (const e of mcpToolRows) {
+        const attrs = e.attributes ?? {};
+        const slug = uidSlug(e.uid);
+        const id = `MCPTool::"${slug}"`;
+        if (seen.has(id)) continue;
+        seen.add(id);
+        items.push({
+            id,
+            label: firstString(attrs._displayName, attrs.displayName, attrs.name) ?? slug,
+            group: 'MCP Tools',
+            description: firstString(attrs.description),
+        });
+    }
+
+    items.sort((a, b) => (a.group === b.group ? a.label.localeCompare(b.label) : a.group.localeCompare(b.group)));
+    return items;
+}

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/features/policy-structure/ImportFromCatalogDialog.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/features/policy-structure/ImportFromCatalogDialog.tsx
@@ -43,7 +43,14 @@ import {
 import { DownloadIcon } from '@gravitee/graphene-core/icons';
 import { useQueryClient } from '@tanstack/react-query';
 import { useDeferredValue, useMemo, useState } from 'react';
-import type { AgentCatalogItem, CatalogItem, McpServerCatalogItem, ModelCatalogItem } from '../../shared/api/aim-catalog.types';
+import { aimCatalogService } from '../../shared/api/aim-catalog.service';
+import type {
+    AgentCatalogItem,
+    CatalogItem,
+    McpServerCatalogItem,
+    McpToolCatalogItem,
+    ModelCatalogItem,
+} from '../../shared/api/aim-catalog.types';
 import { authzApiService } from '../../shared/api/authz-api.service';
 import { authzQueryKeys } from '../../shared/api/query-keys';
 import { useAimCatalogItems, type UseAimCatalogItemsResult } from '../../shared/hooks/useAimCatalogItems';
@@ -143,6 +150,16 @@ function buildEntityId(item: CatalogItem): string {
     return `${tab.entityKindPrefix}.${deriveSlug(item)}`;
 }
 
+/**
+ * Authorization entityId for an MCP tool: `mcptool.{slug}`. Prefers the catalog-provided
+ * `entityId`, falling back to the tool name then the row id — mirroring {@link deriveSlug}
+ * for servers, since older catalog rows (or AIM versions) may not expose `entityId`.
+ */
+function buildToolEntityId(tool: McpToolCatalogItem): string {
+    const slug = slugify(tool.entityId) || slugify(tool.definition.name) || tool.id;
+    return `mcptool.${slug}`;
+}
+
 /** Run `tasks` with up to `concurrency` in-flight at a time. Preserves order in the returned settled array. */
 async function runWithConcurrency<T>(tasks: ReadonlyArray<() => Promise<T>>, concurrency: number): Promise<PromiseSettledResult<T>[]> {
     const results: PromiseSettledResult<T>[] = new Array(tasks.length);
@@ -240,6 +257,33 @@ export function ImportFromCatalogDialog({ open, environmentId, onOpenChange, onI
 
         const successCatalogIds: string[] = [];
         let doneCount = 0;
+        let toolFailureCount = 0;
+
+        const importServerTools = async (server: McpServerCatalogItem, serverEntityId: string): Promise<void> => {
+            const tools = await aimCatalogService.listToolsForServer(environmentId, server.id);
+            if (tools.length === 0) return;
+            const toolTasks = tools.map(tool => async () => {
+                const toolAttributes: Record<string, unknown> = {
+                    _displayName: tool.definition.name,
+                    _catalogId: tool.id,
+                    _importedAt: new Date().toISOString(),
+                };
+                if (tool.definition.description) toolAttributes.description = tool.definition.description;
+                await authzApiService.createEntity(environmentId, {
+                    entityId: buildToolEntityId(tool),
+                    kind: 'RESOURCE',
+                    attributes: toolAttributes,
+                    parents: [serverEntityId],
+                    source: SOURCE_LABEL,
+                });
+            });
+            const settled = await runWithConcurrency(toolTasks, IMPORT_CONCURRENCY);
+            const failed = settled.filter(r => r.status === 'rejected') as PromiseRejectedResult[];
+            if (failed.length > 0) {
+                failed.forEach(r => console.error('catalog tool import failed:', r.reason));
+                throw new Error(`${failed.length} of ${tools.length} tools failed`);
+            }
+        };
 
         const tasks = items.map(item => async () => {
             const entityId = buildEntityId(item);
@@ -260,6 +304,14 @@ export function ImportFromCatalogDialog({ open, environmentId, onOpenChange, onI
                     source: SOURCE_LABEL,
                 });
                 successCatalogIds.push(item.id);
+                if (item.kind === 'mcp-server') {
+                    try {
+                        await importServerTools(item, entityId);
+                    } catch (err) {
+                        toolFailureCount++;
+                        console.error('mcp tool import failed for', entityId, err);
+                    }
+                }
                 return item;
             } finally {
                 doneCount++;
@@ -288,6 +340,9 @@ export function ImportFromCatalogDialog({ open, environmentId, onOpenChange, onI
                 .join('; ');
             toast.error(`Failed to import ${failed.length}: ${sample}`);
             failed.forEach(r => console.error('catalog import failed:', r.reason));
+        }
+        if (toolFailureCount > 0) {
+            toast.error(`${toolFailureCount} MCP server${toolFailureCount === 1 ? '' : 's'} imported with tool errors — see console`);
         }
         if (failed.length === 0) {
             resetAndClose(false);

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/shared/api/aim-catalog.service.ts
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/shared/api/aim-catalog.service.ts
@@ -13,8 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import type { AimPagedResponse, CatalogItem, CatalogItemKind, CatalogItemPage } from './aim-catalog.types';
+import type { AimPagedResponse, CatalogItem, CatalogItemKind, CatalogItemPage, McpToolCatalogItem } from './aim-catalog.types';
 import { authzCoreApiClient } from './authz-api-client';
+
+const TOOLS_PER_PAGE = 200;
+const TOOLS_MAX_PAGES = 25;
 
 /**
  * AIM catalog client. The AIM module is mounted next to authz under the same
@@ -48,4 +51,23 @@ export const aimCatalogService = {
                 perPage: p.pagination.perPage,
                 total: p.pagination.totalCount,
             })),
+
+    listToolsForServer: async (environmentId: string, serverCatalogId: string): Promise<McpToolCatalogItem[]> => {
+        const accumulated: McpToolCatalogItem[] = [];
+        let page = 1;
+        while (page <= TOOLS_MAX_PAGES) {
+            const q = new URLSearchParams();
+            q.set('parentId', serverCatalogId);
+            q.set('page', String(page));
+            q.set('perPage', String(TOOLS_PER_PAGE));
+            const resp = await authzCoreApiClient.get<AimPagedResponse<McpToolCatalogItem>>(
+                aimPath(environmentId, `/catalog/mcp-tools?${q.toString()}`),
+            );
+            const data = resp.data ?? [];
+            accumulated.push(...data);
+            if (accumulated.length >= resp.pagination.totalCount || data.length === 0) break;
+            page++;
+        }
+        return accumulated;
+    },
 };

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/shared/api/aim-catalog.types.ts
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/shared/api/aim-catalog.types.ts
@@ -44,6 +44,12 @@ export interface AgentDefinition {
     readonly url?: string;
 }
 
+export interface McpToolDefinition {
+    readonly name: string;
+    readonly description?: string;
+    readonly inputSchema?: Record<string, unknown>;
+}
+
 interface CatalogItemBase {
     readonly id: string;
     /**
@@ -79,6 +85,16 @@ export interface AgentCatalogItem extends CatalogItemBase {
 }
 
 export type CatalogItem = ModelCatalogItem | McpServerCatalogItem | AgentCatalogItem;
+
+/**
+ * MCP tool catalog row. Fetched per-server via `/catalog/mcp-tools?parentId=`,
+ * not through the kind-tabbed items list, so it is intentionally NOT part of the
+ * {@link CatalogItem} union. `parentId` links the tool back to its MCP server.
+ */
+export interface McpToolCatalogItem extends CatalogItemBase {
+    readonly kind: 'mcp-tool';
+    readonly definition: McpToolDefinition;
+}
 
 export interface AimPagination {
     readonly page: number;

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/shared/entity-kind-registry.ts
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/shared/entity-kind-registry.ts
@@ -29,6 +29,7 @@ export const ENTITY_KIND_REGISTRY: readonly EntityKindEntry[] = [
     { canonical: 'serviceaccount', uiType: 'ServiceAccount', aliases: ['service-account', 'service_account'] },
     { canonical: 'agent-identity', uiType: 'AgentIdentity', aliases: ['agentidentity'], policyType: 'AGENT' },
     { canonical: 'mcp', uiType: 'MCPServer', aliases: ['mcpserver'], policyType: 'MCP' },
+    { canonical: 'mcptool', uiType: 'MCPTool', policyType: 'MCP' },
     { canonical: 'model', uiType: 'Model', aliases: ['llm', 'llmmodel', 'llmroute'], policyType: 'MODEL' },
     { canonical: 'agent', uiType: 'Agent', aliases: ['a2a', 'a2aagent'], policyType: 'AGENT' },
     { canonical: 'api', uiType: 'API', policyType: 'API' },

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/shared/hooks/useEntities.ts
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/shared/hooks/useEntities.ts
@@ -35,6 +35,7 @@ export interface UseEntitiesFilter {
     readonly source?: string;
     readonly entityIdPrefix?: string;
     readonly excludeEntityIdPrefix?: string;
+    readonly enabled?: boolean;
 }
 
 export function useEntities(
@@ -57,13 +58,13 @@ export function useEntities(
         setPage(1);
     }
 
-    const { kind, source, entityIdPrefix, excludeEntityIdPrefix } = filter;
+    const { kind, source, entityIdPrefix, excludeEntityIdPrefix, enabled } = filter;
     const queryClient = useQueryClient();
 
     const query = useQuery({
         queryKey: authzQueryKeys.entities.page(environmentId, page, perPage, kind, source, entityIdPrefix, excludeEntityIdPrefix),
         queryFn: () => authzApiService.listEntities(environmentId, { page, perPage, kind, source, entityIdPrefix, excludeEntityIdPrefix }),
-        enabled: Boolean(environmentId),
+        enabled: Boolean(environmentId) && enabled !== false,
         staleTime: 30_000,
         placeholderData: keepPreviousData,
     });

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/test/java/io/gravitee/gamma/authorization/service/AuthzEntityServiceImplTest.java
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/test/java/io/gravitee/gamma/authorization/service/AuthzEntityServiceImplTest.java
@@ -328,6 +328,53 @@ class AuthzEntityServiceImplTest {
         assertThat(result.totalAffected()).isZero();
     }
 
+    @Test
+    void delete_cascades_to_tools_linked_by_parents_even_outside_the_entityId_prefix() {
+        entityService.upsert(CALLER, create("mcp.filesystem", AuthzEntityKind.RESOURCE, "gravitee-catalog"));
+        entityService.upsert(
+            CALLER,
+            new CreateOrReplaceAuthzEntityCommand(
+                ENV,
+                "mcptool.read_file",
+                AuthzEntityKind.RESOURCE,
+                Map.of(),
+                List.of("mcp.filesystem"),
+                "gravitee-catalog"
+            )
+        );
+        entityService.upsert(
+            CALLER,
+            new CreateOrReplaceAuthzEntityCommand(
+                ENV,
+                "mcptool.write_file",
+                AuthzEntityKind.RESOURCE,
+                Map.of(),
+                List.of("mcp.filesystem"),
+                "gravitee-catalog"
+            )
+        );
+        entityService.upsert(
+            CALLER,
+            new CreateOrReplaceAuthzEntityCommand(
+                ENV,
+                "mcptool.list_repos",
+                AuthzEntityKind.RESOURCE,
+                Map.of(),
+                List.of("mcp.github"),
+                "gravitee-catalog"
+            )
+        );
+
+        AuthzCascadeResult result = entityService.delete(CALLER, "mcp.filesystem");
+
+        assertThat(result.deletedEntityIds()).containsExactlyInAnyOrder(
+            "mcp.filesystem",
+            "mcptool.read_file",
+            "mcptool.write_file"
+        );
+        assertThat(entityRepository.findByEntityId(ENV, "mcptool.list_repos")).isPresent();
+    }
+
     private static CreateOrReplaceAuthzEntityCommand create(String entityId, AuthzEntityKind kind, String source) {
         return new CreateOrReplaceAuthzEntityCommand(ENV, entityId, kind, Map.of(), List.of(), source);
     }


### PR DESCRIPTION
## Summary
- Import MCP tools alongside their server when importing from the AIM catalog. Each tool is stored as a `RESOURCE` entity (`mcptool.<slug>`) linked to its server via `parents`, carrying `_displayName`/`_catalogId`/`description` attributes.
- Surface imported MCP tools in the MCP policy builder, in both the **action** and **resource** selectors, as a dedicated **"MCP Tools"** group shown next to the existing generic action/resource options (nothing removed). Tools are listed env-wide (all tools, any server), not scoped to the selected target.
- Extract the action/resource option-building logic out of `ServicePolicyPage` into pure, unit-tested helpers (`action-options.ts`, `resource-options.ts`).
- Backend: add a parent-aware cascade delete so deleting an MCP server also deletes its imported tools, even though the tool's `entityId` prefix (`mcptool.`) differs from the server's.

## Implementation notes
- Tool tokens are canonical (`MCPTool::"<slug>"` for resources, `Action::"<name>"` for actions), so they round-trip through the existing GAPL emit/parse path; the "MCP Tools" group label is display-only and never enters the token.
- `useEntities` gains an optional `enabled` filter so the `mcptool.*` fetch only runs on the MCP policy page.
- `findByParent` added to `AuthzEntityRepository` (default in-memory impl + Mongo `parents` query).

## Test plan
- [x] `vitest` — 60/60 pass in `policy-management` (incl. new `action-options` / `resource-options` suites)
- [x] `tsc --noEmit` clean, `eslint` clean, `prettier --check` clean
- [x] Java `AuthzEntityServiceImplTest` — 31/31 pass, incl. new parent-aware cascade-delete test
- [x] Manual: in the MCP policy builder, imported tools appear in both the action and resource selectors under "MCP Tools"; selecting one emits `Action::"<tool>"` / `resource == MCPTool::"<tool>"`