### PR TITLE
feat(authz): enforce configurable max entities limit per environment

### DIFF
--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/java/io/gravitee/gamma/authorization/api/AuthzEntityRepository.java
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/java/io/gravitee/gamma/authorization/api/AuthzEntityRepository.java
@@ -45,6 +45,10 @@ public interface AuthzEntityRepository {
 
     List<AuthzEntity> findAll(String environmentId);
 
+    default long count(String environmentId) {
+        return findAll(environmentId).size();
+    }
+
     List<AuthzEntity> findByKind(String environmentId, AuthzEntityKind kind);
 
     List<AuthzEntity> findByEntityIdPrefix(String environmentId, String prefix);

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/java/io/gravitee/gamma/authorization/infra/repository/MongoAuthzEntityRepository.java
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/java/io/gravitee/gamma/authorization/infra/repository/MongoAuthzEntityRepository.java
@@ -88,6 +88,11 @@ public class MongoAuthzEntityRepository implements AuthzEntityRepository {
     }
 
     @Override
+    public long count(String environmentId) {
+        return mongo.count(new Query(Criteria.where("environmentId").is(environmentId)), AuthzEntityMongo.class);
+    }
+
+    @Override
     public List<AuthzEntity> findByKind(String environmentId, AuthzEntityKind kind) {
         var query = new Query(Criteria.where("environmentId").is(environmentId).and("kind").is(kind.name()));
         return mongo.find(query, AuthzEntityMongo.class).stream().map(AuthzEntityDocumentMapper::toDomain).toList();

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/java/io/gravitee/gamma/authorization/rest/exception/AuthzCalls.java
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/java/io/gravitee/gamma/authorization/rest/exception/AuthzCalls.java
@@ -16,6 +16,7 @@
 package io.gravitee.gamma.authorization.rest.exception;
 
 import io.gravitee.gamma.authorization.service.exception.AuthzCascadeTooLargeException;
+import io.gravitee.gamma.authorization.service.exception.AuthzEntityLimitExceededException;
 import io.gravitee.gamma.authorization.service.exception.AuthzEntityNotFoundException;
 import io.gravitee.gamma.authorization.service.exception.AuthzInvalidArgumentException;
 import io.gravitee.gamma.authorization.service.exception.AuthzInvalidEntityIdException;
@@ -54,6 +55,8 @@ public final class AuthzCalls {
             throw error(Status.NOT_FOUND, "EntityNotFound", e);
         } catch (AuthzCascadeTooLargeException e) {
             throw error(Status.REQUEST_ENTITY_TOO_LARGE, "CascadeTooLarge", e);
+        } catch (AuthzEntityLimitExceededException e) {
+            throw error(Status.CONFLICT, "EntityLimitExceeded", e);
         } catch (AuthzInvalidStatusTransitionException e) {
             throw error(Status.CONFLICT, "InvalidStatusTransition", e);
         } catch (AuthzInvalidEntityIdException e) {

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/java/io/gravitee/gamma/authorization/service/AuthzEntityServiceImpl.java
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/java/io/gravitee/gamma/authorization/service/AuthzEntityServiceImpl.java
@@ -35,6 +35,7 @@ import io.gravitee.gamma.authorization.domain.AuthzPolicy;
 import io.gravitee.gamma.authorization.paging.Pageable;
 import io.gravitee.gamma.authorization.paging.PagedResult;
 import io.gravitee.gamma.authorization.service.exception.AuthzCascadeTooLargeException;
+import io.gravitee.gamma.authorization.service.exception.AuthzEntityLimitExceededException;
 import io.gravitee.gamma.authorization.service.exception.AuthzEntityNotFoundException;
 import io.gravitee.gamma.authorization.service.exception.AuthzInvalidArgumentException;
 import io.gravitee.gamma.definition.authz.AuthzEntityIdConstants;
@@ -57,6 +58,7 @@ public class AuthzEntityServiceImpl implements AuthzEntityAdminApi {
     private static final String AGENT_PREFIX = AuthzEntityIdConstants.AGENT_PREFIX;
 
     public static final int DEFAULT_CASCADE_HARD_LIMIT = 500;
+    public static final int DEFAULT_MAX_ENTITIES = 1000;
 
     private final AuthzEntityRepository entityRepository;
     private final AuthzPolicyRepository policyRepository;
@@ -65,6 +67,7 @@ public class AuthzEntityServiceImpl implements AuthzEntityAdminApi {
     private final AuthzEventPublisher eventPublisher;
     private final AuthzAuditPort auditPort;
     private final int cascadeHardLimit;
+    private final int maxEntities;
 
     public AuthzEntityServiceImpl(
         AuthzEntityRepository entityRepository,
@@ -86,6 +89,28 @@ public class AuthzEntityServiceImpl implements AuthzEntityAdminApi {
         AuthzAuditPort auditPort,
         int cascadeHardLimit
     ) {
+        this(
+            entityRepository,
+            policyRepository,
+            entityIdValidator,
+            schemaService,
+            eventPublisher,
+            auditPort,
+            cascadeHardLimit,
+            DEFAULT_MAX_ENTITIES
+        );
+    }
+
+    public AuthzEntityServiceImpl(
+        AuthzEntityRepository entityRepository,
+        AuthzPolicyRepository policyRepository,
+        AuthzEntityIdValidator entityIdValidator,
+        AuthzSchemaAdminApi schemaService,
+        AuthzEventPublisher eventPublisher,
+        AuthzAuditPort auditPort,
+        int cascadeHardLimit,
+        int maxEntities
+    ) {
         this.entityRepository = entityRepository;
         this.policyRepository = policyRepository;
         this.entityIdValidator = entityIdValidator;
@@ -95,7 +120,11 @@ public class AuthzEntityServiceImpl implements AuthzEntityAdminApi {
         if (cascadeHardLimit < 1) {
             throw new IllegalArgumentException("cascadeHardLimit must be >= 1, got " + cascadeHardLimit);
         }
+        if (maxEntities < 1) {
+            throw new IllegalArgumentException("maxEntities must be >= 1, got " + maxEntities);
+        }
         this.cascadeHardLimit = cascadeHardLimit;
+        this.maxEntities = maxEntities;
     }
 
     @Override
@@ -163,6 +192,14 @@ public class AuthzEntityServiceImpl implements AuthzEntityAdminApi {
             .stream()
             .collect(java.util.stream.Collectors.toMap(AuthzEntity::entityId, e -> e, (a, b) -> a, LinkedHashMap::new));
 
+        long newCount = commands.stream().map(CreateOrReplaceAuthzEntityCommand::entityId).distinct().filter(id -> !existingByEntityId.containsKey(id)).count();
+        if (newCount > 0) {
+            long current = entityRepository.count(environmentId);
+            if (current + newCount > maxEntities) {
+                throw new AuthzEntityLimitExceededException(current + newCount, maxEntities);
+            }
+        }
+
         Instant now = TimeProvider.instantNow();
         List<AuthzEntity> toSaveList = new ArrayList<>(commands.size());
         List<UpsertOutcome> outcomes = new ArrayList<>(commands.size());
@@ -180,6 +217,12 @@ public class AuthzEntityServiceImpl implements AuthzEntityAdminApi {
         AuthzEntity existing = preloadedExisting != null
             ? preloadedExisting
             : entityRepository.findByEntityId(command.environmentId(), command.entityId()).orElse(null);
+        if (existing == null) {
+            long current = entityRepository.count(command.environmentId());
+            if (current >= maxEntities) {
+                throw new AuthzEntityLimitExceededException(current + 1, maxEntities);
+            }
+        }
         AuthzEntity toSave = buildUpsertEntity(command, existing, TimeProvider.instantNow());
         AuthzEntity saved = entityRepository.save(toSave);
         return new UpsertOutcome(saved, existing, existing == null);

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/java/io/gravitee/gamma/authorization/service/exception/AuthzEntityLimitExceededException.java
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/java/io/gravitee/gamma/authorization/service/exception/AuthzEntityLimitExceededException.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gamma.authorization.service.exception;
+
+public class AuthzEntityLimitExceededException extends RuntimeException {
+
+    public AuthzEntityLimitExceededException(long attempted, int limit) {
+        super("Creating would bring the environment to " + attempted + " entities, exceeding the configured limit of " + limit);
+    }
+}

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/java/io/gravitee/gamma/module/authz/config/SpringConfig.java
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/java/io/gravitee/gamma/module/authz/config/SpringConfig.java
@@ -132,7 +132,8 @@ public class SpringConfig {
         AuthzSchemaAdminApi schemaService,
         AuthzEventPublisher eventPublisher,
         AuthzAuditPort auditPort,
-        @Value("${gravitee.authz.cascade-hard-limit:500}") int cascadeHardLimit
+        @Value("${gravitee.authz.cascade-hard-limit:500}") int cascadeHardLimit,
+        @Value("${gravitee.authz.entities.max:1000}") int maxEntities
     ) {
         return new AuthzEntityServiceImpl(
             entityRepository,
@@ -141,7 +142,8 @@ public class SpringConfig {
             schemaService,
             eventPublisher,
             auditPort,
-            cascadeHardLimit
+            cascadeHardLimit,
+            maxEntities
         );
     }
 

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/test/java/io/gravitee/gamma/authorization/service/AuthzEntityServiceImplTest.java
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/test/java/io/gravitee/gamma/authorization/service/AuthzEntityServiceImplTest.java
@@ -30,6 +30,7 @@ import io.gravitee.gamma.authorization.event.RecordingAuthzEventPublisher.EventK
 import io.gravitee.gamma.authorization.repository.InMemoryAuthzEntityRepository;
 import io.gravitee.gamma.authorization.repository.InMemoryAuthzPolicyRepository;
 import io.gravitee.gamma.authorization.service.exception.AuthzCascadeTooLargeException;
+import io.gravitee.gamma.authorization.service.exception.AuthzEntityLimitExceededException;
 import io.gravitee.gamma.authorization.service.exception.AuthzEntityNotFoundException;
 import java.time.Clock;
 import java.time.Instant;
@@ -660,5 +661,83 @@ class AuthzEntityServiceImplTest {
 
         assertThat(entityRepository.findByEntityId(ENV, "api.huge")).isPresent();
         assertThat(events.events()).isEmpty();
+    }
+
+    @Test
+    void upsert_creating_above_max_entities_throws_and_saves_nothing() {
+        entityService = serviceWithMaxEntities(2);
+        entityService.upsert(CALLER, create("api.1", AuthzEntityKind.RESOURCE, "apim"));
+        entityService.upsert(CALLER, create("api.2", AuthzEntityKind.RESOURCE, "apim"));
+        events.clear();
+
+        assertThatThrownBy(() -> entityService.upsert(CALLER, create("api.3", AuthzEntityKind.RESOURCE, "apim")))
+            .isInstanceOf(AuthzEntityLimitExceededException.class);
+
+        assertThat(entityRepository.findByEntityId(ENV, "api.3")).isEmpty();
+        assertThat(entityRepository.count(ENV)).isEqualTo(2);
+        assertThat(events.events()).isEmpty();
+    }
+
+    @Test
+    void upsert_replacing_existing_at_max_entities_still_succeeds() {
+        entityService = serviceWithMaxEntities(2);
+        entityService.upsert(CALLER, create("api.1", AuthzEntityKind.RESOURCE, "apim"));
+        entityService.upsert(CALLER, create("api.2", AuthzEntityKind.RESOURCE, "apim"));
+
+        AuthzUpsertResult result = entityService.upsert(CALLER, create("api.1", AuthzEntityKind.RESOURCE, "apim"));
+
+        assertThat(result.created()).isFalse();
+        assertThat(entityRepository.count(ENV)).isEqualTo(2);
+    }
+
+    @Test
+    void bulkUpsert_creating_above_max_entities_throws_and_saves_nothing() {
+        entityService = serviceWithMaxEntities(2);
+        events.clear();
+
+        assertThatThrownBy(() ->
+                entityService.bulkUpsert(
+                    CALLER,
+                    List.of(
+                        create("api.1", AuthzEntityKind.RESOURCE, "apim"),
+                        create("api.2", AuthzEntityKind.RESOURCE, "apim"),
+                        create("api.3", AuthzEntityKind.RESOURCE, "apim")
+                    )
+                )
+            )
+            .isInstanceOf(AuthzEntityLimitExceededException.class);
+
+        assertThat(entityRepository.count(ENV)).isZero();
+        assertThat(events.events()).isEmpty();
+    }
+
+    @Test
+    void bulkUpsert_replacing_existing_does_not_count_against_max_entities() {
+        entityService = serviceWithMaxEntities(2);
+        entityService.upsert(CALLER, create("api.1", AuthzEntityKind.RESOURCE, "apim"));
+        entityService.upsert(CALLER, create("api.2", AuthzEntityKind.RESOURCE, "apim"));
+
+        List<AuthzUpsertResult> results = entityService.bulkUpsert(
+            CALLER,
+            List.of(create("api.1", AuthzEntityKind.RESOURCE, "apim"), create("api.2", AuthzEntityKind.RESOURCE, "apim"))
+        );
+
+        assertThat(results).allMatch(r -> !r.created());
+        assertThat(entityRepository.count(ENV)).isEqualTo(2);
+    }
+
+    private AuthzEntityServiceImpl serviceWithMaxEntities(int maxEntities) {
+        AuthzEntityIdValidator validator = new AuthzEntityIdValidator();
+        AuthzSchemaServiceImpl schemaService = new AuthzSchemaServiceImpl(entityRepository, policyRepository);
+        return new AuthzEntityServiceImpl(
+            entityRepository,
+            policyRepository,
+            validator,
+            schemaService,
+            events,
+            audit,
+            DEFAULT_CASCADE_HARD_LIMIT,
+            maxEntities
+        );
     }
 }


### PR DESCRIPTION
## Summary
- Add a configurable cap on the **total** number of authz entities (principals **and** resources combined) per environment.
- Default limit is **1000**, configurable via `gravitee.authz.entities.max` (same `@Value` pattern as the existing `gravitee.authz.cascade-hard-limit` / `gravitee.authz.sync.max-users`).
- Creating beyond the limit throws `AuthzEntityLimitExceededException`, mapped to **HTTP 409 CONFLICT** in `AuthzCalls` (code `EntityLimitExceeded`).
- Enforced for both single upsert and bulk upsert. Replacing an existing entity does **not** count as a new entity.

## Implementation
- `AuthzEntityRepository#count(environmentId)` — default impl + Mongo override (kindless count → covers principals + resources).
- `AuthzEntityServiceImpl` — `maxEntities` field, enforcement in `doUpsert` / `doBulkUpsert`, backward-compatible 6/7/8-arg constructors.
- `SpringConfig` — wires `gravitee.authz.entities.max` into the service bean.

## Test plan
- [x] `AuthzEntityServiceImplTest` — 35 tests green (incl. 4 new: single/bulk over-limit throws + saves nothing; replace at limit still succeeds; bulk replace does not count against limit).