### PR TITLE
fix: skip users without id in membership enrichment

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/user/use_case/SearchUsersUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/user/use_case/SearchUsersUseCase.java
@@ -30,6 +30,7 @@ import jakarta.validation.constraints.NotNull;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -68,7 +69,12 @@ public class SearchUsersUseCase {
     }
 
     private Map<String, Boolean> buildApplicationMembership(String applicationId, List<User> users) {
-        var userIds = users.stream().map(User::id).toList();
+        var userIds = users.stream().map(User::id).filter(Objects::nonNull).filter(not(String::isBlank)).toList();
+
+        if (userIds.isEmpty()) {
+            return Map.of();
+        }
+
         Set<String> alreadyAddedUserIds = membershipQueryService
             .findByMemberIdsAndMemberTypeAndReferenceType(userIds, Membership.Type.USER, Membership.ReferenceType.APPLICATION)
             .stream()
@@ -76,7 +82,7 @@ public class SearchUsersUseCase {
             .map(Membership::getMemberId)
             .collect(Collectors.toSet());
 
-        return users.stream().collect(Collectors.toMap(User::id, user -> alreadyAddedUserIds.contains(user.id())));
+        return userIds.stream().collect(Collectors.toMap(userId -> userId, alreadyAddedUserIds::contains));
     }
 
     public record Input(

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/user/use_case/SearchUsersUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/user/use_case/SearchUsersUseCaseTest.java
@@ -93,6 +93,33 @@ class SearchUsersUseCaseTest {
     }
 
     @Test
+    void should_ignore_users_without_id_when_enriching_application_membership() {
+        var executionContext = new ExecutionContext(ORGANIZATION_ID, ENVIRONMENT_ID);
+        var userWithoutId = aUser(null, "ref-1", "External", "Adams", "External Adams", "external.adams@example.com");
+        var userWithId = aUser("user-1", "ref-2", "John", "Smith", "John Smith", "john.smith@example.com");
+
+        when(applicationCrudService.findById(APPLICATION_ID, ENVIRONMENT_ID)).thenReturn(new BaseApplicationEntity());
+        when(userQueryService.search(new UserSearchQuery("body-query"))).thenReturn(List.of(userWithoutId, userWithId));
+        when(
+            membershipQueryService.findByMemberIdsAndMemberTypeAndReferenceType(
+                List.of("user-1"),
+                Membership.Type.USER,
+                Membership.ReferenceType.APPLICATION
+            )
+        ).thenReturn(List.of());
+
+        var result = cut.execute(
+            new SearchUsersUseCase.Input(executionContext, new UserSearchQuery("body-query"), Optional.of(APPLICATION_ID))
+        );
+
+        assertThat(result.totalCount()).isEqualTo(2);
+        assertThat(result.data()).extracting(User::id).containsExactly(null, "user-1");
+        assertThat(result.applicationMembership()).hasSize(1).containsEntry("user-1", false);
+        verify(userQueryService).search(new UserSearchQuery("body-query"));
+        verify(applicationCrudService).findById(APPLICATION_ID, ENVIRONMENT_ID);
+    }
+
+    @Test
     void should_fallback_to_wildcard_query_when_no_query_is_provided() {
         var executionContext = new ExecutionContext(ORGANIZATION_ID, ENVIRONMENT_ID);
         var user = aUser("user-1", null, null, "Smith", "John Smith", null);


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-14255

## Description

Fixes user search membership enrichment when Identity Provider results include users without a local Gravitee user id.
Changes:
- skips null/blank user ids before querying application memberships
- keeps users without ids in search results
- excludes users without ids from metadata.applicationMembership
