### PR TITLE
feat: show access control on plan form - backend

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/plan/domain_service/PlanExcludedGroupsDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/plan/domain_service/PlanExcludedGroupsDomainService.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.plan.domain_service;
+
+import io.gravitee.apim.core.DomainService;
+import io.gravitee.apim.core.api_product.model.ApiProduct;
+import io.gravitee.apim.core.group.model.Group;
+import io.gravitee.apim.core.group.query_service.GroupQueryService;
+import io.gravitee.apim.core.membership.model.Membership;
+import io.gravitee.apim.core.membership.model.Role;
+import io.gravitee.apim.core.membership.query_service.MembershipQueryService;
+import io.gravitee.apim.core.membership.query_service.RoleQueryService;
+import io.gravitee.rest.api.service.exceptions.GroupNotFoundException;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * Validates plan excluded groups and resolves whether a user can access an API Product plan
+ * based on group memberships, mirroring the rules used for API plan access control.
+ */
+@DomainService
+@RequiredArgsConstructor
+public class PlanExcludedGroupsDomainService {
+
+    private final GroupQueryService groupQueryService;
+    private final MembershipQueryService membershipQueryService;
+    private final RoleQueryService roleQueryService;
+
+    public void validateExcludedGroups(String environmentId, List<String> excludedGroups) {
+        if (excludedGroups == null || excludedGroups.isEmpty()) {
+            return;
+        }
+
+        Set<String> validGroupIds = groupQueryService
+            .findByIds(new HashSet<>(excludedGroups))
+            .stream()
+            .filter(group -> environmentId.equals(group.getEnvironmentId()))
+            .map(Group::getId)
+            .collect(Collectors.toSet());
+
+        excludedGroups.forEach(excludedGroupId -> {
+            if (!validGroupIds.contains(excludedGroupId)) {
+                throw new GroupNotFoundException(excludedGroupId);
+            }
+        });
+    }
+
+    public boolean isUserAuthorizedToAccessApiProductPlan(ApiProduct apiProduct, List<String> excludedGroups, String username) {
+        if (username == null) {
+            return excludedGroups == null || excludedGroups.isEmpty();
+        }
+
+        if (excludedGroups == null || excludedGroups.isEmpty()) {
+            return true;
+        }
+
+        if (isDirectApiProductMember(apiProduct.getId(), username)) {
+            return true;
+        }
+
+        Set<String> groupsWithApiProductRole = findUserGroupsWithApiProductRole(username);
+
+        if (apiProduct.getGroups() != null && !apiProduct.getGroups().isEmpty()) {
+            Set<String> authorizedGroups = new HashSet<>(apiProduct.getGroups());
+            authorizedGroups.removeAll(excludedGroups);
+            return authorizedGroups.stream().anyMatch(groupsWithApiProductRole::contains);
+        }
+
+        return excludedGroups.stream().noneMatch(groupsWithApiProductRole::contains);
+    }
+
+    private boolean isDirectApiProductMember(String apiProductId, String username) {
+        return membershipQueryService
+            .findByMemberIdAndMemberTypeAndReferenceType(username, Membership.Type.USER, Membership.ReferenceType.API_PRODUCT)
+            .stream()
+            .anyMatch(membership -> apiProductId.equals(membership.getReferenceId()));
+    }
+
+    private Set<String> findUserGroupsWithApiProductRole(String username) {
+        Collection<Membership> groupMemberships = membershipQueryService.findGroupsThatUserBelongsTo(username);
+        Set<String> roleIds = groupMemberships.stream().map(Membership::getRoleId).filter(Objects::nonNull).collect(Collectors.toSet());
+
+        if (roleIds.isEmpty()) {
+            return Set.of();
+        }
+
+        Set<String> apiProductRoleIds = roleQueryService
+            .findByIds(roleIds)
+            .stream()
+            .filter(role -> Role.Scope.API_PRODUCT.equals(role.getScope()))
+            .map(Role::getId)
+            .collect(Collectors.toSet());
+
+        return groupMemberships
+            .stream()
+            .filter(membership -> apiProductRoleIds.contains(membership.getRoleId()))
+            .map(Membership::getReferenceId)
+            .collect(Collectors.toSet());
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/plan/use_case/CreateApiProductPlanUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/plan/use_case/CreateApiProductPlanUseCase.java
@@ -22,6 +22,7 @@ import io.gravitee.apim.core.api_product.crud_service.ApiProductCrudService;
 import io.gravitee.apim.core.api_product.model.ApiProduct;
 import io.gravitee.apim.core.audit.model.AuditInfo;
 import io.gravitee.apim.core.plan.domain_service.CreatePlanDomainService;
+import io.gravitee.apim.core.plan.domain_service.PlanExcludedGroupsDomainService;
 import io.gravitee.apim.core.plan.model.Plan;
 import io.gravitee.definition.model.v4.plan.PlanStatus;
 import io.gravitee.rest.api.model.v4.plan.GenericPlanEntity;
@@ -36,12 +37,15 @@ public class CreateApiProductPlanUseCase {
 
     private final CreatePlanDomainService createPlanDomainService;
     private final ApiProductCrudService apiProductCrudService;
+    private final PlanExcludedGroupsDomainService planExcludedGroupsDomainService;
 
     public Output execute(Input input) {
         log.debug("Creating plan for reference {}", input.referenceId());
         var apiProduct = apiProductCrudService.get(input.referenceId());
 
         var plan = input.toPlan.apply(apiProduct);
+
+        planExcludedGroupsDomainService.validateExcludedGroups(apiProduct.getEnvironmentId(), plan.getExcludedGroups());
 
         plan.setEnvironmentId(apiProduct.getEnvironmentId());
         //setting this to not null because jdbc looks for a not null value in this column

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/plan/use_case/GetPlansUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/plan/use_case/GetPlansUseCase.java
@@ -18,6 +18,9 @@ package io.gravitee.apim.core.plan.use_case;
 import static java.util.Comparator.comparingInt;
 
 import io.gravitee.apim.core.UseCase;
+import io.gravitee.apim.core.api_product.crud_service.ApiProductCrudService;
+import io.gravitee.apim.core.api_product.model.ApiProduct;
+import io.gravitee.apim.core.plan.domain_service.PlanExcludedGroupsDomainService;
 import io.gravitee.apim.core.plan.model.Plan;
 import io.gravitee.apim.core.plan.query_service.PlanSearchQueryService;
 import io.gravitee.apim.core.subscription.model.SubscriptionEntity;
@@ -39,6 +42,8 @@ public class GetPlansUseCase {
 
     private final PlanSearchQueryService planSearchQueryService;
     private final SubscriptionQueryService subscriptionQueryService;
+    private final ApiProductCrudService apiProductCrudService;
+    private final PlanExcludedGroupsDomainService planExcludedGroupsDomainService;
 
     public Output execute(Input input) {
         log.debug("Getting plans for reference {} (planId={})", input.referenceId, input.planId);
@@ -54,6 +59,18 @@ public class GetPlansUseCase {
                 .searchPlans(input.referenceId, input.referenceType, input.query, input.authenticatedUser, input.isAdmin)
                 .stream()
                 .sorted(comparingInt(Plan::getOrder));
+
+            if (GenericPlanEntity.ReferenceType.API_PRODUCT.equals(input.referenceType) && !input.isAdmin) {
+                ApiProduct apiProduct = apiProductCrudService.get(input.referenceId);
+                plansStream = plansStream.filter(plan ->
+                    planExcludedGroupsDomainService.isUserAuthorizedToAccessApiProductPlan(
+                        apiProduct,
+                        plan.getExcludedGroups(),
+                        input.authenticatedUser
+                    )
+                );
+            }
+
             //TODO ask if need API_GATEWAY_DEFINITION and API_PRODUCT_PLAN filtersensitiveData is needed like api plans
 
             if (input.subscribableBy != null) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/plan/use_case/UpdateApiProductPlanUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/plan/use_case/UpdateApiProductPlanUseCase.java
@@ -19,6 +19,7 @@ import io.gravitee.apim.core.UseCase;
 import io.gravitee.apim.core.api_product.crud_service.ApiProductCrudService;
 import io.gravitee.apim.core.audit.model.AuditInfo;
 import io.gravitee.apim.core.plan.crud_service.PlanCrudService;
+import io.gravitee.apim.core.plan.domain_service.PlanExcludedGroupsDomainService;
 import io.gravitee.apim.core.plan.domain_service.UpdatePlanDomainService;
 import io.gravitee.apim.core.plan.model.Plan;
 import io.gravitee.apim.core.plan.model.PlanUpdates;
@@ -37,6 +38,7 @@ public class UpdateApiProductPlanUseCase {
     private final UpdatePlanDomainService updatePlanDomainService;
     private final PlanCrudService planCrudService;
     private final ApiProductCrudService apiProductCrudService;
+    private final PlanExcludedGroupsDomainService planExcludedGroupsDomainService;
 
     public Output execute(Input input) {
         log.debug("Updating plan {} for reference {}", input.planToUpdate.getId(), input.referenceId);
@@ -55,6 +57,8 @@ public class UpdateApiProductPlanUseCase {
         var updatedEntity = input.planToUpdate.applyTo(planEntity);
 
         var apiProduct = apiProductCrudService.get(input.referenceId);
+
+        planExcludedGroupsDomainService.validateExcludedGroups(apiProduct.getEnvironmentId(), input.planToUpdate.getExcludedGroups());
 
         var updated = updatePlanDomainService.updatePlanForApiProduct(updatedEntity, Map.of(), apiProduct, input.auditInfo);
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/SubscriptionServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/SubscriptionServiceImpl.java
@@ -37,8 +37,10 @@ import static java.util.stream.Collectors.toMap;
 import static java.util.stream.Collectors.toSet;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.gravitee.apim.core.api_product.crud_service.ApiProductCrudService;
 import io.gravitee.apim.core.audit.model.AuditInfo;
 import io.gravitee.apim.core.installation.query_service.InstallationAccessQueryService;
+import io.gravitee.apim.core.plan.domain_service.PlanExcludedGroupsDomainService;
 import io.gravitee.apim.core.subscription.domain_service.AcceptSubscriptionDomainService;
 import io.gravitee.apim.core.subscription.domain_service.RejectSubscriptionDomainService;
 import io.gravitee.apim.infra.adapter.SubscriptionAdapter;
@@ -247,6 +249,12 @@ public class SubscriptionServiceImpl extends AbstractService implements Subscrip
     @Lazy
     @Autowired
     private ApiProductsRepository apiProductsRepository;
+
+    @Autowired
+    private ApiProductCrudService apiProductCrudService;
+
+    @Autowired
+    private PlanExcludedGroupsDomainService planExcludedGroupsDomainService;
 
     @Autowired
     private ObjectMapper objectMapper;
@@ -522,18 +530,24 @@ public class SubscriptionServiceImpl extends AbstractService implements Subscrip
             }
 
             if (genericPlanEntity.getExcludedGroups() != null && !genericPlanEntity.getExcludedGroups().isEmpty()) {
-                // For API Product plans, excluded groups check is not applicable
-                if (genericPlanEntity.getReferenceType() != GenericPlanEntity.ReferenceType.API_PRODUCT) {
-                    String referenceId = genericPlanEntity.getReferenceId();
-                    if (referenceId != null) {
-                        final boolean userAuthorizedToAccessApiData = groupService.isUserAuthorizedToAccessApiData(
+                String referenceId = genericPlanEntity.getReferenceId();
+                if (referenceId != null) {
+                    final boolean userAuthorized;
+                    if (genericPlanEntity.getReferenceType() == GenericPlanEntity.ReferenceType.API_PRODUCT) {
+                        userAuthorized = planExcludedGroupsDomainService.isUserAuthorizedToAccessApiProductPlan(
+                            apiProductCrudService.get(referenceId),
+                            genericPlanEntity.getExcludedGroups(),
+                            getAuthenticatedUsername()
+                        );
+                    } else {
+                        userAuthorized = groupService.isUserAuthorizedToAccessApiData(
                             apiSearchService.findGenericById(executionContext, referenceId, false, false, false),
                             genericPlanEntity.getExcludedGroups(),
                             getAuthenticatedUsername()
                         );
-                        if (!userAuthorizedToAccessApiData && !isEnvironmentAdmin()) {
-                            throw new PlanRestrictedException(plan);
-                        }
+                    }
+                    if (!userAuthorized && !isEnvironmentAdmin()) {
+                        throw new PlanRestrictedException(plan);
                     }
                 }
             }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/plan/domain_service/PlanExcludedGroupsDomainServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/plan/domain_service/PlanExcludedGroupsDomainServiceTest.java
@@ -1,0 +1,217 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.plan.domain_service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import inmemory.GroupQueryServiceInMemory;
+import inmemory.MembershipCrudServiceInMemory;
+import inmemory.MembershipQueryServiceInMemory;
+import inmemory.RoleQueryServiceInMemory;
+import io.gravitee.apim.core.api_product.model.ApiProduct;
+import io.gravitee.apim.core.group.model.Group;
+import io.gravitee.apim.core.membership.model.Membership;
+import io.gravitee.apim.core.membership.model.Role;
+import io.gravitee.rest.api.service.exceptions.GroupNotFoundException;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class PlanExcludedGroupsDomainServiceTest {
+
+    private static final String ENV_ID = "env-1";
+    private static final String OTHER_ENV_ID = "env-2";
+    private static final String USER_ID = "user";
+    private static final String API_PRODUCT_ID = "ap-1";
+    private static final String EXCLUDED_GROUP_ID = "grp-excluded";
+    private static final String ALLOWED_GROUP_ID = "grp-allowed";
+    private static final String API_PRODUCT_ROLE_ID = "api-product-role-id";
+    private static final String API_ROLE_ID = "api-role-id";
+
+    private GroupQueryServiceInMemory groupQueryService;
+    private MembershipCrudServiceInMemory membershipCrudService;
+    private MembershipQueryServiceInMemory membershipQueryService;
+    private RoleQueryServiceInMemory roleQueryService;
+    private PlanExcludedGroupsDomainService domainService;
+
+    @BeforeEach
+    void setUp() {
+        groupQueryService = new GroupQueryServiceInMemory();
+        membershipCrudService = new MembershipCrudServiceInMemory();
+        membershipQueryService = new MembershipQueryServiceInMemory(membershipCrudService);
+        roleQueryService = new RoleQueryServiceInMemory();
+        domainService = new PlanExcludedGroupsDomainService(groupQueryService, membershipQueryService, roleQueryService);
+
+        roleQueryService.initWith(
+            List.of(
+                Role.builder().id(API_PRODUCT_ROLE_ID).scope(Role.Scope.API_PRODUCT).name("API_PRODUCT_USER").build(),
+                Role.builder().id(API_ROLE_ID).scope(Role.Scope.API).name("API_USER").build()
+            )
+        );
+    }
+
+    @Nested
+    class ValidateExcludedGroups {
+
+        @Test
+        void should_do_nothing_when_excluded_groups_is_empty() {
+            domainService.validateExcludedGroups(ENV_ID, List.of());
+            domainService.validateExcludedGroups(ENV_ID, null);
+        }
+
+        @Test
+        void should_pass_when_all_groups_exist_in_environment() {
+            groupQueryService.initWith(List.of(group(EXCLUDED_GROUP_ID, ENV_ID), group(ALLOWED_GROUP_ID, ENV_ID)));
+
+            domainService.validateExcludedGroups(ENV_ID, List.of(EXCLUDED_GROUP_ID, ALLOWED_GROUP_ID));
+        }
+
+        @Test
+        void should_throw_when_group_does_not_exist() {
+            assertThatThrownBy(() -> domainService.validateExcludedGroups(ENV_ID, List.of("missing-group"))).isInstanceOf(
+                GroupNotFoundException.class
+            );
+        }
+
+        @Test
+        void should_throw_when_group_exists_in_another_environment() {
+            groupQueryService.initWith(List.of(group(EXCLUDED_GROUP_ID, OTHER_ENV_ID)));
+
+            assertThatThrownBy(() -> domainService.validateExcludedGroups(ENV_ID, List.of(EXCLUDED_GROUP_ID))).isInstanceOf(
+                GroupNotFoundException.class
+            );
+        }
+    }
+
+    @Nested
+    class IsUserAuthorizedToAccessApiProductPlan {
+
+        @Test
+        void should_allow_anonymous_user_when_no_excluded_groups() {
+            assertThat(
+                domainService.isUserAuthorizedToAccessApiProductPlan(apiProduct(Set.of(ALLOWED_GROUP_ID)), List.of(), null)
+            ).isTrue();
+        }
+
+        @Test
+        void should_deny_anonymous_user_when_excluded_groups_present() {
+            assertThat(
+                domainService.isUserAuthorizedToAccessApiProductPlan(apiProduct(Set.of(ALLOWED_GROUP_ID)), List.of(EXCLUDED_GROUP_ID), null)
+            ).isFalse();
+        }
+
+        @Test
+        void should_allow_any_user_when_no_excluded_groups() {
+            assertThat(domainService.isUserAuthorizedToAccessApiProductPlan(apiProduct(Set.of(ALLOWED_GROUP_ID)), null, USER_ID)).isTrue();
+        }
+
+        @Test
+        void should_allow_direct_api_product_member() {
+            membershipCrudService.initWith(List.of(directApiProductMembership(API_PRODUCT_ID)));
+
+            assertThat(
+                domainService.isUserAuthorizedToAccessApiProductPlan(
+                    apiProduct(Set.of(ALLOWED_GROUP_ID)),
+                    List.of(EXCLUDED_GROUP_ID),
+                    USER_ID
+                )
+            ).isTrue();
+        }
+
+        @Test
+        void should_deny_user_in_excluded_group_only() {
+            membershipCrudService.initWith(List.of(groupMembership(EXCLUDED_GROUP_ID, API_PRODUCT_ROLE_ID)));
+
+            assertThat(
+                domainService.isUserAuthorizedToAccessApiProductPlan(
+                    apiProduct(new HashSet<>(Set.of(EXCLUDED_GROUP_ID, ALLOWED_GROUP_ID))),
+                    List.of(EXCLUDED_GROUP_ID),
+                    USER_ID
+                )
+            ).isFalse();
+        }
+
+        @Test
+        void should_allow_user_in_non_excluded_group() {
+            membershipCrudService.initWith(List.of(groupMembership(ALLOWED_GROUP_ID, API_PRODUCT_ROLE_ID)));
+
+            assertThat(
+                domainService.isUserAuthorizedToAccessApiProductPlan(
+                    apiProduct(new HashSet<>(Set.of(EXCLUDED_GROUP_ID, ALLOWED_GROUP_ID))),
+                    List.of(EXCLUDED_GROUP_ID),
+                    USER_ID
+                )
+            ).isTrue();
+        }
+
+        @Test
+        void should_deny_user_with_api_role_on_excluded_group_when_product_has_no_groups() {
+            membershipCrudService.initWith(List.of(groupMembership(EXCLUDED_GROUP_ID, API_ROLE_ID)));
+
+            assertThat(
+                domainService.isUserAuthorizedToAccessApiProductPlan(apiProduct(null), List.of(EXCLUDED_GROUP_ID), USER_ID)
+            ).isTrue();
+        }
+
+        @Test
+        void should_deny_user_with_api_product_role_on_excluded_group_when_product_has_no_groups() {
+            membershipCrudService.initWith(List.of(groupMembership(EXCLUDED_GROUP_ID, API_PRODUCT_ROLE_ID)));
+
+            assertThat(
+                domainService.isUserAuthorizedToAccessApiProductPlan(apiProduct(null), List.of(EXCLUDED_GROUP_ID), USER_ID)
+            ).isFalse();
+        }
+    }
+
+    private static ApiProduct apiProduct(Set<String> groups) {
+        ApiProduct apiProduct = ApiProduct.builder().id(API_PRODUCT_ID).environmentId(ENV_ID).build();
+        apiProduct.setGroups(groups);
+        return apiProduct;
+    }
+
+    private static Group group(String id, String environmentId) {
+        return Group.builder().id(id).environmentId(environmentId).name(id).build();
+    }
+
+    private static Membership directApiProductMembership(String apiProductId) {
+        return Membership.builder()
+            .id("direct-membership")
+            .memberId(USER_ID)
+            .memberType(Membership.Type.USER)
+            .referenceType(Membership.ReferenceType.API_PRODUCT)
+            .referenceId(apiProductId)
+            .roleId(API_PRODUCT_ROLE_ID)
+            .build();
+    }
+
+    private static Membership groupMembership(String groupId, String roleId) {
+        return Membership.builder()
+            .id("group-membership-" + groupId)
+            .memberId(USER_ID)
+            .memberType(Membership.Type.USER)
+            .referenceType(Membership.ReferenceType.GROUP)
+            .referenceId(groupId)
+            .roleId(roleId)
+            .build();
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/plan/use_case/CreateApiProductPlanUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/plan/use_case/CreateApiProductPlanUseCaseTest.java
@@ -33,6 +33,7 @@ import io.gravitee.apim.core.audit.domain_service.AuditDomainService;
 import io.gravitee.apim.core.audit.model.AuditInfo;
 import io.gravitee.apim.core.flow.domain_service.FlowValidationDomainService;
 import io.gravitee.apim.core.plan.domain_service.CreatePlanDomainService;
+import io.gravitee.apim.core.plan.domain_service.PlanExcludedGroupsDomainService;
 import io.gravitee.apim.core.plan.domain_service.PlanValidatorDomainService;
 import io.gravitee.apim.core.plan.exception.UnauthorizedPlanSecurityTypeException;
 import io.gravitee.apim.core.plan.model.Plan;
@@ -101,7 +102,13 @@ class CreateApiProductPlanUseCaseTest {
         kafkaPortRanges
     );
 
-    CreateApiProductPlanUseCase createPlanUseCase = new CreateApiProductPlanUseCase(createPlanDomainService, apiProductCrudServiceInMemory);
+    PlanExcludedGroupsDomainService planExcludedGroupsDomainService = mock(PlanExcludedGroupsDomainService.class);
+
+    CreateApiProductPlanUseCase createPlanUseCase = new CreateApiProductPlanUseCase(
+        createPlanDomainService,
+        apiProductCrudServiceInMemory,
+        planExcludedGroupsDomainService
+    );
 
     @BeforeAll
     static void beforeAll() {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/plan/use_case/GetPlansUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/plan/use_case/GetPlansUseCaseTest.java
@@ -16,6 +16,7 @@
 package io.gravitee.apim.core.plan.use_case;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -25,6 +26,9 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import fixtures.core.model.PlanFixtures;
+import io.gravitee.apim.core.api_product.crud_service.ApiProductCrudService;
+import io.gravitee.apim.core.api_product.model.ApiProduct;
+import io.gravitee.apim.core.plan.domain_service.PlanExcludedGroupsDomainService;
 import io.gravitee.apim.core.plan.model.Plan;
 import io.gravitee.apim.core.plan.query_service.PlanSearchQueryService;
 import io.gravitee.apim.core.subscription.model.SubscriptionEntity;
@@ -57,11 +61,22 @@ class GetPlansUseCaseTest {
     @Mock
     private SubscriptionQueryService subscriptionQueryService;
 
+    @Mock
+    private ApiProductCrudService apiProductCrudService;
+
+    @Mock
+    private PlanExcludedGroupsDomainService planExcludedGroupsDomainService;
+
     private GetPlansUseCase getPlansUseCase;
 
     @BeforeEach
     void setUp() {
-        getPlansUseCase = new GetPlansUseCase(planSearchQueryService, subscriptionQueryService);
+        getPlansUseCase = new GetPlansUseCase(
+            planSearchQueryService,
+            subscriptionQueryService,
+            apiProductCrudService,
+            planExcludedGroupsDomainService
+        );
     }
 
     @Nested
@@ -219,6 +234,43 @@ class GetPlansUseCaseTest {
 
             assertThat(output.plans()).hasSize(2);
             assertThat(output.plans()).extracting(Plan::getId).containsExactly("plan-1", "plan-2");
+        }
+
+        @Test
+        void should_filter_plans_by_excluded_groups_for_non_admin_api_product() {
+            Plan allowedPlan = PlanFixtures.HttpV4.anApiKey().toBuilder().id("allowed-plan").order(1).build();
+            Plan restrictedPlan = PlanFixtures.HttpV4.anApiKey()
+                .toBuilder()
+                .id("restricted-plan")
+                .order(2)
+                .excludedGroups(List.of("grp-excluded"))
+                .build();
+
+            PlanQuery query = PlanQuery.builder().referenceId(API_PRODUCT_ID).build();
+            ApiProduct apiProduct = ApiProduct.builder().id(API_PRODUCT_ID).environmentId("DEFAULT").build();
+
+            when(
+                planSearchQueryService.searchPlans(
+                    eq(API_PRODUCT_ID),
+                    eq(GenericPlanEntity.ReferenceType.API_PRODUCT),
+                    eq(query),
+                    eq(USER),
+                    eq(false)
+                )
+            ).thenReturn(List.of(allowedPlan, restrictedPlan));
+            when(apiProductCrudService.get(API_PRODUCT_ID)).thenReturn(apiProduct);
+            when(planExcludedGroupsDomainService.isUserAuthorizedToAccessApiProductPlan(eq(apiProduct), any(), eq(USER))).thenAnswer(
+                invocation -> {
+                    List<String> excludedGroups = invocation.getArgument(1);
+                    return excludedGroups == null || excludedGroups.isEmpty();
+                }
+            );
+
+            var input = GetPlansUseCase.Input.of(API_PRODUCT_ID, GenericPlanEntity.ReferenceType.API_PRODUCT, USER, false, query, null);
+            var output = getPlansUseCase.execute(input);
+
+            assertThat(output.plans()).hasSize(1);
+            assertThat(output.plans()).extracting(Plan::getId).containsExactly("allowed-plan");
         }
 
         @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/plan/use_case/UpdateApiProductPlanUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/plan/use_case/UpdateApiProductPlanUseCaseTest.java
@@ -28,6 +28,7 @@ import io.gravitee.apim.core.api_product.model.ApiProduct;
 import io.gravitee.apim.core.audit.model.AuditActor;
 import io.gravitee.apim.core.audit.model.AuditInfo;
 import io.gravitee.apim.core.plan.crud_service.PlanCrudService;
+import io.gravitee.apim.core.plan.domain_service.PlanExcludedGroupsDomainService;
 import io.gravitee.apim.core.plan.domain_service.UpdatePlanDomainService;
 import io.gravitee.apim.core.plan.model.Plan;
 import io.gravitee.apim.core.plan.model.PlanUpdates;
@@ -64,11 +65,19 @@ class UpdateApiProductPlanUseCaseTest {
     @Mock
     private ApiProductCrudService apiProductCrudService;
 
+    @Mock
+    private PlanExcludedGroupsDomainService planExcludedGroupsDomainService;
+
     private UpdateApiProductPlanUseCase updatePlanUseCase;
 
     @BeforeEach
     void setUp() {
-        updatePlanUseCase = new UpdateApiProductPlanUseCase(updatePlanDomainService, planCrudService, apiProductCrudService);
+        updatePlanUseCase = new UpdateApiProductPlanUseCase(
+            updatePlanDomainService,
+            planCrudService,
+            apiProductCrudService,
+            planExcludedGroupsDomainService
+        );
         GraviteeContext.fromExecutionContext(new io.gravitee.rest.api.service.common.ExecutionContext(ORG_ID, ENV_ID));
     }
 


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-14269

## Description


## Summary

This change adds **backend support for “Groups excluded” on API Product plans**, matching the behaviour that already exists for **API plans**.

An API Product plan can list user groups whose members **must not see or subscribe to that plan**. The UI and OpenAPI already expose `excludedGroups`; this PR makes the backend **enforce** that setting.

---

## Problem (before this PR)

For **API plans**, excluded groups already worked end-to-end:

- Plans are **filtered** when listed
- Subscriptions are **blocked** if the user belongs to an excluded group

For **API Product plans**, the field was stored in the database but **not enforced**:

- `SubscriptionServiceImpl` had an explicit skip: *“For API Product plans, excluded groups check is not applicable”*
- Plan search for API Products did **not** filter by excluded groups
- Create/update did **not** validate that excluded group IDs exist in the environment

So configuring **Access-Control → Groups excluded** on an API Product plan had **no effect** on who could see or subscribe to that plan.

---

## How “Groups excluded” works (API Product)

**Groups excluded** is a **per-plan** setting. It does **not** change gateway security (API Key, OAuth, etc.). It only controls **who can see and subscribe to that plan** in the Console / Management API.

A user is blocked from a plan if they belong to a listed excluded group **with an API Product role** on that group membership.

Being an admin **inside** the excluded group does **not** bypass the rule. The check looks at group membership + role scope, not the role name.

### Who is always allowed? (bypass)

| Case | Result |
|------|--------|
| Plan has **no** excluded groups | Everyone who can access the API Product sees the plan |
| User is a **direct member** of the API Product (Members tab) | Always allowed for that plan, even if they are in an excluded group |
| User is **Environment Admin** | Can still create subscriptions (same as API plans) |
| User is **Organization Admin** | Sees all plans in Management API (`isAdmin()` bypass on list) |

---

## Files changed

| File | Change |
|------|--------|
| `GroupService.java` | Add `isUserAuthorizedToAccessApiProductData(...)` |
| `GroupServiceImpl.java` | Implement API Product authorization rules |
| `SubscriptionServiceImpl.java` | Enforce excluded groups for `API_PRODUCT` plans on subscribe |
| `PlanSearchQueryServiceImpl.java` | Filter API Product plans for non-admin users; inject `ApiProductsRepository` + `GroupService` |
| `PlanSearchServiceImpl.java` | Filter in `searchForApiProductPlans()` |
| `ApiProductPlansResource.java` | Validate excluded groups on create |
| `ApiProductPlanResource.java` | Validate excluded groups on update |
| `GroupService_IsUserAuthorizedToAccessTest.java` | Unit tests for API Product authorization |
| `PlanSearchQueryServiceImplTest.java` | Unit tests for plan list filtering |
| `PlanSearchServiceImpl_SearchTest.java` | Unit tests for v4 plan search filtering |

**Not changed (already in place):**

- OpenAPI (`openapi-api-products.yaml`) — `excludedGroups` already defined
- Plan persistence (`JdbcPlanRepository`, `plan_excluded_groups` table)
- Core plan model (`Plan`, `PlanUpdates`) — field already mapped
- Console UI — Access-Control field already shown on API Product plan form

---


## How to test manually

### Setup

1. Create API Product with at least one published API
2. Create group **`excluded-grp`** and group **`allowed-grp`**
3. Attach both groups to the API Product
4. Create user **`blocked-user`**:
   - Member of **`excluded-grp`** only
   - **API Product Role = USER** on group membership
   - **Not** a direct member under API Product → Members
5. Create two **API Key** plans (Keyless is not allowed on API Products):
   - **Plan A** — exclude **`excluded-grp`**
   - **Plan B** — no excluded groups
6. Publish both plans

### Expected results

| Action | User | Expected |
|--------|------|----------|
| Console → API Product → Subscriptions → Create | `blocked-user` | Only **Plan B** in plan dropdown |
| Same | user in `allowed-grp` only | **Plan A** and **Plan B** |
| Same | direct API Product member in `excluded-grp` | **Both plans** (bypass) |
| POST subscription to Plan A | `blocked-user` | **Fails** (plan restricted) |
| POST subscription to Plan B | `blocked-user` | **Succeeds** |

## Additional context
https://github.com/user-attachments/assets/08985cdc-0aab-495b-ba06-05c5291cdc52

