### PR TITLE
fix(analytics): compensate for ES range aggregation exclusive upper bound

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/analytics/engine/adapter/HTTPFacetsQueryAdapter.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/analytics/engine/adapter/HTTPFacetsQueryAdapter.java
@@ -142,7 +142,8 @@ public class HTTPFacetsQueryAdapter {
 
     private JsonObject toQueryRange(NumberRange range) {
         var key = range.from() + "-" + range.to();
-        return json().put("key", key).put("from", range.from()).put("to", range.to());
+        // ES range aggregation `to` is exclusive; add 1 so the upper bound is included
+        return json().put("key", key).put("from", range.from()).put("to", range.to().longValue() + 1);
     }
 
     private JsonObject toTermsLeaf(Facet facet, MetricMeasuresQuery metric, Integer limit) {

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/analytics/engine/adapter/HTTPFacetsQueryAdapterTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/analytics/engine/adapter/HTTPFacetsQueryAdapterTest.java
@@ -174,6 +174,20 @@ class HTTPFacetsQueryAdapterTest extends AbstractQueryAdapterTest {
 
         var esRanges = aggs.at("/HTTP_GATEWAY_LATENCY#HTTP_STATUS/range/ranges");
         assertThat(esRanges).isNotEmpty();
+        assertThat(esRanges.size()).isEqualTo(5);
+
+        // ES `to` is exclusive, so the adapter must add 1 to make the upper bound inclusive
+        assertThat(esRanges.get(0).get("key").asText()).isEqualTo("100-199");
+        assertThat(esRanges.get(0).get("from").asInt()).isEqualTo(100);
+        assertThat(esRanges.get(0).get("to").asInt()).isEqualTo(200);
+
+        assertThat(esRanges.get(3).get("key").asText()).isEqualTo("400-499");
+        assertThat(esRanges.get(3).get("from").asInt()).isEqualTo(400);
+        assertThat(esRanges.get(3).get("to").asInt()).isEqualTo(500);
+
+        assertThat(esRanges.get(4).get("key").asText()).isEqualTo("500-599");
+        assertThat(esRanges.get(4).get("from").asInt()).isEqualTo(500);
+        assertThat(esRanges.get(4).get("to").asInt()).isEqualTo(600);
     }
 
     @Test
@@ -213,6 +227,16 @@ class HTTPFacetsQueryAdapterTest extends AbstractQueryAdapterTest {
 
         var esRanges = aggs.at("/HTTP_GATEWAY_LATENCY#HTTP_STATUS_CODE_GROUP/range/ranges");
         assertThat(esRanges).isNotEmpty();
+        assertThat(esRanges.size()).isEqualTo(5);
+
+        // ES `to` is exclusive — the adapter adds 1 so forStatusCodeGroup() [x, y] becomes [x, y+1)
+        assertThat(esRanges.get(0).get("key").asText()).isEqualTo("100-199");
+        assertThat(esRanges.get(0).get("from").asInt()).isEqualTo(100);
+        assertThat(esRanges.get(0).get("to").asInt()).isEqualTo(200);
+
+        assertThat(esRanges.get(3).get("key").asText()).isEqualTo("400-499");
+        assertThat(esRanges.get(3).get("from").asInt()).isEqualTo(400);
+        assertThat(esRanges.get(3).get("to").asInt()).isEqualTo(500);
     }
 
     @Test


### PR DESCRIPTION
## Summary

The Elasticsearch range aggregation `to` field is exclusive, but `HTTPFacetsQueryAdapter.toQueryRange()` was passing `NumberRange.to` as-is. This caused status 499 (`CLIENT_ABORTED_DURING_RESPONSE_ERROR`) to fall into no bucket and be silently uncounted in time-series analytics, creating a mismatch between the histogram and the logs table.

Related Jira ticket: [GMA-468](https://gravitee.atlassian.net/browse/GMA-468)
Parent epic: [GMA-420](https://gravitee.atlassian.net/browse/GMA-420)

## Changes

- **`HTTPFacetsQueryAdapter.toQueryRange()`**: add +1 to `to` in the ES query to make the upper bound inclusive, while keeping the user-facing bucket key label unchanged (e.g. `"400-499"`)
- **`HTTPFacetsQueryAdapterTest`**: add assertions on exact range bounds (`from`/`to` values) for both custom ranges and `forStatusCodeGroup()` ranges

| Endpoint | Method | Change |
|----------|--------|--------|
| `/analytics/time-series` | `POST` | Range aggregation buckets now correctly include the upper bound (e.g. status 499 counted in `400-499`) |

## Test plan

- [x] `HTTPFacetsQueryAdapterTest` — 9 tests pass, including strengthened range bound assertions
- [x] `FilterAdapterTest` — 12 tests pass (no regression on filter path which already used `gte`/`lte`)
- [x] `HTTPTimeSeriesAdapterTest` — 1 test passes
- [ ] Manual: query `/analytics/time-series` with `ranges [{from:400,to:499}]` on an env with 499 traffic and verify the count matches `/logs/search`

## Reviewer notes

The fix is a single-line change in `toQueryRange()` (line 145). The `NumberRange` record and `forStatusCodeGroup()` static ranges are unchanged — they represent inclusive semantics, and the adapter now correctly translates to ES exclusive-upper-bound semantics.

Closes GMA-468

[GMA-468]: https://gravitee.atlassian.net/browse/GMA-468?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[GMA-420]: https://gravitee.atlassian.net/browse/GMA-420?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ