### PR TITLE
test: fix flaky http protocol verticle test

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/test/java/io/gravitee/gateway/reactive/standalone/vertx/HttpProtocolVerticleTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/test/java/io/gravitee/gateway/reactive/standalone/vertx/HttpProtocolVerticleTest.java
@@ -82,11 +82,12 @@ class HttpProtocolVerticleTest {
         client
             .request(HttpMethod.GET, actualPort(), "127.0.0.1", "/")
             .compose(HttpClientRequest::send)
+            .compose(response -> response.body().map(body -> response))
             .onComplete(
                 testContext.succeeding(response ->
                     testContext.verify(() -> {
                         assertThat(response.statusCode()).isEqualTo(HttpStatusCode.OK_200);
-                        testContext.completeNow();
+                        client.close().onComplete(ar -> testContext.completeNow());
                     })
                 )
             );
@@ -102,6 +103,7 @@ class HttpProtocolVerticleTest {
         client
             .request(HttpMethod.GET, actualPort(), "127.0.0.1", "/")
             .compose(HttpClientRequest::send)
+            .compose(response -> response.body().map(body -> response))
             .onComplete(
                 testContext.succeeding(response ->
                     testContext.verify(() -> assertThat(response.statusCode()).isEqualTo(HttpStatusCode.INTERNAL_SERVER_ERROR_500))
@@ -109,11 +111,12 @@ class HttpProtocolVerticleTest {
             )
             .compose(httpClientResponse -> client.request(HttpMethod.GET, actualPort(), "127.0.0.1", "/"))
             .compose(HttpClientRequest::send)
+            .compose(response -> response.body().map(body -> response))
             .onComplete(
                 testContext.succeeding(response ->
                     testContext.verify(() -> {
                         assertThat(response.statusCode()).isEqualTo(HttpStatusCode.OK_200);
-                        testContext.completeNow();
+                        client.close().onComplete(ar -> testContext.completeNow());
                     })
                 )
             );
@@ -151,6 +154,7 @@ class HttpProtocolVerticleTest {
         client
             .request(HttpMethod.GET, actualPort(), "127.0.0.1", "/")
             .compose(HttpClientRequest::send)
+            .compose(response -> response.body().map(body -> response))
             .onComplete(
                 testContext.succeeding(response ->
                     testContext.verify(() -> assertThat(response.statusCode()).isEqualTo(SERVICE_UNAVAILABLE_503))
@@ -158,11 +162,12 @@ class HttpProtocolVerticleTest {
             )
             .compose(httpClientResponse -> client.request(HttpMethod.GET, actualPort(), "127.0.0.1", "/"))
             .compose(HttpClientRequest::send)
+            .compose(response -> response.body().map(body -> response))
             .onComplete(
                 testContext.succeeding(response ->
                     testContext.verify(() -> {
                         assertThat(response.statusCode()).isEqualTo(HttpStatusCode.OK_200);
-                        testContext.completeNow();
+                        client.close().onComplete(ar -> testContext.completeNow());
                     })
                 )
             );


### PR DESCRIPTION
## Problem

`HttpProtocolVerticleTest.http_server_should_listen` is flaky in CI, failing with:

```
io.vertx.core.VertxException: Pool closed
```

## Root cause

In Vert.x 5, closing the HTTP server and the HTTP client is asynchronous. The request/response tests signalled completion (`completeNow()`) as soon as the response status was checked, without consuming the response body nor closing the `HttpClient`. Under CI load (`-T 2C`), the test teardown then closed the client/server connection pool while a request was still in flight, surfacing `Pool closed`.

This is the same class of bug already fixed on the twin `DebugHttpProtocolVerticleTest` (dc1215d34c), which removed a manual early server close. The standalone test never had that line, so its residual race came from the unclosed client + eager completion.

## Fix

On the three request/response tests, fully read the response body (`response.body()`) and close the `HttpClient` before calling `completeNow()`, so nothing remains in flight when the Vert.x extension tears down the verticle. `http_server_should_dispose_when_connection_closed` is left untouched (its completion comes from the dispatcher `doOnDispose`).

## Validation

14 consecutive green runs locally (6 loops × the 2 surefire executions + 1 confirmation run): `Tests run: 4, Failures: 0, Errors: 0`, no `Pool closed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)