### PR TITLE
feat(portal-next): allow editing invitation roles

### DIFF
--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-invitation-edit-dialog/application-invitation-edit-dialog.component.harness.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-invitation-edit-dialog/application-invitation-edit-dialog.component.harness.ts
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ComponentHarness } from '@angular/cdk/testing';
+import { MatButtonHarness } from '@angular/material/button/testing';
+import { MatSelectHarness } from '@angular/material/select/testing';
+
+export class ApplicationInvitationEditDialogHarness extends ComponentHarness {
+  static readonly hostSelector = 'app-application-invitation-edit-dialog';
+
+  private readonly locateRoleSelect = this.locatorFor(MatSelectHarness.with({ selector: '[data-testid="edit-invitation-role-select"]' }));
+  private readonly locateCancelButton = this.locatorFor(
+    MatButtonHarness.with({ selector: '[data-testid="edit-invitation-cancel-button"]' }),
+  );
+  private readonly locateSaveButton = this.locatorFor(MatButtonHarness.with({ selector: '[data-testid="edit-invitation-save-button"]' }));
+  private readonly locateRolesError = this.locatorForOptional('[data-testid="edit-invitation-roles-error"]');
+  private readonly locateSubmitError = this.locatorForOptional('[data-testid="edit-invitation-submit-error"]');
+
+  async getRoleValueText(): Promise<string> {
+    return (await this.locateRoleSelect()).getValueText();
+  }
+
+  async getRoleOptionTexts(): Promise<string[]> {
+    const select = await this.locateRoleSelect();
+    await select.open();
+    return Promise.all((await select.getOptions()).map(option => option.getText()));
+  }
+
+  async selectRole(role: string): Promise<void> {
+    const select = await this.locateRoleSelect();
+    await select.open();
+    await select.clickOptions({ text: role });
+  }
+
+  async clickCancel(): Promise<void> {
+    return (await this.locateCancelButton()).click();
+  }
+
+  async clickSave(): Promise<void> {
+    return (await this.locateSaveButton()).click();
+  }
+
+  async isSaveDisabled(): Promise<boolean> {
+    return (await this.locateSaveButton()).isDisabled();
+  }
+
+  async getRolesErrorText(): Promise<string | null> {
+    const error = await this.locateRolesError();
+    return error ? error.text() : null;
+  }
+
+  async getSubmitErrorText(): Promise<string | null> {
+    const error = await this.locateSubmitError();
+    return error ? error.text() : null;
+  }
+}

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-invitation-edit-dialog/application-invitation-edit-dialog.component.html
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-invitation-edit-dialog/application-invitation-edit-dialog.component.html
@@ -1,0 +1,88 @@
+<!--
+
+    Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<h2 mat-dialog-title i18n="@@editApplicationInvitationDialogTitle">Edit Invitation</h2>
+
+<mat-dialog-content class="application-invitation-edit-dialog">
+  <p class="application-invitation-edit-dialog__description next-gen-body" i18n="@@editApplicationInvitationDialogDescription">
+    Update application role for <span class="next-gen-body-strong">{{ invitationEmail }}</span
+    >.
+  </p>
+
+  @if (rolesResource.isLoading()) {
+    <div class="application-invitation-edit-dialog__loading" aria-live="polite" data-testid="edit-invitation-roles-loading">
+      <mat-progress-spinner diameter="20" mode="indeterminate" />
+      <span class="next-gen-small" i18n="@@editApplicationInvitationRolesLoading">Loading roles...</span>
+    </div>
+  } @else if (rolesResource.error()) {
+    <p
+      class="application-invitation-edit-dialog__error next-gen-small"
+      role="alert"
+      data-testid="edit-invitation-roles-error"
+      i18n="@@editApplicationInvitationRolesError"
+    >
+      An error occurred while loading application roles. Please try again.
+    </p>
+  } @else {
+    <mat-form-field appearance="outline" class="application-invitation-edit-dialog__field">
+      <mat-label i18n="@@editApplicationInvitationRoleLabel">Invitation Role</mat-label>
+      <mat-select
+        [formControl]="roleControl"
+        data-testid="edit-invitation-role-select"
+        aria-label="Invitation role"
+        i18n-aria-label="@@editApplicationInvitationRoleAriaLabel"
+      >
+        @for (role of assignableRoles(); track role.name) {
+          <mat-option [value]="role.name">{{ role.name }}</mat-option>
+        }
+      </mat-select>
+      @if (roleControl.hasError('required') && roleControl.touched) {
+        <mat-error i18n="@@editApplicationInvitationRoleRequired">Application role is required.</mat-error>
+      }
+    </mat-form-field>
+  }
+
+  @if (submitError(); as error) {
+    <p class="application-invitation-edit-dialog__error next-gen-small" data-testid="edit-invitation-submit-error" role="alert">
+      {{ error }}
+    </p>
+  }
+</mat-dialog-content>
+
+<mat-dialog-actions align="end">
+  <button
+    mat-stroked-button
+    type="button"
+    [disabled]="isSubmitting()"
+    (click)="onCancel()"
+    data-testid="edit-invitation-cancel-button"
+    i18n="@@editApplicationInvitationCancelButton"
+  >
+    Cancel
+  </button>
+  <button
+    mat-flat-button
+    color="primary"
+    type="button"
+    [disabled]="!canSubmit()"
+    (click)="onSubmit()"
+    data-testid="edit-invitation-save-button"
+    i18n="@@editApplicationInvitationSaveButton"
+  >
+    Save
+  </button>
+</mat-dialog-actions>

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-invitation-edit-dialog/application-invitation-edit-dialog.component.scss
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-invitation-edit-dialog/application-invitation-edit-dialog.component.scss
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@use '../../../../scss/theme' as app-theme;
+
+.application-invitation-edit-dialog {
+  display: flex;
+  width: 480px;
+  max-width: 100%;
+  flex-direction: column;
+  gap: 16px;
+  padding-top: app-theme.$form-field-container-vertical-padding;
+
+  &__description {
+    margin: 0;
+    color: app-theme.$paragraph-color;
+  }
+
+  &__field {
+    width: 100%;
+  }
+
+  &__loading {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    color: app-theme.$paragraph-color;
+  }
+
+  &__error {
+    margin: 0;
+    color: app-theme.$error-main-color;
+  }
+}

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-invitation-edit-dialog/application-invitation-edit-dialog.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-invitation-edit-dialog/application-invitation-edit-dialog.component.spec.ts
@@ -1,0 +1,170 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { provideHttpClient } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+
+import {
+  ApplicationInvitationEditDialogComponent,
+  ApplicationInvitationEditDialogData,
+} from './application-invitation-edit-dialog.component';
+import { ApplicationInvitationEditDialogHarness } from './application-invitation-edit-dialog.component.harness';
+import { APPLICATION_PRIMARY_OWNER_ROLE_NAME, ApplicationRole } from '../../../../entities/application/application';
+import { ConfigService } from '../../../../services/config.service';
+import { TESTING_BASE_URL } from '../../../../testing/app-testing.module';
+
+const APPLICATION_ID = 'app-1';
+const INVITATION_ID = 'invitation-1';
+const ROLES_URL = `${TESTING_BASE_URL}/configuration/applications/roles`;
+const INVITATION_URL = `${TESTING_BASE_URL}/applications/${APPLICATION_ID}/invitations/${INVITATION_ID}`;
+
+const DIALOG_DATA: ApplicationInvitationEditDialogData = {
+  applicationId: APPLICATION_ID,
+  invitationId: INVITATION_ID,
+  invitationEmail: 'alice@example.com',
+  currentRole: 'USER',
+};
+
+const APPLICATION_ROLES: ApplicationRole[] = [
+  { id: APPLICATION_PRIMARY_OWNER_ROLE_NAME, name: APPLICATION_PRIMARY_OWNER_ROLE_NAME, default: false, system: true },
+  { id: 'EMPTY', name: '', default: false, system: false },
+  { id: 'OWNER', name: 'OWNER', default: false, system: false },
+  { id: 'USER', name: 'USER', default: true, system: false },
+];
+
+describe('ApplicationInvitationEditDialogComponent', () => {
+  let fixture: ComponentFixture<ApplicationInvitationEditDialogComponent>;
+  let harness: ApplicationInvitationEditDialogHarness;
+  let httpTestingController: HttpTestingController;
+  let dialogRef: { close: jest.Mock };
+
+  async function init(
+    data: ApplicationInvitationEditDialogData = DIALOG_DATA,
+    roles: ApplicationRole[] | null = APPLICATION_ROLES,
+    createHarness = true,
+  ): Promise<void> {
+    dialogRef = { close: jest.fn() };
+
+    await TestBed.configureTestingModule({
+      imports: [ApplicationInvitationEditDialogComponent],
+      providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        provideNoopAnimations(),
+        { provide: ConfigService, useValue: { baseURL: TESTING_BASE_URL } },
+        { provide: MAT_DIALOG_DATA, useValue: data },
+        { provide: MatDialogRef, useValue: dialogRef },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ApplicationInvitationEditDialogComponent);
+    httpTestingController = TestBed.inject(HttpTestingController);
+
+    fixture.detectChanges();
+    if (roles) {
+      flushRoles(roles);
+      await fixture.whenStable();
+      fixture.detectChanges();
+    }
+    if (createHarness) {
+      harness = await TestbedHarnessEnvironment.harnessForFixture(fixture, ApplicationInvitationEditDialogHarness);
+    }
+  }
+
+  function flushRoles(roles: ApplicationRole[] = APPLICATION_ROLES): void {
+    const req = httpTestingController.expectOne(ROLES_URL);
+    expect(req.request.method).toBe('GET');
+    req.flush({ data: roles });
+  }
+
+  afterEach(() => httpTestingController.verify());
+
+  it('should preselect current role and keep save disabled while unchanged', async () => {
+    await init();
+
+    expect(await harness.getRoleValueText()).toBe('USER');
+    expect(await harness.isSaveDisabled()).toBe(true);
+  });
+
+  it('should offer only assignable roles', async () => {
+    await init();
+
+    expect(await harness.getRoleOptionTexts()).toEqual(['OWNER', 'USER']);
+  });
+
+  it('should enable save when role changes', async () => {
+    await init();
+
+    await harness.selectRole('OWNER');
+
+    expect(await harness.isSaveDisabled()).toBe(false);
+  });
+
+  it('should update invitation role and close dialog on success', async () => {
+    await init();
+
+    await harness.selectRole('OWNER');
+    await harness.clickSave();
+    fixture.detectChanges();
+
+    const req = httpTestingController.expectOne(INVITATION_URL);
+    expect(req.request.method).toBe('PUT');
+    expect(req.request.body).toEqual({ role: 'OWNER' });
+    req.flush({ id: INVITATION_ID, email: 'alice@example.com', role: 'OWNER' });
+    await fixture.whenStable();
+
+    expect(dialogRef.close).toHaveBeenCalledWith(true);
+  });
+
+  it('should close dialog without update when cancelled', async () => {
+    await init();
+
+    await harness.clickCancel();
+
+    expect(dialogRef.close).toHaveBeenCalledWith(false);
+    httpTestingController.expectNone(INVITATION_URL);
+  });
+
+  it('should keep dialog open and show inline error when update fails', async () => {
+    await init();
+
+    await harness.selectRole('OWNER');
+    await harness.clickSave();
+    fixture.detectChanges();
+
+    httpTestingController.expectOne(INVITATION_URL).flush({ message: 'Server error' }, { status: 500, statusText: 'Error' });
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    expect(dialogRef.close).not.toHaveBeenCalled();
+    expect(await harness.getSubmitErrorText()).toContain('An error occurred while updating the invitation role');
+    expect(await harness.isSaveDisabled()).toBe(false);
+  });
+
+  it('should show recoverable roles loading error', async () => {
+    await init(DIALOG_DATA, null, false);
+
+    httpTestingController.expectOne(ROLES_URL).flush({ message: 'Server error' }, { status: 500, statusText: 'Error' });
+    await fixture.whenStable();
+    fixture.detectChanges();
+    harness = await TestbedHarnessEnvironment.harnessForFixture(fixture, ApplicationInvitationEditDialogHarness);
+
+    expect(await harness.getRolesErrorText()).toContain('An error occurred while loading application roles');
+  });
+});

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-invitation-edit-dialog/application-invitation-edit-dialog.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-invitation-edit-dialog/application-invitation-edit-dialog.component.ts
@@ -1,0 +1,107 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Component, computed, DestroyRef, inject, signal } from '@angular/core';
+import { rxResource, takeUntilDestroyed, toSignal } from '@angular/core/rxjs-interop';
+import { FormControl, ReactiveFormsModule, Validators } from '@angular/forms';
+import { MatButtonModule } from '@angular/material/button';
+import { MAT_DIALOG_DATA, MatDialogModule, MatDialogRef } from '@angular/material/dialog';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+import { MatSelectModule } from '@angular/material/select';
+
+import { isAssignableApplicationRole } from '../../../../entities/application/application';
+import { ApplicationInvitationService } from '../../../../services/application-invitation.service';
+import { ApplicationService } from '../../../../services/application.service';
+
+export interface ApplicationInvitationEditDialogData {
+  applicationId: string;
+  invitationId: string;
+  invitationEmail: string;
+  currentRole: string;
+}
+
+@Component({
+  selector: 'app-application-invitation-edit-dialog',
+  imports: [MatButtonModule, MatDialogModule, MatFormFieldModule, MatProgressSpinnerModule, MatSelectModule, ReactiveFormsModule],
+  templateUrl: './application-invitation-edit-dialog.component.html',
+  styleUrl: './application-invitation-edit-dialog.component.scss',
+})
+export class ApplicationInvitationEditDialogComponent {
+  private readonly applicationInvitationService = inject(ApplicationInvitationService);
+  private readonly applicationService = inject(ApplicationService);
+  private readonly destroyRef = inject(DestroyRef);
+  private readonly dialogRef = inject(MatDialogRef<ApplicationInvitationEditDialogComponent, boolean>);
+  private readonly data: ApplicationInvitationEditDialogData = inject(MAT_DIALOG_DATA);
+
+  readonly invitationEmail = this.data.invitationEmail;
+  readonly roleControl = new FormControl(this.data.currentRole, { nonNullable: true, validators: [Validators.required] });
+  readonly submitError = signal<string | null>(null);
+  readonly isSubmitting = signal(false);
+
+  private readonly selectedRole = toSignal(this.roleControl.valueChanges, {
+    initialValue: this.roleControl.value,
+  });
+
+  protected readonly rolesResource = rxResource({
+    stream: () => this.applicationService.getApplicationRoles(),
+  });
+
+  readonly assignableRoles = computed(() => (this.rolesResource.value() ?? []).filter(isAssignableApplicationRole));
+
+  readonly canSubmit = computed(() => {
+    const selectedRole = this.selectedRole();
+    return (
+      !this.isSubmitting() &&
+      this.rolesResource.hasValue() &&
+      selectedRole !== this.data.currentRole &&
+      this.assignableRoles().some(role => role.name === selectedRole)
+    );
+  });
+
+  onCancel(): void {
+    this.dialogRef.close(false);
+  }
+
+  onSubmit(): void {
+    this.roleControl.markAsTouched();
+    const role = this.roleControl.value;
+
+    if (!this.canSubmit()) {
+      return;
+    }
+
+    this.isSubmitting.set(true);
+    this.submitError.set(null);
+    this.roleControl.disable({ emitEvent: false });
+
+    this.applicationInvitationService
+      .updateApplicationInvitation(this.data.applicationId, this.data.invitationId, { role })
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: () => {
+          this.isSubmitting.set(false);
+          this.dialogRef.close(true);
+        },
+        error: () => {
+          this.isSubmitting.set(false);
+          this.roleControl.enable({ emitEvent: false });
+          this.submitError.set(
+            $localize`:@@editApplicationInvitationRoleError:An error occurred while updating the invitation role. Please try again.`,
+          );
+        },
+      });
+  }
+}

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-invitations/application-tab-invitations.component.harness.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-invitations/application-tab-invitations.component.harness.ts
@@ -81,4 +81,12 @@ export class ApplicationTabInvitationsComponentHarness extends ComponentHarness 
   public async clickDeleteInvitation(): Promise<void> {
     return (await this.getDeleteInvitationButton())!.click();
   }
+
+  public async getEditInvitationButton(): Promise<MatButtonHarness | null> {
+    return (await this.locatePaginatedTable())?.getActionButton('edit') ?? null;
+  }
+
+  public async clickEditInvitation(): Promise<void> {
+    return (await this.getEditInvitationButton())!.click();
+  }
 }

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-invitations/application-tab-invitations.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-invitations/application-tab-invitations.component.spec.ts
@@ -40,6 +40,10 @@ import { fakeUserApplicationPermissions } from '../../../../entities/permission/
 import { ConfigService } from '../../../../services/config.service';
 import { TESTING_BASE_URL } from '../../../../testing/app-testing.module';
 import { ApplicationInvitationCreateDialogComponent } from '../application-invitation-create-dialog/application-invitation-create-dialog.component';
+import {
+  ApplicationInvitationEditDialogComponent,
+  ApplicationInvitationEditDialogData,
+} from '../application-invitation-edit-dialog/application-invitation-edit-dialog.component';
 
 describe('ApplicationTabInvitationsComponent', () => {
   let fixture: ComponentFixture<ApplicationTabInvitationsComponent>;
@@ -332,6 +336,52 @@ describe('ApplicationTabInvitationsComponent', () => {
     expect(emailIcon).not.toBeNull();
     expect(email.textContent.trim()).toBe('bob@example.com');
     expect((await roleCell!.text()).trim()).toBe('POC');
+  });
+
+  describe('edit action', () => {
+    it('should not show edit button when user lacks MEMBER[U] permission', async () => {
+      const harness = await flush(fakeApplicationInvitationsResponse([fakeApplicationInvitation()]));
+
+      expect(await harness.getEditInvitationButton()).toBeNull();
+    });
+
+    it('should show edit button when user has MEMBER[U] permission', async () => {
+      fixture.componentRef.setInput('userApplicationPermissions', fakeUserApplicationPermissions({ MEMBER: ['R', 'U'] }));
+
+      const harness = await flush(fakeApplicationInvitationsResponse([fakeApplicationInvitation()]));
+
+      expect(await harness.getEditInvitationButton()).not.toBeNull();
+    });
+
+    it('should open edit dialog and reload invitations after successful update', async () => {
+      fixture.componentRef.setInput('userApplicationPermissions', fakeUserApplicationPermissions({ MEMBER: ['R', 'U'] }));
+      const afterClosed = new Subject<boolean>();
+      const invitation = fakeApplicationInvitation({ id: 'invitation-1', email: 'alice@example.com', role: 'USER' });
+      const openDialogSpy = jest.spyOn(fixture.debugElement.injector.get(MatDialog), 'open').mockReturnValue({
+        afterClosed: () => afterClosed.asObservable(),
+      } as MatDialogRef<ApplicationInvitationEditDialogComponent, boolean>);
+      const harness = await flush(fakeApplicationInvitationsResponse([invitation]));
+
+      await harness.clickEditInvitation();
+      fixture.detectChanges();
+
+      expect(openDialogSpy).toHaveBeenCalledWith(ApplicationInvitationEditDialogComponent, {
+        data: {
+          applicationId,
+          invitationId: invitation.id,
+          invitationEmail: invitation.email,
+          currentRole: invitation.role,
+        } satisfies ApplicationInvitationEditDialogData,
+      });
+
+      afterClosed.next(true);
+      afterClosed.complete();
+      fixture.detectChanges();
+      httpTestingController
+        .expectOne(req => req.url.includes('invitations/_search'))
+        .flush(fakeApplicationInvitationsResponse([fakeApplicationInvitation({ id: invitation.id, role: 'OWNER' })]));
+      await fixture.whenStable();
+    });
   });
 
   describe('delete action', () => {

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-invitations/application-tab-invitations.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-invitations/application-tab-invitations.component.ts
@@ -36,6 +36,10 @@ import {
   ApplicationInvitationCreateDialogComponent,
   ApplicationInvitationCreateDialogData,
 } from '../application-invitation-create-dialog/application-invitation-create-dialog.component';
+import {
+  ApplicationInvitationEditDialogComponent,
+  ApplicationInvitationEditDialogData,
+} from '../application-invitation-edit-dialog/application-invitation-edit-dialog.component';
 
 interface InvitationTableRow {
   id: string;
@@ -90,6 +94,7 @@ export class ApplicationTabInvitationsComponent {
 
   readonly canRead = computed(() => this.userApplicationPermissions().MEMBER?.includes('R') ?? false);
   readonly canCreate = computed(() => this.userApplicationPermissions().MEMBER?.includes('C') ?? false);
+  readonly canUpdate = computed(() => this.userApplicationPermissions().MEMBER?.includes('U') ?? false);
   readonly canDelete = computed(() => this.userApplicationPermissions().MEMBER?.includes('D') ?? false);
   readonly hasSearchTerm = computed(() => this.searchTerm().trim().length > 0);
   readonly searchFilters = computed<ApplicationInvitationsSearchFilters>(() => {
@@ -97,18 +102,28 @@ export class ApplicationTabInvitationsComponent {
     return email ? { email } : {};
   });
 
-  readonly actions = computed<TableAction<InvitationTableRow>[]>(() =>
-    this.canDelete()
-      ? [
-          {
-            id: 'delete',
-            icon: 'delete_outline',
-            ariaLabel: $localize`:@@deleteApplicationInvitationAriaLabel:Delete invitation`,
-            color: 'warn',
-          },
-        ]
-      : [],
-  );
+  readonly actions = computed<TableAction<InvitationTableRow>[]>(() => {
+    const actions: TableAction<InvitationTableRow>[] = [];
+
+    if (this.canUpdate()) {
+      actions.push({
+        id: 'edit',
+        icon: 'edit',
+        ariaLabel: $localize`:@@editApplicationInvitationAriaLabel:Edit invitation role`,
+      });
+    }
+
+    if (this.canDelete()) {
+      actions.push({
+        id: 'delete',
+        icon: 'delete_outline',
+        ariaLabel: $localize`:@@deleteApplicationInvitationAriaLabel:Delete invitation`,
+        color: 'warn',
+      });
+    }
+
+    return actions;
+  });
 
   readonly requestParams = computed<InvitationsRequestParams | null>(() =>
     this.canRead()
@@ -173,7 +188,9 @@ export class ApplicationTabInvitationsComponent {
   }
 
   onActionClick({ actionId, row }: { actionId: string; row: InvitationTableRow }): void {
-    if (actionId === 'delete') {
+    if (actionId === 'edit') {
+      this.openEditInvitationDialog(row);
+    } else if (actionId === 'delete') {
       this.openDeleteConfirmation(row);
     }
   }
@@ -191,6 +208,29 @@ export class ApplicationTabInvitationsComponent {
       .afterClosed()
       .pipe(
         filter((invitationsCreated): invitationsCreated is true => invitationsCreated === true),
+        tap(() => this.invitationsResource.reload()),
+        takeUntilDestroyed(this.destroyRef),
+      )
+      .subscribe();
+  }
+
+  private openEditInvitationDialog(invitation: InvitationTableRow): void {
+    this.error.set(null);
+    this.matDialog
+      .open<ApplicationInvitationEditDialogComponent, ApplicationInvitationEditDialogData, boolean>(
+        ApplicationInvitationEditDialogComponent,
+        {
+          data: {
+            applicationId: this.applicationId(),
+            invitationId: invitation.id,
+            invitationEmail: invitation.email,
+            currentRole: invitation.role,
+          },
+        },
+      )
+      .afterClosed()
+      .pipe(
+        filter(invitationUpdated => invitationUpdated === true),
         tap(() => this.invitationsResource.reload()),
         takeUntilDestroyed(this.destroyRef),
       )

--- a/gravitee-apim-portal-webui-next/src/entities/application/application-invitation.fixture.ts
+++ b/gravitee-apim-portal-webui-next/src/entities/application/application-invitation.fixture.ts
@@ -15,7 +15,12 @@
  */
 import { isFunction } from 'lodash';
 
-import { ApplicationInvitation, ApplicationInvitationsCreateInput, ApplicationInvitationsResponse } from './application-invitation';
+import {
+  ApplicationInvitation,
+  ApplicationInvitationsCreateInput,
+  ApplicationInvitationsResponse,
+  ApplicationInvitationUpdateInput,
+} from './application-invitation';
 
 export function fakeApplicationInvitation(
   modifier?: Partial<ApplicationInvitation> | ((base: ApplicationInvitation) => ApplicationInvitation),
@@ -54,6 +59,15 @@ export function fakeApplicationInvitationsCreateInput(
     recipients: [{ email: 'alice@example.com' }],
     role: 'USER',
     notify: false,
+    ...modifier,
+  };
+}
+
+export function fakeApplicationInvitationUpdateInput(
+  modifier?: Partial<ApplicationInvitationUpdateInput>,
+): ApplicationInvitationUpdateInput {
+  return {
+    role: 'OWNER',
     ...modifier,
   };
 }

--- a/gravitee-apim-portal-webui-next/src/entities/application/application-invitation.ts
+++ b/gravitee-apim-portal-webui-next/src/entities/application/application-invitation.ts
@@ -29,6 +29,10 @@ export interface ApplicationInvitationsCreateInput {
   notify: boolean;
 }
 
+export interface ApplicationInvitationUpdateInput {
+  role: string;
+}
+
 export interface ApplicationInvitationsSearchFilters {
   email?: string;
 }

--- a/gravitee-apim-portal-webui-next/src/services/application-invitation.service.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/services/application-invitation.service.spec.ts
@@ -18,8 +18,10 @@ import { TestBed } from '@angular/core/testing';
 
 import { ApplicationInvitationService } from './application-invitation.service';
 import {
+  fakeApplicationInvitation,
   fakeApplicationInvitationsCreateInput,
   fakeApplicationInvitationsResponse,
+  fakeApplicationInvitationUpdateInput,
 } from '../entities/application/application-invitation.fixture';
 import { AppTestingModule, TESTING_BASE_URL } from '../testing/app-testing.module';
 
@@ -94,5 +96,22 @@ describe('ApplicationInvitationService', () => {
       r => r.url === `${TESTING_BASE_URL}/applications/${applicationId}/invitations/${invitationId}` && r.method === 'DELETE',
     );
     req.flush(null, { status: 204, statusText: 'No Content' });
+  });
+
+  it('should update application invitation role', done => {
+    const invitationId = 'invitation-1';
+    const input = fakeApplicationInvitationUpdateInput({ role: 'OWNER' });
+    const response = fakeApplicationInvitation({ id: invitationId, role: 'OWNER' });
+
+    service.updateApplicationInvitation(applicationId, invitationId, input).subscribe(res => {
+      expect(res).toEqual(response);
+      done();
+    });
+
+    const req = httpTestingController.expectOne(
+      r => r.url === `${TESTING_BASE_URL}/applications/${applicationId}/invitations/${invitationId}` && r.method === 'PUT',
+    );
+    expect(req.request.body).toEqual(input);
+    req.flush(response);
   });
 });

--- a/gravitee-apim-portal-webui-next/src/services/application-invitation.service.ts
+++ b/gravitee-apim-portal-webui-next/src/services/application-invitation.service.ts
@@ -19,9 +19,11 @@ import { Observable } from 'rxjs';
 
 import { ConfigService } from './config.service';
 import {
+  ApplicationInvitation,
   ApplicationInvitationsCreateInput,
   ApplicationInvitationsResponse,
   ApplicationInvitationsSearchFilters,
+  ApplicationInvitationUpdateInput,
 } from '../entities/application/application-invitation';
 
 @Injectable({
@@ -55,5 +57,16 @@ export class ApplicationInvitationService {
 
   deleteApplicationInvitation(applicationId: string, invitationId: string): Observable<void> {
     return this.http.delete<void>(`${this.configService.baseURL}/applications/${applicationId}/invitations/${invitationId}`);
+  }
+
+  updateApplicationInvitation(
+    applicationId: string,
+    invitationId: string,
+    input: ApplicationInvitationUpdateInput,
+  ): Observable<ApplicationInvitation> {
+    return this.http.put<ApplicationInvitation>(
+      `${this.configService.baseURL}/applications/${applicationId}/invitations/${invitationId}`,
+      input,
+    );
   }
 }


### PR DESCRIPTION


## Issue

https://gravitee.atlassian.net/browse/APIM-14344

## Description

- Add frontend support for editing pending application invitation roles.
- Introduce a dedicated invitation role edit dialog, aligned with the existing member role edit flow.
- Add invitation update API call and wire the edit action into the invitations table.



https://github.com/user-attachments/assets/e9f4dec7-6d5f-4878-9291-cd988ec412d2

