### PR TITLE
fix(authz): resolve AM IdP source name to id when syncing user entity…

### DIFF
--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/java/io/gravitee/gamma/authorization/infra/service_provider/AmSdkDirectoryClient.java
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/java/io/gravitee/gamma/authorization/infra/service_provider/AmSdkDirectoryClient.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.gamma.authorization.infra.service_provider;
 
+import io.gravitee.am.sdk.management.model.FilteredIdentityProviderInfo;
 import io.gravitee.am.sdk.management.model.Group;
 import io.gravitee.am.sdk.management.model.GroupPage;
 import io.gravitee.am.sdk.management.model.Role;
@@ -31,6 +32,8 @@ import io.gravitee.gamma.authorization.core.am.model.AmUserPage;
 import io.gravitee.gamma.authorization.core.am.service_provider.AmDirectoryClient;
 import io.gravitee.gamma.authorization.infra.service_provider.AmSdkDirectoryClientFactory.AmSdkApis;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 /**
  * AM SDK-backed {@link AmDirectoryClient}. Owns the SDK specifics — client construction, the
@@ -60,6 +63,10 @@ public class AmSdkDirectoryClient implements AmDirectoryClient {
         private final AmSdkApis apis;
         private final String domainId;
 
+        // IdP display name -> id, lazily loaded once per session. Reverses AM's management API,
+        // which overwrites a user's `source` (the IdP id) with the IdP name on the way out.
+        private Map<String, String> idpIdByName;
+
         private SdkSession(AmSdkApis apis, String domainId) {
             this.apis = apis;
             this.domainId = domainId;
@@ -70,12 +77,28 @@ public class AmSdkDirectoryClient implements AmDirectoryClient {
             UserPage userPage = AmSdkInvocations.await(
                 apis.userApi().listUsers(AM_DEFAULT_ORGANIZATION, AM_DEFAULT_ENVIRONMENT, domainId, null, null, page, size)
             );
+            Map<String, String> idpIds = idpIdByName();
             List<AmUser> users = (userPage.getData() == null ? List.<User>of() : userPage.getData())
                 .stream()
-                .map(AmSdkDirectoryClient::toAmUser)
+                .map(user -> toAmUser(user, idpIds))
                 .toList();
             long totalCount = userPage.getTotalCount() == null ? 0 : userPage.getTotalCount();
             return new AmUserPage(users, totalCount);
+        }
+
+        // The user `sub` AM issues hashes the IdP *id*, but listUsers returns the IdP *name* in
+        // `source`; map name -> id so the synced PRINCIPAL entity is keyed on the same value.
+        private Map<String, String> idpIdByName() {
+            if (idpIdByName == null) {
+                List<FilteredIdentityProviderInfo> idps = AmSdkInvocations.await(
+                    apis.identityProviderApi().listIdentityProviders(AM_DEFAULT_ORGANIZATION, AM_DEFAULT_ENVIRONMENT, domainId, null)
+                );
+                idpIdByName = (idps == null ? List.<FilteredIdentityProviderInfo>of() : idps)
+                    .stream()
+                    .filter(idp -> idp.getName() != null && idp.getId() != null)
+                    .collect(Collectors.toMap(FilteredIdentityProviderInfo::getName, FilteredIdentityProviderInfo::getId, (first, ignored) -> first));
+            }
+            return idpIdByName;
         }
 
         @Override
@@ -106,15 +129,19 @@ public class AmSdkDirectoryClient implements AmDirectoryClient {
 
         @Override
         public void close() {
-            // Release the underlying Vert.x WebClient pool shared by all three API facades.
+            // Release the underlying Vert.x WebClient pool shared by all the API facades.
             apis.apiClient().getWebClient().close();
         }
     }
 
-    static AmUser toAmUser(User user) {
+    static AmUser toAmUser(User user, Map<String, String> idpIdByName) {
+        // listUsers returns the IdP name in `source`; resolve it back to the IdP id so the entity
+        // matches AM's token `sub`. Fall back to the raw value when the IdP can't be resolved.
+        String source = user.getSource();
+        String sourceId = source == null ? null : idpIdByName.getOrDefault(source, source);
         return new AmUser(
             user.getId(),
-            user.getSource(),
+            sourceId,
             user.getExternalId(),
             user.getEmail(),
             user.getUsername(),

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/java/io/gravitee/gamma/authorization/infra/service_provider/AmSdkDirectoryClient.java
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/java/io/gravitee/gamma/authorization/infra/service_provider/AmSdkDirectoryClient.java
@@ -93,7 +93,7 @@ public class AmSdkDirectoryClient implements AmDirectoryClient {
                 List<FilteredIdentityProviderInfo> idps = AmSdkInvocations.await(
                     apis.identityProviderApi().listIdentityProviders(AM_DEFAULT_ORGANIZATION, AM_DEFAULT_ENVIRONMENT, domainId, null)
                 );
-                idpIdByName = stream(idps)
+                idpIdByName = idps.stream()
                     .filter(idp -> idp.getName() != null && idp.getId() != null)
                     .collect(Collectors.toMap(FilteredIdentityProviderInfo::getName, FilteredIdentityProviderInfo::getId, (first, ignored) -> first));
             }

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/java/io/gravitee/gamma/authorization/infra/service_provider/AmSdkDirectoryClient.java
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/java/io/gravitee/gamma/authorization/infra/service_provider/AmSdkDirectoryClient.java
@@ -93,8 +93,7 @@ public class AmSdkDirectoryClient implements AmDirectoryClient {
                 List<FilteredIdentityProviderInfo> idps = AmSdkInvocations.await(
                     apis.identityProviderApi().listIdentityProviders(AM_DEFAULT_ORGANIZATION, AM_DEFAULT_ENVIRONMENT, domainId, null)
                 );
-                idpIdByName = (idps == null ? List.<FilteredIdentityProviderInfo>of() : idps)
-                    .stream()
+                idpIdByName = stream(idps)
                     .filter(idp -> idp.getName() != null && idp.getId() != null)
                     .collect(Collectors.toMap(FilteredIdentityProviderInfo::getName, FilteredIdentityProviderInfo::getId, (first, ignored) -> first));
             }

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/java/io/gravitee/gamma/authorization/infra/service_provider/AmSdkDirectoryClientFactory.java
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/java/io/gravitee/gamma/authorization/infra/service_provider/AmSdkDirectoryClientFactory.java
@@ -22,6 +22,8 @@ import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import io.gravitee.am.sdk.management.api.GroupApi;
 import io.gravitee.am.sdk.management.api.GroupApiImpl;
+import io.gravitee.am.sdk.management.api.IdentityProviderApi;
+import io.gravitee.am.sdk.management.api.IdentityProviderApiImpl;
 import io.gravitee.am.sdk.management.api.RoleApi;
 import io.gravitee.am.sdk.management.api.RoleApiImpl;
 import io.gravitee.am.sdk.management.api.UserApi;
@@ -36,7 +38,7 @@ import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 
 /**
- * Builds the AM management API facades (user, group, role) from a stored {@link AmConnection},
+ * Builds the AM management API facades (user, group, role, identity provider) from a stored {@link AmConnection},
  * all sharing one {@link ApiClient} (and thus one Vert.x WebClient connection pool). No caching — a
  * sync opens one set per run (see {@code AmSdkDirectoryClient.openSession}) and closes the shared
  * client when done, so an updated connection takes effect on the next sync.
@@ -49,12 +51,24 @@ public class AmSdkDirectoryClientFactory {
         this.vertx = vertx;
     }
 
-    /** The three AM API facades for a connection plus the shared client that owns their HTTP pool. */
-    public record AmSdkApis(ApiClient apiClient, UserApi userApi, GroupApi groupApi, RoleApi roleApi) {}
+    /** The AM API facades for a connection plus the shared client that owns their HTTP pool. */
+    public record AmSdkApis(
+        ApiClient apiClient,
+        UserApi userApi,
+        GroupApi groupApi,
+        RoleApi roleApi,
+        IdentityProviderApi identityProviderApi
+    ) {}
 
     public AmSdkApis create(AmConnection connection) {
         ApiClient apiClient = buildApiClient(connection);
-        return new AmSdkApis(apiClient, new UserApiImpl(apiClient), new GroupApiImpl(apiClient), new RoleApiImpl(apiClient));
+        return new AmSdkApis(
+            apiClient,
+            new UserApiImpl(apiClient),
+            new GroupApiImpl(apiClient),
+            new RoleApiImpl(apiClient),
+            new IdentityProviderApiImpl(apiClient)
+        );
     }
 
     private ApiClient buildApiClient(AmConnection connection) {

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/test/java/io/gravitee/gamma/authorization/core/am/use_case/ComputeSubParameterTest.java
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/test/java/io/gravitee/gamma/authorization/core/am/use_case/ComputeSubParameterTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gamma.authorization.core.am.use_case;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.gamma.authorization.core.am.model.AmUser;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Pins down which inputs reproduce a real AM-issued token {@code sub}, using a live default-IdP user
+ * ({@code demo@gravitee.io}). The sub is {@code UUID.nameUUIDFromBytes("<idpId>:<externalId>")} — the
+ * IdP *id*, not the IdP *name* (which is what listUsers returns in {@code source}), and the user's
+ * {@code externalId}, not its {@code id}.
+ */
+class ComputeSubParameterTest {
+
+    private static final String USER_ID = "5846a39d-062d-4803-86a3-9d062d980384";
+    private static final String EXTERNAL_ID = "7dfafc00-a4aa-4ac5-bafc-00a4aa5ac58c";
+    private static final String SOURCE_ID = "default-idp-3e149b8b-f2b8-4d36-949b-8bf2b8ed362e";
+    private static final String SOURCE_NAME = "Default Identity Provider";
+    private static final String EXPECTED_SUB = "d5854721-cfee-3172-b040-94a319d11c36";
+
+    private static String hash(String input) {
+        return UUID.nameUUIDFromBytes(input.getBytes(StandardCharsets.UTF_8)).toString();
+    }
+
+    private static AmUser user(String source, String externalId) {
+        return new AmUser(USER_ID, source, externalId, null, "demo@gravitee.io", null, true, List.of(), List.of());
+    }
+
+    @Test
+    void idpId_colon_externalId_reproduces_the_real_sub() {
+        assertThat(hash(SOURCE_ID + ":" + EXTERNAL_ID)).isEqualTo(EXPECTED_SUB);
+        assertThat(SyncAmUsersUseCase.computeSub(user(SOURCE_ID, EXTERNAL_ID))).isEqualTo(EXPECTED_SUB);
+    }
+
+    @Test
+    void source_name_does_not_match() {
+        // The bug: hashing the IdP name (what listUsers puts in `source`) instead of the IdP id.
+        assertThat(SyncAmUsersUseCase.computeSub(user(SOURCE_NAME, EXTERNAL_ID))).isNotEqualTo(EXPECTED_SUB);
+    }
+
+    @Test
+    void hashing_the_user_id_instead_of_externalId_does_not_match() {
+        assertThat(SyncAmUsersUseCase.computeSub(user(SOURCE_ID, USER_ID))).isNotEqualTo(EXPECTED_SUB);
+    }
+
+    @Test
+    void null_externalId_does_not_match() {
+        // computeSub falls back to the raw user id when externalId is null.
+        assertThat(SyncAmUsersUseCase.computeSub(user(SOURCE_ID, null))).isNotEqualTo(EXPECTED_SUB);
+    }
+}

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/test/java/io/gravitee/gamma/authorization/infra/service_provider/AmSdkDirectoryClientTest.java
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/test/java/io/gravitee/gamma/authorization/infra/service_provider/AmSdkDirectoryClientTest.java
@@ -24,6 +24,7 @@ import io.gravitee.gamma.authorization.core.am.model.AmGroup;
 import io.gravitee.gamma.authorization.core.am.model.AmRole;
 import io.gravitee.gamma.authorization.core.am.model.AmUser;
 import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
@@ -38,7 +39,7 @@ class AmSdkDirectoryClientTest {
         user.setGroups(List.of("g-1", "g-2"));
         user.setRoles(List.of("r-1"));
 
-        AmUser mapped = AmSdkDirectoryClient.toAmUser(user);
+        AmUser mapped = AmSdkDirectoryClient.toAmUser(user, Map.of());
 
         assertThat(mapped.groups()).containsExactly("g-1", "g-2");
         assertThat(mapped.roles()).containsExactly("r-1");
@@ -49,10 +50,34 @@ class AmSdkDirectoryClientTest {
         User user = new User();
         user.setId("u-1");
 
-        AmUser mapped = AmSdkDirectoryClient.toAmUser(user);
+        AmUser mapped = AmSdkDirectoryClient.toAmUser(user, Map.of());
 
         assertThat(mapped.groups()).isEmpty();
         assertThat(mapped.roles()).isEmpty();
+    }
+
+    @Test
+    void resolves_source_name_back_to_the_idp_id() {
+        // listUsers returns the IdP *name* in `source`; the sync must key the entity on the IdP *id*
+        // so it matches AM's token `sub` (UUID of "idpId:externalId").
+        User user = new User();
+        user.setId("u-1");
+        user.setSource("Default Identity Provider");
+
+        AmUser mapped = AmSdkDirectoryClient.toAmUser(user, Map.of("Default Identity Provider", "default-idp-3e149b8b"));
+
+        assertThat(mapped.source()).isEqualTo("default-idp-3e149b8b");
+    }
+
+    @Test
+    void keeps_source_as_is_when_idp_name_is_not_in_the_map() {
+        User user = new User();
+        user.setId("u-1");
+        user.setSource("default-idp-3e149b8b");
+
+        AmUser mapped = AmSdkDirectoryClient.toAmUser(user, Map.of());
+
+        assertThat(mapped.source()).isEqualTo("default-idp-3e149b8b");
     }
 
     @Test


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/GMA-476

## Description

This pull request fixes a critical bug in how user identities are mapped from the AM management API, ensuring that the correct Identity Provider (IdP) ID is used instead of the IdP name when syncing users. This change guarantees that synced user entities match the `sub` field in AM-issued tokens, which is essential for correct authentication and authorization. The update also expands the AM SDK client to support fetching IdP information and adds comprehensive tests to verify the new behavior.

**Bug fix: Correct mapping of IdP name to IdP ID in user sync**

* The `AmSdkDirectoryClient` now lazily loads a map of IdP display names to IdP IDs, ensuring that when users are fetched, the `source` field is resolved back to the IdP ID (not just the name), so the computed user identifier matches the `sub` in AM tokens. [[1]](diffhunk://#diff-d70b39d8b0807b1442d8314efaa1b7590109a3f88974be2c8761489ab10b61e2R66-R69) [[2]](diffhunk://#diff-d70b39d8b0807b1442d8314efaa1b7590109a3f88974be2c8761489ab10b61e2R80-R102) [[3]](diffhunk://#diff-d70b39d8b0807b1442d8314efaa1b7590109a3f88974be2c8761489ab10b61e2L109-R143)

**SDK client enhancements**

* The `AmSdkDirectoryClientFactory` and its `AmSdkApis` record are updated to include the `IdentityProviderApi`, enabling the client to fetch IdP information needed for the mapping. [[1]](diffhunk://#diff-3c40589b86481d4a5ebc6a1998ef3c0f1d3d7985b2f0bc0d5c62d4a082340bd2R25-R26) [[2]](diffhunk://#diff-3c40589b86481d4a5ebc6a1998ef3c0f1d3d7985b2f0bc0d5c62d4a082340bd2L39-R41) [[3]](diffhunk://#diff-3c40589b86481d4a5ebc6a1998ef3c0f1d3d7985b2f0bc0d5c62d4a082340bd2L52-R71)

**Testing improvements**

* A new test class, `ComputeSubParameterTest`, is added to pin down the logic for reproducing real AM-issued token `sub` values, verifying that the correct IdP ID and external user ID are used in the hash computation.
* Existing tests for user mapping are updated to use the new `toAmUser` signature, and new tests are added to verify the correct resolution of IdP names to IDs and fallback behavior when the mapping is missing. [[1]](diffhunk://#diff-fbd56a97f8862d4f82a3d0c4318fc9a4bda7d126234c34f336307f8d26bd3322R27) [[2]](diffhunk://#diff-fbd56a97f8862d4f82a3d0c4318fc9a4bda7d126234c34f336307f8d26bd3322L41-R42) [[3]](diffhunk://#diff-fbd56a97f8862d4f82a3d0c4318fc9a4bda7d126234c34f336307f8d26bd3322L52-R82)

These changes ensure that user synchronization is robust and consistent with AM's token issuance, preventing subtle bugs in authentication flows.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

