### PR TITLE
fix(console): nullable field handling in open api import

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/mcp/components/open-api-to-mcp-tools/open-api-to-mcp-tools.util.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/mcp/components/open-api-to-mcp-tools/open-api-to-mcp-tools.util.spec.ts
@@ -809,6 +809,76 @@ paths:
     });
   });
 
+  describe('nullable keyword handling', () => {
+    const nullableSpec = JSON.stringify({
+      openapi: '3.0.0',
+      info: { title: 'Test API', version: '1.0.0' },
+      paths: {
+        '/users': {
+          post: {
+            operationId: 'createUser',
+            summary: 'Create user',
+            parameters: [{ name: 'familyId', in: 'query', schema: { type: 'string', nullable: true } }],
+            requestBody: {
+              content: {
+                'application/json': {
+                  schema: {
+                    type: 'object',
+                    properties: { nickname: { type: 'string', nullable: true } },
+                    required: ['nickname'],
+                  },
+                },
+              },
+            },
+            responses: { '201': { description: 'Created' } },
+          },
+        },
+      },
+    });
+
+    it('replaces the nullable keyword with a null type union', async () => {
+      const { result, errors } = await convertOpenApiToMcpTools(nullableSpec);
+
+      expect(errors).toHaveLength(0);
+      expect(result).toHaveLength(1);
+
+      const properties = result[0].toolDefinition.inputSchema['properties'];
+
+      expect(properties['familyId'].type).toEqual(['string', 'null']);
+      expect(properties['familyId']).not.toHaveProperty('nullable');
+
+      expect(properties['bodySchema'].properties['nickname'].type).toEqual(['string', 'null']);
+      expect(properties['bodySchema'].properties['nickname']).not.toHaveProperty('nullable');
+    });
+
+    it('preserves a schema property literally named nullable', async () => {
+      const spec = JSON.stringify({
+        openapi: '3.0.0',
+        info: { title: 'Test API', version: '1.0.0' },
+        paths: {
+          '/flags': {
+            post: {
+              operationId: 'setFlags',
+              requestBody: {
+                content: {
+                  'application/json': { schema: { type: 'object', properties: { nullable: { type: 'boolean' } } } },
+                },
+              },
+              responses: { '201': { description: 'Created' } },
+            },
+          },
+        },
+      });
+
+      const { result, errors } = await convertOpenApiToMcpTools(spec);
+
+      expect(errors).toHaveLength(0);
+      const bodySchema = result[0].toolDefinition.inputSchema['properties']['bodySchema'];
+      expect(bodySchema.properties).toHaveProperty('nullable');
+      expect(bodySchema.properties['nullable'].type).toBe('boolean');
+    });
+  });
+
   describe('Error cases', () => {
     it.each([
       [

--- a/gravitee-apim-console-webui/src/management/api/mcp/components/open-api-to-mcp-tools/open-api-to-mcp-tools.util.ts
+++ b/gravitee-apim-console-webui/src/management/api/mcp/components/open-api-to-mcp-tools/open-api-to-mcp-tools.util.ts
@@ -62,6 +62,48 @@ function removeCircularRefs(obj: unknown, ancestors = new Set<object>()): unknow
   return result;
 }
 
+/**
+ * Translates the OpenAPI 3.0.x `nullable` keyword into valid JSON Schema. `nullable` is not a
+ * JSON Schema keyword, so MCP consumers (e.g. JSON-Schema-validating agent SDKs) reject it.
+ * A `nullable: true` schema is rewritten so that `"null"` becomes a member of its `type`, and the
+ * keyword is dropped in all cases. Expects an acyclic input (run after {@link removeCircularRefs}).
+ */
+function normalizeNullableTypes(obj: unknown): unknown {
+  if (!angular.isObject(obj)) {
+    return obj;
+  }
+
+  if (Array.isArray(obj)) {
+    return obj.map((item) => normalizeNullableTypes(item));
+  }
+
+  const source = obj as Record<string, unknown>;
+  const result: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(source)) {
+    // `nullable` is the OpenAPI keyword only when it carries a boolean; a property literally named
+    // "nullable" inside a `properties` map holds a schema object and must be preserved.
+    if (key === 'nullable' && typeof value === 'boolean') {
+      continue;
+    }
+    result[key] = normalizeNullableTypes(value);
+  }
+
+  // A nullable schema without a `type` is already unconstrained (null is allowed), so only a typed
+  // schema needs `"null"` added; dropping the keyword alone is enough for the untyped case.
+  if (source.nullable === true && result.type !== undefined) {
+    result.type = withNullType(result.type);
+  }
+
+  return result;
+}
+
+function withNullType(type: unknown): unknown {
+  if (Array.isArray(type)) {
+    return type.includes('null') ? type : [...type, 'null'];
+  }
+  return [type, 'null'];
+}
+
 type ParameterSchema = {
   pathParams: Record<string, SchemaObject>;
   queryParams: Record<string, SchemaObject>;
@@ -267,7 +309,7 @@ async function convertOpenApiToMcpTools(specString: string): Promise<OpenApiToMc
       const toolDefinition: MCPToolDefinition = {
         name: toolName,
         description,
-        inputSchema: removeCircularRefs(mergedParameters),
+        inputSchema: normalizeNullableTypes(removeCircularRefs(mergedParameters)),
       };
 
       const gatewayMapping: MCPToolGatewayMapping = generateGatewayMapping(op, method, path, paramSchema);


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-13611

## Description

The console "Generate Tools from OpenAPI" (MCP entrypoint) copied the OpenAPI 3.0.x `nullable`
keyword straight into the generated MCP tool `inputSchema`. `nullable` is not valid JSON Schema, so
JSON-Schema-validating MCP consumers reject the tool. This rewrites `nullable: true` into a `"null"`
member of `type` (e.g. `"string"` → `["string","null"]`) and drops the keyword; a schema property
literally named `nullable` is preserved.

## Additional context

- Conversion is client-side in the console; affected 4.8.x → master.
- Repro: MCP entrypoint → Generate Tools from OpenAPI with a spec containing `nullable: true`.
  Before: `inputSchema` shows `"nullable": true`. After: `"type": ["string","null"]`.
- Tests: `open-api-to-mcp-tools.util.spec.ts` (+2 cases: translation, and property-named-`nullable` guard).
