### PR TITLE
fix(gamma-platform-ui): archived apps navigation, groups field UX, metadata key, remove apps tooltip

### DIFF
--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/create/ApplicationGroupsField.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/create/ApplicationGroupsField.spec.tsx
@@ -73,6 +73,7 @@ describe('ApplicationGroupsField', () => {
 
         const options = screen.getAllByRole('option');
         expect(options.map(option => option.textContent)).toEqual(['Alpha Team', 'Middle Team', 'Zeta Team']);
+        expect(document.querySelector('[data-slot="combobox-empty"]')).toBeNull();
     });
 
     it('adds a group to the selection', async () => {
@@ -111,6 +112,17 @@ describe('ApplicationGroupsField', () => {
         renderField({ isLoading: true });
 
         expect(screen.getByLabelText('Search groups').disabled).toBe(true);
+    });
+
+    it('prevents typing in the groups input', async () => {
+        const user = userEvent.setup();
+        renderField();
+
+        const input = screen.getByLabelText('Search groups');
+        await user.click(input);
+        await user.type(input, 'alpha');
+
+        expect((input as HTMLInputElement).value).toBe('');
     });
 
     it('does not change selection while loading', async () => {

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/create/ApplicationGroupsField.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/create/ApplicationGroupsField.tsx
@@ -79,11 +79,12 @@ export function ApplicationGroupsField({
                         id="application-groups"
                         placeholder={selectedGroupIds.length === 0 ? placeholder : ''}
                         aria-label="Search groups"
+                        readOnly
                     />
                 </ComboboxChips>
                 <ComboboxContent anchor={chipsAnchorRef} align="start">
                     <ComboboxList>
-                        <ComboboxEmpty>No groups available</ComboboxEmpty>
+                        {sortedGroups.length === 0 && !isLoading ? <ComboboxEmpty>No groups available</ComboboxEmpty> : null}
                         {sortedGroups.map(group => (
                             <ComboboxItem key={group.id} value={group.id}>
                                 {group.name}

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/list/ApplicationListTable.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/list/ApplicationListTable.spec.tsx
@@ -1,0 +1,65 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { fireEvent, render, screen } from '@testing-library/react';
+import { useNavigate } from 'react-router-dom';
+
+import { ApplicationListTable } from './ApplicationListTable';
+import type { ApplicationListItem } from '../../types/application';
+
+jest.mock('react-router-dom', () => ({
+    ...jest.requireActual('react-router-dom'),
+    useNavigate: jest.fn(),
+}));
+
+const mockUseNavigate = jest.mocked(useNavigate);
+
+const APPLICATION: ApplicationListItem = {
+    id: 'app-1',
+    name: 'Billing App',
+    status: 'ARCHIVED',
+    type: 'SIMPLE',
+    created_at: 0,
+    updated_at: 1710000000000,
+};
+
+describe('ApplicationListTable', () => {
+    beforeEach(() => {
+        mockUseNavigate.mockReturnValue(jest.fn());
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('navigates to archived application details when clicking the name', () => {
+        const navigate = jest.fn();
+        mockUseNavigate.mockReturnValue(navigate);
+
+        render(
+            <ApplicationListTable
+                applications={[APPLICATION]}
+                isLoading={false}
+                status="ARCHIVED"
+                sorting={[]}
+                onSortingChange={jest.fn()}
+            />,
+        );
+
+        fireEvent.click(screen.getByRole('button', { name: 'Billing App' }));
+
+        expect(navigate).toHaveBeenCalledWith('app-1/general');
+    });
+});

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/list/ApplicationListTable.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/list/ApplicationListTable.tsx
@@ -72,14 +72,15 @@ function buildActiveColumns(navigate: ReturnType<typeof useNavigate>): DataTable
             cell: ({ row }: ColCell<ApplicationListItem>) => {
                 const name = row.original.name;
                 return (
-                    <button
+                    <Button
                         type="button"
-                        className="flex items-center gap-2 font-medium text-left hover:underline"
+                        variant="link"
+                        className="h-auto p-0 flex items-center justify-start gap-2 font-medium text-left text-foreground hover:underline hover:text-foreground"
                         onClick={() => navigate(`${row.original.id}/general`)}
                     >
                         <AppWindowIcon className="size-4 shrink-0 text-muted-foreground" aria-hidden />
                         <span title={name}>{truncateLabel(name)}</span>
-                    </button>
+                    </Button>
                 );
             },
         },
@@ -126,6 +127,7 @@ function buildActiveColumns(navigate: ReturnType<typeof useNavigate>): DataTable
 }
 
 function buildArchivedColumns(
+    navigate: ReturnType<typeof useNavigate>,
     canRestore: boolean,
     onRestore: ((application: ApplicationListItem) => void) | undefined,
 ): DataTableProps<ApplicationListItem>['columns'] {
@@ -136,10 +138,15 @@ function buildArchivedColumns(
             cell: ({ row }: ColCell<ApplicationListItem>) => {
                 const name = row.original.name;
                 return (
-                    <div className="flex items-center gap-2 font-medium">
+                    <Button
+                        type="button"
+                        variant="link"
+                        className="h-auto p-0 flex items-center justify-start gap-2 font-medium text-left text-foreground hover:underline hover:text-foreground"
+                        onClick={() => navigate(`${row.original.id}/general`)}
+                    >
                         <AppWindowIcon className="size-4 shrink-0 text-muted-foreground" aria-hidden />
                         <span title={name}>{truncateLabel(name)}</span>
-                    </div>
+                    </Button>
                 );
             },
         },
@@ -204,7 +211,7 @@ export function ApplicationListTable({
     const navigate = useNavigate();
     const isArchived = status === 'ARCHIVED';
     const activeColumns = useMemo(() => buildActiveColumns(navigate), [navigate]);
-    const archivedColumns = useMemo(() => buildArchivedColumns(canRestore, onRestore), [canRestore, onRestore]);
+    const archivedColumns = useMemo(() => buildArchivedColumns(navigate, canRestore, onRestore), [navigate, canRestore, onRestore]);
     const columns = isArchived ? archivedColumns : activeColumns;
 
     return (

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/list/ApplicationsListView.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/list/ApplicationsListView.tsx
@@ -94,7 +94,7 @@ export function ApplicationsListView({
 
     return (
         <div className="space-y-6">
-            <ApplicationsPageHeader canCreate={canCreate} onRegisterApplication={onRegisterApplication} showInfoTooltip />
+            <ApplicationsPageHeader canCreate={canCreate} onRegisterApplication={onRegisterApplication} />
 
             <ApplicationStatsCards stats={stats} />
 

--- a/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/metadata/ApplicationMetadataSection.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-platform/src/main/ui/features/applications/components/metadata/ApplicationMetadataSection.tsx
@@ -144,19 +144,7 @@ export function ApplicationMetadataSection({
 
                     {canCreate ? (
                         <form className="space-y-3" onSubmit={handleAddMetadata}>
-                            <div className="grid gap-3 md:grid-cols-4">
-                                <div className="space-y-2">
-                                    <RequiredLabel htmlFor="metadata-key">Key</RequiredLabel>
-                                    <Input
-                                        id="metadata-key"
-                                        value={metadataKey}
-                                        placeholder="department"
-                                        readOnly
-                                        required
-                                        aria-required="true"
-                                        className="bg-muted/40"
-                                    />
-                                </div>
+                            <div className="grid gap-3 md:grid-cols-3">
                                 <div className="space-y-2">
                                     <RequiredLabel htmlFor="metadata-name">Name</RequiredLabel>
                                     <Input


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-XXX

## Description

Summary

- Make archived applications clickable in the Applications list table (navigate to application details).
- Fix Groups combobox on application creation:
Don’t show “No groups available” when groups exist.
Prevent free-typing (selection/deselection only).
- Remove the Applications header tooltip (“Consumer applications that subscribe…”).
- Hide Metadata “Key” field during metadata creation on Notification settings (key still visible in edit dialog).



## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

