### PR TITLE
chore(4.11.x): bump kafka resource deps (schema-registry-confluent 4.1.0, reactor-native-kafka 6.1.0)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -303,10 +303,10 @@
         <gravitee-endpoint-azure-service-bus.version>2.0.0</gravitee-endpoint-azure-service-bus.version>
         <gravitee-endpoint-agent-to-agent.version>2.0.0</gravitee-endpoint-agent-to-agent.version>
         <gravitee-policy-graphql-rate-limit.version>1.0.2</gravitee-policy-graphql-rate-limit.version>
-        <gravitee-resource-schema-registry-confluent.version>4.0.0</gravitee-resource-schema-registry-confluent.version>
+        <gravitee-resource-schema-registry-confluent.version>4.1.0</gravitee-resource-schema-registry-confluent.version>
         <gravitee-resource-storage-azure-blob.version>1.1.0</gravitee-resource-storage-azure-blob.version>
         <gravitee-reactor-message.version>10.0.1</gravitee-reactor-message.version>
-        <gravitee-reactor-native-kafka.version>6.0.1</gravitee-reactor-native-kafka.version>
+        <gravitee-reactor-native-kafka.version>6.1.0</gravitee-reactor-native-kafka.version>
         <gravitee-reactor-mcp-proxy.version>1.1.2</gravitee-reactor-mcp-proxy.version>
         <gravitee-reactor-llm-proxy.version>2.10.1</gravitee-reactor-llm-proxy.version>
         <gravitee-reactor-a2a-proxy.version>1.0.0</gravitee-reactor-a2a-proxy.version>


### PR DESCRIPTION
## Summary

Bumps two Kafka-related Gravitee dependencies on branch `4.11.x` to their latest stable releases.

| Dependency | From | To |
|------------|------|----|
| [`gravitee-resource-schema-registry-confluent`](https://github.com/gravitee-io/gravitee-resource-schema-registry-confluent) | `4.0.0` | `4.1.0` |
| [`gravitee-reactor-native-kafka`](https://github.com/gravitee-io/gravitee-reactor-native-kafka) | `6.0.1` | `6.1.0` |

## Changelog

- schema-registry-confluent: see [releases](https://github.com/gravitee-io/gravitee-resource-schema-registry-confluent/releases) (adds OAuth2 client credentials authentication)
- reactor-native-kafka: see [releases](https://github.com/gravitee-io/gravitee-reactor-native-kafka/releases) (SASL extensions on OAUTHBEARER_TOKEN)

## Jira

- [APIM-14319](https://gravitee.atlassian.net/browse/APIM-14319)
- [APIM-14333](https://gravitee.atlassian.net/browse/APIM-14333)

[APIM-14319]: https://gravitee.atlassian.net/browse/APIM-14319?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[APIM-14333]: https://gravitee.atlassian.net/browse/APIM-14333?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ