### PR TITLE
chore(4.11.x): bump gravitee-entrypoint-webhook from 7.1.2 to 7.2.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -291,7 +291,7 @@
         <gravitee-entrypoint-http-get.version>3.0.0</gravitee-entrypoint-http-get.version>
         <gravitee-entrypoint-http-post.version>3.0.0</gravitee-entrypoint-http-post.version>
         <gravitee-entrypoint-sse.version>6.0.0</gravitee-entrypoint-sse.version>
-        <gravitee-entrypoint-webhook.version>7.1.2</gravitee-entrypoint-webhook.version>
+        <gravitee-entrypoint-webhook.version>7.2.0</gravitee-entrypoint-webhook.version>
         <gravitee-entrypoint-websocket.version>3.0.0</gravitee-entrypoint-websocket.version>
         <gravitee-entrypoint-agent-to-agent.version>2.0.0</gravitee-entrypoint-agent-to-agent.version>
         <gravitee-entrypoint-mcp-tool-server.version>2.0.1</gravitee-entrypoint-mcp-tool-server.version>


### PR DESCRIPTION
## Summary

Bumps **[gravitee-io/gravitee-entrypoint-webhook](https://github.com/gravitee-io/gravitee-entrypoint-webhook)** from `7.1.2` to `7.2.0` on branch `4.11.x`.

## Changelog

See the [releases](https://github.com/gravitee-io/gravitee-entrypoint-webhook/releases) page for details.

## Jira

[APIM-13127](https://gravitee.atlassian.net/browse/APIM-13127)

[APIM-13127]: https://gravitee.atlassian.net/browse/APIM-13127?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ