### PR TITLE
chore(deps): update gravitee-reactor-llm-proxy-parent version 2.10.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -308,7 +308,7 @@
         <gravitee-reactor-message.version>10.0.1</gravitee-reactor-message.version>
         <gravitee-reactor-native-kafka.version>6.0.1</gravitee-reactor-native-kafka.version>
         <gravitee-reactor-mcp-proxy.version>1.1.2</gravitee-reactor-mcp-proxy.version>
-        <gravitee-reactor-llm-proxy.version>2.9.1</gravitee-reactor-llm-proxy.version>
+        <gravitee-reactor-llm-proxy.version>2.10.1</gravitee-reactor-llm-proxy.version>
         <gravitee-reactor-a2a-proxy.version>1.0.0</gravitee-reactor-a2a-proxy.version>
         <gravitee-resource-ai-vector-store-redis.version>1.0.1</gravitee-resource-ai-vector-store-redis.version>
         <gravitee-resource-ai-vector-store-aws-s3.version>1.0.0</gravitee-resource-ai-vector-store-aws-s3.version>


### PR DESCRIPTION
Bumps `gravitee-reactor-llm-proxy` from 2.9.1 to 2.10.1.

Issue: https://gravitee.atlassian.net/browse/APIM-14061