### PR TITLE
chore: bump authz PEP policy to 1.0.0-alpha.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -342,7 +342,7 @@
 
         <!-- Authz plugins -->
         <gravitee-service-authz-pdp.version>1.0.0-alpha.4</gravitee-service-authz-pdp.version>
-        <gravitee-policy-authz-pep.version>1.0.0-alpha.6</gravitee-policy-authz-pep.version>
+        <gravitee-policy-authz-pep.version>1.0.0-alpha.7</gravitee-policy-authz-pep.version>
     </properties>
 
     <scm>


### PR DESCRIPTION
Bumps `gravitee-policy-authz-pep.version` from `1.0.0-alpha.6` to `1.0.0-alpha.7`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)