### PR TITLE
chore(authz-ui): remove unused buildPolicyEntityRefs helper

### DIFF
--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/shared/__tests__/policy-entity-refs.test.ts
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/shared/__tests__/policy-entity-refs.test.ts
@@ -14,34 +14,7 @@
  * limitations under the License.
  */
 import { describe, expect, it } from 'vitest';
-import type { PolicyResponse } from '../api/authz-api.types';
-import type { EntityInstance } from '../entity.types';
-import { buildPolicyEntityRefs, deriveTargetEntityId, extractEntityRefsFromPolicyText, type PolicyRef } from '../policy-entity-refs';
-
-function makePolicy(overrides: Partial<PolicyResponse> = {}): PolicyResponse {
-    return {
-        id: overrides.id ?? 'pol-1',
-        environmentId: 'DEFAULT',
-        name: overrides.name ?? 'Policy 1',
-        description: null,
-        policyText: overrides.policyText ?? '',
-        type: overrides.type ?? 'API',
-        target: overrides.target ?? null,
-        status: overrides.status ?? 'DRAFT',
-        createdAt: '2025-01-01T00:00:00.000Z',
-        updatedAt: '2025-01-01T00:00:00.000Z',
-        ...overrides,
-    };
-}
-
-function makeEntity(type: string, id: string): EntityInstance {
-    return {
-        uid: { type, id },
-        attrs: {},
-        parents: [],
-        source: 'local',
-    };
-}
+import { deriveTargetEntityId, extractEntityRefsFromPolicyText } from '../policy-entity-refs';
 
 describe('extractEntityRefsFromPolicyText', () => {
     it('returns empty array for empty input', () => {
@@ -74,110 +47,6 @@ describe('extractEntityRefsFromPolicyText', () => {
     it('returns empty list for malformed / non-policy text without throwing', () => {
         const refs = extractEntityRefsFromPolicyText('this is not a valid policy {{{');
         expect(refs).toEqual([]);
-    });
-});
-
-describe('buildPolicyEntityRefs', () => {
-    it('returns an empty map when no entities or policies are given', () => {
-        expect(buildPolicyEntityRefs([], [])).toEqual(new Map());
-        expect(buildPolicyEntityRefs([makeEntity('User', 'alice')], [])).toEqual(new Map([['User::alice', []]]));
-        expect(buildPolicyEntityRefs([], [makePolicy()])).toEqual(new Map());
-    });
-
-    it('returns no matches when policy text mentions other entities', () => {
-        const entities = [makeEntity('User', 'alice')];
-        const policies = [makePolicy({ policyText: 'permit ( principal == User::"bob" );' })];
-        const map = buildPolicyEntityRefs(entities, policies);
-        expect(map.get('User::alice')).toEqual([]);
-    });
-
-    it('finds a single matching policy and includes clause info', () => {
-        const entities = [makeEntity('User', 'alice')];
-        const policies = [
-            makePolicy({
-                id: 'p-read',
-                name: 'Read access',
-                policyText: 'permit ( principal == User::"alice", action == action::"read" );',
-            }),
-        ];
-        const refs = buildPolicyEntityRefs(entities, policies).get('User::alice') as PolicyRef[];
-        expect(refs).toHaveLength(1);
-        expect(refs[0].policy.id).toBe('p-read');
-        expect(refs[0].clauses).toEqual(['principal']);
-    });
-
-    it('finds multiple distinct policies that reference the same entity', () => {
-        const entities = [makeEntity('User', 'alice')];
-        const policies = [
-            makePolicy({ id: 'p1', policyText: 'permit ( principal == User::"alice" );' }),
-            makePolicy({ id: 'p2', policyText: 'forbid ( principal == User::"alice" );' }),
-            makePolicy({ id: 'p3', policyText: 'permit ( principal == User::"bob" );' }),
-        ];
-        const refs = buildPolicyEntityRefs(entities, policies).get('User::alice') as PolicyRef[];
-        expect(refs.map(r => r.policy.id).sort()).toEqual(['p1', 'p2']);
-    });
-
-    it('distinguishes principal vs action vs resource matches', () => {
-        const entities = [makeEntity('User', 'alice'), makeEntity('Endpoint', 'flights')];
-        const policies = [
-            makePolicy({
-                id: 'p1',
-                policyText: `permit (
-                    principal == User::"alice",
-                    action == action::"read",
-                    resource == Endpoint::"flights"
-                );`,
-            }),
-        ];
-        const map = buildPolicyEntityRefs(entities, policies);
-        const aliceRefs = map.get('User::alice') as PolicyRef[];
-        const flightsRefs = map.get('Endpoint::flights') as PolicyRef[];
-        expect(aliceRefs).toHaveLength(1);
-        expect(aliceRefs[0].clauses).toEqual(['principal']);
-        expect(flightsRefs).toHaveLength(1);
-        expect(flightsRefs[0].clauses).toEqual(['resource']);
-    });
-
-    it('records both clause kinds when an entity appears as principal AND resource in one policy', () => {
-        const entities = [makeEntity('User', 'alice')];
-        const policies = [
-            makePolicy({
-                id: 'p1',
-                policyText: `permit (
-                    principal == User::"alice",
-                    action == action::"impersonate",
-                    resource == User::"alice"
-                );`,
-            }),
-        ];
-        const refs = buildPolicyEntityRefs(entities, policies).get('User::alice') as PolicyRef[];
-        expect(refs).toHaveLength(1);
-        expect(refs[0].clauses.sort()).toEqual(['principal', 'resource']);
-    });
-
-    it('handles malformed policy text gracefully (no throw, no false positive)', () => {
-        const entities = [makeEntity('User', 'alice')];
-        const policies = [
-            makePolicy({ id: 'p-bad', policyText: 'this is not a policy at all }}}' }),
-            makePolicy({ id: 'p-good', policyText: 'permit ( principal == User::"alice" );' }),
-        ];
-        const map = buildPolicyEntityRefs(entities, policies);
-        const refs = map.get('User::alice') as PolicyRef[];
-        expect(refs).toHaveLength(1);
-        expect(refs[0].policy.id).toBe('p-good');
-    });
-
-    it('treats list refs (resource in [A::"x", B::"y"]) the same as scalar refs', () => {
-        const entities = [makeEntity('Endpoint', 'a'), makeEntity('Endpoint', 'b')];
-        const policies = [
-            makePolicy({
-                id: 'p1',
-                policyText: 'permit ( resource in [Endpoint::"a", Endpoint::"b"] );',
-            }),
-        ];
-        const map = buildPolicyEntityRefs(entities, policies);
-        expect((map.get('Endpoint::a') as PolicyRef[])[0].policy.id).toBe('p1');
-        expect((map.get('Endpoint::b') as PolicyRef[])[0].policy.id).toBe('p1');
     });
 });
 

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/shared/policy-entity-refs.ts
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/shared/policy-entity-refs.ts
@@ -13,10 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import type { PolicyResponse } from './api/authz-api.types';
-import { formatEntityUid } from './entity-adapter';
 import { canonicalKindOf, deriveServiceType } from './entity-kind-registry';
-import type { EntityInstance } from './entity.types';
 
 export type PolicyClause = 'principal' | 'action' | 'resource';
 
@@ -24,11 +21,6 @@ export interface EntityRefInPolicy {
     readonly type: string;
     readonly id: string;
     readonly clause: PolicyClause;
-}
-
-export interface PolicyRef {
-    readonly policy: PolicyResponse;
-    readonly clauses: PolicyClause[];
 }
 
 const CLAUSE_KEYWORDS: PolicyClause[] = ['principal', 'action', 'resource'];
@@ -93,61 +85,4 @@ export function deriveTargetEntityId(policyText: string | null | undefined): str
         return `${kind}.${server}`;
     }
     return null;
-}
-
-function entityKey(type: string, id: string): string {
-    return `${type}::${id}`;
-}
-
-/**
- * For each entity, find the policies whose GAPL text references it in any
- * clause. Returns a map keyed by `Type::id` so the EntitiesPage can do an
- * O(1) lookup per row.
- *
- * - Policies with malformed `policyText` simply contribute no refs.
- * - Multiple references to the same entity in the same policy are folded
- *   into a single `PolicyRef` whose `clauses` array lists each distinct
- *   clause kind.
- * - Entities with no matching policy still appear in the map with an empty
- *   array, so callers can distinguish "no matches" from "not yet computed".
- */
-export function buildPolicyEntityRefs(entities: readonly EntityInstance[], policies: readonly PolicyResponse[]): Map<string, PolicyRef[]> {
-    const result = new Map<string, PolicyRef[]>();
-    for (const e of entities) {
-        result.set(entityKey(e.uid.type, e.uid.id), []);
-    }
-    if (entities.length === 0 || policies.length === 0) return result;
-
-    const policyRefs: Array<{ policy: PolicyResponse; refs: EntityRefInPolicy[] }> = policies.map(p => ({
-        policy: p,
-        refs: extractEntityRefsFromPolicyText(p.policyText ?? ''),
-    }));
-
-    for (const e of entities) {
-        const key = entityKey(e.uid.type, e.uid.id);
-        const entityUid = formatEntityUid(e.uid);
-        const matches: PolicyRef[] = [];
-
-        for (const { policy, refs } of policyRefs) {
-            const clauseSet = new Set<PolicyClause>();
-            for (const r of refs) {
-                if (r.type === e.uid.type && r.id === e.uid.id) {
-                    clauseSet.add(r.clause);
-                }
-            }
-            // Policy.target.id is the explicit target attachment (e.g. policy created via
-            // "+ Create Policy for LLM" → target.id="llm.gog"). Treat it as a resource-clause
-            // reference even when the policyText body uses the unbound `resource` keyword.
-            if (policy.target?.id === entityUid) {
-                clauseSet.add('resource');
-            }
-            if (clauseSet.size > 0) {
-                matches.push({ policy, clauses: Array.from(clauseSet) });
-            }
-        }
-
-        result.set(key, matches);
-    }
-
-    return result;
 }


### PR DESCRIPTION
## Issue

N/A — dead-code cleanup.

## Description

`buildPolicyEntityRefs` in `shared/policy-entity-refs.ts` had no callers anywhere in the module (only its own test referenced it). This removes:

- `buildPolicyEntityRefs` function
- its `PolicyRef` interface and the `entityKey` private helper
- the now-unused imports (`PolicyResponse`, `EntityInstance`, `formatEntityUid`)
- the `buildPolicyEntityRefs` test suite + its `makeEntity`/`makePolicy` helpers

Kept (still used by the policy adapter in `authz-api.service.ts`):
- `extractEntityRefsFromPolicyText`
- `deriveTargetEntityId`

## Additional context

- `tsc` clean; `vitest` for `policy-entity-refs.test.ts` 12/12 (extract + derive suites); `nx lint` (eslint + license) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)