### PR TITLE
feat: delete pending application invitations

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/ApplicationInvitationsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/ApplicationInvitationsResource.java
@@ -15,7 +15,9 @@
  */
 package io.gravitee.rest.api.portal.rest.resource;
 
+import io.gravitee.apim.core.invitation.model.InvitationId;
 import io.gravitee.apim.core.invitation.use_case.CreateApplicationInvitationsUseCase;
+import io.gravitee.apim.core.invitation.use_case.DeleteApplicationInvitationUseCase;
 import io.gravitee.apim.core.invitation.use_case.SearchApplicationInvitationsUseCase;
 import io.gravitee.common.http.MediaType;
 import io.gravitee.rest.api.model.common.PageableImpl;
@@ -37,6 +39,7 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import jakarta.ws.rs.BeanParam;
 import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.DELETE;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
@@ -55,6 +58,9 @@ public class ApplicationInvitationsResource extends AbstractResource {
 
     @Inject
     private CreateApplicationInvitationsUseCase createApplicationInvitationsUseCase;
+
+    @Inject
+    private DeleteApplicationInvitationUseCase deleteApplicationInvitationUseCase;
 
     @POST
     @Consumes(MediaType.APPLICATION_JSON)
@@ -103,5 +109,24 @@ public class ApplicationInvitationsResource extends AbstractResource {
         );
 
         return createListResponse(executionContext, invitations, paginationParam, metadata);
+    }
+
+    @DELETE
+    @Path("/{invitationId}")
+    @Produces(MediaType.APPLICATION_JSON)
+    @Permissions({ @Permission(value = RolePermission.APPLICATION_MEMBER, acls = RolePermissionAction.DELETE) })
+    public Response deleteApplicationInvitation(
+        @PathParam("applicationId") String applicationId,
+        @PathParam("invitationId") String invitationId
+    ) {
+        deleteApplicationInvitationUseCase.execute(
+            new DeleteApplicationInvitationUseCase.Input(
+                GraviteeContext.getCurrentEnvironment(),
+                applicationId,
+                InvitationId.of(invitationId)
+            )
+        );
+
+        return Response.noContent().build();
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/ApplicationInvitationsResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/ApplicationInvitationsResourceTest.java
@@ -55,6 +55,7 @@ class ApplicationInvitationsResourceTest extends AbstractResourceTest {
 
     private static final String APPLICATION = "my-application";
     private static final String UNKNOWN_APPLICATION = "unknown-application";
+    private static final String OTHER_APPLICATION = "other-application";
     private static final String INVITATION_ID_1 = "00000000-0000-0000-0000-000000000001";
     private static final String INVITATION_ID_2 = "00000000-0000-0000-0000-000000000002";
     private static final String ROLE_NAME = "USER";
@@ -251,10 +252,60 @@ class ApplicationInvitationsResourceTest extends AbstractResourceTest {
         verify(invitationQueryService, never()).findByApplicationId(anyString(), any(), any());
     }
 
+    @Test
+    void should_delete_invitation() {
+        var invitationId = InvitationId.of(INVITATION_ID_1);
+        when(invitationCrudService.findApplicationInvitationById(invitationId)).thenReturn(
+            Optional.of(anInvitation(INVITATION_ID_1, "alice@example.com"))
+        );
+
+        var response = target(APPLICATION).path("invitations").path(INVITATION_ID_1).request().delete();
+
+        assertThat(response.getStatus()).isEqualTo(HttpStatusCode.NO_CONTENT_204);
+        verify(invitationCrudService).delete(invitationId);
+    }
+
+    @Test
+    void should_return_not_found_when_deleting_invitation_for_unknown_application() {
+        var response = target(UNKNOWN_APPLICATION).path("invitations").path(INVITATION_ID_1).request().delete();
+
+        assertThat(response.getStatus()).isEqualTo(HttpStatusCode.NOT_FOUND_404);
+        verify(invitationCrudService, never()).findApplicationInvitationById(any());
+        verify(invitationCrudService, never()).delete(any());
+    }
+
+    @Test
+    void should_return_not_found_when_deleting_unknown_invitation() {
+        var invitationId = InvitationId.of(INVITATION_ID_1);
+        when(invitationCrudService.findApplicationInvitationById(invitationId)).thenReturn(Optional.empty());
+
+        var response = target(APPLICATION).path("invitations").path(INVITATION_ID_1).request().delete();
+
+        assertThat(response.getStatus()).isEqualTo(HttpStatusCode.NOT_FOUND_404);
+        verify(invitationCrudService, never()).delete(any());
+    }
+
+    @Test
+    void should_return_not_found_when_deleting_invitation_from_another_application() {
+        var invitationId = InvitationId.of(INVITATION_ID_1);
+        when(invitationCrudService.findApplicationInvitationById(invitationId)).thenReturn(
+            Optional.of(anInvitation(INVITATION_ID_1, OTHER_APPLICATION, "alice@example.com"))
+        );
+
+        var response = target(APPLICATION).path("invitations").path(INVITATION_ID_1).request().delete();
+
+        assertThat(response.getStatus()).isEqualTo(HttpStatusCode.NOT_FOUND_404);
+        verify(invitationCrudService, never()).delete(any());
+    }
+
     private ApplicationInvitation anInvitation(String id, String email) {
+        return anInvitation(id, APPLICATION, email);
+    }
+
+    private ApplicationInvitation anInvitation(String id, String applicationId, String email) {
         return new ApplicationInvitation(
             InvitationId.of(id),
-            APPLICATION,
+            applicationId,
             email,
             "USER",
             ZonedDateTime.parse("2026-04-23T09:30:00Z"),

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/invitation/crud_service/InvitationCrudService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/invitation/crud_service/InvitationCrudService.java
@@ -19,9 +19,14 @@ import io.gravitee.apim.core.invitation.model.ApplicationInvitation;
 import io.gravitee.apim.core.invitation.model.Invitation;
 import io.gravitee.apim.core.invitation.model.InvitationId;
 import java.util.List;
+import java.util.Optional;
 
 public interface InvitationCrudService {
     ApplicationInvitation create(ApplicationInvitation invitation);
+
+    default Optional<ApplicationInvitation> findApplicationInvitationById(InvitationId invitationId) {
+        throw new UnsupportedOperationException("findApplicationInvitationById not implemented");
+    }
 
     default List<Invitation> findByEmail(String email) {
         throw new UnsupportedOperationException("findByEmail not implemented");

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/invitation/domain_service/DeleteApplicationInvitationDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/invitation/domain_service/DeleteApplicationInvitationDomainService.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.invitation.domain_service;
+
+import io.gravitee.apim.core.DomainService;
+import io.gravitee.apim.core.invitation.crud_service.InvitationCrudService;
+import io.gravitee.apim.core.invitation.exception.ApplicationInvitationNotFoundException;
+import io.gravitee.apim.core.invitation.model.InvitationId;
+import jakarta.annotation.Nonnull;
+import lombok.RequiredArgsConstructor;
+
+@DomainService
+@RequiredArgsConstructor
+public class DeleteApplicationInvitationDomainService {
+
+    private final InvitationCrudService invitationCrudService;
+
+    public void delete(@Nonnull String applicationId, @Nonnull InvitationId invitationId) {
+        var invitation = invitationCrudService
+            .findApplicationInvitationById(invitationId)
+            .filter(applicationInvitation -> applicationId.equals(applicationInvitation.applicationId()))
+            .orElseThrow(() -> new ApplicationInvitationNotFoundException(invitationId));
+
+        invitationCrudService.delete(invitation.id());
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/invitation/domain_service/DeleteApplicationInvitationDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/invitation/domain_service/DeleteApplicationInvitationDomainService.java
@@ -32,7 +32,7 @@ public class DeleteApplicationInvitationDomainService {
         var invitation = invitationCrudService
             .findApplicationInvitationById(invitationId)
             .filter(applicationInvitation -> applicationId.equals(applicationInvitation.applicationId()))
-            .orElseThrow(() -> new ApplicationInvitationNotFoundException(invitationId));
+            .orElseThrow(() -> new ApplicationInvitationNotFoundException(invitationId.toString()));
 
         invitationCrudService.delete(invitation.id());
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/invitation/exception/ApplicationInvitationNotFoundException.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/invitation/exception/ApplicationInvitationNotFoundException.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.invitation.exception;
+
+import io.gravitee.apim.core.exception.NotFoundDomainException;
+import io.gravitee.apim.core.invitation.model.InvitationId;
+
+public class ApplicationInvitationNotFoundException extends NotFoundDomainException {
+
+    public ApplicationInvitationNotFoundException(InvitationId invitationId) {
+        super("Application invitation not found.", invitationId.toString());
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/invitation/exception/ApplicationInvitationNotFoundException.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/invitation/exception/ApplicationInvitationNotFoundException.java
@@ -16,11 +16,10 @@
 package io.gravitee.apim.core.invitation.exception;
 
 import io.gravitee.apim.core.exception.NotFoundDomainException;
-import io.gravitee.apim.core.invitation.model.InvitationId;
 
 public class ApplicationInvitationNotFoundException extends NotFoundDomainException {
 
-    public ApplicationInvitationNotFoundException(InvitationId invitationId) {
-        super("Application invitation not found.", invitationId.toString());
+    public ApplicationInvitationNotFoundException(String invitationId) {
+        super("Application invitation not found.", invitationId);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/invitation/use_case/DeleteApplicationInvitationUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/invitation/use_case/DeleteApplicationInvitationUseCase.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.invitation.use_case;
+
+import io.gravitee.apim.core.UseCase;
+import io.gravitee.apim.core.application.crud_service.ApplicationCrudService;
+import io.gravitee.apim.core.invitation.domain_service.DeleteApplicationInvitationDomainService;
+import io.gravitee.apim.core.invitation.model.InvitationId;
+import lombok.RequiredArgsConstructor;
+
+@UseCase
+@RequiredArgsConstructor
+public class DeleteApplicationInvitationUseCase {
+
+    private final ApplicationCrudService applicationCrudService;
+    private final DeleteApplicationInvitationDomainService deleteApplicationInvitationDomainService;
+
+    public void execute(Input input) {
+        applicationCrudService.findById(input.applicationId(), input.environmentId());
+        deleteApplicationInvitationDomainService.delete(input.applicationId(), input.invitationId());
+    }
+
+    public record Input(String environmentId, String applicationId, InvitationId invitationId) {}
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/crud_service/invitation/InvitationCrudServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/crud_service/invitation/InvitationCrudServiceImpl.java
@@ -23,8 +23,10 @@ import io.gravitee.apim.core.invitation.model.InvitationId;
 import io.gravitee.apim.infra.adapter.InvitationAdapter;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.InvitationRepository;
+import io.gravitee.repository.management.model.InvitationReferenceType;
 import io.gravitee.rest.api.service.impl.TransactionalService;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Service;
 
@@ -45,6 +47,18 @@ public class InvitationCrudServiceImpl extends TransactionalService implements I
             );
         } catch (TechnicalException e) {
             throw new TechnicalDomainException("An error occurs while trying to create application invitation", e);
+        }
+    }
+
+    @Override
+    public Optional<ApplicationInvitation> findApplicationInvitationById(InvitationId invitationId) {
+        try {
+            return invitationRepository
+                .findById(invitationId.toString())
+                .filter(invitation -> InvitationReferenceType.APPLICATION.name().equals(invitation.getReferenceType()))
+                .map(InvitationAdapter.INSTANCE::toApplicationInvitation);
+        } catch (TechnicalException e) {
+            throw new TechnicalDomainException("An error occurs while trying to find application invitation by id", e);
         }
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/InvitationCrudServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/InvitationCrudServiceInMemory.java
@@ -22,6 +22,7 @@ import io.gravitee.apim.core.invitation.model.InvitationId;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 
 public class InvitationCrudServiceInMemory implements InvitationCrudService, InMemoryAlternative<Invitation> {
 
@@ -31,6 +32,16 @@ public class InvitationCrudServiceInMemory implements InvitationCrudService, InM
     public ApplicationInvitation create(ApplicationInvitation invitation) {
         storage.add(invitation);
         return invitation;
+    }
+
+    @Override
+    public Optional<ApplicationInvitation> findApplicationInvitationById(InvitationId invitationId) {
+        return storage
+            .stream()
+            .filter(ApplicationInvitation.class::isInstance)
+            .map(ApplicationInvitation.class::cast)
+            .filter(invitation -> invitation.id().equals(invitationId))
+            .findFirst();
     }
 
     @Override

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/invitation/domain_service/DeleteApplicationInvitationDomainServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/invitation/domain_service/DeleteApplicationInvitationDomainServiceTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.invitation.domain_service;
+
+import static fixtures.core.model.ApplicationInvitationFixtures.anApplicationInvitation;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.apim.core.invitation.crud_service.InvitationCrudService;
+import io.gravitee.apim.core.invitation.exception.ApplicationInvitationNotFoundException;
+import io.gravitee.apim.core.invitation.model.InvitationId;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class DeleteApplicationInvitationDomainServiceTest {
+
+    private static final String APPLICATION_ID = "application-id";
+    private static final String OTHER_APPLICATION_ID = "other-application-id";
+    private static final String INVITATION_ID = "00000000-0000-0000-0000-000000000001";
+
+    @Mock
+    private InvitationCrudService invitationCrudService;
+
+    private DeleteApplicationInvitationDomainService cut;
+
+    @BeforeEach
+    void setUp() {
+        cut = new DeleteApplicationInvitationDomainService(invitationCrudService);
+    }
+
+    @Test
+    void should_delete_application_invitation() {
+        var invitationId = InvitationId.of(INVITATION_ID);
+        when(invitationCrudService.findApplicationInvitationById(invitationId)).thenReturn(
+            Optional.of(anApplicationInvitation(INVITATION_ID, APPLICATION_ID, "alice@example.com", "USER"))
+        );
+
+        cut.delete(APPLICATION_ID, invitationId);
+
+        verify(invitationCrudService).delete(invitationId);
+    }
+
+    @Test
+    void should_throw_when_invitation_does_not_exist() {
+        var invitationId = InvitationId.of(INVITATION_ID);
+        when(invitationCrudService.findApplicationInvitationById(invitationId)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> cut.delete(APPLICATION_ID, invitationId)).isInstanceOf(ApplicationInvitationNotFoundException.class);
+
+        verify(invitationCrudService, never()).delete(invitationId);
+    }
+
+    @Test
+    void should_throw_when_invitation_belongs_to_another_application() {
+        var invitationId = InvitationId.of(INVITATION_ID);
+        when(invitationCrudService.findApplicationInvitationById(invitationId)).thenReturn(
+            Optional.of(anApplicationInvitation(INVITATION_ID, OTHER_APPLICATION_ID, "alice@example.com", "USER"))
+        );
+
+        assertThatThrownBy(() -> cut.delete(APPLICATION_ID, invitationId)).isInstanceOf(ApplicationInvitationNotFoundException.class);
+
+        verify(invitationCrudService, never()).delete(invitationId);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/invitation/use_case/DeleteApplicationInvitationUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/invitation/use_case/DeleteApplicationInvitationUseCaseTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.invitation.use_case;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.apim.core.application.crud_service.ApplicationCrudService;
+import io.gravitee.apim.core.invitation.domain_service.DeleteApplicationInvitationDomainService;
+import io.gravitee.apim.core.invitation.model.InvitationId;
+import io.gravitee.rest.api.model.BaseApplicationEntity;
+import io.gravitee.rest.api.service.exceptions.ApplicationNotFoundException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class DeleteApplicationInvitationUseCaseTest {
+
+    private static final String ENVIRONMENT_ID = "environment-id";
+    private static final String APPLICATION_ID = "application-id";
+    private static final String INVITATION_ID = "00000000-0000-0000-0000-000000000001";
+
+    @Mock
+    private ApplicationCrudService applicationCrudService;
+
+    @Mock
+    private DeleteApplicationInvitationDomainService deleteApplicationInvitationDomainService;
+
+    private DeleteApplicationInvitationUseCase cut;
+
+    @BeforeEach
+    void setUp() {
+        cut = new DeleteApplicationInvitationUseCase(applicationCrudService, deleteApplicationInvitationDomainService);
+    }
+
+    @Test
+    void should_validate_application_existence_before_deleting_invitation() {
+        var invitationId = InvitationId.of(INVITATION_ID);
+        when(applicationCrudService.findById(APPLICATION_ID, ENVIRONMENT_ID)).thenThrow(new ApplicationNotFoundException(APPLICATION_ID));
+
+        assertThatThrownBy(() ->
+            cut.execute(new DeleteApplicationInvitationUseCase.Input(ENVIRONMENT_ID, APPLICATION_ID, invitationId))
+        ).isInstanceOf(ApplicationNotFoundException.class);
+
+        verifyNoInteractions(deleteApplicationInvitationDomainService);
+    }
+
+    @Test
+    void should_delete_application_invitation() {
+        var invitationId = InvitationId.of(INVITATION_ID);
+        when(applicationCrudService.findById(APPLICATION_ID, ENVIRONMENT_ID)).thenReturn(
+            BaseApplicationEntity.builder().id(APPLICATION_ID).environmentId(ENVIRONMENT_ID).build()
+        );
+
+        cut.execute(new DeleteApplicationInvitationUseCase.Input(ENVIRONMENT_ID, APPLICATION_ID, invitationId));
+
+        verify(deleteApplicationInvitationDomainService).delete(APPLICATION_ID, invitationId);
+    }
+}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-14239

## Description

Implements the first part of invitation mutations: deleting pending application invitations from the Developer Portal.
Changes:
- Adds DELETE /applications/{applicationId}/invitations/{invitationId},
- Adds DeleteApplicationInvitationUseCase and domain service for application-scoped deletion,
- Validates that the application exists in the current environment before deleting.
- Ensures the invitation exists and belongs to the requested application.
- Returns 404 when the application, invitation, or application/invitation relation is invalid.
- Extends invitation CRUD service with application invitation lookup by ID.

## Out of scope
- Invitation role update.
- Resend invitation.
- Notification handling.
