### PR TITLE
feat: run upgraders contributed by Gamma module plugins

### DIFF
--- a/gravitee-gamma/gravitee-gamma-plugin/gravitee-gamma-plugin-module/gravitee-gamma-plugin-module-handler/src/main/java/io/gravitee/plugin/gamma/internal/GammaModulePluginHandler.java
+++ b/gravitee-gamma/gravitee-gamma-plugin/gravitee-gamma-plugin-module/gravitee-gamma-plugin-module-handler/src/main/java/io/gravitee/plugin/gamma/internal/GammaModulePluginHandler.java
@@ -18,12 +18,17 @@ package io.gravitee.plugin.gamma.internal;
 import static io.gravitee.plugin.gamma.internal.GammaModulePlugin.PLUGIN_TYPE;
 
 import io.gravitee.apim.plugin.gamma.api.GammaModule;
+import io.gravitee.node.api.upgrader.UpgradeRecord;
+import io.gravitee.node.api.upgrader.Upgrader;
+import io.gravitee.node.api.upgrader.UpgraderRepository;
 import io.gravitee.plugin.core.api.AbstractPluginHandler;
 import io.gravitee.plugin.core.api.Plugin;
 import io.gravitee.plugin.core.api.PluginClassLoaderFactory;
 import io.gravitee.plugin.core.api.PluginContextFactory;
 import io.gravitee.plugin.core.internal.AnnotationBasedPluginContextConfigurer;
 import io.gravitee.plugin.gamma.spring.GammaModuleConfiguration;
+import java.util.Comparator;
+import java.util.Date;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.ApplicationContext;
@@ -115,9 +120,47 @@ public class GammaModulePluginHandler extends AbstractPluginHandler {
                     }
                 }
             }
+
+            // The node UpgraderService only collects Upgrader beans from the node context, not a plugin's, so a
+            // Gamma module's upgraders are run here instead, once each, tracked by the shared UpgraderRepository.
+            runPluginUpgraders(plugin, pluginCtx);
         } catch (Exception ex) {
             logger.error("Failed to create plugin context for Gamma module '{}'", plugin.id(), ex);
             pluginContextFactory.remove(plugin);
+        }
+    }
+
+    // A failing upgrader is logged, never propagated, so it does not unload the module.
+    private void runPluginUpgraders(Plugin plugin, ApplicationContext pluginCtx) {
+        try {
+            var upgraders = pluginCtx.getBeansOfType(Upgrader.class).values();
+            if (upgraders.isEmpty()) {
+                return;
+            }
+            UpgraderRepository upgraderRepository = applicationContext.getBean(UpgraderRepository.class);
+            logger.info("Gamma module '{}': running {} contributed upgrader(s)", plugin.id(), upgraders.size());
+            upgraders
+                .stream()
+                .sorted(Comparator.comparingInt(Upgrader::getOrder))
+                .forEach(upgrader -> {
+                    String id = upgrader.identifier();
+                    try {
+                        if (upgraderRepository.findById(id).blockingGet() != null) {
+                            logger.debug("Upgrader '{}' (module '{}') already applied, skipping", id, plugin.id());
+                            return;
+                        }
+                        if (upgrader.upgrade()) {
+                            upgraderRepository.create(new UpgradeRecord(id, new Date())).blockingGet();
+                            logger.info("Upgrader '{}' (module '{}') applied", id, plugin.id());
+                        } else {
+                            logger.error("Upgrader '{}' (module '{}') returned false", id, plugin.id());
+                        }
+                    } catch (Exception e) {
+                        logger.error("Upgrader '{}' (module '{}') failed", id, plugin.id(), e);
+                    }
+                });
+        } catch (Exception e) {
+            logger.error("Failed to run upgraders for Gamma module '{}'", plugin.id(), e);
         }
     }
 

--- a/gravitee-gamma/gravitee-gamma-plugin/gravitee-gamma-plugin-module/gravitee-gamma-plugin-module-handler/src/test/java/io/gravitee/plugin/gamma/internal/GammaModuleHandlerTest.java
+++ b/gravitee-gamma/gravitee-gamma-plugin/gravitee-gamma-plugin-module/gravitee-gamma-plugin-module-handler/src/test/java/io/gravitee/plugin/gamma/internal/GammaModuleHandlerTest.java
@@ -20,6 +20,10 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
+import io.gravitee.node.api.upgrader.UpgradeRecord;
+import io.gravitee.node.api.upgrader.Upgrader;
+import io.gravitee.node.api.upgrader.UpgraderException;
+import io.gravitee.node.api.upgrader.UpgraderRepository;
 import io.gravitee.plugin.api.PluginDeploymentContext;
 import io.gravitee.plugin.api.PluginDeploymentContextFactory;
 import io.gravitee.plugin.core.api.Plugin;
@@ -27,9 +31,13 @@ import io.gravitee.plugin.core.api.PluginClassLoader;
 import io.gravitee.plugin.core.api.PluginClassLoaderFactory;
 import io.gravitee.plugin.core.api.PluginContextFactory;
 import io.gravitee.plugin.core.api.PluginManifest;
+import io.reactivex.rxjava3.core.Maybe;
+import io.reactivex.rxjava3.core.Single;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.net.URL;
+import java.util.Date;
+import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.context.ApplicationContext;
@@ -195,5 +203,78 @@ class GammaModuleHandlerTest {
         handler.handle(plugin);
 
         assertThat(manager.getResourceClass("test-plugin")).isNull();
+    }
+
+    @Test
+    void should_run_contributed_upgrader_once_when_not_applied() throws Exception {
+        Upgrader upgrader = mock(Upgrader.class);
+        when(upgrader.identifier()).thenReturn("module.SomeUpgrader");
+        when(upgrader.getOrder()).thenReturn(1);
+        when(upgrader.upgrade()).thenReturn(true);
+
+        UpgraderRepository upgraderRepository = mock(UpgraderRepository.class);
+        when(applicationContext.getBean(UpgraderRepository.class)).thenReturn(upgraderRepository);
+        when(upgraderRepository.findById("module.SomeUpgrader")).thenReturn(Maybe.empty());
+        when(upgraderRepository.create(any())).thenReturn(Single.just(new UpgradeRecord("module.SomeUpgrader", new Date())));
+
+        handler.handle(aGammaPluginWithUpgrader(upgrader));
+
+        verify(upgrader).upgrade();
+        verify(upgraderRepository).create(any());
+    }
+
+    @Test
+    void should_skip_contributed_upgrader_when_already_applied() throws Exception {
+        Upgrader upgrader = mock(Upgrader.class);
+        when(upgrader.identifier()).thenReturn("module.SomeUpgrader");
+        when(upgrader.getOrder()).thenReturn(1);
+
+        UpgraderRepository upgraderRepository = mock(UpgraderRepository.class);
+        when(applicationContext.getBean(UpgraderRepository.class)).thenReturn(upgraderRepository);
+        when(upgraderRepository.findById("module.SomeUpgrader")).thenReturn(
+            Maybe.just(new UpgradeRecord("module.SomeUpgrader", new Date()))
+        );
+
+        handler.handle(aGammaPluginWithUpgrader(upgrader));
+
+        verify(upgrader, never()).upgrade();
+        verify(upgraderRepository, never()).create(any());
+    }
+
+    @Test
+    void should_not_break_module_when_contributed_upgrader_fails() throws Exception {
+        Upgrader upgrader = mock(Upgrader.class);
+        when(upgrader.identifier()).thenReturn("module.SomeUpgrader");
+        when(upgrader.getOrder()).thenReturn(1);
+        when(upgrader.upgrade()).thenThrow(new UpgraderException(new RuntimeException("boom")));
+
+        UpgraderRepository upgraderRepository = mock(UpgraderRepository.class);
+        when(applicationContext.getBean(UpgraderRepository.class)).thenReturn(upgraderRepository);
+        when(upgraderRepository.findById(anyString())).thenReturn(Maybe.empty());
+
+        handler.handle(aGammaPluginWithUpgrader(upgrader));
+
+        // A failing upgrader is swallowed: the module still loads and registers.
+        assertThat(manager.findAll()).hasSize(1);
+    }
+
+    private Plugin aGammaPluginWithUpgrader(Upgrader upgrader) {
+        Plugin plugin = mock(Plugin.class);
+        PluginManifest manifest = mock(PluginManifest.class);
+        when(plugin.id()).thenReturn("aim");
+        when(plugin.type()).thenReturn("gamma-module");
+        when(plugin.manifest()).thenReturn(manifest);
+        when(plugin.clazz()).thenReturn(AGammaModule.class.getName());
+        when(manifest.version()).thenReturn("1.0.0");
+        when(plugin.deployed()).thenReturn(true);
+        when(plugin.dependencies()).thenReturn(
+            new URL[] { GammaModuleHandlerTest.class.getProtectionDomain().getCodeSource().getLocation() }
+        );
+
+        ApplicationContext pluginCtx = mock(ApplicationContext.class);
+        when(pluginCtx.getBeanDefinitionNames()).thenReturn(new String[0]);
+        when(pluginCtx.getBeansOfType(Upgrader.class)).thenReturn(Map.of("someUpgrader", upgrader));
+        when(pluginContextFactory.create(any(GammaModulePluginHandler.GammaModulePluginContextConfigurer.class))).thenReturn(pluginCtx);
+        return plugin;
     }
 }


### PR DESCRIPTION
Gamma modules had no way to run data migrations at startup. The node's `UpgraderService` collects `Upgrader` beans from the node context, but a Gamma module's beans live in the JAX-RS context, so its upgraders were never picked up.

The handler now runs the upgraders a module contributes itself, right after the plugin context is created. Same tracking as the node (`UpgraderRepository`), so each one runs once. A failing upgrader is logged and skipped instead of breaking the module load.

First user is the AIM module, verified locally end to end (the upgrader runs on startup and the data gets migrated). Unit tests cover the handler: an upgrader runs once, is skipped when already applied, and a failing one doesn't break the module.

https://gravitee.atlassian.net/browse/GMA-537