### PR TITLE
perf(jdbc): add key_subscriptions(subscription_id) index for ApiKey appender warmup (APIM-14263)

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_11_8/05_add_key_subscriptions_subscription_id_index.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_11_8/05_add_key_subscriptions_subscription_id_index.yml
@@ -1,0 +1,11 @@
+databaseChangeLog:
+  - changeSet:
+      id: 4.11.8_05_add_key_subscriptions_subscription_id_index
+      author: GraviteeSource Team
+      changes:
+        - createIndex:
+            indexName: idx_${gravitee_prefix}key_subscriptions_subscription_id
+            tableName: ${gravitee_prefix}key_subscriptions
+            columns:
+              - column:
+                  name: subscription_id

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/master.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/master.yml
@@ -340,3 +340,5 @@ databaseChangeLog:
         - file: liquibase/changelogs/v4_11_8/03_add_plans_cross_id_index.yml
     - include:
         - file: liquibase/changelogs/v4_11_8/04_add_subscriptions_plan_id_index.yml
+    - include:
+        - file: liquibase/changelogs/v4_11_8/05_add_key_subscriptions_subscription_id_index.yml


### PR DESCRIPTION
Fixes APIM-14263.

## What
Adds a JDBC index `key_subscriptions(subscription_id)` (Liquibase `v4_11_8/05_…`; additive — keeps the existing PK).

## Why
The gateway-sync **ApiKey appender** (APIM-14203) loads keys via
`select … from keys where id in (select key_id from key_subscriptions where subscription_id in (…chunk…))`.
`key_subscriptions`'s only index is the PK `(key_id, subscription_id)` — leading column `key_id` — so `where subscription_id in (…)` cannot use it and Postgres does a **Parallel Seq Scan per chunk**.

At ~2.4M subs / ~800k `key_subscriptions` rows this is ~2.3 s/chunk (EXPLAIN ANALYZE); over thousands of chunks the **real-gateway warmup hung >30 min with 0/8109 APIs deployed**. The same dataset with no api-keys warms up in ~80 s.

## Mongo parity
MongoDB already has the equivalent — `keys.{subscriptions:1}` (`KeysSubscriptionsIndexUpgrader`, name `s1`). This PR closes the JDBC↔Mongo parity gap; **no Mongo change needed**.

## Notes
- Additive only; no index dropped.
- Independent of (and complementary to) the subscriptions `(plan,id)` index (APIM-14087) already on `4.11.x`.
