### PR TITLE
fix(service): rename TokenServiceImpl to RegistrationTokenServiceImpl to avoid bean name conflict

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/user/RegistrationTokenServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/user/RegistrationTokenServiceImpl.java
@@ -27,11 +27,11 @@ import org.springframework.core.env.Environment;
 import org.springframework.stereotype.Service;
 
 @Service
-public class TokenServiceImpl implements TokenService {
+public class RegistrationTokenServiceImpl implements TokenService {
 
     private final Environment environment;
 
-    public TokenServiceImpl(Environment environment) {
+    public RegistrationTokenServiceImpl(Environment environment) {
         this.environment = environment;
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/user/RegistrationTokenServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/user/RegistrationTokenServiceImplTest.java
@@ -32,19 +32,19 @@ import org.junit.jupiter.api.Test;
 import org.springframework.mock.env.MockEnvironment;
 
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
-class TokenServiceImplTest {
+class RegistrationTokenServiceImplTest {
 
     private static final String JWT_SECRET = "my-test-secret-at-least-256-bits-long-padding-here";
     private static final String USER_EMAIL = "user@example.com";
 
     private MockEnvironment environment;
-    private TokenServiceImpl cut;
+    private RegistrationTokenServiceImpl cut;
 
     @BeforeEach
     void setUp() {
         environment = new MockEnvironment();
         environment.setProperty("jwt.secret", JWT_SECRET);
-        cut = new TokenServiceImpl(environment);
+        cut = new RegistrationTokenServiceImpl(environment);
     }
 
     private String buildToken(String action, String email, String subject) {
@@ -109,7 +109,7 @@ class TokenServiceImplTest {
         @Test
         void should_throw_when_jwt_secret_is_missing() {
             environment = new MockEnvironment();
-            cut = new TokenServiceImpl(environment);
+            cut = new RegistrationTokenServiceImpl(environment);
 
             assertThatThrownBy(() -> cut.decode("any-token"))
                 .isInstanceOf(IllegalStateException.class)


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-14130

## Description

- Renames `io.gravitee.apim.infra.domain_service.user.TokenServiceImpl` → `RegistrationTokenServiceImpl` to eliminate the Spring bean name conflict with the existing `io.gravitee.rest.api.service.impl.TokenServiceImpl`
- Both classes generated the default bean name `tokenServiceImpl`; `InfraServiceSpringConfiguration` scanning `io.gravitee.apim.infra` caused a `BeanDefinitionStoreException` at application startup, crashing the Management API container in E2E runs

## Additional context

- The renamed class implements `io.gravitee.apim.core.user.service_provider.TokenService` (our new core port); the legacy class implements `io.gravitee.rest.api.service.TokenService` — they are unrelated despite the shared name