### PR TITLE
fix(console): fix sidebar navigation race condition for Observability and Analytics

### DIFF
--- a/gravitee-apim-console-webui/src/components/gio-side-nav/gio-side-nav.component.spec.ts
+++ b/gravitee-apim-console-webui/src/components/gio-side-nav/gio-side-nav.component.spec.ts
@@ -26,7 +26,7 @@ import {
   LICENSE_CONFIGURATION_TESTING,
 } from '@gravitee/ui-particles-angular';
 import { ActivatedRoute } from '@angular/router';
-import { of } from 'rxjs';
+import { of, Subject } from 'rxjs';
 
 import { GioSideNavComponent, SIDE_NAV_GROUP_ID } from './gio-side-nav.component';
 import { GioSideNavModule } from './gio-side-nav.module';
@@ -251,6 +251,73 @@ describe('GioSideNavComponent', () => {
 
       const apiProductsItem = fixture.componentInstance.mainMenuItems.find(item => item.displayName === 'API Products');
       expect(apiProductsItem).toBeDefined();
+    });
+  });
+
+  describe('navigation race condition regression (APIM-14285)', () => {
+    it('should set currentEnv before environmentSettingsService.get resolves so menu paths use correct env hrid', async () => {
+      const envSettingsSubject = new Subject<{ apiScore: { enabled: boolean } }>();
+      const envHrid = 'my-env';
+
+      await TestBed.configureTestingModule({
+        declarations: [GioSideNavComponent],
+        imports: [NoopAnimationsModule, GioTestingModule, GioSideNavModule, MatIconTestingModule],
+        providers: [
+          {
+            provide: GioPermissionService,
+            useValue: { hasAnyMatching: () => true },
+          },
+          {
+            provide: Constants,
+            useFactory: () => {
+              const constants = CONSTANTS_TESTING;
+              constants.org.settings = {
+                ...constants.org.settings,
+                licenseExpirationNotification: { enabled: true },
+              };
+              constants.org.currentEnv = { id: 'DEFAULT', name: 'default', hrids: [envHrid], organizationId: 'org' } as any;
+              constants.org.environments = [{ id: 'DEFAULT', name: 'default', hrids: [envHrid], organizationId: 'org' }];
+              return constants;
+            },
+          },
+          {
+            provide: EnvironmentSettingsService,
+            useValue: { get: () => envSettingsSubject.asObservable() },
+          },
+          { provide: 'LicenseConfiguration', useValue: LICENSE_CONFIGURATION_TESTING },
+          { provide: ActivatedRoute, useValue: { params: of({ envHrid }) } },
+          { provide: GioMenuSearchService, useValue: menuSearchService },
+        ],
+      })
+        .overrideProvider(InteractivityChecker, {
+          useValue: { isFocusable: () => true, isTabbable: () => true },
+        })
+        .compileComponents();
+
+      const fix = TestBed.createComponent(GioSideNavComponent);
+      const ctrl = TestBed.inject(HttpTestingController);
+
+      fix.detectChanges();
+      ctrl.expectOne(`${LICENSE_CONFIGURATION_TESTING.resourceURL}`).flush({ tier: '', features: [], packs: [], expiresAt: new Date() });
+
+      // Settings haven't resolved yet — menu built without envSettings
+      const observabilityBefore = fix.componentInstance.mainMenuItems.find(i => i.displayName === 'Observability');
+      expect(observabilityBefore?.routerBasePath).toContain(envHrid);
+
+      // Now resolve env settings
+      envSettingsSubject.next({ apiScore: { enabled: true } });
+      fix.detectChanges();
+
+      // After settings resolve, menu is rebuilt — paths must still use correct env hrid
+      const observability = fix.componentInstance.mainMenuItems.find(i => i.displayName === 'Observability');
+      const analytics = fix.componentInstance.mainMenuItems.find(i => i.displayName === 'Analytics');
+      const kafka = fix.componentInstance.mainMenuItems.find(i => i.displayName === 'Kafka');
+
+      expect(observability?.routerBasePath).toBe(`/${envHrid}/observability`);
+      expect(analytics?.routerBasePath).toBe(`/${envHrid}/analytics`);
+      expect(kafka?.routerBasePath).toBe(`/${envHrid}/clusters`);
+
+      ctrl.verify();
     });
   });
 

--- a/gravitee-apim-console-webui/src/components/gio-side-nav/gio-side-nav.component.ts
+++ b/gravitee-apim-console-webui/src/components/gio-side-nav/gio-side-nav.component.ts
@@ -15,8 +15,8 @@
  */
 import { Component, Inject, OnDestroy, OnInit } from '@angular/core';
 import { GioLicenseService, GioMenuSearchService, LicenseOptions, MenuSearchItem, SelectorItem } from '@gravitee/ui-particles-angular';
-import { distinctUntilChanged, map, takeUntil } from 'rxjs/operators';
-import { Observable, of, Subject } from 'rxjs';
+import { catchError, distinctUntilChanged, map, switchMap, takeUntil } from 'rxjs/operators';
+import { EMPTY, Observable, of, Subject } from 'rxjs';
 import { ActivatedRoute, Router } from '@angular/router';
 
 import { GioPermissionService } from '../../shared/components/gio-permission/gio-permission.service';
@@ -75,10 +75,7 @@ export class GioSideNavComponent implements OnInit, OnDestroy {
       .pipe(
         map(p => p.envHrid),
         distinctUntilChanged(),
-        takeUntil(this.unsubscribe$),
-      )
-      .subscribe({
-        next: _ => {
+        switchMap(_ => {
           this.environments = this.constants.org.environments.map(env => ({ value: env.id, displayValue: env.name }));
           this.currentEnv = this.constants.org.currentEnv;
 
@@ -86,7 +83,13 @@ export class GioSideNavComponent implements OnInit, OnDestroy {
           this.footerMenuItems = this.buildFooterMenuItems();
           this.gioMenuSearchService.removeMenuSearchItems([SIDE_NAV_GROUP_ID]);
           this.gioMenuSearchService.addMenuSearchItems(this.getSideNaveMenuSearchItems());
-        },
+
+          return this.environmentSettingsService.get().pipe(catchError(() => EMPTY));
+        }),
+        takeUntil(this.unsubscribe$),
+      )
+      .subscribe(envSettings => {
+        this.mainMenuItems = this.buildMainMenuItems(envSettings);
       });
 
     if (this.constants.org.settings?.licenseExpirationNotification?.enabled !== undefined) {
@@ -94,10 +97,6 @@ export class GioSideNavComponent implements OnInit, OnDestroy {
     }
 
     this.licenseExpirationDate$ = this.gioLicenseService.getExpiresAt$().pipe(distinctUntilChanged(), takeUntil(this.unsubscribe$));
-
-    this.environmentSettingsService.get().subscribe(envSettings => {
-      this.mainMenuItems = this.buildMainMenuItems(envSettings);
-    });
   }
 
   ngOnDestroy(): void {


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-14285

## Description

Fixed a race condition in the Console sidebar where clicking Observability or Analytics would silently redirect to the Dashboard instead of navigating to the correct page. 
The issue was caused by two independent subscriptions racing to rebuild the sidebar menu on init: when environment settings resolved from cache before the current environment was set, the navigation links ended up with an invalid path. Fixed by chaining the two operations so the environment is always set first.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

