### PR TITLE
fix(analytics): add http-get and http-post to Observability entrypoint-id filter

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/analytics/engine/adapter/FilterAdapter.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/analytics/engine/adapter/FilterAdapter.java
@@ -32,6 +32,8 @@ import java.util.Objects;
 public class FilterAdapter {
 
     static final String ENTRYPOINT_FIELD = "entrypoint-id";
+    static final String HTTP_GET_ENTRYPOINT_ID = "http-get";
+    static final String HTTP_POST_ENTRYPOINT_ID = "http-post";
     static final String HTTP_PROXY_ENTRYPOINT_ID = "http-proxy";
     static final String LLM_PROXY_ENTRYPOINT_ID = "llm-proxy";
     static final String MCP_PROXY_ENTRYPOINT_ID = "mcp-proxy";
@@ -121,7 +123,16 @@ public class FilterAdapter {
     public JsonObject httpFilter() {
         JsonObject termsFilter = JsonObject.of(
             "terms",
-            JsonObject.of(ENTRYPOINT_FIELD, JsonArray.of(HTTP_PROXY_ENTRYPOINT_ID, LLM_PROXY_ENTRYPOINT_ID, MCP_PROXY_ENTRYPOINT_ID))
+            JsonObject.of(
+                ENTRYPOINT_FIELD,
+                JsonArray.of(
+                    HTTP_GET_ENTRYPOINT_ID,
+                    HTTP_POST_ENTRYPOINT_ID,
+                    HTTP_PROXY_ENTRYPOINT_ID,
+                    LLM_PROXY_ENTRYPOINT_ID,
+                    MCP_PROXY_ENTRYPOINT_ID
+                )
+            )
         );
 
         // This is needed for now to get APIs that don't pass the security chain.

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/analytics/engine/adapter/FilterAdapterTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/analytics/engine/adapter/FilterAdapterTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.elasticsearch.v4.analytics.engine.adapter;
+
+import static io.gravitee.repository.elasticsearch.v4.analytics.engine.adapter.FilterAdapter.*;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author GraviteeSource Team
+ */
+class FilterAdapterTest {
+
+    private final FilterAdapter filterAdapter = new FilterAdapter(new HTTPFieldResolver());
+
+    @Test
+    void should_include_all_http_entrypoint_ids_in_http_filter() {
+        var httpFilter = filterAdapter.httpFilter();
+
+        var termsFilter = httpFilter.getJsonObject("bool").getJsonArray("should").getJsonObject(0);
+
+        var entrypointIds = termsFilter.getJsonObject("terms").getJsonArray(ENTRYPOINT_FIELD);
+
+        assertThat(entrypointIds.getList()).containsExactly(
+            HTTP_GET_ENTRYPOINT_ID,
+            HTTP_POST_ENTRYPOINT_ID,
+            HTTP_PROXY_ENTRYPOINT_ID,
+            LLM_PROXY_ENTRYPOINT_ID,
+            MCP_PROXY_ENTRYPOINT_ID
+        );
+    }
+
+    @Test
+    void should_include_field_missing_clause_in_http_filter() {
+        var httpFilter = filterAdapter.httpFilter();
+
+        var shouldClauses = httpFilter.getJsonObject("bool").getJsonArray("should");
+        assertThat(shouldClauses).hasSize(2);
+
+        var fieldMissingClause = shouldClauses.getJsonObject(1);
+        var mustNot = fieldMissingClause.getJsonObject("bool").getJsonObject("must_not");
+        var existsField = mustNot.getJsonObject("exists").getString("field");
+
+        assertThat(existsField).isEqualTo(ENTRYPOINT_FIELD);
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/analytics/engine/adapter/HTTPFacetsQueryAdapterTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/analytics/engine/adapter/HTTPFacetsQueryAdapterTest.java
@@ -15,6 +15,11 @@
  */
 package io.gravitee.repository.elasticsearch.v4.analytics.engine.adapter;
 
+import static io.gravitee.repository.elasticsearch.v4.analytics.engine.adapter.FilterAdapter.HTTP_GET_ENTRYPOINT_ID;
+import static io.gravitee.repository.elasticsearch.v4.analytics.engine.adapter.FilterAdapter.HTTP_POST_ENTRYPOINT_ID;
+import static io.gravitee.repository.elasticsearch.v4.analytics.engine.adapter.FilterAdapter.HTTP_PROXY_ENTRYPOINT_ID;
+import static io.gravitee.repository.elasticsearch.v4.analytics.engine.adapter.FilterAdapter.LLM_PROXY_ENTRYPOINT_ID;
+import static io.gravitee.repository.elasticsearch.v4.analytics.engine.adapter.FilterAdapter.MCP_PROXY_ENTRYPOINT_ID;
 import static io.gravitee.repository.elasticsearch.v4.analytics.engine.adapter.MessageFacetExtractor.REQUEST_ID_AGG_NAME;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -247,10 +252,12 @@ class HTTPFacetsQueryAdapterTest extends AbstractQueryAdapterTest {
 
         var entrypointFilter = should.at("/0/terms/entrypoint-id");
         assertThat(entrypointFilter).isNotNull();
-        assertThat(entrypointFilter.size()).isEqualTo(3);
-        assertThat(entrypointFilter.at("/0").asText()).isEqualTo("http-proxy");
-        assertThat(entrypointFilter.at("/1").asText()).isEqualTo("llm-proxy");
-        assertThat(entrypointFilter.at("/2").asText()).isEqualTo("mcp-proxy");
+        assertThat(entrypointFilter.size()).isEqualTo(5);
+        assertThat(entrypointFilter.at("/0").asText()).isEqualTo(HTTP_GET_ENTRYPOINT_ID);
+        assertThat(entrypointFilter.at("/1").asText()).isEqualTo(HTTP_POST_ENTRYPOINT_ID);
+        assertThat(entrypointFilter.at("/2").asText()).isEqualTo(HTTP_PROXY_ENTRYPOINT_ID);
+        assertThat(entrypointFilter.at("/3").asText()).isEqualTo(LLM_PROXY_ENTRYPOINT_ID);
+        assertThat(entrypointFilter.at("/4").asText()).isEqualTo(MCP_PROXY_ENTRYPOINT_ID);
 
         var fieldMissingFilter = should.at("/1/bool/must_not/exists/field");
         assertThat(fieldMissingFilter).isNotNull();


### PR DESCRIPTION
## Summary

`FilterAdapter.httpFilter()` in the Observability analytics engine only accepted `http-proxy`, `llm-proxy`, and `mcp-proxy` as `entrypoint-id` values. Documents indexed with `http-get` or `http-post` entrypoint IDs were excluded, causing all Observability dashboard widgets to return 0 for LLM_PROXY and MCP_PROXY APIs that use those entrypoints.

<img width="737" height="793" alt="Screenshot 2026-06-03 at 18 13 59" src="https://github.com/user-attachments/assets/3f8fc98d-7c7c-4151-915a-5b410a8c046c" />

<img width="2269" height="813" alt="Screenshot 2026-06-03 at 17 55 13" src="https://github.com/user-attachments/assets/989c29aa-4540-4dfb-9d29-13667ade8d8c" />
<img width="2325" height="807" alt="Screenshot 2026-06-03 at 17 55 01" src="https://github.com/user-attachments/assets/3b581e89-7ff9-4e6c-a189-eec5ad6e7ace" />
<img width="2271" height="867" alt="Screenshot 2026-06-03 at 17 54 24" src="https://github.com/user-attachments/assets/17d7bda2-cef0-461b-86aa-523a0146ad7e" />
<img width="2304" height="804" alt="Screenshot 2026-06-03 at 17 54 09" src="https://github.com/user-attachments/assets/8d6f2274-b8c8-4d8c-8ced-a885b11c1050" />


Closes [GMA-513](https://gravitee.atlassian.net/browse/GMA-513)

## Changes

- Added `http-get` and `http-post` constants and included them in the `entrypoint-id` terms filter of `FilterAdapter.httpFilter()`
- Added `FilterAdapterTest` with tests validating the complete entrypoint-id list and the field-missing fallback clause

## Test plan

- [x] Deploy a LLM_PROXY or MCP_PROXY API with `http-get` or `http-post` entrypoint, send traffic
- [x] Open **API Traffic → Analytics** — verify dashboard shows correct request count
- [x] Open **Observability → Dashboard** — verify widgets now show the same non-zero counts
- [x] Verify existing `http-proxy`, `llm-proxy`, `mcp-proxy` APIs still show correct data
- [x] Run `FilterAdapterTest` — 2 tests pass

[GMA-513]: https://gravitee.atlassian.net/browse/GMA-513?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ