### PR TITLE
chore(master): bump cache, data-cache & redis-cache to async Cache API versions [APIM-13553]

### DIFF
--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/fake/DummyCacheResource.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/fake/DummyCacheResource.java
@@ -15,13 +15,11 @@
  */
 package io.gravitee.apim.integration.tests.fake;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import io.gravitee.gateway.api.ExecutionContext;
 import io.gravitee.gateway.reactive.api.context.GenericExecutionContext;
 import io.gravitee.gateway.reactive.api.context.base.BaseExecutionContext;
-import io.gravitee.policy.cache.CacheResponse;
-import io.gravitee.policy.cache.configuration.SerializationMode;
-import io.gravitee.policy.cache.mapper.CacheResponseMapper;
+import io.gravitee.policy.cache.CachedResponse;
+import io.gravitee.policy.cache.frame.CacheFrame;
 import io.gravitee.policy.cache.resource.CacheElement;
 import io.gravitee.resource.cache.api.Cache;
 import io.gravitee.resource.cache.api.CacheResource;
@@ -33,11 +31,6 @@ import org.junit.jupiter.api.Assertions;
 public class DummyCacheResource extends CacheResource {
 
     private static Cache instance;
-    private static CacheResponseMapper mapper = new CacheResponseMapper();
-
-    static {
-        mapper.setSerializationMode(SerializationMode.TEXT);
-    }
 
     @Override
     public Cache getCache(ExecutionContext executionContext) {
@@ -62,9 +55,10 @@ public class DummyCacheResource extends CacheResource {
         Assertions.assertEquals(expectedSize, ((Map) getDummyCacheInstance().getNativeCache()).size());
     }
 
-    public static CacheResponse getFirstEntry() throws JsonProcessingException {
+    public static CachedResponse getFirstEntry() {
         CacheElement cacheElement = (CacheElement) ((Map) getDummyCacheInstance().getNativeCache()).values().iterator().next();
-        return mapper.readValue(cacheElement.value().toString(), CacheResponse.class);
+        byte[] frame = (byte[]) cacheElement.value();
+        return CacheFrame.decode(frame);
     }
 
     @Override

--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/SharedPolicyGroupV4IntegrationTest.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/SharedPolicyGroupV4IntegrationTest.java
@@ -50,7 +50,7 @@ import io.gravitee.plugin.entrypoint.http.proxy.HttpProxyEntrypointConnectorFact
 import io.gravitee.plugin.policy.PolicyPlugin;
 import io.gravitee.plugin.resource.ResourcePlugin;
 import io.gravitee.policy.cache.CachePolicy;
-import io.gravitee.policy.cache.CacheResponse;
+import io.gravitee.policy.cache.CachedResponse;
 import io.gravitee.policy.cache.configuration.CachePolicyConfiguration;
 import io.gravitee.policy.interrupt.InterruptPolicy;
 import io.gravitee.policy.interrupt.configuration.InterruptPolicyConfiguration;
@@ -268,9 +268,9 @@ class SharedPolicyGroupV4IntegrationTest {
                     .withHeader("X-Request-Header-Outside-1", equalTo("Header Outside 1"))
             );
             DummyCacheResource.checkNumberOfCacheEntries(1);
-            CacheResponse firstEntry = DummyCacheResource.getFirstEntry();
+            CachedResponse firstEntry = DummyCacheResource.getFirstEntry();
             assertThat(firstEntry).isNotNull();
-            assertThat(firstEntry.getContent()).hasToString("response from backend");
+            assertThat(firstEntry.body()).hasToString("response from backend");
         }
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -183,12 +183,12 @@
         <gravitee-policy-assign-content.version>3.1.1</gravitee-policy-assign-content.version>
         <gravitee-policy-assign-metrics.version>3.1.0</gravitee-policy-assign-metrics.version>
         <gravitee-policy-basic-authentication.version>1.6.0</gravitee-policy-basic-authentication.version>
-        <gravitee-policy-cache.version>4.0.0-alpha.1</gravitee-policy-cache.version>
+        <gravitee-policy-cache.version>4.0.0-alpha.4</gravitee-policy-cache.version>
         <gravitee-policy-callout-http.version>7.0.0-alpha.2</gravitee-policy-callout-http.version>
         <gravitee-policy-circuit-breaker.version>2.0.0</gravitee-policy-circuit-breaker.version>
         <gravitee-policy-custom-query-parameters.version>2.0.0</gravitee-policy-custom-query-parameters.version>
         <gravitee-policy-cloud-events.version>1.1.0</gravitee-policy-cloud-events.version>
-        <gravitee-policy-data-cache.version>1.1.0</gravitee-policy-data-cache.version>
+        <gravitee-policy-data-cache.version>2.0.0-alpha.2</gravitee-policy-data-cache.version>
         <gravitee-policy-data-logging-masking.version>3.1.2</gravitee-policy-data-logging-masking.version>
         <gravitee-policy-dynamic-routing.version>1.13.0</gravitee-policy-dynamic-routing.version>
         <gravitee-policy-generate-http-signature.version>1.5.0</gravitee-policy-generate-http-signature.version>
@@ -279,7 +279,7 @@
         <gravitee-resource-auth-provider-http.version>2.0.0-alpha.1</gravitee-resource-auth-provider-http.version>
         <gravitee-resource-auth-provider-inline.version>1.4.0</gravitee-resource-auth-provider-inline.version>
         <gravitee-resource-auth-provider-ldap.version>2.0.1</gravitee-resource-auth-provider-ldap.version>
-        <gravitee-resource-cache-redis.version>4.0.4</gravitee-resource-cache-redis.version>
+        <gravitee-resource-cache-redis.version>5.0.0-alpha.3</gravitee-resource-cache-redis.version>
         <gravitee-resource-oauth2-provider-keycloak.version>4.0.0-alpha.1</gravitee-resource-oauth2-provider-keycloak.version>
         <gravitee-resource-ai-model-text-classification.version>2.2.1</gravitee-resource-ai-model-text-classification.version>
         <gravitee-service-geoip.version>3.0.0</gravitee-service-geoip.version>


### PR DESCRIPTION
## Summary

Part of the **async Cache API** migration epic ([APIM-13553](https://gravitee.atlassian.net/browse/APIM-13553)). Aligns `master` plugin versions with the async Cache API releases. `master` was further behind than `4.12.x` — `policy-cache` also needed bumping here.

| Component | Before | After | Ref |
|-----------|--------|-------|-----|
| `gravitee-policy-cache` | `4.0.0-alpha.1` | `4.0.0-alpha.4` | [policy-cache#101](https://github.com/gravitee-io/gravitee-policy-cache/pull/101) (APIM-13557) |
| `gravitee-policy-data-cache` | `1.1.0` | `2.0.0-alpha.2` | [policy-data-cache#28](https://github.com/gravitee-io/gravitee-policy-data-cache/pull/28) (APIM-13558) |
| `gravitee-resource-cache-redis` | `4.0.4` | `5.0.0-alpha.3` | [resource-cache-redis#72](https://github.com/gravitee-io/gravitee-resource-cache-redis/pull/72) |

## Already aligned on `master` (no change)

- `gravitee-resource-cache-provider-api` → `2.2.0`
- `gravitee-policy-oauth2` → `5.3.0` (includes async migration PR #146, APIM-13700)
- `gravitee-resource-cache` → `3.0.0` (only test validation added in #87; no functional release needed)

## Jira

[APIM-13553](https://gravitee.atlassian.net/browse/APIM-13553)

## Notes

- Targets are **pre-release (alpha)** versions. Companion PR for `4.12.x`: #17431.

[APIM-13553]: https://gravitee.atlassian.net/browse/APIM-13553?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[APIM-13553]: https://gravitee.atlassian.net/browse/APIM-13553?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ