### PR TITLE
chore(deps): update gravitee-reactor-llm-proxy-parent version 3.0.0-alpha.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -311,7 +311,7 @@
         <gravitee-reactor-message.version>11.0.0-alpha.3</gravitee-reactor-message.version>
         <gravitee-reactor-native-kafka.version>7.0.0-alpha.14</gravitee-reactor-native-kafka.version>
         <gravitee-reactor-mcp-proxy.version>3.0.0-feat-mcp-studio-schema-SNAPSHOT</gravitee-reactor-mcp-proxy.version>
-        <gravitee-reactor-llm-proxy.version>3.0.0-alpha.3</gravitee-reactor-llm-proxy.version>
+        <gravitee-reactor-llm-proxy.version>3.0.0-alpha.6</gravitee-reactor-llm-proxy.version>
         <gravitee-reactor-a2a-proxy.version>1.0.0</gravitee-reactor-a2a-proxy.version>
         <gravitee-reactor-edge.version>1.0.0-alpha.9</gravitee-reactor-edge.version>
         <gravitee-resource-ai-vector-store-redis.version>1.0.1</gravitee-resource-ai-vector-store-redis.version>


### PR DESCRIPTION
Bumps `gravitee-reactor-llm-proxy` from 3.0.0-alpha.3 to 3.0.0-alpha.6.

Issue: https://gravitee.atlassian.net/browse/APIM-14061