### PR TITLE
fix(authz-ui): show synced and local principals in entity picker

### DIFF
--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/shared/entity-adapter.ts
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/shared/entity-adapter.ts
@@ -40,6 +40,17 @@ export function parseEntityUid(uid: string): { type: string; id: string } {
 }
 
 /**
+ * Resolve a backend entity to its structured `{ type, id }`, preferring the
+ * explicit `_kind` attribute over the dotted uid prefix. AM-synced principals
+ * keep a bare token sub as their uid (no `<kind>.` prefix) and carry their type
+ * only in `_kind` — so a raw {@link parseEntityUid} would mislabel them as
+ * `Unknown`. Falls back to uid parsing when `_kind` is absent or unknown.
+ */
+export function resolveEntityRef(uid: string, attributes: Record<string, unknown>): { type: string; id: string } {
+    return resolveUid(uid, kindToUiType(attributes['_kind']));
+}
+
+/**
  * Format a structured uid back to the canonical backend form
  * `<lowercase-kind>.<id>`. The id is passed through unchanged because the
  * server-side validator (`[a-z0-9._-]+`) wouldn't have accepted invalid

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/shared/hooks/__tests__/useEntityOptions.test.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/shared/hooks/__tests__/useEntityOptions.test.tsx
@@ -145,6 +145,43 @@ describe('useEntityOptions', () => {
         expect(items[2].getAttribute('data-label')).toBe('u3');
     });
 
+    it('resolves a synced principal stored with a bare sub uid via its _kind attribute', async () => {
+        // AM-synced principals keep the bare token sub as their entityId (no `user.` prefix); the
+        // type lives only in the `_kind` attribute. The chip must still resolve to a User so the
+        // principal type filter does not drop it.
+        const sub = 'c4a2111a-fdb7-39d7-8540-ee725e250f59';
+        listEntitiesSpy.mockResolvedValue(paged([entity(sub, { _kind: 'user', sub, displayName: 'Abagail Friesen' })]));
+
+        const { getByTestId } = render(<Probe env="env-1" opts={{ typeFilter: ['User', 'Group', 'ServiceAccount', 'AgentIdentity'] }} />, {
+            wrapper: makeWrapper(),
+        });
+
+        await waitFor(() => expect(getByTestId('count').textContent).toBe('1'));
+        const item = getByTestId('options').querySelector('li')!;
+        expect(item.getAttribute('data-group')).toBe('User');
+        expect(item.getAttribute('data-label')).toBe('Abagail Friesen');
+        // The bare sub is preserved as the GAPL ref the PEP matches on.
+        expect(item.textContent).toBe(`User::"${sub}"`);
+    });
+
+    it('labels a locally-added principal by its _displayName meta attribute, not the entity id', async () => {
+        // The "Add principal" form stores the human name under the `_displayName` meta key (not the
+        // plain `displayName` the AM sync uses). The chip label must surface it so the user sees the
+        // name they typed, while the inserted GAPL ref keeps the entity id.
+        listEntitiesSpy.mockResolvedValue(paged([entity('user.12345', { _displayName: 'Rafal' })]));
+
+        const { getByTestId } = render(<Probe env="env-1" opts={{ typeFilter: ['User', 'Group', 'ServiceAccount', 'AgentIdentity'] }} />, {
+            wrapper: makeWrapper(),
+        });
+
+        await waitFor(() => expect(getByTestId('count').textContent).toBe('1'));
+        const item = getByTestId('options').querySelector('li')!;
+        expect(item.getAttribute('data-group')).toBe('User');
+        expect(item.getAttribute('data-label')).toBe('Rafal');
+        // The entity id is what lands in the policy, not the display name.
+        expect(item.textContent).toBe('User::"12345"');
+    });
+
     it('issues a single kind=PRINCIPAL fetch and filters client-side when typeFilter is a principal subset', async () => {
         listEntitiesSpy.mockImplementation((_env: string, params: { kind?: string } = {}) => {
             if (params.kind === 'PRINCIPAL') {

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/shared/hooks/useEntityOptions.ts
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/shared/hooks/useEntityOptions.ts
@@ -19,7 +19,7 @@ import { authzApiService, type EntityKindFilter } from '../api/authz-api.service
 import type { EntityResponse } from '../api/authz-api.types';
 import { authzQueryKeys } from '../api/query-keys';
 import type { ChipOption } from '../chip-option';
-import { parseEntityUid } from '../entity-adapter';
+import { resolveEntityRef } from '../entity-adapter';
 
 export interface UseEntityOptionsResult {
     readonly options: readonly ChipOption[];
@@ -49,10 +49,11 @@ function resolveKind(typeFilter: readonly string[] | undefined): EntityKindFilte
 }
 
 // Synced principals carry an unreadable entity id (the AM token `sub`, a UUID). Prefer a
-// human attribute for the chip label, falling back to the id. The id stays visible via the
-// description (it leads the attribute summary as `sub=...`) and is unchanged in the chip's
-// `id` — the GAPL ref the PEP matches on.
-const LABEL_ATTRS = ['displayName', 'email', 'username'] as const;
+// human attribute for the chip label, falling back to the id. `_displayName` is the explicit
+// name set by the local "Add principal" form; `displayName`/`email`/`username` are populated by
+// the AM sync. The id stays visible via the description and is unchanged in the chip's `id` —
+// the GAPL ref the PEP matches on.
+const LABEL_ATTRS = ['_displayName', 'displayName', 'email', 'username'] as const;
 
 function readableLabel(attrs: Record<string, unknown>, fallbackId: string): string {
     for (const key of LABEL_ATTRS) {
@@ -73,7 +74,7 @@ function summarizeAttributes(attrs: Record<string, unknown>): string | undefined
 }
 
 function toChipOption(entity: EntityResponse): ChipOption {
-    const { type, id } = parseEntityUid(entity.uid);
+    const { type, id } = resolveEntityRef(entity.uid, entity.attributes);
     return {
         id: `${type}::"${id}"`,
         label: readableLabel(entity.attributes, id),


### PR DESCRIPTION
## Problem

In the authz module's entity/principal picker (MCP & other policy builders) two kinds of principals were not usable:

1. **AM-synced principals were missing entirely.** Users synced from Gravitee Access Management are stored with the bare token `sub` as their `entityId` (no `<kind>.` dotted prefix) and carry their type only in the `_kind` attribute. The picker resolved the type via `parseEntityUid`, which infers type solely from the uid prefix, so these resolved to `Unknown` and were dropped by the principal type filter.

2. **Locally-added principals showed their id instead of their name.** The "Add principal" form stores the human name under the `_displayName` meta key, but the chip label only looked at `displayName`/`email`/`username`, so the dropdown showed e.g. `12345` instead of `Rafal`.

## Fix

- Add `resolveEntityRef(uid, attributes)` which honors the `_kind` attribute when resolving an entity's `{ type, id }`, falling back to uid parsing when `_kind` is absent/unknown (mirrors the existing `fromBackend` resolution).
- `toChipOption` now uses `resolveEntityRef` so synced principals resolve to their real type and survive the type filter.
- Add `_displayName` (first) to the chip label attributes so locally-added principals show the entered name, alongside the `displayName`/`email`/`username` the AM sync populates.

In all cases the GAPL reference inserted into the policy still carries the entity id / `sub` (`User::"<sub>"`), while the dropdown shows the human-readable name.

## Verification

- Unit tests: `useEntityOptions.test.tsx` — added cases for the bare-`sub` + `_kind` synced principal and the `_displayName` local principal. 10/10 green.
- Manual: verified live in the local stack — synced/local principals appear by name in the picker; selecting one inserts `User::"<id>"` into the policy (confirmed in Code view).

🤖 Generated with [Claude Code](https://claude.com/claude-code)