### PR TITLE
test(e2e): run v4-only specs only on the v4 emulation engine leg

### DIFF
--- a/gravitee-apim-e2e/api-test/src/apis/debug-mode/mapi-v2/debug-my-api-including-query-params-headers-body-and-view-debug-session-with-proper-info.spec.ts
+++ b/gravitee-apim-e2e/api-test/src/apis/debug-mode/mapi-v2/debug-my-api-including-query-params-headers-body-and-view-debug-session-with-proper-info.spec.ts
@@ -60,7 +60,10 @@ describeIfClientGatewayCompatible('Debug my API (incl. query params, Headers and
     ]);
   });
 
-  describe('V4 API Proxy', () => {
+  // V4 APIs run on the v4 engine regardless of V4_EMULATION_ENGINE_DEFAULT, so debugging a V4 API
+  // behaves identically in both matrix legs. Gate it on the v4 emulation leg to avoid running it
+  // twice (the V2 sections below already cover the v3 vs emulation distinction).
+  describeIfV4EmulationEngine('V4 API Proxy', () => {
     let api: any;
     beforeAll(async () => {
       api = await importV4Api({

--- a/gravitee-apim-e2e/api-test/src/apis/imports/mapi-v2/import-api-definition/native-kafka/api-v4-native-kafka-import-only-api.spec.ts
+++ b/gravitee-apim-e2e/api-test/src/apis/imports/mapi-v2/import-api-definition/native-kafka/api-v4-native-kafka-import-only-api.spec.ts
@@ -17,14 +17,14 @@ import { test, describe, expect, afterAll } from '@jest/globals';
 import { APIsApi, ApiV4, HttpListener, KafkaListener, PlanMode, PlanSecurityType } from '@gravitee/management-v2-webclient-sdk/src/lib';
 import { forManagementV2AsApiUser } from '@gravitee/utils/configuration';
 import { MAPIV2ApisFaker } from '@gravitee/fixtures/management/MAPIV2ApisFaker';
-import { created, fail, noContent, succeed } from '@lib/jest-utils';
+import { describeIfV4EmulationEngine, created, fail, noContent, succeed } from '@lib/jest-utils';
 import { MAPIV2PlansFaker } from '@gravitee/fixtures/management/MAPIV2PlansFaker';
 
 const envId = 'DEFAULT';
 
 const v2ApisResourceAsApiPublisher = new APIsApi(forManagementV2AsApiUser());
 
-describe('API - V4 - Native Kafka - Import - Gravitee Definition - Only API -', () => {
+describeIfV4EmulationEngine('API - V4 - Native Kafka - Import - Gravitee Definition - Only API -', () => {
   describe('Create v4 API from import -', () => {
     describe('Create v4 API without ID', () => {
       let importedApi;

--- a/gravitee-apim-e2e/api-test/src/apis/imports/mapi-v2/import-api-definition/native-kafka/api-v4-native-kafka-import-with-everything.spec.ts
+++ b/gravitee-apim-e2e/api-test/src/apis/imports/mapi-v2/import-api-definition/native-kafka/api-v4-native-kafka-import-with-everything.spec.ts
@@ -17,7 +17,7 @@ import { test, describe, expect, afterAll } from '@jest/globals';
 import { APIsApi, APIPlansApi, ApiV4, PlanSecurityType, PlanV4 } from '@gravitee/management-v2-webclient-sdk/src/lib';
 import { forManagementAsAdminUser, forManagementAsApiUser, forManagementV2AsApiUser } from '@gravitee/utils/configuration';
 import { MAPIV2ApisFaker } from '@gravitee/fixtures/management/MAPIV2ApisFaker';
-import { created, noContent, succeed } from '@lib/jest-utils';
+import { describeIfV4EmulationEngine, created, noContent, succeed } from '@lib/jest-utils';
 import { MAPIV2PlansFaker } from '@gravitee/fixtures/management/MAPIV2PlansFaker';
 import { APIsApi as v1APIsApi } from '@gravitee/management-webclient-sdk/src/lib/apis/APIsApi';
 import { UsersApi } from '@gravitee/management-webclient-sdk/src/lib/apis/UsersApi';
@@ -42,7 +42,7 @@ const v1UsersResourceAsAdmin = new UsersApi(forManagementAsAdminUser());
 const v2ApisResourceAsApiPublisher = new APIsApi(forManagementV2AsApiUser());
 const v2APlansResourceAsApiPublisher = new APIPlansApi(forManagementV2AsApiUser());
 
-describe('API - V4 - Native Kafka - Import - Gravitee Definition - With everything', () => {
+describeIfV4EmulationEngine('API - V4 - Native Kafka - Import - Gravitee Definition - With everything', () => {
   describe('Create v4 API from import with everything', () => {
     describe('Create v4 API with two plans', () => {
       let importedApi: ApiV4;

--- a/gravitee-apim-e2e/api-test/src/apis/imports/mapi-v2/import-api-definition/native-kafka/api-v4-native-kafka-import-with-groups.spec.ts
+++ b/gravitee-apim-e2e/api-test/src/apis/imports/mapi-v2/import-api-definition/native-kafka/api-v4-native-kafka-import-with-groups.spec.ts
@@ -16,7 +16,7 @@
 import { test, describe, afterAll, expect } from '@jest/globals';
 import { APIsApi, ApiV4 } from '@gravitee/management-v2-webclient-sdk/src/lib';
 import { forManagementAsAdminUser, forManagementV2AsApiUser } from '@gravitee/utils/configuration';
-import { created, noContent, succeed } from '@lib/jest-utils';
+import { describeIfV4EmulationEngine, created, noContent, succeed } from '@lib/jest-utils';
 import { ApiEntity, GroupEntity } from '@gravitee/management-webclient-sdk/src/lib/models';
 import { MAPIV2ApisFaker } from '@gravitee/fixtures/management/MAPIV2ApisFaker';
 import { GroupsApi } from '@gravitee/management-webclient-sdk/src/lib/apis/GroupsApi';
@@ -28,7 +28,7 @@ const envId = 'DEFAULT';
 const v2ApisResourceAsApiPublisher = new APIsApi(forManagementV2AsApiUser());
 const v1GroupsResourceAsAdmin = new GroupsApi(forManagementAsAdminUser());
 
-describe('API - V4 - Native Kafka - Import - Gravitee Definition - With groups', () => {
+describeIfV4EmulationEngine('API - V4 - Native Kafka - Import - Gravitee Definition - With groups', () => {
   describe('Create v4 API from import with groups', () => {
     let importedApi: ApiV4;
     let group: GroupEntity;

--- a/gravitee-apim-e2e/api-test/src/apis/imports/mapi-v2/import-api-definition/native-kafka/api-v4-native-kafka-import-with-members.spec.ts
+++ b/gravitee-apim-e2e/api-test/src/apis/imports/mapi-v2/import-api-definition/native-kafka/api-v4-native-kafka-import-with-members.spec.ts
@@ -16,7 +16,7 @@
 import { afterAll, describe, expect, test } from '@jest/globals';
 import { APIsApi, ApiV4 } from '@gravitee/management-v2-webclient-sdk/src/lib';
 import { forManagementAsAdminUser, forManagementV2AsAdminUser, forManagementV2AsApiUser } from '@gravitee/utils/configuration';
-import { created, noContent, succeed } from '@lib/jest-utils';
+import { describeIfV4EmulationEngine, created, noContent, succeed } from '@lib/jest-utils';
 import { RoleEntity, RoleScope, UserEntity } from '@gravitee/management-webclient-sdk/src/lib/models';
 import { APIsApi as v1APIsApi } from '@gravitee/management-webclient-sdk/src/lib/apis/APIsApi';
 import { UsersApi } from '@gravitee/management-webclient-sdk/src/lib/apis/UsersApi';
@@ -35,7 +35,7 @@ const v2ApisResourceAsAdmin = new APIsApi(forManagementV2AsAdminUser());
 const v1UsersResourceAsAdmin = new UsersApi(forManagementAsAdminUser());
 const v1ConfigurationResourceAsAdmin = new ConfigurationApi(forManagementAsAdminUser());
 
-describe('API - V4 - Native Kafka - Import - Gravitee Definition - With members', () => {
+describeIfV4EmulationEngine('API - V4 - Native Kafka - Import - Gravitee Definition - With members', () => {
   describe('Create v4 API from import with members', () => {
     const roleName = 'IMPORT_TEST_ROLE';
     let importedApi: ApiV4;

--- a/gravitee-apim-e2e/api-test/src/apis/imports/mapi-v2/import-api-definition/native-kafka/api-v4-native-kafka-import-with-metadata.spec.ts
+++ b/gravitee-apim-e2e/api-test/src/apis/imports/mapi-v2/import-api-definition/native-kafka/api-v4-native-kafka-import-with-metadata.spec.ts
@@ -16,7 +16,7 @@
 import { afterAll, describe, expect, test } from '@jest/globals';
 import { APIsApi, ApiV4, Listener, ListenerType } from '@gravitee/management-v2-webclient-sdk/src/lib';
 import { forManagementAsAdminUser, forManagementAsApiUser, forManagementV2AsApiUser } from '@gravitee/utils/configuration';
-import { created, noContent, succeed } from '@lib/jest-utils';
+import { describeIfV4EmulationEngine, created, noContent, succeed } from '@lib/jest-utils';
 import { APIsApi as v1APIsApi } from '@gravitee/management-webclient-sdk/src/lib/apis/APIsApi';
 import { MAPIV2ApisFaker } from '@gravitee/fixtures/management/MAPIV2ApisFaker';
 import { MAPIV2MetadataFaker } from '@gravitee/fixtures/management/MAPIV2MetadataFaker';
@@ -30,7 +30,7 @@ const v1ApisResourceAsApiPublisher = new v1APIsApi(forManagementAsApiUser());
 const v2ApisResourceAsApiPublisher = new APIsApi(forManagementV2AsApiUser());
 const v1MetadataResourceAsApiPublisher = new MetadataApi(forManagementAsAdminUser());
 
-describe('API - V4 - Native Kafka - Import - Gravitee Definition - With metadata', () => {
+describeIfV4EmulationEngine('API - V4 - Native Kafka - Import - Gravitee Definition - With metadata', () => {
   describe('Create v4 API from import with metadata', () => {
     let importedApiWithApimTeam,
       importedSecondApiWithApimTeam,

--- a/gravitee-apim-e2e/api-test/src/apis/imports/mapi-v2/import-api-definition/native-kafka/api-v4-native-kafka-import-with-pages-and-media.spec.ts
+++ b/gravitee-apim-e2e/api-test/src/apis/imports/mapi-v2/import-api-definition/native-kafka/api-v4-native-kafka-import-with-pages-and-media.spec.ts
@@ -17,7 +17,7 @@ import { test, describe, expect, afterAll } from '@jest/globals';
 import { APIsApi, ApiV4 } from '@gravitee/management-v2-webclient-sdk/src/lib';
 import { forManagementAsApiUser, forManagementV2AsApiUser } from '@gravitee/utils/configuration';
 import { MAPIV2ApisFaker } from '@gravitee/fixtures/management/MAPIV2ApisFaker';
-import { created, noContent, succeed } from '@lib/jest-utils';
+import { describeIfV4EmulationEngine, created, noContent, succeed } from '@lib/jest-utils';
 import { MAPIV2PagesFaker } from '@gravitee/fixtures/management/MAPIV2PagesFaker';
 import { APIPagesApi } from '@gravitee/management-webclient-sdk/src/lib/apis/APIPagesApi';
 import { PageEntity } from '@gravitee/management-webclient-sdk/src/lib/models';
@@ -31,7 +31,7 @@ const envId = 'DEFAULT';
 const v2ApisResourceAsApiPublisher = new APIsApi(forManagementV2AsApiUser());
 const v1ApiPagesResourceAsApiPublisher = new APIPagesApi(forManagementAsApiUser());
 
-describe('API - V4 - Native Kafka - Import - Gravitee Definition - With pages', () => {
+describeIfV4EmulationEngine('API - V4 - Native Kafka - Import - Gravitee Definition - With pages', () => {
   describe('Create v4 API from import with pages', () => {
     describe('Create v4 API with one page without ID', () => {
       let importedApi: ApiV4;

--- a/gravitee-apim-e2e/api-test/src/apis/imports/mapi-v2/import-api-definition/native-kafka/api-v4-native-kafka-import-with-pictures.spec.ts
+++ b/gravitee-apim-e2e/api-test/src/apis/imports/mapi-v2/import-api-definition/native-kafka/api-v4-native-kafka-import-with-pictures.spec.ts
@@ -16,7 +16,7 @@
 import { afterAll, describe, expect, test } from '@jest/globals';
 import { APIsApi, ApiV4 } from '@gravitee/management-v2-webclient-sdk/src/lib';
 import { forManagementV2AsApiUser } from '@gravitee/utils/configuration';
-import { created, noContent, succeed } from '@lib/jest-utils';
+import { describeIfV4EmulationEngine, created, noContent, succeed } from '@lib/jest-utils';
 import { MAPIV2ApisFaker } from '@gravitee/fixtures/management/MAPIV2ApisFaker';
 import { ImagesUtils } from '@gravitee/utils/images';
 
@@ -24,7 +24,7 @@ const envId = 'DEFAULT';
 
 const v2ApisResourceAsApiPublisher = new APIsApi(forManagementV2AsApiUser());
 
-describe('API - V4 - Native Kafka - Import - Gravitee Definition - With pictures', () => {
+describeIfV4EmulationEngine('API - V4 - Native Kafka - Import - Gravitee Definition - With pictures', () => {
   describe('Create v4 API from import with pictures', () => {
     let importedApi: ApiV4;
 

--- a/gravitee-apim-e2e/api-test/src/apis/imports/mapi-v2/import-api-definition/native-kafka/api-v4-native-kafka-import-with-plans.spec.ts
+++ b/gravitee-apim-e2e/api-test/src/apis/imports/mapi-v2/import-api-definition/native-kafka/api-v4-native-kafka-import-with-plans.spec.ts
@@ -17,7 +17,7 @@ import { afterAll, describe, expect, test } from '@jest/globals';
 import { APIPlansApi, APIsApi, ApiV4, PlanSecurityType, PlanV4 } from '@gravitee/management-v2-webclient-sdk/src/lib';
 import { forManagementV2AsApiUser } from '@gravitee/utils/configuration';
 import { MAPIV2ApisFaker } from '@gravitee/fixtures/management/MAPIV2ApisFaker';
-import { created, noContent, succeed } from '@lib/jest-utils';
+import { describeIfV4EmulationEngine, created, noContent, succeed } from '@lib/jest-utils';
 import { MAPIV2PlansFaker } from '@gravitee/fixtures/management/MAPIV2PlansFaker';
 import faker from '@faker-js/faker';
 
@@ -26,7 +26,7 @@ const envId = 'DEFAULT';
 const v2ApisResourceAsApiPublisher = new APIsApi(forManagementV2AsApiUser());
 const v2APlansResourceAsApiPublisher = new APIPlansApi(forManagementV2AsApiUser());
 
-describe('API - V4 - Native Kafka - Import - Gravitee Definition - With plans', () => {
+describeIfV4EmulationEngine('API - V4 - Native Kafka - Import - Gravitee Definition - With plans', () => {
   describe('Create v4 API from import with plans', () => {
     describe('Create v4 API with two plans', () => {
       const keylessPlan = MAPIV2PlansFaker.planV4();

--- a/gravitee-apim-e2e/api-test/src/apis/imports/mapi-v2/import-api-definition/proxy/api-v4-proxy-import-only-api.spec.ts
+++ b/gravitee-apim-e2e/api-test/src/apis/imports/mapi-v2/import-api-definition/proxy/api-v4-proxy-import-only-api.spec.ts
@@ -17,14 +17,14 @@ import { test, describe, expect, afterAll } from '@jest/globals';
 import { APIsApi, ApiV4, HttpListener, PlanMode, PlanSecurityType } from '@gravitee/management-v2-webclient-sdk/src/lib';
 import { forManagementV2AsApiUser } from '@gravitee/utils/configuration';
 import { MAPIV2ApisFaker } from '@gravitee/fixtures/management/MAPIV2ApisFaker';
-import { created, fail, noContent, succeed } from '@lib/jest-utils';
+import { describeIfV4EmulationEngine, created, fail, noContent, succeed } from '@lib/jest-utils';
 import { MAPIV2PlansFaker } from '@gravitee/fixtures/management/MAPIV2PlansFaker';
 
 const envId = 'DEFAULT';
 
 const v2ApisResourceAsApiPublisher = new APIsApi(forManagementV2AsApiUser());
 
-describe('API - V4 - Proxy - Import - Gravitee Definition - Only API -', () => {
+describeIfV4EmulationEngine('API - V4 - Proxy - Import - Gravitee Definition - Only API -', () => {
   test('should fail because of plan mode is invalid', async () => {
     await fail(
       v2ApisResourceAsApiPublisher.createApiWithImportDefinitionRaw({

--- a/gravitee-apim-e2e/api-test/src/apis/imports/mapi-v2/import-api-definition/proxy/api-v4-proxy-import-with-everything.spec.ts
+++ b/gravitee-apim-e2e/api-test/src/apis/imports/mapi-v2/import-api-definition/proxy/api-v4-proxy-import-with-everything.spec.ts
@@ -17,7 +17,7 @@ import { test, describe, expect, afterAll } from '@jest/globals';
 import { APIsApi, APIPlansApi, ApiV4, PlanSecurityType, PlanV4 } from '@gravitee/management-v2-webclient-sdk/src/lib';
 import { forManagementAsAdminUser, forManagementAsApiUser, forManagementV2AsApiUser } from '@gravitee/utils/configuration';
 import { MAPIV2ApisFaker } from '@gravitee/fixtures/management/MAPIV2ApisFaker';
-import { created, noContent, succeed } from '@lib/jest-utils';
+import { describeIfV4EmulationEngine, created, noContent, succeed } from '@lib/jest-utils';
 import { MAPIV2PlansFaker } from '@gravitee/fixtures/management/MAPIV2PlansFaker';
 import { APIsApi as v1APIsApi } from '@gravitee/management-webclient-sdk/src/lib/apis/APIsApi';
 import { UsersApi } from '@gravitee/management-webclient-sdk/src/lib/apis/UsersApi';
@@ -42,7 +42,7 @@ const v1UsersResourceAsAdmin = new UsersApi(forManagementAsAdminUser());
 const v2ApisResourceAsApiPublisher = new APIsApi(forManagementV2AsApiUser());
 const v2APlansResourceAsApiPublisher = new APIPlansApi(forManagementV2AsApiUser());
 
-describe('API - V4 - Proxy - Import - Gravitee Definition - With everything', () => {
+describeIfV4EmulationEngine('API - V4 - Proxy - Import - Gravitee Definition - With everything', () => {
   describe('Create v4 API from import with everything', () => {
     describe('Create v4 API with two plans', () => {
       let importedApi: ApiV4;

--- a/gravitee-apim-e2e/api-test/src/apis/imports/mapi-v2/import-api-definition/proxy/api-v4-proxy-import-with-groups.spec.ts
+++ b/gravitee-apim-e2e/api-test/src/apis/imports/mapi-v2/import-api-definition/proxy/api-v4-proxy-import-with-groups.spec.ts
@@ -16,7 +16,7 @@
 import { test, describe, afterAll, expect } from '@jest/globals';
 import { APIsApi, ApiV4 } from '@gravitee/management-v2-webclient-sdk/src/lib';
 import { forManagementAsAdminUser, forManagementV2AsApiUser } from '@gravitee/utils/configuration';
-import { created, noContent, succeed } from '@lib/jest-utils';
+import { describeIfV4EmulationEngine, created, noContent, succeed } from '@lib/jest-utils';
 import { ApiEntity, GroupEntity } from '@gravitee/management-webclient-sdk/src/lib/models';
 import { MAPIV2ApisFaker } from '@gravitee/fixtures/management/MAPIV2ApisFaker';
 import { GroupsApi } from '@gravitee/management-webclient-sdk/src/lib/apis/GroupsApi';
@@ -28,7 +28,7 @@ const envId = 'DEFAULT';
 const v2ApisResourceAsApiPublisher = new APIsApi(forManagementV2AsApiUser());
 const v1GroupsResourceAsAdmin = new GroupsApi(forManagementAsAdminUser());
 
-describe('API - V4 - Proxy - Import - Gravitee Definition - With groups', () => {
+describeIfV4EmulationEngine('API - V4 - Proxy - Import - Gravitee Definition - With groups', () => {
   describe('Create v4 API from import with groups', () => {
     let importedApi: ApiV4;
     let group: GroupEntity;

--- a/gravitee-apim-e2e/api-test/src/apis/imports/mapi-v2/import-api-definition/proxy/api-v4-proxy-import-with-members.spec.ts
+++ b/gravitee-apim-e2e/api-test/src/apis/imports/mapi-v2/import-api-definition/proxy/api-v4-proxy-import-with-members.spec.ts
@@ -16,7 +16,7 @@
 import { afterAll, describe, expect, test } from '@jest/globals';
 import { APIsApi, ApiV4 } from '@gravitee/management-v2-webclient-sdk/src/lib';
 import { forManagementAsAdminUser, forManagementV2AsAdminUser, forManagementV2AsApiUser } from '@gravitee/utils/configuration';
-import { created, noContent, succeed } from '@lib/jest-utils';
+import { describeIfV4EmulationEngine, created, noContent, succeed } from '@lib/jest-utils';
 import { RoleEntity, RoleScope, UserEntity } from '@gravitee/management-webclient-sdk/src/lib/models';
 import { APIsApi as v1APIsApi } from '@gravitee/management-webclient-sdk/src/lib/apis/APIsApi';
 import { UsersApi } from '@gravitee/management-webclient-sdk/src/lib/apis/UsersApi';
@@ -35,7 +35,7 @@ const v2ApisResourceAsAdmin = new APIsApi(forManagementV2AsAdminUser());
 const v1UsersResourceAsAdmin = new UsersApi(forManagementAsAdminUser());
 const v1ConfigurationResourceAsAdmin = new ConfigurationApi(forManagementAsAdminUser());
 
-describe('API - V4 - Proxy - Import - Gravitee Definition - With members', () => {
+describeIfV4EmulationEngine('API - V4 - Proxy - Import - Gravitee Definition - With members', () => {
   describe('Create v4 API from import with members', () => {
     const roleName = 'IMPORT_TEST_ROLE';
     let importedApi: ApiV4;

--- a/gravitee-apim-e2e/api-test/src/apis/imports/mapi-v2/import-api-definition/proxy/api-v4-proxy-import-with-metadata.spec.ts
+++ b/gravitee-apim-e2e/api-test/src/apis/imports/mapi-v2/import-api-definition/proxy/api-v4-proxy-import-with-metadata.spec.ts
@@ -16,7 +16,7 @@
 import { afterAll, describe, expect, test } from '@jest/globals';
 import { APIsApi, ApiV4 } from '@gravitee/management-v2-webclient-sdk/src/lib';
 import { forManagementAsAdminUser, forManagementAsApiUser, forManagementV2AsApiUser } from '@gravitee/utils/configuration';
-import { created, noContent, succeed } from '@lib/jest-utils';
+import { describeIfV4EmulationEngine, created, noContent, succeed } from '@lib/jest-utils';
 import { APIsApi as v1APIsApi } from '@gravitee/management-webclient-sdk/src/lib/apis/APIsApi';
 import { MAPIV2ApisFaker } from '@gravitee/fixtures/management/MAPIV2ApisFaker';
 import { MAPIV2MetadataFaker } from '@gravitee/fixtures/management/MAPIV2MetadataFaker';
@@ -30,7 +30,7 @@ const v1ApisResourceAsApiPublisher = new v1APIsApi(forManagementAsApiUser());
 const v2ApisResourceAsApiPublisher = new APIsApi(forManagementV2AsApiUser());
 const v1MetadataResourceAsApiPublisher = new MetadataApi(forManagementAsAdminUser());
 
-describe('API - V4 - Proxy - Import - Gravitee Definition - With metadata', () => {
+describeIfV4EmulationEngine('API - V4 - Proxy - Import - Gravitee Definition - With metadata', () => {
   describe('Create v4 API from import with metadata', () => {
     let importedApiWithApimTeam,
       importedSecondApiWithApimTeam,

--- a/gravitee-apim-e2e/api-test/src/apis/imports/mapi-v2/import-api-definition/proxy/api-v4-proxy-import-with-pages-and-media.spec.ts
+++ b/gravitee-apim-e2e/api-test/src/apis/imports/mapi-v2/import-api-definition/proxy/api-v4-proxy-import-with-pages-and-media.spec.ts
@@ -17,7 +17,7 @@ import { test, describe, expect, afterAll } from '@jest/globals';
 import { APIsApi, ApiV4 } from '@gravitee/management-v2-webclient-sdk/src/lib';
 import { forManagementAsApiUser, forManagementV2AsApiUser } from '@gravitee/utils/configuration';
 import { MAPIV2ApisFaker } from '@gravitee/fixtures/management/MAPIV2ApisFaker';
-import { created, noContent, succeed } from '@lib/jest-utils';
+import { describeIfV4EmulationEngine, created, noContent, succeed } from '@lib/jest-utils';
 import { MAPIV2PagesFaker } from '@gravitee/fixtures/management/MAPIV2PagesFaker';
 import { APIPagesApi } from '@gravitee/management-webclient-sdk/src/lib/apis/APIPagesApi';
 import { PageEntity } from '@gravitee/management-webclient-sdk/src/lib/models';
@@ -31,7 +31,7 @@ const envId = 'DEFAULT';
 const v2ApisResourceAsApiPublisher = new APIsApi(forManagementV2AsApiUser());
 const v1ApiPagesResourceAsApiPublisher = new APIPagesApi(forManagementAsApiUser());
 
-describe('API - V4 - Proxy - Import - Gravitee Definition - With pages', () => {
+describeIfV4EmulationEngine('API - V4 - Proxy - Import - Gravitee Definition - With pages', () => {
   describe('Create v4 API from import with pages', () => {
     describe('Create v4 API with one page without ID', () => {
       let importedApi: ApiV4;

--- a/gravitee-apim-e2e/api-test/src/apis/imports/mapi-v2/import-api-definition/proxy/api-v4-proxy-import-with-pictures.spec.ts
+++ b/gravitee-apim-e2e/api-test/src/apis/imports/mapi-v2/import-api-definition/proxy/api-v4-proxy-import-with-pictures.spec.ts
@@ -16,7 +16,7 @@
 import { afterAll, describe, expect, test } from '@jest/globals';
 import { APIsApi, ApiV4 } from '@gravitee/management-v2-webclient-sdk/src/lib';
 import { forManagementV2AsApiUser } from '@gravitee/utils/configuration';
-import { created, noContent, succeed } from '@lib/jest-utils';
+import { describeIfV4EmulationEngine, created, noContent, succeed } from '@lib/jest-utils';
 import { MAPIV2ApisFaker } from '@gravitee/fixtures/management/MAPIV2ApisFaker';
 import { ImagesUtils } from '@gravitee/utils/images';
 
@@ -24,7 +24,7 @@ const envId = 'DEFAULT';
 
 const v2ApisResourceAsApiPublisher = new APIsApi(forManagementV2AsApiUser());
 
-describe('API - V4 - Proxy - Import - Gravitee Definition - With pictures', () => {
+describeIfV4EmulationEngine('API - V4 - Proxy - Import - Gravitee Definition - With pictures', () => {
   describe('Create v4 API from import with pictures', () => {
     let importedApi: ApiV4;
 

--- a/gravitee-apim-e2e/api-test/src/apis/imports/mapi-v2/import-api-definition/proxy/api-v4-proxy-import-with-plans.spec.ts
+++ b/gravitee-apim-e2e/api-test/src/apis/imports/mapi-v2/import-api-definition/proxy/api-v4-proxy-import-with-plans.spec.ts
@@ -17,7 +17,7 @@ import { afterAll, describe, expect, test } from '@jest/globals';
 import { APIPlansApi, APIsApi, ApiV4, PlanSecurityType, PlanV4 } from '@gravitee/management-v2-webclient-sdk/src/lib';
 import { forManagementV2AsApiUser } from '@gravitee/utils/configuration';
 import { MAPIV2ApisFaker } from '@gravitee/fixtures/management/MAPIV2ApisFaker';
-import { created, noContent, succeed } from '@lib/jest-utils';
+import { describeIfV4EmulationEngine, created, noContent, succeed } from '@lib/jest-utils';
 import { MAPIV2PlansFaker } from '@gravitee/fixtures/management/MAPIV2PlansFaker';
 import { faker } from '@faker-js/faker';
 
@@ -26,7 +26,7 @@ const envId = 'DEFAULT';
 const v2ApisResourceAsApiPublisher = new APIsApi(forManagementV2AsApiUser());
 const v2APlansResourceAsApiPublisher = new APIPlansApi(forManagementV2AsApiUser());
 
-describe('API - V4 - Proxy - Import - Gravitee Definition - With plans', () => {
+describeIfV4EmulationEngine('API - V4 - Proxy - Import - Gravitee Definition - With plans', () => {
   describe('Create v4 API from import with plans', () => {
     describe('Create v4 API with two plans', () => {
       const keylessPlan = MAPIV2PlansFaker.planV4();

--- a/gravitee-apim-e2e/api-test/src/apis/imports/mapi-v2/import-swagger/import-swagger.spec.ts
+++ b/gravitee-apim-e2e/api-test/src/apis/imports/mapi-v2/import-swagger/import-swagger.spec.ts
@@ -19,7 +19,7 @@ import { CategoryEntity, GroupEntity, TagEntity } from '../../../../../../lib/ma
 import * as openapiv3 from '@api-test-resources/openapi-withExtensions.json';
 import { afterAll, afterEach, beforeAll, describe, expect, test } from '@jest/globals';
 import { ShardingTagsApi } from '../../../../../../lib/management-webclient-sdk/src/lib/apis/ShardingTagsApi';
-import { created, succeed } from '@lib/jest-utils';
+import { describeIfV4EmulationEngine, created, succeed } from '@lib/jest-utils';
 import { GroupsApi } from '../../../../../../lib/management-webclient-sdk/src/lib/apis/GroupsApi';
 import { CategoriesApi } from '../../../../../../lib/management-webclient-sdk/src/lib/apis/CategoriesApi';
 
@@ -32,7 +32,7 @@ const groupsAsAdmin = new GroupsApi(forManagementAsAdminUser());
 const categoryAsAdmin = new CategoriesApi(forManagementAsAdminUser());
 const documentationAsAdmin = new APIDocumentationApi(forManagementV2AsAdminUser());
 
-describe('API - Imports OpenAPI specification', () => {
+describeIfV4EmulationEngine('API - Imports OpenAPI specification', () => {
   let specification = JSON.stringify(openapiv3);
   let createdTag: TagEntity;
   let createdGroup: GroupEntity;

--- a/gravitee-apim-e2e/api-test/src/apis/imports/mapi-v2/update-api-definition/api-v4-update-from-swagger.spec.ts
+++ b/gravitee-apim-e2e/api-test/src/apis/imports/mapi-v2/update-api-definition/api-v4-update-from-swagger.spec.ts
@@ -17,7 +17,7 @@ import { afterAll, afterEach, beforeAll, describe, expect, test } from '@jest/gl
 import { APIsApi, ApiV4 } from '@gravitee/management-v2-webclient-sdk/src/lib';
 import { forManagementV2AsAdminUser } from '@gravitee/utils/configuration';
 import * as openapiv3 from '@api-test-resources/openapi-withExtensions.json';
-import { created, fail, noContent, succeed } from '@lib/jest-utils';
+import { describeIfV4EmulationEngine, created, fail, noContent, succeed } from '@lib/jest-utils';
 import { MAPIV2ApisFaker } from '@gravitee/fixtures/management/MAPIV2ApisFaker';
 import { faker } from '@faker-js/faker';
 
@@ -25,7 +25,7 @@ const envId = 'DEFAULT';
 
 const v2ApisResource = new APIsApi(forManagementV2AsAdminUser());
 
-describe('API - V4 - Update via Swagger/OpenAPI import', () => {
+describeIfV4EmulationEngine('API - V4 - Update via Swagger/OpenAPI import', () => {
   const specification = JSON.stringify(openapiv3);
 
   describe('Update an existing API from an OpenAPI specification', () => {

--- a/gravitee-apim-e2e/api-test/src/apis/imports/mapi-v2/update-api-definition/api-v4-update-with-definition.spec.ts
+++ b/gravitee-apim-e2e/api-test/src/apis/imports/mapi-v2/update-api-definition/api-v4-update-with-definition.spec.ts
@@ -17,13 +17,13 @@ import { afterAll, describe, expect, test } from '@jest/globals';
 import { APIsApi, ApiV4 } from '@gravitee/management-v2-webclient-sdk/src/lib';
 import { forManagementV2AsApiUser } from '@gravitee/utils/configuration';
 import { MAPIV2ApisFaker } from '@gravitee/fixtures/management/MAPIV2ApisFaker';
-import { created, fail, noContent, succeed } from '@lib/jest-utils';
+import { describeIfV4EmulationEngine, created, fail, noContent, succeed } from '@lib/jest-utils';
 
 const envId = 'DEFAULT';
 
 const v2ApisResource = new APIsApi(forManagementV2AsApiUser());
 
-describe('API - V4 - Update via definition import', () => {
+describeIfV4EmulationEngine('API - V4 - Update via definition import', () => {
   describe('Update an existing PROXY API with a new definition', () => {
     let createdApi: ApiV4;
     const originalDefinition = MAPIV2ApisFaker.apiImportV4();

--- a/gravitee-apim-e2e/api-test/src/apis/logging/mapi-v2/native-api-logs.spec.ts
+++ b/gravitee-apim-e2e/api-test/src/apis/logging/mapi-v2/native-api-logs.spec.ts
@@ -17,7 +17,7 @@ import { afterAll, beforeAll, describe, expect, test } from '@jest/globals';
 import fetch from 'node-fetch';
 import { APIAnalyticsApi, APIsApi, ApiV4 } from '@gravitee/management-v2-webclient-sdk/src/lib';
 import { MAPIV2ApisFaker } from '@gravitee/fixtures/management/MAPIV2ApisFaker';
-import { created, fail, noContent, succeed } from '@lib/jest-utils';
+import { describeIfV4EmulationEngine, created, fail, noContent, succeed } from '@lib/jest-utils';
 import { API_USER, forManagementV2AsApiUser, forManagementV2AsAppUser } from '@gravitee/utils/configuration';
 
 const ENV_ID = 'DEFAULT';
@@ -37,7 +37,7 @@ const rawApiUserGet = (path: string) =>
     headers: { Authorization: basicAuthHeader },
   });
 
-describe('API V4 - Native API Logs', () => {
+describeIfV4EmulationEngine('API V4 - Native API Logs', () => {
   let api: ApiV4;
 
   beforeAll(async () => {

--- a/gravitee-apim-e2e/api-test/src/apis/logging/mapi-v2/search-api-v4-connection-and-message-logs.spec.ts
+++ b/gravitee-apim-e2e/api-test/src/apis/logging/mapi-v2/search-api-v4-connection-and-message-logs.spec.ts
@@ -16,7 +16,7 @@
 import { ApiAggregatedMessageLogsResponse, ApiLogsResponse, APIsApi, HttpListener } from '@gravitee/management-v2-webclient-sdk/src/lib';
 import { forManagementV2AsApiUser } from '@gravitee/utils/configuration';
 import { afterAll, describe, expect, test } from '@jest/globals';
-import { created, noContent } from '@lib/jest-utils';
+import { describeIfV4EmulationEngine, created, noContent } from '@lib/jest-utils';
 import { MAPIV2ApisFaker } from '@gravitee/fixtures/management/MAPIV2ApisFaker';
 import { APIAnalyticsApi, APIPlansApi, ApiV4, Pagination } from '@gravitee/management-v2-webclient-sdk/src/lib';
 import { MAPIV2PlansFaker } from '@gravitee/fixtures/management/MAPIV2PlansFaker';
@@ -28,7 +28,7 @@ const v2ApisResourceAsApiPublisher = new APIsApi(forManagementV2AsApiUser());
 const v2PlansResourceAsApiPublisher = new APIPlansApi(forManagementV2AsApiUser());
 const v2ApiLogsResourceAsApiPublisher = new APIAnalyticsApi(forManagementV2AsApiUser());
 
-describe('API - V4 - MESSAGE - Search logs', () => {
+describeIfV4EmulationEngine('API - V4 - MESSAGE - Search logs', () => {
   describe('Search Message API connection and message logs', () => {
     let importedApi: ApiV4;
     let apiPath;

--- a/gravitee-apim-e2e/api-test/src/apis/logging/mapi-v2/search-api-v4-connection-logs.spec.ts
+++ b/gravitee-apim-e2e/api-test/src/apis/logging/mapi-v2/search-api-v4-connection-logs.spec.ts
@@ -24,7 +24,7 @@ import {
 } from '@gravitee/management-v2-webclient-sdk/src/lib';
 import { forManagementAsAppUser, forManagementV2AsApiUser } from '@gravitee/utils/configuration';
 import { afterAll, beforeEach, describe, expect, test } from '@jest/globals';
-import { created, noContent, succeed } from '@lib/jest-utils';
+import { describeIfV4EmulationEngine, created, noContent, succeed } from '@lib/jest-utils';
 import { MAPIV2ApisFaker } from '@gravitee/fixtures/management/MAPIV2ApisFaker';
 import { APIAnalyticsApi, APIPlansApi } from '@gravitee/management-v2-webclient-sdk/src/lib';
 import { MAPIV2PlansFaker } from '@gravitee/fixtures/management/MAPIV2PlansFaker';
@@ -40,7 +40,7 @@ const applicationManagementApiAsAppUser = new ApplicationsApi(forManagementAsApp
 const v2ApiSubscriptionApiAsApiUser = new APISubscriptionsApi(forManagementV2AsApiUser());
 const v2ApiPlanApiAsApiUser = new APIPlansApi(forManagementV2AsApiUser());
 
-describe('API - V4 - Connection Logs', () => {
+describeIfV4EmulationEngine('API - V4 - Connection Logs', () => {
   describe('WITH V4 API with full logging enabled and API_KEY plan', () => {
     let testContext: Record<string, any>;
 

--- a/gravitee-apim-e2e/api-test/src/apis/mapi-v2/transfer-ownership/api-v4-transfer-ownership.spec.ts
+++ b/gravitee-apim-e2e/api-test/src/apis/mapi-v2/transfer-ownership/api-v4-transfer-ownership.spec.ts
@@ -17,7 +17,7 @@ import { test, describe, expect, afterAll } from '@jest/globals';
 import { APIMembersApi, APIsApi, Api, MembersResponse } from '@gravitee/management-v2-webclient-sdk/src/lib';
 import { API_USER, forManagementAsAdminUser, forManagementV2AsAdminUser, forManagementV2AsApiUser } from '@gravitee/utils/configuration';
 import { MAPIV2ApisFaker } from '@gravitee/fixtures/management/MAPIV2ApisFaker';
-import { created, fail, forbidden, noContent, succeed } from '@lib/jest-utils';
+import { describeIfV4EmulationEngine, created, fail, forbidden, noContent, succeed } from '@lib/jest-utils';
 import { UsersFaker } from '@gravitee/fixtures/management/UsersFaker';
 import { UsersApi } from '@gravitee/management-webclient-sdk/src/lib/apis/UsersApi';
 import { RoleScope } from '@gravitee/management-webclient-sdk/src/lib/models';
@@ -39,7 +39,7 @@ const v2ApisResourceAsAdmin = new APIsApi(forManagementV2AsAdminUser());
 const v2ApiMembersResourceAsApiPublisher = new APIMembersApi(forManagementV2AsApiUser());
 const v2ApiMembersResourceAsAdmin = new APIMembersApi(forManagementV2AsAdminUser());
 
-describe('API - V4 - Transfer Ownership', () => {
+describeIfV4EmulationEngine('API - V4 - Transfer Ownership', () => {
   describe('Transfer ownership to other user', () => {
     const roleName = 'TRANSFER_OWNERSHIP_ROLE';
     let importedApi;

--- a/gravitee-apim-e2e/api-test/src/apis/plans/mapi-v2/create-tcp-api-plan.spec.ts
+++ b/gravitee-apim-e2e/api-test/src/apis/plans/mapi-v2/create-tcp-api-plan.spec.ts
@@ -18,7 +18,7 @@ import { forManagementV2AsApiUser } from '@gravitee/utils/configuration';
 import { APIPlansApi, APIsApi, ApiV4, ListenerType, PlanSecurityType, UpdateApi } from '@gravitee/management-v2-webclient-sdk/src/lib';
 import { afterAll, beforeAll, expect, test } from '@jest/globals';
 import { MAPIV2PlansFaker } from '@gravitee/fixtures/management/MAPIV2PlansFaker';
-import { created, fail, noContent, succeed } from '@lib/jest-utils';
+import { describeIfV4EmulationEngine, created, fail, noContent, succeed } from '@lib/jest-utils';
 import { MAPIV2ApisFaker } from '@gravitee/fixtures/management/MAPIV2ApisFaker';
 import { faker } from '@faker-js/faker';
 
@@ -27,7 +27,7 @@ const envId = 'DEFAULT';
 const v2ApisResourceAsApiPublisher = new APIsApi(forManagementV2AsApiUser());
 const v2APlansResourceAsApiPublisher = new APIPlansApi(forManagementV2AsApiUser());
 
-describe('With a TCP API', () => {
+describeIfV4EmulationEngine('With a TCP API', () => {
   let importedApi: ApiV4;
 
   beforeAll(async () => {

--- a/gravitee-apim-e2e/api-test/src/apis/rollback/mapi-v2/api-v4-rollback.spec.ts
+++ b/gravitee-apim-e2e/api-test/src/apis/rollback/mapi-v2/api-v4-rollback.spec.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { created, noContent, succeed } from '@lib/jest-utils';
+import { describeIfV4EmulationEngine, created, noContent, succeed } from '@lib/jest-utils';
 import { MAPIV2ApisFaker } from '@gravitee/fixtures/management/MAPIV2ApisFaker';
 import { MAPIV2PlansFaker } from '@gravitee/fixtures/management/MAPIV2PlansFaker';
 import {
@@ -30,7 +30,7 @@ import { forManagementV2AsApiUser } from '@gravitee/utils/configuration';
 import { beforeEach, expect, test } from '@jest/globals';
 import { faker } from '@faker-js/faker';
 
-describe('API - V4 - Rollback', () => {
+describeIfV4EmulationEngine('API - V4 - Rollback', () => {
   describe('Rollback API to eventId', () => {
     const envId = 'DEFAULT';
     const v2ApisResourceAsApiPublisher = new APIsApi(forManagementV2AsApiUser());

--- a/gravitee-apim-e2e/lib/jest-utils.ts
+++ b/gravitee-apim-e2e/lib/jest-utils.ts
@@ -167,6 +167,13 @@ function isClientGatewaySupportingApiProductFeature(): boolean {
 }
 
 export const describeIfClientGatewayCompatible = describeIf(isClientGatewaySupportingV4APIDebugFeature());
-export const describeIfClientGatewaySupportingApiProduct = describeIf(isClientGatewaySupportingApiProductFeature());
+
+// API Products are V4-only: the v3 execution mode (V4_EMULATION_ENGINE_DEFAULT=no) only affects how
+// V2 APIs are executed and changes nothing for V4 APIs. Running these tests in the v3 matrix leg is
+// therefore pure duplication with no extra coverage, so we additionally gate them on the v4 emulation
+// engine leg to run them exactly once.
+export const describeIfClientGatewaySupportingApiProduct = describeIf(
+  isClientGatewaySupportingApiProductFeature() && process.env.V4_EMULATION_ENGINE_DEFAULT == 'yes',
+);
 
 export * from './jest-retry';


### PR DESCRIPTION
## Description

The api-test e2e suite runs the whole matrix twice: `execution_mode: ['v3', 'v4-emulation-engine']`. The v3 leg (`V4_EMULATION_ENGINE_DEFAULT=no`) only changes how **V2** APIs are executed; a **V4** API runs on the v4 engine identically in both legs. Several V4-only specs were therefore re-executed in the v3 leg with no extra coverage, inflating CI wall-clock by several minutes.

This PR gates V4-only specs on the v4 emulation engine leg (`describeIfV4EmulationEngine`) so they run exactly once, while preserving the existing client-gateway version gate used for bridge-compatibility:

- API Product specs (V4-only) — combined with the `>= 4.11` client gateway feature gate
- Debug-mode "V4 API Proxy" section
- 25 `mapi-v2` V4-only specs (proxy/native-kafka imports, definition & swagger updates, v4 connection/message logs, transfer ownership, rollback, TCP plan)

V2 and mixed specs are intentionally left running on both legs (e.g. `api-v4-proxy-import.spec.ts`, which despite its name imports a V2 API).

## Additional context

Measured on a CI run of this change: the v3 leg drops by several minutes; the v4-emulation leg is unchanged (same specs, still executed and green). No coverage is lost since the v3 leg added nothing for V4 APIs. The branch keeps the `run-e2e` suffix so the e2e pipeline runs on the PR.