### PR TITLE
feat(ratelimit): enable Redis Cluster for rate limiting [APIM-14146]

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/src/main/resources/config/gravitee.yml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/src/main/resources/config/gravitee.yml
@@ -438,6 +438,15 @@ repositories:
 #            port: 26379
 #          - host: sentinel2
 #            port: 26379
+#      # Redis Cluster settings (mutually exclusive with sentinel)
+#      cluster:
+#        nodes:
+#          - host: redis-node1
+#            port: 6379
+#          - host: redis-node2
+#            port: 6379
+#          - host: redis-node3
+#            port: 6379
 #      # SSL settings
 #      ssl: false
 #      hostnameVerificationAlgorithm: NONE # default value is NONE. Support NONE, HTTPS and LDAPS

--- a/gravitee-apim-repository/gravitee-apim-repository-redis/src/main/java/io/gravitee/repository/redis/common/RedisConnectionFactory.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-redis/src/main/java/io/gravitee/repository/redis/common/RedisConnectionFactory.java
@@ -18,6 +18,7 @@ package io.gravitee.repository.redis.common;
 import io.gravitee.node.vertx.client.redis.VertxRedisClientFactory;
 import io.gravitee.plugin.configurations.redis.HostAndPort;
 import io.gravitee.plugin.configurations.redis.RedisClientOptions;
+import io.gravitee.plugin.configurations.redis.RedisClusterOptions;
 import io.gravitee.plugin.configurations.redis.RedisSentinelOptions;
 import io.gravitee.plugin.configurations.ssl.KeyStore;
 import io.gravitee.plugin.configurations.ssl.SslOptions;
@@ -52,6 +53,7 @@ public class RedisConnectionFactory {
     private final Map<String, String> scripts;
 
     private static final String SENTINEL_PARAMETER_PREFIX = "sentinel.";
+    private static final String CLUSTER_PARAMETER_PREFIX = "cluster.";
     private static final String PASSWORD_PARAMETER = "password";
 
     private static final String STORE_FORMAT_JKS = "JKS";
@@ -110,6 +112,13 @@ public class RedisConnectionFactory {
             );
         } else {
             log.debug("Redis repository configured to use standalone connection");
+        }
+
+        if (isClusterEnabled()) {
+            log.debug("Redis repository configured to use Cluster connection");
+            // useReplicas is pinned to NEVER: rate limiting relies on master-consistent
+            // counters, so reads must never be served from cluster replicas.
+            builder.cluster(RedisClusterOptions.builder().nodes(getClusterNodes()).useReplicas("NEVER").build());
         }
 
         if (ssl) {
@@ -290,6 +299,23 @@ public class RedisConnectionFactory {
         ) {
             String host = readPropertyValue(propertyPrefix + SENTINEL_PARAMETER_PREFIX + "nodes[" + idx + "].host", String.class);
             int port = readPropertyValue(propertyPrefix + SENTINEL_PARAMETER_PREFIX + "nodes[" + idx + "].port", int.class);
+            nodes.add(HostAndPort.builder().host(host).port(port).build());
+        }
+        return nodes;
+    }
+
+    private boolean isClusterEnabled() {
+        return StringUtils.hasLength(readPropertyValue(propertyPrefix + CLUSTER_PARAMETER_PREFIX + "nodes[0].host", String.class));
+    }
+
+    private List<HostAndPort> getClusterNodes() {
+        final List<HostAndPort> nodes = new ArrayList<>();
+        for (int idx = 0; ; idx++) {
+            String host = readPropertyValue(propertyPrefix + CLUSTER_PARAMETER_PREFIX + "nodes[" + idx + "].host", String.class);
+            if (!StringUtils.hasText(host)) {
+                break;
+            }
+            int port = readPropertyValue(propertyPrefix + CLUSTER_PARAMETER_PREFIX + "nodes[" + idx + "].port", int.class);
             nodes.add(HostAndPort.builder().host(host).port(port).build());
         }
         return nodes;

--- a/gravitee-apim-repository/gravitee-apim-repository-redis/src/main/java/io/gravitee/repository/redis/ratelimit/RedisRateLimitRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-redis/src/main/java/io/gravitee/repository/redis/ratelimit/RedisRateLimitRepository.java
@@ -24,6 +24,7 @@ import io.gravitee.repository.ratelimit.model.RateLimit;
 import io.gravitee.repository.redis.vertx.RedisClient;
 import io.reactivex.rxjava3.core.Single;
 import io.vertx.core.AsyncResult;
+import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.redis.client.Response;
 import io.vertx.rxjava3.SingleHelper;
@@ -68,9 +69,37 @@ public class RedisRateLimitRepository implements RateLimitRepository<RateLimit> 
                 redisClient
                     .redisApi()
                     .flatMap(redisAPI ->
-                        redisAPI.evalsha(
-                            convertToList(this.redisClient.scriptSha1(SCRIPT_RATELIMIT_KEY), REDIS_KEY_PREFIX + key, weight, newRate)
-                        )
+                        redisAPI
+                            .evalsha(
+                                convertToList(this.redisClient.scriptSha1(SCRIPT_RATELIMIT_KEY), REDIS_KEY_PREFIX + key, weight, newRate)
+                            )
+                            .recover(t -> {
+                                if (!isNoScript(t)) {
+                                    return Future.failedFuture(t);
+                                }
+                                final String source = this.redisClient.scriptSource(SCRIPT_RATELIMIT_KEY);
+                                if (source == null) {
+                                    return Future.failedFuture(
+                                        new IllegalStateException(
+                                            "Cannot recover from NOSCRIPT: rate-limit script source unavailable (script was never loaded)"
+                                        )
+                                    );
+                                }
+                                // On Redis Cluster, SCRIPT LOAD only reaches the contacted node, so an
+                                // EVALSHA routed by hash slot to another master returns NOSCRIPT. Fall back
+                                // to EVAL with the script source, which caches it on that node for next time.
+                                // NOSCRIPT means the script did not execute, so replaying via EVAL cannot double-count.
+                                log.debug(
+                                    "EVALSHA returned NOSCRIPT; falling back to EVAL to load the rate-limit script on the target node"
+                                );
+                                return redisAPI
+                                    .eval(convertToList(source, REDIS_KEY_PREFIX + key, weight, newRate))
+                                    .recover(evalError -> {
+                                        // Preserve the original NOSCRIPT cause for diagnostics under a fallback storm.
+                                        evalError.addSuppressed(t);
+                                        return Future.failedFuture(evalError);
+                                    });
+                            })
                     )
                     .onFailure(this::logOperationFailure)
                     .onComplete(asyncResultHandler)
@@ -93,6 +122,25 @@ public class RedisRateLimitRepository implements RateLimitRepository<RateLimit> 
             .timeout(operationTimeout, TimeUnit.MILLISECONDS, Single.error(new RedisOperationTimeoutException(operationTimeout)));
     }
 
+    private static final String NOSCRIPT_PREFIX = "NOSCRIPT";
+
+    /**
+     * Returns true only when the error (or one of its causes) is a Redis {@code NOSCRIPT} reply.
+     * Matches the error-code prefix (Redis error replies start with the uppercase code), not a
+     * substring, so unrelated messages can't trigger a (non-idempotent) EVAL replay; walks the
+     * cause chain and is case-insensitive to survive wrapping.
+     */
+    private static boolean isNoScript(Throwable t) {
+        int depth = 0;
+        for (Throwable cause = t; cause != null && depth < 20; cause = cause.getCause(), depth++) {
+            String message = cause.getMessage();
+            if (message != null && message.stripLeading().regionMatches(true, 0, NOSCRIPT_PREFIX, 0, NOSCRIPT_PREFIX.length())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     private void logOperationFailure(Throwable t) {
         long failureCount = operationFailureCounter.getAndIncrement();
         if (failureCount < 10) {
@@ -102,10 +150,13 @@ public class RedisRateLimitRepository implements RateLimitRepository<RateLimit> 
         }
     }
 
-    private List<String> convertToList(String scriptSha1, String key, long weight, RateLimit rate) {
+    // numkeys is "1": only the rate-limit key is a KEY, so all keys touched by the command share
+    // one Redis Cluster hash slot (avoids CROSSSLOT). The weight is passed as an ARGV value, not a key.
+    // scriptRef is a SHA on the EVALSHA path and the script source on the EVAL fallback path.
+    static List<String> convertToList(String scriptRef, String key, long weight, RateLimit rate) {
         return Arrays.asList(
-            scriptSha1,
-            "2", // Number of keys
+            scriptRef,
+            "1", // numkeys
             key,
             Long.toString(weight),
             Long.toString(rate.getCounter()),

--- a/gravitee-apim-repository/gravitee-apim-repository-redis/src/main/java/io/gravitee/repository/redis/vertx/RedisClient.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-redis/src/main/java/io/gravitee/repository/redis/vertx/RedisClient.java
@@ -25,8 +25,8 @@ import io.vertx.redis.client.RedisAPI;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
@@ -45,7 +45,8 @@ public class RedisClient {
     private final VertxRedisClientFactory factory;
     private final RedisClientOptions clientOptions;
     private final Map<String, String> scripts;
-    private final Map<String, String> scriptsSha = new HashMap<>();
+    private final Map<String, String> scriptsSha = new ConcurrentHashMap<>();
+    private final Map<String, String> scriptsSource = new ConcurrentHashMap<>();
     private Future<RedisAPI> redisAPIFuture;
 
     private final AtomicBoolean connected = new AtomicBoolean(false);
@@ -119,15 +120,24 @@ public class RedisClient {
                         String key = entry.getKey();
                         String script = entry.getValue();
                         try (InputStream stream = RedisRateLimitRepository.class.getClassLoader().getResourceAsStream(script)) {
+                            if (stream == null) {
+                                return Future.failedFuture(new IllegalStateException("Lua script not found on classpath: " + script));
+                            }
+                            String source = new String(stream.readAllBytes(), StandardCharsets.UTF_8);
+                            // Keep the source so consumers can fall back to EVAL when a clustered
+                            // node returns NOSCRIPT (SCRIPT LOAD only reaches the contacted node).
+                            scriptsSource.put(key, source);
                             return redisAPI
-                                .script(Arrays.asList(SCRIPT_LOAD_COMMAND, new String(stream.readAllBytes(), StandardCharsets.UTF_8)))
+                                .script(Arrays.asList(SCRIPT_LOAD_COMMAND, source))
                                 .onSuccess(response -> {
                                     log.debug("Lua script '{}' registered to Redis", script);
                                     scriptsSha.put(key, response.toString());
                                 })
                                 .mapEmpty();
                         } catch (Exception ex) {
-                            return Future.failedFuture("Unexpected error while loading lua script");
+                            return Future.failedFuture(
+                                new IllegalStateException("Unexpected error while loading lua script '" + script + "'", ex)
+                            );
                         }
                     })
                     .collect(Collectors.toList())
@@ -142,5 +152,9 @@ public class RedisClient {
 
     public String scriptSha1(final String key) {
         return scriptsSha.get(key);
+    }
+
+    public String scriptSource(final String key) {
+        return scriptsSource.get(key);
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-redis/src/main/resources/scripts/ratelimit/ratelimit.lua
+++ b/gravitee-apim-repository/gravitee-apim-repository-redis/src/main/resources/scripts/ratelimit/ratelimit.lua
@@ -1,6 +1,9 @@
 
 local key = KEYS[1]
-local weight = tonumber(KEYS[2])
+-- weight is passed as an ARGV (not a KEY) so that KEYS[] contains only the rate-limit
+-- key. On Redis Cluster all keys in a command must hash to the same slot; keeping a
+-- single key avoids CROSSSLOT errors.
+local weight = tonumber(ARGV[1])
 
 -- Check that the key already exists
 local exists = redis.call('HEXISTS', key, 'limit')
@@ -10,8 +13,8 @@ redis.call('HINCRBY', key, 'counter', weight)
 
 if exists == 0 then
     -- Create the rate-limit
-    redis.call('HMSET', key, 'limit', tonumber(ARGV[2]), 'reset', tonumber(ARGV[3]), 'subscription', ARGV[4])
-    redis.call('PEXPIREAT', key, tonumber(ARGV[3]))
+    redis.call('HMSET', key, 'limit', tonumber(ARGV[3]), 'reset', tonumber(ARGV[4]), 'subscription', ARGV[5])
+    redis.call('PEXPIREAT', key, tonumber(ARGV[4]))
 end
 
 -- Finally, returns values from Redis

--- a/gravitee-apim-repository/gravitee-apim-repository-redis/src/test/java/io/gravitee/repository/redis/common/RedisConnectionFactoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-redis/src/test/java/io/gravitee/repository/redis/common/RedisConnectionFactoryTest.java
@@ -96,6 +96,24 @@ public class RedisConnectionFactoryTest {
     }
 
     @Test
+    void shouldReturnRedisClientOptionsWithCluster() {
+        environment.setProperty(PROPERTY_PREFIX + ".redis.cluster.nodes[0].host", "node1");
+        environment.setProperty(PROPERTY_PREFIX + ".redis.cluster.nodes[0].port", "6379");
+        environment.setProperty(PROPERTY_PREFIX + ".redis.cluster.nodes[1].host", "node2");
+        environment.setProperty(PROPERTY_PREFIX + ".redis.cluster.nodes[1].port", "6380");
+
+        RedisClientOptions options = redisConnectionFactory.buildRedisClientOptions();
+
+        assertThat(options).isNotNull();
+        assertThat(options.getCluster()).isNotNull();
+        assertThat(options.getCluster().getNodes()).hasSize(2);
+        assertThat(options.getCluster().getNodes().get(0).getHost()).isEqualTo("node1");
+        assertThat(options.getCluster().getNodes().get(1).getPort()).isEqualTo(6380);
+        // Rate limiting must read master-consistent counters — never from replicas.
+        assertThat(options.getCluster().getUseReplicas()).isEqualTo("NEVER");
+    }
+
+    @Test
     void shouldReturnRedisClientOptionsWithSentinelAndSsl() {
         environment.setProperty(PROPERTY_PREFIX + ".redis.ssl", "true");
         environment.setProperty(PROPERTY_PREFIX + ".redis.sentinel.master", "redis-master");

--- a/gravitee-apim-repository/gravitee-apim-repository-redis/src/test/java/io/gravitee/repository/redis/ratelimit/RedisClusterRateLimitRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-redis/src/test/java/io/gravitee/repository/redis/ratelimit/RedisClusterRateLimitRepositoryTest.java
@@ -1,0 +1,188 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.redis.ratelimit;
+
+import static io.gravitee.repository.redis.ratelimit.RateLimitRepositoryConfiguration.SCRIPTS_RATELIMIT_LUA;
+import static io.gravitee.repository.redis.ratelimit.RateLimitRepositoryConfiguration.SCRIPT_RATELIMIT_KEY;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+import com.github.dockerjava.api.model.ExposedPort;
+import com.github.dockerjava.api.model.PortBinding;
+import com.github.dockerjava.api.model.Ports;
+import io.gravitee.platform.repository.api.Scope;
+import io.gravitee.repository.ratelimit.model.RateLimit;
+import io.gravitee.repository.redis.common.RedisConnectionFactory;
+import io.gravitee.repository.redis.vertx.RedisClient;
+import io.vertx.core.Vertx;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.springframework.mock.env.MockEnvironment;
+import org.testcontainers.DockerClientFactory;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.utility.DockerImageName;
+
+/**
+ * Acceptance test for cluster-safe rate limiting (APIM-14146).
+ *
+ * <p>Runs the rate-limit script against a single-node Redis Cluster. A single node still
+ * runs in cluster mode and therefore enforces the CROSSSLOT rule, so this reproduces the
+ * original failure (weight passed as a second KEY hashed to a different slot) while avoiding
+ * the multi-node announce-IP networking issues of a full cluster on Docker Desktop.
+ *
+ * <p><b>Scope:</b> a single node owns all slots, so EVALSHA always hits after the local
+ * SCRIPT LOAD — this does <i>not</i> exercise the cross-master NOSCRIPT path. The
+ * NOSCRIPT&rarr;EVAL fallback is covered by the mock unit test in
+ * {@link RedisRateLimitRepositoryTest} and the manual 3-master smoke test, not here.
+ *
+ * <p>Requires a Docker daemon; skipped (not failed) when none is available.
+ *
+ * @author GraviteeSource Team
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class RedisClusterRateLimitRepositoryTest {
+
+    // A free host port chosen at runtime, used as both the container port and the cluster-announced
+    // port so the announced address (127.0.0.1:PORT) is reachable from the host without collisions.
+    private final int CLUSTER_PORT = findFreePort();
+
+    private final Vertx vertx = Vertx.vertx();
+    private GenericContainer<?> redis;
+    private RedisClient redisClient;
+    private RedisRateLimitRepository repository;
+
+    @BeforeAll
+    void startCluster() throws Exception {
+        assumeTrue(DockerClientFactory.instance().isDockerAvailable(), "Docker not available — skipping Redis cluster integration test");
+        redis = new GenericContainer<>(DockerImageName.parse("redis:7.4"))
+            .withExposedPorts(CLUSTER_PORT)
+            .withCreateContainerCmdModifier(cmd ->
+                cmd.getHostConfig().withPortBindings(new PortBinding(Ports.Binding.bindPort(CLUSTER_PORT), new ExposedPort(CLUSTER_PORT)))
+            )
+            .withCommand(
+                "redis-server --port " +
+                    CLUSTER_PORT +
+                    " --cluster-enabled yes --cluster-node-timeout 5000" +
+                    " --cluster-announce-ip 127.0.0.1 --cluster-announce-port " +
+                    CLUSTER_PORT
+            )
+            .waitingFor(Wait.forListeningPort());
+        redis.start();
+
+        // A single node owning all 16384 slots forms a healthy single-node cluster.
+        redis.execInContainer("redis-cli", "-p", String.valueOf(CLUSTER_PORT), "cluster", "addslotsrange", "0", "16383");
+        awaitClusterStateOk();
+
+        String prefix = Scope.RATE_LIMIT.getName() + ".redis.";
+        MockEnvironment env = new MockEnvironment();
+        env.setProperty(prefix + "cluster.nodes[0].host", "127.0.0.1");
+        env.setProperty(prefix + "cluster.nodes[0].port", String.valueOf(CLUSTER_PORT));
+
+        redisClient = new RedisConnectionFactory(
+            env,
+            vertx,
+            Scope.RATE_LIMIT.getName(),
+            Map.of(SCRIPT_RATELIMIT_KEY, SCRIPTS_RATELIMIT_LUA)
+        ).createRedisClient();
+        awaitConnected(redisClient);
+
+        repository = new RedisRateLimitRepository(redisClient, 5000);
+    }
+
+    private void awaitClusterStateOk() throws Exception {
+        long deadline = System.currentTimeMillis() + 30_000;
+        while (System.currentTimeMillis() < deadline) {
+            var result = redis.execInContainer("redis-cli", "-p", String.valueOf(CLUSTER_PORT), "cluster", "info");
+            if (result.getStdout().contains("cluster_state:ok")) {
+                return;
+            }
+            TimeUnit.MILLISECONDS.sleep(200);
+        }
+        throw new IllegalStateException("Redis cluster did not reach state ok");
+    }
+
+    @AfterAll
+    void stopCluster() {
+        if (redis != null) {
+            redis.stop();
+        }
+        vertx.close();
+    }
+
+    @Test
+    void increments_rate_limit_counters_across_many_slots_without_crossslot() {
+        // Distinct keys hash to many different slots; on the unfixed script each call passed the
+        // weight as a second KEY and failed with CROSSSLOT. Each key must count independently.
+        long reset = 1_900_000_000_000L; // fixed far-future reset so keys don't expire mid-test
+        for (int i = 0; i < 50; i++) {
+            String key = "api-" + i + "-plan-" + i;
+            String subscription = "sub-" + i;
+
+            RateLimit first = increment(key, 1, reset, subscription);
+            assertThat(first.getCounter()).isEqualTo(1);
+
+            RateLimit second = increment(key, 4, reset, subscription);
+            assertThat(second.getCounter()).isEqualTo(5); // 1 + weight(4)
+            assertThat(second.getLimit()).isEqualTo(1000);
+            // Assert reset (ARGV[4]) and subscription (ARGV[5]) too, so a swapped Lua index is caught.
+            assertThat(second.getResetTime()).isEqualTo(reset);
+            assertThat(second.getSubscription()).isEqualTo(subscription);
+        }
+    }
+
+    private static void awaitConnected(RedisClient client) throws InterruptedException {
+        long deadline = System.currentTimeMillis() + 30_000;
+        while (!client.isConnected() && System.currentTimeMillis() < deadline) {
+            TimeUnit.MILLISECONDS.sleep(200);
+        }
+        assertThat(client.isConnected()).as("Redis cluster client connected").isTrue();
+    }
+
+    private RateLimit increment(String key, long weight, long reset, String subscription) {
+        return repository
+            .incrementAndGet(key, weight, () -> {
+                RateLimit rate = new RateLimit(key);
+                rate.setLimit(1000);
+                rate.setResetTime(reset);
+                rate.setSubscription(subscription);
+                return rate;
+            })
+            .blockingGet();
+    }
+
+    // Scan an explicit low range rather than ServerSocket(0): Redis cluster's bus port is
+    // dataPort+10000 and must be <= 65535, so the data port must be < 55535 — but the OS ephemeral
+    // range can sit entirely above that. Close-then-bind is a TOCTOU race (the port could be grabbed
+    // before the container binds), acceptable for this single local test and far better than a fixed port.
+    private static int findFreePort() {
+        for (int port = 20000; port < 30000; port++) {
+            try (java.net.ServerSocket socket = new java.net.ServerSocket(port)) {
+                return socket.getLocalPort();
+            } catch (java.io.IOException ignored) {
+                // in use — try the next one
+            }
+        }
+        throw new IllegalStateException("Could not find a free port in 20000-30000 for the Redis cluster test");
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-redis/src/test/java/io/gravitee/repository/redis/ratelimit/RedisRateLimitRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-redis/src/test/java/io/gravitee/repository/redis/ratelimit/RedisRateLimitRepositoryTest.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.redis.ratelimit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.repository.ratelimit.model.RateLimit;
+import io.gravitee.repository.redis.vertx.RedisClient;
+import io.vertx.core.Future;
+import io.vertx.redis.client.RedisAPI;
+import io.vertx.redis.client.Response;
+import java.util.List;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author GraviteeSource Team
+ */
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class RedisRateLimitRepositoryTest {
+
+    @Test
+    void script_is_invoked_with_a_single_redis_key_for_cluster_slot_safety() {
+        var rate = new RateLimit("api-1");
+        rate.setCounter(0);
+        rate.setLimit(100);
+        rate.setResetTime(123L);
+        rate.setSubscription("sub-1");
+
+        List<String> command = RedisRateLimitRepository.convertToList("sha1", "ratelimit:api-1", 5, rate);
+
+        // EVALSHA <sha> <numkeys> <key...> <arg...>
+        // Exactly one Redis key must be declared so all touched keys share a hash slot
+        // on Redis Cluster (otherwise CROSSSLOT). The weight travels as an ARGV value.
+        assertThat(command.get(1)).isEqualTo("1");
+        assertThat(command.get(2)).isEqualTo("ratelimit:api-1");
+        assertThat(command.get(3)).isEqualTo("5"); // weight, now an ARGV, not a KEY
+    }
+
+    @Test
+    void falls_back_to_eval_when_cluster_node_returns_noscript() {
+        RedisClient redisClient = mock(RedisClient.class);
+        RedisAPI redisAPI = mock(RedisAPI.class);
+
+        when(redisClient.isConnected()).thenReturn(true);
+        when(redisClient.scriptSha1("ratelimit")).thenReturn("the-sha");
+        when(redisClient.scriptSource("ratelimit")).thenReturn("the-script-source");
+        when(redisClient.redisApi()).thenReturn(Future.succeededFuture(redisAPI));
+        // EVALSHA fails because the slot's master never received the SCRIPT LOAD.
+        when(redisAPI.evalsha(anyList())).thenReturn(Future.failedFuture(new RuntimeException("NOSCRIPT No matching script")));
+        // EVAL (with the source) succeeds — Redis caches it on that node and returns the rate.
+        Response evalResponse = rateResponse(7L, 5L, 123L, "sub-1");
+        when(redisAPI.eval(anyList())).thenReturn(Future.succeededFuture(evalResponse));
+
+        var repository = new RedisRateLimitRepository(redisClient, 2000);
+        RateLimit result = repository.incrementAndGet("my-key", 1, () -> new RateLimit("my-key")).blockingGet();
+
+        // The result must be mapped from the fallback EVAL response, not the supplier default.
+        assertThat(result.getCounter()).isEqualTo(7L);
+        assertThat(result.getLimit()).isEqualTo(5L);
+        assertThat(result.getResetTime()).isEqualTo(123L);
+        assertThat(result.getSubscription()).isEqualTo("sub-1");
+        // The fallback EVAL must carry the script SOURCE, not the SHA.
+        verify(redisAPI).eval(argThatStartsWith("the-script-source"));
+    }
+
+    @Test
+    void propagates_non_noscript_errors_without_falling_back_to_eval() {
+        RedisClient redisClient = mock(RedisClient.class);
+        RedisAPI redisAPI = mock(RedisAPI.class);
+
+        when(redisClient.isConnected()).thenReturn(true);
+        when(redisClient.scriptSha1("ratelimit")).thenReturn("the-sha");
+        when(redisClient.redisApi()).thenReturn(Future.succeededFuture(redisAPI));
+        // A non-NOSCRIPT error (e.g. LOADING) must NOT trigger an EVAL replay — the script may have run.
+        when(redisAPI.evalsha(anyList())).thenReturn(Future.failedFuture(new RuntimeException("LOADING Redis is loading the dataset")));
+
+        var repository = new RedisRateLimitRepository(redisClient, 2000);
+
+        assertThatThrownBy(() -> repository.incrementAndGet("my-key", 1, () -> new RateLimit("my-key")).blockingGet()).hasMessageContaining(
+            "LOADING"
+        );
+        verify(redisAPI, never()).eval(anyList());
+    }
+
+    private static Response rateResponse(long counter, long limit, long reset, String subscription) {
+        // Build the field mocks first — calling a stubbing method inside when(...) breaks Mockito.
+        Response counterField = longResponse(counter);
+        Response limitField = longResponse(limit);
+        Response resetField = longResponse(reset);
+        Response subscriptionField = mock(Response.class);
+        when(subscriptionField.toString()).thenReturn(subscription);
+
+        Response r = mock(Response.class);
+        when(r.size()).thenReturn(4);
+        when(r.get(0)).thenReturn(counterField);
+        when(r.get(1)).thenReturn(limitField);
+        when(r.get(2)).thenReturn(resetField);
+        when(r.get(3)).thenReturn(subscriptionField);
+        return r;
+    }
+
+    private static Response longResponse(long value) {
+        Response r = mock(Response.class);
+        when(r.toLong()).thenReturn(value);
+        return r;
+    }
+
+    private static List<String> argThatStartsWith(String first) {
+        return org.mockito.ArgumentMatchers.argThat(list -> list != null && !list.isEmpty() && first.equals(list.get(0)));
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -65,11 +65,11 @@
         <gravitee-integration-api.version>5.1.0</gravitee-integration-api.version>
         <gravitee-json-validation.version>2.2.0</gravitee-json-validation.version>
         <gravitee-kubernetes.version>4.0.0-alpha.1</gravitee-kubernetes.version>
-        <gravitee-node.version>9.0.0-alpha.14</gravitee-node.version>
+        <gravitee-node.version>9.0.0-alpha.17</gravitee-node.version>
         <gravitee-notifier-api.version>2.0.0</gravitee-notifier-api.version>
         <gravitee-platform-repository-api.version>2.0.0</gravitee-platform-repository-api.version>
         <gravitee-plugin.version>5.1.2</gravitee-plugin.version>
-        <gravitee-plugin-common-configurations.version>1.3.0</gravitee-plugin-common-configurations.version>
+        <gravitee-plugin-common-configurations.version>1.4.0</gravitee-plugin-common-configurations.version>
         <gravitee-policy-api.version>1.11.0</gravitee-policy-api.version>
         <gravitee-reporter-api.version>2.3.0</gravitee-reporter-api.version>
         <gravitee-resource-api.version>1.1.0</gravitee-resource-api.version>


### PR DESCRIPTION
## APIM-14146 — Enable Redis Cluster (3/3: rate limiting)

Part of [APIM-14146](https://gravitee.atlassian.net/browse/APIM-14146) (cluster-safe rate limiting, requested by Posten Bring).

Makes Redis-backed rate limiting work on a real multi-master Redis Cluster. Two distinct cluster bugs are fixed.

### Commits
1. **`fix(ratelimit): make Redis rate-limit script cluster-slot-safe`** — `EVALSHA` was sent with `numkeys="2"`, making the numeric *weight* a second KEY that hashes to a different slot → `CROSSSLOT`. Now `numkeys="1"` with the weight passed as `ARGV[1]` (Lua re-indexed). Data format unchanged → **not a breaking change**; existing counters are preserved.
2. **`feat(ratelimit): enable Redis Cluster for rate limiting`** — `RedisConnectionFactory` parses `ratelimit.redis.cluster.nodes[i]` and pins `useReplicas=NEVER` (rate limiting needs master-consistent counters). Commented `cluster:` block added to the distribution `gravitee.yml`.
3. **`fix(ratelimit): fall back to EVAL on NOSCRIPT for Redis Cluster`** — `SCRIPT LOAD` only reaches the contacted master, so `EVALSHA` routed by slot to another master returns `NOSCRIPT`. On `NOSCRIPT` we now fall back to `EVAL` with the script source (cached on that node for subsequent calls).

### Tests
- Unit: `numkeys="1"` slot-safety; `NOSCRIPT`→`EVAL` fallback; cluster config parsing.
- Integration: single-node Redis Cluster Testcontainers acceptance test (reproduces CROSSSLOT on the unfixed script). Full module green (42 tests).

### Local smoke test (real 3-master cluster)
Verified a real gateway built from all three repos against a 6-node (3-master) Redis Cluster: a v4 API with a rate-limit policy (5/60s) returned `200×5` then `429` (`X-Rate-Limit-Remaining: 0`), counter stored on the slot-owning master, **0 CROSSSLOT / 0 NOSCRIPT** errors.

### Release chain
Depends on **PR 2/3** (`gravitee-node`). ⚠️ Before merge, bump `gravitee-node.version` to the alpha released from PR 2 (currently `9.0.0-alpha.14` for local testing).


[APIM-14146]: https://gravitee.atlassian.net/browse/APIM-14146?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ