### PR TITLE
feat(service): add ApplicationInvitationAction to AcceptUserInvitationUseCase

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/mapper/FinalizeRegistrationMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/mapper/FinalizeRegistrationMapper.java
@@ -16,6 +16,7 @@
 package io.gravitee.rest.api.portal.rest.mapper;
 
 import io.gravitee.apim.core.invitation.use_case.AcceptUserInvitationUseCase;
+import io.gravitee.apim.core.invitation.use_case.AcceptUserInvitationUseCase.ApplicationInvitationAction;
 import io.gravitee.apim.core.invitation.use_case.AcceptUserInvitationUseCase.GroupInvitationAction;
 import io.gravitee.apim.core.invitation.use_case.AcceptUserInvitationUseCase.UserRegistrationAction;
 import io.gravitee.apim.core.user.model.DecodedToken;
@@ -34,9 +35,17 @@ public class FinalizeRegistrationMapper {
         DecodedToken decoded,
         FinalizeRegistrationInput input
     ) {
-        var action = JWTHelper.ACTION.GROUP_INVITATION.name().equals(decoded.action())
-            ? new GroupInvitationAction(decoded.email(), decoded.subject())
-            : new UserRegistrationAction(decoded.email(), decoded.subject());
+        var action = switch (decoded.action()) {
+            case String s when JWTHelper.ACTION.GROUP_INVITATION.name().equals(s) -> new GroupInvitationAction(
+                decoded.email(),
+                decoded.subject()
+            );
+            case String s when JWTHelper.ACTION.APPLICATION_INVITATION.name().equals(s) -> new ApplicationInvitationAction(
+                decoded.email(),
+                decoded.subject()
+            );
+            default -> new UserRegistrationAction(decoded.email(), decoded.subject());
+        };
 
         return new AcceptUserInvitationUseCase.Input(
             executionContext,

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/UsersResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/UsersResourceTest.java
@@ -309,6 +309,22 @@ public class UsersResourceTest extends AbstractResourceTest {
     }
 
     @Test
+    public void should_finalize_registration_for_application_invitation_action() {
+        var input = new FinalizeRegistrationInput().token("my-jwt").password("P4s5vv0Rd").firstname("John").lastname("Doe");
+        var decoded = new DecodedToken(JWTHelper.ACTION.APPLICATION_INVITATION.name(), "user@example.com", Optional.of("user-id"));
+        var user = BaseUserEntity.builder().id("user-id").email("user@example.com").build();
+
+        doReturn(decoded).when(registrationTokenService).decode("my-jwt");
+        doReturn(new AcceptUserInvitationUseCase.Output(user)).when(acceptUserInvitationUseCase).execute(any());
+        doReturn(new io.gravitee.rest.api.portal.rest.model.User()).when(userMapper).convert(any(UserEntity.class));
+
+        final Response response = target("registration/_finalize").request().post(Entity.json(input));
+
+        assertEquals(HttpStatusCode.OK_200, response.getStatus());
+        verify(acceptUserInvitationUseCase).execute(any());
+    }
+
+    @Test
     public void should_return_conflict_when_reset_password_action() {
         var input = new FinalizeRegistrationInput().token("my-jwt").password("P4s5vv0Rd").firstname("John").lastname("Doe");
         var decoded = new DecodedToken(JWTHelper.ACTION.RESET_PASSWORD.name(), "user@example.com", Optional.empty());

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/invitation/use_case/AcceptUserInvitationUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/invitation/use_case/AcceptUserInvitationUseCase.java
@@ -63,7 +63,7 @@ public class AcceptUserInvitationUseCase {
                 userRegistrationEnabledService.checkEnabled(input.executionContext());
                 yield List.<Invitation>of();
             }
-            case GroupInvitationAction a -> {
+            case InvitationBasedAction a -> {
                 var invitations = invitationCrudService.findByEmail(a.email());
                 if (invitations.isEmpty()) {
                     throw new InvitationCanceledException(a.email());
@@ -87,7 +87,7 @@ public class AcceptUserInvitationUseCase {
 
         switch (input.action()) {
             case UserRegistrationAction ignored -> {}
-            case GroupInvitationAction ignored -> pendingInvitations.forEach(invitation ->
+            case InvitationBasedAction ignored -> pendingInvitations.forEach(invitation ->
                 processInvitation(input.executionContext(), invitation, user.getId())
             );
         }
@@ -129,15 +129,19 @@ public class AcceptUserInvitationUseCase {
         invitationCrudService.delete(invitation.id());
     }
 
-    public sealed interface Action permits UserRegistrationAction, GroupInvitationAction {
+    public sealed interface Action permits UserRegistrationAction, InvitationBasedAction {
         String email();
 
         Optional<String> existingUserId();
     }
 
+    public sealed interface InvitationBasedAction extends Action permits GroupInvitationAction, ApplicationInvitationAction {}
+
     public record UserRegistrationAction(String email, Optional<String> existingUserId) implements Action {}
 
-    public record GroupInvitationAction(String email, Optional<String> existingUserId) implements Action {}
+    public record GroupInvitationAction(String email, Optional<String> existingUserId) implements InvitationBasedAction {}
+
+    public record ApplicationInvitationAction(String email, Optional<String> existingUserId) implements InvitationBasedAction {}
 
     public record Input(
         ExecutionContext executionContext,

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/common/JWTHelper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/common/JWTHelper.java
@@ -24,6 +24,7 @@ public interface JWTHelper {
         RESET_PASSWORD,
         USER_REGISTRATION,
         GROUP_INVITATION,
+        APPLICATION_INVITATION,
         USER_CREATION,
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/invitation/use_case/AcceptUserInvitationUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/invitation/use_case/AcceptUserInvitationUseCaseTest.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.apim.core.invitation.use_case;
 
+import static fixtures.core.model.ApplicationInvitationFixtures.anApplicationInvitation;
 import static fixtures.core.model.BaseUserEntityFixtures.aBaseUserEntity;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -32,6 +33,7 @@ import io.gravitee.apim.core.audit.model.AuditProperties;
 import io.gravitee.apim.core.invitation.exception.InvitationCanceledException;
 import io.gravitee.apim.core.invitation.model.GroupInvitation;
 import io.gravitee.apim.core.invitation.model.InvitationId;
+import io.gravitee.apim.core.invitation.use_case.AcceptUserInvitationUseCase.ApplicationInvitationAction;
 import io.gravitee.apim.core.invitation.use_case.AcceptUserInvitationUseCase.GroupInvitationAction;
 import io.gravitee.apim.core.invitation.use_case.AcceptUserInvitationUseCase.UserRegistrationAction;
 import io.gravitee.apim.core.user.model.EncodedPassword;
@@ -42,6 +44,7 @@ import io.gravitee.apim.infra.domain_service.user.UserPasswordServiceImpl;
 import io.gravitee.apim.infra.domain_service.user.UserPortalNotificationServiceImpl;
 import io.gravitee.apim.infra.domain_service.user.UserRegistrationEnabledServiceImpl;
 import io.gravitee.apim.infra.json.jackson.JacksonJsonDiffProcessor;
+import io.gravitee.rest.api.model.MembershipReferenceType;
 import io.gravitee.rest.api.model.parameters.Key;
 import io.gravitee.rest.api.model.parameters.ParameterReferenceType;
 import io.gravitee.rest.api.service.NotifierService;
@@ -459,6 +462,104 @@ class AcceptUserInvitationUseCaseTest extends AbstractUseCaseTest {
                     new AcceptUserInvitationUseCase.Input(
                         executionContext,
                         new GroupInvitationAction(USER_EMAIL, Optional.empty()),
+                        Optional.empty(),
+                        Optional.empty(),
+                        Optional.empty()
+                    )
+                )
+            )
+                .isInstanceOf(InvitationCanceledException.class)
+                .hasMessageContaining("user@example.com");
+        }
+    }
+
+    @Nested
+    class ApplicationInvitationAction_Tests {
+
+        @Test
+        void should_create_new_user_and_accept_application_invitation() {
+            var invitation = anApplicationInvitation("00000000-0000-0000-0000-000000000001", "app-1", USER_EMAIL, "USER");
+            invitationCrudService.initWith(List.of(invitation));
+
+            var output = cut.execute(
+                new AcceptUserInvitationUseCase.Input(
+                    executionContext,
+                    new ApplicationInvitationAction(USER_EMAIL, Optional.empty()),
+                    Optional.empty(),
+                    Optional.empty(),
+                    Optional.empty()
+                )
+            );
+
+            assertThat(output.user().getId()).isEqualTo(GENERATED_UUID);
+            assertThat(invitationCrudService.storage()).isEmpty();
+            assertThat(membershipDomainService.storage())
+                .hasSize(1)
+                .first()
+                .satisfies(m -> {
+                    assertThat(m.getReferenceType()).isEqualTo(MembershipReferenceType.APPLICATION);
+                    assertThat(m.getReferenceId()).isEqualTo("app-1");
+                    assertThat(m.getId()).isEqualTo(GENERATED_UUID);
+                });
+            verify(notifierService).trigger(eq(executionContext), eq(PortalHook.USER_REGISTERED), any());
+        }
+
+        @Test
+        void should_accept_multiple_application_invitations() {
+            var inv1 = anApplicationInvitation("00000000-0000-0000-0000-000000000001", "app-1", USER_EMAIL, "USER");
+            var inv2 = anApplicationInvitation("00000000-0000-0000-0000-000000000002", "app-2", USER_EMAIL, "OWNER");
+            invitationCrudService.initWith(List.of(inv1, inv2));
+
+            cut.execute(
+                new AcceptUserInvitationUseCase.Input(
+                    executionContext,
+                    new ApplicationInvitationAction(USER_EMAIL, Optional.empty()),
+                    Optional.empty(),
+                    Optional.empty(),
+                    Optional.empty()
+                )
+            );
+
+            assertThat(invitationCrudService.storage()).isEmpty();
+            assertThat(membershipDomainService.storage())
+                .hasSize(2)
+                .allSatisfy(m -> assertThat(m.getReferenceType()).isEqualTo(MembershipReferenceType.APPLICATION));
+        }
+
+        @Test
+        void should_finalize_existing_user_and_accept_application_invitation() {
+            var invitation = anApplicationInvitation("00000000-0000-0000-0000-000000000001", "app-1", USER_EMAIL, "USER");
+            invitationCrudService.initWith(List.of(invitation));
+            var existingUser = aBaseUserEntity(EXISTING_USER_ID, USER_EMAIL);
+            userCrudService.initWith(List.of(existingUser));
+            when(passwordValidator.validate(RAW_PASSWORD.value())).thenReturn(true);
+
+            var output = cut.execute(
+                new AcceptUserInvitationUseCase.Input(
+                    executionContext,
+                    new ApplicationInvitationAction(USER_EMAIL, Optional.of(EXISTING_USER_ID)),
+                    Optional.of(RAW_PASSWORD),
+                    Optional.empty(),
+                    Optional.empty()
+                )
+            );
+
+            assertThat(output.user().getId()).isEqualTo(EXISTING_USER_ID);
+            assertThat(invitationCrudService.storage()).isEmpty();
+            assertThat(userCrudService.getStoredPassword(EXISTING_USER_ID)).isPresent();
+            assertThat(membershipDomainService.storage())
+                .hasSize(1)
+                .first()
+                .satisfies(m -> assertThat(m.getReferenceType()).isEqualTo(MembershipReferenceType.APPLICATION));
+        }
+
+        @Test
+        void should_throw_when_no_pending_invitations() {
+            assertThatThrownBy(() ->
+                cut.execute(
+                    new AcceptUserInvitationUseCase.Input(
+                        executionContext,
+                        new ApplicationInvitationAction(USER_EMAIL, Optional.empty()),
                         Optional.empty(),
                         Optional.empty(),
                         Optional.empty()


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-14130

## Description

- Added `APPLICATION_INVITATION` to `JWTHelper.ACTION` to distinguish application invitation tokens from group invitation tokens
- Introduced `InvitationBasedAction` sealed sub-interface (`extends Action`, permits `GroupInvitationAction` and `ApplicationInvitationAction`); both use-case switch blocks now pattern-match on `InvitationBasedAction` to avoid duplication
- Updated `FinalizeRegistrationMapper` to route `APPLICATION_INVITATION` JWT action → `ApplicationInvitationAction`, `GROUP_INVITATION` → `GroupInvitationAction`, anything else → `UserRegistrationAction`
- Added `ApplicationInvitationAction_Tests` (4 tests) in `AcceptUserInvitationUseCaseTest` and one portal `UsersResourceTest` case for the new action