### PR TITLE
fix(rest-api): return clean 4xx  on v4 remote API import

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api/RemoteApiDefinitionParser.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api/RemoteApiDefinitionParser.java
@@ -53,7 +53,9 @@ public class RemoteApiDefinitionParser {
      * plain Java methods (not via JAX-RS dispatch), which would otherwise bypass {@code @Valid} constraints
      * on those endpoint parameters.
      *
-     * @throws BadRequestException if the content is not parseable JSON. The Jackson exception detail is
+     * @throws BadRequestException if the content is not parseable JSON, or if it is valid JSON that is not a
+     *     Gravitee export (e.g. {@code {"hello":"world"}} deserializes into an {@link ExportApiV4} with a null
+     *     {@code api}, which would otherwise NPE in the downstream mapper). The Jackson exception detail is
      *     logged at warn level but never returned to the caller, to avoid leaking internal class paths or
      *     fragments of the remote body through the error message.
      * @throws ConstraintViolationException if the parsed definition fails Bean Validation.
@@ -65,6 +67,10 @@ public class RemoteApiDefinitionParser {
         } catch (JsonProcessingException e) {
             log.warn("Failed to parse API definition fetched from URL", e);
             throw new BadRequestException("Invalid API definition format");
+        }
+        if (apiToImport == null || apiToImport.getApi() == null) {
+            log.warn("API definition fetched from URL is valid JSON but is missing the required 'api' object");
+            throw new BadRequestException("Invalid API definition");
         }
         Set<ConstraintViolation<ExportApiV4>> violations = VALIDATOR.validate(apiToImport);
         if (!violations.isEmpty()) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource_UpdateApiWithDefinitionFromUrlTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource_UpdateApiWithDefinitionFromUrlTest.java
@@ -17,7 +17,6 @@ package io.gravitee.rest.api.management.v2.rest.resource.api;
 
 import static io.gravitee.common.http.HttpStatusCode.BAD_REQUEST_400;
 import static io.gravitee.common.http.HttpStatusCode.FORBIDDEN_403;
-import static io.gravitee.common.http.HttpStatusCode.INTERNAL_SERVER_ERROR_500;
 import static io.gravitee.common.http.HttpStatusCode.OK_200;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -34,6 +33,7 @@ import io.gravitee.rest.api.model.permissions.RolePermission;
 import io.gravitee.rest.api.model.permissions.RolePermissionAction;
 import io.gravitee.rest.api.service.HttpClientService;
 import io.gravitee.rest.api.service.common.GraviteeContext;
+import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
 import io.gravitee.rest.api.service.spring.ImportConfiguration;
 import io.vertx.core.buffer.Buffer;
 import jakarta.ws.rs.client.Entity;
@@ -223,7 +223,78 @@ class ApiResource_UpdateApiWithDefinitionFromUrlTest extends ApiResourceTest {
     }
 
     @Test
-    public void should_return_internal_server_error_when_http_client_throws() {
+    public void should_return_bad_request_when_remote_returns_error_status() {
+        // Defect A: the remote URL responds with a non-success status (e.g. 404). HttpClientService surfaces this
+        // as a TechnicalManagementException; it must become a clean 4xx, not a 500 leaking the remote response.
+        grantUpdatePermission();
+
+        when(httpClientService.request(eq(HttpMethod.GET), eq(TEST_URL), any(), any(), any())).thenThrow(
+            new TechnicalManagementException(" Error on url '" + TEST_URL + "'. Status code: 404. Message: Not Found", null)
+        );
+
+        Response response = rootTarget().request().put(Entity.text(TEST_URL));
+
+        assertThat(response.getStatus()).isEqualTo(BAD_REQUEST_400);
+        String body = response.readEntity(String.class);
+        assertThat(body)
+            .contains("Unable to fetch the API definition")
+            .doesNotContain("io.gravitee", "TechnicalManagementException", "Status code", "404");
+    }
+
+    @Test
+    public void should_return_bad_request_when_remote_host_unreachable() {
+        // Defect B: the remote host cannot be resolved/reached. Must become a clean 4xx without leaking the
+        // UnknownHostException or the failing host.
+        grantUpdatePermission();
+
+        when(httpClientService.request(eq(HttpMethod.GET), eq(TEST_URL), any(), any(), any())).thenThrow(
+            new TechnicalManagementException(
+                "Failed to resolve 'nonexistent-host-xyz.invalid'",
+                new java.net.UnknownHostException("nonexistent-host-xyz.invalid")
+            )
+        );
+
+        Response response = rootTarget().request().put(Entity.text(TEST_URL));
+
+        assertThat(response.getStatus()).isEqualTo(BAD_REQUEST_400);
+        String body = response.readEntity(String.class);
+        assertThat(body)
+            .contains("Unable to fetch the API definition")
+            .doesNotContain("io.gravitee", "UnknownHostException", "Failed to resolve", "nonexistent-host");
+    }
+
+    @Test
+    public void should_return_bad_request_when_definition_is_not_a_gravitee_export() {
+        // Defect C: valid JSON that is not a Gravitee export (missing 'api'). Must be a clean 400, not an NPE → 500.
+        grantUpdatePermission();
+
+        Buffer buffer = Buffer.buffer("{\"hello\":\"world\"}");
+        when(httpClientService.request(eq(HttpMethod.GET), eq(TEST_URL), any(), any(), any())).thenReturn(buffer);
+
+        Response response = rootTarget().request().put(Entity.text(TEST_URL));
+
+        assertThat(response.getStatus()).isEqualTo(BAD_REQUEST_400);
+        String body = response.readEntity(String.class);
+        assertThat(body).contains("Invalid API definition").doesNotContain("io.gravitee", "NullPointerException");
+    }
+
+    @Test
+    public void should_return_bad_request_when_definition_fails_bean_validation() {
+        // Valid JSON that deserializes into an ExportApiV4 with a non-null 'api' but violates a Bean Validation
+        // constraint (member displayName is @Size(min=1)). Must surface as a clean 400, not a 500.
+        grantUpdatePermission();
+
+        Buffer buffer = Buffer.buffer("{\"api\":{\"definitionVersion\":\"V4\"},\"members\":[{\"displayName\":\"\"}]}");
+        when(httpClientService.request(eq(HttpMethod.GET), eq(TEST_URL), any(), any(), any())).thenReturn(buffer);
+
+        Response response = rootTarget().request().put(Entity.text(TEST_URL));
+
+        assertThat(response.getStatus()).isEqualTo(BAD_REQUEST_400);
+        String body = response.readEntity(String.class);
+        assertThat(body).contains("Validation error").doesNotContain("io.gravitee", "ConstraintViolationException");
+    }
+
+    private void grantUpdatePermission() {
         when(
             permissionService.hasPermission(
                 GraviteeContext.getExecutionContext(),
@@ -232,14 +303,6 @@ class ApiResource_UpdateApiWithDefinitionFromUrlTest extends ApiResourceTest {
                 RolePermissionAction.UPDATE
             )
         ).thenReturn(true);
-
-        when(httpClientService.request(eq(HttpMethod.GET), eq(TEST_URL), any(), any(), any())).thenThrow(
-            new RuntimeException("Connection refused")
-        );
-
-        Response response = rootTarget().request().put(Entity.text(TEST_URL));
-
-        assertThat(response.getStatus()).isEqualTo(INTERNAL_SERVER_ERROR_500);
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApisResource_CreateApiWithDefinitionFromUrlTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApisResource_CreateApiWithDefinitionFromUrlTest.java
@@ -18,7 +18,7 @@ package io.gravitee.rest.api.management.v2.rest.resource.api;
 import static io.gravitee.common.http.HttpStatusCode.BAD_REQUEST_400;
 import static io.gravitee.common.http.HttpStatusCode.CREATED_201;
 import static io.gravitee.common.http.HttpStatusCode.FORBIDDEN_403;
-import static io.gravitee.common.http.HttpStatusCode.INTERNAL_SERVER_ERROR_500;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -36,6 +36,7 @@ import io.gravitee.rest.api.model.permissions.RolePermission;
 import io.gravitee.rest.api.model.permissions.RolePermissionAction;
 import io.gravitee.rest.api.service.HttpClientService;
 import io.gravitee.rest.api.service.common.GraviteeContext;
+import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
 import io.gravitee.rest.api.service.spring.ImportConfiguration;
 import io.vertx.core.buffer.Buffer;
 import jakarta.ws.rs.client.Entity;
@@ -215,7 +216,78 @@ public class ApisResource_CreateApiWithDefinitionFromUrlTest extends AbstractRes
     }
 
     @Test
-    public void should_return_internal_server_error_when_http_client_throws() {
+    public void should_return_bad_request_when_remote_returns_error_status() {
+        // Defect A: the remote URL responds with a non-success status (e.g. 404). HttpClientService surfaces this
+        // as a TechnicalManagementException; it must become a clean 4xx, not a 500 leaking the remote response.
+        grantCreatePermission();
+
+        when(httpClientService.request(eq(HttpMethod.GET), eq(TEST_URL), any(), any(), any())).thenThrow(
+            new TechnicalManagementException(" Error on url '" + TEST_URL + "'. Status code: 404. Message: Not Found", null)
+        );
+
+        Response response = rootTarget().request(MediaType.APPLICATION_JSON).post(Entity.text(TEST_URL));
+
+        assertEquals(BAD_REQUEST_400, response.getStatus());
+        String body = response.readEntity(String.class);
+        assertThat(body)
+            .contains("Unable to fetch the API definition")
+            .doesNotContain("io.gravitee", "TechnicalManagementException", "Status code", "404");
+    }
+
+    @Test
+    public void should_return_bad_request_when_remote_host_unreachable() {
+        // Defect B: the remote host cannot be resolved/reached. Must become a clean 4xx without leaking the
+        // UnknownHostException or the failing host.
+        grantCreatePermission();
+
+        when(httpClientService.request(eq(HttpMethod.GET), eq(TEST_URL), any(), any(), any())).thenThrow(
+            new TechnicalManagementException(
+                "Failed to resolve 'nonexistent-host-xyz.invalid'",
+                new java.net.UnknownHostException("nonexistent-host-xyz.invalid")
+            )
+        );
+
+        Response response = rootTarget().request(MediaType.APPLICATION_JSON).post(Entity.text(TEST_URL));
+
+        assertEquals(BAD_REQUEST_400, response.getStatus());
+        String body = response.readEntity(String.class);
+        assertThat(body)
+            .contains("Unable to fetch the API definition")
+            .doesNotContain("io.gravitee", "UnknownHostException", "Failed to resolve", "nonexistent-host");
+    }
+
+    @Test
+    public void should_return_bad_request_when_definition_is_not_a_gravitee_export() {
+        // Defect C: valid JSON that is not a Gravitee export (missing 'api'). Must be a clean 400, not an NPE → 500.
+        grantCreatePermission();
+
+        Buffer buffer = Buffer.buffer("{\"hello\":\"world\"}");
+        when(httpClientService.request(eq(HttpMethod.GET), eq(TEST_URL), any(), any(), any())).thenReturn(buffer);
+
+        Response response = rootTarget().request(MediaType.APPLICATION_JSON).post(Entity.text(TEST_URL));
+
+        assertEquals(BAD_REQUEST_400, response.getStatus());
+        String body = response.readEntity(String.class);
+        assertThat(body).contains("Invalid API definition").doesNotContain("io.gravitee", "NullPointerException");
+    }
+
+    @Test
+    public void should_return_bad_request_when_definition_fails_bean_validation() {
+        // Valid JSON that deserializes into an ExportApiV4 with a non-null 'api' but violates a Bean Validation
+        // constraint (member displayName is @Size(min=1)). Must surface as a clean 400, not a 500.
+        grantCreatePermission();
+
+        Buffer buffer = Buffer.buffer("{\"api\":{\"definitionVersion\":\"V4\"},\"members\":[{\"displayName\":\"\"}]}");
+        when(httpClientService.request(eq(HttpMethod.GET), eq(TEST_URL), any(), any(), any())).thenReturn(buffer);
+
+        Response response = rootTarget().request(MediaType.APPLICATION_JSON).post(Entity.text(TEST_URL));
+
+        assertEquals(BAD_REQUEST_400, response.getStatus());
+        String body = response.readEntity(String.class);
+        assertThat(body).contains("Validation error").doesNotContain("io.gravitee", "ConstraintViolationException");
+    }
+
+    private void grantCreatePermission() {
         when(
             permissionService.hasPermission(
                 GraviteeContext.getExecutionContext(),
@@ -224,13 +296,6 @@ public class ApisResource_CreateApiWithDefinitionFromUrlTest extends AbstractRes
                 RolePermissionAction.CREATE
             )
         ).thenReturn(true);
-
-        when(httpClientService.request(eq(HttpMethod.GET), eq(TEST_URL), any(), any(), any())).thenThrow(
-            new RuntimeException("Connection refused")
-        );
-
-        Response response = rootTarget().request(MediaType.APPLICATION_JSON).post(Entity.text(TEST_URL));
-        assertEquals(INTERNAL_SERVER_ERROR_500, response.getStatus());
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/api/FetchApiDefinitionFromUrlDomainServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/api/FetchApiDefinitionFromUrlDomainServiceImpl.java
@@ -18,8 +18,7 @@ package io.gravitee.apim.infra.domain_service.api;
 import io.gravitee.apim.core.api.domain_service.FetchApiDefinitionFromUrlDomainService;
 import io.gravitee.common.http.HttpMethod;
 import io.gravitee.rest.api.service.HttpClientService;
-import io.gravitee.rest.api.service.exceptions.AbstractManagementException;
-import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
+import io.gravitee.rest.api.service.exceptions.ApiDefinitionFetchException;
 import io.gravitee.rest.api.service.sanitizer.UrlSanitizerUtils;
 import io.vertx.core.buffer.Buffer;
 import java.util.List;
@@ -38,6 +37,7 @@ public class FetchApiDefinitionFromUrlDomainServiceImpl implements FetchApiDefin
 
     @Override
     public String fetch(String url, List<String> whitelist, boolean allowPrivate) {
+        // URL allow-listing runs before the fetch; its UrlForbiddenException (400) must propagate untouched.
         UrlSanitizerUtils.checkAllowed(url, whitelist, allowPrivate);
 
         log.debug("Fetching API definition from URL '{}'", url);
@@ -46,12 +46,12 @@ public class FetchApiDefinitionFromUrlDomainServiceImpl implements FetchApiDefin
             String body = buffer == null ? "" : buffer.toString();
             log.debug("Fetched API definition from URL '{}' ({} bytes)", url, body.length());
             return body;
-        } catch (AbstractManagementException e) {
-            log.warn("Failed to fetch API definition from URL '{}': {}", url, e.getMessage());
-            throw e;
         } catch (RuntimeException e) {
+            // Any failure raised while fetching (non-success status, unreachable host, DNS failure, …) is a
+            // client-fixable problem with the supplied URL, not a server fault. Translate it to a clean 4xx and
+            // keep the cause for server-side logging only — never echo it back to the caller.
             log.warn("Failed to fetch API definition from URL '{}'", url, e);
-            throw new TechnicalManagementException("Failed to fetch API definition from URL '" + url + "'", e);
+            throw new ApiDefinitionFetchException(e);
         }
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/exceptions/ApiDefinitionFetchException.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/exceptions/ApiDefinitionFetchException.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.exceptions;
+
+import io.gravitee.common.http.HttpStatusCode;
+import java.util.Map;
+
+/**
+ * Thrown when the API definition cannot be fetched from a remote URL (the host is unreachable, the
+ * remote responds with a non-success status, etc.).
+ *
+ * <p>The cause is preserved for server-side logging but never surfaced to the caller: the message is a
+ * generic, user-facing string so we don't leak the remote response body, the failing host, or the
+ * underlying exception class through the API error.
+ */
+public class ApiDefinitionFetchException extends AbstractManagementException {
+
+    public ApiDefinitionFetchException(Throwable cause) {
+        super(cause);
+    }
+
+    @Override
+    public int getHttpStatusCode() {
+        return HttpStatusCode.BAD_REQUEST_400;
+    }
+
+    @Override
+    public String getTechnicalCode() {
+        return "api.definition.fetch.failed";
+    }
+
+    @Override
+    public Map<String, String> getParameters() {
+        return null;
+    }
+
+    @Override
+    public String getMessage() {
+        return "Unable to fetch the API definition from the provided URL.";
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/api/FetchApiDefinitionFromUrlDomainServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/api/FetchApiDefinitionFromUrlDomainServiceImplTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.infra.domain_service.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.common.http.HttpMethod;
+import io.gravitee.rest.api.service.HttpClientService;
+import io.gravitee.rest.api.service.exceptions.ApiDefinitionFetchException;
+import io.vertx.core.buffer.Buffer;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class FetchApiDefinitionFromUrlDomainServiceImplTest {
+
+    // A public, allow-listable URL so UrlSanitizerUtils.checkAllowed passes and we exercise the fetch itself.
+    private static final String URL = "https://example.com/api-definition.json";
+
+    private HttpClientService httpClientService;
+    private FetchApiDefinitionFromUrlDomainServiceImpl service;
+
+    @BeforeEach
+    void setUp() {
+        httpClientService = mock(HttpClientService.class);
+        service = new FetchApiDefinitionFromUrlDomainServiceImpl(httpClientService);
+    }
+
+    @Test
+    void should_return_body_when_remote_returns_content() {
+        when(httpClientService.request(eq(HttpMethod.GET), eq(URL), any(), any(), any())).thenReturn(Buffer.buffer("{\"api\":{}}"));
+
+        assertThat(service.fetch(URL, List.of(), false)).isEqualTo("{\"api\":{}}");
+    }
+
+    @Test
+    void should_return_empty_string_when_remote_returns_null_body() {
+        // HttpClientService returns null (e.g. an empty response). The null guard substitutes an empty string so the
+        // downstream parser fails cleanly with a 400 rather than NPE-ing into a 500.
+        when(httpClientService.request(eq(HttpMethod.GET), eq(URL), any(), any(), any())).thenReturn(null);
+
+        assertThat(service.fetch(URL, List.of(), false)).isEmpty();
+    }
+
+    @Test
+    void should_translate_fetch_failure_to_clean_exception() {
+        // Any failure raised while fetching must surface as a clean 4xx without leaking the underlying cause.
+        when(httpClientService.request(eq(HttpMethod.GET), eq(URL), any(), any(), any())).thenThrow(
+            new RuntimeException("Status code: 404. Connection refused")
+        );
+
+        assertThatThrownBy(() -> service.fetch(URL, List.of(), false))
+            .isInstanceOf(ApiDefinitionFetchException.class)
+            .hasMessageNotContainingAny("404", "Connection refused");
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/api/OAIDomainServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/api/OAIDomainServiceImplTest.java
@@ -98,6 +98,32 @@ class OAIDomainServiceImplTest {
         ).isExactlyInstanceOf(SwaggerDescriptorException.class);
     }
 
+    @Test
+    void should_throw_clean_exception_when_remote_url_is_unreachable() {
+        // Given an allowed, syntactically-valid URL whose host refuses the connection. The swagger parser fetches
+        // the URL server-side; allow loopback here so we exercise the fetch failure, not the SSRF guard.
+        when(importConfiguration.isAllowImportFromPrivate()).thenReturn(true);
+        var importSwaggerDescriptor = new ImportSwaggerDescriptorEntity();
+        importSwaggerDescriptor.setPayload("http://127.0.0.1:1/openapi.json");
+
+        // When / Then a fetch failure surfaces as a clean 400 SwaggerDescriptorException, never a 500 leaking internals.
+        assertThatThrownBy(() -> oaiDomainService.convert(ORGANIZATION_ID, ENVIRONMENT_ID, importSwaggerDescriptor, false, false))
+            .isExactlyInstanceOf(SwaggerDescriptorException.class)
+            .hasMessageNotContainingAny("io.swagger", "java.net", "Connection", "ConnectException");
+    }
+
+    @Test
+    void should_throw_clean_exception_when_payload_is_valid_json_but_not_a_spec() {
+        // Given valid JSON that is not an OpenAPI document (parity with the Gravitee-definition non-export case).
+        var importSwaggerDescriptor = new ImportSwaggerDescriptorEntity();
+        importSwaggerDescriptor.setPayload("{ \"hello\": \"world\" }");
+
+        // When / Then it is rejected as a clean 400, never an NPE/500.
+        assertThatThrownBy(() -> oaiDomainService.convert(ORGANIZATION_ID, ENVIRONMENT_ID, importSwaggerDescriptor, false, false))
+            .isExactlyInstanceOf(SwaggerDescriptorException.class)
+            .hasMessageNotContainingAny("io.swagger", "NullPointerException", "java.net");
+    }
+
     @Nested
     @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
     class DeferredResponseValidation {


### PR DESCRIPTION

## Issue

https://gravitee.atlassian.net/browse/APIM-12140
## Description

## What
  v4 remote-URL import (`_import/definition-url`) returned HTTP 500 with leaked exception
  details on fetch/validation failures. Now returns clean, user-facing 4xx.

  - **Fetch failures** (remote 404, unreachable host, DNS) → `400` via new
    `ApiDefinitionFetchException` (generic message, cause kept for server logs only).
  - **Valid JSON that isn't a Gravitee definition** (e.g. `{"hello":"world"}`) → `400`
    "Invalid API definition" instead of an NPE → 500 (`RemoteApiDefinitionParser` now
    rejects a null/missing `api`).

  ## OpenAPI path
  Verified the `_import/swagger` URL path already returns a clean `400` for the same
  failures (no 500/leak); added regression tests to lock it in.

  ## Tests
  Both definition-url resource suites updated (404 / unreachable / non-definition →
  4xx + no leaked internals); new OpenAPI cases in `OAIDomainServiceImplTest`. All green.
## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

