### PR TITLE
fix: api product group member role after migration

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/AssignDefaultApiProductRoleToGroupsUpgrader.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/AssignDefaultApiProductRoleToGroupsUpgrader.java
@@ -35,24 +35,27 @@ import io.gravitee.repository.management.model.RoleScope;
 import io.gravitee.rest.api.service.common.ExecutionContext;
 import io.gravitee.rest.api.service.common.UuidString;
 import java.util.Date;
+import java.util.List;
 import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 import lombok.CustomLog;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Component;
 
 /**
- * Backfills the default API_PRODUCT role membership for groups that pre-date the API_PRODUCT scope.
+ * Backfills the default API_PRODUCT role membership for groups that pre-date the API_PRODUCT scope,
+ * and assigns that default role to existing group members who do not yet have an API_PRODUCT role
+ * on the group.
  *
  * <p>For every group across every environment, if no membership of the form
  * {@code (referenceType=API_PRODUCT, referenceId=null, memberType=GROUP, memberId=<groupId>)} exists,
  * this upgrader creates one with the {@code USER} role. This makes {@code GroupEntity.roles[API_PRODUCT]}
- * resolve to a real value going forward, so that adding the group to an API_PRODUCT actually grants its
- * members an effective role through {@link io.gravitee.rest.api.service.impl.MembershipServiceImpl#getUserMember}.
+ * resolve to a real value going forward.
  *
- * <p>Existing group members are intentionally left untouched (conservative migration): they keep their
- * current API/APPLICATION/INTEGRATION roles and only newly added members will pick up the default
- * API_PRODUCT role from the seeded group default.
+ * <p>For every existing {@code USER} member of the group, if no {@code USER→GROUP} membership exists
+ * with an API_PRODUCT-scoped role, this upgrader creates one using the group's default API_PRODUCT role.
  */
 @Component
 @CustomLog
@@ -89,7 +92,7 @@ public class AssignDefaultApiProductRoleToGroupsUpgrader implements Upgrader {
             .forEach(environment -> {
                 ExecutionContext executionContext = new ExecutionContext(environment);
                 try {
-                    backfillDefaultApiProductRoleForGroups(executionContext);
+                    backfillAllGroupsInEnvironment(executionContext);
                 } catch (TechnicalException e) {
                     log.error(
                         "Error backfilling default API_PRODUCT role on groups for environment {}",
@@ -101,7 +104,7 @@ public class AssignDefaultApiProductRoleToGroupsUpgrader implements Upgrader {
         return true;
     }
 
-    private void backfillDefaultApiProductRoleForGroups(ExecutionContext executionContext) throws TechnicalException {
+    private void backfillAllGroupsInEnvironment(ExecutionContext executionContext) throws TechnicalException {
         Optional<String> userRoleId = findApiProductUserRoleId(executionContext.getOrganizationId());
         if (userRoleId.isEmpty()) {
             log.warn(
@@ -112,17 +115,38 @@ public class AssignDefaultApiProductRoleToGroupsUpgrader implements Upgrader {
             return;
         }
 
+        Set<String> apiProductRoleIds = findAllApiProductRoleIds(executionContext.getOrganizationId());
+
         for (Group group : groupRepository.findAllByEnvironment(executionContext.getEnvironmentId())) {
-            if (hasDefaultApiProductRole(group.getId())) {
+            backfillGroupMembers(executionContext.getOrganizationId(), group.getId(), userRoleId.get(), apiProductRoleIds);
+        }
+    }
+
+    private void backfillGroupMembers(String organizationId, String groupId, String defaultUserRoleId, Set<String> apiProductRoleIds)
+        throws TechnicalException {
+        String defaultRoleId = resolveOrCreateDefaultApiProductRoleId(groupId, defaultUserRoleId);
+
+        List<Membership> groupMemberships = membershipRepository.findByReferenceIdAndReferenceType(groupId, MembershipReferenceType.GROUP);
+
+        Set<String> userIdsWithApiProductRole = groupMemberships
+            .stream()
+            .filter(m -> MembershipMemberType.USER.equals(m.getMemberType()))
+            .filter(m -> apiProductRoleIds.contains(m.getRoleId()))
+            .map(Membership::getMemberId)
+            .collect(Collectors.toSet());
+
+        Set<String> userIds = groupMemberships
+            .stream()
+            .filter(m -> MembershipMemberType.USER.equals(m.getMemberType()))
+            .map(Membership::getMemberId)
+            .collect(Collectors.toSet());
+
+        for (String userId : userIds) {
+            if (userIdsWithApiProductRole.contains(userId)) {
                 continue;
             }
-            createDefaultApiProductRoleMembership(group.getId(), userRoleId.get());
-            log.info(
-                "Assigned default API_PRODUCT role '{}' to group {} (env {})",
-                ROLE_API_PRODUCT_USER.getName(),
-                group.getId(),
-                executionContext.getEnvironmentId()
-            );
+            createMemberApiProductRoleMembership(userId, groupId, defaultRoleId);
+            log.info("Assigned default API_PRODUCT role to user {} on group {} (organization {})", userId, groupId, organizationId);
         }
     }
 
@@ -137,11 +161,32 @@ public class AssignDefaultApiProductRoleToGroupsUpgrader implements Upgrader {
             .map(Role::getId);
     }
 
-    private boolean hasDefaultApiProductRole(String groupId) throws TechnicalException {
+    private Set<String> findAllApiProductRoleIds(String organizationId) throws TechnicalException {
+        return roleRepository
+            .findByScopeAndReferenceIdAndReferenceType(RoleScope.API_PRODUCT, organizationId, RoleReferenceType.ORGANIZATION)
+            .stream()
+            .map(Role::getId)
+            .collect(Collectors.toSet());
+    }
+
+    private String resolveOrCreateDefaultApiProductRoleId(String groupId, String defaultUserRoleId) throws TechnicalException {
+        Optional<String> existingDefaultRoleId = findDefaultApiProductRoleId(groupId);
+        if (existingDefaultRoleId.isPresent()) {
+            return existingDefaultRoleId.get();
+        }
+
+        createDefaultApiProductRoleMembership(groupId, defaultUserRoleId);
+        log.info("Assigned default API_PRODUCT role '{}' to group {}", ROLE_API_PRODUCT_USER.getName(), groupId);
+        return defaultUserRoleId;
+    }
+
+    private Optional<String> findDefaultApiProductRoleId(String groupId) throws TechnicalException {
         return membershipRepository
             .findByMemberIdAndMemberTypeAndReferenceType(groupId, MembershipMemberType.GROUP, MembershipReferenceType.API_PRODUCT)
             .stream()
-            .anyMatch(m -> m.getReferenceId() == null);
+            .filter(m -> m.getReferenceId() == null)
+            .map(Membership::getRoleId)
+            .findFirst();
     }
 
     private void createDefaultApiProductRoleMembership(String groupId, String roleId) throws TechnicalException {
@@ -151,6 +196,22 @@ public class AssignDefaultApiProductRoleToGroupsUpgrader implements Upgrader {
             MembershipMemberType.GROUP,
             null,
             MembershipReferenceType.API_PRODUCT,
+            roleId
+        );
+        Date now = new Date();
+        membership.setCreatedAt(now);
+        membership.setUpdatedAt(now);
+        membership.setSource(DEFAULT_SOURCE);
+        membershipRepository.create(membership);
+    }
+
+    private void createMemberApiProductRoleMembership(String userId, String groupId, String roleId) throws TechnicalException {
+        Membership membership = new Membership(
+            UuidString.generateRandom(),
+            userId,
+            MembershipMemberType.USER,
+            groupId,
+            MembershipReferenceType.GROUP,
             roleId
         );
         Date now = new Date();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/AssignDefaultApiProductRoleToGroupsUpgraderTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/AssignDefaultApiProductRoleToGroupsUpgraderTest.java
@@ -35,6 +35,7 @@ import io.gravitee.repository.management.model.MembershipReferenceType;
 import io.gravitee.repository.management.model.Role;
 import io.gravitee.repository.management.model.RoleReferenceType;
 import io.gravitee.repository.management.model.RoleScope;
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import org.junit.Test;
@@ -50,6 +51,7 @@ public class AssignDefaultApiProductRoleToGroupsUpgraderTest {
     private static final String ORG_ID = "org-1";
     private static final String ENV_ID = "env-1";
     private static final String API_PRODUCT_USER_ROLE_ID = "api-product-user-role-id";
+    private static final String API_PRODUCT_OWNER_ROLE_ID = "api-product-owner-role-id";
 
     @InjectMocks
     AssignDefaultApiProductRoleToGroupsUpgrader upgrader;
@@ -76,22 +78,12 @@ public class AssignDefaultApiProductRoleToGroupsUpgraderTest {
     public void should_create_default_api_product_membership_for_groups_missing_one() throws UpgraderException, TechnicalException {
         Environment env = environment();
         when(environmentRepository.findAll()).thenReturn(Set.of(env));
-
-        Role userRole = role();
-        when(
-            roleRepository.findByScopeAndNameAndReferenceIdAndReferenceType(
-                eq(RoleScope.API_PRODUCT),
-                eq(ROLE_API_PRODUCT_USER.getName()),
-                eq(ORG_ID),
-                eq(RoleReferenceType.ORGANIZATION)
-            )
-        ).thenReturn(Optional.of(userRole));
+        stubApiProductRoles();
 
         Group g1 = group("g1");
         Group g2 = group("g2");
         when(groupRepository.findAllByEnvironment(ENV_ID)).thenReturn(Set.of(g1, g2));
 
-        // g1 has no API_PRODUCT default role; g2 already has one
         when(
             membershipRepository.findByMemberIdAndMemberTypeAndReferenceType(
                 "g1",
@@ -101,6 +93,7 @@ public class AssignDefaultApiProductRoleToGroupsUpgraderTest {
         ).thenReturn(Set.of());
         Membership g2Existing = new Membership();
         g2Existing.setReferenceId(null);
+        g2Existing.setRoleId(API_PRODUCT_USER_ROLE_ID);
         when(
             membershipRepository.findByMemberIdAndMemberTypeAndReferenceType(
                 "g2",
@@ -108,6 +101,9 @@ public class AssignDefaultApiProductRoleToGroupsUpgraderTest {
                 MembershipReferenceType.API_PRODUCT
             )
         ).thenReturn(Set.of(g2Existing));
+
+        when(membershipRepository.findByReferenceIdAndReferenceType("g1", MembershipReferenceType.GROUP)).thenReturn(List.of());
+        when(membershipRepository.findByReferenceIdAndReferenceType("g2", MembershipReferenceType.GROUP)).thenReturn(List.of());
 
         upgrader.upgrade();
 
@@ -119,6 +115,79 @@ public class AssignDefaultApiProductRoleToGroupsUpgraderTest {
         assertThat(created.getReferenceType()).isEqualTo(MembershipReferenceType.API_PRODUCT);
         assertThat(created.getReferenceId()).isNull();
         assertThat(created.getRoleId()).isEqualTo(API_PRODUCT_USER_ROLE_ID);
+    }
+
+    @Test
+    public void should_backfill_api_product_role_for_legacy_group_members() throws UpgraderException, TechnicalException {
+        Environment env = environment();
+        when(environmentRepository.findAll()).thenReturn(Set.of(env));
+        stubApiProductRoles();
+        when(groupRepository.findAllByEnvironment(ENV_ID)).thenReturn(Set.of(group("g1")));
+
+        Membership groupDefault = new Membership();
+        groupDefault.setReferenceId(null);
+        groupDefault.setRoleId(API_PRODUCT_USER_ROLE_ID);
+        when(
+            membershipRepository.findByMemberIdAndMemberTypeAndReferenceType(
+                "g1",
+                MembershipMemberType.GROUP,
+                MembershipReferenceType.API_PRODUCT
+            )
+        ).thenReturn(Set.of(groupDefault));
+
+        Membership legacyApiRole = new Membership();
+        legacyApiRole.setMemberId("user-1");
+        legacyApiRole.setMemberType(MembershipMemberType.USER);
+        legacyApiRole.setReferenceId("g1");
+        legacyApiRole.setReferenceType(MembershipReferenceType.GROUP);
+        legacyApiRole.setRoleId("api-user-role-id");
+        when(membershipRepository.findByReferenceIdAndReferenceType("g1", MembershipReferenceType.GROUP)).thenReturn(
+            List.of(legacyApiRole)
+        );
+
+        upgrader.upgrade();
+
+        ArgumentCaptor<Membership> membershipCaptor = ArgumentCaptor.forClass(Membership.class);
+        verify(membershipRepository, times(1)).create(membershipCaptor.capture());
+        Membership created = membershipCaptor.getValue();
+        assertThat(created.getMemberId()).isEqualTo("user-1");
+        assertThat(created.getMemberType()).isEqualTo(MembershipMemberType.USER);
+        assertThat(created.getReferenceType()).isEqualTo(MembershipReferenceType.GROUP);
+        assertThat(created.getReferenceId()).isEqualTo("g1");
+        assertThat(created.getRoleId()).isEqualTo(API_PRODUCT_USER_ROLE_ID);
+    }
+
+    @Test
+    public void should_skip_member_backfill_when_api_product_role_already_exists() throws UpgraderException, TechnicalException {
+        Environment env = environment();
+        when(environmentRepository.findAll()).thenReturn(Set.of(env));
+        stubApiProductRoles();
+        when(groupRepository.findAllByEnvironment(ENV_ID)).thenReturn(Set.of(group("g1")));
+
+        Membership groupDefault = new Membership();
+        groupDefault.setReferenceId(null);
+        groupDefault.setRoleId(API_PRODUCT_USER_ROLE_ID);
+        when(
+            membershipRepository.findByMemberIdAndMemberTypeAndReferenceType(
+                "g1",
+                MembershipMemberType.GROUP,
+                MembershipReferenceType.API_PRODUCT
+            )
+        ).thenReturn(Set.of(groupDefault));
+
+        Membership existingApiProductRole = new Membership();
+        existingApiProductRole.setMemberId("user-1");
+        existingApiProductRole.setMemberType(MembershipMemberType.USER);
+        existingApiProductRole.setReferenceId("g1");
+        existingApiProductRole.setReferenceType(MembershipReferenceType.GROUP);
+        existingApiProductRole.setRoleId(API_PRODUCT_USER_ROLE_ID);
+        when(membershipRepository.findByReferenceIdAndReferenceType("g1", MembershipReferenceType.GROUP)).thenReturn(
+            List.of(existingApiProductRole)
+        );
+
+        upgrader.upgrade();
+
+        verify(membershipRepository, never()).create(any());
     }
 
     @Test
@@ -142,24 +211,17 @@ public class AssignDefaultApiProductRoleToGroupsUpgraderTest {
     }
 
     @Test
-    public void should_be_idempotent_when_all_groups_already_have_default_role() throws UpgraderException, TechnicalException {
+    public void should_be_idempotent_when_all_groups_and_members_already_have_roles() throws UpgraderException, TechnicalException {
         Environment env = environment();
         when(environmentRepository.findAll()).thenReturn(Set.of(env));
-
-        when(
-            roleRepository.findByScopeAndNameAndReferenceIdAndReferenceType(
-                eq(RoleScope.API_PRODUCT),
-                eq(ROLE_API_PRODUCT_USER.getName()),
-                eq(ORG_ID),
-                eq(RoleReferenceType.ORGANIZATION)
-            )
-        ).thenReturn(Optional.of(role()));
+        stubApiProductRoles();
 
         Group g1 = group("g1");
         when(groupRepository.findAllByEnvironment(ENV_ID)).thenReturn(Set.of(g1));
 
         Membership existing = new Membership();
         existing.setReferenceId(null);
+        existing.setRoleId(API_PRODUCT_USER_ROLE_ID);
         when(
             membershipRepository.findByMemberIdAndMemberTypeAndReferenceType(
                 "g1",
@@ -167,6 +229,7 @@ public class AssignDefaultApiProductRoleToGroupsUpgraderTest {
                 MembershipReferenceType.API_PRODUCT
             )
         ).thenReturn(Set.of(existing));
+        when(membershipRepository.findByReferenceIdAndReferenceType("g1", MembershipReferenceType.GROUP)).thenReturn(List.of());
 
         upgrader.upgrade();
 
@@ -176,6 +239,21 @@ public class AssignDefaultApiProductRoleToGroupsUpgraderTest {
     @Test
     public void test_order() {
         assertThat(upgrader.getOrder()).isEqualTo(UpgraderOrder.ASSIGN_DEFAULT_API_PRODUCT_ROLE_TO_GROUPS_UPGRADER);
+    }
+
+    private void stubApiProductRoles() throws TechnicalException {
+        Role userRole = role(API_PRODUCT_USER_ROLE_ID);
+        when(
+            roleRepository.findByScopeAndNameAndReferenceIdAndReferenceType(
+                eq(RoleScope.API_PRODUCT),
+                eq(ROLE_API_PRODUCT_USER.getName()),
+                eq(ORG_ID),
+                eq(RoleReferenceType.ORGANIZATION)
+            )
+        ).thenReturn(Optional.of(userRole));
+        when(
+            roleRepository.findByScopeAndReferenceIdAndReferenceType(RoleScope.API_PRODUCT, ORG_ID, RoleReferenceType.ORGANIZATION)
+        ).thenReturn(Set.of(userRole, role(API_PRODUCT_OWNER_ROLE_ID)));
     }
 
     private Environment environment() {
@@ -192,9 +270,9 @@ public class AssignDefaultApiProductRoleToGroupsUpgraderTest {
         return group;
     }
 
-    private Role role() {
+    private Role role(String id) {
         Role role = new Role();
-        role.setId(API_PRODUCT_USER_ROLE_ID);
+        role.setId(id);
         return role;
     }
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-14272

## Description
Adding the group to an API Product does not grant legacy members an effective API Product role.

Changes:
Fixes a migration gap where AssignDefaultApiProductRoleToGroupsUpgrader only seeded the group-level default API Product role and left existing group members unchanged.

Groups created before API Product support could get a default API_PRODUCT role on the group, but legacy members still had only API / Application / Integration memberships on that group. When such a group was added to an API Product, those users did not receive effective API Product access.

Before:
<img width="1315" height="658" alt="image" src="https://github.com/user-attachments/assets/0e643399-1f73-4014-b079-f77ca2d9dbe2" />

After:
<img width="1315" height="658" alt="image" src="https://github.com/user-attachments/assets/01369576-b9c3-4c77-b9be-5ac1a5a66aec" />

<img width="1503" height="658" alt="image" src="https://github.com/user-attachments/assets/f730cbca-d553-4011-baa1-c330b2d0cb80" />
