### PR TITLE
fix(GKO-2934): remove EDGE from Automation API type

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/java/io/gravitee/apim/rest/api/automation/mapper/ApiMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/java/io/gravitee/apim/rest/api/automation/mapper/ApiMapper.java
@@ -52,7 +52,9 @@ import java.util.Map;
 import java.util.Objects;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
+import org.mapstruct.MappingConstants;
 import org.mapstruct.MappingTarget;
+import org.mapstruct.ValueMapping;
 import org.mapstruct.factory.Mappers;
 
 /**
@@ -62,6 +64,11 @@ import org.mapstruct.factory.Mappers;
 @Mapper(uses = { DateMapper.class, OriginContextMapper.class, ServiceMapper.class })
 public interface ApiMapper {
     ApiMapper INSTANCE = Mappers.getMapper(ApiMapper.class);
+
+    @ValueMapping(source = "EDGE", target = MappingConstants.THROW_EXCEPTION)
+    io.gravitee.apim.rest.api.automation.model.ApiType map(io.gravitee.rest.api.management.v2.rest.model.ApiType type);
+
+    io.gravitee.rest.api.management.v2.rest.model.ApiType map(io.gravitee.apim.rest.api.automation.model.ApiType type);
 
     @Mapping(target = "listeners", expression = "java(mapApiV4SpecListeners(apiV4Spec))")
     @Mapping(target = "plans", expression = "java(mapApiV4SpecPlans(apiV4Spec))")

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/java/io/gravitee/apim/rest/api/automation/mapper/SharedPolicyGroupMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/java/io/gravitee/apim/rest/api/automation/mapper/SharedPolicyGroupMapper.java
@@ -15,12 +15,15 @@
  */
 package io.gravitee.apim.rest.api.automation.mapper;
 
+import io.gravitee.apim.core.plugin.model.FlowPhase;
 import io.gravitee.apim.core.shared_policy_group.model.SharedPolicyGroup;
 import io.gravitee.apim.core.shared_policy_group.model.SharedPolicyGroupCRDStatus;
 import io.gravitee.apim.rest.api.automation.model.Errors;
 import io.gravitee.apim.rest.api.automation.model.LegacySharedPolicyGroupSpec;
+import io.gravitee.apim.rest.api.automation.model.SharedPolicyGroupApiType;
 import io.gravitee.apim.rest.api.automation.model.SharedPolicyGroupState;
 import io.gravitee.apim.rest.api.automation.model.StepV4;
+import io.gravitee.definition.model.v4.ApiType;
 import io.gravitee.definition.model.v4.flow.step.Step;
 import io.gravitee.rest.api.management.v2.rest.mapper.ConfigurationSerializationMapper;
 import io.gravitee.rest.api.management.v2.rest.mapper.DateMapper;
@@ -40,10 +43,19 @@ import org.mapstruct.factory.Mappers;
 public interface SharedPolicyGroupMapper {
     SharedPolicyGroupMapper INSTANCE = Mappers.getMapper(SharedPolicyGroupMapper.class);
 
-    @ValueMapping(source = "EDGE", target = MappingConstants.THROW_EXCEPTION)
-    io.gravitee.apim.rest.api.automation.model.ApiType map(io.gravitee.definition.model.v4.ApiType apiType);
+    ApiType mapApiType(SharedPolicyGroupApiType apiType);
 
-    io.gravitee.definition.model.v4.ApiType map(io.gravitee.apim.rest.api.automation.model.ApiType apiType);
+    FlowPhase mapFlowPhase(io.gravitee.apim.rest.api.automation.model.FlowPhase phase);
+
+    @ValueMapping(source = "PROXY", target = "PROXY")
+    @ValueMapping(source = "MESSAGE", target = "MESSAGE")
+    @ValueMapping(source = MappingConstants.ANY_REMAINING, target = MappingConstants.THROW_EXCEPTION)
+    SharedPolicyGroupApiType mapSharedPolicyGroupApiType(ApiType apiType);
+
+    @ValueMapping(source = "ENTRYPOINT_CONNECT", target = MappingConstants.THROW_EXCEPTION)
+    @ValueMapping(source = "INTERACT", target = MappingConstants.THROW_EXCEPTION)
+    @ValueMapping(source = MappingConstants.ANY_REMAINING, target = MappingConstants.THROW_EXCEPTION)
+    io.gravitee.apim.rest.api.automation.model.FlowPhase mapAutomationFlowPhase(FlowPhase phase);
 
     @Mapping(target = "sharedPolicyGroupId", ignore = true)
     @Mapping(target = "originContext", ignore = true)

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/java/io/gravitee/apim/rest/api/automation/mapper/SharedPolicyGroupMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/java/io/gravitee/apim/rest/api/automation/mapper/SharedPolicyGroupMapper.java
@@ -27,7 +27,9 @@ import io.gravitee.rest.api.management.v2.rest.mapper.DateMapper;
 import io.gravitee.rest.api.management.v2.rest.mapper.OriginContextMapper;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
+import org.mapstruct.MappingConstants;
 import org.mapstruct.MappingTarget;
+import org.mapstruct.ValueMapping;
 import org.mapstruct.factory.Mappers;
 
 /**
@@ -37,6 +39,11 @@ import org.mapstruct.factory.Mappers;
 @Mapper(uses = { ConfigurationSerializationMapper.class, DateMapper.class, OriginContextMapper.class })
 public interface SharedPolicyGroupMapper {
     SharedPolicyGroupMapper INSTANCE = Mappers.getMapper(SharedPolicyGroupMapper.class);
+
+    @ValueMapping(source = "EDGE", target = MappingConstants.THROW_EXCEPTION)
+    io.gravitee.apim.rest.api.automation.model.ApiType map(io.gravitee.definition.model.v4.ApiType apiType);
+
+    io.gravitee.definition.model.v4.ApiType map(io.gravitee.apim.rest.api.automation.model.ApiType apiType);
 
     @Mapping(target = "sharedPolicyGroupId", ignore = true)
     @Mapping(target = "originContext", ignore = true)

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/resources/open-api.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/resources/open-api.yaml
@@ -1715,7 +1715,7 @@ components:
         hrid:
           $ref: "#/components/schemas/Hrid"
         apiType:
-          $ref: "#/components/schemas/ApiType"
+          $ref: "#/components/schemas/SharedPolicyGroupApiType"
         description:
           type: string
           description: The description of the shared policy group
@@ -1746,14 +1746,18 @@ components:
         - apiType
         - name
         - phase
+    SharedPolicyGroupApiType:
+      type: string
+      description: API type compatible with a shared policy group.
+      enum:
+        - PROXY
+        - MESSAGE
     FlowPhase:
       type: string
-      description: The execution phase of a policy.
+      description: The execution phase of a shared policy group policy. Only phases compatible with PROXY and MESSAGE API types are supported.
       enum:
         - REQUEST
         - RESPONSE
-        - ENTRYPOINT_CONNECT
-        - INTERACT
         - PUBLISH
         - SUBSCRIBE
     PlanV4:

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/resources/open-api.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/resources/open-api.yaml
@@ -1912,7 +1912,6 @@ components:
         - MESSAGE
       enum:
         - A2A_PROXY
-        - EDGE
         - LLM_PROXY
         - MCP_PROXY
         - MESSAGE

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/resource/ApisResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/resource/ApisResourceTest.java
@@ -134,6 +134,19 @@ class ApisResourceTest extends AbstractResourceTest {
         }
 
         @Test
+        void should_reject_edge_api_type() {
+            try (
+                var response = rootTarget()
+                    .queryParam("dryRun", false)
+                    .request()
+                    .accept(MediaType.APPLICATION_JSON_TYPE)
+                    .put(Entity.json(readJSON("api-with-edge-type.json")))
+            ) {
+                assertThat(response.getStatus()).isEqualTo(400);
+            }
+        }
+
+        @Test
         void should_return_state_from_hrid_and_have_spg_hrid_replaced() {
             var state = expectEntity("api-with-hrid-spg-hrid.json");
             SoftAssertions.assertSoftly(soft -> {
@@ -264,6 +277,19 @@ class ApisResourceTest extends AbstractResourceTest {
                     .request()
                     .accept(MediaType.APPLICATION_JSON_TYPE)
                     .put(Entity.json(readJSON("api-with-no-hrid.json")))
+            ) {
+                assertThat(response.getStatus()).isEqualTo(400);
+            }
+        }
+
+        @Test
+        void should_reject_edge_api_type() {
+            try (
+                var response = rootTarget()
+                    .queryParam("dryRun", dryRun)
+                    .request()
+                    .accept(MediaType.APPLICATION_JSON_TYPE)
+                    .put(Entity.json(readJSON("api-with-edge-type.json")))
             ) {
                 assertThat(response.getStatus()).isEqualTo(400);
             }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/resource/SharedPolicyGroupResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/resource/SharedPolicyGroupResourceTest.java
@@ -323,4 +323,34 @@ class SharedPolicyGroupResourceTest extends AbstractResourceTest {
             }
         }
     }
+
+    @Nested
+    class InvalidSpec {
+
+        @Test
+        void should_return_400_when_api_type_is_native() {
+            putInvalidSpecAndAssertBadRequest(readJSON("shared-policy-group.json").replace("\"PROXY\"", "\"NATIVE\""));
+        }
+
+        @Test
+        void should_return_400_when_phase_is_entrypoint_connect() {
+            putInvalidSpecAndAssertBadRequest(readJSON("shared-policy-group.json").replace("\"REQUEST\"", "\"ENTRYPOINT_CONNECT\""));
+        }
+
+        @Test
+        void should_return_400_when_phase_is_interact() {
+            putInvalidSpecAndAssertBadRequest(readJSON("shared-policy-group.json").replace("\"REQUEST\"", "\"INTERACT\""));
+        }
+
+        @Test
+        void should_return_400_when_proxy_api_type_has_subscribe_phase() {
+            putInvalidSpecAndAssertBadRequest(readJSON("shared-policy-group.json").replace("\"REQUEST\"", "\"SUBSCRIBE\""));
+        }
+
+        private void putInvalidSpecAndAssertBadRequest(String spec) {
+            try (var response = rootTarget().request().put(Entity.json(spec))) {
+                assertThat(response.getStatus()).isEqualTo(400);
+            }
+        }
+    }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/resource/SharedPolicyGroupResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/resource/SharedPolicyGroupResourceTest.java
@@ -263,6 +263,18 @@ class SharedPolicyGroupResourceTest extends AbstractResourceTest {
                     assertThat(response.getStatus()).isEqualTo(400);
                 }
             }
+
+            @Test
+            void should_reject_edge_api_type() {
+                try (
+                    var response = rootTarget()
+                        .queryParam("dryRun", false)
+                        .request()
+                        .put(Entity.json(readJSON("shared-policy-group-with-edge-type.json")))
+                ) {
+                    assertThat(response.getStatus()).isEqualTo(400);
+                }
+            }
         }
 
         @Nested
@@ -287,6 +299,18 @@ class SharedPolicyGroupResourceTest extends AbstractResourceTest {
                         .queryParam("dryRun", true)
                         .request()
                         .put(Entity.json(readJSON("shared-policy-group-with-cross-id-and-no-hrid.json")))
+                ) {
+                    assertThat(response.getStatus()).isEqualTo(400);
+                }
+            }
+
+            @Test
+            void should_reject_edge_api_type() {
+                try (
+                    var response = rootTarget()
+                        .queryParam("dryRun", true)
+                        .request()
+                        .put(Entity.json(readJSON("shared-policy-group-with-edge-type.json")))
                 ) {
                     assertThat(response.getStatus()).isEqualTo(400);
                 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/resources/io/gravitee/apim/rest/api/automation/resource/api-with-edge-type.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/resources/io/gravitee/apim/rest/api/automation/resource/api-with-edge-type.json
@@ -1,0 +1,74 @@
+{
+    "name": "api-v4-edge",
+    "hrid": "api-hrid",
+    "description": "API v4 spec with forbidden EDGE type",
+    "version": "1.0",
+    "type": "EDGE",
+    "listeners": [
+        {
+            "type": "HTTP",
+            "paths": [
+                {
+                    "path": "/test-edge"
+                }
+            ],
+            "entrypoints": [
+                {
+                    "type": "http-proxy",
+                    "qos": "AUTO"
+                }
+            ]
+        }
+    ],
+    "endpointGroups": [
+        {
+            "name": "Default HTTP proxy group",
+            "type": "http-proxy",
+            "endpoints": [
+                {
+                    "name": "Default HTTP proxy",
+                    "type": "http-proxy",
+                    "inheritConfiguration": false,
+                    "configuration": {
+                        "target": "https://api.gravitee.io/echo"
+                    },
+                    "secondary": false
+                }
+            ]
+        }
+    ],
+    "flowExecution": {
+        "mode": "DEFAULT",
+        "matchRequired": false
+    },
+    "state": "STARTED",
+    "lifecycleState": "PUBLISHED",
+    "visibility": "PUBLIC",
+    "flows": [],
+    "plans": [
+        {
+            "name": "Keyless plan",
+            "hrid": "KEY_LESS",
+            "description": "No authentication",
+            "type": "API",
+            "status": "PUBLISHED",
+            "validation": "AUTO",
+            "mode": "STANDARD",
+            "security": {
+                "type": "KEY_LESS"
+            },
+            "flows": [
+                {
+                    "enabled": true,
+                    "selectors": [
+                        {
+                            "type": "HTTP",
+                            "path": "/",
+                            "pathOperator": "STARTS_WITH"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/resources/io/gravitee/apim/rest/api/automation/resource/shared-policy-group-with-edge-type.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/resources/io/gravitee/apim/rest/api/automation/resource/shared-policy-group-with-edge-type.json
@@ -1,0 +1,26 @@
+{
+  "hrid": "spg-foo",
+  "name": "SPG Foo",
+  "description": "A shared policy group with forbidden EDGE type",
+  "apiType": "EDGE",
+  "phase": "REQUEST",
+  "steps": [
+    {
+      "name": "rate-limit",
+      "description": "Shared rate limiting policy",
+      "enabled": true,
+      "policy": "rate-limit",
+      "configuration": {
+        "async": false,
+        "addHeaders": true,
+        "rate": {
+          "useKeyOnly": false,
+          "periodTime": 1,
+          "limit": 10,
+          "periodTimeUnit": "MINUTES",
+          "key": ""
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Issue
https://gravitee.atlassian.net/browse/GKO-2934

## Summary
- Remove `EDGE` from Automation API OpenAPI `ApiType` enum.
- Fail fast if `EDGE` is encountered during ApiType mapping.

## Test plan
- [x] `mvn -pl gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest test`