### PR TITLE
feat(console): add sharding tags on api-products

### DIFF
--- a/gravitee-apim-console-webui/src/entities/management-api-v2/api-product/apiProduct.ts
+++ b/gravitee-apim-console-webui/src/entities/management-api-v2/api-product/apiProduct.ts
@@ -44,6 +44,10 @@ export interface ApiProduct {
    */
   groups?: string[];
   /**
+   * The list of sharding tags associated with this API Product.
+   */
+  tags?: string[];
+  /**
    * The date (as timestamp) when the API Product was created.
    */
   createdAt?: Date;

--- a/gravitee-apim-console-webui/src/management/api-products/api-products.routes.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/api-products.routes.ts
@@ -124,6 +124,15 @@ export const API_PRODUCTS_ROUTES: Routes = [
           },
         },
       },
+      {
+        path: 'deployment',
+        loadComponent: () => import('./deployment/api-product-deployment.component').then(m => m.ApiProductDeploymentComponent),
+        data: {
+          permissions: {
+            anyOf: ['api_product-definition-r'],
+          },
+        },
+      },
     ],
   },
 ];

--- a/gravitee-apim-console-webui/src/management/api-products/deployment/api-product-deployment.component.html
+++ b/gravitee-apim-console-webui/src/management/api-products/deployment/api-product-deployment.component.html
@@ -1,0 +1,57 @@
+<!--
+
+    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+
+@if (apiProduct(); as product) {
+  <form [formGroup]="form" class="deployment">
+    <mat-card class="deployment__card">
+      <mat-card-content>
+        <h3 class="deployment__card__title">Deployment configuration</h3>
+        <p class="deployment__card__subtitle">Control where this API Product is deployed</p>
+
+        <div class="deployment__card__field-title">Sharding tags</div>
+        <p class="deployment__card__field-description">
+          Choose the sharding tags that you want to assign to the API Product. This dictates where it is deployed. Sharding tags are
+          configured at the Organization level.
+        </p>
+
+        <mat-form-field appearance="outline" class="deployment__card__field">
+          <mat-label>Sharding tags</mat-label>
+          <mat-select formControlName="tags" aria-label="Sharding tags selection" data-testid="api_product_sharding_tags" multiple>
+            @for (tag of shardingTags(); track tag.id) {
+              <mat-option [value]="tag.key">
+                {{ tag.name }}
+                @if (tag.description) {
+                  <span> - {{ tag.description }}</span>
+                }
+              </mat-option>
+            }
+          </mat-select>
+        </mat-form-field>
+      </mat-card-content>
+    </mat-card>
+
+    @if (form.dirty && form.valid) {
+      <gio-save-bar
+        [form]="form"
+        [formInitialValues]="initialFormValue()"
+        (resetClicked)="onReset()"
+        (submitted)="onSubmit()"
+      ></gio-save-bar>
+    }
+  </form>
+}

--- a/gravitee-apim-console-webui/src/management/api-products/deployment/api-product-deployment.component.scss
+++ b/gravitee-apim-console-webui/src/management/api-products/deployment/api-product-deployment.component.scss
@@ -14,34 +14,35 @@
  * limitations under the License.
  */
 
-export interface UpdateApiProduct {
-  /**
-   * API Product's name. Must be unique within the environment.
-   */
-  name: string;
-  /**
-   * API Product's version.
-   */
-  version: string;
-  /**
-   * API Product's description.
-   */
-  description?: string;
-  /**
-   * List of API IDs included in the product.
-   */
-  apiIds?: string[];
-  /**
-   * Groups attached to this API Product.
-   */
-  groups?: string[];
-  /**
-   * The list of sharding tags associated with this API Product.
-   */
-  tags?: string[];
-  /**
-   * Disable membership notifications.
-   * @default false
-   */
-  disableMembershipNotifications?: boolean;
+@use '../../../scss/gio-layout' as gio-layout;
+
+:host {
+  @include gio-layout.gio-responsive-margin-container;
+}
+
+.deployment {
+  &__card {
+    margin-bottom: 24px;
+
+    &__title {
+      margin: 0 0 4px;
+    }
+
+    &__subtitle {
+      margin: 0 0 24px;
+    }
+
+    &__field-title {
+      font-weight: 600;
+      margin-bottom: 4px;
+    }
+
+    &__field-description {
+      margin: 0 0 16px;
+    }
+
+    &__field {
+      width: 100%;
+    }
+  }
 }

--- a/gravitee-apim-console-webui/src/management/api-products/deployment/api-product-deployment.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/deployment/api-product-deployment.component.spec.ts
@@ -1,0 +1,137 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { HarnessLoader } from '@angular/cdk/testing';
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { MatSelectHarness } from '@angular/material/select/testing';
+import { MatIconTestingModule } from '@angular/material/icon/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { HttpTestingController } from '@angular/common/http/testing';
+import { ActivatedRoute } from '@angular/router';
+import { of } from 'rxjs';
+
+import { ApiProductDeploymentComponent } from './api-product-deployment.component';
+
+import { CONSTANTS_TESTING, GioTestingModule } from '../../../shared/testing';
+import { ApiProduct } from '../../../entities/management-api-v2/api-product';
+import { Constants } from '../../../entities/Constants';
+import { SnackBarService } from '../../../services-ngx/snack-bar.service';
+import { GioTestingPermissionProvider } from '../../../shared/components/gio-permission/gio-permission.service';
+
+describe('ApiProductDeploymentComponent', () => {
+  const API_PRODUCT_ID = 'product-1';
+  const fakeApiProduct: ApiProduct = {
+    id: API_PRODUCT_ID,
+    name: 'Test API Product',
+    version: '1.0',
+    description: 'Test description',
+    apiIds: ['api-1'],
+    tags: ['tag-1'],
+  };
+
+  let fixture: ComponentFixture<ApiProductDeploymentComponent>;
+  let loader: HarnessLoader;
+  let httpTestingController: HttpTestingController;
+  const fakeSnackBarService = { error: jest.fn(), success: jest.fn() };
+
+  const init = async (permissions: string[] = ['api_product-definition-u']) => {
+    await TestBed.configureTestingModule({
+      imports: [ApiProductDeploymentComponent, GioTestingModule, MatIconTestingModule, NoopAnimationsModule],
+      providers: [
+        { provide: Constants, useValue: CONSTANTS_TESTING },
+        { provide: SnackBarService, useValue: fakeSnackBarService },
+        { provide: GioTestingPermissionProvider, useValue: permissions },
+        {
+          provide: ActivatedRoute,
+          useValue: { params: of({ apiProductId: API_PRODUCT_ID }), snapshot: { params: { apiProductId: API_PRODUCT_ID } } },
+        },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ApiProductDeploymentComponent);
+    loader = TestbedHarnessEnvironment.loader(fixture);
+    httpTestingController = TestBed.inject(HttpTestingController);
+    fixture.detectChanges();
+  };
+
+  const flushLoad = (product: ApiProduct = fakeApiProduct) => {
+    httpTestingController.expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/api-products/${API_PRODUCT_ID}`).flush(product);
+    httpTestingController
+      .expectOne(req => req.url.endsWith('/configuration/tags'))
+      .flush([
+        { id: '1', key: 'tag-1', name: 'Tag 1', description: '' },
+        { id: '2', key: 'tag-2', name: 'Tag 2', description: 'Second tag' },
+      ]);
+  };
+
+  afterEach(() => {
+    httpTestingController.match(req => req.url.endsWith('/configuration/tags')).forEach(r => r.flush([]));
+    httpTestingController.verify();
+    jest.clearAllMocks();
+  });
+
+  it('should load product tags into the sharding tags selector', async () => {
+    await init();
+    flushLoad();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    expect(fixture.componentInstance.form.getRawValue().tags).toEqual(['tag-1']);
+    const select = await loader.getHarness(MatSelectHarness.with({ selector: '[formControlName="tags"]' }));
+    expect(await select.isDisabled()).toBe(false);
+  });
+
+  it('should disable the selector without api_product-definition-u', async () => {
+    await init(['api_product-definition-r']);
+    flushLoad();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    const select = await loader.getHarness(MatSelectHarness.with({ selector: '[formControlName="tags"]' }));
+    expect(await select.isDisabled()).toBe(true);
+  });
+
+  it('should persist selected sharding tags on submit', async () => {
+    await init();
+    flushLoad();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    fixture.componentInstance.form.controls.tags.setValue(['tag-1', 'tag-2']);
+    fixture.componentInstance.form.markAsDirty();
+    fixture.componentInstance.onSubmit();
+    await fixture.whenStable();
+
+    const updateReq = httpTestingController.expectOne({
+      method: 'PUT',
+      url: `${CONSTANTS_TESTING.env.v2BaseURL}/api-products/${API_PRODUCT_ID}`,
+    });
+    expect(updateReq.request.body.tags).toEqual(['tag-1', 'tag-2']);
+    expect(updateReq.request.body.name).toBe('Test API Product');
+    expect(updateReq.request.body.apiIds).toEqual(['api-1']);
+    updateReq.flush({ ...fakeApiProduct, tags: ['tag-1', 'tag-2'] });
+    await fixture.whenStable();
+
+    // reload after save
+    httpTestingController.expectOne(`${CONSTANTS_TESTING.env.v2BaseURL}/api-products/${API_PRODUCT_ID}`).flush({
+      ...fakeApiProduct,
+      tags: ['tag-1', 'tag-2'],
+    });
+    await fixture.whenStable();
+
+    expect(fakeSnackBarService.success).toHaveBeenCalledWith('Configuration successfully saved!');
+  });
+});

--- a/gravitee-apim-console-webui/src/management/api-products/deployment/api-product-deployment.component.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/deployment/api-product-deployment.component.ts
@@ -1,0 +1,137 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Component, DestroyRef, effect, inject, signal } from '@angular/core';
+import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-interop';
+import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
+import { ActivatedRoute } from '@angular/router';
+import { EMPTY, merge, of, Subject } from 'rxjs';
+import { catchError, map, switchMap, tap } from 'rxjs/operators';
+import { MatCardModule } from '@angular/material/card';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatSelectModule } from '@angular/material/select';
+import { GioSaveBarModule } from '@gravitee/ui-particles-angular';
+
+import { ApiProduct, UpdateApiProduct } from '../../../entities/management-api-v2/api-product';
+import { ApiProductV2Service } from '../../../services-ngx/api-product-v2.service';
+import { SnackBarService } from '../../../services-ngx/snack-bar.service';
+import { GioPermissionService } from '../../../shared/components/gio-permission/gio-permission.service';
+import { TagService } from '../../../services-ngx/tag.service';
+import { Tag } from '../../../entities/tag/tag';
+
+interface DeploymentForm {
+  tags: FormControl<string[]>;
+}
+
+@Component({
+  selector: 'api-product-deployment',
+  templateUrl: './api-product-deployment.component.html',
+  styleUrls: ['./api-product-deployment.component.scss'],
+  standalone: true,
+  imports: [ReactiveFormsModule, MatCardModule, MatFormFieldModule, MatSelectModule, GioSaveBarModule],
+})
+export class ApiProductDeploymentComponent {
+  private readonly destroyRef = inject(DestroyRef);
+  private readonly activatedRoute = inject(ActivatedRoute);
+  private readonly apiProductV2Service = inject(ApiProductV2Service);
+  private readonly permissionService = inject(GioPermissionService);
+  private readonly snackBarService = inject(SnackBarService);
+  private readonly tagService = inject(TagService);
+
+  protected readonly isReadOnly = !this.permissionService.hasAnyMatching(['api_product-definition-u']);
+
+  protected readonly shardingTags = toSignal(this.tagService.list().pipe(catchError(() => of([] as Tag[]))), {
+    initialValue: [] as Tag[],
+  });
+
+  readonly form = new FormGroup<DeploymentForm>({
+    tags: new FormControl<string[]>({ value: [], disabled: this.isReadOnly }, { nonNullable: true }),
+  });
+  readonly initialFormValue = signal<Record<string, unknown> | null>(null);
+  private readonly reload$ = new Subject<void>();
+
+  private readonly apiProductId = toSignal(this.activatedRoute.params.pipe(map(p => p['apiProductId'] ?? null)), {
+    initialValue: null as string | null,
+  });
+
+  readonly apiProduct = toSignal(
+    merge(toObservable(this.apiProductId), this.reload$).pipe(
+      switchMap(() => {
+        const id = this.apiProductId();
+        return id
+          ? this.apiProductV2Service.get(id).pipe(
+              catchError(error => {
+                this.snackBarService.error(error.error?.message || 'An error occurred while loading the API Product');
+                return of(null);
+              }),
+            )
+          : of(null);
+      }),
+    ),
+    { initialValue: null as ApiProduct | null },
+  );
+
+  private readonly _formSync = effect(() => {
+    const product = this.apiProduct();
+    if (!product) return;
+
+    this.form.reset({ tags: product.tags ?? [] });
+    if (this.isReadOnly) {
+      this.form.disable({ emitEvent: false });
+    } else {
+      this.form.enable({ emitEvent: false });
+    }
+    this.initialFormValue.set(this.form.getRawValue());
+  });
+
+  onSubmit(): void {
+    const product = this.apiProduct();
+    if (!product) return;
+
+    const updateApiProduct: UpdateApiProduct = {
+      name: product.name,
+      version: product.version,
+      description: product.description,
+      apiIds: product.apiIds,
+      groups: product.groups,
+      disableMembershipNotifications: product.disableMembershipNotifications,
+      tags: this.form.getRawValue().tags ?? [],
+    };
+
+    this.apiProductV2Service
+      .update(product.id, updateApiProduct)
+      .pipe(
+        tap(() => {
+          this.apiProductV2Service.notifyApiProductChanged();
+          this.initialFormValue.set(this.form.getRawValue());
+          this.snackBarService.success('Configuration successfully saved!');
+          this.reload$.next();
+        }),
+        catchError(error => {
+          this.snackBarService.error(error.error?.message || error.message || 'An error occurred while updating the API Product');
+          return EMPTY;
+        }),
+        takeUntilDestroyed(this.destroyRef),
+      )
+      .subscribe();
+  }
+
+  onReset(): void {
+    const initial = this.initialFormValue();
+    if (!initial) return;
+    this.form.reset(initial);
+  }
+}

--- a/gravitee-apim-console-webui/src/management/api-products/list/api-product-list.component.html
+++ b/gravitee-apim-console-webui/src/management/api-products/list/api-product-list.component.html
@@ -106,6 +106,21 @@
           </td>
         </ng-container>
 
+        <!-- Sharding Tags Column -->
+        <ng-container matColumnDef="tags">
+          <th mat-header-cell *matHeaderCellDef id="tags">Sharding Tags</th>
+          <td mat-cell *matCellDef="let element">
+            @if (element.tags.length > 0) {
+              {{ element.tags[0] }}
+              @if (element.tags.length - 1 > 0) {
+                <span class="tags__badge gio-badge-neutral" [matTooltip]="element.tags.join(', ')">
+                  {{ element.tags.length - 1 }} more
+                </span>
+              }
+            }
+          </td>
+        </ng-container>
+
         <!-- Owner Column -->
         <ng-container matColumnDef="owner">
           <th mat-header-cell *matHeaderCellDef mat-sort-header id="owner">Owner</th>

--- a/gravitee-apim-console-webui/src/management/api-products/list/api-product-list.component.scss
+++ b/gravitee-apim-console-webui/src/management/api-products/list/api-product-list.component.scss
@@ -119,9 +119,17 @@ $typography: map.get(gio.$mat-theme, typography);
 
 .mat-column-apis,
 .mat-column-version,
+.mat-column-tags,
 .mat-column-owner,
 .mat-column-actions {
   padding: 0 8px;
+}
+
+.mat-column-tags {
+  .tags__badge {
+    margin-left: 4px;
+    cursor: default;
+  }
 }
 
 .mat-column-name {

--- a/gravitee-apim-console-webui/src/management/api-products/list/api-product-list.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/list/api-product-list.component.spec.ts
@@ -111,6 +111,7 @@ describe('ApiProductListComponent', () => {
       name: 'Payments API Product',
       version: '1.0',
       apiIds: ['api-1', 'api-2'],
+      tags: ['tag-1'],
       primaryOwner: { displayName: 'Jane Doe' } as any,
     };
 
@@ -124,7 +125,27 @@ describe('ApiProductListComponent', () => {
     expect(rowCells[1]).toContain('Payments API Product');
     expect(rowCells[2]).toContain('2');
     expect(rowCells[3]).toContain('1.0');
-    expect(rowCells[4]).toContain('Jane Doe');
+    expect(rowCells[4]).toContain('tag-1');
+    expect(rowCells[5]).toContain('Jane Doe');
+  });
+
+  it('should display sharding tags with a "more" badge when several tags are assigned', async () => {
+    const apiProduct: ApiProduct = {
+      id: 'product-1',
+      name: 'Payments API Product',
+      version: '1.0',
+      apiIds: ['api-1'],
+      tags: ['tag-1', 'tag-2', 'tag-3'],
+      primaryOwner: { displayName: 'Jane Doe' } as any,
+    };
+
+    await initComponent([apiProduct]);
+
+    const table = await loader.getHarness(MatTableHarness.with({ selector: '#apiProductsTable' }));
+    const rows = await table.getRows();
+    const rowCells = await rows[0].getCellTextByIndex();
+    expect(rowCells[4]).toContain('tag-1');
+    expect(rowCells[4]).toContain('2 more');
   });
 
   it('should display multiple API products', async () => {
@@ -280,7 +301,7 @@ describe('ApiProductListComponent', () => {
     const table = await loader.getHarness(MatTableHarness.with({ selector: '#apiProductsTable' }));
     const rows = await table.getRows();
     const rowCells = await rows[0].getCellTextByIndex();
-    expect(rowCells[4]).toContain('N/A');
+    expect(rowCells[5]).toContain('N/A');
   });
 
   it('should display zero APIs count when apiIds is empty', async () => {

--- a/gravitee-apim-console-webui/src/management/api-products/list/api-product-list.component.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/list/api-product-list.component.ts
@@ -68,6 +68,7 @@ export type ApiProductTableDS = {
   version: string;
   numberOfApis: number;
   owner: string;
+  tags: string[];
   picture?: string;
 }[];
 
@@ -111,7 +112,7 @@ export class ApiProductListComponent {
   private readonly snackBarService = inject(SnackBarService);
   private readonly permissionService = inject(GioPermissionService);
 
-  displayedColumns = ['picture', 'name', 'apis', 'version', 'owner', 'actions'];
+  displayedColumns = ['picture', 'name', 'apis', 'version', 'tags', 'owner', 'actions'];
   searchLabel = 'Search';
   canCreateApiProduct = this.permissionService.hasAnyMatching(['environment-api_product-c']);
 
@@ -198,6 +199,7 @@ export class ApiProductListComponent {
       version: product.version,
       numberOfApis: product.apiIds?.length || 0,
       owner: product.primaryOwner?.displayName || 'N/A',
+      tags: product.tags ?? [],
       picture: product._links?.pictureUrl,
     }));
   }

--- a/gravitee-apim-console-webui/src/management/api-products/navigation/api-product-navigation.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/navigation/api-product-navigation.component.spec.ts
@@ -303,4 +303,26 @@ describe('ApiProductNavigationComponent', () => {
       expect(fixture.nativeElement.textContent).not.toContain('Consumers');
     });
   });
+
+  describe('Deployment menu item visibility', () => {
+    it('should show Deployment menu item when user has api product definition read permission', async () => {
+      await configureNavigationTestBed(['api_product-definition-r']);
+      createFixture();
+      flushRequests(fakeApiProduct);
+      await fixture.whenStable();
+      fixture.detectChanges();
+
+      expect(fixture.nativeElement.textContent).toContain('Deployment');
+    });
+
+    it('should hide Deployment menu item when user lacks api product definition read permission', async () => {
+      await configureNavigationTestBed(['api_product-member-r']);
+      createFixture();
+      flushRequests(fakeApiProduct);
+      await fixture.whenStable();
+      fixture.detectChanges();
+
+      expect(fixture.nativeElement.textContent).not.toContain('Deployment');
+    });
+  });
 });

--- a/gravitee-apim-console-webui/src/management/api-products/navigation/api-product-navigation.component.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/navigation/api-product-navigation.component.ts
@@ -263,25 +263,32 @@ export class ApiProductNavigationComponent {
 
     const hasPlanRead = this.permissionService.hasAnyMatching(['api_product-plan-r']);
     const hasSubscriptionRead = this.permissionService.hasAnyMatching(['api_product-subscription-r']);
-    if (!hasPlanRead && !hasSubscriptionRead) {
-      return items;
+    if (hasPlanRead || hasSubscriptionRead) {
+      const tabs: ApiProductTabMenuItem[] = [];
+      if (hasPlanRead) {
+        tabs.push({ displayName: 'Plans', routerLink: 'consumers/plans' });
+      }
+      if (hasSubscriptionRead) {
+        tabs.push({ displayName: 'Subscriptions', routerLink: 'consumers/subscriptions' });
+      }
+
+      items.push({
+        displayName: 'Consumers',
+        routerLink: 'consumers',
+        icon: 'gio:cloud-consumers',
+        header: { title: 'Consumers', subtitle: 'Manage how your API Product is consumed' },
+        tabs,
+      });
     }
 
-    const tabs: ApiProductTabMenuItem[] = [];
-    if (hasPlanRead) {
-      tabs.push({ displayName: 'Plans', routerLink: 'consumers/plans' });
+    if (this.canAccessApiProductDefinition()) {
+      items.push({
+        displayName: 'Deployment',
+        routerLink: 'deployment',
+        icon: 'gio:rocket',
+        header: { title: 'Deployment', subtitle: 'Manage sharding tags and where this API Product is deployed.' },
+      });
     }
-    if (hasSubscriptionRead) {
-      tabs.push({ displayName: 'Subscriptions', routerLink: 'consumers/subscriptions' });
-    }
-
-    items.push({
-      displayName: 'Consumers',
-      routerLink: 'consumers',
-      icon: 'gio:cloud-consumers',
-      header: { title: 'Consumers', subtitle: 'Manage how your API Product is consumed' },
-      tabs,
-    });
 
     return items;
   }

--- a/gravitee-apim-console-webui/src/management/api-products/plans/edit/api-product-plan-edit.component.html
+++ b/gravitee-apim-console-webui/src/management/api-products/plans/edit/api-product-plan-edit.component.html
@@ -34,6 +34,7 @@
         [isFederated]="false"
         [isNative]="false"
         [showRestrictionStep]="false"
+        [referenceTags]="shardingTags()"
         [planMenuItem]="planMenuItem()!"
         [planStatus]="currentPlanStatus()"
       ></api-plan-form>

--- a/gravitee-apim-console-webui/src/management/api-products/plans/edit/api-product-plan-edit.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/plans/edit/api-product-plan-edit.component.spec.ts
@@ -84,6 +84,12 @@ describe('ApiProductPlanEditComponent', () => {
 
   afterEach(() => {
     flushGroupsRequest();
+    // The plan form now constrains sharding tags to the API Product's tags, which triggers these ambient loads.
+    httpTestingController
+      .match(`${CONSTANTS_TESTING.env.v2BaseURL}/api-products/${API_PRODUCT_ID}`)
+      .forEach(r => r.flush({ id: API_PRODUCT_ID, name: 'Product', version: '1.0', tags: [] }));
+    httpTestingController.match(req => req.url.endsWith('/configuration/tags')).forEach(r => r.flush([]));
+    httpTestingController.match(req => req.url.endsWith('/user/tags')).forEach(r => r.flush([]));
     httpTestingController.verify();
     jest.clearAllMocks();
   });

--- a/gravitee-apim-console-webui/src/management/api-products/plans/edit/api-product-plan-edit.component.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/plans/edit/api-product-plan-edit.component.ts
@@ -28,6 +28,7 @@ import { GioPermissionService } from '../../../../shared/components/gio-permissi
 import { SnackBarService } from '../../../../services-ngx/snack-bar.service';
 import { AVAILABLE_PLANS_FOR_MENU, PlanFormType, PlanMenuItemVM } from '../../../../services-ngx/constants.service';
 import { CreatePlanV4, Plan, PlanStatus } from '../../../../entities/management-api-v2';
+import { ApiProduct } from '../../../../entities/management-api-v2/api-product';
 import { ApiPlanFormModule } from '../../../api/component/plan/api-plan-form.module';
 import { ApiPlanFormComponent, PlanFormValue } from '../../../api/component/plan/api-plan-form.component';
 import { GioGoBackButtonModule } from '../../../../shared/components/gio-go-back-button/gio-go-back-button.module';
@@ -68,6 +69,16 @@ export class ApiProductPlanEditComponent {
 
   private readonly apiProductId = toSignal(this.activatedRoute.paramMap.pipe(map(p => p.get('apiProductId') ?? '')), { initialValue: '' });
   private readonly planId = toSignal(this.activatedRoute.paramMap.pipe(map(p => p.get('planId') ?? null)), { initialValue: null });
+
+  private readonly apiProduct = toSignal(
+    toObservable(this.apiProductId).pipe(
+      switchMap(id => (id ? this.apiProductV2Service.get(id).pipe(catchError(() => of(null))) : of(null))),
+    ),
+    { initialValue: null as ApiProduct | null },
+  );
+
+  // Sharding tags available for product plans are constrained to the API Product's own tags.
+  protected readonly shardingTags = computed(() => this.apiProduct()?.tags ?? []);
 
   protected readonly mode = computed(() => (this.planId() ? 'edit' : 'create') as 'create' | 'edit');
   protected readonly isReadOnly = computed(() => !this.permissionService.hasAnyMatching(['api_product-plan-u']));

--- a/gravitee-apim-console-webui/src/management/api-products/plans/list/api-product-plan-list.component.html
+++ b/gravitee-apim-console-webui/src/management/api-products/plans/list/api-product-plan-list.component.html
@@ -19,7 +19,7 @@
   [plans]="plansTableDS()"
   [planMenuItems]="planMenuItems"
   [isLoadingData]="isLoadingData()"
-  [context]="{ isReadOnly: isReadOnly(), isV2Api: false, showDeployOnColumn: false }"
+  [context]="{ isReadOnly: isReadOnly(), isV2Api: false, showDeployOnColumn: true }"
   [filterState]="{ statuses: apiPlanStatus(), selectedStatus: selectedStatus() }"
   (typeSelected)="onPlanTypeSelected($event)"
   (planSelected)="onPlanSelected($event)"

--- a/gravitee-apim-console-webui/src/management/api-products/plans/list/api-product-plan-list.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/plans/list/api-product-plan-list.component.spec.ts
@@ -130,13 +130,17 @@ describe('ApiProductPlanListComponent', () => {
       expect(row).toContain('JWT Plan');
     }));
 
-    it('omits deploy-on column for API product plans table', fakeAsync(async () => {
+    it('shows deploy-on column with sharding tags for API product plans table', fakeAsync(async () => {
       await init();
       fixture.detectChanges();
-      flushPlansList([]);
+      const plan = { ...fakePlanV4({ name: 'JWT Plan', security: { type: 'JWT' }, status: 'PUBLISHED', tags: ['tag-1', 'tag-2'] }) };
+      flushPlansList([plan]);
 
       const headers = await planListHarness.getHeaderColumnNames();
-      expect(headers['deploy-on']).toBeUndefined();
+      expect(headers['deploy-on']).toBe('Deploy on');
+
+      const [row] = await planListHarness.getRowCells();
+      expect(row).toContain('tag-1, tag-2');
     }));
   });
 

--- a/gravitee-apim-console-webui/src/management/api/component/plan/1-general-step/plan-edit-general-step.component.html
+++ b/gravitee-apim-console-webui/src/management/api/component/plan/1-general-step/plan-edit-general-step.component.html
@@ -98,7 +98,7 @@
       </mat-form-field>
     }
 
-    @if (!isFederated && (api$ | async)) {
+    @if (!isFederated && (hasReferenceTags || (api$ | async))) {
       <h2>Deployment</h2>
 
       <mat-form-field>

--- a/gravitee-apim-console-webui/src/management/api/component/plan/1-general-step/plan-edit-general-step.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/component/plan/1-general-step/plan-edit-general-step.component.spec.ts
@@ -20,13 +20,15 @@ import { HarnessLoader } from '@angular/cdk/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { MatInputHarness } from '@angular/material/input/testing';
 import { MatFormFieldHarness } from '@angular/material/form-field/testing';
+import { MatSelectHarness } from '@angular/material/select/testing';
 import { MatIconTestingModule } from '@angular/material/icon/testing';
 
 import { PlanEditGeneralStepComponent } from './plan-edit-general-step.component';
 
 import { ApiPlanFormModule } from '../api-plan-form.module';
 import { GioTestingModule, CONSTANTS_TESTING } from '../../../../../shared/testing';
-import { fakeNativeKafkaApiV4, fakeApiV4 } from '../../../../../entities/management-api-v2';
+import { ApiV4, fakeNativeKafkaApiV4, fakeApiV4 } from '../../../../../entities/management-api-v2';
+import { Tag } from '../../../../../entities/tag/tag';
 
 describe('PlanEditGeneralStepComponent — Kafka port routing', () => {
   let fixture: ComponentFixture<PlanEditGeneralStepComponent>;
@@ -328,6 +330,134 @@ describe('PlanEditGeneralStepComponent — Kafka port routing', () => {
 
       expect(component.generalForm.get('brokerRangeStart').value).toBe(9200);
       expect(component.generalForm.get('brokerRangeEnd').value).toBe(9202);
+    });
+  });
+});
+
+describe('PlanEditGeneralStepComponent — reference tags (API Product context)', () => {
+  let fixture: ComponentFixture<PlanEditGeneralStepComponent>;
+  let component: PlanEditGeneralStepComponent;
+  let loader: HarnessLoader;
+  let httpTestingController: HttpTestingController;
+
+  const fakeTag = (key: string): Tag => ({ id: key, key, name: key, description: '' });
+
+  const setupComponent = (referenceTags: string[] | undefined, api?: ApiV4) => {
+    TestBed.configureTestingModule({
+      declarations: [PlanEditGeneralStepComponent],
+      imports: [NoopAnimationsModule, GioTestingModule, ApiPlanFormModule, MatIconTestingModule],
+    });
+
+    fixture = TestBed.createComponent(PlanEditGeneralStepComponent);
+    component = fixture.componentInstance;
+    loader = TestbedHarnessEnvironment.loader(fixture);
+    httpTestingController = TestBed.inject(HttpTestingController);
+
+    component.mode = 'create';
+    component.referenceTags = referenceTags;
+    if (api) {
+      component.api = api;
+    }
+    fixture.detectChanges();
+  };
+
+  const flushRequests = ({ tags = [], userTags = [], apiId }: { tags?: Tag[]; userTags?: string[]; apiId?: string } = {}) => {
+    if (apiId) {
+      httpTestingController
+        .expectOne({ method: 'GET', url: `${CONSTANTS_TESTING.env.baseURL}/apis/${apiId}/pages?type=MARKDOWN&api=${apiId}` })
+        .flush([]);
+    }
+    httpTestingController.expectOne({ method: 'GET', url: `${CONSTANTS_TESTING.org.baseURL}/configuration/tags` }).flush(tags);
+    httpTestingController.expectOne({ method: 'GET', url: `${CONSTANTS_TESTING.org.baseURL}/user/tags` }).flush(userTags);
+    httpTestingController.expectOne({ method: 'GET', url: `${CONSTANTS_TESTING.env.baseURL}/configuration/groups` }).flush([]);
+    fixture.detectChanges();
+  };
+
+  const getShardingTagsSelectOrNull = () =>
+    loader.getHarnessOrNull(MatSelectHarness.with({ selector: '[aria-label="Sharding tags selection"]' }));
+
+  afterEach(() => {
+    httpTestingController.verify();
+  });
+
+  describe('hasReferenceTags flag', () => {
+    it('should be true when referenceTags is provided (even an empty array)', () => {
+      setupComponent([]);
+      flushRequests();
+
+      expect(component.hasReferenceTags).toBe(true);
+    });
+
+    it('should be false when referenceTags is left undefined', () => {
+      setupComponent(undefined);
+      // Without referenceTags or an API the Deployment section is not rendered, so only the
+      // always-visible Access-Control groups request is issued.
+      httpTestingController.expectOne({ method: 'GET', url: `${CONSTANTS_TESTING.env.baseURL}/configuration/groups` }).flush([]);
+      fixture.detectChanges();
+
+      expect(component.hasReferenceTags).toBe(false);
+    });
+  });
+
+  describe('Deployment section visibility', () => {
+    it('should show the Deployment (sharding tags) section when referenceTags is set even without an API context', async () => {
+      setupComponent([]);
+      flushRequests();
+
+      expect((fixture.nativeElement as HTMLElement).textContent).toContain('Deployment');
+      expect(await getShardingTagsSelectOrNull()).not.toBeNull();
+    });
+
+    it('should NOT show the Deployment (sharding tags) section when neither referenceTags nor an API are set', async () => {
+      setupComponent(undefined);
+      // The Deployment section is not rendered, so shardingTags$ is never subscribed and only the
+      // always-visible Access-Control groups request is issued.
+      httpTestingController.expectOne({ method: 'GET', url: `${CONSTANTS_TESTING.env.baseURL}/configuration/groups` }).flush([]);
+      fixture.detectChanges();
+
+      expect(await getShardingTagsSelectOrNull()).toBeNull();
+    });
+  });
+
+  describe('Sharding tags intersection', () => {
+    it('should only enable tags that belong to both the reference tags and the user tags', async () => {
+      setupComponent(['tag-a']);
+      flushRequests({ tags: [fakeTag('tag-a'), fakeTag('tag-b'), fakeTag('tag-c')], userTags: ['tag-a', 'tag-b'] });
+
+      const shardingTagsSelect = await loader.getHarness(MatSelectHarness.with({ selector: '[aria-label="Sharding tags selection"]' }));
+      await shardingTagsSelect.open();
+      const options = await shardingTagsSelect.getOptions();
+      const optionStates = await Promise.all(
+        options.map(async option => ({ text: await option.getText(), disabled: await option.isDisabled() })),
+      );
+
+      expect(optionStates).toEqual(
+        expect.arrayContaining([
+          { text: 'tag-a', disabled: false },
+          { text: 'tag-b', disabled: true },
+          { text: 'tag-c', disabled: true },
+        ]),
+      );
+    });
+
+    it('should let referenceTags take precedence over the API tags when both are present', async () => {
+      const api = fakeApiV4({ type: 'PROXY', tags: ['tag-b'] });
+      setupComponent(['tag-a'], api);
+      flushRequests({ tags: [fakeTag('tag-a'), fakeTag('tag-b')], userTags: ['tag-a', 'tag-b'], apiId: api.id });
+
+      const shardingTagsSelect = await loader.getHarness(MatSelectHarness.with({ selector: '[aria-label="Sharding tags selection"]' }));
+      await shardingTagsSelect.open();
+      const options = await shardingTagsSelect.getOptions();
+      const optionStates = await Promise.all(
+        options.map(async option => ({ text: await option.getText(), disabled: await option.isDisabled() })),
+      );
+
+      expect(optionStates).toEqual(
+        expect.arrayContaining([
+          { text: 'tag-a', disabled: false },
+          { text: 'tag-b', disabled: true },
+        ]),
+      );
     });
   });
 });

--- a/gravitee-apim-console-webui/src/management/api/component/plan/1-general-step/plan-edit-general-step.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/component/plan/1-general-step/plan-edit-general-step.component.ts
@@ -27,7 +27,7 @@ import {
 } from '@angular/forms';
 import { ErrorStateMatcher } from '@angular/material/core';
 import { includes } from 'lodash';
-import { combineLatest, of, ReplaySubject } from 'rxjs';
+import { BehaviorSubject, combineLatest, ReplaySubject } from 'rxjs';
 import { map, startWith, switchMap } from 'rxjs/operators';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
@@ -98,6 +98,15 @@ export class PlanEditGeneralStepComponent implements OnInit {
 
   public api$ = new ReplaySubject<ApiV2 | ApiV4 | ApiFederated>(1);
 
+  /**
+   * Tags allowed for this reference (e.g. an API Product's sharding tags) when there is no API context.
+   * When set (even to an empty array), the Deployment / sharding-tags section is shown and the selectable
+   * tags are constrained to this list (intersected with the user's allowed tags). When left undefined, the
+   * section is driven by the API ({@link api}) as before.
+   */
+  private readonly referenceTags$ = new BehaviorSubject<string[] | null>(null);
+  public hasReferenceTags = false;
+
   public generalForm: UntypedFormGroup;
 
   @Input()
@@ -105,6 +114,12 @@ export class PlanEditGeneralStepComponent implements OnInit {
     if (api) {
       this.api$.next(api);
     }
+  }
+
+  @Input()
+  public set referenceTags(tags: string[] | undefined) {
+    this.hasReferenceTags = tags != null;
+    this.referenceTags$.next(tags ?? null);
   }
 
   @Input()
@@ -154,13 +169,18 @@ export class PlanEditGeneralStepComponent implements OnInit {
     ),
     map(pages => pages.filter(page => page.published)),
   );
-  shardingTags$ = this.api$.pipe(
-    // Only load tags if api is defined
-    switchMap(api => combineLatest([this.tagService.list(), of(api), this.currentUserService.getTags()])),
-    map(([tags, api, userTags]) => {
+  shardingTags$ = combineLatest([
+    this.referenceTags$,
+    this.api$.pipe(startWith(null)),
+    this.tagService.list(),
+    this.currentUserService.getTags(),
+  ]).pipe(
+    map(([referenceTags, api, tags, userTags]) => {
+      // Reference tags (API Product) take precedence; otherwise fall back to the API's tags.
+      const allowedTags = referenceTags ?? api?.tags ?? [];
       return tags.map(tag => ({
         ...tag,
-        disabled: !includes(userTags, tag.key) || !includes(api.tags, tag.key),
+        disabled: !includes(userTags, tag.key) || !includes(allowedTags, tag.key),
       }));
     }),
   );

--- a/gravitee-apim-console-webui/src/management/api/component/plan/api-plan-form.component.html
+++ b/gravitee-apim-console-webui/src/management/api/component/plan/api-plan-form.component.html
@@ -24,6 +24,7 @@
     <plan-edit-general-step
       matStepContent
       [api]="api"
+      [referenceTags]="referenceTags"
       [isFederated]="isFederated"
       [hideAccessControl]="hideAccessControl"
       [isNative]="isNative"

--- a/gravitee-apim-console-webui/src/management/api/component/plan/api-plan-form.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/component/plan/api-plan-form.component.ts
@@ -166,6 +166,12 @@ export class ApiPlanFormComponent implements OnInit, AfterViewInit, OnDestroy, C
   @Input({ required: true }) isTcpApi!: boolean;
 
   /**
+   * Allowed sharding tags when there is no API context (e.g. an API Product's tags). When provided, the plan's
+   * sharding-tags section is shown and constrained to these tags. Leave undefined for the API-driven behavior.
+   */
+  @Input() referenceTags?: string[];
+
+  /**
    * When set, overrides the default restriction step visibility (e.g. use false to hide for API Product).
    * When undefined, restriction step is shown in create mode for non-TCP, non-native APIs.
    */


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-14343

## Description

This PR adds sharding tags support to API Products and API Product plans in the Management Console UI, addressing the Console UI part of the epic [APIM-14162](https://gravitee.atlassian.net/browse/APIM-14162).

### What's changed

**New Deployment page for API Products**
- Added a new `Deployment` section under the API Product navigation menu (requires `api_product-definition-r` permission to view, `api_product-definition-u` to edit).
- - The page provides a multi-select dropdown listing all organization-level sharding tags, allowing users to assign sharding tags to an API Product and control which gateways it is deployed to.
- - The selected tags are persisted via a `PUT` on the API Product; a save bar appears when changes are detected.
**API Product entity updates**
- Added `tags?: string[]` to both the `ApiProduct` and `UpdateApiProduct` TypeScript interfaces.
**Plan sharding tags constrained to API Product tags**
- When creating or editing a plan on an API Product, the sharding tags selector in the plan form is now constrained to the tags already assigned to the parent API Product (instead of showing all tags).
- - Introduced a new `referenceTags` input on `ApiPlanFormComponent` and `PlanEditGeneralStepComponent` that, when provided, drives the Deployment section of the plan form instead of the API-level tags. The Deployment section is shown whenever `referenceTags` is set (even if empty).
- - The `ApiProductPlanEditComponent` fetches the parent API Product and passes its tags down as `referenceTags`.
**Navigation**
- Added a `deployment` route to the API Products routing module.
- - Added a `Deployment` menu item (with rocket icon) to the API Product navigation, visible to users with `api_product-definition-r` permission.
- - Refactored the Consumers menu item conditional logic for correctness.
### Screen recording

https://github.com/user-attachments/assets/107e2a6e-f67d-4404-b682-0f81f6213533

## Additional context

- Sharding tags are configured at the Organization level; the new Deployment page reads them from `/configuration/tags`.
- - Plan-level tag validation against the product's tags is enforced by the backend (see [APIM-14341](https://gravitee.atlassian.net/browse/APIM-14341) / [APIM-14342](https://gravitee.atlassian.net/browse/APIM-14342)).
- - Unit tests are included for the new `ApiProductDeploymentComponent` (load, read-only mode, and save flows) and the updated `ApiProductPlanEditComponent` after-each cleanup.

[APIM-14162]: https://gravitee.atlassian.net/browse/APIM-14162?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[APIM-14341]: https://gravitee.atlassian.net/browse/APIM-14341?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ