### PR TITLE
fix(console): preserve user's expanded folders after publish/delete a…

### DIFF
--- a/gravitee-apim-console-webui/src/portal/components/flat-tree/flat-tree.component.html
+++ b/gravitee-apim-console-webui/src/portal/components/flat-tree/flat-tree.component.html
@@ -21,6 +21,7 @@
     class="flat-tree"
     [dataSource]="tree()"
     [childrenAccessor]="childrenAccessor"
+    [expansionKey]="getNodeId"
     cdkDropList
     (cdkDropListDropped)="onDrop($event)"
   >

--- a/gravitee-apim-console-webui/src/portal/components/flat-tree/flat-tree.component.ts
+++ b/gravitee-apim-console-webui/src/portal/components/flat-tree/flat-tree.component.ts
@@ -186,7 +186,7 @@ export class FlatTreeComponent {
     return this.getPublishActionState(node).tooltip;
   }
 
-  treeBase = viewChild(MatTree);
+  treeBase = viewChild<MatTree<SectionNode, string>>(MatTree);
   contextMenuTrigger = viewChild('contextMenuTrigger', { read: MatMenuTrigger });
   contextMenuAnchor = viewChild('contextMenuTrigger', { read: ElementRef });
   contextMenuNode = signal<FlatTreeNode | null>(null);
@@ -194,6 +194,12 @@ export class FlatTreeComponent {
   canCreate: boolean;
   canUpdate: boolean;
   canDelete: boolean;
+
+  // Used by MatTree's [expansionKey] so expansion state is keyed by id, not object reference,
+  // and therefore preserved across [dataSource] refreshes (after publish/delete/move).
+  readonly getNodeId = (node: SectionNode): string => node.id;
+
+  private treeInitialized = false;
 
   constructor() {
     this.canCreate = this.permissionService.hasAnyMatching(['environment-documentation-c']);
@@ -203,12 +209,12 @@ export class FlatTreeComponent {
     effect(() => {
       const nodes = this.tree();
       const tree = this.treeBase();
+      if (nodes.length === 0 || !tree || this.treeInitialized) return;
 
-      if (nodes.length > 0 && tree) {
-        queueMicrotask(() => {
-          tree.expandAll();
-        });
-      }
+      queueMicrotask(() => {
+        tree.expandAll();
+        this.treeInitialized = true;
+      });
     });
   }
 


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/EXT-126

## Description

### Summary
Folders in the portal navigation tree now keep their collapsed/expanded state after publish, unpublish, delete, or move actions. Previously any such action forced the whole tree open again, making users lose their place in large trees. Initial page load still opens everything by default.

### Video

Video presenting preserved tree expansion:

https://github.com/user-attachments/assets/b563e993-b64e-4249-8d22-451e2c7586e3

