### PR TITLE
fix(logs): include metrics without entrypoint-id in logs search

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/log/adapter/connection/SearchMetricsQueryAdapter.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/log/adapter/connection/SearchMetricsQueryAdapter.java
@@ -127,8 +127,19 @@ public class SearchMetricsQueryAdapter {
 
     private static void addEntrypointIdsFilter(MetricsQuery.Filter filter, List<JsonObject> mustFilterList) {
         if (!CollectionUtils.isEmpty(filter.getEntrypointIds())) {
+            var termsFilter = JsonObject.of(
+                "terms",
+                JsonObject.of(RequestV2MetricsV4Fields.ENTRYPOINT_ID.v4Metrics(), filter.getEntrypointIds())
+            );
+            var fieldMissingFilter = JsonObject.of(
+                "bool",
+                JsonObject.of(
+                    "must_not",
+                    JsonObject.of("exists", JsonObject.of("field", RequestV2MetricsV4Fields.ENTRYPOINT_ID.v4Metrics()))
+                )
+            );
             mustFilterList.add(
-                JsonObject.of("terms", JsonObject.of(RequestV2MetricsV4Fields.ENTRYPOINT_ID.v4Metrics(), filter.getEntrypointIds()))
+                JsonObject.of("bool", JsonObject.of("should", JsonArray.of(termsFilter, fieldMissingFilter), "minimum_should_match", 1))
             );
         }
     }

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/log/adapter/connection/SearchMetricsQueryAdapterTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/log/adapter/connection/SearchMetricsQueryAdapterTest.java
@@ -497,25 +497,41 @@ class SearchMetricsQueryAdapterTest {
             Arguments.of(
                 MetricsQuery.Filter.builder().entrypointIds(Set.of("http-post", "http-get")).build(),
                 """
-                                         {
-                                             "from": 0,
-                                             "size": 20,
-                                             "query": {
-                                                 "bool": {
-                                                     "must": [
-                                                         {
-                                                             "terms": {
-                                                                 "entrypoint-id": ["http-post", "http-get"]
-                                                             }
-                                                         }
-                                                     ]
-                                                 }
-                                             },
-                                             "sort": [
-                                                 { "@timestamp": { "order": "desc" } },
-                                                 { "request-id": { "order": "asc", "unmapped_type": "keyword" } }
-                                             ]
-                                          }
+                {
+                    "from": 0,
+                    "size": 20,
+                    "query": {
+                        "bool": {
+                            "must": [
+                                {
+                                    "bool": {
+                                        "should": [
+                                            {
+                                                "terms": {
+                                                    "entrypoint-id": ["http-post", "http-get"]
+                                                }
+                                            },
+                                            {
+                                                "bool": {
+                                                    "must_not": {
+                                                        "exists": {
+                                                            "field": "entrypoint-id"
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        ],
+                                        "minimum_should_match": 1
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "sort": [
+                        { "@timestamp": { "order": "desc" } },
+                        { "request-id": { "order": "asc", "unmapped_type": "keyword" } }
+                    ]
+                }
                 """
             ),
             Arguments.of(
@@ -667,6 +683,99 @@ class SearchMetricsQueryAdapterTest {
                 .build();
 
             assertThat(hasTermsOn(query, RequestV2MetricsV4Fields.ERROR_KEY)).isFalse();
+        }
+    }
+
+    @Nested
+    class EntrypointIdsFilter {
+
+        @Test
+        void should_include_missing_entrypoint_fallback_when_entrypoint_ids_provided() {
+            var result = SearchMetricsQueryAdapter.adapt(
+                MetricsQuery.builder()
+                    .page(1)
+                    .size(20)
+                    .filter(MetricsQuery.Filter.builder().entrypointIds(Set.of("llm-proxy", "mcp-proxy")).build())
+                    .build()
+            );
+
+            assertThatJson(result)
+                .when(IGNORING_ARRAY_ORDER)
+                .isEqualTo(
+                    """
+                    {
+                        "from": 0,
+                        "size": 20,
+                        "query": {
+                            "bool": {
+                                "must": [
+                                    {
+                                        "bool": {
+                                            "should": [
+                                                {
+                                                    "terms": {
+                                                        "entrypoint-id": ["llm-proxy", "mcp-proxy"]
+                                                    }
+                                                },
+                                                {
+                                                    "bool": {
+                                                        "must_not": {
+                                                            "exists": {
+                                                                "field": "entrypoint-id"
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            ],
+                                            "minimum_should_match": 1
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "sort": [
+                            { "@timestamp": { "order": "desc" } },
+                            { "request-id": { "order": "asc", "unmapped_type": "keyword" } }
+                        ]
+                    }
+                    """
+                );
+        }
+
+        @Test
+        void should_not_add_entrypoint_filter_when_entrypoint_ids_null() {
+            var query = MetricsQuery.builder()
+                .page(1)
+                .size(20)
+                .filter(MetricsQuery.Filter.builder().apiIds(Set.of("api-1")).entrypointIds(null).build())
+                .build();
+
+            var result = new JsonObject(SearchMetricsQueryAdapter.adapt(query));
+            var mustClauses = result.getJsonObject("query").getJsonObject("bool").getJsonArray("must");
+            assertThat(
+                mustClauses
+                    .stream()
+                    .map(o -> (JsonObject) o)
+                    .noneMatch(clause -> clause.toString().contains("entrypoint-id"))
+            ).isTrue();
+        }
+
+        @Test
+        void should_not_add_entrypoint_filter_when_entrypoint_ids_empty() {
+            var query = MetricsQuery.builder()
+                .page(1)
+                .size(20)
+                .filter(MetricsQuery.Filter.builder().apiIds(Set.of("api-1")).entrypointIds(Set.of()).build())
+                .build();
+
+            var result = new JsonObject(SearchMetricsQueryAdapter.adapt(query));
+            var mustClauses = result.getJsonObject("query").getJsonObject("bool").getJsonArray("must");
+            assertThat(
+                mustClauses
+                    .stream()
+                    .map(o -> (JsonObject) o)
+                    .noneMatch(clause -> clause.toString().contains("entrypoint-id"))
+            ).isTrue();
         }
     }
 


### PR DESCRIPTION
## Summary

The logs search endpoint (`/logs/search`) excluded metrics documents where the `entrypoint-id` field was absent, causing a count mismatch with the analytics time-series endpoint which includes those documents via a fallback clause. This aligns both endpoints so the logs table count matches the analytics chart.

Refs [GMA-475](https://gravitee.atlassian.net/browse/GMA-475)

## Changes

- Replace the strict ES `terms` query on `entrypoint-id` in `SearchMetricsQueryAdapter.addEntrypointIdsFilter()` with a `bool.should` clause that matches requested entrypoint-id values **or** documents where the field is absent (mirrors `FilterAdapter.httpFilter()` pattern from analytics)
- Update the existing parameterized test to reflect the new query structure
- Add a dedicated `@Nested EntrypointIdsFilter` test class with 3 tests (fallback present, null guard, empty guard)

## Test plan

- [ ] Run `SearchMetricsQueryAdapterTest` — all 15 tests pass
- [ ] On an environment with LLM/MCP APIs that have pre-entrypoint failures, verify `/logs/search` with `ENTRYPOINT IN [llm-proxy, mcp-proxy, mcp]` now returns non-zero results matching the analytics time-series count
- [ ] Verify that logs with a populated `entrypoint-id` still appear correctly (no regression)
- [ ] Verify that logs search without any `ENTRYPOINT` filter is unaffected

[GMA-475]: https://gravitee.atlassian.net/browse/GMA-475?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ