### PR TITLE
chore(deps): bump gravitee-policy-kafka-topic-mapping to 2.0.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -320,7 +320,7 @@
         <gravitee-service-secrets.version>3.0.1</gravitee-service-secrets.version>
         <gravitee-policy-interops.version>1.1.3</gravitee-policy-interops.version>
         <gravitee-policy-kafka-quota.version>1.2.1</gravitee-policy-kafka-quota.version>
-        <gravitee-policy-kafka-topic-mapping.version>2.0.0</gravitee-policy-kafka-topic-mapping.version>
+        <gravitee-policy-kafka-topic-mapping.version>2.0.1</gravitee-policy-kafka-topic-mapping.version>
         <gravitee-policy-kafka-acl.version>3.0.1</gravitee-policy-kafka-acl.version>
         <gravitee-policy-kafka-transform-key.version>1.0.0</gravitee-policy-kafka-transform-key.version>
         <gravitee-policy-kafka-message-filtering.version>1.0.0</gravitee-policy-kafka-message-filtering.version>


### PR DESCRIPTION
Bumps gravitee-policy-kafka-topic-mapping from 2.0.0 to 2.0.1.