### PR TITLE
fix(analytics): add containsKey guard in LLM Painless scripts

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/analytics/engine/aggregation/LLMTotalCostBuilder.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/analytics/engine/aggregation/LLMTotalCostBuilder.java
@@ -27,10 +27,13 @@ import java.util.Map;
  */
 public class LLMTotalCostBuilder {
 
+    private static final String SENT_COST_FIELD = "additional-metrics.double_llm-proxy_sent-cost";
+    private static final String RECEIVED_COST_FIELD = "additional-metrics.double_llm-proxy_received-cost";
+
     private static final String SCRIPT_SOURCE = """
-        (doc['additional-metrics.double_llm-proxy_sent-cost'].size() > 0 ? doc['additional-metrics.double_llm-proxy_sent-cost'].value : 0) + \
-        (doc['additional-metrics.double_llm-proxy_received-cost'].size() > 0 ? doc['additional-metrics.double_llm-proxy_received-cost'].value : 0)
-        """;
+        (doc.containsKey('%s') && doc['%s'].size() > 0 ? doc['%s'].value : 0) + \
+        (doc.containsKey('%s') && doc['%s'].size() > 0 ? doc['%s'].value : 0)
+        """.formatted(SENT_COST_FIELD, SENT_COST_FIELD, SENT_COST_FIELD, RECEIVED_COST_FIELD, RECEIVED_COST_FIELD, RECEIVED_COST_FIELD);
 
     public Map<String, JsonObject> buildSum(String aggName) {
         return Map.of(aggName, json().put("sum", json().put("script", script())));

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/analytics/engine/aggregation/LLMTotalTokenBuilder.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/analytics/engine/aggregation/LLMTotalTokenBuilder.java
@@ -27,10 +27,20 @@ import java.util.Map;
  */
 public class LLMTotalTokenBuilder {
 
+    private static final String SENT_TOKENS_FIELD = "additional-metrics.long_llm-proxy_tokens-sent";
+    private static final String RECEIVED_TOKENS_FIELD = "additional-metrics.long_llm-proxy_tokens-received";
+
     private static final String SCRIPT_SOURCE = """
-        (doc['additional-metrics.long_llm-proxy_tokens-sent'].size() > 0 ? doc['additional-metrics.long_llm-proxy_tokens-sent'].value : 0) + \
-        (doc['additional-metrics.long_llm-proxy_tokens-received'].size() > 0 ? doc['additional-metrics.long_llm-proxy_tokens-received'].value : 0)
-        """;
+        (doc.containsKey('%s') && doc['%s'].size() > 0 ? doc['%s'].value : 0) + \
+        (doc.containsKey('%s') && doc['%s'].size() > 0 ? doc['%s'].value : 0)
+        """.formatted(
+            SENT_TOKENS_FIELD,
+            SENT_TOKENS_FIELD,
+            SENT_TOKENS_FIELD,
+            RECEIVED_TOKENS_FIELD,
+            RECEIVED_TOKENS_FIELD,
+            RECEIVED_TOKENS_FIELD
+        );
 
     public Map<String, JsonObject> buildSum(String aggName) {
         return Map.of(aggName, json().put("sum", json().put("script", script())));

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/analytics/engine/aggregation/LLMTotalCostBuilderTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/analytics/engine/aggregation/LLMTotalCostBuilderTest.java
@@ -40,9 +40,11 @@ class LLMTotalCostBuilderTest {
         assertThat(sumAgg.containsKey("script")).isTrue();
 
         var script = sumAgg.getJsonObject("script");
-        assertThat(script.getString("source")).contains("additional-metrics.double_llm-proxy_sent-cost");
-        assertThat(script.getString("source")).contains("additional-metrics.double_llm-proxy_received-cost");
-        assertThat(script.getString("source")).contains("+");
+        var source = script.getString("source");
+        assertThat(source).contains("additional-metrics.double_llm-proxy_sent-cost");
+        assertThat(source).contains("additional-metrics.double_llm-proxy_received-cost");
+        assertThat(source).contains("+");
+        assertThat(source).contains("doc.containsKey(");
     }
 
     @Test
@@ -58,8 +60,10 @@ class LLMTotalCostBuilderTest {
         assertThat(avgAgg.containsKey("script")).isTrue();
 
         var script = avgAgg.getJsonObject("script");
-        assertThat(script.getString("source")).contains("additional-metrics.double_llm-proxy_sent-cost");
-        assertThat(script.getString("source")).contains("additional-metrics.double_llm-proxy_received-cost");
-        assertThat(script.getString("source")).contains("+");
+        var source = script.getString("source");
+        assertThat(source).contains("additional-metrics.double_llm-proxy_sent-cost");
+        assertThat(source).contains("additional-metrics.double_llm-proxy_received-cost");
+        assertThat(source).contains("+");
+        assertThat(source).contains("doc.containsKey(");
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/analytics/engine/aggregation/LLMTotalTokenBuilderTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/analytics/engine/aggregation/LLMTotalTokenBuilderTest.java
@@ -40,9 +40,11 @@ class LLMTotalTokenBuilderTest {
         assertThat(sumAgg.containsKey("script")).isTrue();
 
         var script = sumAgg.getJsonObject("script");
-        assertThat(script.getString("source")).contains("additional-metrics.long_llm-proxy_tokens-sent");
-        assertThat(script.getString("source")).contains("additional-metrics.long_llm-proxy_tokens-received");
-        assertThat(script.getString("source")).contains("+");
+        var source = script.getString("source");
+        assertThat(source).contains("additional-metrics.long_llm-proxy_tokens-sent");
+        assertThat(source).contains("additional-metrics.long_llm-proxy_tokens-received");
+        assertThat(source).contains("+");
+        assertThat(source).contains("doc.containsKey(");
     }
 
     @Test
@@ -58,8 +60,10 @@ class LLMTotalTokenBuilderTest {
         assertThat(avgAgg.containsKey("script")).isTrue();
 
         var script = avgAgg.getJsonObject("script");
-        assertThat(script.getString("source")).contains("additional-metrics.long_llm-proxy_tokens-sent");
-        assertThat(script.getString("source")).contains("additional-metrics.long_llm-proxy_tokens-received");
-        assertThat(script.getString("source")).contains("+");
+        var source = script.getString("source");
+        assertThat(source).contains("additional-metrics.long_llm-proxy_tokens-sent");
+        assertThat(source).contains("additional-metrics.long_llm-proxy_tokens-received");
+        assertThat(source).contains("+");
+        assertThat(source).contains("doc.containsKey(");
     }
 }


### PR DESCRIPTION
## Summary

Fix HTTP 500 errors on LLM analytics endpoints (`/measures`, `/time-series`, `/facets`) when querying `LLM_PROMPT_TOKEN_TOTAL_COST` or `LLM_PROMPT_TOTAL_TOKEN` metrics in environments where the LLM proxy plugin has not yet ingested any data (i.e. the cost/token fields are absent from the Elasticsearch mapping).

Closes [GMA-462](https://gravitee.atlassian.net/browse/GMA-462)

## Changes

- **`LLMTotalCostBuilder.java`**: Add `doc.containsKey()` guards before accessing `additional-metrics.double_llm-proxy_sent-cost` and `additional-metrics.double_llm-proxy_received-cost` in the Painless script, so the script gracefully returns 0 when these fields are not mapped
- **`LLMTotalTokenBuilder.java`**: Apply the same defensive `doc.containsKey()` pattern to `additional-metrics.long_llm-proxy_tokens-sent` and `additional-metrics.long_llm-proxy_tokens-received` for consistency
- **`LLMTotalCostBuilderTest.java`** / **`LLMTotalTokenBuilderTest.java`**: Add assertions verifying the generated Painless scripts contain the `containsKey` guard

## Test plan

- [ ] Deploy to a test environment where no LLM proxy data has been ingested
- [ ] Query `POST /management/v2/environments/DEFAULT/analytics/measures` with `LLM_PROMPT_TOKEN_TOTAL_COST` metric — should return 0 instead of HTTP 500
- [ ] Query `POST /management/v2/environments/DEFAULT/analytics/time-series` with `LLM_PROMPT_TOKEN_TOTAL_COST` metric — should return empty buckets instead of HTTP 500
- [ ] Query the same endpoints with `LLM_PROMPT_TOTAL_TOKEN` metric — should also succeed
- [ ] In an environment with actual LLM data, verify the metrics still return correct non-zero values

[GMA-462]: https://gravitee.atlassian.net/browse/GMA-462?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ