### PR TITLE
chore(deps): bump gravitee-reactor-native-kafka to 7.0.0-alpha.20

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -309,7 +309,7 @@
         <gravitee-resource-schema-registry-embedded.version>1.0.0-alpha.1</gravitee-resource-schema-registry-embedded.version>
         <gravitee-resource-storage-azure-blob.version>1.1.0</gravitee-resource-storage-azure-blob.version>
         <gravitee-reactor-message.version>11.0.0-alpha.3</gravitee-reactor-message.version>
-        <gravitee-reactor-native-kafka.version>7.0.0-alpha.14</gravitee-reactor-native-kafka.version>
+        <gravitee-reactor-native-kafka.version>7.0.0-alpha.20</gravitee-reactor-native-kafka.version>
         <gravitee-reactor-mcp-proxy.version>3.0.0-feat-mcp-studio-schema-SNAPSHOT</gravitee-reactor-mcp-proxy.version>
         <gravitee-reactor-llm-proxy.version>3.0.0-alpha.6</gravitee-reactor-llm-proxy.version>
         <gravitee-reactor-a2a-proxy.version>1.0.0</gravitee-reactor-a2a-proxy.version>


### PR DESCRIPTION
## Summary
Bump `gravitee-reactor-native-kafka` from `7.0.0-alpha.14` → `7.0.0-alpha.20`.

Release notes: https://github.com/gravitee-io/gravitee-reactor-native-kafka/releases/tag/7.0.0-alpha.20

## Changes between alpha.14 and alpha.20
- `fix(virtualcluster)`: satisfy execution-context-logging archrule
- `refactor(virtualcluster)`: split `OFFSET_COMMIT`/`OFFSET_FETCH` out into `OffsetCommitFetchRouter`
- `refactor(virtualcluster)`: thread `execCtx` into multicluster handlers for ctx-bound logging
- `refactor(virtualcluster)`: thread `execCtx` into multiplex handlers
- `refactor(virtualcluster)`: thread `execCtx` through router fan-outs
- `refactor(virtualcluster)`: extract `MetadataServingService` from VCE
- `refactor(virtualcluster)`: centralize gateway-internal request framing
- `refactor(virtualcluster)`: isolate KIP-848 multiplex state in Consumer
- `chore(virtualcluster)`: prettier sweep across the refactoring branch

Full diff: https://github.com/gravitee-io/gravitee-reactor-native-kafka/compare/7.0.0-alpha.14...7.0.0-alpha.20

## Test plan
- [ ] CI build green
- [ ] Native Kafka integration tests pass