### PR TITLE
chore(deps): bump gravitee-policy-callout-http version 5.4.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -181,7 +181,7 @@
         <gravitee-policy-assign-metrics.version>3.1.0</gravitee-policy-assign-metrics.version>
         <gravitee-policy-basic-authentication.version>1.6.0</gravitee-policy-basic-authentication.version>
         <gravitee-policy-cache.version>3.0.0</gravitee-policy-cache.version>
-        <gravitee-policy-callout-http.version>5.4.1</gravitee-policy-callout-http.version>
+        <gravitee-policy-callout-http.version>5.4.2</gravitee-policy-callout-http.version>
         <gravitee-policy-circuit-breaker.version>2.0.0</gravitee-policy-circuit-breaker.version>
         <gravitee-policy-custom-query-parameters.version>2.0.0</gravitee-policy-custom-query-parameters.version>
         <gravitee-policy-cloud-events.version>1.1.0</gravitee-policy-cloud-events.version>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-14283

## Description

Bump gravitee-policy-callout-http to 5.4.2.