### PR TITLE
Prepare next milestone release of 4.12.0

### DIFF
--- a/.circleci/ci/src/jobs/backend/job-backend-build-and-publish-on-download-website.ts
+++ b/.circleci/ci/src/jobs/backend/job-backend-build-and-publish-on-download-website.ts
@@ -85,7 +85,7 @@ for pathToArtefactFile in $(find . -path '*target/gravitee-apim*.zip'); do
     # e.g. ./gravitee-apim-repository/gravitee-apim-repository-mongodb/target/gravitee-apim-repository-mongodb-4.4.21.zip => gravitee-apim-repository-mongodb-4.4.21.zip
     artefactFile=\${pathToArtefactFile##*/}
 
-    regex="(.*)-[0-9]+.[0-9]+.[0-9]+(-(alpha|beta|rc).[0-9]+)?"
+    regex="(.*)-[0-9]+.[0-9]+.[0-9]+(-(alpha|beta|milestone|rc).[0-9]+)?"
     [[ $artefactFile =~ $regex ]]
     artefactName=\${BASH_REMATCH[1]}
 

--- a/.circleci/ci/src/jobs/job-release-commit-and-prepare-next-version.ts
+++ b/.circleci/ci/src/jobs/job-release-commit-and-prepare-next-version.ts
@@ -80,6 +80,7 @@ sed -i "s#<changelist>.*</changelist>#<changelist></changelist>#" pom.xml
 sed -i 's/"version": ".*"/"version": "${environment.graviteeioVersion}"/' gravitee-apim-console-webui/build.json
 sed -i 's/"version": ".*"/"version": "${environment.graviteeioVersion}"/' gravitee-apim-portal-webui/build.json
 sed -i 's/"version": ".*"/"version": "${environment.graviteeioVersion}"/' gravitee-apim-portal-webui-next/build.json
+sed -i 's/"version": ".*"/"version": "${environment.graviteeioVersion}"/' gravitee-gamma/gravitee-gamma-control-plane-webui/build.json
 
 git add --update
 git commit -m "${environment.graviteeioVersion}"
@@ -94,6 +95,7 @@ sed -i 's#version: ".*"#version: "${nextVersion}${nextQualifier}-SNAPSHOT"#' gra
 sed -i 's#"version": ".*"#"version": "${nextVersion}${nextQualifier}-SNAPSHOT"#' gravitee-apim-console-webui/build.json
 sed -i 's#"version": ".*"#"version": "${nextVersion}${nextQualifier}-SNAPSHOT"#' gravitee-apim-portal-webui/build.json
 sed -i 's#"version": ".*"#"version": "${nextVersion}${nextQualifier}-SNAPSHOT"#' gravitee-apim-portal-webui-next/build.json
+sed -i 's#"version": ".*"#"version": "${nextVersion}${nextQualifier}-SNAPSHOT"#' gravitee-gamma/gravitee-gamma-control-plane-webui/build.json
 
 # Helm chart increase version, appVersion and clean the artifacthub.io/changes annotation
 ${this.buildHelmCommand(nextVersion, nextQualifier)}

--- a/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-alpha.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-alpha.yml
@@ -471,7 +471,7 @@ jobs:
                 # e.g. ./gravitee-apim-repository/gravitee-apim-repository-mongodb/target/gravitee-apim-repository-mongodb-4.4.21.zip => gravitee-apim-repository-mongodb-4.4.21.zip
                 artefactFile=${pathToArtefactFile##*/}
 
-                regex="(.*)-[0-9]+.[0-9]+.[0-9]+(-(alpha|beta|rc).[0-9]+)?"
+                regex="(.*)-[0-9]+.[0-9]+.[0-9]+(-(alpha|beta|milestone|rc).[0-9]+)?"
                 [[ $artefactFile =~ $regex ]]
                 artefactName=${BASH_REMATCH[1]}
 

--- a/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-alpha.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-alpha.yml
@@ -529,6 +529,7 @@ jobs:
             sed -i 's/"version": ".*"/"version": "4.2.0-alpha.1"/' gravitee-apim-console-webui/build.json
             sed -i 's/"version": ".*"/"version": "4.2.0-alpha.1"/' gravitee-apim-portal-webui/build.json
             sed -i 's/"version": ".*"/"version": "4.2.0-alpha.1"/' gravitee-apim-portal-webui-next/build.json
+            sed -i 's/"version": ".*"/"version": "4.2.0-alpha.1"/' gravitee-gamma/gravitee-gamma-control-plane-webui/build.json
 
             git add --update
             git commit -m "4.2.0-alpha.1"
@@ -543,6 +544,7 @@ jobs:
             sed -i 's#"version": ".*"#"version": "4.2.0-alpha.2-SNAPSHOT"#' gravitee-apim-console-webui/build.json
             sed -i 's#"version": ".*"#"version": "4.2.0-alpha.2-SNAPSHOT"#' gravitee-apim-portal-webui/build.json
             sed -i 's#"version": ".*"#"version": "4.2.0-alpha.2-SNAPSHOT"#' gravitee-apim-portal-webui-next/build.json
+            sed -i 's#"version": ".*"#"version": "4.2.0-alpha.2-SNAPSHOT"#' gravitee-gamma/gravitee-gamma-control-plane-webui/build.json
 
             # Helm chart increase version, appVersion and clean the artifacthub.io/changes annotation
             sed -e "0,/^version:/{s/version:.*/version: 4.2.0-alpha.2/}" \

--- a/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-dry-run.yml
@@ -471,7 +471,7 @@ jobs:
                 # e.g. ./gravitee-apim-repository/gravitee-apim-repository-mongodb/target/gravitee-apim-repository-mongodb-4.4.21.zip => gravitee-apim-repository-mongodb-4.4.21.zip
                 artefactFile=${pathToArtefactFile##*/}
 
-                regex="(.*)-[0-9]+.[0-9]+.[0-9]+(-(alpha|beta|rc).[0-9]+)?"
+                regex="(.*)-[0-9]+.[0-9]+.[0-9]+(-(alpha|beta|milestone|rc).[0-9]+)?"
                 [[ $artefactFile =~ $regex ]]
                 artefactName=${BASH_REMATCH[1]}
 

--- a/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-dry-run.yml
@@ -529,6 +529,7 @@ jobs:
             sed -i 's/"version": ".*"/"version": "4.2.0"/' gravitee-apim-console-webui/build.json
             sed -i 's/"version": ".*"/"version": "4.2.0"/' gravitee-apim-portal-webui/build.json
             sed -i 's/"version": ".*"/"version": "4.2.0"/' gravitee-apim-portal-webui-next/build.json
+            sed -i 's/"version": ".*"/"version": "4.2.0"/' gravitee-gamma/gravitee-gamma-control-plane-webui/build.json
 
             git add --update
             git commit -m "4.2.0"
@@ -543,6 +544,7 @@ jobs:
             sed -i 's#"version": ".*"#"version": "4.2.1-SNAPSHOT"#' gravitee-apim-console-webui/build.json
             sed -i 's#"version": ".*"#"version": "4.2.1-SNAPSHOT"#' gravitee-apim-portal-webui/build.json
             sed -i 's#"version": ".*"#"version": "4.2.1-SNAPSHOT"#' gravitee-apim-portal-webui-next/build.json
+            sed -i 's#"version": ".*"#"version": "4.2.1-SNAPSHOT"#' gravitee-gamma/gravitee-gamma-control-plane-webui/build.json
 
             # Helm chart increase version, appVersion and clean the artifacthub.io/changes annotation
             sed -e "0,/^version:/{s/version:.*/version: 4.2.1/}" \

--- a/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-latest.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-latest.yml
@@ -471,7 +471,7 @@ jobs:
                 # e.g. ./gravitee-apim-repository/gravitee-apim-repository-mongodb/target/gravitee-apim-repository-mongodb-4.4.21.zip => gravitee-apim-repository-mongodb-4.4.21.zip
                 artefactFile=${pathToArtefactFile##*/}
 
-                regex="(.*)-[0-9]+.[0-9]+.[0-9]+(-(alpha|beta|rc).[0-9]+)?"
+                regex="(.*)-[0-9]+.[0-9]+.[0-9]+(-(alpha|beta|milestone|rc).[0-9]+)?"
                 [[ $artefactFile =~ $regex ]]
                 artefactName=${BASH_REMATCH[1]}
 

--- a/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-latest.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-latest.yml
@@ -529,6 +529,7 @@ jobs:
             sed -i 's/"version": ".*"/"version": "4.2.0"/' gravitee-apim-console-webui/build.json
             sed -i 's/"version": ".*"/"version": "4.2.0"/' gravitee-apim-portal-webui/build.json
             sed -i 's/"version": ".*"/"version": "4.2.0"/' gravitee-apim-portal-webui-next/build.json
+            sed -i 's/"version": ".*"/"version": "4.2.0"/' gravitee-gamma/gravitee-gamma-control-plane-webui/build.json
 
             git add --update
             git commit -m "4.2.0"
@@ -543,6 +544,7 @@ jobs:
             sed -i 's#"version": ".*"#"version": "4.2.1-SNAPSHOT"#' gravitee-apim-console-webui/build.json
             sed -i 's#"version": ".*"#"version": "4.2.1-SNAPSHOT"#' gravitee-apim-portal-webui/build.json
             sed -i 's#"version": ".*"#"version": "4.2.1-SNAPSHOT"#' gravitee-apim-portal-webui-next/build.json
+            sed -i 's#"version": ".*"#"version": "4.2.1-SNAPSHOT"#' gravitee-gamma/gravitee-gamma-control-plane-webui/build.json
 
             # Helm chart increase version, appVersion and clean the artifacthub.io/changes annotation
             sed -e "0,/^version:/{s/version:.*/version: 4.2.1/}" \

--- a/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-no-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-no-dry-run.yml
@@ -471,7 +471,7 @@ jobs:
                 # e.g. ./gravitee-apim-repository/gravitee-apim-repository-mongodb/target/gravitee-apim-repository-mongodb-4.4.21.zip => gravitee-apim-repository-mongodb-4.4.21.zip
                 artefactFile=${pathToArtefactFile##*/}
 
-                regex="(.*)-[0-9]+.[0-9]+.[0-9]+(-(alpha|beta|rc).[0-9]+)?"
+                regex="(.*)-[0-9]+.[0-9]+.[0-9]+(-(alpha|beta|milestone|rc).[0-9]+)?"
                 [[ $artefactFile =~ $regex ]]
                 artefactName=${BASH_REMATCH[1]}
 

--- a/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-no-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/full-release/release-4-2-0-no-dry-run.yml
@@ -529,6 +529,7 @@ jobs:
             sed -i 's/"version": ".*"/"version": "4.2.0"/' gravitee-apim-console-webui/build.json
             sed -i 's/"version": ".*"/"version": "4.2.0"/' gravitee-apim-portal-webui/build.json
             sed -i 's/"version": ".*"/"version": "4.2.0"/' gravitee-apim-portal-webui-next/build.json
+            sed -i 's/"version": ".*"/"version": "4.2.0"/' gravitee-gamma/gravitee-gamma-control-plane-webui/build.json
 
             git add --update
             git commit -m "4.2.0"
@@ -543,6 +544,7 @@ jobs:
             sed -i 's#"version": ".*"#"version": "4.2.1-SNAPSHOT"#' gravitee-apim-console-webui/build.json
             sed -i 's#"version": ".*"#"version": "4.2.1-SNAPSHOT"#' gravitee-apim-portal-webui/build.json
             sed -i 's#"version": ".*"#"version": "4.2.1-SNAPSHOT"#' gravitee-apim-portal-webui-next/build.json
+            sed -i 's#"version": ".*"#"version": "4.2.1-SNAPSHOT"#' gravitee-gamma/gravitee-gamma-control-plane-webui/build.json
 
             # Helm chart increase version, appVersion and clean the artifacthub.io/changes annotation
             sed -e "0,/^version:/{s/version:.*/version: 4.2.1/}" \

--- a/.circleci/ci/src/pipelines/tests/resources/maven-release/maven-release.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/maven-release/maven-release.yml
@@ -115,6 +115,7 @@ jobs:
             sed -i 's/"version": ".*"/"version": "1.2.3"/' gravitee-apim-console-webui/build.json
             sed -i 's/"version": ".*"/"version": "1.2.3"/' gravitee-apim-portal-webui/build.json
             sed -i 's/"version": ".*"/"version": "1.2.3"/' gravitee-apim-portal-webui-next/build.json
+            sed -i 's/"version": ".*"/"version": "1.2.3"/' gravitee-gamma/gravitee-gamma-control-plane-webui/build.json
 
             git add --update
             git commit -m "1.2.3"
@@ -129,6 +130,7 @@ jobs:
             sed -i 's#"version": ".*"#"version": "1.2.4-SNAPSHOT"#' gravitee-apim-console-webui/build.json
             sed -i 's#"version": ".*"#"version": "1.2.4-SNAPSHOT"#' gravitee-apim-portal-webui/build.json
             sed -i 's#"version": ".*"#"version": "1.2.4-SNAPSHOT"#' gravitee-apim-portal-webui-next/build.json
+            sed -i 's#"version": ".*"#"version": "1.2.4-SNAPSHOT"#' gravitee-gamma/gravitee-gamma-control-plane-webui/build.json
 
             # Helm chart increase version, appVersion and clean the artifacthub.io/changes annotation
             sed -e "0,/^version:/{s/version:.*/version: 1.2.4/}" \

--- a/.circleci/ci/src/pipelines/tests/resources/release/release-4-2-0-alpha.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/release/release-4-2-0-alpha.yml
@@ -345,6 +345,7 @@ jobs:
             sed -i 's/"version": ".*"/"version": "4.2.0-alpha.1"/' gravitee-apim-console-webui/build.json
             sed -i 's/"version": ".*"/"version": "4.2.0-alpha.1"/' gravitee-apim-portal-webui/build.json
             sed -i 's/"version": ".*"/"version": "4.2.0-alpha.1"/' gravitee-apim-portal-webui-next/build.json
+            sed -i 's/"version": ".*"/"version": "4.2.0-alpha.1"/' gravitee-gamma/gravitee-gamma-control-plane-webui/build.json
 
             git add --update
             git commit -m "4.2.0-alpha.1"
@@ -359,6 +360,7 @@ jobs:
             sed -i 's#"version": ".*"#"version": "4.2.0-alpha.2-SNAPSHOT"#' gravitee-apim-console-webui/build.json
             sed -i 's#"version": ".*"#"version": "4.2.0-alpha.2-SNAPSHOT"#' gravitee-apim-portal-webui/build.json
             sed -i 's#"version": ".*"#"version": "4.2.0-alpha.2-SNAPSHOT"#' gravitee-apim-portal-webui-next/build.json
+            sed -i 's#"version": ".*"#"version": "4.2.0-alpha.2-SNAPSHOT"#' gravitee-gamma/gravitee-gamma-control-plane-webui/build.json
 
             # Helm chart increase version, appVersion and clean the artifacthub.io/changes annotation
             sed -e "0,/^version:/{s/version:.*/version: 4.2.0-alpha.2/}" \

--- a/.circleci/ci/src/pipelines/tests/resources/release/release-4-2-0-alpha.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/release/release-4-2-0-alpha.yml
@@ -287,7 +287,7 @@ jobs:
                 # e.g. ./gravitee-apim-repository/gravitee-apim-repository-mongodb/target/gravitee-apim-repository-mongodb-4.4.21.zip => gravitee-apim-repository-mongodb-4.4.21.zip
                 artefactFile=${pathToArtefactFile##*/}
 
-                regex="(.*)-[0-9]+.[0-9]+.[0-9]+(-(alpha|beta|rc).[0-9]+)?"
+                regex="(.*)-[0-9]+.[0-9]+.[0-9]+(-(alpha|beta|milestone|rc).[0-9]+)?"
                 [[ $artefactFile =~ $regex ]]
                 artefactName=${BASH_REMATCH[1]}
 

--- a/.circleci/ci/src/pipelines/tests/resources/release/release-4-2-0-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/release/release-4-2-0-dry-run.yml
@@ -287,7 +287,7 @@ jobs:
                 # e.g. ./gravitee-apim-repository/gravitee-apim-repository-mongodb/target/gravitee-apim-repository-mongodb-4.4.21.zip => gravitee-apim-repository-mongodb-4.4.21.zip
                 artefactFile=${pathToArtefactFile##*/}
 
-                regex="(.*)-[0-9]+.[0-9]+.[0-9]+(-(alpha|beta|rc).[0-9]+)?"
+                regex="(.*)-[0-9]+.[0-9]+.[0-9]+(-(alpha|beta|milestone|rc).[0-9]+)?"
                 [[ $artefactFile =~ $regex ]]
                 artefactName=${BASH_REMATCH[1]}
 

--- a/.circleci/ci/src/pipelines/tests/resources/release/release-4-2-0-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/release/release-4-2-0-dry-run.yml
@@ -345,6 +345,7 @@ jobs:
             sed -i 's/"version": ".*"/"version": "4.2.0"/' gravitee-apim-console-webui/build.json
             sed -i 's/"version": ".*"/"version": "4.2.0"/' gravitee-apim-portal-webui/build.json
             sed -i 's/"version": ".*"/"version": "4.2.0"/' gravitee-apim-portal-webui-next/build.json
+            sed -i 's/"version": ".*"/"version": "4.2.0"/' gravitee-gamma/gravitee-gamma-control-plane-webui/build.json
 
             git add --update
             git commit -m "4.2.0"
@@ -359,6 +360,7 @@ jobs:
             sed -i 's#"version": ".*"#"version": "4.2.1-SNAPSHOT"#' gravitee-apim-console-webui/build.json
             sed -i 's#"version": ".*"#"version": "4.2.1-SNAPSHOT"#' gravitee-apim-portal-webui/build.json
             sed -i 's#"version": ".*"#"version": "4.2.1-SNAPSHOT"#' gravitee-apim-portal-webui-next/build.json
+            sed -i 's#"version": ".*"#"version": "4.2.1-SNAPSHOT"#' gravitee-gamma/gravitee-gamma-control-plane-webui/build.json
 
             # Helm chart increase version, appVersion and clean the artifacthub.io/changes annotation
             sed -e "0,/^version:/{s/version:.*/version: 4.2.1/}" \

--- a/.circleci/ci/src/pipelines/tests/resources/release/release-4-2-0.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/release/release-4-2-0.yml
@@ -287,7 +287,7 @@ jobs:
                 # e.g. ./gravitee-apim-repository/gravitee-apim-repository-mongodb/target/gravitee-apim-repository-mongodb-4.4.21.zip => gravitee-apim-repository-mongodb-4.4.21.zip
                 artefactFile=${pathToArtefactFile##*/}
 
-                regex="(.*)-[0-9]+.[0-9]+.[0-9]+(-(alpha|beta|rc).[0-9]+)?"
+                regex="(.*)-[0-9]+.[0-9]+.[0-9]+(-(alpha|beta|milestone|rc).[0-9]+)?"
                 [[ $artefactFile =~ $regex ]]
                 artefactName=${BASH_REMATCH[1]}
 

--- a/.circleci/ci/src/pipelines/tests/resources/release/release-4-2-0.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/release/release-4-2-0.yml
@@ -345,6 +345,7 @@ jobs:
             sed -i 's/"version": ".*"/"version": "4.2.0"/' gravitee-apim-console-webui/build.json
             sed -i 's/"version": ".*"/"version": "4.2.0"/' gravitee-apim-portal-webui/build.json
             sed -i 's/"version": ".*"/"version": "4.2.0"/' gravitee-apim-portal-webui-next/build.json
+            sed -i 's/"version": ".*"/"version": "4.2.0"/' gravitee-gamma/gravitee-gamma-control-plane-webui/build.json
 
             git add --update
             git commit -m "4.2.0"
@@ -359,6 +360,7 @@ jobs:
             sed -i 's#"version": ".*"#"version": "4.2.1-SNAPSHOT"#' gravitee-apim-console-webui/build.json
             sed -i 's#"version": ".*"#"version": "4.2.1-SNAPSHOT"#' gravitee-apim-portal-webui/build.json
             sed -i 's#"version": ".*"#"version": "4.2.1-SNAPSHOT"#' gravitee-apim-portal-webui-next/build.json
+            sed -i 's#"version": ".*"#"version": "4.2.1-SNAPSHOT"#' gravitee-gamma/gravitee-gamma-control-plane-webui/build.json
 
             # Helm chart increase version, appVersion and clean the artifacthub.io/changes annotation
             sed -e "0,/^version:/{s/version:.*/version: 4.2.1/}" \

--- a/gravitee-apim-console-webui/build.json
+++ b/gravitee-apim-console-webui/build.json
@@ -1,3 +1,3 @@
 {
-  "version": "4.12.0-alpha.2-SNAPSHOT"
+  "version": "4.12.0-milestone.1-SNAPSHOT"
 }

--- a/gravitee-apim-distribution/pom.xml
+++ b/gravitee-apim-distribution/pom.xml
@@ -1471,19 +1471,6 @@
                 </dependency>
                 <dependency>
                     <groupId>com.graviteesource.entrypoint</groupId>
-                    <artifactId>gravitee-entrypoint-mcp-studio</artifactId>
-                    <version>${gravitee-reactor-mcp-proxy.version}</version>
-                    <type>zip</type>
-                    <scope>runtime</scope>
-                    <exclusions>
-                        <exclusion>
-                            <groupId>*</groupId>
-                            <artifactId>*</artifactId>
-                        </exclusion>
-                    </exclusions>
-                </dependency>
-                <dependency>
-                    <groupId>com.graviteesource.entrypoint</groupId>
                     <artifactId>gravitee-entrypoint-a2a-proxy</artifactId>
                     <version>${gravitee-reactor-a2a-proxy.version}</version>
                     <type>zip</type>
@@ -1631,19 +1618,6 @@
                 <dependency>
                     <groupId>com.graviteesource.endpoint</groupId>
                     <artifactId>gravitee-endpoint-mcp-proxy</artifactId>
-                    <version>${gravitee-reactor-mcp-proxy.version}</version>
-                    <type>zip</type>
-                    <scope>runtime</scope>
-                    <exclusions>
-                        <exclusion>
-                            <groupId>*</groupId>
-                            <artifactId>*</artifactId>
-                        </exclusion>
-                    </exclusions>
-                </dependency>
-                <dependency>
-                    <groupId>com.graviteesource.endpoint</groupId>
-                    <artifactId>gravitee-endpoint-mcp-http</artifactId>
                     <version>${gravitee-reactor-mcp-proxy.version}</version>
                     <type>zip</type>
                     <scope>runtime</scope>

--- a/gravitee-apim-portal-webui-next/build.json
+++ b/gravitee-apim-portal-webui-next/build.json
@@ -1,3 +1,3 @@
 {
-  "version": "4.12.0-alpha.2-SNAPSHOT"
+  "version": "4.12.0-milestone.1-SNAPSHOT"
 }

--- a/gravitee-apim-portal-webui/build.json
+++ b/gravitee-apim-portal-webui/build.json
@@ -1,3 +1,3 @@
 {
-  "version": "4.12.0-alpha.2-SNAPSHOT"
+  "version": "4.12.0-milestone.1-SNAPSHOT"
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/resources/portal-openapi.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/resources/portal-openapi.yaml
@@ -10,7 +10,7 @@ info:
     license:
         name: Apache 2.0
         url: http://www.apache.org/licenses/LICENSE-2.0
-    version: "4.12.0-alpha.2-SNAPSHOT"
+    version: "4.12.0-milestone.1-SNAPSHOT"
 servers:
     - url: /portal/environments/{envId}
       description: The portal API for a given environment

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/pom.xml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/pom.xml
@@ -310,19 +310,6 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>com.graviteesource.gamma.module</groupId>
-            <artifactId>gravitee-gamma-module-aim</artifactId>
-            <version>${gravitee-gamma-module-aim.version}</version>
-            <type>zip</type>
-            <scope>runtime</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>*</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
             <groupId>io.gravitee.gamma.module</groupId>
             <artifactId>gravitee-gamma-module-authz</artifactId>
             <version>${project.version}</version>

--- a/gravitee-gamma/gravitee-gamma-control-plane-webui/build.json
+++ b/gravitee-gamma/gravitee-gamma-control-plane-webui/build.json
@@ -1,3 +1,3 @@
 {
-    "version": "4.12.0-SNAPSHOT"
+    "version": "4.12.0-milestone.1-SNAPSHOT"
 }

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 name: apim
 # Also update CHANGELOG.md
-version: 4.12.0-alpha.2
-appVersion: 4.12.0-alpha.2
+version: 4.12.0-milestone.1
+appVersion: 4.12.0-milestone.1
 description: Official Gravitee.io Helm chart for API Management
 home: https://gravitee.io
 sources:

--- a/pom.xml
+++ b/pom.xml
@@ -310,7 +310,7 @@
         <gravitee-resource-storage-azure-blob.version>1.1.0</gravitee-resource-storage-azure-blob.version>
         <gravitee-reactor-message.version>11.0.0-alpha.3</gravitee-reactor-message.version>
         <gravitee-reactor-native-kafka.version>7.0.0-alpha.14</gravitee-reactor-native-kafka.version>
-        <gravitee-reactor-mcp-proxy.version>3.0.0-feat-mcp-studio-schema-SNAPSHOT</gravitee-reactor-mcp-proxy.version>
+        <gravitee-reactor-mcp-proxy.version>3.0.0-alpha.4</gravitee-reactor-mcp-proxy.version>
         <gravitee-reactor-llm-proxy.version>3.0.0-alpha.6</gravitee-reactor-llm-proxy.version>
         <gravitee-reactor-a2a-proxy.version>1.0.0</gravitee-reactor-a2a-proxy.version>
         <gravitee-reactor-edge.version>1.0.0-alpha.9</gravitee-reactor-edge.version>

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
     <properties>
         <!-- Version properties -->
         <revision>4.12.0</revision>
-        <sha1>-alpha.2</sha1>
+        <sha1>-milestone.1</sha1>
         <changelist>-SNAPSHOT</changelist>
 
         <!-- Vert.X version is mandatory for vertx-grpc-protoc-plugin2

--- a/pom.xml
+++ b/pom.xml
@@ -337,9 +337,6 @@
         <gravitee-policy-native-ipfiltering.version>1.0.1</gravitee-policy-native-ipfiltering.version>
         <gravitee-resource-ai-model-token-classification.version>1.0.0</gravitee-resource-ai-model-token-classification.version>
 
-        <!-- Gamma plugins -->
-        <gravitee-gamma-module-aim.version>1.0.0-alpha.120</gravitee-gamma-module-aim.version>
-
         <!-- Authz plugins -->
         <gravitee-service-authz-pdp.version>1.0.0-alpha.4</gravitee-service-authz-pdp.version>
         <gravitee-policy-authz-pep.version>1.0.0-alpha.7</gravitee-policy-authz-pep.version>


### PR DESCRIPTION
## Description

- Update build.json of gamma-ui
- support `milestone` qualifier for pre-releases
- update all files that contain a version to prepare next milestone release of 4.12
- remove SNAPSHOT version of MCP reactor because it's not ready for 4.12.0
- remove AIM Module because it's not ready for 4.12.0

Everything is [skip ci] so we do not impact the 4.12.x dev environment currently used