### PR TITLE
fix(repository-elasticsearch): skip log docs with malformed @timestamp

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/log/ElasticLogRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/log/ElasticLogRepository.java
@@ -228,7 +228,11 @@ public class ElasticLogRepository extends AbstractElasticsearchRepository implem
                 log = searchResponse.getSearchHits().getHits().get(0).getSource();
             }
 
-            return LogBuilder.createExtendedLog(searchHit, log);
+            final ExtendedLog extendedLog = LogBuilder.createExtendedLog(searchHit, log);
+            if (extendedLog == null) {
+                throw new AnalyticsException("Request [" + requestId + "] has malformed data and cannot be parsed");
+            }
+            return extendedLog;
         } catch (Exception e) {
             logger.error("Request [{}] does not exist", requestId, e);
             throw new AnalyticsException("Request [" + requestId + "] does not exist");
@@ -244,7 +248,10 @@ public class ElasticLogRepository extends AbstractElasticsearchRepository implem
         final TabularResponse tabularResponse = new TabularResponse(total);
         final List<Log> logs = new ArrayList<>(hits.getHits().size());
         for (int i = 0; i < hits.getHits().size(); i++) {
-            logs.add(LogBuilder.createLog(hits.getHits().get(i)));
+            final Log entry = LogBuilder.createLog(hits.getHits().get(i));
+            if (entry != null) {
+                logs.add(entry);
+            }
         }
         tabularResponse.setLogs(logs);
 

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/log/LogBuilder.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/log/LogBuilder.java
@@ -92,6 +92,10 @@ final class LogBuilder {
     static ExtendedLog createExtendedLog(final SearchHit hit, final JsonNode log) {
         ExtendedLog extentedLog = createLog(hit, new ExtendedLog());
 
+        if (extentedLog == null) {
+            return null;
+        }
+
         // Add client and proxy requests / responses
         if (log != null) {
             extentedLog.setClientRequest(createRequest(log.get(FIELD_CLIENT_REQUEST)));
@@ -109,11 +113,19 @@ final class LogBuilder {
         log.setTransactionId(source.get(FIELD_TRANSACTION_ID).asText());
         log.setGateway(source.get(FIELD_GATEWAY).asText());
 
+        final JsonNode timestampNode = source.get(FIELD_TIMESTAMP);
+        final String rawTimestamp = (timestampNode == null) ? null : timestampNode.asText();
+
+        if (rawTimestamp == null || rawTimestamp.isBlank()) {
+            logger.warn("Skipping log doc id={}: missing or blank @timestamp", hit.getId());
+            return null;
+        }
+
         try {
-            log.setTimestamp(dtf.parse((source.get(FIELD_TIMESTAMP).asText())).getTime());
-        } catch (final ParseException e) {
-            logger.error("Impossible to parse date", e);
-            throw new IllegalArgumentException("Impossible to parse timestamp field", e);
+            log.setTimestamp(dtf.parse(rawTimestamp).getTime());
+        } catch (final ParseException | NumberFormatException e) {
+            logger.warn("Skipping log doc id={} with malformed @timestamp value [{}]: {}", hit.getId(), rawTimestamp, e.getMessage());
+            return null;
         }
 
         log.setUri(source.get(FIELD_URI).asText());

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/log/LogBuilderTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/log/LogBuilderTest.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.elasticsearch.log;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.gravitee.elasticsearch.model.SearchHit;
+import io.gravitee.repository.log.model.Log;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/**
+ * Unit tests for {@link LogBuilder}.
+ *
+ * <p>Covers the resilience of {@code createLog} to malformed {@code @timestamp}
+ * values observed in production (notably from log ingestion pipelines that
+ * inject pseudo-scientific-notation strings into {@code @timestamp}).
+ *
+ * @author GraviteeSource Team
+ */
+class LogBuilderTest {
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    private static final String VALID_TIMESTAMP = "2026-06-02T07:42:51.312Z";
+
+    /**
+     * Minimal valid log document with all the fields {@link LogBuilder#createLog} accesses.
+     */
+    private static final String VALID_LOG_JSON =
+        "{" +
+        "\"@timestamp\":\"" +
+        VALID_TIMESTAMP +
+        "\"," +
+        "\"transaction\":\"tx-1\"," +
+        "\"gateway\":\"gw-1\"," +
+        "\"uri\":\"/foo\"," +
+        "\"method\":1," +
+        "\"status\":200," +
+        "\"response-time\":42," +
+        "\"local-address\":\"127.0.0.1\"," +
+        "\"remote-address\":\"127.0.0.1\"" +
+        "}";
+
+    @Test
+    void createLog_parses_valid_iso8601_timestamp() throws Exception {
+        Log result = LogBuilder.createLog(hitFromJson("id-ok", VALID_LOG_JSON));
+
+        assertThat(result).isNotNull();
+        assertThat(result.getId()).isEqualTo("id-ok");
+        assertThat(result.getTimestamp()).isEqualTo(1780386171312L);
+        assertThat(result.getTransactionId()).isEqualTo("tx-1");
+        assertThat(result.getGateway()).isEqualTo("gw-1");
+    }
+
+    @Test
+    void createLog_returns_null_when_timestamp_node_is_missing() throws Exception {
+        String json = "{" + "\"transaction\":\"tx-1\"," + "\"gateway\":\"gw-1\"" + "}";
+
+        Log result = LogBuilder.createLog(hitFromJson("id-missing-ts", json));
+
+        assertThat(result).isNull();
+    }
+
+    @Test
+    void createLog_returns_null_when_timestamp_is_json_null() throws Exception {
+        String json = "{" + "\"@timestamp\":null," + "\"transaction\":\"tx-1\"," + "\"gateway\":\"gw-1\"" + "}";
+
+        Log result = LogBuilder.createLog(hitFromJson("id-null-ts", json));
+
+        assertThat(result).isNull();
+    }
+
+    @ParameterizedTest(name = "createLog returns null for blank @timestamp = [{0}]")
+    @NullAndEmptySource
+    @ValueSource(strings = { " ", "   ", "\t", "\n" })
+    void createLog_returns_null_when_timestamp_is_blank(String blankValue) throws Exception {
+        String value = (blankValue == null) ? "null" : "\"" + blankValue.replace("\t", "\\t").replace("\n", "\\n") + "\"";
+        String json = "{" + "\"@timestamp\":" + value + "," + "\"transaction\":\"tx-1\"," + "\"gateway\":\"gw-1\"" + "}";
+
+        Log result = LogBuilder.createLog(hitFromJson("id-blank-ts", json));
+
+        assertThat(result).isNull();
+    }
+
+    /**
+     * Real-world malformed values observed at a SaaS customer (OldMutual). All
+     * trigger {@link java.lang.NumberFormatException} inside
+     * {@code SimpleDateFormat.parse} via {@code FloatingDecimal} / {@code DigitList},
+     * which the buggy revision of {@link LogBuilder} did not catch.
+     */
+    @ParameterizedTest(name = "createLog returns null for malformed @timestamp = [{0}]")
+    @ValueSource(strings = { ".22EE1", ".122EE2", ".2E2026", ".2202026EE4", ".202E202E1", "4482026.E44482026E4", "not-a-date" })
+    void createLog_returns_null_when_timestamp_is_malformed(String malformedTimestamp) throws Exception {
+        String json = "{" + "\"@timestamp\":\"" + malformedTimestamp + "\"," + "\"transaction\":\"tx-1\"," + "\"gateway\":\"gw-1\"" + "}";
+
+        Log result = LogBuilder.createLog(hitFromJson("id-bad-ts", json));
+
+        assertThat(result).isNull();
+    }
+
+    @Test
+    void createLog_does_not_throw_NumberFormatException_for_scientific_like_value() {
+        // Guard against regression: prior code propagated NFE because the catch
+        // only handled ParseException, taking down the whole /apis/{id}/logs response.
+        String json = "{" + "\"@timestamp\":\".122EE2\"," + "\"transaction\":\"tx-1\"," + "\"gateway\":\"gw-1\"" + "}";
+
+        // Must not throw — must return null instead.
+        Log result = LogBuilder.createLog(hitFromJson("id-nfe", json));
+
+        assertThat(result).isNull();
+    }
+
+    private static SearchHit hitFromJson(String id, String json) {
+        try {
+            SearchHit hit = new SearchHit();
+            hit.setId(id);
+            JsonNode source = OBJECT_MAPPER.readTree(json);
+            hit.setSource(source);
+            return hit;
+        } catch (Exception e) {
+            throw new IllegalStateException("Failed to build SearchHit for test", e);
+        }
+    }
+}


### PR DESCRIPTION
https://gravitee.atlassian.net/browse/APIM-14380
## Summary

`LogBuilder.createLog` parses `@timestamp` via `SimpleDateFormat`, whose internal `DigitList`/`DecimalFormat` throws `NumberFormatException` (not `ParseException`) on inputs that look like scientific notation but are malformed — e.g. `""`, `.22EE1`, `.122EE2`, `.2E2026`, `.2202026EE4`, `.202E202E1`, `4482026.E44482026E4`. The existing `try/catch` only handles `ParseException`, so the NFE escapes and crashes the whole `toTabularResponse` / `findById` call, returning HTTP 500 for the entire page of logs.

When this happens repeatedly (Console **Logs** page auto-refresh on an affected API), the cumulative memory pressure on the APIM Management API pod can lead to OOMKill and cascading unavailability of colocated services (Bridge Server endpoints, etc.).

## Changes

- `LogBuilder.createLog` returns `null` when `@timestamp` is missing, blank, or cannot be parsed (catches `ParseException` AND `NumberFormatException`), and logs a `WARN` with the doc id + offending raw value to help diagnose the upstream data quality issue.
- `createExtendedLog` propagates the `null`.
- `ElasticLogRepository.toTabularResponse` filters out `null` entries, so a single malformed doc no longer breaks the whole page.
- `ElasticLogRepository.findById` throws a clearer `AnalyticsException` when the single doc requested is malformed.

## Reproduction

```java
new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSXXX").parse(".122EE2");
// → java.lang.NumberFormatException: For input string: ".122EE2"
//   at FloatingDecimal.readJavaFormatString
//   at Double.parseDouble
//   at DigitList.getDouble
//   at DecimalFormat.parse
//   at SimpleDateFormat.subParse
```

## Test plan

- [x] Unit tests added in `LogBuilderTest` covering: valid ISO timestamp, missing field, JSON `null`, blank string, and 7 real-world malformed values observed in production
- [x] Existing integration tests in `ElasticsearchLogRepositoryTest` (22 tests) still pass
- [x] `LuceneEscapeTest` (12 tests) still passes
- [x] prettier-java formatting applied

## Versions affected

Bug present on all 4.x branches up to and including HEAD of `master`. This PR targets `4.8.x`; forward-port to `4.9.x`, `4.10.x`, `4.11.x`, and `master` recommended.

## Limitations

- This change does not clean docs already polluted in Elasticsearch — operators must purge via `_delete_by_query` on the offending pattern (typically docs from a misconfigured Logstash filter copying a custom metric value into `@timestamp`).
- The same `catch (ParseException)`-only pattern exists in `gravitee-apim-repository-elasticsearch/.../healthcheck/query/LogBuilder.java` and would benefit from the same treatment — left out of this PR to keep the change focused.