### PR TITLE
fix(mapi): preserve flowExecution on V4 CRD import create

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/model/crd/ApiCRDSpec.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/model/crd/ApiCRDSpec.java
@@ -184,7 +184,7 @@ public class ApiCRDSpec {
      */
     public io.gravitee.definition.model.v4.Api.ApiBuilder<?, ?> toApiDefinitionBuilder() {
         // Currently we can't use MapStruct in core. We will need to discuss as team if we want to introduce a rule to allow MapStruct in core.
-        return io.gravitee.definition.model.v4.Api.builder()
+        var builder = io.gravitee.definition.model.v4.Api.builder()
             .analytics(analytics)
             .apiVersion(version)
             .definitionVersion(DefinitionVersion.V4)
@@ -202,6 +202,10 @@ public class ApiCRDSpec {
             .tags(tags)
             .type(ApiType.valueOf(type))
             .allowedInApiProducts(allowedInApiProducts);
+        if (flowExecution != null) {
+            builder.flowExecution(flowExecution);
+        }
+        return builder;
     }
 
     /**

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/model/factory/ApiModelFactoryTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/model/factory/ApiModelFactoryTest.java
@@ -25,6 +25,8 @@ import io.gravitee.definition.model.DefinitionVersion;
 import io.gravitee.definition.model.v4.ApiType;
 import io.gravitee.definition.model.v4.endpointgroup.Endpoint;
 import io.gravitee.definition.model.v4.endpointgroup.EndpointGroup;
+import io.gravitee.definition.model.v4.flow.execution.FlowExecution;
+import io.gravitee.definition.model.v4.flow.execution.FlowMode;
 import io.gravitee.definition.model.v4.listener.entrypoint.Entrypoint;
 import io.gravitee.definition.model.v4.listener.http.HttpListener;
 import io.gravitee.definition.model.v4.listener.http.Path;
@@ -132,6 +134,27 @@ class ApiModelFactoryTest {
 
         assertThat(api.isAllowMultiJwtOauth2Subscriptions()).isTrue();
         assertThat(api.getApiDefinitionHttpV4().getAllowedInApiProducts()).isTrue();
+    }
+
+    @Test
+    void fromCrd_should_preserve_flowExecution_when_specified() {
+        var flowExecution = new FlowExecution();
+        flowExecution.setMode(FlowMode.BEST_MATCH);
+        flowExecution.setMatchRequired(true);
+        var crd = minimalProxyCrd(true, true).toBuilder().flowExecution(flowExecution).build();
+
+        Api api = ApiModelFactory.fromCrd(crd, ENVIRONMENT_ID);
+
+        assertThat(api.getApiDefinitionHttpV4().getFlowExecution()).isEqualTo(flowExecution);
+    }
+
+    @Test
+    void fromCrd_should_default_flowExecution_when_omitted() {
+        var crd = minimalProxyCrd(true, true);
+
+        Api api = ApiModelFactory.fromCrd(crd, ENVIRONMENT_ID);
+
+        assertThat(api.getApiDefinitionHttpV4().getFlowExecution()).isEqualTo(new FlowExecution());
     }
 
     private static ApiCRDSpec minimalProxyCrd(boolean allowedInApiProducts, boolean allowMultiJwtOauth2Subscriptions) {


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-14210

## Description

The V4 `_import/crd` **create** path dropped the submitted `flowExecution` and persisted defaults (`mode=default, matchRequired=false`); only create was affected, update worked.

- Root cause: the hand-written `ApiCRDSpec.toApiDefinitionBuilder()` never copied `flowExecution` (update maps it via MapStruct, so it was unaffected).
- Fix: add `.flowExecution(...)` to the create-path builder, null-guarded to keep the `@Builder.Default` value when a CRD omits the field.
- HTTP-only — `NativeApi` has no `flowExecution`.
- Same class of bug as `34158fbaf9`, which fixed the export/import path but missed the CRD builder.
- Regression tests added in `ApiModelFactoryTest` (preserved when specified, default retained when omitted).

## Additional context

Reproduction — `PUT .../apis/_import/crd` with a V4 HTTP-proxy CRD containing `"flowExecution": { "mode": "best-match", "matchRequired": true }`:

- Pre-fix: persisted `{ "mode": "default", "matchRequired": false }`
- Post-fix: persisted `{ "mode": "best-match", "matchRequired": true }`

Verified live on `docker/quick-setup/mongodb` against the authoritative MongoDB record.