### PR TITLE
feat(portal): add application invitation delete action

### DIFF
--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-invitations/application-tab-invitations.component.harness.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-invitations/application-tab-invitations.component.harness.ts
@@ -25,6 +25,7 @@ export class ApplicationTabInvitationsComponentHarness extends ComponentHarness 
   private readonly locateLoader = this.locatorForOptional(LoaderHarness);
   private readonly locateSectionTitle = this.locatorForOptional('[data-testid="invitations-section-title"]');
   private readonly locateErrorMessage = this.locatorForOptional('[data-testid="invitations-list-error"]');
+  private readonly locateDeleteErrorMessage = this.locatorForOptional('[data-testid="invitations-delete-error"]');
   private readonly locateEmptyState = this.locatorForOptional('[data-testid="invitations-empty-state"]');
   private readonly locateSearchBar = this.locatorForOptional('app-search-bar');
   private readonly locateSearchNoMatch = this.locatorForOptional('[data-testid="invitations-search-no-match"]');
@@ -43,6 +44,10 @@ export class ApplicationTabInvitationsComponentHarness extends ComponentHarness 
 
   public async getErrorMessage(): Promise<TestElement | null> {
     return this.locateErrorMessage();
+  }
+
+  public async getDeleteErrorMessage(): Promise<TestElement | null> {
+    return this.locateDeleteErrorMessage();
   }
 
   public async getEmptyState(): Promise<TestElement | null> {
@@ -67,5 +72,13 @@ export class ApplicationTabInvitationsComponentHarness extends ComponentHarness 
 
   public async getPaginatedTable(): Promise<PaginatedTableHarness | null> {
     return this.locatePaginatedTable();
+  }
+
+  public async getDeleteInvitationButton(): Promise<MatButtonHarness | null> {
+    return (await this.locatePaginatedTable())?.getActionButton('delete') ?? null;
+  }
+
+  public async clickDeleteInvitation(): Promise<void> {
+    return (await this.getDeleteInvitationButton())!.click();
   }
 }

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-invitations/application-tab-invitations.component.html
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-invitations/application-tab-invitations.component.html
@@ -37,6 +37,9 @@
   <h4 class="next-gen-h4 invitations__title" data-testid="invitations-section-title">
     {{ sectionTitle() }}
   </h4>
+  @if (error(); as errorText) {
+    <p class="invitations__error next-gen-small" data-testid="invitations-delete-error" role="alert">{{ errorText }}</p>
+  }
   @if (invitationsResource.isLoading()) {
     <app-loader />
   } @else if (invitationsResource.error()) {
@@ -61,8 +64,10 @@
       [currentPage]="currentPage()"
       [pageSize]="pageSize()"
       [navigable]="false"
+      [actions]="actions()"
       (pageChange)="onPageChange($event)"
       (pageSizeChange)="onPageSizeChange($event)"
+      (actionClick)="onActionClick($event)"
     >
       <ng-template appTableCell="email" let-row>
         <span class="invitations__email">
@@ -74,9 +79,6 @@
       </ng-template>
       <ng-template appTableCell="role" let-row>
         <span class="next-gen-small" data-testid="invitation-role">{{ row.role }}</span>
-      </ng-template>
-      <ng-template appTableCell="actions">
-        <span data-testid="invitation-actions"></span>
       </ng-template>
     </app-paginated-table>
   }

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-invitations/application-tab-invitations.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-invitations/application-tab-invitations.component.spec.ts
@@ -13,6 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { InteractivityChecker } from '@angular/cdk/a11y';
+import { HarnessLoader } from '@angular/cdk/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { provideHttpClient } from '@angular/common/http';
 import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
@@ -24,6 +26,8 @@ import { Subject } from 'rxjs';
 
 import { ApplicationTabInvitationsComponent } from './application-tab-invitations.component';
 import { ApplicationTabInvitationsComponentHarness } from './application-tab-invitations.component.harness';
+import { ConfirmDialogComponent } from '../../../../components/confirm-dialog/confirm-dialog.component';
+import { ConfirmDialogHarness } from '../../../../components/confirm-dialog/confirm-dialog.harness';
 import {
   ApplicationInvitationsResponse,
   ApplicationInvitationsSearchFilters,
@@ -40,11 +44,12 @@ import { ApplicationInvitationCreateDialogComponent } from '../application-invit
 describe('ApplicationTabInvitationsComponent', () => {
   let fixture: ComponentFixture<ApplicationTabInvitationsComponent>;
   let httpTestingController: HttpTestingController;
+  let rootLoader: HarnessLoader;
   const applicationId = 'app-1';
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [ApplicationTabInvitationsComponent],
+      imports: [ApplicationTabInvitationsComponent, ConfirmDialogComponent],
       providers: [
         provideHttpClient(),
         provideHttpClientTesting(),
@@ -52,10 +57,13 @@ describe('ApplicationTabInvitationsComponent', () => {
         provideRouter([]),
         { provide: ConfigService, useValue: { baseURL: TESTING_BASE_URL } },
       ],
-    }).compileComponents();
+    })
+      .overrideProvider(InteractivityChecker, { useValue: { isFocusable: () => true, isTabbable: () => true } })
+      .compileComponents();
 
     fixture = TestBed.createComponent(ApplicationTabInvitationsComponent);
     httpTestingController = TestBed.inject(HttpTestingController);
+    rootLoader = TestbedHarnessEnvironment.documentRootLoader(fixture);
     fixture.componentRef.setInput('applicationId', applicationId);
     fixture.componentRef.setInput('userApplicationPermissions', fakeUserApplicationPermissions({ MEMBER: ['R'] }));
   });
@@ -87,8 +95,8 @@ describe('ApplicationTabInvitationsComponent', () => {
     expect(await harness.getPaginatedTable()).not.toBeNull();
   });
 
-  it('should show invitation data columns and an empty actions column', () => {
-    expect(fixture.componentInstance.tableColumns.map(column => column.id)).toEqual(['email', 'role', 'actions']);
+  it('should show invitation data columns', () => {
+    expect(fixture.componentInstance.tableColumns.map(column => column.id)).toEqual(['email', 'role']);
   });
 
   it('should show section title with total invitation count from paginate metadata', async () => {
@@ -326,11 +334,123 @@ describe('ApplicationTabInvitationsComponent', () => {
     expect((await roleCell!.text()).trim()).toBe('POC');
   });
 
-  it('should render empty actions cell', async () => {
-    const harness = await flush(fakeApplicationInvitationsResponse([fakeApplicationInvitation()]));
-    const table = await harness.getPaginatedTable();
-    const actionsCell = await table!.getCellElement(0, 'actions');
-    expect((await actionsCell!.text()).trim()).toBe('');
+  describe('delete action', () => {
+    it('should not show delete button when user lacks MEMBER[D] permission', async () => {
+      const harness = await flush(fakeApplicationInvitationsResponse([fakeApplicationInvitation()]));
+
+      expect(await harness.getDeleteInvitationButton()).toBeNull();
+    });
+
+    it('should show delete button when user has MEMBER[D] permission', async () => {
+      fixture.componentRef.setInput('userApplicationPermissions', fakeUserApplicationPermissions({ MEMBER: ['R', 'D'] }));
+
+      const harness = await flush(fakeApplicationInvitationsResponse([fakeApplicationInvitation()]));
+
+      expect(await harness.getDeleteInvitationButton()).not.toBeNull();
+    });
+
+    it('should open confirmation dialog on delete click', async () => {
+      fixture.componentRef.setInput('userApplicationPermissions', fakeUserApplicationPermissions({ MEMBER: ['R', 'D'] }));
+      const harness = await flush(fakeApplicationInvitationsResponse([fakeApplicationInvitation({ email: 'alice@example.com' })]));
+
+      await harness.clickDeleteInvitation();
+      fixture.detectChanges();
+
+      const dialog = await rootLoader.getHarnessOrNull(ConfirmDialogHarness);
+      expect(dialog).not.toBeNull();
+      expect(await dialog!.getTitle()).toBe('Delete invitation?');
+      expect(await dialog!.getContent()).toContain('alice@example.com');
+      await dialog!.cancel();
+    });
+
+    it('should not send DELETE request when dialog is cancelled', async () => {
+      fixture.componentRef.setInput('userApplicationPermissions', fakeUserApplicationPermissions({ MEMBER: ['R', 'D'] }));
+      const harness = await flush(fakeApplicationInvitationsResponse([fakeApplicationInvitation()]));
+
+      await harness.clickDeleteInvitation();
+      fixture.detectChanges();
+
+      const dialog = await rootLoader.getHarnessOrNull(ConfirmDialogHarness);
+      await dialog!.cancel();
+      fixture.detectChanges();
+
+      httpTestingController.expectNone(r => r.method === 'DELETE');
+    });
+
+    it('should send DELETE request and reload list on confirm', async () => {
+      fixture.componentRef.setInput('userApplicationPermissions', fakeUserApplicationPermissions({ MEMBER: ['R', 'D'] }));
+      const invitation = fakeApplicationInvitation({ id: 'invitation-1', email: 'alice@example.com' });
+      const harness = await flush(fakeApplicationInvitationsResponse([invitation]));
+
+      await harness.clickDeleteInvitation();
+      fixture.detectChanges();
+
+      const dialog = await rootLoader.getHarnessOrNull(ConfirmDialogHarness);
+      await dialog!.confirm();
+      fixture.detectChanges();
+
+      httpTestingController
+        .expectOne(r => r.url === `${TESTING_BASE_URL}/applications/${applicationId}/invitations/${invitation.id}` && r.method === 'DELETE')
+        .flush(null, { status: 204, statusText: 'No Content' });
+      fixture.detectChanges();
+
+      httpTestingController.expectOne(r => r.url.includes('invitations/_search')).flush(fakeApplicationInvitationsResponse([]));
+      await fixture.whenStable();
+    });
+
+    it('should move to previous page after deleting the last invitation from the current page', async () => {
+      fixture.componentRef.setInput('userApplicationPermissions', fakeUserApplicationPermissions({ MEMBER: ['R', 'D'] }));
+      const invitation = fakeApplicationInvitation({ id: 'invitation-last-page' });
+      await flush(fakeApplicationInvitationsResponse([fakeApplicationInvitation({ id: 'invitation-page-1' })], 11));
+      fixture.componentInstance.onPageChange(2);
+      fixture.detectChanges();
+      const pageTwoRequest = httpTestingController.expectOne(r => r.url.includes('invitations/_search') && r.params.get('page') === '2');
+      pageTwoRequest.flush(fakeApplicationInvitationsResponse([invitation], 11));
+      await fixture.whenStable();
+      fixture.detectChanges();
+      const harness = await getHarness();
+
+      await harness.clickDeleteInvitation();
+      fixture.detectChanges();
+
+      const dialog = await rootLoader.getHarnessOrNull(ConfirmDialogHarness);
+      await dialog!.confirm();
+      fixture.detectChanges();
+
+      httpTestingController
+        .expectOne(r => r.url === `${TESTING_BASE_URL}/applications/${applicationId}/invitations/${invitation.id}` && r.method === 'DELETE')
+        .flush(null, { status: 204, statusText: 'No Content' });
+      fixture.detectChanges();
+
+      const reloadRequest = httpTestingController.expectOne(r => r.url.includes('invitations/_search') && r.params.get('page') === '1');
+      expect(reloadRequest.request.params.get('size')).toBe('10');
+      reloadRequest.flush(fakeApplicationInvitationsResponse([fakeApplicationInvitation({ id: 'remaining-invitation' })], 10));
+      await fixture.whenStable();
+    });
+
+    it('should show inline error when delete fails', async () => {
+      fixture.componentRef.setInput('userApplicationPermissions', fakeUserApplicationPermissions({ MEMBER: ['R', 'D'] }));
+      const invitation = fakeApplicationInvitation({ id: 'invitation-1' });
+      const harness = await flush(fakeApplicationInvitationsResponse([invitation]));
+
+      await harness.clickDeleteInvitation();
+      fixture.detectChanges();
+
+      const dialog = await rootLoader.getHarnessOrNull(ConfirmDialogHarness);
+      await dialog!.confirm();
+      fixture.detectChanges();
+
+      httpTestingController
+        .expectOne(r => r.url === `${TESTING_BASE_URL}/applications/${applicationId}/invitations/${invitation.id}` && r.method === 'DELETE')
+        .flush({ error: 'Server error' }, { status: 500, statusText: 'Internal Server Error' });
+      await fixture.whenStable();
+      fixture.detectChanges();
+
+      const error = await harness.getDeleteErrorMessage();
+      expect(error).not.toBeNull();
+      expect(await error!.getAttribute('role')).toBe('alert');
+      expect(await error!.text()).toContain('An error occurred while deleting the invitation');
+    });
   });
 
   it('should POST with page=2 when page changes', async () => {

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-invitations/application-tab-invitations.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-invitations/application-tab-invitations.component.ts
@@ -18,10 +18,11 @@ import { rxResource, takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { MatButtonModule } from '@angular/material/button';
 import { MatDialog, MatDialogModule } from '@angular/material/dialog';
 import { MatIcon } from '@angular/material/icon';
-import { filter, map, of, tap } from 'rxjs';
+import { EMPTY, filter, map, of, switchMap, tap } from 'rxjs';
 
+import { ConfirmDialogComponent, ConfirmDialogData } from '../../../../components/confirm-dialog/confirm-dialog.component';
 import { LoaderComponent } from '../../../../components/loader/loader.component';
-import { PaginatedTableComponent, TableColumn } from '../../../../components/paginated-table/paginated-table.component';
+import { PaginatedTableComponent, TableAction, TableColumn } from '../../../../components/paginated-table/paginated-table.component';
 import { TableCellDirective } from '../../../../components/paginated-table/table-cell.directive';
 import { SearchBarComponent } from '../../../../components/search-bar/search-bar.component';
 import {
@@ -72,6 +73,7 @@ export class ApplicationTabInvitationsComponent {
   readonly currentPage = signal(1);
   readonly pageSize = signal(10);
   readonly searchTerm = signal('');
+  readonly error = signal<string | null>(null);
   readonly displayedTotalElements = signal<number | null>(null);
   readonly sectionTitle = computed(() => {
     const totalElements = this.displayedTotalElements();
@@ -84,16 +86,29 @@ export class ApplicationTabInvitationsComponent {
   readonly tableColumns: TableColumn[] = [
     { id: 'email', label: $localize`:@@applicationInvitationsColumnEmail:Email` },
     { id: 'role', label: $localize`:@@applicationInvitationsColumnRole:Role` },
-    { id: 'actions', label: $localize`:@@applicationInvitationsColumnActions:Actions` },
   ];
 
   readonly canRead = computed(() => this.userApplicationPermissions().MEMBER?.includes('R') ?? false);
   readonly canCreate = computed(() => this.userApplicationPermissions().MEMBER?.includes('C') ?? false);
+  readonly canDelete = computed(() => this.userApplicationPermissions().MEMBER?.includes('D') ?? false);
   readonly hasSearchTerm = computed(() => this.searchTerm().trim().length > 0);
   readonly searchFilters = computed<ApplicationInvitationsSearchFilters>(() => {
     const email = this.searchTerm().trim();
     return email ? { email } : {};
   });
+
+  readonly actions = computed<TableAction<InvitationTableRow>[]>(() =>
+    this.canDelete()
+      ? [
+          {
+            id: 'delete',
+            icon: 'delete_outline',
+            ariaLabel: $localize`:@@deleteApplicationInvitationAriaLabel:Delete invitation`,
+            color: 'warn',
+          },
+        ]
+      : [],
+  );
 
   readonly requestParams = computed<InvitationsRequestParams | null>(() =>
     this.canRead()
@@ -157,7 +172,14 @@ export class ApplicationTabInvitationsComponent {
     this.currentPage.set(1);
   }
 
+  onActionClick({ actionId, row }: { actionId: string; row: InvitationTableRow }): void {
+    if (actionId === 'delete') {
+      this.openDeleteConfirmation(row);
+    }
+  }
+
   openCreateInvitationDialog(): void {
+    this.error.set(null);
     this.matDialog
       .open<ApplicationInvitationCreateDialogComponent, ApplicationInvitationCreateDialogData, boolean>(
         ApplicationInvitationCreateDialogComponent,
@@ -173,6 +195,44 @@ export class ApplicationTabInvitationsComponent {
         takeUntilDestroyed(this.destroyRef),
       )
       .subscribe();
+  }
+
+  private openDeleteConfirmation(invitation: InvitationTableRow): void {
+    this.error.set(null);
+    this.matDialog
+      .open<ConfirmDialogComponent, ConfirmDialogData, boolean>(ConfirmDialogComponent, {
+        role: 'alertdialog',
+        data: {
+          title: $localize`:@@deleteApplicationInvitationDialogTitle:Delete invitation?`,
+          content: $localize`:@@deleteApplicationInvitationDialogContent:Are you sure you want to delete the invitation for ${invitation.email}:invitationEmail:?`,
+          confirmLabel: $localize`:@@deleteApplicationInvitationDialogConfirm:Delete`,
+          cancelLabel: $localize`:@@deleteApplicationInvitationDialogCancel:Cancel`,
+        },
+      })
+      .afterClosed()
+      .pipe(
+        switchMap(confirmed =>
+          confirmed ? this.applicationInvitationService.deleteApplicationInvitation(this.applicationId(), invitation.id) : EMPTY,
+        ),
+        tap(() => this.reloadInvitationsAfterDelete()),
+        takeUntilDestroyed(this.destroyRef),
+      )
+      .subscribe({
+        error: () =>
+          this.error.set($localize`:@@deleteApplicationInvitationError:An error occurred while deleting the invitation. Please try again.`),
+      });
+  }
+
+  private reloadInvitationsAfterDelete(): void {
+    const totalElementsAfterDelete = Math.max(this.totalElements() - 1, 0);
+    const lastPageAfterDelete = Math.max(1, Math.ceil(totalElementsAfterDelete / this.pageSize()));
+
+    if (this.currentPage() > lastPageAfterDelete) {
+      this.currentPage.set(lastPageAfterDelete);
+      return;
+    }
+
+    this.invitationsResource.reload();
   }
 
   private toRow(invitation: ApplicationInvitation): InvitationTableRow {

--- a/gravitee-apim-portal-webui-next/src/services/application-invitation.service.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/services/application-invitation.service.spec.ts
@@ -84,4 +84,15 @@ describe('ApplicationInvitationService', () => {
     expect(req.request.body).toEqual(input);
     req.flush(response);
   });
+
+  it('should delete application invitation', done => {
+    const invitationId = 'invitation-1';
+
+    service.deleteApplicationInvitation(applicationId, invitationId).subscribe(() => done());
+
+    const req = httpTestingController.expectOne(
+      r => r.url === `${TESTING_BASE_URL}/applications/${applicationId}/invitations/${invitationId}` && r.method === 'DELETE',
+    );
+    req.flush(null, { status: 204, statusText: 'No Content' });
+  });
 });

--- a/gravitee-apim-portal-webui-next/src/services/application-invitation.service.ts
+++ b/gravitee-apim-portal-webui-next/src/services/application-invitation.service.ts
@@ -52,4 +52,8 @@ export class ApplicationInvitationService {
   ): Observable<ApplicationInvitationsResponse> {
     return this.http.post<ApplicationInvitationsResponse>(`${this.configService.baseURL}/applications/${applicationId}/invitations`, input);
   }
+
+  deleteApplicationInvitation(applicationId: string, invitationId: string): Observable<void> {
+    return this.http.delete<void>(`${this.configService.baseURL}/applications/${applicationId}/invitations/${invitationId}`);
+  }
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-14238

## Description

Adds the pending invitation delete action in the Portal invitations tab.
Includes:
- confirmation dialog before deletion
- ApplicationInvitationService.deleteApplicationInvitation
- list reload after successful deletion
- pagination fallback when deleting the last item on the current page

https://github.com/user-attachments/assets/535a3a84-070c-4f56-a606-b7c172b9d41e

