### PR TITLE
fix: keep v2 api groups as ids for non-kubernetes origin

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/domain_service/ValidateApiCRDDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/domain_service/ValidateApiCRDDomainService.java
@@ -118,6 +118,7 @@ public class ValidateApiCRDDomainService implements Validator<ValidateApiCRDDoma
                     input.auditInfo.environmentId(),
                     input.spec().getGroups(),
                     input.spec().getDefinitionVersion(),
+                    input.spec().getDefinitionContext() != null ? input.spec().getDefinitionContext().getOrigin() : null,
                     Group.GroupEvent.API_CREATE,
                     true
                 )
@@ -129,6 +130,7 @@ public class ValidateApiCRDDomainService implements Validator<ValidateApiCRDDoma
                 new ValidatePortalNotificationDomainService.Input(
                     input.spec().getConsoleNotificationConfiguration(),
                     input.spec().getDefinitionVersion(),
+                    input.spec().getDefinitionContext() != null ? input.spec().getDefinitionContext().getOrigin() : null,
                     sanitizedBuilder.build().getGroups(),
                     input.auditInfo()
                 )

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/use_case/UpdateApiGroupsUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/use_case/UpdateApiGroupsUseCase.java
@@ -59,7 +59,8 @@ public class UpdateApiGroupsUseCase {
         var validationInput = new ValidateGroupsDomainService.Input(
             input.auditInfo().environmentId(),
             input.groups(),
-            api.getDefinitionVersion().getLabel()
+            api.getDefinitionVersion().getLabel(),
+            api.getOriginContext().name()
         );
         var validationResult = validateGroupsDomainService.validateAndSanitize(validationInput);
         Set<String> sanitizedGroups = validationResult.value().map(ValidateGroupsDomainService.Input::groups).orElse(input.groups());

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/application/domain_service/ValidateApplicationCRDDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/application/domain_service/ValidateApplicationCRDDomainService.java
@@ -65,6 +65,7 @@ public class ValidateApplicationCRDDomainService implements Validator<ValidateAp
                     input.auditInfo.environmentId(),
                     input.spec().getGroups(),
                     null,
+                    null,
                     Group.GroupEvent.APPLICATION_CREATE,
                     true
                 )

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/group/domain_service/ValidateGroupsDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/group/domain_service/ValidateGroupsDomainService.java
@@ -23,6 +23,7 @@ import io.gravitee.apim.core.group.model.Group;
 import io.gravitee.apim.core.group.query_service.GroupQueryService;
 import io.gravitee.apim.core.utils.StringUtils;
 import io.gravitee.apim.core.validation.Validator;
+import io.gravitee.definition.model.DefinitionContext;
 import io.gravitee.definition.model.DefinitionVersion;
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -45,15 +46,16 @@ public class ValidateGroupsDomainService implements Validator<ValidateGroupsDoma
         String environmentId,
         Set<String> groups,
         String definitionVersion,
+        String origin,
         Group.GroupEvent groupEvent,
         boolean addDefaultGroups
     ) implements Validator.Input {
-        public Input(String environmentId, Set<String> groups, String definitionVersion) {
-            this(environmentId, groups, definitionVersion, null, false);
+        public Input(String environmentId, Set<String> groups, String definitionVersion, String origin) {
+            this(environmentId, groups, definitionVersion, origin, null, false);
         }
 
         Input sanitized(Set<String> sanitizedGroups) {
-            return new Input(environmentId, sanitizedGroups, definitionVersion, groupEvent, addDefaultGroups);
+            return new Input(environmentId, sanitizedGroups, definitionVersion, origin, groupEvent, addDefaultGroups);
         }
     }
 
@@ -101,7 +103,10 @@ public class ValidateGroupsDomainService implements Validator<ValidateGroupsDoma
         var sanitizedFromIds = noPrimaryOwnerResultFromIds.value().orElse(List.of());
         var sanitizedFromNames = noPrimaryOwnerResultFromNames.value().orElse(List.of());
 
-        if (DefinitionVersion.V2.getLabel().equals(input.definitionVersion)) {
+        if (
+            DefinitionVersion.V2.getLabel().equals(input.definitionVersion) &&
+            DefinitionContext.ORIGIN_KUBERNETES.equalsIgnoreCase(input.origin)
+        ) {
             sanitizedGroups.addAll(sanitizedFromIds.stream().map(Group::getName).toList());
             sanitizedGroups.addAll(sanitizedFromNames.stream().map(Group::getName).toList());
         } else {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/integration/use_case/UpdateIntegrationUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/integration/use_case/UpdateIntegrationUseCase.java
@@ -74,6 +74,7 @@ public class UpdateIntegrationUseCase {
                 input.auditInfo.environmentId(),
                 input.updateFields().groups(),
                 null,
+                null,
                 Group.GroupEvent.API_CREATE,
                 false
             )

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/notification/domain_service/ValidatePortalNotificationDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/notification/domain_service/ValidatePortalNotificationDomainService.java
@@ -20,6 +20,7 @@ import io.gravitee.apim.core.audit.model.AuditInfo;
 import io.gravitee.apim.core.group.domain_service.ValidateGroupsDomainService;
 import io.gravitee.apim.core.utils.CollectionUtils;
 import io.gravitee.apim.core.validation.Validator;
+import io.gravitee.definition.model.DefinitionContext;
 import io.gravitee.rest.api.model.notification.NotificationConfigType;
 import io.gravitee.rest.api.model.notification.PortalNotificationConfigEntity;
 import java.util.ArrayList;
@@ -38,6 +39,7 @@ public class ValidatePortalNotificationDomainService implements Validator<Valida
     public record Input(
         PortalNotificationConfigEntity portalNotificationConfig,
         String definitionVersion,
+        String origin,
         Set<String> allowedGroups,
         AuditInfo auditInfo
     ) implements Validator.Input {}
@@ -58,6 +60,7 @@ public class ValidatePortalNotificationDomainService implements Validator<Valida
                         input.auditInfo.environmentId(),
                         CollectionUtils.stream(consoleNotification.getGroups()).collect(Collectors.toSet()),
                         input.definitionVersion(),
+                        input.origin(),
                         null,
                         false
                     )

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiValidationServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiValidationServiceImpl.java
@@ -107,6 +107,7 @@ public class ApiValidationServiceImpl extends AbstractService implements ApiVali
                     executionContext.getEnvironmentId(),
                     api.getGroups(),
                     api.getGraviteeDefinitionVersion(),
+                    api.getDefinitionContext() != null ? api.getDefinitionContext().getOrigin() : null,
                     Group.GroupEvent.API_CREATE,
                     false
                 )
@@ -118,6 +119,7 @@ public class ApiValidationServiceImpl extends AbstractService implements ApiVali
                 new ValidatePortalNotificationDomainService.Input(
                     api.getConsoleNotificationConfiguration(),
                     api.getGraviteeDefinitionVersion(),
+                    api.getDefinitionContext() != null ? api.getDefinitionContext().getOrigin() : null,
                     api.getGroups(),
                     auditInfo
                 )

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/domain_service/ValidateApiCRDDomainServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/domain_service/ValidateApiCRDDomainServiceTest.java
@@ -136,9 +136,9 @@ class ValidateApiCRDDomainServiceTest {
             )
         ).thenAnswer(call -> Validator.Result.ofValue(call.getArgument(0)));
 
-        when(groupsValidator.validateAndSanitize(new ValidateGroupsDomainService.Input(ENV_ID, any(), null, API_CREATE, true))).thenAnswer(
-            call -> Validator.Result.ofValue(call.getArgument(0))
-        );
+        when(
+            groupsValidator.validateAndSanitize(new ValidateGroupsDomainService.Input(ENV_ID, any(), null, null, API_CREATE, true))
+        ).thenAnswer(call -> Validator.Result.ofValue(call.getArgument(0)));
 
         when(resourceValidator.validateAndSanitize(new ValidateResourceDomainService.Input(ENV_ID, any()))).thenAnswer(call ->
             Validator.Result.ofValue(call.getArgument(0))
@@ -154,7 +154,7 @@ class ValidateApiCRDDomainServiceTest {
 
         when(
             portalNotificationValidator.validateAndSanitize(
-                new ValidatePortalNotificationDomainService.Input(consoleNotificationConfiguration, any(), null, AUDIT_INFO)
+                new ValidatePortalNotificationDomainService.Input(consoleNotificationConfiguration, any(), null, null, AUDIT_INFO)
             )
         ).thenAnswer(call -> Validator.Result.ofValue(call.getArgument(0)));
 
@@ -187,9 +187,9 @@ class ValidateApiCRDDomainServiceTest {
             )
         ).thenAnswer(call -> Validator.Result.ofValue(call.getArgument(0)));
 
-        when(groupsValidator.validateAndSanitize(new ValidateGroupsDomainService.Input(ENV_ID, any(), null, API_CREATE, true))).thenAnswer(
-            call -> Validator.Result.ofValue(call.getArgument(0))
-        );
+        when(
+            groupsValidator.validateAndSanitize(new ValidateGroupsDomainService.Input(ENV_ID, any(), null, null, API_CREATE, true))
+        ).thenAnswer(call -> Validator.Result.ofValue(call.getArgument(0)));
 
         when(resourceValidator.validateAndSanitize(new ValidateResourceDomainService.Input(ENV_ID, any()))).thenAnswer(call ->
             Validator.Result.ofValue(call.getArgument(0))
@@ -205,7 +205,7 @@ class ValidateApiCRDDomainServiceTest {
 
         when(
             portalNotificationValidator.validateAndSanitize(
-                new ValidatePortalNotificationDomainService.Input(consoleNotificationConfiguration, any(), null, AUDIT_INFO)
+                new ValidatePortalNotificationDomainService.Input(consoleNotificationConfiguration, any(), null, null, AUDIT_INFO)
             )
         ).thenAnswer(call -> Validator.Result.ofValue(call.getArgument(0)));
 
@@ -237,9 +237,9 @@ class ValidateApiCRDDomainServiceTest {
             )
         ).thenAnswer(call -> Validator.Result.ofValue(call.getArgument(0)));
 
-        when(groupsValidator.validateAndSanitize(new ValidateGroupsDomainService.Input(ENV_ID, any(), null, API_CREATE, true))).thenAnswer(
-            call -> Validator.Result.ofValue(call.getArgument(0))
-        );
+        when(
+            groupsValidator.validateAndSanitize(new ValidateGroupsDomainService.Input(ENV_ID, any(), null, null, API_CREATE, true))
+        ).thenAnswer(call -> Validator.Result.ofValue(call.getArgument(0)));
 
         when(resourceValidator.validateAndSanitize(new ValidateResourceDomainService.Input(ENV_ID, any()))).thenAnswer(call ->
             Validator.Result.ofValue(call.getArgument(0))
@@ -255,7 +255,7 @@ class ValidateApiCRDDomainServiceTest {
 
         when(
             portalNotificationValidator.validateAndSanitize(
-                new ValidatePortalNotificationDomainService.Input(consoleNotificationConfiguration, any(), null, AUDIT_INFO)
+                new ValidatePortalNotificationDomainService.Input(consoleNotificationConfiguration, any(), null, null, AUDIT_INFO)
             )
         ).thenAnswer(call -> Validator.Result.ofValue(call.getArgument(0)));
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/group/domain_service/ValidateGroupsDomainServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/group/domain_service/ValidateGroupsDomainServiceTest.java
@@ -23,6 +23,7 @@ import inmemory.GroupQueryServiceInMemory;
 import io.gravitee.apim.core.group.model.Group;
 import io.gravitee.apim.core.group.model.Group.GroupEventRule;
 import io.gravitee.apim.core.validation.Validator;
+import io.gravitee.definition.model.DefinitionContext;
 import io.gravitee.definition.model.DefinitionVersion;
 import java.util.List;
 import java.util.Set;
@@ -66,7 +67,14 @@ class ValidateGroupsDomainServiceTest {
     void should_return_warnings_with_group_with_primary_owner_and_sanitize_v2() {
         var givenGroups = Set.of("group-with-po-id", "group-without-po");
 
-        var input = new ValidateGroupsDomainService.Input(ENVIRONMENT, givenGroups, DefinitionVersion.V2.getLabel(), API_CREATE, true);
+        var input = new ValidateGroupsDomainService.Input(
+            ENVIRONMENT,
+            givenGroups,
+            DefinitionVersion.V2.getLabel(),
+            DefinitionContext.ORIGIN_KUBERNETES,
+            API_CREATE,
+            true
+        );
 
         var result = validateGroupsDomainService.validateAndSanitize(input);
 
@@ -90,7 +98,14 @@ class ValidateGroupsDomainServiceTest {
     void should_return_groups_without_default_groups_v2() {
         var givenGroups = Set.of("group-without-po");
 
-        var input = new ValidateGroupsDomainService.Input(ENVIRONMENT, givenGroups, DefinitionVersion.V2.getLabel(), API_CREATE, false);
+        var input = new ValidateGroupsDomainService.Input(
+            ENVIRONMENT,
+            givenGroups,
+            DefinitionVersion.V2.getLabel(),
+            DefinitionContext.ORIGIN_KUBERNETES,
+            API_CREATE,
+            false
+        );
 
         var result = validateGroupsDomainService.validateAndSanitize(input);
 
@@ -102,10 +117,61 @@ class ValidateGroupsDomainServiceTest {
     }
 
     @Test
+    void should_sanitize_v2_groups_as_ids_for_management_origin() {
+        var givenGroups = Set.of("group-without-po");
+
+        var input = new ValidateGroupsDomainService.Input(
+            ENVIRONMENT,
+            givenGroups,
+            DefinitionVersion.V2.getLabel(),
+            DefinitionContext.ORIGIN_MANAGEMENT,
+            API_CREATE,
+            false
+        );
+
+        var result = validateGroupsDomainService.validateAndSanitize(input);
+
+        SoftAssertions.assertSoftly(soft -> {
+            soft.assertThat(result.value()).isNotEmpty();
+            soft.assertThat(result.value()).hasValue(input.sanitized(Set.of("group-without-po-id")));
+            soft.assertThat(result.errors()).isEmpty();
+        });
+    }
+
+    @Test
+    void should_sanitize_v2_groups_as_ids_when_origin_is_null() {
+        var givenGroups = Set.of("group-without-po");
+
+        var input = new ValidateGroupsDomainService.Input(
+            ENVIRONMENT,
+            givenGroups,
+            DefinitionVersion.V2.getLabel(),
+            null,
+            API_CREATE,
+            false
+        );
+
+        var result = validateGroupsDomainService.validateAndSanitize(input);
+
+        SoftAssertions.assertSoftly(soft -> {
+            soft.assertThat(result.value()).isNotEmpty();
+            soft.assertThat(result.value()).hasValue(input.sanitized(Set.of("group-without-po-id")));
+            soft.assertThat(result.errors()).isEmpty();
+        });
+    }
+
+    @Test
     void should_return_warnings_with_group_with_primary_owner_and_sanitize_v4() {
         var givenGroups = Set.of("group-with-po", "group-without-po-id");
 
-        var input = new ValidateGroupsDomainService.Input(ENVIRONMENT, givenGroups, DefinitionVersion.V4.getLabel(), API_CREATE, true);
+        var input = new ValidateGroupsDomainService.Input(
+            ENVIRONMENT,
+            givenGroups,
+            DefinitionVersion.V4.getLabel(),
+            null,
+            API_CREATE,
+            true
+        );
 
         var result = validateGroupsDomainService.validateAndSanitize(input);
 
@@ -129,7 +195,14 @@ class ValidateGroupsDomainServiceTest {
     void should_return_groups_without_default_groups_v4() {
         var givenGroups = Set.of("group-without-po-id");
 
-        var input = new ValidateGroupsDomainService.Input(ENVIRONMENT, givenGroups, DefinitionVersion.V4.getLabel(), API_CREATE, false);
+        var input = new ValidateGroupsDomainService.Input(
+            ENVIRONMENT,
+            givenGroups,
+            DefinitionVersion.V4.getLabel(),
+            null,
+            API_CREATE,
+            false
+        );
 
         var result = validateGroupsDomainService.validateAndSanitize(input);
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/notification/domain_service/ValidatePortalNotificationDomainServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/notification/domain_service/ValidatePortalNotificationDomainServiceTest.java
@@ -69,7 +69,7 @@ class ValidatePortalNotificationDomainServiceTest {
 
     @Test
     void should_validate_null_notification() {
-        var input = new ValidatePortalNotificationDomainService.Input(null, "4.0.0", null, AUDIT_INFO);
+        var input = new ValidatePortalNotificationDomainService.Input(null, "4.0.0", null, null, AUDIT_INFO);
         var result = underTest.validateAndSanitize(input);
 
         verify(groupValidator, never()).validateAndSanitize(any());
@@ -84,7 +84,7 @@ class ValidatePortalNotificationDomainServiceTest {
         when(groupValidator.validateAndSanitize(groupInput)).thenReturn(Validator.Result.ofValue(groupInput));
 
         PortalNotificationConfigEntity notification = portalNotification(NotificationConfigType.PORTAL);
-        var input = new ValidatePortalNotificationDomainService.Input(notification, "4.0.0", null, AUDIT_INFO);
+        var input = new ValidatePortalNotificationDomainService.Input(notification, "4.0.0", null, null, AUDIT_INFO);
 
         var result = underTest.validateAndSanitize(input);
         assertThat(result.value()).isPresent();
@@ -97,7 +97,7 @@ class ValidatePortalNotificationDomainServiceTest {
         when(groupValidator.validateAndSanitize(groupInput)).thenReturn(Validator.Result.ofValue(groupInput));
 
         PortalNotificationConfigEntity notification = portalNotification(NotificationConfigType.GENERIC);
-        var input = new ValidatePortalNotificationDomainService.Input(notification, "4.0.0", null, AUDIT_INFO);
+        var input = new ValidatePortalNotificationDomainService.Input(notification, "4.0.0", null, null, AUDIT_INFO);
 
         var result = underTest.validateAndSanitize(input);
 
@@ -115,7 +115,7 @@ class ValidatePortalNotificationDomainServiceTest {
         when(groupValidator.validateAndSanitize(any())).thenReturn(Validator.Result.ofErrors(List.of(Validator.Error.severe("failed!"))));
 
         PortalNotificationConfigEntity notification = portalNotification(NotificationConfigType.PORTAL);
-        var input = new ValidatePortalNotificationDomainService.Input(notification, "4.0.0", null, AUDIT_INFO);
+        var input = new ValidatePortalNotificationDomainService.Input(notification, "4.0.0", null, null, AUDIT_INFO);
 
         var result = underTest.validateAndSanitize(input);
 
@@ -146,7 +146,7 @@ class ValidatePortalNotificationDomainServiceTest {
 
         PortalNotificationConfigEntity notification = portalNotification(NotificationConfigType.PORTAL);
         notification.setGroups(CollectionUtils.stream(consoleNotificationGroup).toList());
-        var input = new ValidatePortalNotificationDomainService.Input(notification, "4.0.0", allowedGroups, AUDIT_INFO);
+        var input = new ValidatePortalNotificationDomainService.Input(notification, "4.0.0", null, allowedGroups, AUDIT_INFO);
 
         var result = underTest.validateAndSanitize(input);
 
@@ -178,6 +178,6 @@ class ValidatePortalNotificationDomainServiceTest {
     }
 
     private static ValidateGroupsDomainService.Input groupInput(Set<String> groups) {
-        return new ValidateGroupsDomainService.Input(ENVIRONMENT_ID, groups, "4.0.0", null, false);
+        return new ValidateGroupsDomainService.Input(ENVIRONMENT_ID, groups, "4.0.0", null, null, false);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiValidationServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiValidationServiceImplTest.java
@@ -189,6 +189,7 @@ public class ApiValidationServiceImplTest {
                 new ValidatePortalNotificationDomainService.Input(
                     new PortalNotificationConfigEntity(),
                     "2.0.0",
+                    null,
                     Set.of(),
                     new AuditInfo("mock", "mock", null)
                 )


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-14317

## Description

After upgrading to 4.11.9 / 4.10.16 / 4.9.21 / 4.8.28, changing the groups of a V2 API made any further save fail with `These groups [xxx, yyy] do not exist.`

The root cause is in `ValidateGroupsDomainService`: for V2 APIs the resolved groups were always converted to their **names**. That is only correct for the Kubernetes operator flow; for console/management updates the groups must stay as **ids**. Once a group had been persisted by name, the next validation could no longer resolve it and rejected the save.

The validation now maps groups to names **only** for the `kubernetes` origin. The origin is plumbed through `ValidateGroupsDomainService.Input` and its callers (`ApiValidationServiceImpl`, `ValidateApiCRDDomainService`, `UpdateApiGroupsUseCase`, `ValidatePortalNotificationDomainService`).

## Additional context

Reproduction steps from the ticket:
1. Have a V2 API with groups
2. Add or remove a group on the API
3. Perform any other change (e.g. enable logging) and save
4. Before the fix: save fails with `These groups [...] do not exist.`
5. After the fix: save succeeds