### PR TITLE
feat: add application invitation role update

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/mapper/ApplicationInvitationUpdateInputMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/mapper/ApplicationInvitationUpdateInputMapper.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.portal.rest.mapper;
+
+import io.gravitee.apim.core.invitation.model.UpdateApplicationInvitation;
+import io.gravitee.rest.api.portal.rest.model.InvitationUpdateInput;
+import org.mapstruct.Mapper;
+import org.mapstruct.factory.Mappers;
+
+@Mapper
+public interface ApplicationInvitationUpdateInputMapper {
+    ApplicationInvitationUpdateInputMapper INSTANCE = Mappers.getMapper(ApplicationInvitationUpdateInputMapper.class);
+
+    default UpdateApplicationInvitation toUpdateApplicationInvitation(InvitationUpdateInput input) {
+        return new UpdateApplicationInvitation(normalizeRoleName(input.getRole()));
+    }
+
+    private String normalizeRoleName(String roleName) {
+        return roleName.trim();
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/ApplicationInvitationsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/ApplicationInvitationsResource.java
@@ -19,15 +19,18 @@ import io.gravitee.apim.core.invitation.model.InvitationId;
 import io.gravitee.apim.core.invitation.use_case.CreateApplicationInvitationsUseCase;
 import io.gravitee.apim.core.invitation.use_case.DeleteApplicationInvitationUseCase;
 import io.gravitee.apim.core.invitation.use_case.SearchApplicationInvitationsUseCase;
+import io.gravitee.apim.core.invitation.use_case.UpdateApplicationInvitationUseCase;
 import io.gravitee.common.http.MediaType;
 import io.gravitee.rest.api.model.common.PageableImpl;
 import io.gravitee.rest.api.model.permissions.RolePermission;
 import io.gravitee.rest.api.model.permissions.RolePermissionAction;
 import io.gravitee.rest.api.portal.rest.mapper.ApplicationInvitationMapper;
+import io.gravitee.rest.api.portal.rest.mapper.ApplicationInvitationUpdateInputMapper;
 import io.gravitee.rest.api.portal.rest.mapper.ApplicationInvitationsCreateInputMapper;
 import io.gravitee.rest.api.portal.rest.mapper.ApplicationInvitationsSearchCriteriaMapper;
 import io.gravitee.rest.api.portal.rest.model.ApplicationInvitationsSearchInput;
 import io.gravitee.rest.api.portal.rest.model.InvitationCreateInput;
+import io.gravitee.rest.api.portal.rest.model.InvitationUpdateInput;
 import io.gravitee.rest.api.portal.rest.model.InvitationsResponse;
 import io.gravitee.rest.api.portal.rest.resource.param.PaginationParam;
 import io.gravitee.rest.api.rest.annotation.Permission;
@@ -41,6 +44,7 @@ import jakarta.ws.rs.BeanParam;
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.DELETE;
 import jakarta.ws.rs.POST;
+import jakarta.ws.rs.PUT;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
@@ -61,6 +65,9 @@ public class ApplicationInvitationsResource extends AbstractResource {
 
     @Inject
     private DeleteApplicationInvitationUseCase deleteApplicationInvitationUseCase;
+
+    @Inject
+    private UpdateApplicationInvitationUseCase updateApplicationInvitationUseCase;
 
     @POST
     @Consumes(MediaType.APPLICATION_JSON)
@@ -128,5 +135,28 @@ public class ApplicationInvitationsResource extends AbstractResource {
         );
 
         return Response.noContent().build();
+    }
+
+    @PUT
+    @Path("/{invitationId}")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    @Permissions({ @Permission(value = RolePermission.APPLICATION_MEMBER, acls = RolePermissionAction.UPDATE) })
+    public Response updateApplicationInvitation(
+        @PathParam("applicationId") String applicationId,
+        @PathParam("invitationId") String invitationId,
+        @Valid @NotNull(message = "Input must not be null.") InvitationUpdateInput input
+    ) {
+        var output = updateApplicationInvitationUseCase.execute(
+            new UpdateApplicationInvitationUseCase.Input(
+                GraviteeContext.getCurrentOrganization(),
+                GraviteeContext.getCurrentEnvironment(),
+                applicationId,
+                InvitationId.of(invitationId),
+                ApplicationInvitationUpdateInputMapper.INSTANCE.toUpdateApplicationInvitation(input)
+            )
+        );
+
+        return Response.ok(INVITATION_MAPPER.toInvitation(output.invitation())).build();
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/mapper/ApplicationInvitationUpdateInputMapperTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/mapper/ApplicationInvitationUpdateInputMapperTest.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.portal.rest.mapper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.rest.api.portal.rest.model.InvitationUpdateInput;
+import org.junit.jupiter.api.Test;
+
+class ApplicationInvitationUpdateInputMapperTest {
+
+    @Test
+    void should_map_and_normalize_role_name() {
+        var input = new InvitationUpdateInput().role(" OWNER ");
+
+        var result = ApplicationInvitationUpdateInputMapper.INSTANCE.toUpdateApplicationInvitation(input);
+
+        assertThat(result.roleName()).isEqualTo("OWNER");
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/ApplicationInvitationsResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/ApplicationInvitationsResourceTest.java
@@ -41,6 +41,7 @@ import io.gravitee.rest.api.portal.rest.model.ApplicationInvitationsSearchFilter
 import io.gravitee.rest.api.portal.rest.model.ApplicationInvitationsSearchInput;
 import io.gravitee.rest.api.portal.rest.model.InvitationCreateInput;
 import io.gravitee.rest.api.portal.rest.model.InvitationRecipientInput;
+import io.gravitee.rest.api.portal.rest.model.InvitationUpdateInput;
 import io.gravitee.rest.api.portal.rest.model.InvitationsResponse;
 import jakarta.ws.rs.client.Entity;
 import jakarta.ws.rs.core.Response;
@@ -59,6 +60,7 @@ class ApplicationInvitationsResourceTest extends AbstractResourceTest {
     private static final String INVITATION_ID_1 = "00000000-0000-0000-0000-000000000001";
     private static final String INVITATION_ID_2 = "00000000-0000-0000-0000-000000000002";
     private static final String ROLE_NAME = "USER";
+    private static final String UPDATED_ROLE_NAME = "OWNER";
 
     @Autowired
     private InvitationQueryService invitationQueryService;
@@ -85,7 +87,7 @@ class ApplicationInvitationsResourceTest extends AbstractResourceTest {
         applicationCrudService.reset();
         roleQueryService.reset();
         applicationCrudService.initWith(List.of(BaseApplicationEntity.builder().id(APPLICATION).environmentId("DEFAULT").build()));
-        roleQueryService.initWith(List.of(applicationRole()));
+        roleQueryService.initWith(List.of(applicationRole(ROLE_NAME), applicationRole(UPDATED_ROLE_NAME)));
         when(permissionService.hasPermission(any(), any(), any(), any())).thenReturn(true);
     }
 
@@ -298,6 +300,115 @@ class ApplicationInvitationsResourceTest extends AbstractResourceTest {
         verify(invitationCrudService, never()).delete(any());
     }
 
+    @Test
+    void should_update_invitation_role() {
+        var invitationId = InvitationId.of(INVITATION_ID_1);
+        when(invitationCrudService.findApplicationInvitationById(invitationId)).thenReturn(
+            Optional.of(anInvitation(INVITATION_ID_1, "alice@example.com"))
+        );
+        when(invitationCrudService.update(any(ApplicationInvitation.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        var response = target(APPLICATION)
+            .path("invitations")
+            .path(INVITATION_ID_1)
+            .request()
+            .put(Entity.json(new InvitationUpdateInput().role(" " + UPDATED_ROLE_NAME + " ")));
+
+        assertThat(response.getStatus()).isEqualTo(HttpStatusCode.OK_200);
+        var invitation = response.readEntity(io.gravitee.rest.api.portal.rest.model.Invitation.class);
+        assertThat(invitation.getId()).isEqualTo(INVITATION_ID_1);
+        assertThat(invitation.getEmail()).isEqualTo("alice@example.com");
+        assertThat(invitation.getRole()).isEqualTo(UPDATED_ROLE_NAME);
+        verify(invitationCrudService).update(
+            argThat(
+                updatedInvitation ->
+                    updatedInvitation.id().equals(invitationId) &&
+                    updatedInvitation.applicationId().equals(APPLICATION) &&
+                    updatedInvitation.email().equals("alice@example.com") &&
+                    updatedInvitation.roleName().equals(UPDATED_ROLE_NAME)
+            )
+        );
+    }
+
+    @Test
+    void should_return_not_found_when_updating_invitation_for_unknown_application() {
+        var response = target(UNKNOWN_APPLICATION)
+            .path("invitations")
+            .path(INVITATION_ID_1)
+            .request()
+            .put(Entity.json(new InvitationUpdateInput().role(UPDATED_ROLE_NAME)));
+
+        assertThat(response.getStatus()).isEqualTo(HttpStatusCode.NOT_FOUND_404);
+        verify(invitationCrudService, never()).findApplicationInvitationById(any());
+        verify(invitationCrudService, never()).update(any());
+    }
+
+    @Test
+    void should_return_not_found_when_updating_unknown_invitation() {
+        var invitationId = InvitationId.of(INVITATION_ID_1);
+        when(invitationCrudService.findApplicationInvitationById(invitationId)).thenReturn(Optional.empty());
+
+        var response = target(APPLICATION)
+            .path("invitations")
+            .path(INVITATION_ID_1)
+            .request()
+            .put(Entity.json(new InvitationUpdateInput().role(UPDATED_ROLE_NAME)));
+
+        assertThat(response.getStatus()).isEqualTo(HttpStatusCode.NOT_FOUND_404);
+        verify(invitationCrudService, never()).update(any());
+    }
+
+    @Test
+    void should_return_not_found_when_updating_invitation_from_another_application() {
+        var invitationId = InvitationId.of(INVITATION_ID_1);
+        when(invitationCrudService.findApplicationInvitationById(invitationId)).thenReturn(
+            Optional.of(anInvitation(INVITATION_ID_1, OTHER_APPLICATION, "alice@example.com"))
+        );
+
+        var response = target(APPLICATION)
+            .path("invitations")
+            .path(INVITATION_ID_1)
+            .request()
+            .put(Entity.json(new InvitationUpdateInput().role(UPDATED_ROLE_NAME)));
+
+        assertThat(response.getStatus()).isEqualTo(HttpStatusCode.NOT_FOUND_404);
+        verify(invitationCrudService, never()).update(any());
+    }
+
+    @Test
+    void should_return_bad_request_when_updating_invitation_with_blank_role() {
+        var invitationId = InvitationId.of(INVITATION_ID_1);
+        when(invitationCrudService.findApplicationInvitationById(invitationId)).thenReturn(
+            Optional.of(anInvitation(INVITATION_ID_1, "alice@example.com"))
+        );
+
+        var response = target(APPLICATION)
+            .path("invitations")
+            .path(INVITATION_ID_1)
+            .request()
+            .put(Entity.json(new InvitationUpdateInput().role(" ")));
+
+        assertThat(response.getStatus()).isEqualTo(HttpStatusCode.BAD_REQUEST_400);
+        verify(invitationCrudService, never()).update(any());
+    }
+
+    @Test
+    void should_return_bad_request_when_updating_invitation_with_unknown_role() {
+        var invitationId = InvitationId.of(INVITATION_ID_1);
+        when(invitationCrudService.findApplicationInvitationById(invitationId)).thenReturn(
+            Optional.of(anInvitation(INVITATION_ID_1, "alice@example.com"))
+        );
+
+        var response = target(APPLICATION)
+            .path("invitations")
+            .path(INVITATION_ID_1)
+            .request()
+            .put(Entity.json(new InvitationUpdateInput().role("UNKNOWN")));
+
+        assertThat(response.getStatus()).isEqualTo(HttpStatusCode.BAD_REQUEST_400);
+        verify(invitationCrudService, never()).update(any());
+    }
+
     private ApplicationInvitation anInvitation(String id, String email) {
         return anInvitation(id, APPLICATION, email);
     }
@@ -320,10 +431,10 @@ class ApplicationInvitationsResourceTest extends AbstractResourceTest {
             .notify(notify);
     }
 
-    private Role applicationRole() {
+    private Role applicationRole(String roleName) {
         return Role.builder()
-            .id("application-user-role")
-            .name(ROLE_NAME)
+            .id("application-%s-role".formatted(roleName.toLowerCase()))
+            .name(roleName)
             .referenceId("DEFAULT")
             .referenceType(Role.ReferenceType.ORGANIZATION)
             .scope(Role.Scope.APPLICATION)

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/invitation/crud_service/InvitationCrudService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/invitation/crud_service/InvitationCrudService.java
@@ -24,6 +24,10 @@ import java.util.Optional;
 public interface InvitationCrudService {
     ApplicationInvitation create(ApplicationInvitation invitation);
 
+    default ApplicationInvitation update(ApplicationInvitation invitation) {
+        throw new UnsupportedOperationException("update not implemented");
+    }
+
     default Optional<ApplicationInvitation> findApplicationInvitationById(InvitationId invitationId) {
         throw new UnsupportedOperationException("findApplicationInvitationById not implemented");
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/invitation/domain_service/CreateApplicationInvitationsDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/invitation/domain_service/CreateApplicationInvitationsDomainService.java
@@ -15,8 +15,6 @@
  */
 package io.gravitee.apim.core.invitation.domain_service;
 
-import static io.gravitee.rest.api.service.common.ReferenceContext.Type.ORGANIZATION;
-
 import io.gravitee.apim.core.DomainService;
 import io.gravitee.apim.core.exception.ConflictDomainException;
 import io.gravitee.apim.core.exception.ValidationDomainException;
@@ -24,9 +22,6 @@ import io.gravitee.apim.core.invitation.crud_service.InvitationCrudService;
 import io.gravitee.apim.core.invitation.model.ApplicationInvitation;
 import io.gravitee.apim.core.invitation.model.InvitationReference;
 import io.gravitee.apim.core.invitation.query_service.InvitationQueryService;
-import io.gravitee.apim.core.membership.exception.RoleNotFoundException;
-import io.gravitee.apim.core.membership.query_service.RoleQueryService;
-import io.gravitee.rest.api.service.common.ReferenceContext;
 import jakarta.annotation.Nonnull;
 import jakarta.mail.internet.AddressException;
 import jakarta.mail.internet.InternetAddress;
@@ -40,7 +35,7 @@ public class CreateApplicationInvitationsDomainService {
 
     private final InvitationQueryService invitationQueryService;
     private final InvitationCrudService invitationCrudService;
-    private final RoleQueryService roleQueryService;
+    private final ValidateApplicationInvitationRoleDomainService validateApplicationInvitationRoleDomainService;
 
     public List<ApplicationInvitation> create(
         @Nonnull String organizationId,
@@ -53,7 +48,7 @@ public class CreateApplicationInvitationsDomainService {
             throw new UnsupportedOperationException("Application invitation notifications are not implemented yet.");
         }
 
-        validateRoleName(organizationId, roleName);
+        validateApplicationInvitationRoleDomainService.validate(organizationId, roleName);
         var emails = validateRecipients(recipientEmails);
 
         validateNoPendingInvitation(applicationId, emails);
@@ -62,17 +57,6 @@ public class CreateApplicationInvitationsDomainService {
             .map(email -> ApplicationInvitation.create(applicationId, email, roleName))
             .map(invitationCrudService::create)
             .toList();
-    }
-
-    private void validateRoleName(String organizationId, String roleName) {
-        if (roleName == null || roleName.isBlank()) {
-            throw new ValidationDomainException("Application invitation role must not be blank.");
-        }
-
-        var referenceContext = new ReferenceContext(ORGANIZATION, organizationId);
-        roleQueryService
-            .findApplicationRole(roleName, referenceContext)
-            .orElseThrow(() -> new RoleNotFoundException(roleName, referenceContext));
     }
 
     private Set<String> validateRecipients(Set<String> recipients) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/invitation/domain_service/UpdateApplicationInvitationDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/invitation/domain_service/UpdateApplicationInvitationDomainService.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.invitation.domain_service;
+
+import io.gravitee.apim.core.DomainService;
+import io.gravitee.apim.core.invitation.crud_service.InvitationCrudService;
+import io.gravitee.apim.core.invitation.exception.ApplicationInvitationNotFoundException;
+import io.gravitee.apim.core.invitation.model.ApplicationInvitation;
+import io.gravitee.apim.core.invitation.model.InvitationId;
+import io.gravitee.apim.core.invitation.model.UpdateApplicationInvitation;
+import jakarta.annotation.Nonnull;
+import lombok.RequiredArgsConstructor;
+
+@DomainService
+@RequiredArgsConstructor
+public class UpdateApplicationInvitationDomainService {
+
+    private final InvitationCrudService invitationCrudService;
+    private final ValidateApplicationInvitationRoleDomainService validateApplicationInvitationRoleDomainService;
+
+    public ApplicationInvitation update(
+        @Nonnull String organizationId,
+        @Nonnull String applicationId,
+        @Nonnull InvitationId invitationId,
+        @Nonnull UpdateApplicationInvitation updateApplicationInvitation
+    ) {
+        var invitation = invitationCrudService
+            .findApplicationInvitationById(invitationId)
+            .filter(applicationInvitation -> applicationId.equals(applicationInvitation.applicationId()))
+            .orElseThrow(() -> new ApplicationInvitationNotFoundException(invitationId.toString()));
+
+        validateApplicationInvitationRoleDomainService.validate(organizationId, updateApplicationInvitation.roleName());
+
+        return invitationCrudService.update(invitation.updateRole(updateApplicationInvitation.roleName()));
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/invitation/domain_service/ValidateApplicationInvitationRoleDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/invitation/domain_service/ValidateApplicationInvitationRoleDomainService.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.invitation.domain_service;
+
+import static io.gravitee.rest.api.service.common.ReferenceContext.Type.ORGANIZATION;
+
+import io.gravitee.apim.core.DomainService;
+import io.gravitee.apim.core.exception.ValidationDomainException;
+import io.gravitee.apim.core.membership.exception.RoleNotFoundException;
+import io.gravitee.apim.core.membership.query_service.RoleQueryService;
+import io.gravitee.rest.api.service.common.ReferenceContext;
+import jakarta.annotation.Nonnull;
+import lombok.RequiredArgsConstructor;
+
+@DomainService
+@RequiredArgsConstructor
+public class ValidateApplicationInvitationRoleDomainService {
+
+    private final RoleQueryService roleQueryService;
+
+    public void validate(@Nonnull String organizationId, String roleName) {
+        if (roleName == null || roleName.isBlank()) {
+            throw new ValidationDomainException("Application invitation role must not be blank.");
+        }
+
+        var referenceContext = new ReferenceContext(ORGANIZATION, organizationId);
+        roleQueryService
+            .findApplicationRole(roleName, referenceContext)
+            .orElseThrow(() -> new RoleNotFoundException(roleName, referenceContext));
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/invitation/model/ApplicationInvitation.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/invitation/model/ApplicationInvitation.java
@@ -30,4 +30,8 @@ public record ApplicationInvitation(
         var now = TimeProvider.now();
         return new ApplicationInvitation(InvitationId.random(), applicationId, email, roleName, now, now);
     }
+
+    public ApplicationInvitation updateRole(String roleName) {
+        return new ApplicationInvitation(id, applicationId, email, roleName, createdAt, TimeProvider.now());
+    }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/invitation/model/UpdateApplicationInvitation.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/invitation/model/UpdateApplicationInvitation.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.invitation.model;
+
+public record UpdateApplicationInvitation(String roleName) {}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/invitation/use_case/UpdateApplicationInvitationUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/invitation/use_case/UpdateApplicationInvitationUseCase.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.invitation.use_case;
+
+import io.gravitee.apim.core.UseCase;
+import io.gravitee.apim.core.application.crud_service.ApplicationCrudService;
+import io.gravitee.apim.core.invitation.domain_service.UpdateApplicationInvitationDomainService;
+import io.gravitee.apim.core.invitation.model.ApplicationInvitation;
+import io.gravitee.apim.core.invitation.model.InvitationId;
+import io.gravitee.apim.core.invitation.model.UpdateApplicationInvitation;
+import lombok.RequiredArgsConstructor;
+
+@UseCase
+@RequiredArgsConstructor
+public class UpdateApplicationInvitationUseCase {
+
+    private final ApplicationCrudService applicationCrudService;
+    private final UpdateApplicationInvitationDomainService updateApplicationInvitationDomainService;
+
+    public Output execute(Input input) {
+        applicationCrudService.findById(input.applicationId(), input.environmentId());
+        return new Output(
+            updateApplicationInvitationDomainService.update(
+                input.organizationId(),
+                input.applicationId(),
+                input.invitationId(),
+                input.updateApplicationInvitation()
+            )
+        );
+    }
+
+    public record Input(
+        String organizationId,
+        String environmentId,
+        String applicationId,
+        InvitationId invitationId,
+        UpdateApplicationInvitation updateApplicationInvitation
+    ) {}
+
+    public record Output(ApplicationInvitation invitation) {}
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/crud_service/invitation/InvitationCrudServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/crud_service/invitation/InvitationCrudServiceImpl.java
@@ -51,6 +51,17 @@ public class InvitationCrudServiceImpl extends TransactionalService implements I
     }
 
     @Override
+    public ApplicationInvitation update(ApplicationInvitation invitation) {
+        try {
+            return InvitationAdapter.INSTANCE.toApplicationInvitation(
+                invitationRepository.update(InvitationAdapter.INSTANCE.toRepository(invitation))
+            );
+        } catch (TechnicalException | IllegalStateException e) {
+            throw new TechnicalDomainException("An error occurs while trying to update application invitation", e);
+        }
+    }
+
+    @Override
     public Optional<ApplicationInvitation> findApplicationInvitationById(InvitationId invitationId) {
         try {
             return invitationRepository

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/invitation/domain_service/CreateApplicationInvitationsDomainServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/invitation/domain_service/CreateApplicationInvitationsDomainServiceTest.java
@@ -70,7 +70,11 @@ class CreateApplicationInvitationsDomainServiceTest {
 
     @BeforeEach
     void setUp() {
-        cut = new CreateApplicationInvitationsDomainService(invitationQueryService, invitationCrudService, roleQueryService);
+        cut = new CreateApplicationInvitationsDomainService(
+            invitationQueryService,
+            invitationCrudService,
+            new ValidateApplicationInvitationRoleDomainService(roleQueryService)
+        );
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/invitation/domain_service/UpdateApplicationInvitationDomainServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/invitation/domain_service/UpdateApplicationInvitationDomainServiceTest.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.invitation.domain_service;
+
+import static fixtures.core.model.ApplicationInvitationFixtures.anApplicationInvitation;
+import static fixtures.core.model.RoleFixtures.anApplicationRole;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.apim.core.exception.ValidationDomainException;
+import io.gravitee.apim.core.invitation.crud_service.InvitationCrudService;
+import io.gravitee.apim.core.invitation.exception.ApplicationInvitationNotFoundException;
+import io.gravitee.apim.core.invitation.model.ApplicationInvitation;
+import io.gravitee.apim.core.invitation.model.InvitationId;
+import io.gravitee.apim.core.invitation.model.UpdateApplicationInvitation;
+import io.gravitee.apim.core.membership.exception.RoleNotFoundException;
+import io.gravitee.apim.core.membership.query_service.RoleQueryService;
+import io.gravitee.common.utils.TimeProvider;
+import io.gravitee.rest.api.service.common.ReferenceContext;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.Optional;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class UpdateApplicationInvitationDomainServiceTest {
+
+    private static final String ORGANIZATION_ID = "organization-id";
+    private static final String APPLICATION_ID = "application-id";
+    private static final String OTHER_APPLICATION_ID = "other-application-id";
+    private static final String INVITATION_ID = "00000000-0000-0000-0000-000000000001";
+    private static final String CURRENT_ROLE_NAME = "USER";
+    private static final String UPDATED_ROLE_NAME = "OWNER";
+    private static final Instant UPDATE_TIME = Instant.parse("2026-04-23T10:15:00Z");
+
+    @Mock
+    private InvitationCrudService invitationCrudService;
+
+    @Mock
+    private RoleQueryService roleQueryService;
+
+    private UpdateApplicationInvitationDomainService cut;
+
+    @BeforeEach
+    void setUp() {
+        TimeProvider.overrideClock(Clock.fixed(UPDATE_TIME, ZoneId.systemDefault()));
+        cut = new UpdateApplicationInvitationDomainService(
+            invitationCrudService,
+            new ValidateApplicationInvitationRoleDomainService(roleQueryService)
+        );
+    }
+
+    @AfterEach
+    void tearDown() {
+        TimeProvider.overrideClock(Clock.systemDefaultZone());
+    }
+
+    @Test
+    void should_update_application_invitation_role() {
+        var invitationId = InvitationId.of(INVITATION_ID);
+        var invitation = anApplicationInvitation(INVITATION_ID, APPLICATION_ID, "alice@example.com", CURRENT_ROLE_NAME);
+        givenInvitation(invitationId, invitation);
+        givenExistingRole(UPDATED_ROLE_NAME);
+        when(invitationCrudService.update(any(ApplicationInvitation.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        var result = cut.update(ORGANIZATION_ID, APPLICATION_ID, invitationId, new UpdateApplicationInvitation(UPDATED_ROLE_NAME));
+
+        assertThat(result.id()).isEqualTo(invitation.id());
+        assertThat(result.applicationId()).isEqualTo(APPLICATION_ID);
+        assertThat(result.email()).isEqualTo("alice@example.com");
+        assertThat(result.roleName()).isEqualTo(UPDATED_ROLE_NAME);
+        assertThat(result.createdAt()).isEqualTo(invitation.createdAt());
+        assertThat(result.updatedAt()).isEqualTo(UPDATE_TIME.atZone(ZoneId.systemDefault()));
+
+        var invitationCaptor = ArgumentCaptor.forClass(ApplicationInvitation.class);
+        verify(invitationCrudService).update(invitationCaptor.capture());
+        assertThat(invitationCaptor.getValue().roleName()).isEqualTo(UPDATED_ROLE_NAME);
+    }
+
+    @Test
+    void should_throw_when_invitation_does_not_exist() {
+        var invitationId = InvitationId.of(INVITATION_ID);
+        when(invitationCrudService.findApplicationInvitationById(invitationId)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() ->
+            cut.update(ORGANIZATION_ID, APPLICATION_ID, invitationId, new UpdateApplicationInvitation(UPDATED_ROLE_NAME))
+        ).isInstanceOf(ApplicationInvitationNotFoundException.class);
+
+        verifyNoInteractions(roleQueryService);
+        verify(invitationCrudService, never()).update(any());
+    }
+
+    @Test
+    void should_throw_when_invitation_belongs_to_another_application() {
+        var invitationId = InvitationId.of(INVITATION_ID);
+        givenInvitation(invitationId, anApplicationInvitation(INVITATION_ID, OTHER_APPLICATION_ID, "alice@example.com", CURRENT_ROLE_NAME));
+
+        assertThatThrownBy(() ->
+            cut.update(ORGANIZATION_ID, APPLICATION_ID, invitationId, new UpdateApplicationInvitation(UPDATED_ROLE_NAME))
+        ).isInstanceOf(ApplicationInvitationNotFoundException.class);
+
+        verifyNoInteractions(roleQueryService);
+        verify(invitationCrudService, never()).update(any());
+    }
+
+    @Test
+    void should_reject_blank_role() {
+        var invitationId = InvitationId.of(INVITATION_ID);
+        givenInvitation(invitationId, anApplicationInvitation(INVITATION_ID, APPLICATION_ID, "alice@example.com", CURRENT_ROLE_NAME));
+
+        assertThatThrownBy(() -> cut.update(ORGANIZATION_ID, APPLICATION_ID, invitationId, new UpdateApplicationInvitation(" ")))
+            .isInstanceOf(ValidationDomainException.class)
+            .hasMessageContaining("role must not be blank");
+
+        verifyNoInteractions(roleQueryService);
+        verify(invitationCrudService, never()).update(any());
+    }
+
+    @Test
+    void should_reject_unknown_role() {
+        var invitationId = InvitationId.of(INVITATION_ID);
+        givenInvitation(invitationId, anApplicationInvitation(INVITATION_ID, APPLICATION_ID, "alice@example.com", CURRENT_ROLE_NAME));
+        when(roleQueryService.findApplicationRole(eq(UPDATED_ROLE_NAME), any(ReferenceContext.class))).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() ->
+            cut.update(ORGANIZATION_ID, APPLICATION_ID, invitationId, new UpdateApplicationInvitation(UPDATED_ROLE_NAME))
+        ).isInstanceOf(RoleNotFoundException.class);
+
+        verify(invitationCrudService, never()).update(any());
+    }
+
+    private void givenInvitation(InvitationId invitationId, ApplicationInvitation invitation) {
+        when(invitationCrudService.findApplicationInvitationById(invitationId)).thenReturn(Optional.of(invitation));
+    }
+
+    private void givenExistingRole(String roleName) {
+        when(roleQueryService.findApplicationRole(eq(roleName), any(ReferenceContext.class))).thenReturn(
+            Optional.of(anApplicationRole("role-id", roleName))
+        );
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/invitation/use_case/UpdateApplicationInvitationUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/invitation/use_case/UpdateApplicationInvitationUseCaseTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.invitation.use_case;
+
+import static fixtures.core.model.ApplicationInvitationFixtures.anApplicationInvitation;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.apim.core.application.crud_service.ApplicationCrudService;
+import io.gravitee.apim.core.invitation.domain_service.UpdateApplicationInvitationDomainService;
+import io.gravitee.apim.core.invitation.model.InvitationId;
+import io.gravitee.apim.core.invitation.model.UpdateApplicationInvitation;
+import io.gravitee.rest.api.model.BaseApplicationEntity;
+import io.gravitee.rest.api.service.exceptions.ApplicationNotFoundException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class UpdateApplicationInvitationUseCaseTest {
+
+    private static final String ORGANIZATION_ID = "organization-id";
+    private static final String ENVIRONMENT_ID = "environment-id";
+    private static final String APPLICATION_ID = "application-id";
+    private static final String INVITATION_ID = "00000000-0000-0000-0000-000000000001";
+    private static final String ROLE_NAME = "OWNER";
+
+    @Mock
+    private ApplicationCrudService applicationCrudService;
+
+    @Mock
+    private UpdateApplicationInvitationDomainService updateApplicationInvitationDomainService;
+
+    private UpdateApplicationInvitationUseCase cut;
+
+    @BeforeEach
+    void setUp() {
+        cut = new UpdateApplicationInvitationUseCase(applicationCrudService, updateApplicationInvitationDomainService);
+    }
+
+    @Test
+    void should_validate_application_existence_before_updating_invitation() {
+        var invitationId = InvitationId.of(INVITATION_ID);
+        var update = new UpdateApplicationInvitation(ROLE_NAME);
+        when(applicationCrudService.findById(APPLICATION_ID, ENVIRONMENT_ID)).thenThrow(new ApplicationNotFoundException(APPLICATION_ID));
+
+        assertThatThrownBy(() ->
+            cut.execute(new UpdateApplicationInvitationUseCase.Input(ORGANIZATION_ID, ENVIRONMENT_ID, APPLICATION_ID, invitationId, update))
+        ).isInstanceOf(ApplicationNotFoundException.class);
+
+        verifyNoInteractions(updateApplicationInvitationDomainService);
+    }
+
+    @Test
+    void should_update_application_invitation() {
+        var invitationId = InvitationId.of(INVITATION_ID);
+        var update = new UpdateApplicationInvitation(ROLE_NAME);
+        var updatedInvitation = anApplicationInvitation(INVITATION_ID, APPLICATION_ID, "alice@example.com", ROLE_NAME);
+        when(applicationCrudService.findById(APPLICATION_ID, ENVIRONMENT_ID)).thenReturn(
+            BaseApplicationEntity.builder().id(APPLICATION_ID).environmentId(ENVIRONMENT_ID).build()
+        );
+        when(updateApplicationInvitationDomainService.update(ORGANIZATION_ID, APPLICATION_ID, invitationId, update)).thenReturn(
+            updatedInvitation
+        );
+
+        var output = cut.execute(
+            new UpdateApplicationInvitationUseCase.Input(ORGANIZATION_ID, ENVIRONMENT_ID, APPLICATION_ID, invitationId, update)
+        );
+
+        assertThat(output.invitation()).isEqualTo(updatedInvitation);
+        verify(updateApplicationInvitationDomainService).update(ORGANIZATION_ID, APPLICATION_ID, invitationId, update);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/crud_service/invitation/InvitationCrudServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/crud_service/invitation/InvitationCrudServiceImplTest.java
@@ -84,6 +84,29 @@ class InvitationCrudServiceImplTest {
         assertThat(throwable).isInstanceOf(TechnicalDomainException.class).hasMessageContaining("create application invitation");
     }
 
+    @Test
+    void should_update_application_invitation() {
+        invitationRepository.initWith(List.of(aRepositoryApplicationInvitation(INVITATION_ID_1, APPLICATION_ID, "alice@example.com")));
+        var invitationToUpdate = anApplicationInvitation(INVITATION_ID_1, APPLICATION_ID, "alice@example.com", "OWNER");
+
+        var result = cut.update(invitationToUpdate);
+
+        assertThat(result.id().toString()).isEqualTo(INVITATION_ID_1);
+        assertThat(result.roleName()).isEqualTo("OWNER");
+        assertThat(invitationRepository.storage().get(INVITATION_ID_1).getApplicationRole()).isEqualTo("OWNER");
+    }
+
+    @Test
+    void should_throw_technical_domain_exception_when_update_fails() {
+        invitationRepository.failsWith(new TechnicalException("error"));
+
+        var throwable = catchThrowable(() ->
+            cut.update(anApplicationInvitation(INVITATION_ID_1, APPLICATION_ID, "alice@example.com", ROLE))
+        );
+
+        assertThat(throwable).isInstanceOf(TechnicalDomainException.class).hasMessageContaining("update application invitation");
+    }
+
     @Nested
     class FindByEmail {
 


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-14239

##  Summary

Adds backend support for updating an application invitation role.
Includes:
- PUT /applications/{applicationId}/invitations/{invitationId} portal endpoint
- update use case and domain service for application invitations
- shared validation for application invitation roles
- repository update path through InvitationCrudService
