### PR TITLE
fix(portal): fix OIDC login icon contrast when button color is unset

### DIFF
--- a/gravitee-apim-portal-webui/package.json
+++ b/gravitee-apim-portal-webui/package.json
@@ -40,7 +40,7 @@
     "@fontsource/dm-sans": "5.2.5",
     "@fontsource/ibm-plex-sans": "5.2.5",
     "@fontsource/montserrat": "5.2.5",
-    "@gravitee/ui-components": "4.3.2",
+    "@gravitee/ui-components": "4.4.1",
     "@highcharts/map-collection": "2.3.0",
     "@ngx-translate/core": "14.0.0",
     "@ngx-translate/http-loader": "7.0.0",

--- a/gravitee-apim-portal-webui/src/app/pages/login/login.component.spec.ts
+++ b/gravitee-apim-portal-webui/src/app/pages/login/login.component.spec.ts
@@ -43,4 +43,26 @@ describe('LoginComponent', () => {
   it('should create', () => {
     expect(component).toBeTruthy();
   });
+
+  describe('getProviderStyle', () => {
+    it('should return empty style when color is unset', () => {
+      expect(component.getProviderStyle({ type: 'OIDC' } as never)).toBe('');
+    });
+
+    it('should return empty style when color is whitespace only', () => {
+      expect(component.getProviderStyle({ type: 'OIDC', color: '   ' } as never)).toBe('');
+    });
+
+    it('should include background and contrasting text color for dark hex', () => {
+      expect(component.getProviderStyle({ type: 'OIDC', color: '#000000' } as never)).toBe(
+        '--gv-button-oidc--bgc:#000000;--gv-button--c:#ffffff;',
+      );
+    });
+
+    it('should include background and contrasting text color for light hex', () => {
+      expect(component.getProviderStyle({ type: 'OIDC', color: '#ffffff' } as never)).toBe(
+        '--gv-button-oidc--bgc:#ffffff;--gv-button--c:#000000;',
+      );
+    });
+  });
 });

--- a/gravitee-apim-portal-webui/src/app/pages/login/login.component.ts
+++ b/gravitee-apim-portal-webui/src/app/pages/login/login.component.ts
@@ -107,10 +107,22 @@ export class LoginComponent implements OnInit, AfterViewInit, OnDestroy {
     return this.loginForm.valid.valueOf();
   }
 
-  getProviderStyle(provider) {
-    if (provider.color) {
-      return `--gv-button-${provider.type.toLowerCase()}--bgc:${provider.color};`;
+  getProviderStyle(provider: IdentityProvider): string {
+    const color = provider.color?.trim();
+    if (!color) {
+      return '';
     }
-    return '';
+    const textColor = colorIsDark(color) ? '#ffffff' : '#000000';
+    return `--gv-button-${provider.type.toLowerCase()}--bgc:${color};--gv-button--c:${textColor};`;
   }
 }
+
+const colorIsDark = (bgColor: string): boolean => {
+  const hex = bgColor.charAt(0) === '#' ? bgColor.substring(1, 7) : bgColor;
+  const r = Number.parseInt(hex.substring(0, 2), 16);
+  const g = Number.parseInt(hex.substring(2, 4), 16);
+  const b = Number.parseInt(hex.substring(4, 6), 16);
+  const uicolors = [r / 255, g / 255, b / 255];
+  const c = uicolors.map(col => (col <= 0.03928 ? col / 12.92 : Math.pow((col + 0.055) / 1.055, 2.4)));
+  return 0.2126 * c[0] + 0.7152 * c[1] + 0.0722 * c[2] <= 0.179;
+};

--- a/gravitee-apim-portal-webui/yarn.lock
+++ b/gravitee-apim-portal-webui/yarn.lock
@@ -3288,7 +3288,7 @@ __metadata:
     "@fontsource/dm-sans": "npm:5.2.5"
     "@fontsource/ibm-plex-sans": "npm:5.2.5"
     "@fontsource/montserrat": "npm:5.2.5"
-    "@gravitee/ui-components": "npm:4.3.2"
+    "@gravitee/ui-components": "npm:4.4.1"
     "@highcharts/map-collection": "npm:2.3.0"
     "@messageformat/core": "npm:3.4.0"
     "@ngneat/spectator": "npm:19.4.1"
@@ -3345,9 +3345,9 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@gravitee/ui-components@npm:4.3.2":
-  version: 4.3.2
-  resolution: "@gravitee/ui-components@npm:4.3.2"
+"@gravitee/ui-components@npm:4.4.1":
+  version: 4.4.1
+  resolution: "@gravitee/ui-components@npm:4.4.1"
   dependencies:
     "@codemirror/basic-setup": "npm:^0.19.1"
     "@codemirror/language-data": "npm:^0.19.1"
@@ -3361,7 +3361,7 @@ __metadata:
     date-fns: "npm:^2.26.0"
     dompurify: "npm:3.1.5"
     jdenticon: "npm:^3.1.0"
-    jsonschema: "npm:^1.4.0"
+    jsonschema: "npm:1.4.1"
     lit: "npm:^2.0.2"
     object-path: "npm:^0.11.8"
     resize-observer-polyfill: "npm:^1.5.1"
@@ -3386,7 +3386,7 @@ __metadata:
       optional: true
     highlight.js:
       optional: true
-  checksum: 10c0/2418f85b063bab96845d7b53ff128f99f16c1ab42c9eabbebca94b10baf2301d15b17d24f596896fa437c7a6008ca65750696861748b79be15ff75570c152ceb
+  checksum: 10c0/fb9c77e1f58c55dacbf8a8e31e447c74706398f1ef586a6336aa68c21968426ca45e8c33117f24c4370c398e8e7a2e8bc8ab72a527c2f97b0b74c8d8fce6eab9
   languageName: node
   linkType: hard
 
@@ -12480,10 +12480,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jsonschema@npm:^1.4.0":
-  version: 1.5.0
-  resolution: "jsonschema@npm:1.5.0"
-  checksum: 10c0/c24ddb8d741f02efc0da3ad9b597a275f6b595062903d3edbfaa535c3f9c4c98613df68da5cb6635ed9aeab30d658986fea61d7662fc5b2b92840d5a1e21235e
+"jsonschema@npm:1.4.1":
+  version: 1.4.1
+  resolution: "jsonschema@npm:1.4.1"
+  checksum: 10c0/c3422d3fc7d33ff7234a806ffa909bb6fb5d1cd664bea229c64a1785dc04cbccd5fc76cf547c6ab6dd7881dbcaf3540a6a9f925a5956c61a9cd3e23a3c1796ef
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-14026

## Description

Added provider text-color computation (same logic family as Console: dark bg -> white text, light bg -> black text). Extended provider model with computed textColor.
Updated style generation so provider button styles include text color variable (--gv-button--c) alongside background variable when relevant.

1. Non-hex provider colors get forced black text — incomplete fix + narrow regression · Low · breaking-change: No

- **What:** A configured provider color that isn't 6-digit hex (#abc, darkblue, rgb(...)) is treated as "light" and gets forced black text, even on a dark background.
- **Where:** gravitee-apim-portal-webui/src/app/pages/login/login.component.ts:165 (if (!match) { return false; }) → :128 (colorIsDarkAdvanced(color) ? '#ffffff' : '#000000').
- **Why it matters:** An operator who sets a dark non-hex SSO button color sees an unreadable black-on-dark label. It's a regression for that input: the old code emitted no text-color variable, so gv-button fell back to its white default (readable); the new code forces black. Reachability is bounded — the console color picker enforces ^#[0-9a-f]{6}$, so this is only settable via direct REST API.
- **Fix:** Have getProviderTextColor return undefined (not #000000) when HEX_RGB_PATTERN doesn't match, so unparseable colors fall back to the component default instead of forced black.
- **Rule:** none.

## Additional context


https://github.com/user-attachments/assets/0de9a4eb-5b06-45cd-b233-ae284ab53e2b

