### PR TITLE
feat(helm): add Redis resource pool and cluster config to gateway (APIM-13790)

### DIFF
--- a/helm/README.adoc
+++ b/helm/README.adoc
@@ -516,6 +516,19 @@ gateway:
 |`+gateway.ratelimit.redis.password+` |Redis password |`+false+`
 |`+gateway.ratelimit.hazelcast.configPath+` |Hazelcast rate-limit configuration file path |`+${gravitee.home}/config/hazelcast-ratelimit.xml+`
 |`+gateway.ratelimit.hazelcast.port+` |Hazelcast rate-limit member and Kubernetes discovery service port |`+5901+`
+|`+gateway.cacheRedis.maxPoolSize+` |Redis cache resource (cache-redis) max connections per endpoint (gateway-wide, rendered to `resources.cacheRedis`) |`+6+`
+|`+gateway.cacheRedis.maxPoolWaiting+` |Redis cache resource max queued requests waiting for a connection |`+1024+`
+|`+gateway.cacheRedis.poolCleanerInterval+` |Redis cache resource idle-connection cleaner interval (ms) |`+30000+`
+|`+gateway.cacheRedis.poolRecycleTimeout+` |Redis cache resource idle connection recycle timeout (ms) |`+180000+`
+|`+gateway.cacheRedis.maxWaitingHandlers+` |Redis cache resource max queued commands on a connection |`+1024+`
+|`+gateway.cacheRedis.connectTimeout+` |Redis cache resource TCP connect timeout (ms) |`+2000+`
+|`+gateway.ratelimit.redis.cluster.nodes+` |Redis Cluster nodes (`host`/`port`) for cluster-safe rate limiting; mutually exclusive with `sentinel` |`+unset+`
+|`+gateway.aiVectorStoreRedis.maxPoolSize+` |AI vector store Redis resource (ai-vector-store-redis, APIM 4.12+) max connections per endpoint (rendered to `resources.aiVectorStoreRedis`) |`+6+`
+|`+gateway.aiVectorStoreRedis.maxPoolWaiting+` |AI vector store Redis resource max queued requests waiting for a connection |`+1024+`
+|`+gateway.aiVectorStoreRedis.poolCleanerInterval+` |AI vector store Redis resource idle-connection cleaner interval (ms) |`+30000+`
+|`+gateway.aiVectorStoreRedis.poolRecycleTimeout+` |AI vector store Redis resource idle connection recycle timeout (ms) |`+180000+`
+|`+gateway.aiVectorStoreRedis.maxWaitingHandlers+` |AI vector store Redis resource max queued commands on a connection |`+1024+`
+|`+gateway.aiVectorStoreRedis.connectTimeout+` |AI vector store Redis resource TCP connect timeout (ms) |`+2000+`
 |===
 
 

--- a/helm/templates/gateway/gateway-configmap.yaml
+++ b/helm/templates/gateway/gateway-configmap.yaml
@@ -604,6 +604,14 @@ data:
                 port: {{ .port }}
               {{- end }}
           {{- end }}
+          {{- if (not (empty ((.Values.gateway.ratelimit.redis.cluster).nodes))) }}
+          cluster:
+            nodes:
+              {{- range .Values.gateway.ratelimit.redis.cluster.nodes }}
+              - host: {{ .host }}
+                port: {{ .port }}
+              {{- end }}
+          {{- end }}
           {{- if (not (empty (.Values.gateway.ratelimit.redis.operation))) }}
           operation:
             timeout: {{ .Values.gateway.ratelimit.redis.operation.timeout | default "10" }}
@@ -619,6 +627,21 @@ data:
         hazelcast:
           config-path: {{ $hzCfg.configPath | default "${gravitee.home}/config/hazelcast-ratelimit.xml" }}
         {{- end }}
+
+    {{- if or .Values.gateway.cacheRedis .Values.gateway.aiVectorStoreRedis }}
+    # Global connection-pool / timeout settings for Redis-backed resource plugins.
+    # Each block is shared across every resource of that type targeting the same Redis
+    # endpoint (single shared Vert.x client; Vert.x does not support runtime pool resize).
+    resources:
+      {{- if .Values.gateway.cacheRedis }}
+      cacheRedis:
+        {{- toYaml .Values.gateway.cacheRedis | nindent 8 }}
+      {{- end }}
+      {{- if .Values.gateway.aiVectorStoreRedis }}
+      aiVectorStoreRedis:
+        {{- toYaml .Values.gateway.aiVectorStoreRedis | nindent 8 }}
+      {{- end }}
+    {{- end }}
 
     # Sharding tags configuration
     # Allows to define inclusion/exclusion sharding tags to only deploy a part of APIs. To exclude just prefix the tag with '!'.

--- a/helm/tests/gateway/configmap_cache_redis_test.yaml
+++ b/helm/tests/gateway/configmap_cache_redis_test.yaml
@@ -1,0 +1,81 @@
+suite: Test Gateway default configmap - Redis resource pools
+templates:
+  - "gateway/gateway-configmap.yaml"
+tests:
+  - it: Does not render resources block when no Redis resource pool is configured
+    template: gateway/gateway-configmap.yaml
+    asserts:
+      - notMatchRegex:
+          path: data["gravitee.yml"]
+          pattern: "cacheRedis:"
+      - notMatchRegex:
+          path: data["gravitee.yml"]
+          pattern: "aiVectorStoreRedis:"
+  - it: Renders resources.cacheRedis pool settings when configured
+    template: gateway/gateway-configmap.yaml
+    set:
+      gateway:
+        cacheRedis:
+          maxPoolSize: 60
+          maxPoolWaiting: 1024
+          poolCleanerInterval: 30000
+          poolRecycleTimeout: 180000
+          maxWaitingHandlers: 1024
+          connectTimeout: 2000
+    asserts:
+      - matchRegex:
+          path: data["gravitee.yml"]
+          pattern: |
+            resources:
+            \s+cacheRedis:
+            \s+connectTimeout: 2000
+            \s+maxPoolSize: 60
+            \s+maxPoolWaiting: 1024
+            \s+maxWaitingHandlers: 1024
+            \s+poolCleanerInterval: 30000
+            \s+poolRecycleTimeout: 180000
+  - it: Renders only the overridden cacheRedis pool settings
+    template: gateway/gateway-configmap.yaml
+    set:
+      gateway:
+        cacheRedis:
+          maxPoolSize: 60
+    asserts:
+      - matchRegex:
+          path: data["gravitee.yml"]
+          pattern: |
+            resources:
+            \s+cacheRedis:
+            \s+maxPoolSize: 60
+  - it: Renders resources.aiVectorStoreRedis pool settings when configured
+    template: gateway/gateway-configmap.yaml
+    set:
+      gateway:
+        aiVectorStoreRedis:
+          maxPoolSize: 12
+          connectTimeout: 2000
+    asserts:
+      - matchRegex:
+          path: data["gravitee.yml"]
+          pattern: |
+            resources:
+            \s+aiVectorStoreRedis:
+            \s+connectTimeout: 2000
+            \s+maxPoolSize: 12
+  - it: Renders both Redis resource pools under a single resources block
+    template: gateway/gateway-configmap.yaml
+    set:
+      gateway:
+        cacheRedis:
+          maxPoolSize: 60
+        aiVectorStoreRedis:
+          maxPoolSize: 12
+    asserts:
+      - matchRegex:
+          path: data["gravitee.yml"]
+          pattern: |
+            resources:
+            \s+cacheRedis:
+            \s+maxPoolSize: 60
+            \s+aiVectorStoreRedis:
+            \s+maxPoolSize: 12

--- a/helm/tests/gateway/configmap_redis_test.yaml
+++ b/helm/tests/gateway/configmap_redis_test.yaml
@@ -125,6 +125,39 @@ tests:
             \s           port: 26379
             \s         - host: sent2
             \s           port: 26379
+  - it: Set configuration with Redis Cluster nodes
+    template: gateway/gateway-configmap.yaml
+    set:
+      ratelimit:
+        type: redis
+      gateway:
+        ratelimit:
+          redis:
+            host: redis
+            port: 6379
+            cluster:
+              nodes:
+                - host: node1
+                  port: 6379
+                - host: node2
+                  port: 6379
+                - host: node3
+                  port: 6379
+    asserts:
+      - matchRegex:
+          path: data["gravitee.yml"]
+          pattern: |
+            \s   redis:
+            \s     host: redis
+            \s     port: 6379
+            \s     cluster:
+            \s       nodes:
+            \s         - host: node1
+            \s           port: 6379
+            \s         - host: node2
+            \s           port: 6379
+            \s         - host: node3
+            \s           port: 6379
   - it: Set full SSL configuration
     template: gateway/gateway-configmap.yaml
     set:

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -1735,11 +1735,44 @@ gateway:
     #         port: 26379
     #       - host: sentinel2
     #         port: 26379
+    #   # Redis Cluster (cluster-safe rate limiting). Mutually exclusive with sentinel.
+    #   # Enabled implicitly when nodes are set; replicas are never used for rate-limit counters.
+    #   cluster:
+    #     nodes:
+    #       - host: redis-node1
+    #         port: 6379
+    #       - host: redis-node2
+    #         port: 6379
+    #       - host: redis-node3
+    #         port: 6379
     #   operation:
     #     timeout: 10 # in milliseconds
     #   tcp:
     #     connectTimeout: 5000 # in milliseconds
     #     idleTimeout: 0 # in milliseconds
+  # Global connection-pool / timeout settings for the Redis cache resource (cache-redis plugin).
+  # Rendered into gravitee.yml under resources.cacheRedis.*. A single shared Vert.x Redis client
+  # is used for all cache-redis resources pointing at the same endpoint, and Vert.x pools cannot
+  # be resized at runtime, so these are gateway-wide (not per-API) and apply on restart.
+  # Uncomment to override the plugin defaults shown below.
+  # cacheRedis:
+  #   maxPoolSize: 6           # max simultaneous connections per Redis endpoint
+  #   maxPoolWaiting: 1024     # max queued requests waiting for a connection
+  #   poolCleanerInterval: 30000   # idle-connection cleaner interval (ms)
+  #   poolRecycleTimeout: 180000   # idle connection recycle timeout (ms)
+  #   maxWaitingHandlers: 1024 # max queued commands on a connection
+  #   connectTimeout: 2000     # TCP connect timeout (ms)
+  # Global connection-pool / timeout settings for the AI vector store Redis resource
+  # (ai-vector-store-redis plugin, APIM 4.12+). Rendered into gravitee.yml under
+  # resources.aiVectorStoreRedis.*. Same shared-client / gateway-wide semantics as cacheRedis.
+  # Uncomment to override the plugin defaults shown below.
+  # aiVectorStoreRedis:
+  #   maxPoolSize: 6           # max simultaneous connections per Redis endpoint
+  #   maxPoolWaiting: 1024     # max queued requests waiting for a connection
+  #   poolCleanerInterval: 30000   # idle-connection cleaner interval (ms)
+  #   poolRecycleTimeout: 180000   # idle connection recycle timeout (ms)
+  #   maxWaitingHandlers: 1024 # max queued commands on a connection
+  #   connectTimeout: 2000     # TCP connect timeout (ms)
   management:
       http:
       #  url: "https://bridge.example.com:18092"


### PR DESCRIPTION
## What

Adds the Helm gateway configuration for the new Redis-backed resource pools and Redis Cluster rate limiting introduced in APIM 4.12.x. All settings render into the gateway `gravitee.yml` and are unset by default (zero behavior change for existing deployments).

Relates to: APIM-13790 (epic APIM-13553 — Rewrite Redis Cache Resource with Vert.x client), plus APIM-14146 (Redis Cluster) and APIM-14271 (ai-vector-store-redis).

## Changes

- **`resources.cacheRedis.*`** (cache-redis plugin global pool) — rendered from `gateway.cacheRedis.*`. Six gateway-wide pool/timeout keys (`maxPoolSize` 6, `maxPoolWaiting` 1024, `poolCleanerInterval` 30000, `poolRecycleTimeout` 180000, `maxWaitingHandlers` 1024, `connectTimeout` 2000). These moved out of per-API config because a single shared Vert.x client is used per Redis endpoint and Vert.x pools cannot be resized at runtime (cache-redis PR #82 / `RedisCacheGlobalOptions`).
- **`resources.aiVectorStoreRedis.*`** (ai-vector-store-redis plugin global pool, APIM 4.12+) — rendered from `gateway.aiVectorStoreRedis.*`. Same six keys/defaults, mirroring cache-redis (APIM-14271).
- **`ratelimit.redis.cluster.nodes[]`** — rendered from `gateway.ratelimit.redis.cluster.nodes[]` (host/port), mirroring the existing `sentinel` block. Enables cluster-safe rate limiting (APIM-14146); cluster mode is enabled implicitly by node presence (`useReplicas` is forced `NEVER` by the gateway for counter consistency, so it is not exposed).
- `values.yaml` documented (commented) blocks, `README.adoc` value-table rows, and helm-unittest coverage.

## Tests

`helm unittest -f 'tests/gateway/*.yaml' .` → **57 suites / 282 tests pass**, including new cases for both resource pools (full/partial/combined) and the rate-limit cluster block.

## Notes / caveats

- ⚠️ **`aiVectorStoreRedis`** is based on `gravitee-resource-ai-vector-store-redis` PR #19, which is **still in code review** (breaking change, 4.12-only). The prefix `resources.aiVectorStoreRedis.` is a test-guarded constant in that PR but is not yet merged — if it is renamed before merge, this Helm mapping must be updated to match (mismatched keys silently fall back to defaults).
- The distribution `gravitee.yml` already documents the `ratelimit.redis.cluster` stub; it does not yet carry `resources.cacheRedis.*` / `resources.aiVectorStoreRedis.*` doc stubs (optional follow-up, out of scope here).
