### PR TITLE
feat: allow groups to be patched on the v4 API PATCH endpoint

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-apis.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-apis.yaml
@@ -359,7 +359,7 @@ paths:
                 Partially update a V4 HTTP Proxy API using JSON Patch (RFC 6902) or JSON Merge Patch (RFC 7396).
 
                 Only the following fields are patchable: name, description, apiVersion, visibility, labels, tags,
-                lifecycleState, categories, analytics, failover, flowExecution, flows, services, resources, endpointGroups,
+                lifecycleState, categories, groups, analytics, failover, flowExecution, flows, services, resources, endpointGroups,
                 allowedInApiProducts, allowMultiJwtOauth2Subscriptions, disableMembershipNotifications,
                 properties, responseTemplates, listeners.
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource_PatchApiGroupsTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource_PatchApiGroupsTest.java
@@ -1,0 +1,175 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.management.v2.rest.resource.api;
+
+import static assertions.MAPIAssertions.assertThat;
+import static io.gravitee.common.http.HttpStatusCode.BAD_REQUEST_400;
+import static io.gravitee.common.http.HttpStatusCode.OK_200;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.when;
+
+import fixtures.core.model.ApiFixtures;
+import inmemory.InMemoryAlternative;
+import io.gravitee.apim.core.api.domain_service.UpdateApiDomainService;
+import io.gravitee.apim.core.api.model.Api;
+import io.gravitee.apim.core.membership.model.Membership;
+import io.gravitee.apim.core.membership.model.PrimaryOwnerEntity;
+import io.gravitee.definition.model.DefinitionVersion;
+import io.gravitee.definition.model.v4.ApiType;
+import io.gravitee.rest.api.management.v2.rest.model.ApiV4;
+import io.gravitee.rest.api.model.v4.api.ApiEntity;
+import io.gravitee.rest.api.service.exceptions.InvalidDataException;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.client.Entity;
+import java.time.Instant;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Stream;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+public class ApiResource_PatchApiGroupsTest extends ApiResourceTest {
+
+    private static final String MERGE_PATCH_TYPE = "application/merge-patch+json";
+    private static final String JSON_PATCH_TYPE = "application/json-patch+json";
+
+    @Inject
+    UpdateApiDomainService updateApiDomainService;
+
+    @Override
+    protected String contextPath() {
+        return "/environments/" + ENVIRONMENT + "/apis";
+    }
+
+    @BeforeEach
+    void setUpApiAndPrimaryOwner() {
+        givenApiWithGroups(Set.of("group-1"));
+
+        var apiEntity = new ApiEntity();
+        apiEntity.setId(API);
+        apiEntity.setDefinitionVersion(DefinitionVersion.V4);
+        apiEntity.setType(ApiType.PROXY);
+        apiEntity.setUpdatedAt(Date.from(Instant.ofEpochMilli(1000)));
+        when(apiSearchServiceV4.findGenericById(any(), eq(API), any(boolean.class), any(boolean.class), any(boolean.class))).thenReturn(
+            apiEntity
+        );
+
+        roleQueryService.resetSystemRoles(ORGANIZATION);
+        primaryOwnerDomainService.initWith(
+            List.of(Map.entry(API, PrimaryOwnerEntity.builder().id(USER_NAME).type(PrimaryOwnerEntity.Type.USER).build()))
+        );
+        membershipQueryServiceInMemory.initWith(
+            List.of(
+                Membership.builder()
+                    .memberId(USER_NAME)
+                    .referenceId(API)
+                    .roleId("api-po-id-" + ORGANIZATION)
+                    .referenceType(Membership.ReferenceType.API)
+                    .memberType(Membership.Type.USER)
+                    .build()
+            )
+        );
+
+        doAnswer(inv -> inv.getArgument(0))
+            .when(updateApiDomainService)
+            .updateV4(any(), any());
+        doAnswer(inv -> inv.getArgument(0))
+            .when(updateApiDomainService)
+            .validateV4(any(), any());
+    }
+
+    @AfterEach
+    public void tearDown() {
+        Stream.of(apiCrudService, membershipQueryServiceInMemory, primaryOwnerDomainService).forEach(InMemoryAlternative::reset);
+        reset(updateApiDomainService, apiSearchServiceV4);
+    }
+
+    private void givenApiWithGroups(Set<String> groups) {
+        var api = ApiFixtures.aProxyApiV4().toBuilder().groups(new HashSet<>(groups)).build();
+        apiCrudService.initWith(List.of(api));
+    }
+
+    @Test
+    void merge_patch_sets_groups_returns_200_and_reflects_groups() {
+        var body = "{\"groups\":[\"group-2\"]}";
+        var response = rootTarget(API).request().method("PATCH", Entity.entity(body, MERGE_PATCH_TYPE));
+
+        var apiV4 = assertThat(response).hasStatus(OK_200).asEntity(ApiV4.class).actual();
+        Assertions.assertThat(apiV4.getGroups()).containsExactly("group-2");
+        Assertions.assertThat(capturePersistedGroups()).containsExactly("group-2");
+    }
+
+    @Test
+    void merge_patch_groups_null_clears_groups() {
+        var body = "{\"groups\":null}";
+        var response = rootTarget(API).request().method("PATCH", Entity.entity(body, MERGE_PATCH_TYPE));
+
+        var apiV4 = assertThat(response).hasStatus(OK_200).asEntity(ApiV4.class).actual();
+        Assertions.assertThat(apiV4.getGroups()).isNullOrEmpty();
+        Assertions.assertThat(capturePersistedGroups()).isNullOrEmpty();
+    }
+
+    @Test
+    void json_patch_replace_groups_returns_200_and_reflects_groups() {
+        var body = "[{\"op\":\"replace\",\"path\":\"/groups\",\"value\":[\"group-2\"]}]";
+        var response = rootTarget(API).request().method("PATCH", Entity.entity(body, JSON_PATCH_TYPE));
+
+        var apiV4 = assertThat(response).hasStatus(OK_200).asEntity(ApiV4.class).actual();
+        Assertions.assertThat(apiV4.getGroups()).containsExactly("group-2");
+    }
+
+    @Test
+    void json_patch_remove_groups_clears_groups() {
+        var body = "[{\"op\":\"remove\",\"path\":\"/groups\"}]";
+        var response = rootTarget(API).request().method("PATCH", Entity.entity(body, JSON_PATCH_TYPE));
+
+        var apiV4 = assertThat(response).hasStatus(OK_200).asEntity(ApiV4.class).actual();
+        Assertions.assertThat(apiV4.getGroups()).isNullOrEmpty();
+        Assertions.assertThat(capturePersistedGroups()).isNullOrEmpty();
+    }
+
+    @Test
+    void patch_with_unknown_group_is_rejected_and_not_persisted() {
+        doThrow(new InvalidDataException("These groups [unknown-group] do not exist")).when(updateApiDomainService).updateV4(any(), any());
+
+        var body = "{\"groups\":[\"unknown-group\"]}";
+        var response = rootTarget(API).request().method("PATCH", Entity.entity(body, MERGE_PATCH_TYPE));
+
+        var error = assertThat(response).hasStatus(BAD_REQUEST_400).asError().actual();
+        Assertions.assertThat(error.getTechnicalCode()).isEqualTo("data.invalid");
+        Assertions.assertThat(apiCrudService.get(API).getGroups()).containsExactly("group-1");
+    }
+
+    private Set<String> capturePersistedGroups() {
+        var captor = ArgumentCaptor.forClass(Api.class);
+        Mockito.verify(updateApiDomainService).updateV4(captor.capture(), any());
+        return captor.getValue().getGroups();
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/use_case/PatchApiUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/use_case/PatchApiUseCase.java
@@ -95,6 +95,7 @@ public class PatchApiUseCase {
     private static final String FIELD_RESOURCES = "resources";
     private static final String FIELD_LISTENERS = "listeners";
     private static final String FIELD_ENDPOINT_GROUPS = "endpointGroups";
+    private static final String FIELD_GROUPS = "groups";
 
     private static final String JSON_PATCH_PATH_PREFIX = "/";
 
@@ -139,7 +140,8 @@ public class PatchApiUseCase {
         FIELD_FLOWS,
         FIELD_RESOURCES,
         FIELD_LISTENERS,
-        FIELD_ENDPOINT_GROUPS
+        FIELD_ENDPOINT_GROUPS,
+        FIELD_GROUPS
     );
 
     private static final int MAX_PATCH_OPS = 200;
@@ -488,7 +490,7 @@ public class PatchApiUseCase {
             .categories(categories)
             .allowMultiJwtOauth2Subscriptions(allowMultiJwt)
             .disableMembershipNotifications(disableMembershipNotifications)
-            .groups(existingApi.getGroups())
+            .groups(resolveNullableSet(patchType, rawPatchNode, patchedNode, FIELD_GROUPS, existingApi.getGroups()))
             .apiDefinitionValue(updatedDefinition)
             .build();
     }
@@ -951,6 +953,7 @@ public class PatchApiUseCase {
         Set<String> tags,
         String lifecycleState,
         Set<String> categories,
+        Set<String> groups,
         PatchableAnalytics analytics,
         Failover failover,
         PatchableFlowExecution flowExecution,
@@ -976,6 +979,7 @@ public class PatchApiUseCase {
                 httpV4.getTags(),
                 api.getApiLifecycleState() != null ? api.getApiLifecycleState().name() : null,
                 api.getCategories(),
+                api.getGroups(),
                 PatchableAnalytics.from(httpV4.getAnalytics()),
                 httpV4.getFailover(),
                 PatchableFlowExecution.from(httpV4.getFlowExecution()),

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/PatchApiUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/PatchApiUseCaseTest.java
@@ -302,8 +302,16 @@ class PatchApiUseCaseTest {
         return clearFieldVariants("tags");
     }
 
+    static Stream<Arguments> clearGroupsVariants() {
+        return clearFieldVariants("groups");
+    }
+
     static Stream<Arguments> clearDescriptionVariants() {
         return clearFieldVariants("description");
+    }
+
+    static Api apiWithGroups(Set<String> groups) {
+        return ApiFixtures.aProxyApiV4().toBuilder().groups(groups).build();
     }
 
     static Api apiWithServices(ApiServices services) {
@@ -624,15 +632,109 @@ class PatchApiUseCaseTest {
                 .isInstanceOf(ApiPatchNotAllowedException.class)
                 .hasMessageContaining("type");
         }
+    }
+
+    @Nested
+    class Groups {
 
         @ParameterizedTest
         @EnumSource(PatchApiUseCase.PatchType.class)
-        void groups_field_is_rejected(PatchApiUseCase.PatchType type) {
-            givenExistingApi(ApiFixtures.aProxyApiV4().toBuilder().groups(new HashSet<>(List.of("g-1"))).build());
+        void groups_field_is_set(PatchApiUseCase.PatchType type) {
+            givenExistingApi(apiWithGroups(new HashSet<>(List.of("group-1"))));
 
-            assertThatThrownBy(() -> execute(type, setField(type, "groups", List.of("g-2")), false)).isInstanceOf(
-                ValidationDomainException.class
-            );
+            var output = execute(type, setField(type, "groups", List.of("group-2")), false);
+
+            assertThat(output.api().getGroups()).containsExactly("group-2");
+        }
+
+        @Test
+        void json_patch_add_sets_groups() {
+            givenExistingApi(apiWithGroups(new HashSet<>(List.of("group-1"))));
+
+            var output = execute(PatchApiUseCase.PatchType.JSON_PATCH, patch("add", "/groups", List.of("group-2")), false);
+
+            assertThat(output.api().getGroups()).containsExactly("group-2");
+        }
+
+        @ParameterizedTest
+        @MethodSource("io.gravitee.apim.core.api.use_case.PatchApiUseCaseTest#clearGroupsVariants")
+        void groups_field_is_cleared(PatchApiUseCase.PatchType type, String body) {
+            givenExistingApi(apiWithGroups(new HashSet<>(List.of("group-1"))));
+
+            var output = execute(type, body, false);
+
+            assertThat(output.api().getGroups()).isEmpty();
+        }
+
+        @ParameterizedTest
+        @EnumSource(PatchApiUseCase.PatchType.class)
+        void omitting_groups_preserves_existing_groups(PatchApiUseCase.PatchType type) {
+            givenExistingApi(apiWithGroups(new HashSet<>(List.of("group-1"))));
+
+            var output = execute(type, setField(type, "name", "new-name"), false);
+
+            assertThat(output.api().getGroups()).containsExactly("group-1");
+        }
+
+        @ParameterizedTest
+        @EnumSource(PatchApiUseCase.PatchType.class)
+        void patched_groups_flow_through_to_update_unsanitized(PatchApiUseCase.PatchType type) {
+            givenExistingApi(apiWithGroups(new HashSet<>(List.of("group-1"))));
+
+            execute(type, setField(type, "groups", List.of("foreign-po-group", "missing-group")), false);
+
+            var apiCaptor = ArgumentCaptor.forClass(Api.class);
+            verify(updateApiDomainService).updateV4(apiCaptor.capture(), any());
+            assertThat(apiCaptor.getValue().getGroups()).containsExactlyInAnyOrder("foreign-po-group", "missing-group");
+        }
+
+        @ParameterizedTest
+        @EnumSource(PatchApiUseCase.PatchType.class)
+        void groups_field_is_set_when_stored_groups_is_null(PatchApiUseCase.PatchType type) {
+            givenExistingApi(apiWithGroups(null));
+
+            var output = execute(type, setField(type, "groups", List.of("group-2")), false);
+
+            assertThat(output.api().getGroups()).containsExactly("group-2");
+        }
+
+        @Test
+        void json_patch_add_sets_groups_when_stored_groups_is_null() {
+            givenExistingApi(apiWithGroups(null));
+
+            var output = execute(PatchApiUseCase.PatchType.JSON_PATCH, patch("add", "/groups", List.of("group-2")), false);
+
+            assertThat(output.api().getGroups()).containsExactly("group-2");
+        }
+
+        @ParameterizedTest
+        @MethodSource("io.gravitee.apim.core.api.use_case.PatchApiUseCaseTest#clearGroupsVariants")
+        void groups_field_is_cleared_when_stored_groups_is_null(PatchApiUseCase.PatchType type, String body) {
+            givenExistingApi(apiWithGroups(null));
+
+            var output = execute(type, body, false);
+
+            assertThat(output.api().getGroups()).isEmpty();
+        }
+
+        @ParameterizedTest
+        @EnumSource(PatchApiUseCase.PatchType.class)
+        void invalid_groups_value_produces_400(PatchApiUseCase.PatchType type) {
+            assertThatThrownBy(() -> execute(type, setField(type, "groups", Map.of("not", "an-array")), false))
+                .isInstanceOf(ValidationDomainException.class)
+                .hasMessageContaining("groups");
+        }
+
+        @ParameterizedTest
+        @EnumSource(PatchApiUseCase.PatchType.class)
+        void dry_run_invokes_validation_with_patched_groups(PatchApiUseCase.PatchType type) {
+            stubValidateV4ReturnsArgument();
+
+            execute(type, setField(type, "groups", List.of("group-2")), true);
+
+            var apiCaptor = ArgumentCaptor.forClass(Api.class);
+            verify(updateApiDomainService).validateV4(apiCaptor.capture(), any());
+            assertThat(apiCaptor.getValue().getGroups()).containsExactly("group-2");
         }
     }
 


### PR DESCRIPTION
## Issue

[APIM-14050](https://gravitee.atlassian.net/browse/APIM-14050)

## Why

The v4 `PATCH /api/{apiId}` endpoint applies an explicit allow-list of patchable fields, and `groups` was not on it — any patch touching `groups` was rejected with `"field is not patchable"`. Group assignments could only be changed through the dedicated `PUT /api/{apiId}/groups` endpoint. This brings the generic v4 PATCH endpoint to parity with the full-update path, so a team can change an API's group assignments through the same patch request used for every other field.

## What changed

All production changes land in `PatchApiUseCase` (`gravitee-apim-rest-api-service`):

- **Allow-list** — added the `groups` field to the patchable allow-list.
- **Current-state node** — added `groups` to the `PatchableView` record so JSON-Patch `replace`/`remove` on `/groups` has a path to target (merge-patch tolerates an absent path; JSON-Patch does not).
- **Apply patched value** — the patched `groups` value now flows through via the same `resolveNullableSet` helper used for `tags`/`categories`, instead of being hard-preserved from the existing API.

Validation and sanitization come for free: the persist (`updateV4`) and dry-run (`validateV4`) paths already run `GroupValidationService` unconditionally, so PATCH inherits the exact `PUT /api/{id}` full-update semantics (ID-based group validation, API-context-aware primary-owner-group handling). No new validation wiring, Kubernetes guard, or audit code was needed.

The OpenAPI operation description for `PATCH /api/{apiId}` was updated to list `groups` among the patchable fields.

## User-facing impact

- **Behaviour change**: `groups` is now patchable on `PATCH /api/{apiId}` (v4) for both JSON-Patch (RFC 6902) and JSON-Merge-Patch (RFC 7386) bodies. Field omitted → unchanged; explicit `null` / JSON-Patch `remove /groups` → cleared; array → that set, sanitized downstream. The response `ApiV4` reflects the sanitized `groups`.
- **Intentional semantics**: PATCH rides the full-update path (`GroupValidationService`), not the stricter dedicated `PUT /groups` path — group refs are resolved by ID, the API's own primary-owner group is retained, and a foreign primary-owner group is discarded by sanitization.
- **Not breaking**: additive change (one new allow-list entry). Previously-rejected `groups` patches simply start succeeding.
- **Documentation**: the OpenAPI spec description is updated in this PR. Permission parity and Kubernetes-managed-API handling are out of scope and tracked separately.

## How to test

Against a v4 HTTP Proxy API:

- Merge-patch set: `PATCH` body `{"groups":["<groupId>"]}` → `200`, `ApiV4.groups` contains the group.
- Merge-patch clear: `{"groups":null}` → `200`, groups cleared.
- JSON-Patch remove: `[{"op":"remove","path":"/groups"}]` → `200`, groups cleared.
- Foreign primary-owner group: patch in a group that is the primary-owner group of a different API → that group is discarded (sanitized), matching `PUT /api/{id}`.

## Known Issues

- [F17806657940319] MINOR — `gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/api/UpdateApiDomainServiceImpl.java:107` — The dry-run path resolves groups via `coalesce(sanitized.getGroups(), original.getGroups())`, falling back to the original groups when the sanitizer returns null. A `dryRun=true` clear-groups preview can therefore still show the pre-patch groups, diverging from what the real update persists (an empty set). The file is not edited by this change; the pattern is pre-existing and shared with `categories`/`labels`, but this change is the first to make it reachable for `groups`. Tracked separately.


[APIM-14050]: https://gravitee.atlassian.net/browse/APIM-14050?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ