### PR TITLE
fix(authz): sync AM group membership into user parents

### DIFF
--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/java/io/gravitee/gamma/authorization/core/am/model/AmGroupMembersPage.java
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/java/io/gravitee/gamma/authorization/core/am/model/AmGroupMembersPage.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gamma.authorization.core.am.model;
+
+import java.util.List;
+
+/** One page of an AM group's member user ids. */
+public record AmGroupMembersPage(List<String> memberUserIds, long totalCount) {}

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/java/io/gravitee/gamma/authorization/core/am/service_provider/AmDirectoryClient.java
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/java/io/gravitee/gamma/authorization/core/am/service_provider/AmDirectoryClient.java
@@ -17,6 +17,7 @@ package io.gravitee.gamma.authorization.core.am.service_provider;
 
 import io.gravitee.apim.plugin.gamma.api.identity.AmConnection;
 import io.gravitee.gamma.authorization.core.am.model.AmAgentPage;
+import io.gravitee.gamma.authorization.core.am.model.AmGroupMembersPage;
 import io.gravitee.gamma.authorization.core.am.model.AmGroupPage;
 import io.gravitee.gamma.authorization.core.am.model.AmRolePage;
 import io.gravitee.gamma.authorization.core.am.model.AmUserPage;
@@ -38,6 +39,9 @@ public interface AmDirectoryClient {
         AmUserPage fetchUsers(int page, int size);
 
         AmGroupPage fetchGroups(int page, int size);
+
+        /** One page of a group's member user ids. AM keeps membership on the group, not the user. */
+        AmGroupMembersPage fetchGroupMembers(String groupId, int page, int size);
 
         AmRolePage fetchRoles(int page, int size);
 

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/java/io/gravitee/gamma/authorization/core/am/use_case/SyncAmUsersUseCase.java
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/java/io/gravitee/gamma/authorization/core/am/use_case/SyncAmUsersUseCase.java
@@ -31,6 +31,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
@@ -40,8 +41,10 @@ import lombok.CustomLog;
 /**
  * Pages every user, group, role, and agent out of the AM domain on the connection and upserts each
  * as a PRINCIPAL authz entity via {@link AuthzEntityAdminApi#bulkUpsert}. Groups and roles are synced
- * first (they are the parent entities users reference); each user's {@code parents} is then set to
- * its group + role ids. Agents (AM applications of type AGENT) are projected last as generic,
+ * first (they are the parent entities users reference); each user's {@code parents} is then set to the
+ * canonical engine UIDs ({@code Group::"id"} / {@code Role::"id"}) of its groups and roles. Group
+ * membership is inverted from {@code group.members} (AM does not expose a user's groups on the user).
+ * Agents (AM applications of type AGENT) are projected last as generic,
  * user-independent principals keyed on a name-UUID of their OAuth {@code client_id} so the
  * request-time PEP matches them. Upsert-only: entities removed in AM are left as stale entities. Invoked on a
  * worker thread by the infra job manager.
@@ -73,6 +76,13 @@ public class SyncAmUsersUseCase {
         int entitiesUpserted = 0;
         List<CreateOrReplaceAuthzEntityCommand> batch = new ArrayList<>();
 
+        // AM keeps group membership on the group (group.members), not on the user — listUsers never
+        // returns a user's groups. So we invert it here: while paging groups, page each group's
+        // members and record group-id per member, then attach those ids to the member's parents in
+        // the user phase. Keyed by AM user id (== AmUser.id()).
+        Map<String, List<String>> groupIdsByUserId = new LinkedHashMap<>();
+        int membershipEntries = 0;
+
         try (AmDirectoryClient.Session session = directoryClient.openSession(input.connection())) {
             // Groups and roles first: they are the parent entities the user upserts reference.
             for (AmGroup group : pageThrough((p, s) -> {
@@ -82,6 +92,27 @@ public class SyncAmUsersUseCase {
                 batch.add(groupCommand(env, group));
                 if (batch.size() >= syncConfig.batchSize()) {
                     entitiesUpserted += flush(caller, batch);
+                }
+                // Bound membership inversion by the same ceiling as users/agents so a large directory
+                // can't blow up memory / AM round-trips. Groups past the cap are still upserted as
+                // entities — only their member edges are skipped — and we log rather than truncate
+                // silently. The lazy member cursor stops paging once we break.
+                if (membershipEntries >= syncConfig.maxEntities()) {
+                    continue;
+                }
+                for (String memberId : pageThrough((p, s) -> {
+                    var mp = session.fetchGroupMembers(group.id(), p, s);
+                    return new Page<>(mp.memberUserIds(), mp.totalCount());
+                }, syncConfig.pageSize())) {
+                    groupIdsByUserId.computeIfAbsent(memberId, k -> new ArrayList<>()).add(group.id());
+                    if (++membershipEntries >= syncConfig.maxEntities()) {
+                        log.warn(
+                            "AM sync: group-membership cap ({}) reached for domain {}; remaining group memberships skipped this run",
+                            syncConfig.maxEntities(),
+                            domain
+                        );
+                        break;
+                    }
                 }
             }
             for (AmRole role : pageThrough((p, s) -> {
@@ -101,7 +132,7 @@ public class SyncAmUsersUseCase {
                 return new Page<>(up.users(), up.totalCount());
             }, syncConfig.pageSize())) {
                 usersFetched++;
-                batch.add(userCommand(env, user));
+                batch.add(userCommand(env, user, groupIdsByUserId.getOrDefault(user.id(), List.of())));
                 if (batch.size() >= syncConfig.batchSize()) {
                     entitiesUpserted += flush(caller, batch);
                 }
@@ -192,7 +223,7 @@ public class SyncAmUsersUseCase {
         return count;
     }
 
-    private CreateOrReplaceAuthzEntityCommand userCommand(String environmentId, AmUser user) {
+    private CreateOrReplaceAuthzEntityCommand userCommand(String environmentId, AmUser user, List<String> groupIdsFromMembership) {
         String sub = computeSub(user);
         // Map.copyOf (inside the command) rejects null values, so only put attributes AM populated.
         Map<String, Object> attributes = new LinkedHashMap<>();
@@ -217,16 +248,26 @@ public class SyncAmUsersUseCase {
             attributes.put("enabled", user.enabled());
         }
 
-        // Membership: the user's parents are the canonical engine UIDs of its AM group + role
-        // entities (Group::"id" / Role::"id"), matching the type those entities derive from their
-        // _kind so the PDP resolves `principal in Group::"id"`; a bare id would not match the typed
-        // entity. Replaced wholesale on every upsert, so a membership dropped in AM disappears from
-        // parents on the next sync.
-        List<String> parents = new ArrayList<>();
+        // Membership: the user's parents are the canonical engine UIDs (Group::"id" / Role::"id")
+        // of its AM groups + roles, matching the type those entities derive from their _kind so the
+        // PDP resolves `principal in Group::"id"`. Group ids come from inverting group.members (AM
+        // does not expose a user's groups on the user); user.groups() is also honoured for IdP-mapped
+        // groups AM may set on the user. Deduped, and replaced wholesale on every upsert so a
+        // membership dropped in AM disappears from parents on the next sync.
+        LinkedHashSet<String> parents = new LinkedHashSet<>();
         user.groups().forEach(g -> parents.add(membershipUid("group", g)));
+        groupIdsFromMembership.forEach(g -> parents.add(membershipUid("group", g)));
         user.roles().forEach(r -> parents.add(membershipUid("role", r)));
 
-        return new CreateOrReplaceAuthzEntityCommand(environmentId, sub, AuthzEntityKind.PRINCIPAL, null, attributes, parents, SOURCE);
+        return new CreateOrReplaceAuthzEntityCommand(
+            environmentId,
+            sub,
+            AuthzEntityKind.PRINCIPAL,
+            null,
+            attributes,
+            new ArrayList<>(parents),
+            SOURCE
+        );
     }
 
     private static String membershipUid(String kindHint, String id) {

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/main/java/io/gravitee/gamma/authorization/infra/service_provider/AmSdkDirectoryClient.java
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/main/java/io/gravitee/gamma/authorization/infra/service_provider/AmSdkDirectoryClient.java
@@ -28,6 +28,7 @@ import io.gravitee.apim.plugin.gamma.api.identity.AmConnection;
 import io.gravitee.gamma.authorization.core.am.model.AmAgent;
 import io.gravitee.gamma.authorization.core.am.model.AmAgentPage;
 import io.gravitee.gamma.authorization.core.am.model.AmGroup;
+import io.gravitee.gamma.authorization.core.am.model.AmGroupMembersPage;
 import io.gravitee.gamma.authorization.core.am.model.AmGroupPage;
 import io.gravitee.gamma.authorization.core.am.model.AmRole;
 import io.gravitee.gamma.authorization.core.am.model.AmRolePage;
@@ -37,6 +38,7 @@ import io.gravitee.gamma.authorization.core.am.service_provider.AmDirectoryClien
 import io.gravitee.gamma.authorization.infra.service_provider.AmSdkDirectoryClientFactory.AmSdkApis;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 /**
@@ -120,6 +122,20 @@ public class AmSdkDirectoryClient implements AmDirectoryClient {
                 .toList();
             long totalCount = groupPage.getTotalCount() == null ? 0 : groupPage.getTotalCount();
             return new AmGroupPage(groups, totalCount);
+        }
+
+        @Override
+        public AmGroupMembersPage fetchGroupMembers(String groupId, int page, int size) {
+            UserPage memberPage = AmSdkInvocations.await(
+                apis.groupApi().getGroupMembers(AM_DEFAULT_ORGANIZATION, AM_DEFAULT_ENVIRONMENT, domainId, groupId, page, size)
+            );
+            List<String> memberUserIds = (memberPage.getData() == null ? List.<User>of() : memberPage.getData())
+                .stream()
+                .map(User::getId)
+                .filter(Objects::nonNull)
+                .toList();
+            long totalCount = memberPage.getTotalCount() == null ? 0 : memberPage.getTotalCount();
+            return new AmGroupMembersPage(memberUserIds, totalCount);
         }
 
         @Override

--- a/gravitee-gamma/gravitee-gamma-module-authz/src/test/java/io/gravitee/gamma/authorization/core/am/use_case/SyncAmUsersUseCaseTest.java
+++ b/gravitee-gamma/gravitee-gamma-module-authz/src/test/java/io/gravitee/gamma/authorization/core/am/use_case/SyncAmUsersUseCaseTest.java
@@ -19,6 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -33,6 +34,7 @@ import io.gravitee.gamma.authorization.core.am.exception.AmSyncException;
 import io.gravitee.gamma.authorization.core.am.model.AmAgent;
 import io.gravitee.gamma.authorization.core.am.model.AmAgentPage;
 import io.gravitee.gamma.authorization.core.am.model.AmGroup;
+import io.gravitee.gamma.authorization.core.am.model.AmGroupMembersPage;
 import io.gravitee.gamma.authorization.core.am.model.AmGroupPage;
 import io.gravitee.gamma.authorization.core.am.model.AmRole;
 import io.gravitee.gamma.authorization.core.am.model.AmRolePage;
@@ -72,8 +74,13 @@ class SyncAmUsersUseCaseTest {
         when(amDirectoryClient.openSession(CONNECTION)).thenReturn(session);
         authzEntityAdminApi = mock(AuthzEntityAdminApi.class);
         when(session.fetchGroups(anyInt(), anyInt())).thenReturn(new AmGroupPage(List.of(), 0));
+        when(session.fetchGroupMembers(anyString(), anyInt(), anyInt())).thenReturn(new AmGroupMembersPage(List.of(), 0));
         when(session.fetchRoles(anyInt(), anyInt())).thenReturn(new AmRolePage(List.of(), 0));
         when(session.fetchAgents(anyInt(), anyInt())).thenReturn(new AmAgentPage(List.of(), 0));
+    }
+
+    private void stubGroupMembers(String groupId, int page, AmGroupMembersPage membersPage) {
+        when(session.fetchGroupMembers(eq(groupId), eq(page), eq(50))).thenReturn(membersPage);
     }
 
     private SyncAmUsersUseCase.Output run() {
@@ -308,6 +315,111 @@ class SyncAmUsersUseCaseTest {
         // Role::"id"), matching the type those entities derive from their _kind, so `principal in
         // Group::"g-1"` resolves in the PDP. A bare "g-1" would not match the typed group entity.
         assertThat(user.parents()).containsExactlyInAnyOrder("Group::\"g-1\"", "Role::\"r-1\"");
+    }
+
+    @Test
+    void links_users_to_groups_via_group_membership_when_the_user_object_carries_no_groups() {
+        // Real AM shape: listUsers returns no groups on the user; membership lives in group.members.
+        // The sync must invert group.members so the member still gets the group in its parents.
+        stubGroupPage(0, new AmGroupPage(List.of(new AmGroup("g-1", "Engineering")), 1L));
+        stubGroupMembers("g-1", 0, new AmGroupMembersPage(List.of("sub-1"), 1L));
+        stubRolePage(0, new AmRolePage(List.of(new AmRole("r-1", "ADMIN")), 1L));
+        stubPage(0, page(1, userWithMemberships("sub-1", List.of(), List.of("r-1"))));
+
+        run();
+
+        CreateOrReplaceAuthzEntityCommand user = captureAllUpserts()
+            .stream()
+            .filter(c -> c.entityId().equals("sub-1"))
+            .findFirst()
+            .orElseThrow();
+        assertThat(user.parents()).containsExactlyInAnyOrder("Group::\"g-1\"", "Role::\"r-1\"");
+    }
+
+    @Test
+    void does_not_duplicate_a_group_present_both_on_the_user_and_in_group_membership() {
+        stubGroupPage(0, new AmGroupPage(List.of(new AmGroup("g-1", "Engineering")), 1L));
+        stubGroupMembers("g-1", 0, new AmGroupMembersPage(List.of("sub-1"), 1L));
+        // user.groups() already carries g-1 (e.g. an IdP-mapped group) AND the user is a group member.
+        stubPage(0, page(1, userWithMemberships("sub-1", List.of("g-1"), List.of())));
+
+        run();
+
+        CreateOrReplaceAuthzEntityCommand user = captureAllUpserts()
+            .stream()
+            .filter(c -> c.entityId().equals("sub-1"))
+            .findFirst()
+            .orElseThrow();
+        assertThat(user.parents()).containsExactly("Group::\"g-1\"");
+    }
+
+    @Test
+    void resolves_membership_with_one_member_fetch_per_group_independent_of_user_count() {
+        // Performance guard: membership is joined by paging each group's members once (per group),
+        // never per user. With G groups and U users the member fetches stay O(G + members/page),
+        // not O(G * U). Here 2 groups + 3 users => exactly 2 member fetches.
+        stubGroupPage(0, new AmGroupPage(List.of(new AmGroup("g-1", "G1"), new AmGroup("g-2", "G2")), 2L));
+        stubGroupMembers("g-1", 0, new AmGroupMembersPage(List.of("sub-1"), 1L));
+        stubGroupMembers("g-2", 0, new AmGroupMembersPage(List.of("sub-2"), 1L));
+        stubPage(
+            0,
+            page(
+                3,
+                userWithMemberships("sub-1", List.of(), List.of()),
+                userWithMemberships("sub-2", List.of(), List.of()),
+                userWithMemberships("sub-3", List.of(), List.of())
+            )
+        );
+
+        run();
+
+        verify(session, times(2)).fetchGroupMembers(anyString(), anyInt(), anyInt());
+        verify(session).fetchGroupMembers(eq("g-1"), eq(0), anyInt());
+        verify(session).fetchGroupMembers(eq("g-2"), eq(0), anyInt());
+    }
+
+    @Test
+    void leaves_a_non_member_user_without_the_group() {
+        stubGroupPage(0, new AmGroupPage(List.of(new AmGroup("g-1", "Engineering")), 1L));
+        stubGroupMembers("g-1", 0, new AmGroupMembersPage(List.of("sub-1"), 1L));
+        stubPage(0, page(2, userWithMemberships("sub-1", List.of(), List.of()), userWithMemberships("sub-2", List.of(), List.of())));
+
+        run();
+
+        List<CreateOrReplaceAuthzEntityCommand> all = captureAllUpserts();
+        assertThat(all.stream().filter(c -> c.entityId().equals("sub-1")).findFirst().orElseThrow().parents()).containsExactly("Group::\"g-1\"");
+        assertThat(all.stream().filter(c -> c.entityId().equals("sub-2")).findFirst().orElseThrow().parents()).isEmpty();
+    }
+
+    @Test
+    void pages_through_multi_page_group_membership() {
+        // totalCount=2 with one member per page forces the nested member cursor onto page 1.
+        stubGroupPage(0, new AmGroupPage(List.of(new AmGroup("g-1", "Engineering")), 1L));
+        stubGroupMembers("g-1", 0, new AmGroupMembersPage(List.of("sub-1"), 2L));
+        stubGroupMembers("g-1", 1, new AmGroupMembersPage(List.of("sub-2"), 2L));
+        stubPage(0, page(2, userWithMemberships("sub-1", List.of(), List.of()), userWithMemberships("sub-2", List.of(), List.of())));
+
+        run();
+
+        List<CreateOrReplaceAuthzEntityCommand> all = captureAllUpserts();
+        assertThat(all.stream().filter(c -> c.entityId().equals("sub-1")).findFirst().orElseThrow().parents()).containsExactly("Group::\"g-1\"");
+        assertThat(all.stream().filter(c -> c.entityId().equals("sub-2")).findFirst().orElseThrow().parents()).containsExactly("Group::\"g-1\"");
+        verify(session).fetchGroupMembers(eq("g-1"), eq(0), anyInt());
+        verify(session).fetchGroupMembers(eq("g-1"), eq(1), anyInt());
+    }
+
+    @Test
+    void caps_group_membership_inversion_at_max_entities_and_stops_fetching_members() {
+        // maxEntities=1: g-1's single member fills the cap, so g-2's members are never fetched.
+        stubGroupPage(0, new AmGroupPage(List.of(new AmGroup("g-1", "G1"), new AmGroup("g-2", "G2")), 2L));
+        stubGroupMembers("g-1", 0, new AmGroupMembersPage(List.of("sub-1"), 1L));
+        stubGroupMembers("g-2", 0, new AmGroupMembersPage(List.of("sub-2"), 1L));
+        stubPage(0, page(1, userWithMemberships("sub-1", List.of(), List.of())));
+
+        run(new SyncAmUsersUseCase.SyncConfig(1, PAGE_SIZE, BATCH_SIZE));
+
+        verify(session).fetchGroupMembers(eq("g-1"), eq(0), anyInt());
+        verify(session, never()).fetchGroupMembers(eq("g-2"), anyInt(), anyInt());
     }
 
     @Test


### PR DESCRIPTION
> Stacked on #17513 (`feat/authz-populate-entity-type`). Merge after it.

## Problem

The AM user sync silently dropped **group membership**. A synced user's `parents` only ever contained its roles, never its groups.

Root cause: AM stores group membership on the **group** (`group.members`), not on the user — the management `listUsers` endpoint never returns a user's groups (`user.getGroups()` is null for AM-managed membership). The sync read membership from `user.getGroups()`, so groups were lost. Roles still worked because they are stored on the user (`user.getRoles()`).

## Fix

While paging groups, page each group's members via `getGroupMembers` and record the group id per member. In the user phase, attach those group ids to the member's `parents`. `user.getGroups()` is still honoured (for IdP-mapped groups AM may set on the user); the combined set is deduplicated.

Building on #17513, each parent is emitted as a canonical engine UID (`Group::"id"` / `Role::"id"`) via the same `_kind`→type mapping the group/role entities use, so `principal in Group::"id"` resolves in the PDP.

## Verification

- **Unit**: `SyncAmUsersUseCaseTest` 25/0 — real AM shape (`user.getGroups()` empty, member resolved via `group.members` → `Group::"id"` in parents), dedup, non-member exclusion.
- **Performance**: membership joined with **one member fetch per group**, never per user — `O(G + members/page)` AM round-trips, not `O(G * U)`. Covered by a regression test (2 groups + 3 users ⇒ exactly 2 member fetches).
- **Live e2e** (local AM + APIM stack): a user that is a member of a group (via `group.members`) and assigned a role. Before: synced parents held only the role. After: parents hold **both** the group id and the role id.

🤖 Generated with [Claude Code](https://claude.com/claude-code)