### PR TITLE
feat(authz): granular entityType — write-time derive + read path

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/authz/AuthzEntityMapper.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/authz/AuthzEntityMapper.java
@@ -22,6 +22,7 @@ import io.gravitee.gamma.definition.authz.AuthzEntityKind;
 import io.gravitee.gateway.services.sync.process.common.model.SyncAction;
 import io.gravitee.repository.management.model.Event;
 import io.reactivex.rxjava3.core.Maybe;
+import java.util.List;
 import lombok.CustomLog;
 import lombok.RequiredArgsConstructor;
 
@@ -46,7 +47,7 @@ public class AuthzEntityMapper {
                     .kind(kind)
                     .entityType(wire.getEntityType())
                     .attributes(wire.getAttributes())
-                    .parents(wire.getParents())
+                    .parents(normalizeParents(wire.getParents()))
                     .syncAction(SyncAction.DEPLOY)
                     .build();
             } catch (Exception e) {
@@ -85,6 +86,14 @@ public class AuthzEntityMapper {
 
     private static AuthzEntityReactorDeployable.Kind toGatewayKind(AuthzEntityKind wireKind) {
         return AuthzEntityReactorDeployable.Kind.valueOf(wireKind.name());
+    }
+
+    // Emit parents in the engine's canonical quoted form Type::"id" so the PDP can parse them directly.
+    private static List<String> normalizeParents(List<String> parents) {
+        if (parents == null) {
+            return null;
+        }
+        return parents.stream().map(AuthzEntityIdConstants::normalizeParentUid).toList();
     }
 
     /**

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/authz/AuthzEntityMapperTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/authz/AuthzEntityMapperTest.java
@@ -102,7 +102,30 @@ class AuthzEntityMapperTest {
         assertThat(d).isNotNull();
         assertThat(d.engineUid()).isEqualTo("Principal::\"idp.am.alice\"");
         assertThat(d.kind()).isEqualTo(AuthzEntityReactorDeployable.Kind.PRINCIPAL);
+        // A typeless bare-id parent passes through untouched.
         assertThat(d.parents()).containsExactly("idp.am.admins");
+    }
+
+    @Test
+    void toDeploy_normalizes_typed_parent_uids_to_the_canonical_quoted_form() {
+        Event event = event(
+            "evt-parents",
+            """
+            {
+              "entityId": "alice",
+              "entityType": "User",
+              "kind": "PRINCIPAL",
+              "attributes": {},
+              "parents": ["Group::engineering", "Role::\\"admin\\"", "bare-id"]
+            }
+            """
+        );
+
+        AuthzEntityReactorDeployable d = mapper.toDeploy(event).blockingGet();
+
+        assertThat(d).isNotNull();
+        // Unquoted typed parent is re-quoted; already-quoted stays; bare id passes through.
+        assertThat(d.parents()).containsExactly("Group::\"engineering\"", "Role::\"admin\"", "bare-id");
     }
 
     @Test

--- a/gravitee-gamma/gravitee-gamma-definition-model/src/main/java/io/gravitee/gamma/definition/authz/AuthzEntityIdConstants.java
+++ b/gravitee-gamma/gravitee-gamma-definition-model/src/main/java/io/gravitee/gamma/definition/authz/AuthzEntityIdConstants.java
@@ -15,6 +15,9 @@
  */
 package io.gravitee.gamma.definition.authz;
 
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
 import java.util.Set;
 
 public final class AuthzEntityIdConstants {
@@ -49,6 +52,42 @@ public final class AuthzEntityIdConstants {
             }
         }
         return false;
+    }
+
+    // Transitional bridge: maps a _kind attribute value (principals) or an entityId prefix segment
+    // (resources) to the canonical engine type name. Mirrors the FE entity-kind-registry.ts. The
+    // schema is the source of truth for which types are valid; this only types legacy/sync data
+    // that carries _kind/prefix rather than an explicit entityType.
+    private static final Map<String, String> ENGINE_TYPE_BY_HINT = new HashMap<>();
+
+    static {
+        registerEngineType("User", "user");
+        registerEngineType("Group", "group");
+        registerEngineType("Role", "role");
+        registerEngineType("ServiceAccount", "serviceaccount", "service-account", "service_account");
+        registerEngineType("AgentIdentity", "agent-identity", "agentidentity");
+        registerEngineType("MCPServer", "mcp", "mcpserver");
+        registerEngineType("MCPTool", "mcptool");
+        registerEngineType("Model", "model", "llm", "llmmodel", "llmroute");
+        registerEngineType("Agent", "agent", "a2a", "a2aagent");
+        registerEngineType("API", "api");
+        registerEngineType("Event", "event");
+        registerEngineType("Resource", "resource");
+        registerEngineType("Action", "action");
+    }
+
+    private static void registerEngineType(String engineType, String... hints) {
+        for (String hint : hints) {
+            ENGINE_TYPE_BY_HINT.put(hint.toLowerCase(Locale.ROOT), engineType);
+        }
+    }
+
+    /** A {@code _kind} value or entityId prefix segment → canonical engine type, or {@code null} when unknown. */
+    public static String engineTypeForHint(String hint) {
+        if (hint == null || hint.isBlank()) {
+            return null;
+        }
+        return ENGINE_TYPE_BY_HINT.get(hint.toLowerCase(Locale.ROOT));
     }
 
     private AuthzEntityIdConstants() {}

--- a/gravitee-gamma/gravitee-gamma-definition-model/src/main/java/io/gravitee/gamma/definition/authz/AuthzEntityIdConstants.java
+++ b/gravitee-gamma/gravitee-gamma-definition-model/src/main/java/io/gravitee/gamma/definition/authz/AuthzEntityIdConstants.java
@@ -90,5 +90,34 @@ public final class AuthzEntityIdConstants {
         return ENGINE_TYPE_BY_HINT.get(hint.toLowerCase(Locale.ROOT));
     }
 
+    /**
+     * Canonical engine UID wire form: {@code Type::"id"} (the quoted form the engine's parser expects).
+     * No escaping is applied: entityIds are constrained by {@link #FORMAT_REGEX} (lowercase, digits,
+     * {@code _ : - .}) and types are canonical names, so neither can contain a quote/backslash.
+     */
+    public static String toEngineUid(String entityType, String entityId) {
+        return entityType + "::\"" + entityId + "\"";
+    }
+
+    /**
+     * Normalize a reference UID to the canonical quoted form {@code Type::"id"} so the engine parser
+     * accepts it directly. Re-quotes the unquoted legacy {@code Type::id}; leaves an already-quoted
+     * UID, a typeless bare id (no {@code ::}), and null untouched. The type/id split is the last
+     * {@code ::}, mirroring the engine's own parse (a namespaced type keeps its inner {@code ::}).
+     */
+    public static String normalizeParentUid(String uid) {
+        if (uid == null || uid.contains("::\"") || !uid.contains("::")) {
+            return uid;
+        }
+        int sep = uid.lastIndexOf("::");
+        String type = uid.substring(0, sep);
+        String id = uid.substring(sep + 2);
+        if (type.isBlank() || id.isBlank()) {
+            // Not a normalizable Type::id (e.g. "Type::" or "::id") — leave it for the parser to reject.
+            return uid;
+        }
+        return toEngineUid(type, id);
+    }
+
     private AuthzEntityIdConstants() {}
 }

--- a/gravitee-gamma/gravitee-gamma-definition-model/src/test/java/io/gravitee/gamma/definition/authz/AuthzEntityIdConstantsTest.java
+++ b/gravitee-gamma/gravitee-gamma-definition-model/src/test/java/io/gravitee/gamma/definition/authz/AuthzEntityIdConstantsTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gamma.definition.authz;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class AuthzEntityIdConstantsTest {
+
+    @Test
+    void maps_principal_kind_hints_to_engine_types() {
+        assertThat(AuthzEntityIdConstants.engineTypeForHint("user")).isEqualTo("User");
+        assertThat(AuthzEntityIdConstants.engineTypeForHint("group")).isEqualTo("Group");
+        assertThat(AuthzEntityIdConstants.engineTypeForHint("role")).isEqualTo("Role");
+        assertThat(AuthzEntityIdConstants.engineTypeForHint("agent-identity")).isEqualTo("AgentIdentity");
+    }
+
+    @Test
+    void maps_resource_prefixes_to_engine_types() {
+        assertThat(AuthzEntityIdConstants.engineTypeForHint("mcp")).isEqualTo("MCPServer");
+        assertThat(AuthzEntityIdConstants.engineTypeForHint("mcptool")).isEqualTo("MCPTool");
+        assertThat(AuthzEntityIdConstants.engineTypeForHint("model")).isEqualTo("Model");
+        assertThat(AuthzEntityIdConstants.engineTypeForHint("api")).isEqualTo("API");
+        assertThat(AuthzEntityIdConstants.engineTypeForHint("agent")).isEqualTo("Agent");
+    }
+
+    @Test
+    void accepts_aliases_and_is_case_insensitive() {
+        assertThat(AuthzEntityIdConstants.engineTypeForHint("service-account")).isEqualTo("ServiceAccount");
+        assertThat(AuthzEntityIdConstants.engineTypeForHint("LLM")).isEqualTo("Model");
+        assertThat(AuthzEntityIdConstants.engineTypeForHint("MCPServer")).isEqualTo("MCPServer");
+    }
+
+    @Test
+    void returns_null_for_unknown_or_blank_hint() {
+        assertThat(AuthzEntityIdConstants.engineTypeForHint("dupa")).isNull();
+        assertThat(AuthzEntityIdConstants.engineTypeForHint("")).isNull();
+        assertThat(AuthzEntityIdConstants.engineTypeForHint(null)).isNull();
+    }
+}

--- a/gravitee-gamma/gravitee-gamma-definition-model/src/test/java/io/gravitee/gamma/definition/authz/AuthzEntityIdConstantsTest.java
+++ b/gravitee-gamma/gravitee-gamma-definition-model/src/test/java/io/gravitee/gamma/definition/authz/AuthzEntityIdConstantsTest.java
@@ -51,4 +51,31 @@ class AuthzEntityIdConstantsTest {
         assertThat(AuthzEntityIdConstants.engineTypeForHint("")).isNull();
         assertThat(AuthzEntityIdConstants.engineTypeForHint(null)).isNull();
     }
+
+    @Test
+    void toEngineUid_builds_the_canonical_quoted_form() {
+        assertThat(AuthzEntityIdConstants.toEngineUid("User", "alice")).isEqualTo("User::\"alice\"");
+        assertThat(AuthzEntityIdConstants.toEngineUid("API", "api.payments")).isEqualTo("API::\"api.payments\"");
+    }
+
+    @Test
+    void normalizeParentUid_requotes_unquoted_typed_uids() {
+        assertThat(AuthzEntityIdConstants.normalizeParentUid("Group::engineering")).isEqualTo("Group::\"engineering\"");
+        // Namespaced type: split on the LAST '::' so the type keeps its inner '::'.
+        assertThat(AuthzEntityIdConstants.normalizeParentUid("myapp::Report::r1")).isEqualTo("myapp::Report::\"r1\"");
+    }
+
+    @Test
+    void normalizeParentUid_leaves_canonical_bare_and_null_untouched() {
+        assertThat(AuthzEntityIdConstants.normalizeParentUid("Group::\"engineering\"")).isEqualTo("Group::\"engineering\"");
+        assertThat(AuthzEntityIdConstants.normalizeParentUid("bare-id")).isEqualTo("bare-id");
+        assertThat(AuthzEntityIdConstants.normalizeParentUid(null)).isNull();
+    }
+
+    @Test
+    void normalizeParentUid_does_not_manufacture_empty_component_uids() {
+        // Malformed Type::/::id must pass through unchanged, not become Type::"" / ::"id".
+        assertThat(AuthzEntityIdConstants.normalizeParentUid("Group::")).isEqualTo("Group::");
+        assertThat(AuthzEntityIdConstants.normalizeParentUid("::engineering")).isEqualTo("::engineering");
+    }
 }

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/java/io/gravitee/gamma/authorization/core/am/use_case/SyncAmUsersUseCase.java
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/java/io/gravitee/gamma/authorization/core/am/use_case/SyncAmUsersUseCase.java
@@ -25,6 +25,7 @@ import io.gravitee.gamma.authorization.core.am.model.AmUser;
 import io.gravitee.gamma.authorization.core.am.service_provider.AmDirectoryClient;
 import io.gravitee.gamma.authorization.domain.AuthzEntityKind;
 import io.gravitee.gamma.authorization.service.CreateOrReplaceAuthzEntityCommand;
+import io.gravitee.gamma.definition.authz.AuthzEntityIdConstants;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -216,12 +217,21 @@ public class SyncAmUsersUseCase {
             attributes.put("enabled", user.enabled());
         }
 
-        // Membership: the user's parents are its AM group + role ids. Replaced wholesale on every
-        // upsert, so a membership dropped in AM disappears from parents on the next sync.
-        List<String> parents = new ArrayList<>(user.groups());
-        parents.addAll(user.roles());
+        // Membership: the user's parents are the canonical engine UIDs of its AM group + role
+        // entities (Group::"id" / Role::"id"), matching the type those entities derive from their
+        // _kind so the PDP resolves `principal in Group::"id"`; a bare id would not match the typed
+        // entity. Replaced wholesale on every upsert, so a membership dropped in AM disappears from
+        // parents on the next sync.
+        List<String> parents = new ArrayList<>();
+        user.groups().forEach(g -> parents.add(membershipUid("group", g)));
+        user.roles().forEach(r -> parents.add(membershipUid("role", r)));
 
         return new CreateOrReplaceAuthzEntityCommand(environmentId, sub, AuthzEntityKind.PRINCIPAL, null, attributes, parents, SOURCE);
+    }
+
+    private static String membershipUid(String kindHint, String id) {
+        String type = AuthzEntityIdConstants.engineTypeForHint(kindHint);
+        return type != null ? AuthzEntityIdConstants.toEngineUid(type, id) : id;
     }
 
     private CreateOrReplaceAuthzEntityCommand groupCommand(String environmentId, AmGroup group) {

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/java/io/gravitee/gamma/authorization/service/CreateOrReplaceAuthzEntityCommand.java
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/java/io/gravitee/gamma/authorization/service/CreateOrReplaceAuthzEntityCommand.java
@@ -17,6 +17,7 @@ package io.gravitee.gamma.authorization.service;
 
 import io.gravitee.gamma.authorization.api.AuthzValidators;
 import io.gravitee.gamma.authorization.domain.AuthzEntityKind;
+import io.gravitee.gamma.definition.authz.AuthzEntityIdConstants;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import java.util.List;
@@ -32,11 +33,12 @@ public record CreateOrReplaceAuthzEntityCommand(
     @NotBlank String source
 ) {
     public CreateOrReplaceAuthzEntityCommand {
-        // Backwards-compatible: legacy callers (no entityType) fall back to the kind-default.
-        // Done before validate so the value seen by hibernate-validator matches the canonical
-        // constructor parameter list.
+        // Derive a granular engine type from the _kind hint (principals) or the entityId prefix
+        // (resources) when the caller didn't supply one; fall back to the kind-default umbrella.
+        // A supplied entityType is kept verbatim. Done before validate so the validator sees the
+        // canonical value.
         if (entityType == null || entityType.isBlank()) {
-            entityType = kind != null ? kind.defaultEntityType() : null;
+            entityType = deriveEntityType(kind, entityId, attributes);
         }
         AuthzValidators.validateCtor(
             CreateOrReplaceAuthzEntityCommand.class,
@@ -50,6 +52,24 @@ public record CreateOrReplaceAuthzEntityCommand(
         );
         attributes = Map.copyOf(attributes);
         parents = List.copyOf(parents);
+    }
+
+    private static String deriveEntityType(AuthzEntityKind kind, String entityId, Map<String, Object> attributes) {
+        Object kindHint = attributes == null ? null : attributes.get("_kind");
+        String byKind = kindHint instanceof String s ? AuthzEntityIdConstants.engineTypeForHint(s) : null;
+        if (byKind != null) {
+            return byKind;
+        }
+        if (entityId != null) {
+            int dot = entityId.indexOf('.');
+            if (dot > 0) {
+                String byPrefix = AuthzEntityIdConstants.engineTypeForHint(entityId.substring(0, dot));
+                if (byPrefix != null) {
+                    return byPrefix;
+                }
+            }
+        }
+        return kind != null ? kind.defaultEntityType() : null;
     }
 
     /**

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/features/policy-structure/CreateEntityDialog.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/features/policy-structure/CreateEntityDialog.tsx
@@ -48,8 +48,10 @@ import { useEffect, useMemo, useState } from 'react';
 import { authzApiService } from '../../shared/api/authz-api.service';
 import { authzQueryKeys } from '../../shared/api/query-keys';
 import { formatEntityUid, fromBackend } from '../../shared/entity-adapter';
-import { ENTITY_KIND_REGISTRY } from '../../shared/entity-kind-registry';
+import { ENTITY_KIND_REGISTRY, kindToUiType, uiTypeToKind } from '../../shared/entity-kind-registry';
+import { type ParsedSchema } from '../../shared/engine-schema';
 import { useEntities } from '../../shared/hooks/useEntities';
+import { useParsedSchema } from '../../shared/hooks/useParsedSchema';
 import { AttributeEditor, type AttributeRow } from './AttributeEditor';
 import { attrsFromRows } from './attribute-rows';
 
@@ -82,6 +84,46 @@ const RESOURCE_PRESETS: readonly { canonical: string; label: string }[] = [
 
 const CUSTOM_TYPE = '__custom__';
 
+const UMBRELLA_TYPE: Record<EntityKind, string> = {
+    PRINCIPAL: 'Principal',
+    RESOURCE: 'Resource',
+};
+
+interface TypeOption {
+    readonly value: string;
+    readonly label: string;
+    readonly badge: string;
+    readonly prefix: string;
+    readonly entityType: string;
+}
+
+function presetOptions(kind: EntityKind): TypeOption[] {
+    const presets = kind === 'PRINCIPAL' ? PRINCIPAL_PRESETS : RESOURCE_PRESETS;
+    return presets.map(p => ({
+        value: p.canonical,
+        label: p.label,
+        badge: p.canonical,
+        prefix: p.canonical,
+        entityType: kindToUiType(p.canonical) ?? p.label,
+    }));
+}
+
+function schemaOptions(parsed: ParsedSchema, kind: EntityKind): TypeOption[] {
+    const names = new Set<string>();
+    for (const action of parsed.actions) {
+        for (const name of kind === 'PRINCIPAL' ? action.principals : action.resources) {
+            names.add(name);
+        }
+    }
+    return [...names].map(name => ({
+        value: name,
+        label: name,
+        badge: uiTypeToKind(name),
+        prefix: uiTypeToKind(name),
+        entityType: name,
+    }));
+}
+
 function slugify(value: string): string {
     return value
         .normalize('NFD')
@@ -105,9 +147,16 @@ export interface CreateEntityDialogProps {
 
 export function CreateEntityDialog({ open, kind, environmentId, onOpenChange, onCreated }: CreateEntityDialogProps) {
     const queryClient = useQueryClient();
-    const presets = kind === 'PRINCIPAL' ? PRINCIPAL_PRESETS : RESOURCE_PRESETS;
+    const { parsed } = useParsedSchema(environmentId);
 
-    const [typeSelection, setTypeSelection] = useState<string>(presets[0]!.canonical);
+    const typeOptions = useMemo<TypeOption[]>(() => {
+        const fromSchema = schemaOptions(parsed, kind);
+        return fromSchema.length > 0 ? fromSchema : presetOptions(kind);
+    }, [parsed, kind]);
+
+    const defaultSelection = typeOptions[0]!.value;
+
+    const [typeSelection, setTypeSelection] = useState<string>(defaultSelection);
     const [customPrefix, setCustomPrefix] = useState('');
     const [slug, setSlug] = useState('');
     const [slugTouched, setSlugTouched] = useState(false);
@@ -122,7 +171,7 @@ export function CreateEntityDialog({ open, kind, environmentId, onOpenChange, on
     // resets (e.g. from successful import) don't fight the local state machine.
     useEffect(() => {
         if (!open) {
-            setTypeSelection(presets[0]!.canonical);
+            setTypeSelection(defaultSelection);
             setCustomPrefix('');
             setSlug('');
             setSlugTouched(false);
@@ -133,7 +182,15 @@ export function CreateEntityDialog({ open, kind, environmentId, onOpenChange, on
             setSubmitError(null);
             setSubmitting(false);
         }
-    }, [open, presets]);
+    }, [open, defaultSelection]);
+
+    // When the schema resolves after the dialog is already open, a stale preset
+    // selection can no longer exist in the new options — snap back to the default.
+    useEffect(() => {
+        if (typeSelection !== CUSTOM_TYPE && !typeOptions.some(o => o.value === typeSelection)) {
+            setTypeSelection(defaultSelection);
+        }
+    }, [typeOptions, typeSelection, defaultSelection]);
 
     // Auto-derive slug from displayName until the user touches the slug field.
     useEffect(() => {
@@ -141,7 +198,9 @@ export function CreateEntityDialog({ open, kind, environmentId, onOpenChange, on
     }, [displayName, slugTouched]);
 
     const isCustom = typeSelection === CUSTOM_TYPE;
-    const canonicalPrefix = isCustom ? customPrefix.trim().toLowerCase() : typeSelection;
+    const selectedOption = typeOptions.find(o => o.value === typeSelection);
+    const canonicalPrefix = isCustom ? customPrefix.trim().toLowerCase() : (selectedOption?.prefix ?? typeSelection);
+    const entityType = isCustom ? UMBRELLA_TYPE[kind] : (selectedOption?.entityType ?? UMBRELLA_TYPE[kind]);
     const entityId = canonicalPrefix && slug ? `${canonicalPrefix}.${slug}` : '';
 
     const customPrefixError =
@@ -209,6 +268,7 @@ export function CreateEntityDialog({ open, kind, environmentId, onOpenChange, on
             await authzApiService.createEntity(environmentId, {
                 entityId,
                 kind,
+                entityType,
                 attributes,
                 parents: parentIds,
                 source: 'local',
@@ -265,11 +325,11 @@ export function CreateEntityDialog({ open, kind, environmentId, onOpenChange, on
                                     <SelectValue />
                                 </SelectTrigger>
                                 <SelectContent>
-                                    {presets.map(p => (
-                                        <SelectItem key={p.canonical} value={p.canonical}>
-                                            {p.label}
+                                    {typeOptions.map(option => (
+                                        <SelectItem key={option.value} value={option.value}>
+                                            {option.label}
                                             <Badge variant="outline" className="ml-2 font-mono text-xs">
-                                                {p.canonical}
+                                                {option.badge}
                                             </Badge>
                                         </SelectItem>
                                     ))}

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/features/policy-structure/__tests__/CreateEntityDialog.test.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/features/policy-structure/__tests__/CreateEntityDialog.test.tsx
@@ -40,6 +40,15 @@ vi.mock('../../../shared/api/authz-api.service', () => ({
     },
 }));
 
+const useParsedSchemaSpy = vi.fn();
+vi.mock('../../../shared/hooks/useParsedSchema', () => ({
+    useParsedSchema: (env: string) => useParsedSchemaSpy(env),
+}));
+
+function parsedResult(actions: Array<{ name: string; principals: string[]; resources: string[] }>) {
+    return { parsed: { entities: [], actions }, isLoading: false, error: undefined };
+}
+
 vi.mock('@gravitee/graphene-core', async importOriginal => {
     const actual = await importOriginal<Record<string, unknown>>();
     return {
@@ -78,6 +87,8 @@ beforeEach(() => {
     getEntitySpy.mockReset();
     createEntitySpy.mockReset();
     toastSuccessSpy.mockReset();
+    useParsedSchemaSpy.mockReset();
+    useParsedSchemaSpy.mockReturnValue(parsedResult([]));
     seedParents([]);
     getEntitySpy.mockResolvedValue(null);
     createEntitySpy.mockResolvedValue({
@@ -306,5 +317,78 @@ describe('CreateEntityDialog', () => {
 
         expect(screen.getByText(/"mcp" is a preset type/i)).toBeInTheDocument();
         expect(screen.getByRole('button', { name: /Create Resource/i })).toBeDisabled();
+    });
+
+    const SCHEMA_ACTIONS = [{ name: 'read', principals: ['User', 'Subject'], resources: ['Report'] }];
+
+    it('drives the PRINCIPAL type list from the schema and sends the chosen schema type', async () => {
+        const user = userEvent.setup();
+        useParsedSchemaSpy.mockReturnValue(parsedResult(SCHEMA_ACTIONS));
+        renderDialog({ kind: 'PRINCIPAL' });
+
+        await user.click(screen.getByLabelText('Entity type'));
+        expect(await screen.findByRole('option', { name: /User/i })).toBeInTheDocument();
+        expect(screen.getByRole('option', { name: /Subject/i })).toBeInTheDocument();
+        // Hardcoded presets are not offered when the schema declares principals.
+        expect(screen.queryByRole('option', { name: /Service Account/i })).not.toBeInTheDocument();
+
+        await user.click(screen.getByRole('option', { name: /Subject/i }));
+        await user.type(screen.getByLabelText(/Display name/i), 'alice');
+        await user.click(screen.getByRole('button', { name: /Create Principal/i }));
+
+        await waitFor(() => expect(createEntitySpy).toHaveBeenCalledTimes(1));
+        const [, req] = createEntitySpy.mock.calls[0];
+        expect(req).toMatchObject({ entityType: 'Subject', entityId: 'subject.alice', kind: 'PRINCIPAL' });
+    });
+
+    it('drives the RESOURCE type list from the schema and sends the chosen schema type', async () => {
+        const user = userEvent.setup();
+        useParsedSchemaSpy.mockReturnValue(parsedResult(SCHEMA_ACTIONS));
+        renderDialog({ kind: 'RESOURCE' });
+
+        await user.click(screen.getByLabelText('Entity type'));
+        expect(await screen.findByRole('option', { name: /Report/i })).toBeInTheDocument();
+
+        await user.click(screen.getByRole('option', { name: /Report/i }));
+        await user.type(screen.getByLabelText(/Display name/i), 'q1');
+        await user.click(screen.getByRole('button', { name: /Create Resource/i }));
+
+        await waitFor(() => expect(createEntitySpy).toHaveBeenCalledTimes(1));
+        const [, req] = createEntitySpy.mock.calls[0];
+        expect(req).toMatchObject({ entityType: 'Report', entityId: 'report.q1', kind: 'RESOURCE' });
+    });
+
+    it('falls back to built-in presets when there is no schema and sends the built-in entityType', async () => {
+        const user = userEvent.setup();
+        useParsedSchemaSpy.mockReturnValue(parsedResult([]));
+        renderDialog({ kind: 'PRINCIPAL' });
+
+        await user.click(screen.getByLabelText('Entity type'));
+        // Built-in presets are offered (User is the default selection).
+        expect(await screen.findByRole('option', { name: /Service Account/i })).toBeInTheDocument();
+        await user.keyboard('{Escape}');
+
+        await user.type(screen.getByLabelText(/Display name/i), 'Alice');
+        await user.click(screen.getByRole('button', { name: /Create Principal/i }));
+
+        await waitFor(() => expect(createEntitySpy).toHaveBeenCalledTimes(1));
+        const [, req] = createEntitySpy.mock.calls[0];
+        expect(req).toMatchObject({ entityType: 'User', entityId: 'user.alice', kind: 'PRINCIPAL' });
+    });
+
+    it('sends the kind umbrella entityType for an "Other" custom prefix', async () => {
+        const user = userEvent.setup();
+        useParsedSchemaSpy.mockReturnValue(parsedResult([]));
+        renderDialog({ kind: 'RESOURCE' });
+
+        await user.click(screen.getByLabelText('Entity type'));
+        await user.click(await screen.findByRole('option', { name: /Other \(custom prefix\)/i }));
+        await user.type(screen.getByLabelText(/Custom prefix/i), 'webhook');
+        await user.type(screen.getByLabelText(/Display name/i), 'Slack hook');
+
+        await user.click(screen.getByRole('button', { name: /Create Resource/i }));
+        await waitFor(() => expect(createEntitySpy).toHaveBeenCalledTimes(1));
+        const [, req] = createEntitySpy.mock.calls[0];
+        expect(req).toMatchObject({ entityType: 'Resource', entityId: 'webhook.slack-hook' });
     });
 });

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/shared/__tests__/entity-adapter.test.ts
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/shared/__tests__/entity-adapter.test.ts
@@ -102,6 +102,30 @@ describe('fromBackend', () => {
         expect(inst.uid).toEqual({ type: 'Group', id: 'eng' });
     });
 
+    it('prefers the stored entityType over the uid prefix and _kind', () => {
+        // A bare (prefixless) uid still resolves its type from entityType.
+        expect(fromBackend({ ...base, uid: 'abc-123', entityType: 'User', attributes: {} }).uid).toEqual({
+            type: 'User',
+            id: 'abc-123',
+        });
+        // entityType wins over a stale/mismatched _kind, and the matching prefix is still stripped.
+        expect(fromBackend({ ...base, uid: 'mcp.weather', entityType: 'MCPServer', attributes: { _kind: 'user' } }).uid).toEqual({
+            type: 'MCPServer',
+            id: 'weather',
+        });
+    });
+
+    it('falls back to _kind / prefix when entityType is blank', () => {
+        expect(fromBackend({ ...base, uid: 'group.eng', entityType: '   ', attributes: {} }).uid).toEqual({ type: 'Group', id: 'eng' });
+    });
+
+    it('passes a custom/namespaced entityType through verbatim (id kept whole)', () => {
+        expect(fromBackend({ ...base, uid: 'report.q1', entityType: 'myapp::Report', attributes: {} }).uid).toEqual({
+            type: 'myapp::Report',
+            id: 'report.q1',
+        });
+    });
+
     it('defaults source to local when not in attributes', () => {
         const inst = fromBackend(base);
         expect(inst.source).toBe('local');

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/shared/api/__tests__/authz-api.service.test.ts
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/shared/api/__tests__/authz-api.service.test.ts
@@ -17,6 +17,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { authzApiService } from '../authz-api.service';
 
 const get = vi.fn();
+const post = vi.fn();
 const put = vi.fn();
 const del = vi.fn();
 const post = vi.fn();
@@ -102,6 +103,31 @@ function canonicalEntity(overrides: Record<string, unknown> = {}) {
         ...overrides,
     };
 }
+
+describe('authzApiService.createEntity', () => {
+    beforeEach(() => post.mockReset());
+
+    it('POSTs the request verbatim (including entityType) and returns the adapted entity', async () => {
+        post.mockResolvedValue(canonicalEntity({ entityType: 'User' }));
+
+        const req = {
+            entityId: 'user.alice',
+            kind: 'PRINCIPAL' as const,
+            entityType: 'User',
+            attributes: { _displayName: 'Alice' },
+            parents: [],
+            source: 'local',
+        };
+        const res = await authzApiService.createEntity('DEFAULT', req);
+
+        expect(post).toHaveBeenCalledTimes(1);
+        const [path, sentBody] = post.mock.calls[0];
+        expect(path).toBe('/environments/DEFAULT/modules/authz/entities');
+        expect(sentBody).toEqual(req);
+        expect((sentBody as { entityType: string }).entityType).toBe('User');
+        expect(res.uid).toBe('user.alice');
+    });
+});
 
 describe('authzApiService.updateEntity', () => {
     beforeEach(() => put.mockReset());

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/shared/api/__tests__/authz-api.service.test.ts
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/shared/api/__tests__/authz-api.service.test.ts
@@ -20,7 +20,6 @@ const get = vi.fn();
 const post = vi.fn();
 const put = vi.fn();
 const del = vi.fn();
-const post = vi.fn();
 vi.mock('../authz-api-client', () => ({
     authzCoreApiClient: {
         get: (path: string) => get(path),

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/shared/api/authz-api.service.ts
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/shared/api/authz-api.service.ts
@@ -345,6 +345,7 @@ export const authzApiService = {
 export interface CreateEntityRequest {
     readonly entityId: string;
     readonly kind: 'PRINCIPAL' | 'RESOURCE';
+    readonly entityType?: string;
     readonly attributes: Record<string, unknown>;
     readonly parents: readonly string[];
     readonly source: string;

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/shared/api/authz-api.service.ts
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/shared/api/authz-api.service.ts
@@ -55,6 +55,7 @@ export interface EntityListParams extends PaginationParams {
 interface CanonicalEntity {
     readonly id: string;
     readonly entityId: string;
+    readonly entityType?: string;
     readonly kind: 'PRINCIPAL' | 'RESOURCE';
     readonly attributes: Record<string, unknown>;
     readonly parents: readonly string[];
@@ -119,6 +120,7 @@ function adaptEntityResponse(c: CanonicalEntity): EntityResponse {
         id: c.id,
         environmentId: c.environmentId,
         uid: c.entityId,
+        entityType: c.entityType,
         attributes: attrs,
         parents: [...c.parents],
         createdAt: c.createdAt,

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/shared/api/authz-api.types.ts
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/shared/api/authz-api.types.ts
@@ -47,6 +47,9 @@ export interface EntityResponse {
     readonly id: string;
     readonly environmentId: string;
     readonly uid: string;
+    /** Canonical engine type (e.g. User, Group, API). Authoritative when present; the FE should
+     *  prefer it over deriving the type from the uid prefix or the _kind attribute. */
+    readonly entityType?: string;
     readonly attributes: Record<string, unknown>;
     readonly parents: string[];
     readonly createdAt: string;

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/shared/entity-adapter.ts
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/shared/entity-adapter.ts
@@ -46,8 +46,19 @@ export function parseEntityUid(uid: string): { type: string; id: string } {
  * only in `_kind` — so a raw {@link parseEntityUid} would mislabel them as
  * `Unknown`. Falls back to uid parsing when `_kind` is absent or unknown.
  */
-export function resolveEntityRef(uid: string, attributes: Record<string, unknown>): { type: string; id: string } {
-    return resolveUid(uid, kindToUiType(attributes['_kind']));
+// The stored entityType is the canonical engine type (== the registry uiType); prefer it, falling
+// back to the legacy derivation for entities that predate typed entityType. One definition so the
+// picker path and fromBackend never diverge.
+function preferType(entityType: string | undefined, fallback: string | undefined): string | undefined {
+    return entityType && entityType.trim() ? entityType : fallback;
+}
+
+export function resolveEntityRef(
+    uid: string,
+    attributes: Record<string, unknown>,
+    entityType?: string,
+): { type: string; id: string } {
+    return resolveUid(uid, preferType(entityType, kindToUiType(attributes['_kind'])));
 }
 
 /**
@@ -64,13 +75,9 @@ export function formatEntityUid(u: { type: string; id: string }): string {
 
 /**
  * Convert a backend EntityResponse to the richer frontend EntityInstance.
- *
- * - Splits reserved meta keys out of attributes.
- * - Parses parents from string form to structured objects.
- * - For dotted entityIds, strips the kind prefix from the structured `id`
- *   when an explicit `_kind` attribute matches the prefix — keeps round-trip
- *   stable for both single-segment (`user.alice`) and multi-segment
- *   (`mcp.flight-api.search`) ids.
+ * Splits reserved meta out of attributes and parses parents. The structured uid type comes from
+ * {@link preferType} (entityType first, then `_kind`/uid-prefix); the matching prefix is stripped
+ * from the id, keeping round-trip stable for bare and dotted ids alike.
  */
 export function fromBackend(e: EntityResponse): EntityInstance {
     const attrs: Record<string, AttrValue> = {};
@@ -99,7 +106,7 @@ export function fromBackend(e: EntityResponse): EntityInstance {
         }
     }
 
-    const uid = resolveUid(e.uid, kindOverride);
+    const uid = resolveUid(e.uid, preferType(e.entityType, kindOverride));
 
     const parents = e.parents.map(parseEntityUid);
 

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/shared/entity-adapter.ts
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/shared/entity-adapter.ts
@@ -53,11 +53,7 @@ function preferType(entityType: string | undefined, fallback: string | undefined
     return entityType && entityType.trim() ? entityType : fallback;
 }
 
-export function resolveEntityRef(
-    uid: string,
-    attributes: Record<string, unknown>,
-    entityType?: string,
-): { type: string; id: string } {
+export function resolveEntityRef(uid: string, attributes: Record<string, unknown>, entityType?: string): { type: string; id: string } {
     return resolveUid(uid, preferType(entityType, kindToUiType(attributes['_kind'])));
 }
 

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/shared/hooks/__tests__/useEntityOptions.test.tsx
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/shared/hooks/__tests__/useEntityOptions.test.tsx
@@ -164,6 +164,20 @@ describe('useEntityOptions', () => {
         expect(item.textContent).toBe(`User::"${sub}"`);
     });
 
+    it('resolves a bare-sub principal via the stored entityType (preferred over _kind)', async () => {
+        const sub = 'a1b2c3d4-0000-0000-0000-000000000000';
+        listEntitiesSpy.mockResolvedValue(paged([{ ...entity(sub, { displayName: 'Carol' }), entityType: 'User' }]));
+
+        const { getByTestId } = render(<Probe env="env-1" opts={{ typeFilter: ['User', 'Group', 'ServiceAccount', 'AgentIdentity'] }} />, {
+            wrapper: makeWrapper(),
+        });
+
+        await waitFor(() => expect(getByTestId('count').textContent).toBe('1'));
+        const item = getByTestId('options').querySelector('li')!;
+        expect(item.getAttribute('data-group')).toBe('User');
+        expect(item.textContent).toBe(`User::"${sub}"`);
+    });
+
     it('labels a locally-added principal by its _displayName meta attribute, not the entity id', async () => {
         // The "Add principal" form stores the human name under the `_displayName` meta key (not the
         // plain `displayName` the AM sync uses). The chip label must surface it so the user sees the

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/shared/hooks/useEntityOptions.ts
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/ui/shared/hooks/useEntityOptions.ts
@@ -74,7 +74,7 @@ function summarizeAttributes(attrs: Record<string, unknown>): string | undefined
 }
 
 function toChipOption(entity: EntityResponse): ChipOption {
-    const { type, id } = resolveEntityRef(entity.uid, entity.attributes);
+    const { type, id } = resolveEntityRef(entity.uid, entity.attributes, entity.entityType);
     return {
         id: `${type}::"${id}"`,
         label: readableLabel(entity.attributes, id),

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/test/java/io/gravitee/gamma/authorization/core/am/use_case/SyncAmUsersUseCaseTest.java
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/test/java/io/gravitee/gamma/authorization/core/am/use_case/SyncAmUsersUseCaseTest.java
@@ -152,6 +152,25 @@ class SyncAmUsersUseCaseTest {
     }
 
     @Test
+    void derives_granular_entity_type_per_kind_from_the_kind_hint() {
+        // AM sync passes entityType=null + _kind; CreateOrReplaceAuthzEntityCommand must derive the
+        // granular engine type (not the umbrella Principal) so synced principals match typed policies.
+        stubGroupPage(0, new AmGroupPage(List.of(new AmGroup("g-1", "Engineering")), 1L));
+        stubRolePage(0, new AmRolePage(List.of(new AmRole("r-1", "ADMIN")), 1L));
+        stubAgentPage(0, new AmAgentPage(List.of(agent("app-1", "agent-client", "Bot", "AUTONOMOUS")), 1L));
+        stubPage(0, page(1, user("sub-1", "alice", null, null, null)));
+
+        run();
+
+        List<CreateOrReplaceAuthzEntityCommand> all = captureAllUpserts();
+        assertThat(all.stream().filter(c -> c.entityId().equals("sub-1")).findFirst().orElseThrow().entityType()).isEqualTo("User");
+        assertThat(all.stream().filter(c -> c.entityId().equals("g-1")).findFirst().orElseThrow().entityType()).isEqualTo("Group");
+        assertThat(all.stream().filter(c -> c.entityId().equals("r-1")).findFirst().orElseThrow().entityType()).isEqualTo("Role");
+        String agentId = java.util.UUID.nameUUIDFromBytes("agent-client".getBytes(java.nio.charset.StandardCharsets.UTF_8)).toString();
+        assertThat(all.stream().filter(c -> c.entityId().equals(agentId)).findFirst().orElseThrow().entityType()).isEqualTo("AgentIdentity");
+    }
+
+    @Test
     void keys_the_entity_on_the_token_sub_when_source_is_present() {
         // AM V2 issues sub = MD5-UUID("source:externalId"); the entity must be keyed on that, not the user id.
         AmUser user = new AmUser("internal-id", "github", "ext-42", null, "alice", null, null, List.of(), List.of());

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/test/java/io/gravitee/gamma/authorization/core/am/use_case/SyncAmUsersUseCaseTest.java
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/test/java/io/gravitee/gamma/authorization/core/am/use_case/SyncAmUsersUseCaseTest.java
@@ -304,7 +304,10 @@ class SyncAmUsersUseCaseTest {
 
         CreateOrReplaceAuthzEntityCommand user = all.stream().filter(c -> c.entityId().equals("sub-1")).findFirst().orElseThrow();
         assertThat(user.attributes()).containsEntry("_kind", "user");
-        assertThat(user.parents()).containsExactlyInAnyOrder("g-1", "r-1");
+        // Parents carry the canonical engine UID of the referenced group/role entities (Group::"id" /
+        // Role::"id"), matching the type those entities derive from their _kind, so `principal in
+        // Group::"g-1"` resolves in the PDP. A bare "g-1" would not match the typed group entity.
+        assertThat(user.parents()).containsExactlyInAnyOrder("Group::\"g-1\"", "Role::\"r-1\"");
     }
 
     @Test

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/test/java/io/gravitee/gamma/authorization/service/AuthzEntityServiceImplTest.java
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/test/java/io/gravitee/gamma/authorization/service/AuthzEntityServiceImplTest.java
@@ -128,7 +128,7 @@ class AuthzEntityServiceImplTest {
     void upsert_without_entityType_defaults_to_kind_default_at_domain_level() {
         AuthzUpsertResult resource = entityService.upsert(
             CALLER,
-            new CreateOrReplaceAuthzEntityCommand(ENV, "api.123", AuthzEntityKind.RESOURCE, Map.of(), List.of(), "apim")
+            new CreateOrReplaceAuthzEntityCommand(ENV, "webhook.123", AuthzEntityKind.RESOURCE, Map.of(), List.of(), "apim")
         );
         AuthzUpsertResult principal = entityService.upsert(
             CALLER,

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/test/java/io/gravitee/gamma/authorization/service/CreateOrReplaceAuthzEntityCommandTest.java
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/test/java/io/gravitee/gamma/authorization/service/CreateOrReplaceAuthzEntityCommandTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gamma.authorization.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.gamma.authorization.domain.AuthzEntityKind;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class CreateOrReplaceAuthzEntityCommandTest {
+
+    private static CreateOrReplaceAuthzEntityCommand cmd(String entityId, AuthzEntityKind kind, String entityType, Map<String, Object> attrs) {
+        return new CreateOrReplaceAuthzEntityCommand("env-1", entityId, kind, entityType, attrs, List.of(), "src");
+    }
+
+    @Test
+    void derives_principal_type_from_kind_attribute_when_unset() {
+        assertThat(cmd("alice", AuthzEntityKind.PRINCIPAL, null, Map.of("_kind", "user")).entityType()).isEqualTo("User");
+        assertThat(cmd("eng", AuthzEntityKind.PRINCIPAL, null, Map.of("_kind", "group")).entityType()).isEqualTo("Group");
+        assertThat(cmd("x", AuthzEntityKind.PRINCIPAL, null, Map.of("_kind", "agent-identity")).entityType()).isEqualTo("AgentIdentity");
+    }
+
+    @Test
+    void derives_resource_type_from_entityid_prefix_when_unset() {
+        assertThat(cmd("mcp.weather", AuthzEntityKind.RESOURCE, null, Map.of()).entityType()).isEqualTo("MCPServer");
+        assertThat(cmd("api.payments", AuthzEntityKind.RESOURCE, null, Map.of()).entityType()).isEqualTo("API");
+        assertThat(cmd("mcptool.search", AuthzEntityKind.RESOURCE, null, Map.of()).entityType()).isEqualTo("MCPTool");
+    }
+
+    @Test
+    void keeps_an_explicitly_supplied_entityType() {
+        assertThat(cmd("mcp.weather", AuthzEntityKind.RESOURCE, "CustomThing", Map.of()).entityType()).isEqualTo("CustomThing");
+    }
+
+    @Test
+    void falls_back_to_kind_default_when_no_signal() {
+        assertThat(cmd("alice", AuthzEntityKind.PRINCIPAL, null, Map.of()).entityType()).isEqualTo("Principal");
+        assertThat(cmd("webhook.x", AuthzEntityKind.RESOURCE, null, Map.of()).entityType()).isEqualTo("Resource");
+        assertThat(cmd("x", AuthzEntityKind.PRINCIPAL, null, Map.of("_kind", "dupa")).entityType()).isEqualTo("Principal");
+    }
+
+    @Test
+    void prefers_kind_attribute_over_entityid_prefix() {
+        assertThat(cmd("user.alice", AuthzEntityKind.PRINCIPAL, null, Map.of("_kind", "user")).entityType()).isEqualTo("User");
+    }
+}


### PR DESCRIPTION
> **Stacked on #17508** (→ which stacks on #17482). Review/merge those first; retarget to the default branch as they land.

## What
Make `entityType` the granular, authoritative type for authz entities — populated at write time and read by the UI — and align parent UIDs across the stack.

**Write-time derive (P1)**
- `AuthzEntityIdConstants.engineTypeForHint` maps `_kind`/prefix → canonical engine type (`User`/`Group`/`MCPServer`/`API`/…).
- `CreateOrReplaceAuthzEntityCommand` derives granular `entityType` when none is supplied — so **every** inbound path flows through one point: REST create, and AM sync (which passes `entityType=null` + `_kind`). Regression test asserts AM sync yields `User`/`Group`/`Role`/`AgentIdentity`.
- FE create dialog sources its type list from the engine-parsed schema and sends `entityType`.

**Parent-UID normalization (P2)**
- `toEngineUid`/`normalizeParentUid` (SSOT in definition-model); the gateway sync re-quotes parents to the canonical `Type::"id"`. (The matching PDP change — dropping the `parseParentUid` workaround — is gravitee-service-authz-pdp#7.)

**Read path (P3)**
- `EntityResponse.entityType` surfaced; `resolveEntityRef`/`fromBackend`/the entity picker prefer it, falling back to `_kind`/uid-prefix only for legacy entities. The prefix/`_kind` derivation tower stays as that fallback — its removal is deferred until existing data is migrated (P4) and the in-flight FE PRs land.

## Verification
- Backend: definition-model 8, module-authz 41, AM-sync suite 21. FE: 518. `tsc` clean.
- AuthZEN parity (reference engine alpha.14 ↔ Gamma/PDP) agrees on authorization decisions incl. **group membership** (eval/batch/search-subject 29/29, search-resource 28/29) with the PDP `parseParentUid` workaround removed. (search-action / one tag scenario are parity-harness provisioning gaps, not this change.)

## Not in this PR
- **P4** — migrating existing umbrella (`Principal`/`Resource`) entities to granular (breaking, coordinated; fixes the live umbrella-vs-typed-policy mismatch).
- Full deletion of the FE derivation tower (after P4 + once #17468/#17287 land).

🤖 Generated with [Claude Code](https://claude.com/claude-code)