### PR TITLE
Support 'milestone' qualifier in release artefact regex

### DIFF
--- a/.circleci/ci/src/jobs/backend/job-backend-build-and-publish-on-download-website.ts
+++ b/.circleci/ci/src/jobs/backend/job-backend-build-and-publish-on-download-website.ts
@@ -85,7 +85,7 @@ for pathToArtefactFile in $(find . -path '*target/gravitee-apim*.zip'); do
     # e.g. ./gravitee-apim-repository/gravitee-apim-repository-mongodb/target/gravitee-apim-repository-mongodb-4.4.21.zip => gravitee-apim-repository-mongodb-4.4.21.zip
     artefactFile=\${pathToArtefactFile##*/}
 
-    regex="(.*)-[0-9]+.[0-9]+.[0-9]+(-(alpha|beta|rc).[0-9]+)?"
+    regex="(.*)-[0-9]+.[0-9]+.[0-9]+(-(alpha|beta|milestone|rc).[0-9]+)?"
     [[ $artefactFile =~ $regex ]]
     artefactName=\${BASH_REMATCH[1]}
 

--- a/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-alpha.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-alpha.yml
@@ -471,7 +471,7 @@ jobs:
                 # e.g. ./gravitee-apim-repository/gravitee-apim-repository-mongodb/target/gravitee-apim-repository-mongodb-4.4.21.zip => gravitee-apim-repository-mongodb-4.4.21.zip
                 artefactFile=${pathToArtefactFile##*/}
 
-                regex="(.*)-[0-9]+.[0-9]+.[0-9]+(-(alpha|beta|rc).[0-9]+)?"
+                regex="(.*)-[0-9]+.[0-9]+.[0-9]+(-(alpha|beta|milestone|rc).[0-9]+)?"
                 [[ $artefactFile =~ $regex ]]
                 artefactName=${BASH_REMATCH[1]}
 

--- a/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-dry-run.yml
@@ -471,7 +471,7 @@ jobs:
                 # e.g. ./gravitee-apim-repository/gravitee-apim-repository-mongodb/target/gravitee-apim-repository-mongodb-4.4.21.zip => gravitee-apim-repository-mongodb-4.4.21.zip
                 artefactFile=${pathToArtefactFile##*/}
 
-                regex="(.*)-[0-9]+.[0-9]+.[0-9]+(-(alpha|beta|rc).[0-9]+)?"
+                regex="(.*)-[0-9]+.[0-9]+.[0-9]+(-(alpha|beta|milestone|rc).[0-9]+)?"
                 [[ $artefactFile =~ $regex ]]
                 artefactName=${BASH_REMATCH[1]}
 

--- a/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-latest.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-latest.yml
@@ -471,7 +471,7 @@ jobs:
                 # e.g. ./gravitee-apim-repository/gravitee-apim-repository-mongodb/target/gravitee-apim-repository-mongodb-4.4.21.zip => gravitee-apim-repository-mongodb-4.4.21.zip
                 artefactFile=${pathToArtefactFile##*/}
 
-                regex="(.*)-[0-9]+.[0-9]+.[0-9]+(-(alpha|beta|rc).[0-9]+)?"
+                regex="(.*)-[0-9]+.[0-9]+.[0-9]+(-(alpha|beta|milestone|rc).[0-9]+)?"
                 [[ $artefactFile =~ $regex ]]
                 artefactName=${BASH_REMATCH[1]}
 

--- a/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-no-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-no-dry-run.yml
@@ -471,7 +471,7 @@ jobs:
                 # e.g. ./gravitee-apim-repository/gravitee-apim-repository-mongodb/target/gravitee-apim-repository-mongodb-4.4.21.zip => gravitee-apim-repository-mongodb-4.4.21.zip
                 artefactFile=${pathToArtefactFile##*/}
 
-                regex="(.*)-[0-9]+.[0-9]+.[0-9]+(-(alpha|beta|rc).[0-9]+)?"
+                regex="(.*)-[0-9]+.[0-9]+.[0-9]+(-(alpha|beta|milestone|rc).[0-9]+)?"
                 [[ $artefactFile =~ $regex ]]
                 artefactName=${BASH_REMATCH[1]}
 

--- a/.circleci/ci/src/pipelines/tests/resources/release/release-4-2-0-alpha.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/release/release-4-2-0-alpha.yml
@@ -287,7 +287,7 @@ jobs:
                 # e.g. ./gravitee-apim-repository/gravitee-apim-repository-mongodb/target/gravitee-apim-repository-mongodb-4.4.21.zip => gravitee-apim-repository-mongodb-4.4.21.zip
                 artefactFile=${pathToArtefactFile##*/}
 
-                regex="(.*)-[0-9]+.[0-9]+.[0-9]+(-(alpha|beta|rc).[0-9]+)?"
+                regex="(.*)-[0-9]+.[0-9]+.[0-9]+(-(alpha|beta|milestone|rc).[0-9]+)?"
                 [[ $artefactFile =~ $regex ]]
                 artefactName=${BASH_REMATCH[1]}
 

--- a/.circleci/ci/src/pipelines/tests/resources/release/release-4-2-0-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/release/release-4-2-0-dry-run.yml
@@ -287,7 +287,7 @@ jobs:
                 # e.g. ./gravitee-apim-repository/gravitee-apim-repository-mongodb/target/gravitee-apim-repository-mongodb-4.4.21.zip => gravitee-apim-repository-mongodb-4.4.21.zip
                 artefactFile=${pathToArtefactFile##*/}
 
-                regex="(.*)-[0-9]+.[0-9]+.[0-9]+(-(alpha|beta|rc).[0-9]+)?"
+                regex="(.*)-[0-9]+.[0-9]+.[0-9]+(-(alpha|beta|milestone|rc).[0-9]+)?"
                 [[ $artefactFile =~ $regex ]]
                 artefactName=${BASH_REMATCH[1]}
 

--- a/.circleci/ci/src/pipelines/tests/resources/release/release-4-2-0.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/release/release-4-2-0.yml
@@ -287,7 +287,7 @@ jobs:
                 # e.g. ./gravitee-apim-repository/gravitee-apim-repository-mongodb/target/gravitee-apim-repository-mongodb-4.4.21.zip => gravitee-apim-repository-mongodb-4.4.21.zip
                 artefactFile=${pathToArtefactFile##*/}
 
-                regex="(.*)-[0-9]+.[0-9]+.[0-9]+(-(alpha|beta|rc).[0-9]+)?"
+                regex="(.*)-[0-9]+.[0-9]+.[0-9]+(-(alpha|beta|milestone|rc).[0-9]+)?"
                 [[ $artefactFile =~ $regex ]]
                 artefactName=${BASH_REMATCH[1]}
 


### PR DESCRIPTION
## Description

Add `milestone` to the prerelease qualifier alternation used when computing the download-website publish path, alongside `alpha`/`beta`/`rc`, so milestone pre-releases are recognized like the other Maven pre-release qualifiers. Update the release/full-release test fixtures accordingly.
