### PR TITLE
feat(rest-api): PATCH endpoint for partial v4 HTTP Proxy plan updates

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/java/io/gravitee/apim/rest/api/automation/spring/RestAutomationConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/java/io/gravitee/apim/rest/api/automation/spring/RestAutomationConfiguration.java
@@ -17,9 +17,11 @@ package io.gravitee.apim.rest.api.automation.spring;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.gravitee.apim.core.api.use_case.PatchApiUseCase.ApiV4Deserializer;
+import io.gravitee.apim.core.plan.use_case.PatchPlanUseCase.PlanFlowsConverter;
 import io.gravitee.apim.infra.spring.UsecaseSpringConfiguration;
 import io.gravitee.el.ExpressionLanguageInitializer;
 import io.gravitee.rest.api.management.v2.rest.adapter.PatchApiV4Deserializer;
+import io.gravitee.rest.api.management.v2.rest.adapter.PatchPlanFlowsDeserializer;
 import io.gravitee.rest.api.service.spring.ServiceConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -38,6 +40,11 @@ public class RestAutomationConfiguration {
     @Bean
     public ApiV4Deserializer apiV4Deserializer(ObjectMapper objectMapper) {
         return new PatchApiV4Deserializer(objectMapper);
+    }
+
+    @Bean
+    public PlanFlowsConverter planFlowsDeserializer(ObjectMapper objectMapper) {
+        return new PatchPlanFlowsDeserializer(objectMapper);
     }
 
     @Bean

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/spring/ResourceContextConfiguration.java
@@ -138,6 +138,7 @@ import io.gravitee.apim.core.plan.domain_service.PlanSynchronizationService;
 import io.gravitee.apim.core.plan.domain_service.UpdatePlanDomainService;
 import io.gravitee.apim.core.plan.domain_service.ValidatePlanDomainService;
 import io.gravitee.apim.core.plan.query_service.PlanSearchQueryService;
+import io.gravitee.apim.core.plan.use_case.PatchPlanUseCase.PlanFlowsConverter;
 import io.gravitee.apim.core.plugin.crud_service.PolicyPluginCrudService;
 import io.gravitee.apim.core.plugin.domain_service.EndpointConnectorPluginDomainService;
 import io.gravitee.apim.core.policy.domain_service.PolicyValidationDomainService;
@@ -214,6 +215,7 @@ import io.gravitee.node.api.license.LicenseManager;
 import io.gravitee.repository.management.api.ApiRepository;
 import io.gravitee.repository.management.api.ApplicationRepository;
 import io.gravitee.rest.api.management.v2.rest.adapter.PatchApiV4Deserializer;
+import io.gravitee.rest.api.management.v2.rest.adapter.PatchPlanFlowsDeserializer;
 import io.gravitee.rest.api.service.ApiDuplicatorService;
 import io.gravitee.rest.api.service.ApiKeyService;
 import io.gravitee.rest.api.service.ApiMetadataService;
@@ -261,6 +263,11 @@ public class ResourceContextConfiguration {
     @Bean
     public ApiV4Deserializer apiV4Deserializer(ObjectMapper objectMapper) {
         return new PatchApiV4Deserializer(objectMapper);
+    }
+
+    @Bean
+    public PlanFlowsConverter planFlowsDeserializer(ObjectMapper objectMapper) {
+        return new PatchPlanFlowsDeserializer(objectMapper);
     }
 
     @Bean

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/adapter/PatchApiV4Deserializer.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/adapter/PatchApiV4Deserializer.java
@@ -28,6 +28,9 @@ import io.gravitee.rest.api.management.v2.rest.model.GenericApi;
 import java.io.IOException;
 import java.util.List;
 
+/**
+ * @author GraviteeSource Team
+ */
 public class PatchApiV4Deserializer implements ApiV4Deserializer {
 
     private static final List<String> POLYMORPHIC_LIST_FIELDS = List.of("listeners", "endpointGroups", "flows", "resources");

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/adapter/PatchPlanFlowsDeserializer.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/adapter/PatchPlanFlowsDeserializer.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.management.v2.rest.adapter;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.gravitee.apim.core.exception.ValidationDomainException;
+import io.gravitee.apim.core.plan.use_case.PatchPlanUseCase.PlanFlowsConverter;
+import io.gravitee.definition.model.v4.flow.Flow;
+import io.gravitee.rest.api.management.v2.rest.mapper.FlowMapper;
+import io.gravitee.rest.api.management.v2.rest.model.FlowV4;
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * @author GraviteeSource Team
+ */
+public class PatchPlanFlowsDeserializer implements PlanFlowsConverter {
+
+    private final ObjectMapper objectMapper;
+
+    public PatchPlanFlowsDeserializer(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    public JsonNode toCurrentFlowsNode(List<Flow> flows) {
+        return objectMapper.valueToTree(FlowMapper.INSTANCE.mapFromHttpV4(flows));
+    }
+
+    @Override
+    public List<Flow> fromPatchedFlowsNode(JsonNode flowsNode) {
+        try {
+            var restFlows = objectMapper.readerForListOf(FlowV4.class).<List<FlowV4>>readValue(flowsNode);
+            return FlowMapper.INSTANCE.mapToHttpV4(restFlows);
+        } catch (IOException e) {
+            throw new ValidationDomainException("Invalid value for field 'flows': " + e.getMessage(), e);
+        }
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/AbstractResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/AbstractResource.java
@@ -21,6 +21,7 @@ import static io.gravitee.rest.api.model.MembershipReferenceType.GROUP;
 
 import io.gravitee.apim.core.audit.model.AuditActor;
 import io.gravitee.apim.core.audit.model.AuditInfo;
+import io.gravitee.apim.core.utils.StringUtils;
 import io.gravitee.rest.api.idp.api.authentication.UserDetails;
 import io.gravitee.rest.api.management.v2.rest.model.Links;
 import io.gravitee.rest.api.management.v2.rest.pagination.PaginationLinks;
@@ -292,25 +293,53 @@ public abstract class AbstractResource {
     }
 
     protected void evaluateIfMatch(final HttpHeaders headers, final String etagValue) {
+        evaluateIfMatch(headers, etagValue, false);
+    }
+
+    protected void evaluateIfMatchStrictly(final HttpHeaders headers, final String etagValue) {
+        evaluateIfMatch(headers, etagValue, true);
+    }
+
+    private void evaluateIfMatch(final HttpHeaders headers, final String etagValue, final boolean strict) {
         String ifMatch = headers.getHeaderString(HttpHeaders.IF_MATCH);
 
-        if (Objects.nonNull(ifMatch) && !ifMatch.isEmpty()) {
-            // Handle case for -gzip appended automatically (and sadly) by Apache
-            ifMatch = ifMatch.replaceAll("-gzip", "");
+        if (StringUtils.isEmpty(ifMatch)) {
+            return;
+        }
+        // If-Match: * matches any tag; resource existence is the caller's responsibility.
+        if (strict && "*".equals(ifMatch)) {
+            return;
+        }
 
-            Set<MatchingEntityTag> matchingTags;
-            try {
-                matchingTags = HttpHeaderReader.readMatchingEntityTag(ifMatch);
-            } catch (java.text.ParseException e) {
-                return;
+        // Handle case for -gzip appended automatically (and sadly) by Apache.
+        // Weak validators (W/"...") are accepted as-is: with epoch-millis ETags every comparison is byte-identical,
+        // so the RFC 7232 strong-comparison distinction has no practical effect here.
+        var normalizedIfMatch = ifMatch.replace("-gzip", "");
+
+        Set<MatchingEntityTag> matchingTags;
+        try {
+            matchingTags = HttpHeaderReader.readMatchingEntityTag(normalizedIfMatch);
+        } catch (java.text.ParseException e) {
+            if (strict) {
+                throw new PreconditionFailedException(e);
             }
+            log.debug("Ignoring unparseable If-Match header '{}' on non-strict precondition path", ifMatch);
+            return;
+        }
 
-            MatchingEntityTag ifMatchHeader = matchingTags.iterator().next();
-            EntityTag eTag = new EntityTag(etagValue, ifMatchHeader.isWeak());
-
-            if (matchingTags != MatchingEntityTag.ANY_MATCH && !matchingTags.contains(eTag)) {
+        if (matchingTags.isEmpty()) {
+            if (strict) {
                 throw new PreconditionFailedException();
             }
+            log.debug("Ignoring If-Match header '{}' resolving to an empty tag set on non-strict precondition path", ifMatch);
+            return;
+        }
+
+        var ifMatchHeader = matchingTags.iterator().next();
+        var eTag = new EntityTag(etagValue, ifMatchHeader.isWeak());
+
+        if (matchingTags != MatchingEntityTag.ANY_MATCH && !matchingTags.contains(eTag)) {
+            throw new PreconditionFailedException();
         }
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiPlansResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiPlansResource.java
@@ -20,6 +20,7 @@ import static java.util.Comparator.comparingInt;
 import io.gravitee.apim.core.audit.model.AuditActor;
 import io.gravitee.apim.core.audit.model.AuditInfo;
 import io.gravitee.apim.core.plan.use_case.CreatePlanUseCase;
+import io.gravitee.apim.core.plan.use_case.PatchPlanUseCase;
 import io.gravitee.apim.core.plan.use_case.UpdateFederatedPlanUseCase;
 import io.gravitee.apim.core.plan.use_case.UpdatePlanUseCase;
 import io.gravitee.apim.core.subscription.model.SubscriptionEntity;
@@ -57,6 +58,7 @@ import io.gravitee.rest.api.service.GroupService;
 import io.gravitee.rest.api.service.common.ExecutionContext;
 import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.exceptions.GroupNotFoundException;
+import io.gravitee.rest.api.service.exceptions.PreconditionFailedException;
 import io.gravitee.rest.api.service.v4.PlanSearchService;
 import io.gravitee.rest.api.service.v4.PlanService;
 import jakarta.annotation.Nonnull;
@@ -68,15 +70,19 @@ import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.DELETE;
 import jakarta.ws.rs.DefaultValue;
 import jakarta.ws.rs.GET;
+import jakarta.ws.rs.PATCH;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.PUT;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.Response;
 import java.util.Date;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -91,11 +97,19 @@ public class ApiPlansResource extends AbstractResource {
     private static final Logger log = NodeLoggerFactory.getLogger(ApiPlansResource.class);
     private static final String FLOW = "flow";
 
+    private static final jakarta.ws.rs.core.MediaType JSON_PATCH_MEDIA_TYPE = new jakarta.ws.rs.core.MediaType(
+        "application",
+        "json-patch+json"
+    );
+
     private final PlanMapper planMapper = PlanMapper.INSTANCE;
     private final FlowMapper flowMapper = FlowMapper.INSTANCE;
 
     @Inject
     private PlanService planServiceV4;
+
+    @Inject
+    private PatchPlanUseCase patchPlanUseCase;
 
     @Inject
     private CreatePlanUseCase createPlanUseCase;
@@ -238,10 +252,7 @@ public class ApiPlansResource extends AbstractResource {
         final ExecutionContext executionContext = GraviteeContext.getExecutionContext();
         final GenericPlanEntity planEntity = planSearchService.findById(executionContext, planId);
 
-        if (
-            GenericPlanEntity.ReferenceType.API.equals(planEntity.getReferenceType()) &&
-            !java.util.Objects.equals(apiId, planEntity.getReferenceId())
-        ) {
+        if (planDoesNotBelongToApi(planEntity)) {
             return Response.status(Response.Status.NOT_FOUND).entity(planNotFoundError(planId)).build();
         }
 
@@ -270,10 +281,7 @@ public class ApiPlansResource extends AbstractResource {
         final ExecutionContext executionContext = GraviteeContext.getExecutionContext();
         final GenericPlanEntity planEntity = planSearchService.findById(executionContext, planId);
 
-        if (
-            GenericPlanEntity.ReferenceType.API.equals(planEntity.getReferenceType()) &&
-            !java.util.Objects.equals(apiId, planEntity.getReferenceId())
-        ) {
+        if (planDoesNotBelongToApi(planEntity)) {
             return Response.status(Response.Status.NOT_FOUND).entity(planNotFoundError(planId)).build();
         }
 
@@ -332,6 +340,65 @@ public class ApiPlansResource extends AbstractResource {
         };
     }
 
+    @PATCH
+    @Path("/{planId}")
+    @Consumes({ MediaType.APPLICATION_JSON, "application/merge-patch+json", "application/json-patch+json" })
+    @Produces(MediaType.APPLICATION_JSON)
+    @Permissions({ @Permission(value = RolePermission.API_PLAN, acls = { RolePermissionAction.UPDATE }) })
+    public Response patchApiPlan(
+        @PathParam("planId") String planId,
+        @QueryParam("dryRun") @DefaultValue("false") boolean dryRun,
+        @Context HttpHeaders headers,
+        String body
+    ) {
+        final ExecutionContext executionContext = GraviteeContext.getExecutionContext();
+        final GenericPlanEntity planEntity = planSearchService.findById(executionContext, planId);
+
+        if (planDoesNotBelongToApi(planEntity)) {
+            return Response.status(Response.Status.NOT_FOUND).entity(planNotFoundError(planId)).build();
+        }
+
+        Date precondition = resolvePlanUpdatedAt(planEntity);
+        if (precondition != null) {
+            evaluateIfMatchStrictly(headers, Long.toString(precondition.getTime()));
+        } else {
+            String ifMatch = headers.getHeaderString(HttpHeaders.IF_MATCH);
+            if (ifMatch != null && !ifMatch.isEmpty() && !"*".equals(ifMatch)) {
+                throw new PreconditionFailedException();
+            }
+        }
+
+        var plan = patchPlanUseCase
+            .execute(
+                PatchPlanUseCase.Input.builder()
+                    .apiId(apiId)
+                    .planId(planId)
+                    .patchType(resolvePatchType(headers))
+                    .patchBody(body)
+                    .dryRun(dryRun)
+                    .auditInfo(getAuditInfo())
+                    .build()
+            )
+            .plan();
+
+        var planV4 = planMapper.map(plan);
+        var updatedAt = plan.getUpdatedAt();
+        return applyCacheHeaders(Response.ok(planV4), updatedAt == null ? null : Date.from(updatedAt.toInstant())).build();
+    }
+
+    private PatchPlanUseCase.PatchType resolvePatchType(HttpHeaders headers) {
+        var contentType = headers.getMediaType();
+        return contentType != null && JSON_PATCH_MEDIA_TYPE.isCompatible(contentType)
+            ? PatchPlanUseCase.PatchType.JSON_PATCH
+            : PatchPlanUseCase.PatchType.MERGE_PATCH;
+    }
+
+    private boolean planDoesNotBelongToApi(GenericPlanEntity planEntity) {
+        return (
+            GenericPlanEntity.ReferenceType.API.equals(planEntity.getReferenceType()) && !Objects.equals(apiId, planEntity.getReferenceId())
+        );
+    }
+
     @DELETE
     @Path("/{planId}")
     @Produces(MediaType.APPLICATION_JSON)
@@ -340,10 +407,7 @@ public class ApiPlansResource extends AbstractResource {
         final ExecutionContext executionContext = GraviteeContext.getExecutionContext();
         final GenericPlanEntity planEntity = planSearchService.findById(executionContext, planId);
 
-        if (
-            GenericPlanEntity.ReferenceType.API.equals(planEntity.getReferenceType()) &&
-            !java.util.Objects.equals(apiId, planEntity.getReferenceId())
-        ) {
+        if (planDoesNotBelongToApi(planEntity)) {
             return Response.status(Response.Status.NOT_FOUND).entity(planNotFoundError(planId)).build();
         }
 
@@ -360,10 +424,7 @@ public class ApiPlansResource extends AbstractResource {
         final ExecutionContext executionContext = GraviteeContext.getExecutionContext();
         final GenericPlanEntity planEntity = planSearchService.findById(executionContext, planId);
 
-        if (
-            GenericPlanEntity.ReferenceType.API.equals(planEntity.getReferenceType()) &&
-            !java.util.Objects.equals(apiId, planEntity.getReferenceId())
-        ) {
+        if (planDoesNotBelongToApi(planEntity)) {
             return Response.status(Response.Status.NOT_FOUND).entity(planNotFoundError(planId)).build();
         }
 
@@ -378,10 +439,7 @@ public class ApiPlansResource extends AbstractResource {
         final ExecutionContext executionContext = GraviteeContext.getExecutionContext();
         final GenericPlanEntity planEntity = planSearchService.findById(executionContext, planId);
 
-        if (
-            GenericPlanEntity.ReferenceType.API.equals(planEntity.getReferenceType()) &&
-            !java.util.Objects.equals(apiId, planEntity.getReferenceId())
-        ) {
+        if (planDoesNotBelongToApi(planEntity)) {
             return Response.status(Response.Status.NOT_FOUND).entity(planNotFoundError(planId)).build();
         }
 
@@ -400,10 +458,7 @@ public class ApiPlansResource extends AbstractResource {
         final ExecutionContext executionContext = GraviteeContext.getExecutionContext();
         final GenericPlanEntity planEntity = planSearchService.findById(executionContext, planId);
 
-        if (
-            GenericPlanEntity.ReferenceType.API.equals(planEntity.getReferenceType()) &&
-            !java.util.Objects.equals(apiId, planEntity.getReferenceId())
-        ) {
+        if (planDoesNotBelongToApi(planEntity)) {
             return Response.status(Response.Status.NOT_FOUND).entity(planNotFoundError(planId)).build();
         }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource.java
@@ -135,7 +135,6 @@ import io.gravitee.rest.api.service.exceptions.ApiNotFoundException;
 import io.gravitee.rest.api.service.exceptions.ForbiddenAccessException;
 import io.gravitee.rest.api.service.exceptions.ForbiddenFeatureException;
 import io.gravitee.rest.api.service.exceptions.InvalidLicenseException;
-import io.gravitee.rest.api.service.exceptions.PreconditionFailedException;
 import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
 import io.gravitee.rest.api.service.exceptions.TransferOwnershipNotAllowedException;
 import io.gravitee.rest.api.service.spring.ImportConfiguration;
@@ -182,7 +181,6 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import lombok.CustomLog;
-import org.glassfish.jersey.message.internal.HttpHeaderReader;
 
 /**
  * Defines the REST resources to manage API v4.
@@ -1322,22 +1320,6 @@ public class ApiResource extends AbstractResource {
         baos.write(image.getContent(), 0, image.getContent().length);
 
         return Response.ok(baos).cacheControl(cc).tag(etag).type(image.getType()).build();
-    }
-
-    private void evaluateIfMatchStrictly(final HttpHeaders headers, final String etagValue) {
-        String ifMatch = headers.getHeaderString(HttpHeaders.IF_MATCH);
-
-        if (Objects.nonNull(ifMatch) && !ifMatch.isEmpty()) {
-            if ("*".equals(ifMatch)) {
-                return;
-            }
-            try {
-                HttpHeaderReader.readMatchingEntityTag(ifMatch.replace("-gzip", ""));
-            } catch (java.text.ParseException e) {
-                throw new PreconditionFailedException();
-            }
-            evaluateIfMatch(headers, etagValue);
-        }
     }
 
     private Response apiResponse(GenericApiEntity apiEntity) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/spring/RestManagementConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/spring/RestManagementConfiguration.java
@@ -22,6 +22,7 @@ import io.gravitee.apim.core.analytics_engine.domain_service.QueryFilterTransfor
 import io.gravitee.apim.core.analytics_engine.domain_service.UnitEnrichmentPostProcessor;
 import io.gravitee.apim.core.analytics_engine.query_service.AnalyticsDefinitionQueryService;
 import io.gravitee.apim.core.api.use_case.PatchApiUseCase.ApiV4Deserializer;
+import io.gravitee.apim.core.plan.use_case.PatchPlanUseCase.PlanFlowsConverter;
 import io.gravitee.apim.core.user.domain_service.UserContextLoader;
 import io.gravitee.apim.infra.domain_service.analytics_engine.ManagementContextLoader;
 import io.gravitee.apim.infra.domain_service.analytics_engine.processors.ApiTypeFilterTransformer;
@@ -33,6 +34,7 @@ import io.gravitee.el.ExpressionLanguageInitializer;
 import io.gravitee.repository.management.api.ApiRepository;
 import io.gravitee.rest.api.kafkaexplorer.spring.KafkaExplorerSpringConfiguration;
 import io.gravitee.rest.api.management.v2.rest.adapter.PatchApiV4Deserializer;
+import io.gravitee.rest.api.management.v2.rest.adapter.PatchPlanFlowsDeserializer;
 import io.gravitee.rest.api.management.v2.rest.mapper.FlowMapper;
 import io.gravitee.rest.api.management.v2.rest.model.FlowV4;
 import io.gravitee.rest.api.management.v2.rest.resource.api.RemoteApiDefinitionParser;
@@ -60,6 +62,11 @@ public class RestManagementConfiguration {
     @Bean
     public ApiV4Deserializer apiV4Deserializer(ObjectMapper objectMapper) {
         return new PatchApiV4Deserializer(objectMapper);
+    }
+
+    @Bean
+    public PlanFlowsConverter planFlowsDeserializer(ObjectMapper objectMapper) {
+        return new PatchPlanFlowsDeserializer(objectMapper);
     }
 
     @Bean

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-apis.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-apis.yaml
@@ -1366,6 +1366,116 @@ paths:
                                 $ref: "#/components/schemas/Plan"
                 default:
                     $ref: "#/components/responses/Error"
+        patch:
+            tags:
+                - API Plans
+            summary: Partially update one API's plan
+            description: |-
+                Apply a partial update to an API's plan using JSON Merge Patch (RFC 7396) or JSON Patch (RFC 6902).
+
+                Only v4 HTTP Proxy API plans support this operation.
+
+                Only the following fields are patchable: name, description, security (configuration only),
+                validation, selectionRule, tags, excludedGroups, characteristics, commentRequired,
+                generalConditions, flows.
+
+                The status field cannot be patched — use the dedicated plan lifecycle endpoints
+                (_close, _publish, _deprecate) to change a plan's status. Targeting status or any other
+                non-allow-listed field is rejected with 400.
+
+                A request sent with the application/json content type is treated as JSON Merge Patch
+                (RFC 7396); only application/json-patch+json is interpreted as JSON Patch (RFC 6902).
+
+                Optimistic concurrency is supported via the optional If-Match precondition. Read the plan
+                first to obtain its ETag, then send that value in the If-Match request header on the patch.
+                If the plan has been modified since (ETag mismatch), the request is rejected with 412. The
+                response echoes the new ETag so callers can chain further updates.
+
+                Use dryRun=true to preview the result without persisting.
+
+                User must have the API_PLAN[UPDATE] permission.
+            operationId: patchApiPlan
+            parameters:
+                - name: dryRun
+                  in: query
+                  required: false
+                  schema:
+                      type: boolean
+                      default: false
+                - name: If-Match
+                  in: header
+                  required: false
+                  description: |-
+                      Optional optimistic-concurrency precondition. Supply the plan's current ETag (as returned by a prior read or patch).
+                      If the plan was modified since that ETag was read, the request is rejected with 412.
+                  schema:
+                      type: string
+            requestBody:
+                content:
+                    application/merge-patch+json:
+                        schema:
+                            type: object
+                    application/json-patch+json:
+                        schema:
+                            type: array
+                            items:
+                                type: object
+                    application/json:
+                        schema:
+                            type: object
+                required: true
+            responses:
+                "200":
+                    description: API's plan successfully patched
+                    headers:
+                        ETag:
+                            description: |-
+                                Entity tag identifying the plan version. Value is the plan's last-updated timestamp expressed as epoch milliseconds (quoted per RFC 7232).
+                                Clients may pass this value back in `If-Match` on subsequent mutating requests to detect concurrent updates.
+                            schema:
+                                type: string
+                                example: '"1705314645123"'
+                        Last-Modified:
+                            description: |-
+                                Plan's last-updated timestamp as an RFC 7231 HTTP-date (one-second resolution). Informational only.
+                                Use the `ETag` value, not `Last-Modified`, for `If-Match` requests — `Last-Modified` loses millisecond precision.
+                            schema:
+                                type: string
+                                example: "Mon, 15 Jan 2024 10:30:45 GMT"
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/Plan"
+                "400":
+                    description: |-
+                        Invalid patch request — for example targeting the status field or any other
+                        non-allow-listed field, a malformed patch body, or a plan that is not a v4 HTTP Proxy plan.
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/Error"
+                "404":
+                    description: No plan with the given identifier exists for this API (including a plan that belongs to a different API).
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/Error"
+                "412":
+                    description: The If-Match precondition failed — the plan was modified since the supplied ETag was read.
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/Error"
+                "415":
+                    description: |-
+                        Unsupported media type. The request body must be sent with one of application/json,
+                        application/merge-patch+json, or application/json-patch+json.
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/Error"
+                default:
+                    $ref: "#/components/responses/Error"
         delete:
             tags:
                 - API Plans

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/adapter/PatchPlanFlowsDeserializerTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/adapter/PatchPlanFlowsDeserializerTest.java
@@ -19,11 +19,15 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.gravitee.apim.core.exception.ValidationDomainException;
+import io.gravitee.common.http.HttpMethod;
 import io.gravitee.definition.jackson.datatype.GraviteeMapper;
 import io.gravitee.definition.model.v4.flow.Flow;
+import io.gravitee.definition.model.v4.flow.selector.ConditionSelector;
 import io.gravitee.definition.model.v4.flow.selector.HttpSelector;
+import io.gravitee.definition.model.v4.flow.step.Step;
 import java.io.IOException;
 import java.util.List;
+import java.util.Set;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
@@ -123,5 +127,110 @@ class PatchPlanFlowsDeserializerTest {
 
         assertThat(result).hasSize(1);
         assertThat(result.get(0).getId()).isEqualTo(FLOW_ID);
+    }
+
+    @Test
+    void round_trip_preserves_populated_tags() throws IOException {
+        var flow = Flow.builder()
+            .id(FLOW_ID)
+            .name("my-flow")
+            .enabled(true)
+            .selectors(List.of(HttpSelector.builder().path("/api").build()))
+            .tags(Set.of("tag1", "tag2"))
+            .build();
+
+        var result = deserializer.fromPatchedFlowsNode(deserializer.toCurrentFlowsNode(List.of(flow)));
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getTags()).containsExactlyInAnyOrder("tag1", "tag2");
+    }
+
+    @Test
+    void round_trip_normalizes_null_tags_to_empty() throws IOException {
+        var flow = Flow.builder()
+            .id(FLOW_ID)
+            .name("my-flow")
+            .enabled(true)
+            .selectors(List.of(HttpSelector.builder().path("/api").build()))
+            .build();
+
+        var result = deserializer.fromPatchedFlowsNode(deserializer.toCurrentFlowsNode(List.of(flow)));
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getTags()).isEmpty();
+        assertThat(result.get(0).getSubscribe()).isEmpty();
+        assertThat(result.get(0).getPublish()).isEmpty();
+    }
+
+    @Test
+    void round_trip_preserves_populated_methods() throws IOException {
+        var flow = Flow.builder()
+            .id(FLOW_ID)
+            .name("my-flow")
+            .enabled(true)
+            .selectors(List.of(HttpSelector.builder().path("/api").methods(Set.of(HttpMethod.GET, HttpMethod.POST)).build()))
+            .build();
+
+        var result = deserializer.fromPatchedFlowsNode(deserializer.toCurrentFlowsNode(List.of(flow)));
+
+        assertThat(result).hasSize(1);
+        var selector = (HttpSelector) result.get(0).getSelectors().get(0);
+        assertThat(selector.getMethods()).containsExactlyInAnyOrder(HttpMethod.GET, HttpMethod.POST);
+    }
+
+    @Test
+    void round_trip_normalizes_null_methods_to_empty() throws IOException {
+        var flow = Flow.builder()
+            .id(FLOW_ID)
+            .name("my-flow")
+            .enabled(true)
+            .selectors(List.of(HttpSelector.builder().path("/api").build()))
+            .build();
+
+        var result = deserializer.fromPatchedFlowsNode(deserializer.toCurrentFlowsNode(List.of(flow)));
+
+        assertThat(result).hasSize(1);
+        var selector = (HttpSelector) result.get(0).getSelectors().get(0);
+        assertThat(selector.getMethods()).isEmpty();
+    }
+
+    @Test
+    void round_trip_preserves_request_and_response_steps() throws IOException {
+        var requestStep = Step.builder().name("req-step").policy("transform-headers").build();
+        var responseStep = Step.builder().name("resp-step").policy("cache").build();
+        var flow = Flow.builder()
+            .id(FLOW_ID)
+            .name("my-flow")
+            .enabled(true)
+            .selectors(List.of(HttpSelector.builder().path("/api").build()))
+            .request(List.of(requestStep))
+            .response(List.of(responseStep))
+            .build();
+
+        var result = deserializer.fromPatchedFlowsNode(deserializer.toCurrentFlowsNode(List.of(flow)));
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getRequest()).hasSize(1);
+        assertThat(result.get(0).getRequest().get(0).getName()).isEqualTo("req-step");
+        assertThat(result.get(0).getRequest().get(0).getPolicy()).isEqualTo("transform-headers");
+        assertThat(result.get(0).getResponse()).hasSize(1);
+        assertThat(result.get(0).getResponse().get(0).getName()).isEqualTo("resp-step");
+        assertThat(result.get(0).getResponse().get(0).getPolicy()).isEqualTo("cache");
+    }
+
+    @Test
+    void round_trip_preserves_condition_selector() throws IOException {
+        var flow = Flow.builder()
+            .id(FLOW_ID)
+            .name("my-flow")
+            .enabled(true)
+            .selectors(List.of(ConditionSelector.builder().condition("{#request.content.length() > 10}").build()))
+            .build();
+
+        var result = deserializer.fromPatchedFlowsNode(deserializer.toCurrentFlowsNode(List.of(flow)));
+
+        assertThat(result).hasSize(1);
+        var selector = (ConditionSelector) result.get(0).getSelectors().get(0);
+        assertThat(selector.getCondition()).isEqualTo("{#request.content.length() > 10}");
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/adapter/PatchPlanFlowsDeserializerTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/adapter/PatchPlanFlowsDeserializerTest.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.management.v2.rest.adapter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.gravitee.apim.core.exception.ValidationDomainException;
+import io.gravitee.definition.jackson.datatype.GraviteeMapper;
+import io.gravitee.definition.model.v4.flow.Flow;
+import io.gravitee.definition.model.v4.flow.selector.HttpSelector;
+import java.io.IOException;
+import java.util.List;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class PatchPlanFlowsDeserializerTest {
+
+    private final GraviteeMapper mapper = new GraviteeMapper(false);
+    private final PatchPlanFlowsDeserializer deserializer = new PatchPlanFlowsDeserializer(mapper);
+
+    private static final String FLOW_ID = "flow-id-1";
+
+    private static Flow aFlowWithHttpSelector() {
+        return Flow.builder()
+            .id(FLOW_ID)
+            .name("my-flow")
+            .enabled(true)
+            .selectors(List.of(HttpSelector.builder().path("/api").build()))
+            .build();
+    }
+
+    @Test
+    void fromPatchedFlowsNode_accepts_uppercase_HTTP_selector_and_returns_domain_flow_with_HttpSelector() throws IOException {
+        var node = mapper.readTree(
+            "[{\"id\":\"" +
+                FLOW_ID +
+                "\",\"name\":\"my-flow\",\"enabled\":true,\"selectors\":[{\"type\":\"HTTP\",\"path\":\"/api\",\"pathOperator\":\"STARTS_WITH\"}]}]"
+        );
+
+        var result = deserializer.fromPatchedFlowsNode(node);
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getSelectors()).hasSize(1);
+        assertThat(result.get(0).getSelectors().get(0)).isInstanceOf(HttpSelector.class);
+    }
+
+    @Test
+    void fromPatchedFlowsNode_rejects_lowercase_http_selector_discriminator_with_ValidationDomainException() {
+        var node = mapper.valueToTree(
+            List.of(
+                mapper
+                    .createObjectNode()
+                    .put("name", "my-flow")
+                    .put("enabled", true)
+                    .set(
+                        "selectors",
+                        mapper
+                            .createArrayNode()
+                            .add(mapper.createObjectNode().put("type", "http").put("path", "/api").put("pathOperator", "STARTS_WITH"))
+                    )
+            )
+        );
+
+        assertThatThrownBy(() -> deserializer.fromPatchedFlowsNode(node))
+            .isInstanceOf(ValidationDomainException.class)
+            .hasCauseInstanceOf(IOException.class);
+    }
+
+    @Test
+    void fromPatchedFlowsNode_rejects_BOGUS_selector_discriminator_with_ValidationDomainException() {
+        var node = mapper.valueToTree(
+            List.of(
+                mapper
+                    .createObjectNode()
+                    .put("name", "my-flow")
+                    .put("enabled", true)
+                    .set(
+                        "selectors",
+                        mapper
+                            .createArrayNode()
+                            .add(mapper.createObjectNode().put("type", "BOGUS").put("path", "/api").put("pathOperator", "STARTS_WITH"))
+                    )
+            )
+        );
+
+        assertThatThrownBy(() -> deserializer.fromPatchedFlowsNode(node))
+            .isInstanceOf(ValidationDomainException.class)
+            .hasCauseInstanceOf(IOException.class);
+    }
+
+    @Test
+    void toCurrentFlowsNode_emits_uppercase_HTTP_for_HttpSelector() {
+        var flows = List.of(aFlowWithHttpSelector());
+
+        var result = deserializer.toCurrentFlowsNode(flows);
+
+        assertThat(result.isArray()).isTrue();
+        assertThat(result.get(0).path("selectors").get(0).path("type").asText()).isEqualTo("HTTP");
+    }
+
+    @Test
+    void round_trip_preserves_flow_id() throws IOException {
+        var flows = List.of(aFlowWithHttpSelector());
+        var node = deserializer.toCurrentFlowsNode(flows);
+
+        var result = deserializer.fromPatchedFlowsNode(node);
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getId()).isEqualTo(FLOW_ID);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiPlansResource_PatchApiPlanTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiPlansResource_PatchApiPlanTest.java
@@ -1,0 +1,719 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.management.v2.rest.resource.api;
+
+import static assertions.MAPIAssertions.assertThat;
+import static io.gravitee.common.http.HttpStatusCode.BAD_REQUEST_400;
+import static io.gravitee.common.http.HttpStatusCode.NOT_FOUND_404;
+import static io.gravitee.common.http.HttpStatusCode.OK_200;
+import static io.gravitee.common.http.HttpStatusCode.PRECONDITION_FAILED_412;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import fixtures.core.model.ApiFixtures;
+import fixtures.core.model.PlanFixtures;
+import inmemory.ApiCrudServiceInMemory;
+import inmemory.PlanCrudServiceInMemory;
+import io.gravitee.apim.core.plan.domain_service.UpdatePlanDomainService;
+import io.gravitee.definition.model.flow.Operator;
+import io.gravitee.definition.model.v4.flow.Flow;
+import io.gravitee.definition.model.v4.flow.selector.HttpSelector;
+import io.gravitee.repository.management.model.Api;
+import io.gravitee.rest.api.management.v2.rest.model.BaseSelector;
+import io.gravitee.rest.api.management.v2.rest.model.Error;
+import io.gravitee.rest.api.management.v2.rest.model.PlanV4;
+import io.gravitee.rest.api.management.v2.rest.resource.AbstractResourceTest;
+import io.gravitee.rest.api.model.EnvironmentEntity;
+import io.gravitee.rest.api.model.v4.plan.BasePlanEntity;
+import io.gravitee.rest.api.model.v4.plan.GenericPlanEntity;
+import io.gravitee.rest.api.service.common.GraviteeContext;
+import io.gravitee.rest.api.service.v4.PlanSearchService;
+import jakarta.ws.rs.client.Entity;
+import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.core.Response;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.yaml.snakeyaml.Yaml;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+public class ApiPlansResource_PatchApiPlanTest extends AbstractResourceTest {
+
+    static final String API = "my-api";
+    static final String PLAN = "my-plan";
+    static final String ENVIRONMENT = "my-env";
+
+    private static final String MERGE_PATCH_TYPE = "application/merge-patch+json";
+    private static final String JSON_PATCH_TYPE = "application/json-patch+json";
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    @Autowired
+    ApiCrudServiceInMemory apiCrudService;
+
+    @Autowired
+    PlanCrudServiceInMemory planCrudServiceInMemory;
+
+    @Autowired
+    UpdatePlanDomainService updatePlanDomainService;
+
+    @Autowired
+    PlanSearchService planSearchService;
+
+    @Override
+    protected String contextPath() {
+        return "/environments/" + ENVIRONMENT + "/apis/" + API + "/plans";
+    }
+
+    @BeforeEach
+    void init() throws Exception {
+        var api = Api.builder().id(API).environmentId(ENVIRONMENT).build();
+        when(apiRepository.findById(API)).thenReturn(Optional.of(api));
+
+        var environmentEntity = EnvironmentEntity.builder().id(ENVIRONMENT).organizationId(ORGANIZATION).build();
+        when(environmentService.findById(ENVIRONMENT)).thenReturn(environmentEntity);
+        when(environmentService.findByOrgAndIdOrHrid(ORGANIZATION, ENVIRONMENT)).thenReturn(environmentEntity);
+
+        GraviteeContext.setCurrentEnvironment(ENVIRONMENT);
+        GraviteeContext.setCurrentOrganization(ORGANIZATION);
+
+        var updatedAt = ZonedDateTime.ofInstant(Instant.ofEpochMilli(1000), ZoneId.systemDefault());
+
+        apiCrudService.initWith(List.of(ApiFixtures.aProxyApiV4().toBuilder().id(API).updatedAt(updatedAt).build()));
+
+        planCrudServiceInMemory.initWith(
+            List.of(
+                PlanFixtures.aPlanHttpV4()
+                    .toBuilder()
+                    .id(PLAN)
+                    .name("Original Name")
+                    .referenceId(API)
+                    .referenceType(GenericPlanEntity.ReferenceType.API)
+                    .updatedAt(updatedAt)
+                    .build()
+            )
+        );
+
+        reset(updatePlanDomainService);
+        when(updatePlanDomainService.update(any(), any(), any(), any(), any())).thenAnswer(inv -> inv.getArgument(0));
+
+        stubPlanSearch(API, Date.from(updatedAt.toInstant()));
+    }
+
+    private void stubPlanSearch(String referenceId, Date updatedAt) {
+        var planEntity = BasePlanEntity.builder()
+            .id(PLAN)
+            .referenceId(referenceId)
+            .referenceType(GenericPlanEntity.ReferenceType.API)
+            .updatedAt(updatedAt)
+            .build();
+        when(planSearchService.findById(any(), eq(PLAN))).thenReturn(planEntity);
+    }
+
+    private void seedPlanWithNullUpdatedAt() {
+        planCrudServiceInMemory.reset();
+        planCrudServiceInMemory.initWith(
+            List.of(
+                PlanFixtures.aPlanHttpV4()
+                    .toBuilder()
+                    .id(PLAN)
+                    .name("Original Name")
+                    .referenceId(API)
+                    .referenceType(GenericPlanEntity.ReferenceType.API)
+                    .updatedAt(null)
+                    .build()
+            )
+        );
+        stubPlanSearch(API, null);
+    }
+
+    @AfterEach
+    public void tearDown() {
+        super.tearDown();
+        apiCrudService.reset();
+        planCrudServiceInMemory.reset();
+        GraviteeContext.cleanContext();
+        reset(apiRepository);
+    }
+
+    @Test
+    void should_return_200_and_updated_plan_for_json_patch_on_allow_listed_field() {
+        var patchDoc = "[{\"op\":\"replace\",\"path\":\"/name\",\"value\":\"Patched Name\"}]";
+
+        var response = rootTarget().path(PLAN).request().method("PATCH", Entity.entity(patchDoc, JSON_PATCH_TYPE));
+
+        assertThat(response).hasStatus(OK_200);
+        assertThat(response.readEntity(PlanV4.class).getName()).isEqualTo("Patched Name");
+    }
+
+    @Test
+    void should_return_200_and_updated_plan_for_merge_patch_on_allow_listed_field() {
+        var response = rootTarget().path(PLAN).request().method("PATCH", Entity.entity("{\"name\":\"Patched Name\"}", MERGE_PATCH_TYPE));
+
+        assertThat(response).hasStatus(OK_200);
+        assertThat(response.readEntity(PlanV4.class).getName()).isEqualTo("Patched Name");
+        verify(updatePlanDomainService).update(any(), any(), any(), any(), any());
+    }
+
+    @Test
+    void should_return_200_with_patched_flows_in_response_body() {
+        var patchDoc = "{\"flows\":[{\"name\":\"Patched Flow\",\"enabled\":true}]}";
+
+        var response = rootTarget().path(PLAN).request().method("PATCH", Entity.entity(patchDoc, MERGE_PATCH_TYPE));
+
+        assertThat(response).hasStatus(OK_200);
+        var flows = response.readEntity(PlanV4.class).getFlows();
+        assertThat(flows).hasSize(1);
+        assertThat(flows.get(0).getName()).isEqualTo("Patched Flow");
+    }
+
+    @Test
+    void should_treat_application_json_content_type_as_merge_patch_and_return_200() {
+        var response = rootTarget().path(PLAN).request().method("PATCH", Entity.entity("{\"name\":\"Patched Name\"}", "application/json"));
+
+        assertThat(response).hasStatus(OK_200);
+        assertThat(response.readEntity(PlanV4.class).getName()).isEqualTo("Patched Name");
+    }
+
+    @Test
+    void should_return_200_with_would_be_state_when_dry_run() {
+        var response = rootTarget()
+            .path(PLAN)
+            .queryParam("dryRun", "true")
+            .request()
+            .method("PATCH", Entity.entity("{\"name\":\"Dry Run Name\"}", MERGE_PATCH_TYPE));
+
+        assertThat(response).hasStatus(OK_200);
+        assertThat(response.readEntity(PlanV4.class).getName()).isEqualTo("Dry Run Name");
+    }
+
+    @Test
+    void should_not_invoke_write_path_when_dry_run() {
+        var response = rootTarget()
+            .path(PLAN)
+            .queryParam("dryRun", "true")
+            .request()
+            .method("PATCH", Entity.entity("{\"name\":\"Dry Run Name\"}", MERGE_PATCH_TYPE));
+
+        assertThat(response).hasStatus(OK_200);
+        assertThat(response.readEntity(PlanV4.class).getName()).isEqualTo("Dry Run Name");
+        verify(updatePlanDomainService).validate(any(), any(), any(), any());
+        verify(updatePlanDomainService, never()).update(any(), any(), any(), any(), any());
+    }
+
+    @Test
+    void should_return_400_when_patch_touches_status_field() {
+        var patchDoc = "[{\"op\":\"replace\",\"path\":\"/status\",\"value\":\"CLOSED\"}]";
+
+        var response = rootTarget().path(PLAN).request().method("PATCH", Entity.entity(patchDoc, JSON_PATCH_TYPE));
+
+        assertThat(response).hasStatus(BAD_REQUEST_400);
+    }
+
+    @Test
+    void should_proceed_without_412_when_if_match_header_is_absent() {
+        var response = rootTarget().path(PLAN).request().method("PATCH", Entity.entity("{\"name\":\"No Precondition\"}", MERGE_PATCH_TYPE));
+
+        assertThat(response).hasStatus(OK_200);
+    }
+
+    @Test
+    void should_return_412_when_if_match_header_does_not_match_plan_etag() {
+        var response = rootTarget()
+            .path(PLAN)
+            .request()
+            .header(HttpHeaders.IF_MATCH, "\"wrong-etag\"")
+            .method("PATCH", Entity.entity("{\"name\":\"Conflict\"}", MERGE_PATCH_TYPE));
+
+        assertThat(response).hasStatus(PRECONDITION_FAILED_412);
+    }
+
+    @Test
+    void should_return_200_when_if_match_header_matches_plan_etag() {
+        var response = rootTarget()
+            .path(PLAN)
+            .request()
+            .header(HttpHeaders.IF_MATCH, "\"1000\"")
+            .method("PATCH", Entity.entity("{\"name\":\"Matched Precondition\"}", MERGE_PATCH_TYPE));
+
+        assertThat(response).hasStatus(OK_200);
+    }
+
+    @Test
+    void should_return_400_when_plan_patch_is_attempted_on_v2_api() {
+        apiCrudService.reset();
+        apiCrudService.initWith(List.of(ApiFixtures.aProxyApiV2().toBuilder().id(API).build()));
+
+        var response = rootTarget().path(PLAN).request().method("PATCH", Entity.entity("{\"name\":\"Scoped Out\"}", MERGE_PATCH_TYPE));
+
+        assertThat(response).hasStatus(BAD_REQUEST_400);
+    }
+
+    @Test
+    void should_return_400_when_api_is_v4_message_type() {
+        apiCrudService.reset();
+        apiCrudService.initWith(List.of(ApiFixtures.aMessageApiV4().toBuilder().id(API).build()));
+
+        var response = rootTarget()
+            .path(PLAN)
+            .request()
+            .method("PATCH", Entity.entity("{\"name\":\"Message API Patch\"}", MERGE_PATCH_TYPE));
+
+        assertThat(response).hasStatus(BAD_REQUEST_400);
+    }
+
+    @Test
+    void should_return_404_when_plan_belongs_to_different_api() {
+        planCrudServiceInMemory.reset();
+        planCrudServiceInMemory.initWith(
+            List.of(
+                PlanFixtures.aPlanHttpV4()
+                    .toBuilder()
+                    .id(PLAN)
+                    .referenceId("ANOTHER-API")
+                    .referenceType(GenericPlanEntity.ReferenceType.API)
+                    .build()
+            )
+        );
+        stubPlanSearch("ANOTHER-API", null);
+
+        var response = rootTarget().path(PLAN).request().method("PATCH", Entity.entity("{\"name\":\"Cross API Patch\"}", MERGE_PATCH_TYPE));
+
+        assertThat(response).hasStatus(NOT_FOUND_404);
+    }
+
+    @Test
+    void should_return_404_not_412_when_plan_belongs_to_different_api_and_if_match_is_present() {
+        planCrudServiceInMemory.reset();
+        planCrudServiceInMemory.initWith(
+            List.of(
+                PlanFixtures.aPlanHttpV4()
+                    .toBuilder()
+                    .id(PLAN)
+                    .referenceId("ANOTHER-API")
+                    .referenceType(GenericPlanEntity.ReferenceType.API)
+                    .updatedAt(ZonedDateTime.ofInstant(Instant.ofEpochMilli(1000), ZoneId.systemDefault()))
+                    .build()
+            )
+        );
+        stubPlanSearch("ANOTHER-API", Date.from(Instant.ofEpochMilli(1000)));
+
+        var response = rootTarget()
+            .path(PLAN)
+            .request()
+            .header(HttpHeaders.IF_MATCH, "\"wrong-etag\"")
+            .method("PATCH", Entity.entity("{\"name\":\"Cross API Patch\"}", MERGE_PATCH_TYPE));
+
+        assertThat(response).hasStatus(NOT_FOUND_404);
+    }
+
+    @Test
+    void should_return_200_when_if_match_is_wildcard() {
+        var response = rootTarget()
+            .path(PLAN)
+            .request()
+            .header(HttpHeaders.IF_MATCH, "*")
+            .method("PATCH", Entity.entity("{\"name\":\"Wildcard Match\"}", MERGE_PATCH_TYPE));
+
+        assertThat(response).hasStatus(OK_200);
+    }
+
+    @Test
+    void should_return_200_when_if_match_is_weak_validator_matching_plan_etag() {
+        var response = rootTarget()
+            .path(PLAN)
+            .request()
+            .header(HttpHeaders.IF_MATCH, "W/\"1000\"")
+            .method("PATCH", Entity.entity("{\"name\":\"Weak Validator Match\"}", MERGE_PATCH_TYPE));
+
+        assertThat(response).hasStatus(OK_200);
+    }
+
+    @Test
+    void should_return_200_when_if_match_has_gzip_suffix_matching_plan_etag() {
+        var response = rootTarget()
+            .path(PLAN)
+            .request()
+            .header(HttpHeaders.IF_MATCH, "\"1000-gzip\"")
+            .method("PATCH", Entity.entity("{\"name\":\"Gzip Suffix Match\"}", MERGE_PATCH_TYPE));
+
+        assertThat(response).hasStatus(OK_200);
+    }
+
+    @Test
+    void should_return_412_for_malformed_if_match_header() {
+        var response = rootTarget()
+            .path(PLAN)
+            .request()
+            .header(HttpHeaders.IF_MATCH, "not-an-etag-no-quotes")
+            .method("PATCH", Entity.entity("{\"name\":\"Malformed ETag\"}", MERGE_PATCH_TYPE));
+
+        assertThat(response).hasStatus(PRECONDITION_FAILED_412);
+    }
+
+    @Test
+    void should_return_412_when_if_match_header_is_empty_tag_set() {
+        var response = rootTarget()
+            .path(PLAN)
+            .request()
+            .header(HttpHeaders.IF_MATCH, "-gzip")
+            .method("PATCH", Entity.entity("{\"name\":\"Empty Tag Set\"}", MERGE_PATCH_TYPE));
+
+        assertThat(response).hasStatus(PRECONDITION_FAILED_412);
+    }
+
+    @Test
+    void should_return_200_when_plan_has_null_updatedAt() {
+        seedPlanWithNullUpdatedAt();
+
+        var response = rootTarget().path(PLAN).request().method("PATCH", Entity.entity("{\"name\":\"Null UpdatedAt\"}", MERGE_PATCH_TYPE));
+
+        assertThat(response).hasStatus(OK_200);
+        assertThat(response.getHeaderString(HttpHeaders.ETAG)).isNull();
+        assertThat(response.getHeaderString(HttpHeaders.LAST_MODIFIED)).isNull();
+    }
+
+    @Test
+    void should_return_412_when_if_match_header_is_present_and_plan_has_null_updatedAt() {
+        seedPlanWithNullUpdatedAt();
+
+        var response = rootTarget()
+            .path(PLAN)
+            .request()
+            .header(HttpHeaders.IF_MATCH, "\"1000\"")
+            .method("PATCH", Entity.entity("{\"name\":\"Null UpdatedAt With Precondition\"}", MERGE_PATCH_TYPE));
+
+        assertThat(response).hasStatus(PRECONDITION_FAILED_412);
+    }
+
+    @Test
+    void should_return_200_when_if_match_wildcard_is_present_and_plan_has_null_updatedAt() {
+        seedPlanWithNullUpdatedAt();
+
+        var response = rootTarget()
+            .path(PLAN)
+            .request()
+            .header(HttpHeaders.IF_MATCH, "*")
+            .method("PATCH", Entity.entity("{\"name\":\"Null UpdatedAt With Wildcard Precondition\"}", MERGE_PATCH_TYPE));
+
+        assertThat(response).hasStatus(OK_200);
+    }
+
+    @Test
+    void should_include_etag_and_last_modified_headers_in_successful_patch_response() {
+        var response = rootTarget().path(PLAN).request().method("PATCH", Entity.entity("{\"name\":\"Check Headers\"}", MERGE_PATCH_TYPE));
+
+        assertThat(response).hasStatus(OK_200);
+        assertThat(response.getHeaderString(HttpHeaders.ETAG)).isEqualTo("\"1000\"");
+        assertThat(response.getHeaderString(HttpHeaders.LAST_MODIFIED)).isNotNull();
+    }
+
+    @Test
+    void should_treat_content_type_with_parameters_as_merge_patch() {
+        var response = rootTarget()
+            .path(PLAN)
+            .request()
+            .method("PATCH", Entity.entity("{\"name\":\"Charset Patch\"}", "application/json; charset=utf-8"));
+
+        assertThat(response).hasStatus(OK_200);
+        assertThat(response.readEntity(PlanV4.class).getName()).isEqualTo("Charset Patch");
+    }
+
+    @Test
+    void should_return_404_when_plan_has_api_product_reference_type_and_different_reference_id() {
+        planCrudServiceInMemory.reset();
+        planCrudServiceInMemory.initWith(
+            List.of(
+                PlanFixtures.aPlanHttpV4()
+                    .toBuilder()
+                    .id(PLAN)
+                    .referenceId("ANOTHER-API")
+                    .referenceType(GenericPlanEntity.ReferenceType.API_PRODUCT)
+                    .build()
+            )
+        );
+        var planEntity = BasePlanEntity.builder()
+            .id(PLAN)
+            .referenceId("ANOTHER-API")
+            .referenceType(GenericPlanEntity.ReferenceType.API_PRODUCT)
+            .build();
+        when(planSearchService.findById(any(), eq(PLAN))).thenReturn(planEntity);
+
+        var response = rootTarget()
+            .path(PLAN)
+            .request()
+            .method("PATCH", Entity.entity("{\"name\":\"API Product Patch\"}", MERGE_PATCH_TYPE));
+
+        assertThat(response).hasStatus(NOT_FOUND_404);
+    }
+
+    @Test
+    void should_return_200_for_merge_patch_with_contract_shaped_http_selector() {
+        var patchDoc =
+            "{\"flows\":[{\"name\":\"Flow\",\"enabled\":true,\"selectors\":[{\"type\":\"HTTP\",\"path\":\"/\",\"pathOperator\":\"EQUALS\"}]}]}";
+
+        Response response = rootTarget().path(PLAN).request().method("PATCH", Entity.entity(patchDoc, MERGE_PATCH_TYPE));
+
+        assertThat(response).hasStatus(OK_200);
+        var flows = response.readEntity(PlanV4.class).getFlows();
+        assertThat(flows).hasSize(1);
+        assertThat(flows.get(0).getSelectors()).hasSize(1);
+    }
+
+    @Test
+    void should_serialise_flow_selector_as_uppercase_http_type_in_patch_response_body() {
+        var patchDoc =
+            "{\"flows\":[{\"name\":\"Flow\",\"enabled\":true,\"selectors\":[{\"type\":\"HTTP\",\"path\":\"/\",\"pathOperator\":\"EQUALS\"}]}]}";
+
+        Response response = rootTarget().path(PLAN).request().method("PATCH", Entity.entity(patchDoc, MERGE_PATCH_TYPE));
+
+        assertThat(response).hasStatus(OK_200);
+        var selector = response.readEntity(PlanV4.class).getFlows().get(0).getSelectors().get(0);
+        assertThat(selector.getHttpSelector()).isNotNull();
+        assertThat(selector.getHttpSelector().getType()).isEqualTo(BaseSelector.TypeEnum.HTTP);
+    }
+
+    @Test
+    void should_return_200_for_json_patch_replace_flow_with_contract_shaped_http_selector() {
+        flowCrudService.savePlanFlows(
+            PLAN,
+            List.of(
+                Flow.builder()
+                    .id("flow-id")
+                    .name("Flow")
+                    .enabled(true)
+                    .selectors(List.of(HttpSelector.builder().path("/").pathOperator(Operator.EQUALS).build()))
+                    .build()
+            )
+        );
+
+        var patchDoc =
+            "[{\"op\":\"replace\",\"path\":\"/flows/0\",\"value\":{\"name\":\"Replaced Flow\",\"enabled\":true,\"selectors\":[{\"type\":\"HTTP\",\"path\":\"/replaced\",\"pathOperator\":\"EQUALS\"}]}}]";
+
+        Response response = rootTarget().path(PLAN).request().method("PATCH", Entity.entity(patchDoc, JSON_PATCH_TYPE));
+
+        assertThat(response).hasStatus(OK_200);
+        var flows = response.readEntity(PlanV4.class).getFlows();
+        assertThat(flows).hasSize(1);
+        assertThat(flows.get(0).getName()).isEqualTo("Replaced Flow");
+        assertThat(flows.get(0).getSelectors()).hasSize(1);
+    }
+
+    @Test
+    void should_keep_flow_selector_uppercase_http_when_patching_back_exact_get_body() throws Exception {
+        flowCrudService.savePlanFlows(
+            PLAN,
+            List.of(
+                Flow.builder()
+                    .id("flow-id")
+                    .name("Flow")
+                    .enabled(true)
+                    .selectors(List.of(HttpSelector.builder().path("/").pathOperator(Operator.EQUALS).build()))
+                    .build()
+            )
+        );
+
+        Response getShaped = rootTarget()
+            .path(PLAN)
+            .request()
+            .method("PATCH", Entity.entity("{\"name\":\"Original Name\"}", MERGE_PATCH_TYPE));
+        assertThat(getShaped).hasStatus(OK_200);
+        JsonNode emittedFlows = OBJECT_MAPPER.readTree(getShaped.readEntity(String.class)).get("flows");
+        assertThat(emittedFlows.get(0).get("selectors").get(0).get("type").asText()).isEqualTo("HTTP");
+
+        var roundTripPatch = "{\"flows\":" + OBJECT_MAPPER.writeValueAsString(emittedFlows) + "}";
+
+        Response roundTrip = rootTarget().path(PLAN).request().method("PATCH", Entity.entity(roundTripPatch, MERGE_PATCH_TYPE));
+
+        assertThat(roundTrip).hasStatus(OK_200);
+        var selector = roundTrip.readEntity(PlanV4.class).getFlows().get(0).getSelectors().get(0);
+        assertThat(selector.getHttpSelector()).isNotNull();
+        assertThat(selector.getHttpSelector().getType()).isEqualTo(BaseSelector.TypeEnum.HTTP);
+    }
+
+    @Test
+    void should_return_400_for_merge_patch_with_lowercase_http_selector_discriminator() {
+        var patchDoc =
+            "{\"flows\":[{\"name\":\"Flow\",\"enabled\":true,\"selectors\":[{\"type\":\"http\",\"path\":\"/\",\"pathOperator\":\"EQUALS\"}]}]}";
+
+        Response response = rootTarget().path(PLAN).request().method("PATCH", Entity.entity(patchDoc, MERGE_PATCH_TYPE));
+
+        assertThat(response).hasStatus(BAD_REQUEST_400);
+    }
+
+    @Test
+    void should_return_400_for_bogus_selector_discriminator_with_error_message_referencing_flows() {
+        var patchDoc =
+            "{\"flows\":[{\"name\":\"Flow\",\"enabled\":true,\"selectors\":[{\"type\":\"BOGUS\",\"path\":\"/\",\"pathOperator\":\"EQUALS\"}]}]}";
+
+        Response response = rootTarget().path(PLAN).request().method("PATCH", Entity.entity(patchDoc, MERGE_PATCH_TYPE));
+
+        assertThat(response).hasStatus(BAD_REQUEST_400);
+        assertThat(response.readEntity(Error.class).getMessage()).contains("flows");
+    }
+
+    @Test
+    void should_return_200_with_contract_shaped_selector_on_dry_run_and_leave_stored_flows_unchanged() {
+        flowCrudService.savePlanFlows(
+            PLAN,
+            List.of(
+                Flow.builder()
+                    .id("flow-id")
+                    .name("Original Flow")
+                    .enabled(true)
+                    .selectors(List.of(HttpSelector.builder().path("/original").pathOperator(Operator.EQUALS).build()))
+                    .build()
+            )
+        );
+        var patchDoc =
+            "{\"flows\":[{\"name\":\"Patched Flow\",\"enabled\":true,\"selectors\":[{\"type\":\"HTTP\",\"path\":\"/patched\",\"pathOperator\":\"EQUALS\"}]}]}";
+
+        Response response = rootTarget()
+            .path(PLAN)
+            .queryParam("dryRun", "true")
+            .request()
+            .method("PATCH", Entity.entity(patchDoc, MERGE_PATCH_TYPE));
+
+        assertThat(response).hasStatus(OK_200);
+        var selector = response.readEntity(PlanV4.class).getFlows().get(0).getSelectors().get(0);
+        assertThat(selector.getHttpSelector()).isNotNull();
+        assertThat(selector.getHttpSelector().getType()).isEqualTo(BaseSelector.TypeEnum.HTTP);
+        var storedFlows = flowCrudService.getPlanV4Flows(PLAN);
+        assertThat(storedFlows).hasSize(1);
+        assertThat(storedFlows.get(0).getId()).isEqualTo("flow-id");
+        assertThat(storedFlows.get(0).getName()).isEqualTo("Original Flow");
+    }
+
+    @Test
+    void should_return_200_with_byte_identical_flows_on_scalar_only_name_patch() {
+        flowCrudService.savePlanFlows(
+            PLAN,
+            List.of(
+                Flow.builder()
+                    .id("flow-id")
+                    .name("Flow")
+                    .enabled(true)
+                    .selectors(List.of(HttpSelector.builder().path("/").pathOperator(Operator.EQUALS).build()))
+                    .build()
+            )
+        );
+
+        Response response = rootTarget()
+            .path(PLAN)
+            .request()
+            .method("PATCH", Entity.entity("{\"name\":\"Scalar Only\"}", MERGE_PATCH_TYPE));
+
+        assertThat(response).hasStatus(OK_200);
+        var flows = response.readEntity(PlanV4.class).getFlows();
+        assertThat(flows).hasSize(1);
+        assertThat(flows.get(0).getId()).isEqualTo("flow-id");
+        assertThat(flows.get(0).getSelectors().get(0).getHttpSelector()).isNotNull();
+        assertThat(flows.get(0).getSelectors().get(0).getHttpSelector().getType()).isEqualTo(BaseSelector.TypeEnum.HTTP);
+    }
+
+    @Test
+    void should_return_400_on_dry_run_with_bogus_selector_discriminator_and_leave_stored_flows_unchanged() {
+        flowCrudService.savePlanFlows(
+            PLAN,
+            List.of(
+                Flow.builder()
+                    .id("flow-id")
+                    .name("Flow")
+                    .enabled(true)
+                    .selectors(List.of(HttpSelector.builder().path("/").pathOperator(Operator.EQUALS).build()))
+                    .build()
+            )
+        );
+        var patchDoc =
+            "{\"flows\":[{\"name\":\"Flow\",\"enabled\":true,\"selectors\":[{\"type\":\"BOGUS\",\"path\":\"/\",\"pathOperator\":\"EQUALS\"}]}]}";
+
+        Response response = rootTarget()
+            .path(PLAN)
+            .queryParam("dryRun", "true")
+            .request()
+            .method("PATCH", Entity.entity(patchDoc, MERGE_PATCH_TYPE));
+
+        assertThat(response).hasStatus(BAD_REQUEST_400);
+        var storedFlows = flowCrudService.getPlanV4Flows(PLAN);
+        assertThat(storedFlows).hasSize(1);
+        assertThat(storedFlows.get(0).getId()).isEqualTo("flow-id");
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void should_document_patch_operation_in_openapi_spec() throws Exception {
+        var stream = getClass().getClassLoader().getResourceAsStream("openapi/openapi-apis.yaml");
+        assertThat(stream).as("openapi-apis.yaml must be on the classpath").isNotNull();
+
+        var yaml = new String(stream.readAllBytes(), StandardCharsets.UTF_8);
+
+        var parser = new Yaml();
+        Map<String, Object> spec = parser.load(yaml);
+        var paths = (Map<String, Object>) spec.get("paths");
+        var planIdPath = (Map<String, Object>) paths.get("/environments/{envId}/apis/{apiId}/plans/{planId}");
+
+        assertThat(planIdPath).as("/environments/{envId}/apis/{apiId}/plans/{planId} must define a 'patch' operation").containsKey("patch");
+
+        Map<String, Object> patch = (Map<String, Object>) planIdPath.get("patch");
+
+        String description = (String) patch.get("description");
+        assertThat(description)
+            .as("patch operation must document the allow-listed patchable fields")
+            .contains("name")
+            .contains("security")
+            .contains("flows");
+        assertThat(description).as("patch operation must document that status is not patchable").contains("status field cannot be patched");
+
+        Map<String, Object> requestBodyContent = (Map<String, Object>) ((Map<String, Object>) patch.get("requestBody")).get("content");
+        assertThat(requestBodyContent)
+            .as("patch requestBody must document both JSON Patch and JSON Merge Patch content types")
+            .containsKeys(JSON_PATCH_TYPE, MERGE_PATCH_TYPE);
+
+        Map<String, Object> responses = (Map<String, Object>) patch.get("responses");
+        assertThat(responses).as("patch operation must document its error response codes").containsKeys("400", "404", "412");
+
+        Map<String, Object> okResponse = (Map<String, Object>) responses.get("200");
+        Map<String, Object> okHeaders = (Map<String, Object>) okResponse.get("headers");
+        assertThat(okHeaders).as("patch 200 response must document the ETag header").containsKey("ETag");
+
+        List<Map<String, Object>> parameters = (List<Map<String, Object>>) patch.get("parameters");
+        assertThat(parameters)
+            .as("patch operation must document the If-Match precondition header")
+            .anySatisfy(parameter -> {
+                assertThat(parameter).containsEntry("name", "If-Match");
+                assertThat(parameter).containsEntry("in", "header");
+            });
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/spring/ResourceContextConfiguration.java
@@ -32,6 +32,7 @@ import inmemory.CRDMembersDomainServiceInMemory;
 import inmemory.CategoryQueryServiceInMemory;
 import inmemory.GroupCrudServiceInMemory;
 import inmemory.GroupQueryServiceInMemory;
+import inmemory.KafkaPortRangeCrudServiceInMemory;
 import inmemory.NewtAIProviderInMemory;
 import inmemory.PageCrudServiceInMemory;
 import inmemory.PageSourceDomainServiceInMemory;
@@ -174,6 +175,7 @@ import io.gravitee.apim.core.plan.domain_service.VerifyPlanPortRangesDomainServi
 import io.gravitee.apim.core.plan.use_case.CreateApiProductPlanUseCase;
 import io.gravitee.apim.core.plan.use_case.CreatePlanUseCase;
 import io.gravitee.apim.core.plan.use_case.GetPlansUseCase;
+import io.gravitee.apim.core.plan.use_case.PatchPlanUseCase.PlanFlowsConverter;
 import io.gravitee.apim.core.plan.use_case.PlanOperationsUseCase;
 import io.gravitee.apim.core.plan.use_case.UpdateApiProductPlanUseCase;
 import io.gravitee.apim.core.plan.use_case.UpdateFederatedPlanUseCase;
@@ -273,6 +275,7 @@ import io.gravitee.repository.log.v4.api.AnalyticsRepository;
 import io.gravitee.repository.management.api.ApiRepository;
 import io.gravitee.repository.management.api.ApplicationRepository;
 import io.gravitee.repository.management.api.CustomDashboardRepository;
+import io.gravitee.rest.api.management.v2.rest.adapter.PatchPlanFlowsDeserializer;
 import io.gravitee.rest.api.management.v2.rest.mapper.ApiMapper;
 import io.gravitee.rest.api.management.v2.rest.model.ApiV4;
 import io.gravitee.rest.api.management.v2.rest.utils.SubscriptionExpandHelper;
@@ -332,6 +335,11 @@ public class ResourceContextConfiguration {
     @Bean
     public ApiV4Deserializer apiV4Deserializer(ObjectMapper objectMapper) {
         return new io.gravitee.rest.api.management.v2.rest.adapter.PatchApiV4Deserializer(objectMapper);
+    }
+
+    @Bean
+    public PlanFlowsConverter planFlowsDeserializer(ObjectMapper objectMapper) {
+        return new PatchPlanFlowsDeserializer(objectMapper);
     }
 
     @Bean
@@ -803,6 +811,11 @@ public class ResourceContextConfiguration {
     }
 
     @Bean
+    public KafkaPortRangeCrudServiceInMemory kafkaPortRangeCrudService() {
+        return new KafkaPortRangeCrudServiceInMemory();
+    }
+
+    @Bean
     public ValidateApiCRDUseCase validateApiCRDUseCase(
         CategoryQueryServiceInMemory categoryQueryService,
         UserDomainServiceInMemory userDomainService,
@@ -817,7 +830,7 @@ public class ResourceContextConfiguration {
         ParametersQueryService parametersQueryService,
         PolicyValidationDomainService policyValidationDomainService,
         PageCrudService pageCrudService,
-        VerifyPlanPortRangesDomainService verifyPlanPortRangesDomainService
+        KafkaPortRangeCrudServiceInMemory kafkaPortRangeCrudService
     ) {
         ValidateGroupsDomainService groupsValidator = new ValidateGroupsDomainService(groupQueryService);
         return new ValidateApiCRDUseCase(
@@ -835,7 +848,7 @@ public class ResourceContextConfiguration {
                 ),
                 new ValidatePlanDomainService(
                     new PlanValidatorDomainService(parametersQueryService, policyValidationDomainService, pageCrudService),
-                    verifyPlanPortRangesDomainService
+                    new VerifyPlanPortRangesDomainService(kafkaPortRangeCrudService)
                 ),
                 new ValidatePortalNotificationDomainService(groupsValidator)
             )

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/spring/RestManagementConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/spring/RestManagementConfiguration.java
@@ -19,11 +19,14 @@ import com.fasterxml.jackson.databind.JsonNode;
 import io.gravitee.apim.core.api.model.Api;
 import io.gravitee.apim.core.api.use_case.PatchApiUseCase.ApiV4Deserializer;
 import io.gravitee.apim.core.api.use_case.PatchApiUseCase.ApiV4Fields;
+import io.gravitee.apim.core.plan.use_case.PatchPlanUseCase.PlanFlowsConverter;
 import io.gravitee.apim.infra.spring.UsecaseSpringConfiguration;
+import io.gravitee.definition.model.v4.flow.Flow;
 import io.gravitee.el.ExpressionLanguageInitializer;
 import io.gravitee.plugin.core.spring.PluginConfiguration;
 import io.gravitee.rest.api.idp.core.spring.IdentityProviderPluginConfiguration;
 import io.gravitee.rest.api.service.spring.ServiceConfiguration;
+import java.util.List;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
@@ -44,6 +47,11 @@ public class RestManagementConfiguration {
     }
 
     @Bean
+    public PlanFlowsConverter planFlowsDeserializer() {
+        return new PlanFlowsPatchNotSupportedDeserializer();
+    }
+
+    @Bean
     public ExpressionLanguageInitializer expressionLanguageInitializer() {
         return new ExpressionLanguageInitializer();
     }
@@ -59,6 +67,21 @@ public class RestManagementConfiguration {
 
         @Override
         public ApiV4Fields fromPatchedNode(JsonNode patchedNode) {
+            throw new UnsupportedOperationException(MESSAGE);
+        }
+    }
+
+    private static class PlanFlowsPatchNotSupportedDeserializer implements PlanFlowsConverter {
+
+        private static final String MESSAGE = "plan flows PATCH is served only by management-v2 REST API";
+
+        @Override
+        public JsonNode toCurrentFlowsNode(List<Flow> flows) {
+            throw new UnsupportedOperationException(MESSAGE);
+        }
+
+        @Override
+        public List<Flow> fromPatchedFlowsNode(JsonNode flowsNode) {
             throw new UnsupportedOperationException(MESSAGE);
         }
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/spring/ResourceContextConfiguration.java
@@ -18,6 +18,7 @@ package io.gravitee.rest.api.management.rest.spring;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import fakes.spring.FakeConfiguration;
 import inmemory.ApiCrudServiceInMemory;
@@ -130,6 +131,7 @@ import io.gravitee.apim.core.permission.domain_service.PermissionDomainService;
 import io.gravitee.apim.core.plan.domain_service.CreatePlanDomainService;
 import io.gravitee.apim.core.plan.domain_service.PlanSynchronizationService;
 import io.gravitee.apim.core.plan.query_service.PlanSearchQueryService;
+import io.gravitee.apim.core.plan.use_case.PatchPlanUseCase.PlanFlowsConverter;
 import io.gravitee.apim.core.plugin.crud_service.PolicyPluginCrudService;
 import io.gravitee.apim.core.plugin.domain_service.EndpointConnectorPluginDomainService;
 import io.gravitee.apim.core.policy.domain_service.PolicyValidationDomainService;
@@ -199,6 +201,7 @@ import io.gravitee.apim.infra.spring.UsecaseSpringConfiguration;
 import io.gravitee.common.event.EventManager;
 import io.gravitee.common.util.DataEncryptor;
 import io.gravitee.definition.jackson.datatype.GraviteeMapper;
+import io.gravitee.definition.model.v4.flow.Flow;
 import io.gravitee.node.api.license.LicenseManager;
 import io.gravitee.repository.management.api.ApplicationRepository;
 import io.gravitee.repository.management.api.GroupRepository;
@@ -272,6 +275,7 @@ import io.gravitee.rest.api.service.search.SearchEngineService;
 import io.gravitee.rest.api.service.v4.ApiGroupService;
 import io.gravitee.rest.api.service.v4.PlanSearchService;
 import io.vertx.rxjava3.core.Vertx;
+import java.util.List;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
@@ -685,6 +689,11 @@ public class ResourceContextConfiguration {
     @Bean
     public ApiV4Deserializer apiV4Deserializer() {
         return new V4PatchNotSupportedDeserializer();
+    }
+
+    @Bean
+    public PlanFlowsConverter planFlowsDeserializer() {
+        return new PlanFlowsPatchNotSupportedDeserializer();
     }
 
     private static class V4PatchNotSupportedDeserializer implements ApiV4Deserializer {
@@ -1477,5 +1486,20 @@ public class ResourceContextConfiguration {
     @Bean
     public io.gravitee.apim.core.log.crud_service.NativeApiLogCrudService nativeApiLogCrudService() {
         return mock(io.gravitee.apim.core.log.crud_service.NativeApiLogCrudService.class);
+    }
+
+    private static class PlanFlowsPatchNotSupportedDeserializer implements PlanFlowsConverter {
+
+        private static final String MESSAGE = "plan flows PATCH is served only by management-v2 REST API";
+
+        @Override
+        public JsonNode toCurrentFlowsNode(List<Flow> flows) {
+            throw new UnsupportedOperationException(MESSAGE);
+        }
+
+        @Override
+        public List<Flow> fromPatchedFlowsNode(JsonNode flowsNode) {
+            throw new UnsupportedOperationException(MESSAGE);
+        }
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/spring/ResourceContextConfiguration.java
@@ -140,6 +140,7 @@ import io.gravitee.apim.core.permission.domain_service.PermissionDomainService;
 import io.gravitee.apim.core.plan.domain_service.CreatePlanDomainService;
 import io.gravitee.apim.core.plan.domain_service.PlanSynchronizationService;
 import io.gravitee.apim.core.plan.query_service.PlanSearchQueryService;
+import io.gravitee.apim.core.plan.use_case.PatchPlanUseCase.PlanFlowsConverter;
 import io.gravitee.apim.core.plugin.crud_service.PolicyPluginCrudService;
 import io.gravitee.apim.core.plugin.domain_service.EndpointConnectorPluginDomainService;
 import io.gravitee.apim.core.policy.domain_service.PolicyValidationDomainService;
@@ -210,6 +211,7 @@ import io.gravitee.apim.infra.sanitizer.HtmlSanitizerImpl;
 import io.gravitee.apim.infra.spring.UsecaseSpringConfiguration;
 import io.gravitee.common.util.DataEncryptor;
 import io.gravitee.definition.jackson.datatype.GraviteeMapper;
+import io.gravitee.definition.model.v4.flow.Flow;
 import io.gravitee.node.api.license.LicenseManager;
 import io.gravitee.repository.management.api.ApplicationRepository;
 import io.gravitee.rest.api.portal.rest.mapper.AnalyticsMapper;
@@ -283,6 +285,7 @@ import io.gravitee.rest.api.service.v4.ApiSearchService;
 import io.gravitee.rest.api.service.v4.EndpointConnectorPluginService;
 import io.gravitee.rest.api.service.v4.PlanSearchService;
 import io.vertx.rxjava3.core.Vertx;
+import java.util.List;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
@@ -729,6 +732,11 @@ public class ResourceContextConfiguration {
     @Bean
     public ApiV4Deserializer apiV4Deserializer() {
         return new V4PatchNotSupportedDeserializer();
+    }
+
+    @Bean
+    public PlanFlowsConverter planFlowsDeserializer() {
+        return new PlanFlowsPatchNotSupportedDeserializer();
     }
 
     @Bean
@@ -1526,6 +1534,21 @@ public class ResourceContextConfiguration {
 
         @Override
         public ApiV4Fields fromPatchedNode(JsonNode patchedNode) {
+            throw new UnsupportedOperationException(MESSAGE);
+        }
+    }
+
+    private static class PlanFlowsPatchNotSupportedDeserializer implements PlanFlowsConverter {
+
+        private static final String MESSAGE = "plan flows PATCH is served only by management-v2 REST API";
+
+        @Override
+        public JsonNode toCurrentFlowsNode(List<Flow> flows) {
+            throw new UnsupportedOperationException(MESSAGE);
+        }
+
+        @Override
+        public List<Flow> fromPatchedFlowsNode(JsonNode flowsNode) {
             throw new UnsupportedOperationException(MESSAGE);
         }
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/plan/domain_service/UpdatePlanDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/plan/domain_service/UpdatePlanDomainService.java
@@ -200,8 +200,9 @@ public class UpdatePlanDomainService {
         BinaryOperator<Plan> updateFunction
     ) {
         var sanitizedFlows = validateAndSanitizeHttpV4Flows(flows, api);
+        var existingFlows = flowCrudService.getPlanV4Flows(existingPlan.getId());
 
-        if (!planSynchronizationService.checkSynchronized(existingPlan, List.of(), updatePlan, sanitizedFlows)) {
+        if (!planSynchronizationService.checkSynchronized(existingPlan, existingFlows, updatePlan, sanitizedFlows)) {
             updatePlan.setNeedRedeployAt(Date.from(updatePlan.getUpdatedAt().toInstant()));
         }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/plan/domain_service/UpdatePlanDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/plan/domain_service/UpdatePlanDomainService.java
@@ -136,6 +136,11 @@ public class UpdatePlanDomainService {
         };
     }
 
+    public void validate(Plan planToUpdate, List<Flow> flows, Api api, AuditInfo auditInfo) {
+        updatePreFlightChecks(planToUpdate, getPlanStatusMap(api), api, auditInfo);
+        validateAndSanitizeHttpV4Flows(flows, api);
+    }
+
     private Map<String, PlanStatus> getPlanStatusMap(Api api) {
         return getPlanStatusMap(api.getId(), GenericPlanEntity.ReferenceType.API);
     }
@@ -194,12 +199,7 @@ public class UpdatePlanDomainService {
         AuditInfo auditInfo,
         BinaryOperator<Plan> updateFunction
     ) {
-        var sanitizedFlows = flowValidationDomainService.validateAndSanitizeHttpV4(api.getType(), flows);
-        flowValidationDomainService.validatePathParameters(
-            api.getType(),
-            api.getApiDefinitionHttpV4().getFlows() != null ? api.getApiDefinitionHttpV4().getFlows().stream() : Stream.empty(),
-            sanitizedFlows.stream()
-        );
+        var sanitizedFlows = validateAndSanitizeHttpV4Flows(flows, api);
 
         if (!planSynchronizationService.checkSynchronized(existingPlan, List.of(), updatePlan, sanitizedFlows)) {
             updatePlan.setNeedRedeployAt(Date.from(updatePlan.getUpdatedAt().toInstant()));
@@ -211,6 +211,16 @@ public class UpdatePlanDomainService {
 
         createAuditLog(existingPlan, updated, auditInfo);
         return updated;
+    }
+
+    private List<Flow> validateAndSanitizeHttpV4Flows(List<Flow> flows, Api api) {
+        var sanitizedFlows = flowValidationDomainService.validateAndSanitizeHttpV4(api.getType(), flows);
+        flowValidationDomainService.validatePathParameters(
+            api.getType(),
+            api.getApiDefinitionHttpV4().getFlows() != null ? api.getApiDefinitionHttpV4().getFlows().stream() : Stream.empty(),
+            sanitizedFlows.stream()
+        );
+        return sanitizedFlows;
     }
 
     private Plan updateNativeV4ApiPlan(

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/plan/exception/PlanForApiNotFoundException.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/plan/exception/PlanForApiNotFoundException.java
@@ -15,14 +15,14 @@
  */
 package io.gravitee.apim.core.plan.exception;
 
-import io.gravitee.apim.core.exception.ValidationDomainException;
+import io.gravitee.apim.core.exception.NotFoundDomainException;
 
 /**
  * @author GraviteeSource Team
  */
-public class PlanInvalidException extends ValidationDomainException {
+public class PlanForApiNotFoundException extends NotFoundDomainException {
 
-    public PlanInvalidException(String message) {
-        super(message);
+    public PlanForApiNotFoundException(String planId, String apiId) {
+        super("Plan [" + planId + "] not found for API [" + apiId + "]", planId);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/plan/exception/PlanNotFoundException.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/plan/exception/PlanNotFoundException.java
@@ -17,6 +17,9 @@ package io.gravitee.apim.core.plan.exception;
 
 import io.gravitee.apim.core.exception.ValidationDomainException;
 
+/**
+ * @author GraviteeSource Team
+ */
 public class PlanNotFoundException extends ValidationDomainException {
 
     public PlanNotFoundException(String planId) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/plan/exception/PlanPatchNotAllowedException.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/plan/exception/PlanPatchNotAllowedException.java
@@ -16,13 +16,14 @@
 package io.gravitee.apim.core.plan.exception;
 
 import io.gravitee.apim.core.exception.ValidationDomainException;
+import java.util.Map;
 
 /**
  * @author GraviteeSource Team
  */
-public class PlanInvalidException extends ValidationDomainException {
+public class PlanPatchNotAllowedException extends ValidationDomainException {
 
-    public PlanInvalidException(String message) {
-        super(message);
+    public PlanPatchNotAllowedException(String fieldName, String reason) {
+        super("Field '" + fieldName + "' cannot be patched: " + reason, Map.of("field", fieldName), "plan.patch.fieldNotAllowed");
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/plan/use_case/CreatePlanUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/plan/use_case/CreatePlanUseCase.java
@@ -34,6 +34,9 @@ import java.util.List;
 import java.util.function.Function;
 import lombok.RequiredArgsConstructor;
 
+/**
+ * @author GraviteeSource Team
+ */
 @RequiredArgsConstructor
 @UseCase
 public class CreatePlanUseCase {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/plan/use_case/PatchPlanUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/plan/use_case/PatchPlanUseCase.java
@@ -1,0 +1,486 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.plan.use_case;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.gravitee.apim.core.UseCase;
+import io.gravitee.apim.core.api.crud_service.ApiCrudService;
+import io.gravitee.apim.core.audit.model.AuditInfo;
+import io.gravitee.apim.core.exception.ValidationDomainException;
+import io.gravitee.apim.core.flow.crud_service.FlowCrudService;
+import io.gravitee.apim.core.json_patch.domain_service.JsonPatchDomainService;
+import io.gravitee.apim.core.plan.crud_service.PlanCrudService;
+import io.gravitee.apim.core.plan.domain_service.UpdatePlanDomainService;
+import io.gravitee.apim.core.plan.exception.PlanForApiNotFoundException;
+import io.gravitee.apim.core.plan.exception.PlanPatchNotAllowedException;
+import io.gravitee.apim.core.plan.model.Plan;
+import io.gravitee.apim.core.plan.model.PlanWithFlows;
+import io.gravitee.definition.model.DefinitionVersion;
+import io.gravitee.definition.model.v4.ApiType;
+import io.gravitee.definition.model.v4.flow.Flow;
+import io.gravitee.definition.model.v4.plan.PlanSecurity;
+import io.gravitee.rest.api.model.v4.plan.GenericPlanEntity;
+import jakarta.annotation.Nonnull;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import lombok.Builder;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * @author GraviteeSource Team
+ */
+@UseCase
+@RequiredArgsConstructor
+public class PatchPlanUseCase {
+
+    private static final String FIELD_NAME = "name";
+    private static final String FIELD_DESCRIPTION = "description";
+    private static final String FIELD_SECURITY_CONFIGURATION = "security";
+    private static final String FIELD_VALIDATION = "validation";
+    private static final String FIELD_SELECTION_RULE = "selectionRule";
+    private static final String FIELD_TAGS = "tags";
+    private static final String FIELD_EXCLUDED_GROUPS = "excludedGroups";
+    private static final String FIELD_CHARACTERISTICS = "characteristics";
+    private static final String FIELD_COMMENT_REQUIRED = "commentRequired";
+    private static final String FIELD_GENERAL_CONDITIONS = "generalConditions";
+    private static final String FIELD_FLOWS = "flows";
+
+    private static final Set<String> ALLOWED_FIELDS = Set.of(
+        FIELD_NAME,
+        FIELD_DESCRIPTION,
+        FIELD_SECURITY_CONFIGURATION,
+        FIELD_VALIDATION,
+        FIELD_SELECTION_RULE,
+        FIELD_TAGS,
+        FIELD_EXCLUDED_GROUPS,
+        FIELD_CHARACTERISTICS,
+        FIELD_COMMENT_REQUIRED,
+        FIELD_GENERAL_CONDITIONS,
+        FIELD_FLOWS
+    );
+
+    private static final Set<String> NON_NULLABLE_FIELDS = Set.of(
+        FIELD_NAME,
+        FIELD_VALIDATION,
+        FIELD_SECURITY_CONFIGURATION,
+        FIELD_COMMENT_REQUIRED
+    );
+
+    static final int MAX_PATCH_OPS = 200;
+
+    private final ApiCrudService apiCrudService;
+    private final PlanCrudService planCrudService;
+    private final FlowCrudService flowCrudService;
+    private final UpdatePlanDomainService updatePlanDomainService;
+    private final JsonPatchDomainService jsonPatchDomainService;
+    private final ObjectMapper objectMapper;
+    private final PlanFlowsConverter planFlowsConverter;
+
+    public interface PlanFlowsConverter {
+        JsonNode toCurrentFlowsNode(@Nonnull List<Flow> flows);
+
+        List<Flow> fromPatchedFlowsNode(JsonNode flowsNode);
+    }
+
+    public Output execute(Input input) {
+        if (input.patchType() == null) {
+            throw new ValidationDomainException("A patchType must be provided");
+        }
+
+        var plan = planCrudService
+            .findByPlanIdAndReferenceIdAndReferenceType(input.planId(), input.apiId(), GenericPlanEntity.ReferenceType.API.name())
+            .orElseThrow(() -> new PlanForApiNotFoundException(input.planId(), input.apiId()));
+
+        var api = apiCrudService.get(input.apiId());
+
+        if (!DefinitionVersion.V4.equals(api.getDefinitionVersion())) {
+            throw new ValidationDomainException("Plan PATCH is only supported for V4 API plans");
+        }
+        if (!ApiType.PROXY.equals(api.getType())) {
+            throw new ValidationDomainException("Plan PATCH is only supported for HTTP Proxy API plans");
+        }
+
+        var currentFlows = flowCrudService.getPlanV4Flows(plan.getId());
+
+        var currentNode = toJsonNode(plan, currentFlows);
+        var patchNode = parseBody(input.patchBody());
+
+        enforceAllowList(input.patchType(), patchNode);
+
+        var explicitNulls = collectExplicitNulls(input.patchType(), patchNode);
+        rejectNullOnNonNullableFields(explicitNulls);
+
+        var patchedNode = applyPatch(input.patchType(), patchNode, currentNode, input.planId(), input.apiId());
+
+        var patched = applyPatchedValues(plan, patchedNode, explicitNulls);
+        var patchedFlows = extractFlows(patchedNode, currentFlows, explicitNulls);
+
+        if (input.dryRun()) {
+            updatePlanDomainService.validate(patched, patchedFlows, api, input.auditInfo());
+            return new Output(new PlanWithFlows(patched, patchedFlows));
+        }
+
+        var saved = updatePlanDomainService.update(patched, patchedFlows, null, api, input.auditInfo());
+        return new Output(new PlanWithFlows(saved, patchedFlows));
+    }
+
+    private JsonNode toJsonNode(Plan plan, List<Flow> currentFlows) {
+        var node = objectMapper.createObjectNode();
+        var def = plan.getPlanDefinitionHttpV4();
+        node.put(FIELD_NAME, plan.getName());
+        node.put(FIELD_DESCRIPTION, plan.getDescription());
+        node.put(FIELD_VALIDATION, plan.getValidation() != null ? plan.getValidation().name() : null);
+        node.put(FIELD_COMMENT_REQUIRED, plan.isCommentRequired());
+        node.put(FIELD_GENERAL_CONDITIONS, plan.getGeneralConditions());
+        if (def != null) {
+            node.put(FIELD_SELECTION_RULE, def.getSelectionRule());
+            if (def.getSecurity() != null) {
+                node.set(FIELD_SECURITY_CONFIGURATION, objectMapper.valueToTree(def.getSecurity()));
+            }
+            if (def.getTags() != null) {
+                node.set(FIELD_TAGS, objectMapper.valueToTree(def.getTags()));
+            }
+        }
+        if (currentFlows != null) {
+            try {
+                node.set(FIELD_FLOWS, planFlowsConverter.toCurrentFlowsNode(currentFlows));
+            } catch (RuntimeException e) {
+                throw new ValidationDomainException("Failed to serialise current flows for patch merge", e);
+            }
+        }
+        if (plan.getExcludedGroups() != null) {
+            node.set(FIELD_EXCLUDED_GROUPS, objectMapper.valueToTree(plan.getExcludedGroups()));
+        }
+        if (plan.getCharacteristics() != null) {
+            node.set(FIELD_CHARACTERISTICS, objectMapper.valueToTree(plan.getCharacteristics()));
+        }
+        return node;
+    }
+
+    private JsonNode parseBody(String body) {
+        if (body == null || body.isBlank()) {
+            throw new ValidationDomainException("Patch body is required");
+        }
+        try {
+            return objectMapper.readTree(body);
+        } catch (JsonProcessingException e) {
+            throw new ValidationDomainException("Invalid patch body: " + e.getMessage(), e);
+        }
+    }
+
+    private void enforceAllowList(PatchType patchType, JsonNode patchNode) {
+        if (patchType == PatchType.JSON_PATCH) {
+            enforceAllowListJsonPatch(patchNode);
+        } else {
+            enforceAllowListMergePatch(patchNode);
+        }
+    }
+
+    private void enforceAllowListJsonPatch(JsonNode patchArray) {
+        if (!patchArray.isArray()) {
+            throw new ValidationDomainException("JSON Patch body must be a JSON array");
+        }
+        if (patchArray.size() > MAX_PATCH_OPS) {
+            throw new ValidationDomainException("JSON Patch request exceeds maximum of " + MAX_PATCH_OPS + " operations");
+        }
+        var index = 0;
+        for (JsonNode op : patchArray) {
+            // Allow-list applies to every op, including the read-only RFC 6902 `test` op, so non-patchable pointers cannot be probed.
+            var pathNode = op.path("path");
+            if (pathNode.isMissingNode() || !pathNode.isTextual()) {
+                throw new ValidationDomainException("JSON Patch operation at index " + index + " is missing required 'path' field");
+            }
+            var rawPath = pathNode.asText();
+            validateJsonPatchField(index, "path", rawPath);
+
+            var opName = op.path("op").asText();
+            if ("move".equals(opName) || "copy".equals(opName)) {
+                var fromNode = op.path("from");
+                if (fromNode.isMissingNode() || !fromNode.isTextual()) {
+                    throw new ValidationDomainException("JSON Patch operation at index " + index + " is missing required 'from' field");
+                }
+                validateJsonPatchField(index, "from", fromNode.asText());
+            }
+            index++;
+        }
+    }
+
+    private void validateJsonPatchField(int opIndex, String fieldLabel, String pointer) {
+        if (!pointer.isEmpty() && !pointer.startsWith("/")) {
+            throw new ValidationDomainException(
+                "JSON Patch operation at index " +
+                    opIndex +
+                    " has '" +
+                    fieldLabel +
+                    "' value '" +
+                    pointer +
+                    "' which is not a valid JSON Pointer"
+            );
+        }
+        var field = extractTopLevelField(pointer);
+        if (field.isEmpty()) {
+            throw new ValidationDomainException(
+                "JSON Patch operation at index " +
+                    opIndex +
+                    " has '" +
+                    fieldLabel +
+                    "' value '" +
+                    pointer +
+                    "' which does not target a specific field"
+            );
+        }
+        validateField(field);
+    }
+
+    private void enforceAllowListMergePatch(JsonNode mergePatchNode) {
+        if (!mergePatchNode.isObject()) {
+            throw new ValidationDomainException("JSON Merge Patch body must be a JSON object");
+        }
+        var fieldNames = mergePatchNode.fieldNames();
+        while (fieldNames.hasNext()) {
+            validateField(fieldNames.next());
+        }
+    }
+
+    private String extractTopLevelField(String jsonPointer) {
+        if (jsonPointer.isEmpty()) {
+            return "";
+        }
+        var withoutLeadingSlash = jsonPointer.startsWith("/") ? jsonPointer.substring(1) : jsonPointer;
+        var slashIndex = withoutLeadingSlash.indexOf('/');
+        return slashIndex < 0 ? withoutLeadingSlash : withoutLeadingSlash.substring(0, slashIndex);
+    }
+
+    private Set<String> collectExplicitNulls(PatchType patchType, JsonNode patchNode) {
+        var explicitNulls = new HashSet<String>();
+        if (patchType == PatchType.JSON_PATCH) {
+            for (JsonNode op : patchNode) {
+                var opName = op.path("op").asText();
+                var pointer = op.path("path").asText();
+                var topLevelField = extractTopLevelField(pointer);
+                boolean clearsField;
+                if ("remove".equals(opName)) {
+                    clearsField = true;
+                } else if ("add".equals(opName) || "replace".equals(opName)) {
+                    clearsField = op.path("value").isNull();
+                } else {
+                    clearsField = false;
+                }
+                if (!clearsField) {
+                    continue;
+                }
+                if (pointer.equals("/" + topLevelField)) {
+                    explicitNulls.add(topLevelField);
+                }
+            }
+        } else {
+            var fields = patchNode.fields();
+            while (fields.hasNext()) {
+                var entry = fields.next();
+                if (entry.getValue().isNull()) {
+                    explicitNulls.add(entry.getKey());
+                }
+            }
+        }
+        return explicitNulls;
+    }
+
+    private void rejectNullOnNonNullableFields(Set<String> explicitNulls) {
+        for (String field : explicitNulls) {
+            if (NON_NULLABLE_FIELDS.contains(field)) {
+                throw new ValidationDomainException("Field '" + field + "' cannot be set to null");
+            }
+        }
+    }
+
+    private void validateField(String field) {
+        if ("status".equals(field)) {
+            throw new PlanPatchNotAllowedException(field, "use plan lifecycle endpoints to change plan status");
+        }
+        if (!ALLOWED_FIELDS.contains(field)) {
+            throw new PlanPatchNotAllowedException(field, "field is not patchable");
+        }
+    }
+
+    private JsonNode applyPatch(PatchType patchType, JsonNode patchNode, JsonNode currentNode, String planId, String apiId) {
+        try {
+            if (patchType == PatchType.JSON_PATCH) {
+                return jsonPatchDomainService.applyJsonPatch(patchNode, currentNode);
+            }
+            return jsonPatchDomainService.applyMergePatch(patchNode, currentNode);
+        } catch (ValidationDomainException e) {
+            throw new ValidationDomainException(
+                "Failed to apply patch on plan [" + planId + "] of API [" + apiId + "]: " + e.getMessage(),
+                e
+            );
+        }
+    }
+
+    private Plan applyPatchedValues(Plan existing, JsonNode patchedNode, Set<String> explicitNulls) {
+        var name = textOrDefault(patchedNode, FIELD_NAME, explicitNulls, existing.getName());
+        if (name == null || name.isBlank()) {
+            throw new ValidationDomainException("'name' cannot be blank");
+        }
+
+        var description = textOrDefault(patchedNode, FIELD_DESCRIPTION, explicitNulls, existing.getDescription());
+        var commentRequired = booleanOrDefault(patchedNode, FIELD_COMMENT_REQUIRED, existing.isCommentRequired());
+        var generalConditions = textOrDefault(patchedNode, FIELD_GENERAL_CONDITIONS, explicitNulls, existing.getGeneralConditions());
+
+        var validationNode = patchedNode.get(FIELD_VALIDATION);
+        var validation = existing.getValidation();
+        if (validationNode != null && !validationNode.isNull()) {
+            try {
+                validation = Plan.PlanValidationType.valueOf(validationNode.asText());
+            } catch (IllegalArgumentException e) {
+                throw new ValidationDomainException("Invalid validation value: " + validationNode.asText(), e);
+            }
+        }
+
+        var excludedGroups = stringListOrDefault(patchedNode, FIELD_EXCLUDED_GROUPS, explicitNulls, existing.getExcludedGroups());
+        var characteristics = stringListOrDefault(patchedNode, FIELD_CHARACTERISTICS, explicitNulls, existing.getCharacteristics());
+
+        var updatedPlan = existing
+            .toBuilder()
+            .name(name)
+            .description(description)
+            .commentRequired(commentRequired)
+            .generalConditions(generalConditions)
+            .validation(validation)
+            .excludedGroups(excludedGroups)
+            .characteristics(characteristics)
+            .build();
+
+        var def = existing.getPlanDefinitionHttpV4();
+        if (def != null) {
+            var selectionRule = textOrDefault(patchedNode, FIELD_SELECTION_RULE, explicitNulls, def.getSelectionRule());
+
+            var existingSecurityType = def.getSecurity() != null ? def.getSecurity().getType() : null;
+            var securityNode = patchedNode.get(FIELD_SECURITY_CONFIGURATION);
+            PlanSecurity security;
+            if (securityNode != null && !securityNode.isNull()) {
+                var convertedSecurity = convertField(securityNode, PlanSecurity.class, FIELD_SECURITY_CONFIGURATION);
+                if (convertedSecurity == null) {
+                    throw new ValidationDomainException("Invalid value for field 'security'");
+                }
+                security = convertedSecurity.withType(existingSecurityType);
+            } else {
+                security = def.getSecurity();
+            }
+
+            var tags = explicitNulls.contains(FIELD_TAGS) ? null : tagsOrDefault(patchedNode, def.getTags());
+
+            var updatedDef = def.toBuilder().name(name).selectionRule(selectionRule).security(security).tags(tags).build();
+            updatedPlan = updatedPlan.toBuilder().planDefinitionHttpV4(updatedDef).build();
+        }
+
+        return updatedPlan;
+    }
+
+    private List<Flow> extractFlows(JsonNode patchedNode, List<Flow> currentFlows, Set<String> explicitNulls) {
+        if (explicitNulls.contains(FIELD_FLOWS)) {
+            return List.of();
+        }
+        var flowsNode = patchedNode.get(FIELD_FLOWS);
+        if (flowsNode == null || flowsNode.isNull()) {
+            return currentFlows;
+        }
+        return planFlowsConverter.fromPatchedFlowsNode(flowsNode);
+    }
+
+    private <T> T convertField(JsonNode node, Class<T> type, String fieldName) {
+        try {
+            return objectMapper.convertValue(node, type);
+        } catch (IllegalArgumentException e) {
+            throw new ValidationDomainException("Invalid value for field '" + fieldName + "': " + e.getMessage(), e);
+        }
+    }
+
+    private <T> T convertField(JsonNode node, TypeReference<T> type, String fieldName) {
+        try {
+            return objectMapper.convertValue(node, type);
+        } catch (IllegalArgumentException e) {
+            throw new ValidationDomainException("Invalid value for field '" + fieldName + "': " + e.getMessage(), e);
+        }
+    }
+
+    private String textOrDefault(JsonNode node, String field, Set<String> explicitNulls, String defaultValue) {
+        if (explicitNulls.contains(field)) {
+            return null;
+        }
+        var fieldNode = node.get(field);
+        if (fieldNode == null || fieldNode.isNull()) {
+            return defaultValue;
+        }
+        if (!fieldNode.isTextual()) {
+            throw new ValidationDomainException("Invalid value for field '" + field + "'");
+        }
+        return fieldNode.asText(defaultValue);
+    }
+
+    private List<String> stringListOrDefault(JsonNode node, String field, Set<String> explicitNulls, List<String> defaultValue) {
+        if (explicitNulls.contains(field)) {
+            return null;
+        }
+        if (!node.has(field)) {
+            return defaultValue;
+        }
+        var fieldNode = node.get(field);
+        if (fieldNode == null || fieldNode.isNull()) {
+            return null;
+        }
+        return convertField(fieldNode, new TypeReference<List<String>>() {}, field);
+    }
+
+    private Set<String> tagsOrDefault(JsonNode node, Set<String> defaultValue) {
+        var fieldNode = node.get(FIELD_TAGS);
+        if (fieldNode == null || fieldNode.isNull()) {
+            return defaultValue;
+        }
+        return convertField(fieldNode, new TypeReference<Set<String>>() {}, FIELD_TAGS);
+    }
+
+    private boolean booleanOrDefault(JsonNode node, String field, boolean defaultValue) {
+        var fieldNode = node.get(field);
+        if (fieldNode == null || fieldNode.isNull()) {
+            return defaultValue;
+        }
+        if (!fieldNode.isBoolean()) {
+            throw new ValidationDomainException("Invalid value for field '" + field + "'");
+        }
+        return fieldNode.asBoolean(defaultValue);
+    }
+
+    public enum PatchType {
+        JSON_PATCH,
+        MERGE_PATCH,
+    }
+
+    @Builder
+    public record Input(String apiId, String planId, PatchType patchType, String patchBody, boolean dryRun, AuditInfo auditInfo) {
+        public Input {
+            Objects.requireNonNull(apiId, "apiId must not be null");
+            Objects.requireNonNull(planId, "planId must not be null");
+            Objects.requireNonNull(auditInfo, "auditInfo must not be null");
+        }
+    }
+
+    public record Output(PlanWithFlows plan) {}
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/plan/use_case/PatchPlanUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/plan/use_case/PatchPlanUseCase.java
@@ -26,6 +26,7 @@ import io.gravitee.apim.core.exception.ValidationDomainException;
 import io.gravitee.apim.core.flow.crud_service.FlowCrudService;
 import io.gravitee.apim.core.json_patch.domain_service.JsonPatchDomainService;
 import io.gravitee.apim.core.plan.crud_service.PlanCrudService;
+import io.gravitee.apim.core.plan.domain_service.PlanExcludedGroupsDomainService;
 import io.gravitee.apim.core.plan.domain_service.UpdatePlanDomainService;
 import io.gravitee.apim.core.plan.exception.PlanForApiNotFoundException;
 import io.gravitee.apim.core.plan.exception.PlanPatchNotAllowedException;
@@ -93,6 +94,7 @@ public class PatchPlanUseCase {
     private final JsonPatchDomainService jsonPatchDomainService;
     private final ObjectMapper objectMapper;
     private final PlanFlowsConverter planFlowsConverter;
+    private final PlanExcludedGroupsDomainService planExcludedGroupsDomainService;
 
     public interface PlanFlowsConverter {
         JsonNode toCurrentFlowsNode(@Nonnull List<Flow> flows);
@@ -132,6 +134,10 @@ public class PatchPlanUseCase {
 
         var patched = applyPatchedValues(plan, patchedNode, explicitNulls);
         var patchedFlows = extractFlows(patchedNode, currentFlows, explicitNulls, patchTargetsFlows(input.patchType(), patchNode));
+
+        if (patchTargetsExcludedGroups(input.patchType(), patchNode)) {
+            planExcludedGroupsDomainService.validateExcludedGroups(input.auditInfo().environmentId(), patched.getExcludedGroups());
+        }
 
         if (input.dryRun()) {
             updatePlanDomainService.validate(patched, patchedFlows, api, input.auditInfo());
@@ -440,6 +446,24 @@ public class PatchPlanUseCase {
 
     private boolean pointerTargetsFlows(String pointer, String flowsPointer) {
         return pointer.equals(flowsPointer) || pointer.startsWith(flowsPointer + "/");
+    }
+
+    private boolean patchTargetsExcludedGroups(PatchType patchType, JsonNode patchNode) {
+        if (patchType == PatchType.MERGE_PATCH) {
+            return patchNode.has(FIELD_EXCLUDED_GROUPS);
+        }
+        if (!patchNode.isArray()) {
+            return false;
+        }
+        for (JsonNode op : patchNode) {
+            if (FIELD_EXCLUDED_GROUPS.equals(extractTopLevelField(op.path("path").asText()))) {
+                return true;
+            }
+            if ("move".equals(op.path("op").asText()) && FIELD_EXCLUDED_GROUPS.equals(extractTopLevelField(op.path("from").asText()))) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private <T> T convertField(JsonNode node, Class<T> type, String fieldName) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/plan/use_case/PatchPlanUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/plan/use_case/PatchPlanUseCase.java
@@ -272,35 +272,42 @@ public class PatchPlanUseCase {
     private Set<String> collectExplicitNulls(PatchType patchType, JsonNode patchNode) {
         var explicitNulls = new HashSet<String>();
         if (patchType == PatchType.JSON_PATCH) {
-            for (JsonNode op : patchNode) {
-                var opName = op.path("op").asText();
-                var pointer = op.path("path").asText();
-                var topLevelField = extractTopLevelField(pointer);
-                boolean clearsField;
-                if ("remove".equals(opName)) {
-                    clearsField = true;
-                } else if ("add".equals(opName) || "replace".equals(opName)) {
-                    clearsField = op.path("value").isNull();
-                } else {
-                    clearsField = false;
-                }
-                if (!clearsField) {
-                    continue;
-                }
-                if (pointer.equals("/" + topLevelField)) {
-                    explicitNulls.add(topLevelField);
-                }
-            }
+            collectJsonPatchExplicitNulls(patchNode, explicitNulls);
         } else {
-            var fields = patchNode.fields();
-            while (fields.hasNext()) {
-                var entry = fields.next();
-                if (entry.getValue().isNull()) {
-                    explicitNulls.add(entry.getKey());
-                }
-            }
+            collectMergePatchExplicitNulls(patchNode, explicitNulls);
         }
         return explicitNulls;
+    }
+
+    private void collectJsonPatchExplicitNulls(JsonNode patchNode, Set<String> explicitNulls) {
+        for (JsonNode op : patchNode) {
+            var opName = op.path("op").asText();
+            var pointer = op.path("path").asText();
+            var topLevelField = extractTopLevelField(pointer);
+            if (clearsField(op, opName) && pointer.equals("/" + topLevelField)) {
+                explicitNulls.add(topLevelField);
+            }
+        }
+    }
+
+    private boolean clearsField(JsonNode op, String opName) {
+        if ("remove".equals(opName)) {
+            return true;
+        }
+        if ("add".equals(opName) || "replace".equals(opName)) {
+            return op.path("value").isNull();
+        }
+        return false;
+    }
+
+    private void collectMergePatchExplicitNulls(JsonNode patchNode, Set<String> explicitNulls) {
+        var fields = patchNode.fields();
+        while (fields.hasNext()) {
+            var entry = fields.next();
+            if (entry.getValue().isNull()) {
+                explicitNulls.add(entry.getKey());
+            }
+        }
     }
 
     private void rejectNullOnNonNullableFields(Set<String> explicitNulls) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/plan/use_case/PatchPlanUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/plan/use_case/PatchPlanUseCase.java
@@ -131,7 +131,7 @@ public class PatchPlanUseCase {
         var patchedNode = applyPatch(input.patchType(), patchNode, currentNode, input.planId(), input.apiId());
 
         var patched = applyPatchedValues(plan, patchedNode, explicitNulls);
-        var patchedFlows = extractFlows(patchedNode, currentFlows, explicitNulls);
+        var patchedFlows = extractFlows(patchedNode, currentFlows, explicitNulls, patchTargetsFlows(input.patchType(), patchNode));
 
         if (input.dryRun()) {
             updatePlanDomainService.validate(patched, patchedFlows, api, input.auditInfo());
@@ -394,15 +394,41 @@ public class PatchPlanUseCase {
         return updatedPlan;
     }
 
-    private List<Flow> extractFlows(JsonNode patchedNode, List<Flow> currentFlows, Set<String> explicitNulls) {
+    private List<Flow> extractFlows(JsonNode patchedNode, List<Flow> currentFlows, Set<String> explicitNulls, boolean patchTargetsFlows) {
         if (explicitNulls.contains(FIELD_FLOWS)) {
             return List.of();
+        }
+        if (!patchTargetsFlows) {
+            return currentFlows;
         }
         var flowsNode = patchedNode.get(FIELD_FLOWS);
         if (flowsNode == null || flowsNode.isNull()) {
             return currentFlows;
         }
         return planFlowsConverter.fromPatchedFlowsNode(flowsNode);
+    }
+
+    private boolean patchTargetsFlows(PatchType patchType, JsonNode patchNode) {
+        if (patchType == PatchType.MERGE_PATCH) {
+            return patchNode.has(FIELD_FLOWS);
+        }
+        if (!patchNode.isArray()) {
+            return false;
+        }
+        var flowsPointer = "/" + FIELD_FLOWS;
+        for (JsonNode op : patchNode) {
+            if (pointerTargetsFlows(op.path("path").asText(), flowsPointer)) {
+                return true;
+            }
+            if ("move".equals(op.path("op").asText()) && pointerTargetsFlows(op.path("from").asText(), flowsPointer)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private boolean pointerTargetsFlows(String pointer, String flowsPointer) {
+        return pointer.equals(flowsPointer) || pointer.startsWith(flowsPointer + "/");
     }
 
     private <T> T convertField(JsonNode node, Class<T> type, String fieldName) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/plan/use_case/PatchPlanUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/plan/use_case/PatchPlanUseCase.java
@@ -375,30 +375,34 @@ public class PatchPlanUseCase {
             .characteristics(characteristics)
             .build();
 
+        return applyPlanDefinition(updatedPlan, existing, patchedNode, explicitNulls, name);
+    }
+
+    private Plan applyPlanDefinition(Plan updatedPlan, Plan existing, JsonNode patchedNode, Set<String> explicitNulls, String name) {
         var def = existing.getPlanDefinitionHttpV4();
-        if (def != null) {
-            var selectionRule = textOrDefault(patchedNode, FIELD_SELECTION_RULE, explicitNulls, def.getSelectionRule());
-
-            var existingSecurityType = def.getSecurity() != null ? def.getSecurity().getType() : null;
-            var securityNode = patchedNode.get(FIELD_SECURITY_CONFIGURATION);
-            PlanSecurity security;
-            if (securityNode != null && !securityNode.isNull()) {
-                var convertedSecurity = convertField(securityNode, PlanSecurity.class, FIELD_SECURITY_CONFIGURATION);
-                if (convertedSecurity == null) {
-                    throw new ValidationDomainException("Invalid value for field 'security'");
-                }
-                security = convertedSecurity.withType(existingSecurityType);
-            } else {
-                security = def.getSecurity();
-            }
-
-            var tags = explicitNulls.contains(FIELD_TAGS) ? null : tagsOrDefault(patchedNode, def.getTags());
-
-            var updatedDef = def.toBuilder().name(name).selectionRule(selectionRule).security(security).tags(tags).build();
-            updatedPlan = updatedPlan.toBuilder().planDefinitionHttpV4(updatedDef).build();
+        if (def == null) {
+            return updatedPlan;
         }
 
-        return updatedPlan;
+        var selectionRule = textOrDefault(patchedNode, FIELD_SELECTION_RULE, explicitNulls, def.getSelectionRule());
+
+        var existingSecurityType = def.getSecurity() != null ? def.getSecurity().getType() : null;
+        var securityNode = patchedNode.get(FIELD_SECURITY_CONFIGURATION);
+        PlanSecurity security;
+        if (securityNode != null && !securityNode.isNull()) {
+            var convertedSecurity = convertField(securityNode, PlanSecurity.class, FIELD_SECURITY_CONFIGURATION);
+            if (convertedSecurity == null) {
+                throw new ValidationDomainException("Invalid value for field 'security'");
+            }
+            security = convertedSecurity.withType(existingSecurityType);
+        } else {
+            security = def.getSecurity();
+        }
+
+        var tags = explicitNulls.contains(FIELD_TAGS) ? null : tagsOrDefault(patchedNode, def.getTags());
+
+        var updatedDef = def.toBuilder().name(name).selectionRule(selectionRule).security(security).tags(tags).build();
+        return updatedPlan.toBuilder().planDefinitionHttpV4(updatedDef).build();
     }
 
     private List<Flow> extractFlows(JsonNode patchedNode, List<Flow> currentFlows, Set<String> explicitNulls, boolean patchTargetsFlows) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/FlowAdapter.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/FlowAdapter.java
@@ -111,6 +111,7 @@ public interface FlowAdapter {
 
     FlowHttpSelector toRepository(HttpSelector source);
 
+    @Mapping(target = "pathOperator", source = "pathOperator", defaultValue = "STARTS_WITH")
     HttpSelector toModel(FlowHttpSelector source);
 
     FlowChannelSelector toRepository(ChannelSelector source);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/exceptions/PreconditionFailedException.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/exceptions/PreconditionFailedException.java
@@ -21,6 +21,12 @@ import java.util.Map;
 
 public class PreconditionFailedException extends AbstractManagementException {
 
+    public PreconditionFailedException() {}
+
+    public PreconditionFailedException(Throwable cause) {
+        super(cause);
+    }
+
     @Override
     public int getHttpStatusCode() {
         return HttpStatusCode.PRECONDITION_FAILED_412;
@@ -28,7 +34,7 @@ public class PreconditionFailedException extends AbstractManagementException {
 
     @Override
     public String getMessage() {
-        return "Precondition failed";
+        return getCause() != null ? "Precondition failed: " + getCause().getMessage() : "Precondition failed";
     }
 
     @Override

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/fakes/FakePolicyValidationDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/fakes/FakePolicyValidationDomainService.java
@@ -25,10 +25,16 @@ import java.util.List;
 
 public class FakePolicyValidationDomainService implements PolicyValidationDomainService {
 
+    public static final String SANITIZING_POLICY = "sanitize-config-policy";
+    public static final String SANITIZED_CONFIGURATION = "{\"sanitized\":true}";
+
     @Override
     public String validateAndSanitizeConfiguration(String policyName, String configuration) {
         if (policyName.contains("throw_invalid_data_exception")) {
             throw new InvalidDataException("Invalid configuration for policy " + policyName);
+        }
+        if (SANITIZING_POLICY.equals(policyName)) {
+            return SANITIZED_CONFIGURATION;
         }
         return configuration;
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/plan/domain_service/UpdatePlanDomainServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/plan/domain_service/UpdatePlanDomainServiceTest.java
@@ -497,6 +497,43 @@ class UpdatePlanDomainServiceTest {
     }
 
     @Nested
+    class Validate {
+
+        @ParameterizedTest
+        @MethodSource("io.gravitee.apim.core.plan.domain_service.UpdatePlanDomainServiceTest#v4testData")
+        void should_not_throw_for_a_valid_plan_and_flows(Api api, Plan plan, List<Flow> flows) {
+            givenExistingPlan(plan);
+
+            Assertions.assertThatCode(() -> service.validate(plan, flows, api, AUDIT_INFO)).doesNotThrowAnyException();
+        }
+
+        @Test
+        void should_throw_when_flows_are_invalid() {
+            var plan = PlanFixtures.HttpV4.anApiKey()
+                .toBuilder()
+                .apiId(API_ID)
+                .planDefinitionHttpV4(
+                    fixtures.definition.PlanFixtures.HttpV4Definition.anApiKeyV4()
+                        .toBuilder()
+                        .tags(Set.of(TAG))
+                        .status(PlanStatus.STAGING)
+                        .build()
+                )
+                .build();
+            givenExistingPlan(plan);
+            List<Flow> invalidFlows = List.of(
+                Flow.builder().name("invalid").selectors(List.of(new HttpSelector(), new ChannelSelector())).build()
+            );
+
+            var throwable = Assertions.catchThrowable(() -> service.validate(plan, invalidFlows, API_PROXY_V4, AUDIT_INFO));
+
+            assertThat(throwable)
+                .isInstanceOf(ValidationDomainException.class)
+                .hasMessageContaining("The flow [invalid] contains selectors that couldn't apply");
+        }
+    }
+
+    @Nested
     class Common {
 
         @ParameterizedTest

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/plan/exception/PlanForApiNotFoundExceptionTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/plan/exception/PlanForApiNotFoundExceptionTest.java
@@ -15,14 +15,19 @@
  */
 package io.gravitee.apim.core.plan.exception;
 
-import io.gravitee.apim.core.exception.ValidationDomainException;
+import static org.assertj.core.api.Assertions.assertThat;
 
-/**
- * @author GraviteeSource Team
- */
-public class PlanInvalidException extends ValidationDomainException {
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
 
-    public PlanInvalidException(String message) {
-        super(message);
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class PlanForApiNotFoundExceptionTest {
+
+    @Test
+    void message_identifies_both_plan_id_and_api_id() {
+        var ex = new PlanForApiNotFoundException("p1", "api1");
+
+        assertThat(ex.getMessage()).contains("p1").contains("api1");
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/plan/exception/PlanPatchNotAllowedExceptionTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/plan/exception/PlanPatchNotAllowedExceptionTest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.plan.exception;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class PlanPatchNotAllowedExceptionTest {
+
+    @Test
+    void exposes_field_name_in_parameters_and_includes_reason_in_message() {
+        var ex = new PlanPatchNotAllowedException("status", "use lifecycle endpoints");
+
+        assertThat(ex.getParameters()).containsEntry("field", "status");
+        assertThat(ex.getMessage()).contains("status").contains("use lifecycle endpoints");
+        assertThat(ex.getTechnicalCode()).isEqualTo("plan.patch.fieldNotAllowed");
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/plan/use_case/PatchPlanUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/plan/use_case/PatchPlanUseCaseTest.java
@@ -782,7 +782,7 @@ class PatchPlanUseCaseTest {
         void merge_with_unknown_excluded_group_throws_GroupNotFoundException() {
             assertThatThrownBy(() -> executeMerge("{\"excludedGroups\":[\"does-not-exist\"]}")).isInstanceOf(GroupNotFoundException.class);
 
-            assertThat(planCrudService.storage().get(0).getExcludedGroups()).doesNotContain("does-not-exist");
+            assertThat(planCrudService.storage().get(0).getExcludedGroups()).isNullOrEmpty();
         }
 
         @Test
@@ -793,10 +793,31 @@ class PatchPlanUseCaseTest {
         }
 
         @Test
+        void json_patch_move_from_excluded_groups_triggers_validation() {
+            var seeded = PlanFixtures.aPlanHttpV4().toBuilder().excludedGroups(List.of("does-not-exist")).build();
+            seed(seeded);
+
+            assertThatThrownBy(() ->
+                executeJsonPatch("[{\"op\":\"move\",\"from\":\"/excludedGroups/0\",\"path\":\"/excludedGroups/0\"}]")
+            ).isInstanceOf(GroupNotFoundException.class);
+        }
+
+        @Test
         void merge_with_known_excluded_groups_succeeds() {
             var output = executeMerge("{\"excludedGroups\":[\"g1\",\"g2\"]}");
 
             assertThat(output.plan().getExcludedGroups()).containsExactly("g1", "g2");
+            assertThat(planCrudService.storage().get(0).getExcludedGroups()).containsExactly("g1", "g2");
+        }
+
+        @Test
+        void json_patch_not_targeting_excluded_groups_skips_validation() {
+            var seeded = PlanFixtures.aPlanHttpV4().toBuilder().excludedGroups(List.of("stale-group")).build();
+            seed(seeded);
+
+            var output = executeJsonPatch("[{\"op\":\"replace\",\"path\":\"/name\",\"value\":\"Renamed\"}]");
+
+            assertThat(output.plan().getExcludedGroups()).containsExactly("stale-group");
         }
 
         @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/plan/use_case/PatchPlanUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/plan/use_case/PatchPlanUseCaseTest.java
@@ -890,6 +890,27 @@ class PatchPlanUseCaseTest {
     }
 
     @Nested
+    class NonFlowPatchDoesNotForceRedeploy {
+
+        @Test
+        void name_only_patch_on_plan_without_flows_does_not_set_needRedeployAt() {
+            var output = executeMerge("{\"name\":\"Renamed\"}");
+
+            assertThat(output.plan().getNeedRedeployAt()).isNull();
+        }
+
+        @Test
+        void name_only_patch_on_plan_with_unchanged_flows_does_not_set_needRedeployAt() {
+            var step = Step.builder().name("policy-step").policy("a-policy").configuration("{\"k\":\"v\"}").build();
+            flowCrudService.savePlanFlows(PLAN_ID, List.of(Flow.builder().name("Flow").enabled(true).request(List.of(step)).build()));
+
+            var output = executeMerge("{\"name\":\"Renamed\"}");
+
+            assertThat(output.plan().getNeedRedeployAt()).isNull();
+        }
+    }
+
+    @Nested
     class DryRunJsonPatch {
 
         @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/plan/use_case/PatchPlanUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/plan/use_case/PatchPlanUseCaseTest.java
@@ -1,0 +1,1136 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.plan.use_case;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import fakes.FakePolicyValidationDomainService;
+import fixtures.core.model.ApiFixtures;
+import fixtures.core.model.AuditInfoFixtures;
+import fixtures.core.model.PlanFixtures;
+import inmemory.ApiCrudServiceInMemory;
+import inmemory.AuditCrudServiceInMemory;
+import inmemory.EntrypointPluginQueryServiceInMemory;
+import inmemory.FlowCrudServiceInMemory;
+import inmemory.KafkaPortRangeCrudServiceInMemory;
+import inmemory.PageCrudServiceInMemory;
+import inmemory.ParametersQueryServiceInMemory;
+import inmemory.PlanCrudServiceInMemory;
+import inmemory.PlanQueryServiceInMemory;
+import inmemory.UserCrudServiceInMemory;
+import io.gravitee.apim.core.audit.domain_service.AuditDomainService;
+import io.gravitee.apim.core.audit.model.AuditEntity;
+import io.gravitee.apim.core.exception.ValidationDomainException;
+import io.gravitee.apim.core.flow.domain_service.FlowValidationDomainService;
+import io.gravitee.apim.core.json.JsonDiffProcessor;
+import io.gravitee.apim.core.json_patch.domain_service.JsonPatchDomainService;
+import io.gravitee.apim.core.plan.domain_service.PlanSynchronizationService;
+import io.gravitee.apim.core.plan.domain_service.PlanValidatorDomainService;
+import io.gravitee.apim.core.plan.domain_service.ReorderPlanDomainService;
+import io.gravitee.apim.core.plan.domain_service.UpdatePlanDomainService;
+import io.gravitee.apim.core.plan.domain_service.VerifyPlanPortRangesDomainService;
+import io.gravitee.apim.core.plan.exception.PlanForApiNotFoundException;
+import io.gravitee.apim.core.plan.exception.PlanPatchNotAllowedException;
+import io.gravitee.apim.core.plan.model.Plan;
+import io.gravitee.apim.core.plan.use_case.PatchPlanUseCase.PlanFlowsConverter;
+import io.gravitee.apim.core.policy.domain_service.PolicyValidationDomainService;
+import io.gravitee.apim.infra.domain_service.json_patch.JsonMergePatchServiceImpl;
+import io.gravitee.apim.infra.domain_service.json_patch.JsonPatchServiceImpl;
+import io.gravitee.apim.infra.domain_service.plan.PlanSynchronizationLegacyWrapper;
+import io.gravitee.apim.infra.json.jackson.JacksonJsonDiffProcessor;
+import io.gravitee.definition.model.v4.flow.Flow;
+import io.gravitee.definition.model.v4.plan.PlanSecurity;
+import io.gravitee.repository.management.model.Parameter;
+import io.gravitee.rest.api.model.parameters.Key;
+import io.gravitee.rest.api.service.processor.SynchronizationService;
+import java.io.IOException;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.IntStream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class PatchPlanUseCaseTest {
+
+    private static final String API_ID = "my-api";
+    private static final String PLAN_ID = "my-plan";
+
+    private final ApiCrudServiceInMemory apiCrudService = new ApiCrudServiceInMemory();
+    private final PlanCrudServiceInMemory planCrudService = new PlanCrudServiceInMemory();
+    private final FlowCrudServiceInMemory flowCrudService = new FlowCrudServiceInMemory();
+    private final PlanQueryServiceInMemory planQueryService = new PlanQueryServiceInMemory();
+    private final AuditCrudServiceInMemory auditCrudService = new AuditCrudServiceInMemory();
+    private final UserCrudServiceInMemory userCrudService = new UserCrudServiceInMemory();
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final JsonPatchDomainService jsonPatchDomainService = new JsonPatchDomainService(
+        new JsonMergePatchServiceImpl(),
+        new JsonPatchServiceImpl()
+    );
+    private final FakePolicyValidationDomainService policyValidationDomainService = new FakePolicyValidationDomainService();
+    private final EntrypointPluginQueryServiceInMemory entrypointConnectorPluginService = new EntrypointPluginQueryServiceInMemory();
+    private final FlowValidationDomainService flowValidationDomainService = new FlowValidationDomainService(
+        policyValidationDomainService,
+        entrypointConnectorPluginService
+    );
+    private final ParametersQueryServiceInMemory parametersQueryService = new ParametersQueryServiceInMemory();
+    private final PageCrudServiceInMemory pageCrudService = new PageCrudServiceInMemory();
+    private final PlanValidatorDomainService planValidatorDomainService = new PlanValidatorDomainService(
+        parametersQueryService,
+        policyValidationDomainService,
+        pageCrudService
+    );
+    private final SynchronizationService synchronizationService = new SynchronizationService(objectMapper);
+    private final PlanSynchronizationService planSynchronizationService = new PlanSynchronizationLegacyWrapper(synchronizationService);
+    private final JsonDiffProcessor jsonDiffProcessor = new JacksonJsonDiffProcessor();
+    private final AuditDomainService auditDomainService = new AuditDomainService(auditCrudService, userCrudService, jsonDiffProcessor);
+    private final ReorderPlanDomainService reorderPlanDomainService = new ReorderPlanDomainService(planQueryService, planCrudService);
+    private final KafkaPortRangeCrudServiceInMemory kafkaPortRanges = new KafkaPortRangeCrudServiceInMemory();
+    private final UpdatePlanDomainService updatePlanDomainService = new UpdatePlanDomainService(
+        planQueryService,
+        planCrudService,
+        planValidatorDomainService,
+        flowValidationDomainService,
+        flowCrudService,
+        auditDomainService,
+        planSynchronizationService,
+        reorderPlanDomainService,
+        new VerifyPlanPortRangesDomainService(kafkaPortRanges),
+        kafkaPortRanges
+    );
+
+    private PatchPlanUseCase useCase;
+
+    @BeforeEach
+    void setUp() {
+        apiCrudService.reset();
+        planCrudService.reset();
+        planQueryService.reset();
+        flowCrudService.reset();
+        auditCrudService.reset();
+        userCrudService.reset();
+        var plans = List.of(PlanFixtures.aPlanHttpV4());
+        useCase = new PatchPlanUseCase(
+            apiCrudService,
+            planCrudService,
+            flowCrudService,
+            updatePlanDomainService,
+            jsonPatchDomainService,
+            objectMapper,
+            new PlanFlowsConverter() {
+                @Override
+                public JsonNode toCurrentFlowsNode(List<Flow> flows) {
+                    return objectMapper.valueToTree(flows);
+                }
+
+                @Override
+                public List<Flow> fromPatchedFlowsNode(JsonNode flowsNode) {
+                    try {
+                        return objectMapper.readerForListOf(Flow.class).readValue(flowsNode);
+                    } catch (IOException e) {
+                        throw new ValidationDomainException("Invalid value for field 'flows': " + e.getMessage(), e);
+                    }
+                }
+            }
+        );
+        apiCrudService.initWith(List.of(ApiFixtures.aProxyApiV4()));
+        planCrudService.initWith(plans);
+        planQueryService.initWith(plans);
+        parametersQueryService.initWith(
+            List.of(
+                Parameter.builder().key(Key.PLAN_SECURITY_KEYLESS_ENABLED.key()).value("true").build(),
+                Parameter.builder().key(Key.PLAN_SECURITY_APIKEY_ENABLED.key()).value("true").build()
+            )
+        );
+    }
+
+    private PatchPlanUseCase.Input.InputBuilder baseInput() {
+        return PatchPlanUseCase.Input.builder()
+            .apiId(API_ID)
+            .planId(PLAN_ID)
+            .dryRun(false)
+            .auditInfo(AuditInfoFixtures.anAuditInfo("org-id", "env-id", "user-id"));
+    }
+
+    private PatchPlanUseCase.Output executeMerge(String body) {
+        return useCase.execute(baseInput().patchType(PatchPlanUseCase.PatchType.MERGE_PATCH).patchBody(body).build());
+    }
+
+    private PatchPlanUseCase.Output executeJsonPatch(String body) {
+        return useCase.execute(baseInput().patchType(PatchPlanUseCase.PatchType.JSON_PATCH).patchBody(body).build());
+    }
+
+    private void seed(Plan... plans) {
+        planCrudService.reset();
+        planQueryService.reset();
+        var planList = List.of(plans);
+        planCrudService.initWith(planList);
+        planQueryService.initWith(planList);
+    }
+
+    @Nested
+    class ApplyJsonPatchToAllowListedField {
+
+        @Test
+        void replace_name_returns_updated_plan_and_persists_one_update() {
+            var output = executeJsonPatch("[{\"op\":\"replace\",\"path\":\"/name\",\"value\":\"Renamed\"}]");
+
+            assertThat(output.plan().getName()).isEqualTo("Renamed");
+            assertThat(planCrudService.storage()).hasSize(1);
+            assertThat(planCrudService.storage().get(0).getName()).isEqualTo("Renamed");
+        }
+
+        @Test
+        void replace_description_updates_only_description() {
+            var output = executeJsonPatch("[{\"op\":\"replace\",\"path\":\"/description\",\"value\":\"new description\"}]");
+
+            assertThat(output.plan().getDescription()).isEqualTo("new description");
+            assertThat(output.plan().getName()).isEqualTo(PlanFixtures.aPlanHttpV4().getName());
+        }
+
+        @Test
+        void replace_validation_updates_enum() {
+            var output = executeJsonPatch("[{\"op\":\"replace\",\"path\":\"/validation\",\"value\":\"MANUAL\"}]");
+
+            assertThat(output.plan().getValidation()).isEqualTo(Plan.PlanValidationType.MANUAL);
+        }
+
+        @Test
+        void replace_selection_rule_updates_definition_field() {
+            var output = executeJsonPatch(
+                "[{\"op\":\"replace\",\"path\":\"/selectionRule\",\"value\":\"#context.attributes['foo'] == 'bar'\"}]"
+            );
+
+            assertThat(output.plan().getPlanDefinitionHttpV4().getSelectionRule()).isEqualTo("#context.attributes['foo'] == 'bar'");
+        }
+
+        @Test
+        void replace_comment_required_updates_boolean() {
+            var output = executeJsonPatch("[{\"op\":\"replace\",\"path\":\"/commentRequired\",\"value\":true}]");
+
+            assertThat(output.plan().isCommentRequired()).isTrue();
+        }
+
+        @Test
+        void replace_general_conditions_updates_text() {
+            var output = executeJsonPatch("[{\"op\":\"replace\",\"path\":\"/generalConditions\",\"value\":\"terms-and-conditions\"}]");
+
+            assertThat(output.plan().getGeneralConditions()).isEqualTo("terms-and-conditions");
+        }
+
+        @Test
+        void replace_excluded_groups_updates_list() {
+            var output = executeJsonPatch("[{\"op\":\"replace\",\"path\":\"/excludedGroups\",\"value\":[\"g1\",\"g2\"]}]");
+
+            assertThat(output.plan().getExcludedGroups()).containsExactly("g1", "g2");
+        }
+
+        @Test
+        void replace_characteristics_updates_list() {
+            var output = executeJsonPatch("[{\"op\":\"replace\",\"path\":\"/characteristics\",\"value\":[\"public\",\"v2\"]}]");
+
+            assertThat(output.plan().getCharacteristics()).containsExactly("public", "v2");
+        }
+
+        @Test
+        void remove_description_clears_the_field() {
+            var output = executeJsonPatch("[{\"op\":\"remove\",\"path\":\"/description\"}]");
+
+            assertThat(output.plan().getDescription()).isNull();
+        }
+    }
+
+    @Nested
+    class ApplyMergePatchToAllowListedField {
+
+        @Test
+        void merge_description_updates_only_description() {
+            var originalName = PlanFixtures.aPlanHttpV4().getName();
+
+            var output = executeMerge("{\"description\":\"new description\"}");
+
+            assertThat(output.plan().getDescription()).isEqualTo("new description");
+            assertThat(output.plan().getName()).isEqualTo(originalName);
+        }
+
+        @Test
+        void merge_with_explicit_null_tags_clears_the_tag_set() {
+            var seeded = PlanFixtures.aPlanHttpV4();
+            seeded.getPlanDefinitionHttpV4().setTags(Set.of("tag1"));
+            seed(seeded);
+
+            var output = executeMerge("{\"tags\":null}");
+
+            assertThat(output.plan().getPlanDefinitionHttpV4().getTags()).isNullOrEmpty();
+        }
+
+        @Test
+        void merge_with_absent_key_preserves_existing_value() {
+            var originalName = PlanFixtures.aPlanHttpV4().getName();
+
+            var output = executeMerge("{\"description\":\"new description\"}");
+
+            assertThat(output.plan().getName()).isEqualTo(originalName);
+        }
+
+        @Test
+        void merge_selection_rule_on_plan_without_http_v4_definition_is_a_no_op() {
+            seed(PlanFixtures.aPlanNativeV4());
+
+            var output = executeMerge("{\"selectionRule\":\"#context.attributes['foo'] == 'bar'\"}");
+
+            assertThat(output.plan().getPlanDefinitionHttpV4()).isNull();
+        }
+
+        @Test
+        void merge_security_on_plan_without_http_v4_definition_is_a_no_op() {
+            seed(PlanFixtures.aPlanNativeV4());
+
+            var output = executeMerge("{\"security\":{\"type\":\"API_KEY\",\"configuration\":{\"foo\":\"bar\"}}}");
+
+            assertThat(output.plan().getPlanDefinitionHttpV4()).isNull();
+        }
+    }
+
+    @Nested
+    class RejectStatusPatch {
+
+        @Test
+        void json_patch_on_status_throws_PlanPatchNotAllowedException_with_field_metadata() {
+            assertThatThrownBy(() ->
+                executeJsonPatch("[{\"op\":\"replace\",\"path\":\"/status\",\"value\":\"CLOSED\"}]")
+            ).isInstanceOfSatisfying(PlanPatchNotAllowedException.class, ex -> {
+                assertThat(ex.getParameters()).containsEntry("field", "status");
+                assertThat(ex.getMessage()).contains("use plan lifecycle endpoints");
+            });
+        }
+
+        @Test
+        void merge_patch_with_status_key_throws_PlanPatchNotAllowedException() {
+            assertThatThrownBy(() -> executeMerge("{\"status\":\"CLOSED\"}")).isInstanceOfSatisfying(
+                PlanPatchNotAllowedException.class,
+                ex -> assertThat(ex.getParameters()).containsEntry("field", "status")
+            );
+        }
+
+        @Test
+        void json_patch_on_nested_status_path_is_rejected_at_top_level_status() {
+            assertThatThrownBy(() ->
+                executeJsonPatch("[{\"op\":\"replace\",\"path\":\"/status/foo\",\"value\":\"X\"}]")
+            ).isInstanceOfSatisfying(PlanPatchNotAllowedException.class, ex ->
+                assertThat(ex.getParameters()).containsEntry("field", "status")
+            );
+        }
+
+        @Test
+        void json_patch_move_from_status_throws_PlanPatchNotAllowedException_with_field_metadata() {
+            assertThatThrownBy(() ->
+                executeJsonPatch("[{\"op\":\"move\",\"from\":\"/status\",\"path\":\"/name\"}]")
+            ).isInstanceOfSatisfying(PlanPatchNotAllowedException.class, ex -> {
+                assertThat(ex.getParameters()).containsEntry("field", "status");
+                assertThat(ex.getMessage()).contains("use plan lifecycle endpoints");
+            });
+        }
+
+        @Test
+        void json_patch_copy_from_status_throws_PlanPatchNotAllowedException_with_field_metadata() {
+            assertThatThrownBy(() ->
+                executeJsonPatch("[{\"op\":\"copy\",\"from\":\"/status\",\"path\":\"/name\"}]")
+            ).isInstanceOfSatisfying(PlanPatchNotAllowedException.class, ex -> {
+                assertThat(ex.getParameters()).containsEntry("field", "status");
+                assertThat(ex.getMessage()).contains("use plan lifecycle endpoints");
+            });
+        }
+
+        @Test
+        void json_patch_test_op_against_non_patchable_field_is_rejected() {
+            assertThatThrownBy(() ->
+                executeJsonPatch("[{\"op\":\"test\",\"path\":\"/status\",\"value\":\"PUBLISHED\"}]")
+            ).isInstanceOfSatisfying(PlanPatchNotAllowedException.class, ex -> {
+                assertThat(ex.getParameters()).containsEntry("field", "status");
+                assertThat(ex.getMessage()).contains("use plan lifecycle endpoints");
+            });
+        }
+    }
+
+    @Nested
+    class RejectUnlistedField {
+
+        @Test
+        void json_patch_on_id_throws_PlanPatchNotAllowedException_with_field_is_not_patchable() {
+            assertThatThrownBy(() ->
+                executeJsonPatch("[{\"op\":\"replace\",\"path\":\"/id\",\"value\":\"new-id\"}]")
+            ).isInstanceOfSatisfying(PlanPatchNotAllowedException.class, ex -> {
+                assertThat(ex.getParameters()).containsEntry("field", "id");
+                assertThat(ex.getMessage()).contains("field is not patchable");
+            });
+        }
+
+        @Test
+        void merge_patch_with_created_at_throws_PlanPatchNotAllowedException() {
+            assertThatThrownBy(() -> executeMerge("{\"createdAt\":\"2024-01-01T00:00:00Z\"}")).isInstanceOfSatisfying(
+                PlanPatchNotAllowedException.class,
+                ex -> assertThat(ex.getParameters()).containsEntry("field", "createdAt")
+            );
+        }
+
+        @Test
+        void json_patch_on_security_type_is_ignored_and_leaves_the_type_frozen() {
+            var originalType = planCrudService.storage().get(0).getPlanDefinitionHttpV4().getSecurity().getType();
+
+            var output = executeJsonPatch("[{\"op\":\"replace\",\"path\":\"/security/type\",\"value\":\"API_KEY\"}]");
+
+            assertThat(output.plan().getPlanDefinitionHttpV4().getSecurity().getType()).isEqualTo(originalType);
+        }
+
+        @Test
+        void json_patch_with_null_value_on_nested_security_pointer_leaves_top_level_security_unchanged() {
+            var originalSecurity = planCrudService.storage().get(0).getPlanDefinitionHttpV4().getSecurity();
+
+            var output = executeJsonPatch("[{\"op\":\"replace\",\"path\":\"/security/type\",\"value\":null}]");
+
+            var patchedSecurity = output.plan().getPlanDefinitionHttpV4().getSecurity();
+            assertThat(patchedSecurity).isNotNull();
+            assertThat(patchedSecurity.getType()).isEqualTo(originalSecurity.getType());
+        }
+    }
+
+    @Nested
+    class RejectMalformedPatch {
+
+        @Test
+        void json_patch_body_is_not_a_json_array() {
+            assertThatThrownBy(() -> executeJsonPatch("{\"op\":\"replace\"}"))
+                .isInstanceOf(ValidationDomainException.class)
+                .hasMessageContaining("JSON Patch body must be a JSON array");
+        }
+
+        @Test
+        void json_patch_op_missing_path_surfaces_index() {
+            assertThatThrownBy(() -> executeJsonPatch("[{\"op\":\"add\",\"value\":\"x\"},{\"op\":\"replace\",\"value\":\"y\"}]"))
+                .isInstanceOf(ValidationDomainException.class)
+                .hasMessageContaining("index 0")
+                .hasMessageContaining("missing required 'path' field");
+        }
+
+        @Test
+        void json_patch_move_op_missing_from_surfaces_index() {
+            assertThatThrownBy(() -> executeJsonPatch("[{\"op\":\"move\",\"path\":\"/name\"}]"))
+                .isInstanceOf(ValidationDomainException.class)
+                .hasMessageContaining("index 0")
+                .hasMessageContaining("missing required 'from' field");
+        }
+
+        @Test
+        void json_patch_move_op_from_does_not_start_with_slash() {
+            assertThatThrownBy(() -> executeJsonPatch("[{\"op\":\"move\",\"from\":\"status\",\"path\":\"/name\"}]"))
+                .isInstanceOf(ValidationDomainException.class)
+                .hasMessageContaining("index 0")
+                .hasMessageContaining("'from' value 'status'")
+                .hasMessageContaining("not a valid JSON Pointer");
+        }
+
+        @Test
+        void json_patch_copy_op_from_is_just_slash_empty_top_level_field() {
+            assertThatThrownBy(() -> executeJsonPatch("[{\"op\":\"copy\",\"from\":\"/\",\"path\":\"/name\"}]"))
+                .isInstanceOf(ValidationDomainException.class)
+                .hasMessageContaining("index 0")
+                .hasMessageContaining("'from' value '/'")
+                .hasMessageContaining("does not target a specific field");
+        }
+
+        @Test
+        void merge_patch_with_non_textual_description_object_throws_ValidationDomainException() {
+            assertThatThrownBy(() -> executeMerge("{\"description\":{\"nested\":\"obj\"}}"))
+                .isInstanceOf(ValidationDomainException.class)
+                .hasMessageContaining("Invalid value for field 'description'");
+        }
+
+        @Test
+        void merge_patch_with_non_boolean_comment_required_throws_ValidationDomainException() {
+            assertThatThrownBy(() -> executeMerge("{\"commentRequired\":\"yes\"}"))
+                .isInstanceOf(ValidationDomainException.class)
+                .hasMessageContaining("Invalid value for field 'commentRequired'");
+        }
+
+        @Test
+        void json_patch_op_path_is_non_textual_number() {
+            assertThatThrownBy(() -> executeJsonPatch("[{\"op\":\"replace\",\"path\":42,\"value\":\"x\"}]"))
+                .isInstanceOf(ValidationDomainException.class)
+                .hasMessageContaining("missing required 'path' field");
+        }
+
+        @Test
+        void json_patch_op_path_does_not_start_with_slash() {
+            assertThatThrownBy(() -> executeJsonPatch("[{\"op\":\"replace\",\"path\":\"name\",\"value\":\"x\"}]"))
+                .isInstanceOf(ValidationDomainException.class)
+                .hasMessageContaining("not a valid JSON Pointer");
+        }
+
+        @Test
+        void json_patch_op_path_is_just_slash_empty_top_level_field() {
+            assertThatThrownBy(() -> executeJsonPatch("[{\"op\":\"replace\",\"path\":\"/\",\"value\":\"x\"}]"))
+                .isInstanceOf(ValidationDomainException.class)
+                .hasMessageContaining("does not target a specific field");
+        }
+
+        @Test
+        void merge_patch_body_is_not_a_json_object() {
+            assertThatThrownBy(() -> executeMerge("[1,2,3]"))
+                .isInstanceOf(ValidationDomainException.class)
+                .hasMessageContaining("JSON Merge Patch body must be a JSON object");
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = { "", "   " })
+        void patch_body_is_blank(String body) {
+            assertThatThrownBy(() -> useCase.execute(baseInput().patchType(PatchPlanUseCase.PatchType.MERGE_PATCH).patchBody(body).build()))
+                .isInstanceOf(ValidationDomainException.class)
+                .hasMessageContaining("Patch body is required");
+            assertThatThrownBy(() -> useCase.execute(baseInput().patchType(PatchPlanUseCase.PatchType.JSON_PATCH).patchBody(body).build()))
+                .isInstanceOf(ValidationDomainException.class)
+                .hasMessageContaining("Patch body is required");
+        }
+
+        @Test
+        void patch_body_is_unparsable_json() {
+            assertThatThrownBy(() -> executeMerge("{not json"))
+                .isInstanceOf(ValidationDomainException.class)
+                .hasMessageContaining("Invalid patch body");
+        }
+
+        @Test
+        void null_patch_type_is_rejected_instead_of_silently_defaulting_to_merge_patch() {
+            assertThatThrownBy(() -> useCase.execute(baseInput().patchType(null).patchBody("{\"name\":\"Renamed\"}").build()))
+                .isInstanceOf(ValidationDomainException.class)
+                .hasMessageContaining("patchType");
+        }
+    }
+
+    @Nested
+    class RejectTooManyOps {
+
+        @Test
+        void json_patch_with_201_ops_is_rejected() {
+            var body = buildJsonPatchOps(201);
+
+            assertThatThrownBy(() -> executeJsonPatch(body))
+                .isInstanceOf(ValidationDomainException.class)
+                .hasMessageContaining("exceeds maximum of 200 operations");
+        }
+
+        @Test
+        void json_patch_with_exactly_200_ops_is_accepted() {
+            var body = buildJsonPatchOps(200);
+
+            var output = executeJsonPatch(body);
+
+            assertThat(output.plan().getName()).isEqualTo("n199");
+        }
+
+        private String buildJsonPatchOps(int count) {
+            var joiner = new StringBuilder("[");
+            IntStream.range(0, count).forEach(i -> {
+                if (i > 0) joiner.append(',');
+                joiner.append("{\"op\":\"replace\",\"path\":\"/name\",\"value\":\"n").append(i).append("\"}");
+            });
+            joiner.append("]");
+            return joiner.toString();
+        }
+    }
+
+    @Nested
+    class DryRun {
+
+        @Test
+        void dry_run_merge_patch_returns_updated_plan_but_does_not_persist() {
+            var originalName = planCrudService.storage().get(0).getName();
+
+            var output = useCase.execute(
+                baseInput().patchType(PatchPlanUseCase.PatchType.MERGE_PATCH).patchBody("{\"name\":\"Renamed\"}").dryRun(true).build()
+            );
+
+            assertThat(output.plan().getName()).isEqualTo("Renamed");
+            assertThat(planCrudService.storage().get(0).getName()).isEqualTo(originalName);
+        }
+
+        @Test
+        void dry_run_rejects_domain_invalid_would_be_state_and_persists_nothing() {
+            var originalTags = planCrudService.storage().get(0).getPlanDefinitionHttpV4().getTags();
+
+            assertThatThrownBy(() ->
+                useCase.execute(
+                    baseInput()
+                        .patchType(PatchPlanUseCase.PatchType.MERGE_PATCH)
+                        .patchBody("{\"tags\":[\"forbidden-tag\"]}")
+                        .dryRun(true)
+                        .build()
+                )
+            ).isInstanceOf(ValidationDomainException.class);
+
+            assertThat(planCrudService.storage().get(0).getPlanDefinitionHttpV4().getTags()).isEqualTo(originalTags);
+            assertThat(auditCrudService.storage()).isEmpty();
+        }
+
+        @Test
+        void dry_run_still_rejects_disallowed_patches() {
+            assertThatThrownBy(() ->
+                useCase.execute(
+                    baseInput()
+                        .patchType(PatchPlanUseCase.PatchType.JSON_PATCH)
+                        .patchBody("[{\"op\":\"replace\",\"path\":\"/status\",\"value\":\"CLOSED\"}]")
+                        .dryRun(true)
+                        .build()
+                )
+            ).isInstanceOf(PlanPatchNotAllowedException.class);
+        }
+
+        @Test
+        void dry_run_with_valid_flows_does_not_persist_flows() {
+            flowCrudService.savePlanFlows(PLAN_ID, List.of(Flow.builder().id("flow-id").name("Original").enabled(true).build()));
+
+            useCase.execute(
+                baseInput()
+                    .patchType(PatchPlanUseCase.PatchType.MERGE_PATCH)
+                    .patchBody("{\"flows\":[{\"name\":\"Patched\",\"enabled\":true}]}")
+                    .dryRun(true)
+                    .build()
+            );
+
+            assertThat(flowCrudService.getPlanV4Flows(PLAN_ID)).hasSize(1);
+            assertThat(flowCrudService.getPlanV4Flows(PLAN_ID).get(0).getId()).isEqualTo("flow-id");
+        }
+
+        @Test
+        void dry_run_with_bogus_selector_discriminator_throws_ValidationDomainException_before_dryRun_guard() {
+            var originalName = planCrudService.storage().get(0).getName();
+
+            assertThatThrownBy(() ->
+                useCase.execute(
+                    baseInput()
+                        .patchType(PatchPlanUseCase.PatchType.MERGE_PATCH)
+                        .patchBody(
+                            "{\"flows\":[{\"name\":\"Flow\",\"enabled\":true,\"selectors\":[{\"type\":\"BOGUS\",\"path\":\"/\",\"pathOperator\":\"EQUALS\"}]}]}"
+                        )
+                        .dryRun(true)
+                        .build()
+                )
+            )
+                .isInstanceOf(ValidationDomainException.class)
+                .hasMessageContaining("flows");
+
+            assertThat(planCrudService.storage().get(0).getName()).isEqualTo(originalName);
+        }
+    }
+
+    @Nested
+    class ScopeGuard {
+
+        @Test
+        void non_v4_api_throws_ValidationDomainException_with_v4_only_message() {
+            apiCrudService.reset();
+            apiCrudService.initWith(List.of(ApiFixtures.aProxyApiV2()));
+
+            assertThatThrownBy(() -> executeMerge("{\"name\":\"X\"}"))
+                .isInstanceOf(ValidationDomainException.class)
+                .hasMessage("Plan PATCH is only supported for V4 API plans");
+        }
+
+        @Test
+        void non_proxy_v4_api_throws_ValidationDomainException_with_http_proxy_only_message() {
+            apiCrudService.reset();
+            apiCrudService.initWith(List.of(ApiFixtures.aMessageApiV4()));
+
+            assertThatThrownBy(() -> executeMerge("{\"name\":\"X\"}"))
+                .isInstanceOf(ValidationDomainException.class)
+                .hasMessage("Plan PATCH is only supported for HTTP Proxy API plans");
+        }
+    }
+
+    @Nested
+    class CrossApiNotFound {
+
+        @Test
+        void plan_with_mismatched_reference_id_throws_PlanForApiNotFoundException() {
+            planCrudService.reset();
+            var planForOtherApi = PlanFixtures.aPlanHttpV4().toBuilder().referenceId("OTHER-API").build();
+            planCrudService.initWith(List.of(planForOtherApi));
+
+            assertThatThrownBy(() -> executeMerge("{\"name\":\"X\"}")).isInstanceOfSatisfying(PlanForApiNotFoundException.class, ex -> {
+                assertThat(ex.getMessage()).contains(PLAN_ID);
+                assertThat(ex.getMessage()).contains(API_ID);
+            });
+        }
+
+        @Test
+        void plan_does_not_exist_throws_PlanForApiNotFoundException() {
+            planCrudService.reset();
+
+            assertThatThrownBy(() -> executeMerge("{\"name\":\"X\"}")).isInstanceOf(PlanForApiNotFoundException.class);
+        }
+    }
+
+    @Nested
+    class PerFieldTypeCoercion {
+
+        @Test
+        void merge_with_boolean_updates_comment_required() {
+            var output = executeMerge("{\"commentRequired\":true}");
+
+            assertThat(output.plan().isCommentRequired()).isTrue();
+        }
+
+        @Test
+        void merge_with_enum_value_updates_validation() {
+            var output = executeMerge("{\"validation\":\"MANUAL\"}");
+
+            assertThat(output.plan().getValidation()).isEqualTo(Plan.PlanValidationType.MANUAL);
+        }
+
+        @Test
+        void merge_with_invalid_enum_value_throws_ValidationDomainException() {
+            assertThatThrownBy(() -> executeMerge("{\"validation\":\"NOT_A_VALUE\"}"))
+                .isInstanceOf(ValidationDomainException.class)
+                .hasMessageContaining("Invalid validation value: NOT_A_VALUE");
+        }
+
+        @Test
+        void merge_with_string_list_updates_tags() {
+            var output = executeMerge("{\"excludedGroups\":[\"a\",\"b\"]}");
+
+            assertThat(output.plan().getExcludedGroups()).containsExactly("a", "b");
+        }
+
+        @Test
+        void merge_with_non_string_list_entries_throws_ValidationDomainException() {
+            assertThatThrownBy(() -> executeMerge("{\"excludedGroups\":[{\"nested\":\"obj\"}]}"))
+                .isInstanceOf(ValidationDomainException.class)
+                .hasMessageContaining("Invalid value for field 'excludedGroups'");
+        }
+
+        @Test
+        void json_patch_with_explicit_null_string_list_clears_excluded_groups() {
+            var seeded = PlanFixtures.aPlanHttpV4().toBuilder().excludedGroups(List.of("g1", "g2")).build();
+            seed(seeded);
+
+            var output = executeJsonPatch("[{\"op\":\"replace\",\"path\":\"/excludedGroups\",\"value\":null}]");
+
+            assertThat(output.plan().getExcludedGroups()).isNull();
+        }
+
+        @Test
+        void merge_missing_comment_required_preserves_existing_boolean() {
+            var seeded = PlanFixtures.aPlanHttpV4().toBuilder().commentRequired(true).build();
+            seed(seeded);
+
+            var output = executeMerge("{\"description\":\"x\"}");
+
+            assertThat(output.plan().isCommentRequired()).isTrue();
+        }
+    }
+
+    @Nested
+    class BlankNameRejection {
+
+        @Test
+        void merge_with_empty_name_throws_ValidationDomainException() {
+            assertThatThrownBy(() -> executeMerge("{\"name\":\"\"}"))
+                .isInstanceOf(ValidationDomainException.class)
+                .hasMessageContaining("'name' cannot be blank");
+        }
+
+        @Test
+        void merge_with_whitespace_only_name_throws_ValidationDomainException() {
+            assertThatThrownBy(() -> executeMerge("{\"name\":\"   \"}"))
+                .isInstanceOf(ValidationDomainException.class)
+                .hasMessageContaining("'name' cannot be blank");
+        }
+
+        @Test
+        void merge_with_explicit_null_name_throws_ValidationDomainException() {
+            assertThatThrownBy(() -> executeMerge("{\"name\":null}"))
+                .isInstanceOf(ValidationDomainException.class)
+                .hasMessageContaining("Field 'name' cannot be set to null");
+        }
+    }
+
+    @Nested
+    class TagsFieldProjection {
+
+        @Test
+        void merge_patch_updating_tags_persists_the_new_tag_set() {
+            var output = executeMerge("{\"tags\":[\"tag1\"]}");
+
+            assertThat(output.plan().getPlanDefinitionHttpV4().getTags()).containsExactly("tag1");
+            assertThat(planCrudService.storage().get(0).getPlanDefinitionHttpV4().getTags()).containsExactly("tag1");
+        }
+
+        @Test
+        void json_patch_add_on_tags_persists_the_new_tag_set() {
+            var output = executeJsonPatch("[{\"op\":\"add\",\"path\":\"/tags\",\"value\":[\"tag1\"]}]");
+
+            assertThat(output.plan().getPlanDefinitionHttpV4().getTags()).containsExactly("tag1");
+        }
+    }
+
+    @Nested
+    class SecurityFieldProjection {
+
+        @Test
+        void merge_patch_updates_security_configuration_but_keeps_the_type_frozen() {
+            var originalType = planCrudService.storage().get(0).getPlanDefinitionHttpV4().getSecurity().getType();
+
+            var output = executeMerge("{\"security\":{\"type\":\"API_KEY\",\"configuration\":{\"foo\":\"bar\"}}}");
+
+            var security = output.plan().getPlanDefinitionHttpV4().getSecurity();
+            assertThat(security).isNotNull();
+            assertThat(security.getType()).isEqualTo(originalType);
+            assertThat(security.getConfiguration()).contains("\"foo\":\"bar\"");
+        }
+    }
+
+    @Nested
+    class FlowsFieldProjection {
+
+        @Test
+        void merge_patch_setting_flows_to_empty_replaces_the_flow_list() {
+            flowCrudService.savePlanFlows(PLAN_ID, List.of(new Flow()));
+
+            var output = executeMerge("{\"flows\":[]}");
+
+            assertThat(output.plan().getPlanDefinitionHttpV4().getFlows()).isNullOrEmpty();
+            assertThat(flowCrudService.getPlanV4Flows(PLAN_ID)).isEmpty();
+        }
+
+        @Test
+        void json_patch_replace_on_flows_replaces_the_flow_list() {
+            flowCrudService.savePlanFlows(PLAN_ID, List.of(new Flow()));
+
+            var output = executeJsonPatch("[{\"op\":\"replace\",\"path\":\"/flows\",\"value\":[]}]");
+
+            assertThat(output.plan().getPlanDefinitionHttpV4().getFlows()).isNullOrEmpty();
+        }
+
+        @Test
+        void scalar_only_name_patch_leaves_flows_untouched() {
+            flowCrudService.savePlanFlows(PLAN_ID, List.of(Flow.builder().id("flow-id").name("Original").enabled(true).build()));
+
+            var output = executeMerge("{\"name\":\"Scalar Only\"}");
+
+            assertThat(output.plan().getName()).isEqualTo("Scalar Only");
+            assertThat(flowCrudService.getPlanV4Flows(PLAN_ID)).hasSize(1);
+            assertThat(flowCrudService.getPlanV4Flows(PLAN_ID).get(0).getId()).isEqualTo("flow-id");
+        }
+    }
+
+    @Nested
+    class DryRunJsonPatch {
+
+        @Test
+        void dry_run_json_patch_returns_updated_plan_but_does_not_persist() {
+            var originalName = planCrudService.storage().get(0).getName();
+
+            var output = useCase.execute(
+                baseInput()
+                    .patchType(PatchPlanUseCase.PatchType.JSON_PATCH)
+                    .patchBody("[{\"op\":\"replace\",\"path\":\"/name\",\"value\":\"Dry JSON Patched\"}]")
+                    .dryRun(true)
+                    .build()
+            );
+
+            assertThat(output.plan().getName()).isEqualTo("Dry JSON Patched");
+            assertThat(planCrudService.storage().get(0).getName()).isEqualTo(originalName);
+        }
+    }
+
+    @Nested
+    class RemoveOpOnNonNullableScalar {
+
+        @Test
+        void json_patch_remove_on_name_is_rejected_like_replace_with_null() {
+            assertThatThrownBy(() -> executeJsonPatch("[{\"op\":\"remove\",\"path\":\"/name\"}]"))
+                .isInstanceOf(ValidationDomainException.class)
+                .hasMessageContaining("Field 'name' cannot be set to null");
+        }
+
+        @Test
+        void json_patch_remove_with_nested_pointer_on_nullable_field_does_not_clear_top_level_field() {
+            var seeded = PlanFixtures.aPlanHttpV4().toBuilder().description("seeded description").build();
+            seeded.getPlanDefinitionHttpV4().setTags(Set.of("tag1"));
+            seed(seeded);
+
+            var output = executeJsonPatch("[{\"op\":\"remove\",\"path\":\"/tags/0\"}]");
+
+            assertThat(output.plan().getPlanDefinitionHttpV4().getTags()).isNotNull();
+            assertThat(output.plan().getDescription()).isEqualTo("seeded description");
+        }
+    }
+
+    @Nested
+    class AuditLogging {
+
+        @Test
+        void successful_non_dry_run_patch_emits_one_audit_entry_for_the_plan() {
+            executeMerge("{\"name\":\"Audited\"}");
+
+            assertThat(auditCrudService.storage())
+                .hasSize(1)
+                .first()
+                .satisfies(entry -> assertThat(entry.getProperties()).containsValue(PLAN_ID));
+        }
+
+        @Test
+        void dry_run_patch_emits_no_audit_entry() {
+            useCase.execute(
+                baseInput().patchType(PatchPlanUseCase.PatchType.MERGE_PATCH).patchBody("{\"name\":\"DryAudit\"}").dryRun(true).build()
+            );
+
+            assertThat(auditCrudService.storage()).isEmpty();
+        }
+    }
+
+    @Nested
+    class DomainInvalidPostPatchState {
+
+        @Test
+        void valid_shaped_flow_patch_rejected_by_real_flow_validator_propagates_field_level_detail_and_persists_nothing() {
+            var originalFlows = flowCrudService.getPlanV4Flows(PLAN_ID);
+
+            assertThatThrownBy(() ->
+                executeMerge("{\"flows\":[{\"name\":\"f1\",\"selectors\":[{\"type\":\"channel\",\"channel\":\"/c\"}]}]}")
+            ).isInstanceOfSatisfying(ValidationDomainException.class, ex -> {
+                assertThat(ex.getParameters()).containsEntry("flowName", "f1");
+                assertThat(ex.getParameters()).containsEntry("invalidSelectors", "channel");
+            });
+
+            assertThat(auditCrudService.storage()).isEmpty();
+            assertThat(flowCrudService.getPlanV4Flows(PLAN_ID)).isEqualTo(originalFlows);
+        }
+    }
+
+    @Nested
+    class MalformedStructuredFieldCoercion {
+
+        @Test
+        void merge_with_type_incoherent_flows_throws_ValidationDomainException_not_IllegalArgumentException() {
+            assertThatThrownBy(() -> executeMerge("{\"flows\":[{\"name\":{\"nested\":\"object\"}}]}"))
+                .isInstanceOf(ValidationDomainException.class)
+                .hasMessageContaining("Invalid value for field 'flows'");
+        }
+
+        @Test
+        void merge_with_type_incoherent_security_throws_ValidationDomainException_not_IllegalArgumentException() {
+            assertThatThrownBy(() -> executeMerge("{\"security\":[1,2,3]}"))
+                .isInstanceOf(ValidationDomainException.class)
+                .hasMessageContaining("security");
+        }
+
+        @Test
+        void merge_with_type_incoherent_tags_throws_ValidationDomainException_not_IllegalArgumentException() {
+            assertThatThrownBy(() -> executeMerge("{\"tags\":\"not-an-array\"}"))
+                .isInstanceOf(ValidationDomainException.class)
+                .hasMessageContaining("tags");
+        }
+
+        @Test
+        void merge_flows_with_bogus_selector_discriminator_throws_ValidationDomainException_referencing_flows_and_does_not_persist() {
+            var originalName = planCrudService.storage().get(0).getName();
+
+            assertThatThrownBy(() ->
+                executeMerge(
+                    "{\"flows\":[{\"name\":\"Flow\",\"enabled\":true,\"selectors\":[{\"type\":\"BOGUS\",\"path\":\"/\",\"pathOperator\":\"EQUALS\"}]}]}"
+                )
+            ).isInstanceOfSatisfying(ValidationDomainException.class, ex -> assertThat(ex.getMessage()).contains("flows"));
+            assertThat(planCrudService.storage().get(0).getName()).isEqualTo(originalName);
+        }
+    }
+
+    @Nested
+    class PlanIsolationFullFields {
+
+        @Test
+        void patching_plan_a_does_not_mutate_plan_b_tags_or_characteristics() {
+            var planA = PlanFixtures.aPlanHttpV4();
+            var planB = PlanFixtures.aPlanHttpV4().toBuilder().id("plan-b").name("Plan B").build();
+            planB.getPlanDefinitionHttpV4().setTags(null);
+            seed(planA, planB);
+
+            useCase.execute(
+                baseInput()
+                    .planId(planA.getId())
+                    .patchType(PatchPlanUseCase.PatchType.MERGE_PATCH)
+                    .patchBody("{\"tags\":[\"tag1\"],\"characteristics\":[\"c1\"]}")
+                    .build()
+            );
+
+            var planBAfter = planCrudService
+                .storage()
+                .stream()
+                .filter(p -> "plan-b".equals(p.getId()))
+                .findFirst()
+                .orElseThrow();
+            assertThat(planBAfter.getPlanDefinitionHttpV4().getTags()).isNullOrEmpty();
+            assertThat(planBAfter.getCharacteristics()).isNullOrEmpty();
+        }
+    }
+
+    @Nested
+    class RfcNullClearing {
+
+        private void seedFullyPopulatedPlan() {
+            var seeded = PlanFixtures.aPlanHttpV4()
+                .toBuilder()
+                .description("seeded description")
+                .generalConditions("seeded-gc")
+                .excludedGroups(List.of("g1", "g2"))
+                .characteristics(List.of("c1", "c2"))
+                .build();
+            seeded.getPlanDefinitionHttpV4().setSelectionRule("#context.attributes['x'] == 'y'");
+            seeded.getPlanDefinitionHttpV4().setTags(Set.of("tag1"));
+            seed(seeded);
+        }
+
+        @Test
+        void merge_explicit_null_clears_description() {
+            seedFullyPopulatedPlan();
+
+            var output = executeMerge("{\"description\":null}");
+
+            assertThat(output.plan().getDescription()).isNull();
+        }
+
+        @Test
+        void merge_explicit_null_clears_general_conditions() {
+            seedFullyPopulatedPlan();
+
+            var output = executeMerge("{\"generalConditions\":null}");
+
+            assertThat(output.plan().getGeneralConditions()).isNull();
+        }
+
+        @Test
+        void merge_explicit_null_clears_selection_rule() {
+            seedFullyPopulatedPlan();
+
+            var output = executeMerge("{\"selectionRule\":null}");
+
+            assertThat(output.plan().getPlanDefinitionHttpV4().getSelectionRule()).isNull();
+        }
+
+        @Test
+        void merge_explicit_null_clears_excluded_groups() {
+            seedFullyPopulatedPlan();
+
+            var output = executeMerge("{\"excludedGroups\":null}");
+
+            assertThat(output.plan().getExcludedGroups()).isNull();
+        }
+
+        @Test
+        void merge_explicit_null_clears_characteristics() {
+            seedFullyPopulatedPlan();
+
+            var output = executeMerge("{\"characteristics\":null}");
+
+            assertThat(output.plan().getCharacteristics()).isNull();
+        }
+
+        @Test
+        void merge_explicit_null_clears_tags() {
+            seedFullyPopulatedPlan();
+
+            var output = executeMerge("{\"tags\":null}");
+
+            assertThat(output.plan().getPlanDefinitionHttpV4().getTags()).isNullOrEmpty();
+        }
+
+        @Test
+        void merge_explicit_null_clears_flows() {
+            seedFullyPopulatedPlan();
+            flowCrudService.savePlanFlows(PLAN_ID, List.of(new Flow()));
+
+            var output = executeMerge("{\"flows\":null}");
+
+            assertThat(output.plan().getPlanDefinitionHttpV4().getFlows()).isNullOrEmpty();
+            assertThat(flowCrudService.getPlanV4Flows(PLAN_ID)).isEmpty();
+        }
+
+        @Test
+        void json_patch_replace_null_clears_description() {
+            seedFullyPopulatedPlan();
+
+            var output = executeJsonPatch("[{\"op\":\"replace\",\"path\":\"/description\",\"value\":null}]");
+
+            assertThat(output.plan().getDescription()).isNull();
+        }
+
+        @Test
+        void json_patch_add_null_clears_description() {
+            seedFullyPopulatedPlan();
+
+            var output = executeJsonPatch("[{\"op\":\"add\",\"path\":\"/description\",\"value\":null}]");
+
+            assertThat(output.plan().getDescription()).isNull();
+        }
+
+        @Test
+        void json_patch_replace_null_clears_flows() {
+            seedFullyPopulatedPlan();
+            flowCrudService.savePlanFlows(PLAN_ID, List.of(new Flow()));
+
+            var output = executeJsonPatch("[{\"op\":\"replace\",\"path\":\"/flows\",\"value\":null}]");
+
+            assertThat(output.plan().getPlanDefinitionHttpV4().getFlows()).isNullOrEmpty();
+            assertThat(flowCrudService.getPlanV4Flows(PLAN_ID)).isEmpty();
+        }
+
+        @Test
+        void merge_explicit_null_validation_throws_ValidationDomainException() {
+            assertThatThrownBy(() -> executeMerge("{\"validation\":null}"))
+                .isInstanceOf(ValidationDomainException.class)
+                .hasMessageContaining("Field 'validation' cannot be set to null");
+        }
+
+        @Test
+        void merge_explicit_null_security_throws_ValidationDomainException() {
+            assertThatThrownBy(() -> executeMerge("{\"security\":null}"))
+                .isInstanceOf(ValidationDomainException.class)
+                .hasMessageContaining("Field 'security' cannot be set to null");
+        }
+
+        @Test
+        void merge_explicit_null_comment_required_throws_ValidationDomainException() {
+            assertThatThrownBy(() -> executeMerge("{\"commentRequired\":null}"))
+                .isInstanceOf(ValidationDomainException.class)
+                .hasMessageContaining("Field 'commentRequired' cannot be set to null");
+        }
+
+        @Test
+        void json_patch_replace_null_name_throws_ValidationDomainException() {
+            assertThatThrownBy(() -> executeJsonPatch("[{\"op\":\"replace\",\"path\":\"/name\",\"value\":null}]"))
+                .isInstanceOf(ValidationDomainException.class)
+                .hasMessageContaining("Field 'name' cannot be set to null");
+        }
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/plan/use_case/PatchPlanUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/plan/use_case/PatchPlanUseCaseTest.java
@@ -28,18 +28,24 @@ import inmemory.ApiCrudServiceInMemory;
 import inmemory.AuditCrudServiceInMemory;
 import inmemory.EntrypointPluginQueryServiceInMemory;
 import inmemory.FlowCrudServiceInMemory;
+import inmemory.GroupQueryServiceInMemory;
 import inmemory.KafkaPortRangeCrudServiceInMemory;
+import inmemory.MembershipCrudServiceInMemory;
+import inmemory.MembershipQueryServiceInMemory;
 import inmemory.PageCrudServiceInMemory;
 import inmemory.ParametersQueryServiceInMemory;
 import inmemory.PlanCrudServiceInMemory;
 import inmemory.PlanQueryServiceInMemory;
+import inmemory.RoleQueryServiceInMemory;
 import inmemory.UserCrudServiceInMemory;
 import io.gravitee.apim.core.audit.domain_service.AuditDomainService;
 import io.gravitee.apim.core.audit.model.AuditEntity;
 import io.gravitee.apim.core.exception.ValidationDomainException;
 import io.gravitee.apim.core.flow.domain_service.FlowValidationDomainService;
+import io.gravitee.apim.core.group.model.Group;
 import io.gravitee.apim.core.json.JsonDiffProcessor;
 import io.gravitee.apim.core.json_patch.domain_service.JsonPatchDomainService;
+import io.gravitee.apim.core.plan.domain_service.PlanExcludedGroupsDomainService;
 import io.gravitee.apim.core.plan.domain_service.PlanSynchronizationService;
 import io.gravitee.apim.core.plan.domain_service.PlanValidatorDomainService;
 import io.gravitee.apim.core.plan.domain_service.ReorderPlanDomainService;
@@ -60,6 +66,7 @@ import io.gravitee.definition.model.v4.flow.step.Step;
 import io.gravitee.definition.model.v4.plan.PlanSecurity;
 import io.gravitee.repository.management.model.Parameter;
 import io.gravitee.rest.api.model.parameters.Key;
+import io.gravitee.rest.api.service.exceptions.GroupNotFoundException;
 import io.gravitee.rest.api.service.processor.SynchronizationService;
 import java.io.IOException;
 import java.util.List;
@@ -109,6 +116,15 @@ class PatchPlanUseCaseTest {
     private final AuditDomainService auditDomainService = new AuditDomainService(auditCrudService, userCrudService, jsonDiffProcessor);
     private final ReorderPlanDomainService reorderPlanDomainService = new ReorderPlanDomainService(planQueryService, planCrudService);
     private final KafkaPortRangeCrudServiceInMemory kafkaPortRanges = new KafkaPortRangeCrudServiceInMemory();
+    private final GroupQueryServiceInMemory groupQueryService = new GroupQueryServiceInMemory();
+    private final MembershipCrudServiceInMemory membershipCrudService = new MembershipCrudServiceInMemory();
+    private final MembershipQueryServiceInMemory membershipQueryService = new MembershipQueryServiceInMemory(membershipCrudService);
+    private final RoleQueryServiceInMemory roleQueryService = new RoleQueryServiceInMemory();
+    private final PlanExcludedGroupsDomainService planExcludedGroupsDomainService = new PlanExcludedGroupsDomainService(
+        groupQueryService,
+        membershipQueryService,
+        roleQueryService
+    );
     private final UpdatePlanDomainService updatePlanDomainService = new UpdatePlanDomainService(
         planQueryService,
         planCrudService,
@@ -132,6 +148,8 @@ class PatchPlanUseCaseTest {
         flowCrudService.reset();
         auditCrudService.reset();
         userCrudService.reset();
+        groupQueryService.reset();
+        groupQueryService.initWith(List.of(group("g1"), group("g2"), group("a"), group("b")));
         var plans = List.of(PlanFixtures.aPlanHttpV4());
         useCase = new PatchPlanUseCase(
             apiCrudService,
@@ -154,7 +172,8 @@ class PatchPlanUseCaseTest {
                         throw new ValidationDomainException("Invalid value for field 'flows': " + e.getMessage(), e);
                     }
                 }
-            }
+            },
+            planExcludedGroupsDomainService
         );
         apiCrudService.initWith(List.of(ApiFixtures.aProxyApiV4()));
         planCrudService.initWith(plans);
@@ -189,6 +208,10 @@ class PatchPlanUseCaseTest {
         var planList = List.of(plans);
         planCrudService.initWith(planList);
         planQueryService.initWith(planList);
+    }
+
+    private static Group group(String id) {
+        return Group.builder().id(id).environmentId("env-id").name(id).build();
     }
 
     @Nested
@@ -749,6 +772,41 @@ class PatchPlanUseCaseTest {
             var output = executeMerge("{\"description\":\"x\"}");
 
             assertThat(output.plan().isCommentRequired()).isTrue();
+        }
+    }
+
+    @Nested
+    class ExcludedGroupsValidation {
+
+        @Test
+        void merge_with_unknown_excluded_group_throws_GroupNotFoundException() {
+            assertThatThrownBy(() -> executeMerge("{\"excludedGroups\":[\"does-not-exist\"]}")).isInstanceOf(GroupNotFoundException.class);
+
+            assertThat(planCrudService.storage().get(0).getExcludedGroups()).doesNotContain("does-not-exist");
+        }
+
+        @Test
+        void json_patch_with_unknown_excluded_group_throws_GroupNotFoundException() {
+            assertThatThrownBy(() ->
+                executeJsonPatch("[{\"op\":\"replace\",\"path\":\"/excludedGroups\",\"value\":[\"g1\",\"does-not-exist\"]}]")
+            ).isInstanceOf(GroupNotFoundException.class);
+        }
+
+        @Test
+        void merge_with_known_excluded_groups_succeeds() {
+            var output = executeMerge("{\"excludedGroups\":[\"g1\",\"g2\"]}");
+
+            assertThat(output.plan().getExcludedGroups()).containsExactly("g1", "g2");
+        }
+
+        @Test
+        void patch_not_targeting_excluded_groups_does_not_validate_existing_groups() {
+            var seeded = PlanFixtures.aPlanHttpV4().toBuilder().excludedGroups(List.of("stale-group")).build();
+            seed(seeded);
+
+            var output = executeMerge("{\"description\":\"x\"}");
+
+            assertThat(output.plan().getExcludedGroups()).containsExactly("stale-group");
         }
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/plan/use_case/PatchPlanUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/plan/use_case/PatchPlanUseCaseTest.java
@@ -54,7 +54,9 @@ import io.gravitee.apim.infra.domain_service.json_patch.JsonMergePatchServiceImp
 import io.gravitee.apim.infra.domain_service.json_patch.JsonPatchServiceImpl;
 import io.gravitee.apim.infra.domain_service.plan.PlanSynchronizationLegacyWrapper;
 import io.gravitee.apim.infra.json.jackson.JacksonJsonDiffProcessor;
+import io.gravitee.definition.model.v4.flow.AbstractFlow;
 import io.gravitee.definition.model.v4.flow.Flow;
+import io.gravitee.definition.model.v4.flow.step.Step;
 import io.gravitee.definition.model.v4.plan.PlanSecurity;
 import io.gravitee.repository.management.model.Parameter;
 import io.gravitee.rest.api.model.parameters.Key;
@@ -841,6 +843,49 @@ class PatchPlanUseCaseTest {
             assertThat(output.plan().getName()).isEqualTo("Scalar Only");
             assertThat(flowCrudService.getPlanV4Flows(PLAN_ID)).hasSize(1);
             assertThat(flowCrudService.getPlanV4Flows(PLAN_ID).get(0).getId()).isEqualTo("flow-id");
+        }
+    }
+
+    @Nested
+    class FlowSanitizationReflectedInResponse {
+
+        @Test
+        void persist_returns_sanitized_flow_configuration_matching_stored_state() {
+            seedPlanWithSanitizingFlow();
+
+            var output = executeMerge("{\"name\":\"Renamed\"}");
+
+            var responseConfiguration = firstRequestStepConfiguration(output.plan().getFlows());
+            assertThat(responseConfiguration).isEqualTo(FakePolicyValidationDomainService.SANITIZED_CONFIGURATION);
+
+            var storedConfiguration = flowCrudService.getPlanV4Flows(PLAN_ID).get(0).getRequest().get(0).getConfiguration();
+            assertThat(responseConfiguration).isEqualTo(storedConfiguration);
+        }
+
+        @Test
+        void dry_run_returns_sanitized_flow_configuration_in_preview() {
+            seedPlanWithSanitizingFlow();
+
+            var output = useCase.execute(
+                baseInput().patchType(PatchPlanUseCase.PatchType.MERGE_PATCH).patchBody("{\"name\":\"Renamed\"}").dryRun(true).build()
+            );
+
+            assertThat(firstRequestStepConfiguration(output.plan().getFlows())).isEqualTo(
+                FakePolicyValidationDomainService.SANITIZED_CONFIGURATION
+            );
+        }
+
+        private void seedPlanWithSanitizingFlow() {
+            var step = Step.builder()
+                .name("policy-step")
+                .policy(FakePolicyValidationDomainService.SANITIZING_POLICY)
+                .configuration("{\"raw\":\"value\"}")
+                .build();
+            flowCrudService.savePlanFlows(PLAN_ID, List.of(Flow.builder().name("Flow").enabled(true).request(List.of(step)).build()));
+        }
+
+        private String firstRequestStepConfiguration(List<? extends AbstractFlow> flows) {
+            return ((Flow) flows.get(0)).getRequest().get(0).getConfiguration();
         }
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/adapter/FlowAdapterTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/adapter/FlowAdapterTest.java
@@ -15,6 +15,8 @@
  */
 package io.gravitee.apim.infra.adapter;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import fixtures.definition.FlowFixtures;
 import io.gravitee.common.http.HttpMethod;
 import io.gravitee.common.utils.TimeProvider;
@@ -515,6 +517,21 @@ class FlowAdapterTest {
                         .build()
                 );
         });
+    }
+
+    @Test
+    void should_default_http_selector_path_operator_to_starts_with_when_repository_path_operator_is_null() {
+        var repository = Flow.builder()
+            .name("my-flow")
+            .enabled(true)
+            .selectors(List.of(FlowHttpSelector.builder().path("/").pathOperator(null).methods(Set.of(HttpMethod.GET)).build()))
+            .build();
+
+        var result = FlowAdapter.INSTANCE.toFlowV4(repository);
+
+        assertThat(result.getSelectors()).containsExactly(
+            HttpSelector.builder().path("/").pathOperator(Operator.STARTS_WITH).methods(Set.of(HttpMethod.GET)).build()
+        );
     }
 
     @Test


### PR DESCRIPTION
## Issue

[APIM-14082](https://gravitee.atlassian.net/browse/APIM-14082)

## Why

Plans are not included in the `UpdateApiV4` schema, so `PATCH /apis/{apiId}` cannot reach plan fields. When an API publisher needs to change only a subset of plan fields (e.g. name or rate-limit config), they previously had to re-send the full plan definition via `PUT`. A dedicated PATCH endpoint makes partial updates safe and eliminates that full-object round-trip.

## What changed

- **`PatchPlanUseCase`** — new domain use case that applies JSON Patch (RFC 6902) or JSON Merge Patch (RFC 7396) to a v4 HTTP Proxy plan; enforces an allow-list of 11 patchable fields, rejects `status` changes, validates post-patch state, and supports a dry-run mode.
- **`ApiPlansResource`** — new `PATCH /apis/{apiId}/plans/{planId}` endpoint wired to `PatchPlanUseCase`; handles `application/json-patch+json`, `application/merge-patch+json`, and `application/json` (treated as merge-patch); enforces `If-Match` / ETag precondition when the header is present; returns ETag and Last-Modified on success.
- **`AbstractResource`** — precondition-check helpers extracted and reused by the PATCH endpoint.
- **`PlanForApiNotFoundException` / `PlanPatchNotAllowedException`** — new domain exceptions for cross-plan ownership violation and disallowed-field patches.
- **`UpdatePlanDomainService`** — minor adjustments to support the patched plan payload.
- **`PreconditionFailedException`** — extended to cover `412` from ETag mismatches.
- **`openapi-apis.yaml`** — documents the PATCH endpoint: patchable fields, content-type semantics, `dryRun` query param, `If-Match` / ETag, and error codes.

## User-facing impact

New `PATCH /apis/{apiId}/plans/{planId}` endpoint on the Management REST API v2:
- Accepts `application/json-patch+json` (RFC 6902), `application/merge-patch+json` (RFC 7396), or plain `application/json` (treated as merge-patch).
- `?dryRun=true` validates the patch and returns the would-be plan state without persisting.
- `If-Match` header is optional; when provided and mismatched, returns `412 Precondition Failed`.
- Patch documents touching `status` return `400`; those exceeding 200 operations return `400`.
- Scoped to v4 HTTP Proxy APIs only; other API types return `4xx`.

[APIM-14082]: https://gravitee.atlassian.net/browse/APIM-14082?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
