### PR TITLE
feat(console): show access control on plan form - Frontend

### DIFF
--- a/gravitee-apim-console-webui/src/management/api-products/plans/edit/api-product-plan-edit.component.html
+++ b/gravitee-apim-console-webui/src/management/api-products/plans/edit/api-product-plan-edit.component.html
@@ -33,7 +33,6 @@
         [isTcpApi]="false"
         [isFederated]="false"
         [isNative]="false"
-        [hideAccessControl]="true"
         [showRestrictionStep]="false"
         [planMenuItem]="planMenuItem()!"
         [planStatus]="currentPlanStatus()"

--- a/gravitee-apim-console-webui/src/management/api-products/plans/edit/api-product-plan-edit.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/plans/edit/api-product-plan-edit.component.spec.ts
@@ -42,6 +42,10 @@ describe('ApiProductPlanEditComponent', () => {
   let notifyApiProductChangedSpy: jest.SpyInstance;
   const snackBarService = { error: jest.fn(), success: jest.fn() };
 
+  function flushGroupsRequest(): void {
+    httpTestingController.match({ method: 'GET', url: `${CONSTANTS_TESTING.env.baseURL}/configuration/groups` }).forEach(r => r.flush([]));
+  }
+
   async function setup(
     params: { planId?: string; queryParams?: Record<string, string> } = {},
     permissions: string[] = ['api_product-plan-u', 'api_product-plan-r'],
@@ -79,8 +83,25 @@ describe('ApiProductPlanEditComponent', () => {
   }
 
   afterEach(() => {
+    flushGroupsRequest();
     httpTestingController.verify();
     jest.clearAllMocks();
+  });
+
+  describe('access control', () => {
+    it('shows groups excluded on the general step', fakeAsync(async () => {
+      await setup({ queryParams: { selectedPlanMenuItem: 'API_KEY' } });
+      tick();
+      flushGroupsRequest();
+      fixture.detectChanges();
+      httpTestingController.match(`${CONSTANTS_TESTING.org.v2BaseURL}/plugins/policies/api-key/schema`).forEach(r => r.flush({}));
+      tick();
+      fixture.detectChanges();
+
+      const planForm = await harness.getPlanForm();
+      expect(await planForm.getExcludedGroupsInput()).toBeTruthy();
+      expect(await planForm.getGeneralConditionsInput()).toBeNull();
+    }));
   });
 
   /** Submits the plan form by dispatching submit so ngSubmit runs. */


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-14269

## Description

This PR enables the **Access-Control** section on the **API Product plan** create and edit screens in the Console.

Users can choose which **groups are excluded** from subscribing to a plan. Members of those groups will not be able to subscribe to that plan.

The change is small: we stop hiding a section that already exists in the shared plan form.

Remove `[hideAccessControl]="true"` from the API Product plan edit page.

---

## How it works (for reviewers)

```
api-product-plan-edit
    └── api-plan-form (shared)
            └── plan-edit-general-step
                    └── @if (!hideAccessControl) → "Groups excluded" dropdown
```

1. User opens create or edit plan for an API Product.
2. The page renders `api-plan-form` **without** `hideAccessControl`.
3. The General step loads groups from `GET .../configuration/groups`.
4. User selects excluded groups; values are stored in `excludedGroups` on the plan.
5. On save, create/update API Product plan APIs send `excludedGroups` in the payload (existing behavior).

---

## Files changed

| File | Change |
|------|--------|
| `src/management/api-products/plans/edit/api-product-plan-edit.component.html` | Removed `[hideAccessControl]="true"` |
| `src/management/api-products/plans/edit/api-product-plan-edit.component.spec.ts` | Test + HTTP mock for groups list |




## Additional context


https://github.com/user-attachments/assets/08985cdc-0aab-495b-ba06-05c5291cdc52


