### PR TITLE
feat(gateway): populate organizationId/environmentId on v4 Log reportable

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/processor/logging/LogInitProcessor.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/processor/logging/LogInitProcessor.java
@@ -80,6 +80,8 @@ public class LogInitProcessor implements Processor {
             .clientIdentifier(request.clientIdentifier())
             .apiId(ctx.getAttribute(ATTR_API))
             .apiName(ctx.getAttribute(ContextAttributes.ATTR_API_NAME))
+            .organizationId(ctx.metrics().getOrganizationId())
+            .environmentId(ctx.metrics().getEnvironmentId())
             .build();
         ctx.metrics().setLog(log);
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/v4/processor/logging/LogInitProcessorTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/v4/processor/logging/LogInitProcessorTest.java
@@ -47,6 +47,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 class LogInitProcessorTest extends AbstractV4ProcessorTest {
 
     protected static final String REQUEST_ID = "requestId";
+    protected static final String ORGANIZATION_ID = "orgId";
+    protected static final String ENVIRONMENT_ID = "envId";
     private final LogInitProcessor cut = LogInitProcessor.instance();
 
     @Mock
@@ -92,6 +94,8 @@ class LogInitProcessorTest extends AbstractV4ProcessorTest {
         when(loggingContext.entrypointRequest()).thenReturn(false);
         when(mockRequest.timestamp()).thenReturn(timestamp);
         when(mockRequest.id()).thenReturn(REQUEST_ID);
+        when(mockMetrics.getOrganizationId()).thenReturn(ORGANIZATION_ID);
+        when(mockMetrics.getEnvironmentId()).thenReturn(ENVIRONMENT_ID);
 
         final TestObserver<Void> obs = cut.execute(ctx).test();
         obs.assertComplete();
@@ -103,6 +107,8 @@ class LogInitProcessorTest extends AbstractV4ProcessorTest {
         assertNotNull(log);
         assertEquals(timestamp, log.getTimestamp());
         assertEquals(REQUEST_ID, log.getRequestId());
+        assertEquals(ORGANIZATION_ID, log.getOrganizationId());
+        assertEquals(ENVIRONMENT_ID, log.getEnvironmentId());
         assertNull(log.getEntrypointRequest());
     }
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-policy/src/main/java/io/gravitee/gateway/reactive/policy/adapter/context/MetricsAdapter.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-policy/src/main/java/io/gravitee/gateway/reactive/policy/adapter/context/MetricsAdapter.java
@@ -341,6 +341,8 @@ public class MetricsAdapter extends Metrics {
             metrics.setLog(
                 io.gravitee.reporter.api.v4.log.Log.builder()
                     .timestamp(log.getTimestamp())
+                    .organizationId(metrics.getOrganizationId())
+                    .environmentId(metrics.getEnvironmentId())
                     .entrypointRequest(log.getClientRequest())
                     .entrypointResponse(log.getClientResponse())
                     .endpointRequest(log.getProxyRequest())

--- a/gravitee-apim-gateway/gravitee-apim-gateway-policy/src/test/java/io/gravitee/gateway/reactive/policy/adapter/context/MetricsAdapterTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-policy/src/test/java/io/gravitee/gateway/reactive/policy/adapter/context/MetricsAdapterTest.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.gateway.reactive.policy.adapter.context;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyDouble;
@@ -35,6 +36,7 @@ import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -596,11 +598,19 @@ class MetricsAdapterTest {
         // Then
         verify(metricsV4, never()).setLog(any());
 
+        // Given an underlying v4 metrics already carrying the scoping fields populated upstream
+        // (DefaultApiReactor.prepareMetrics / SyncApiReactor) — the adapted v4 Log inherits them.
+        when(metricsV4.getOrganizationId()).thenReturn("orgId");
+        when(metricsV4.getEnvironmentId()).thenReturn("envId");
+
         // When
         metricsAdapter.setLog(mock(Log.class));
 
         // Then
-        verify(metricsV4).setLog(any());
+        ArgumentCaptor<io.gravitee.reporter.api.v4.log.Log> captor = ArgumentCaptor.forClass(io.gravitee.reporter.api.v4.log.Log.class);
+        verify(metricsV4).setLog(captor.capture());
+        assertThat(captor.getValue().getOrganizationId()).isEqualTo("orgId");
+        assertThat(captor.getValue().getEnvironmentId()).isEqualTo("envId");
     }
 
     @Test

--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
         <gravitee-plugin.version>5.1.2</gravitee-plugin.version>
         <gravitee-plugin-common-configurations.version>1.3.0</gravitee-plugin-common-configurations.version>
         <gravitee-policy-api.version>1.11.0</gravitee-policy-api.version>
-        <gravitee-reporter-api.version>2.3.0</gravitee-reporter-api.version>
+        <gravitee-reporter-api.version>2.4.0</gravitee-reporter-api.version>
         <gravitee-resource-api.version>1.1.0</gravitee-resource-api.version>
         <gravitee-resource-auth-provider-api.version>1.3.0</gravitee-resource-auth-provider-api.version>
         <gravitee-resource-cache-provider-api.version>2.2.0</gravitee-resource-cache-provider-api.version>


### PR DESCRIPTION
## Summary
- Bump `gravitee-reporter-api` to **2.4.0** (adds `organizationId` + `environmentId` to v4 `Log` / `MessageLog` — released from [gravitee-io/gravitee-reporter-api#134](https://github.com/gravitee-io/gravitee-reporter-api/pull/134)).
- `LogInitProcessor.initLogEntity` — extend the v4 `Log` builder with `.organizationId(ctx.metrics().getOrganizationId())` + `.environmentId(ctx.metrics().getEnvironmentId())`.
- `MetricsAdapter.setLog` (v3 → v4 bridge) — same two builder fields, sourced from the underlying v4 `metrics`.

The values were already on `v4 Metrics` (set up-front by `DefaultApiReactor.prepareMetrics` / `SyncApiReactor`), so both call sites read them from the same source rather than threading them through fresh.

## Why
Downstream reporters that need to scope log records by tenant (notably the OTel reporter, which is about to stamp `gravitee.env.id` as a per-record OTLP attribute) couldn't, because the `Log` reportable didn't carry the env. This PR closes that gap on the producer side — same pattern as `Metrics` follows today.

Without this, the gamma trace explorer drops payload logs at read time because its env filter targets an attribute the OTel reporter has no way to stamp per-call.

## Follow-up PRs
- `gravitee-reactor-message` — same for `MessageLog` in `MessageReporter` (separate repo).
- `gravitee-reporter-otel` — drop static-config org, lazy-init Logger from first record's org, stamp `gravitee.env.id` as a per-record attribute.
- `gravitee-api-management` (gamma read path) — switch the envId filter from `resource.attributes.gravitee.env.id` to `attributes.gravitee.env.id`.

## Test plan
- [ ] CI green
- [x] `LogInitProcessorTest.shouldCreateLogWhenLoggingConditionIsEvaluatedToTrue` extended to stub `mockMetrics.getOrganizationId/EnvironmentId` and assert they flow through onto the captured Log.
- [x] `MetricsAdapterTest.should_delegate_setLog_to_metrics_v4` extended to capture the v4 Log built by the bridge and assert org/env propagation from the underlying v4 metrics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)