### PR TITLE
chore: upgrade alpha plugins and resources to their latest versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -183,8 +183,8 @@
         <gravitee-policy-assign-content.version>3.1.1</gravitee-policy-assign-content.version>
         <gravitee-policy-assign-metrics.version>3.1.0</gravitee-policy-assign-metrics.version>
         <gravitee-policy-basic-authentication.version>1.6.0</gravitee-policy-basic-authentication.version>
-        <gravitee-policy-cache.version>4.0.0-alpha.1</gravitee-policy-cache.version>
-        <gravitee-policy-callout-http.version>7.0.0-alpha.2</gravitee-policy-callout-http.version>
+        <gravitee-policy-cache.version>4.0.0-alpha.4</gravitee-policy-cache.version>
+        <gravitee-policy-callout-http.version>7.0.0-alpha.3</gravitee-policy-callout-http.version>
         <gravitee-policy-circuit-breaker.version>2.0.0</gravitee-policy-circuit-breaker.version>
         <gravitee-policy-custom-query-parameters.version>2.0.0</gravitee-policy-custom-query-parameters.version>
         <gravitee-policy-cloud-events.version>1.1.0</gravitee-policy-cloud-events.version>
@@ -207,7 +207,7 @@
         <gravitee-policy-json-validation.version>2.2.0-alpha.4</gravitee-policy-json-validation.version>
         <gravitee-policy-json-xml.version>3.0.3</gravitee-policy-json-xml.version>
         <gravitee-policy-jws.version>2.0.0</gravitee-policy-jws.version>
-        <gravitee-policy-jwt.version>8.0.0-alpha.2</gravitee-policy-jwt.version>
+        <gravitee-policy-jwt.version>8.0.0-alpha.3</gravitee-policy-jwt.version>
         <gravitee-policy-keyless.version>4.0.0</gravitee-policy-keyless.version>
         <gravitee-policy-latency.version>2.0.1</gravitee-policy-latency.version>
         <gravitee-policy-metrics-reporter.version>3.0.1</gravitee-policy-metrics-reporter.version>
@@ -246,10 +246,10 @@
         <gravitee-policy-http-redirect.version>1.0.2</gravitee-policy-http-redirect.version>
 
         <gravitee-resource-cache.version>3.0.0</gravitee-resource-cache.version>
-        <gravitee-resource-oauth2-provider-am.version>5.0.0-alpha.2</gravitee-resource-oauth2-provider-am.version>
+        <gravitee-resource-oauth2-provider-am.version>5.0.0-alpha.3</gravitee-resource-oauth2-provider-am.version>
         <gravitee-resource-oauth2-provider-auth0.version>1.0.0</gravitee-resource-oauth2-provider-auth0.version>
-        <gravitee-resource-oauth2-provider-entra-id.version>2.0.0-alpha.1</gravitee-resource-oauth2-provider-entra-id.version>
-        <gravitee-resource-oauth2-provider-generic.version>6.0.0-alpha.1</gravitee-resource-oauth2-provider-generic.version>
+        <gravitee-resource-oauth2-provider-entra-id.version>2.0.0-alpha.2</gravitee-resource-oauth2-provider-entra-id.version>
+        <gravitee-resource-oauth2-provider-generic.version>6.0.0-alpha.3</gravitee-resource-oauth2-provider-generic.version>
         <gravitee-resource-content-provider-inline.version>1.1.1</gravitee-resource-content-provider-inline.version>
         <gravitee-service-discovery-consul.version>1.3.0</gravitee-service-discovery-consul.version>
         <!-- Management API Only -->


### PR DESCRIPTION
## Issue

N/A — no associated issue

## Description

Upgrade the alpha plugins and resources to their latest released versions:

- `gravitee-policy-cache`: 4.0.0-alpha.1 -> 4.0.0-alpha.4
- `gravitee-policy-callout-http`: 7.0.0-alpha.2 -> 7.0.0-alpha.3
- `gravitee-policy-jwt`: 8.0.0-alpha.2 -> 8.0.0-alpha.3
- `gravitee-resource-oauth2-provider-am`: 5.0.0-alpha.2 -> 5.0.0-alpha.3
- `gravitee-resource-oauth2-provider-entra-id`: 2.0.0-alpha.1 -> 2.0.0-alpha.2
- `gravitee-resource-oauth2-provider-generic`: 6.0.0-alpha.1 -> 6.0.0-alpha.3

## Additional context

<!-- N/A -->