### PR TITLE
fix(portal): add charset=UTF-8 to page content Content-Type header

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/ApiPageResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/ApiPageResource.java
@@ -46,6 +46,7 @@ import lombok.CustomLog;
 public class ApiPageResource extends AbstractResource {
 
     private static final String INCLUDE_CONTENT = "content";
+    private static final String TEXT_PLAIN_UTF_8 = MediaType.TEXT_PLAIN + ";charset=UTF-8";
 
     @Inject
     private PageMapper pageMapper;
@@ -100,7 +101,7 @@ public class ApiPageResource extends AbstractResource {
 
     @GET
     @Path("content")
-    @Produces(MediaType.TEXT_PLAIN)
+    @Produces(TEXT_PLAIN_UTF_8)
     @RequirePortalAuth
     public Response getPageContentByApiIdAndPageId(@PathParam("apiId") String apiId, @PathParam("pageId") String pageId) {
         final ApiQuery apiQuery = new ApiQuery();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/PageResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/PageResource.java
@@ -39,6 +39,9 @@ import java.util.List;
  */
 public class PageResource extends AbstractResource {
 
+    private static final String INCLUDE_CONTENT = "content";
+    private static final String TEXT_PLAIN_UTF_8 = MediaType.TEXT_PLAIN + ";charset=UTF-8";
+
     @Inject
     private PageMapper pageMapper;
 
@@ -47,8 +50,6 @@ public class PageResource extends AbstractResource {
 
     @Inject
     private AccessControlService accessControlService;
-
-    private static final String INCLUDE_CONTENT = "content";
 
     @GET
     @Produces(MediaType.APPLICATION_JSON)
@@ -93,7 +94,7 @@ public class PageResource extends AbstractResource {
 
     @GET
     @Path("content")
-    @Produces(MediaType.TEXT_PLAIN)
+    @Produces(TEXT_PLAIN_UTF_8)
     @RequirePortalAuth
     public Response getPageContentByPageId(@PathParam("pageId") String pageId) {
         PageEntity pageEntity = pageService.findById(pageId, null);


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-14229

## Description

Add charset=UTF-8 to the Content-Type header returned by the portal page content endpoint, ensuring proper character encoding for non-ASCII content.

## Additional context
Before Fix::

https://github.com/user-attachments/assets/43d33c61-354a-4cd3-a817-058178821b98

**After FIX:**

https://github.com/user-attachments/assets/bdad09db-1a95-4065-b5f6-236709cf260a


<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

