### PR TITLE
fix(portal): hide empty API access section for federated APIs

### DIFF
--- a/gravitee-apim-portal-webui-next/src/components/api-access/api-access.component.html
+++ b/gravitee-apim-portal-webui-next/src/components/api-access/api-access.component.html
@@ -15,152 +15,154 @@
     limitations under the License.
 
 -->
-<mat-card appearance="outlined" class="api-access">
-  @if (subscription?.status === 'ACCEPTED' || planSecurity === 'KEY_LESS') {
-    <mat-card-header>
-      <div class="api-access__header-row">
-        <div class="next-gen-h5 api-access__header" i18n="@@subscriptionDetailsApiAccessHeader">API access</div>
-        @if (planSecurity === 'API_KEY' && subscription?.status === 'ACCEPTED' && canManageApiKey) {
-          <button
-            mat-stroked-button
-            type="button"
-            matTooltip="Renew API Key"
-            i18n-matTooltip="@@subscriptionDetailsRenewApiKeyTooltip"
-            [disabled]="isRenewingApiKey()"
-            data-testid="renew-api-key-button"
-            (click)="renewApiKey()"
-          >
-            <span class="next-gen-small-bold" i18n="@@subscriptionDetailsRenewApiKey">Renew API Key</span>
-          </button>
-        }
-      </div>
-    </mat-card-header>
-    <mat-card-content class="api-access__copy-code-content">
-      @if (planSecurity === 'OAUTH2' || planSecurity === 'JWT') {
-        <app-copy-code id="client-id" title="Client ID" [text]="clientId ?? ''" />
+@if (shouldRenderApiAccessCard()) {
+  <mat-card appearance="outlined" class="api-access">
+    @if (subscription?.status === 'ACCEPTED' || planSecurity === 'KEY_LESS') {
+      <mat-card-header>
+        <div class="api-access__header-row">
+          <div class="next-gen-h5 api-access__header" i18n="@@subscriptionDetailsApiAccessHeader">API access</div>
+          @if (planSecurity === 'API_KEY' && subscription?.status === 'ACCEPTED' && canManageApiKey) {
+            <button
+              mat-stroked-button
+              type="button"
+              matTooltip="Renew API Key"
+              i18n-matTooltip="@@subscriptionDetailsRenewApiKeyTooltip"
+              [disabled]="isRenewingApiKey()"
+              data-testid="renew-api-key-button"
+              (click)="renewApiKey()"
+            >
+              <span class="next-gen-small-bold" i18n="@@subscriptionDetailsRenewApiKey">Renew API Key</span>
+            </button>
+          }
+        </div>
+      </mat-card-header>
+      <mat-card-content class="api-access__copy-code-content">
+        @if (planSecurity === 'OAUTH2' || planSecurity === 'JWT') {
+          <app-copy-code id="client-id" title="Client ID" [text]="clientId ?? ''" />
 
-        @if (!!clientSecret) {
-          <app-copy-code id="client-secret" title="Client Secret" [text]="clientSecret" mode="PASSWORD" />
+          @if (!!clientSecret) {
+            <app-copy-code id="client-secret" title="Client Secret" [text]="clientSecret" mode="PASSWORD" />
+          }
         }
-      }
-      @if (apiType === 'NATIVE') {
-        <app-native-kafka-api-access
-          [entrypointUrls]="entrypointUrlValues()"
-          [planSecurity]="planSecurity"
-          [apiKey]="primaryApiKey()"
-          [apiKeyConfigUsername]="resolvedApiKeyConfigUsername()"
-          [clientId]="clientId ?? ''"
-        />
-      } @else {
-        @if (planSecurity === 'API_KEY') {
-          <div class="api-access__copy-code-content__api-keys-list">
-            <div class="next-gen-h5" i18n="@@subscriptionDetailsApiAccessApiKeysHeader">API keys</div>
-            @if (apiKeyRenewFeedback(); as renewFeedback) {
-              <div
-                class="next-gen-body api-access__renew-feedback"
-                [class.api-access__renew-feedback--error]="renewFeedback.type === 'error'"
-                [class.api-access__renew-feedback--success]="renewFeedback.type === 'success'"
-                [attr.role]="renewFeedback.type === 'error' ? 'alert' : null"
-                [attr.aria-live]="renewFeedback.type === 'success' ? 'polite' : null"
-                data-testid="renew-api-key-feedback"
-              >
-                {{ renewFeedback.message }}
-              </div>
-            }
-            @if (apiKeyRows().length > 0) {
-              <app-paginated-table
-                [columns]="apiKeysColumns"
-                [rows]="displayedApiKeyRows()"
-                [totalElements]="totalApiKeyElements()"
-                [currentPage]="apiKeysCurrentPage()"
-                [pageSize]="apiKeysPageSize()"
-                [pageSizeOptions]="apiKeysPageSizeOptions"
-                [navigable]="false"
-                (pageChange)="onApiKeysPageChange($event)"
-                (pageSizeChange)="onApiKeysPageSizeChange($event)"
-              >
-                <ng-template appTableCell="status" let-apiKey>
-                  <mat-icon
-                    [svgIcon]="apiKey.statusIcon"
-                    [attr.aria-label]="apiKey.statusLabel"
-                    [attr.data-status-icon]="apiKey.statusIcon"
-                    data-testid="api-key-status-icon"
-                  />
-                </ng-template>
-                <ng-template appTableCell="revoke" let-apiKey>
-                  @if (canManageApiKey && apiKey.isActive) {
-                    <button
-                      mat-icon-button
-                      type="button"
-                      color="warn"
-                      [disabled]="isRevokingApiKey || isRevokeApiKeyDialogOpen"
-                      matTooltip="Revoke"
-                      i18n-matTooltip="@@subscriptionDetailsApiAccessRevokeTooltip"
-                      [attr.aria-label]="apiKey.revokeAriaLabel"
-                      [attr.data-api-key]="apiKey.key"
-                      data-testid="api-key-revoke-button"
-                      (click)="revokeApiKeyRow(apiKey)"
-                    >
-                      <mat-icon svgIcon="gio:x-circle" />
-                    </button>
-                  }
-                </ng-template>
-              </app-paginated-table>
-            } @else {
-              <div class="next-gen-body" i18n="@@subscriptionDetailsApiAccessApiKeysEmpty">No API keys available.</div>
-            }
-          </div>
-        }
-        @if (shouldShowApiAccessContent()) {
-          <div class="api-access__copy-code-content__calling-api">
-            <div class="next-gen-h5" i18n="@@subscriptionDetailsApiAccessCallingTheApi">Calling the API</div>
-            @if (entrypointUrlValues().length === 1) {
-              <app-copy-code id="base-url" title="Base URL" [text]="entrypointUrlValues()[0]" />
-            } @else if (entrypointUrlValues().length > 1) {
-              <mat-form-field appearance="outline" subscriptSizing="dynamic">
-                <mat-label class="next-gen-body" i18n="@@subscriptionDetailsApiAccessBaseUrls">Base URLs</mat-label>
-                <mat-select
-                  [value]="selectedEntrypointUrlValue()"
-                  id="select-entrypoints"
-                  (selectionChange)="selectedEntrypointUrl.set($event.value)"
+        @if (apiType === 'NATIVE') {
+          <app-native-kafka-api-access
+            [entrypointUrls]="entrypointUrlValues()"
+            [planSecurity]="planSecurity"
+            [apiKey]="primaryApiKey()"
+            [apiKeyConfigUsername]="resolvedApiKeyConfigUsername()"
+            [clientId]="clientId ?? ''"
+          />
+        } @else {
+          @if (planSecurity === 'API_KEY') {
+            <div class="api-access__copy-code-content__api-keys-list">
+              <div class="next-gen-h5" i18n="@@subscriptionDetailsApiAccessApiKeysHeader">API keys</div>
+              @if (apiKeyRenewFeedback(); as renewFeedback) {
+                <div
+                  class="next-gen-body api-access__renew-feedback"
+                  [class.api-access__renew-feedback--error]="renewFeedback.type === 'error'"
+                  [class.api-access__renew-feedback--success]="renewFeedback.type === 'success'"
+                  [attr.role]="renewFeedback.type === 'error' ? 'alert' : null"
+                  [attr.aria-live]="renewFeedback.type === 'success' ? 'polite' : null"
+                  data-testid="renew-api-key-feedback"
                 >
-                  @for (entrypointUrl of entrypointUrlValues(); track entrypointUrl) {
-                    <mat-option [value]="entrypointUrl">{{ entrypointUrl }}</mat-option>
-                  }
-                </mat-select>
-                <app-copy-code-icon
-                  matSuffix
-                  (click)="$event.stopPropagation()"
-                  [contentToCopy]="selectedEntrypointUrlValue()"
-                  [label]="selectedEntrypointUrlValue()"
-                />
-              </mat-form-field>
-            }
+                  {{ renewFeedback.message }}
+                </div>
+              }
+              @if (apiKeyRows().length > 0) {
+                <app-paginated-table
+                  [columns]="apiKeysColumns"
+                  [rows]="displayedApiKeyRows()"
+                  [totalElements]="totalApiKeyElements()"
+                  [currentPage]="apiKeysCurrentPage()"
+                  [pageSize]="apiKeysPageSize()"
+                  [pageSizeOptions]="apiKeysPageSizeOptions"
+                  [navigable]="false"
+                  (pageChange)="onApiKeysPageChange($event)"
+                  (pageSizeChange)="onApiKeysPageSizeChange($event)"
+                >
+                  <ng-template appTableCell="status" let-apiKey>
+                    <mat-icon
+                      [svgIcon]="apiKey.statusIcon"
+                      [attr.aria-label]="apiKey.statusLabel"
+                      [attr.data-status-icon]="apiKey.statusIcon"
+                      data-testid="api-key-status-icon"
+                    />
+                  </ng-template>
+                  <ng-template appTableCell="revoke" let-apiKey>
+                    @if (canManageApiKey && apiKey.isActive) {
+                      <button
+                        mat-icon-button
+                        type="button"
+                        color="warn"
+                        [disabled]="isRevokingApiKey || isRevokeApiKeyDialogOpen"
+                        matTooltip="Revoke"
+                        i18n-matTooltip="@@subscriptionDetailsApiAccessRevokeTooltip"
+                        [attr.aria-label]="apiKey.revokeAriaLabel"
+                        [attr.data-api-key]="apiKey.key"
+                        data-testid="api-key-revoke-button"
+                        (click)="revokeApiKeyRow(apiKey)"
+                      >
+                        <mat-icon svgIcon="gio:x-circle" />
+                      </button>
+                    }
+                  </ng-template>
+                </app-paginated-table>
+              } @else {
+                <div class="next-gen-body" i18n="@@subscriptionDetailsApiAccessApiKeysEmpty">No API keys available.</div>
+              }
+            </div>
+          }
+          @if (shouldShowApiAccessContent()) {
+            <div class="api-access__copy-code-content__calling-api">
+              <div class="next-gen-h5" i18n="@@subscriptionDetailsApiAccessCallingTheApi">Calling the API</div>
+              @if (entrypointUrlValues().length === 1) {
+                <app-copy-code id="base-url" title="Base URL" [text]="entrypointUrlValues()[0]" />
+              } @else if (entrypointUrlValues().length > 1) {
+                <mat-form-field appearance="outline" subscriptSizing="dynamic">
+                  <mat-label class="next-gen-body" i18n="@@subscriptionDetailsApiAccessBaseUrls">Base URLs</mat-label>
+                  <mat-select
+                    [value]="selectedEntrypointUrlValue()"
+                    id="select-entrypoints"
+                    (selectionChange)="selectedEntrypointUrl.set($event.value)"
+                  >
+                    @for (entrypointUrl of entrypointUrlValues(); track entrypointUrl) {
+                      <mat-option [value]="entrypointUrl">{{ entrypointUrl }}</mat-option>
+                    }
+                  </mat-select>
+                  <app-copy-code-icon
+                    matSuffix
+                    (click)="$event.stopPropagation()"
+                    [contentToCopy]="selectedEntrypointUrlValue()"
+                    [label]="selectedEntrypointUrlValue()"
+                  />
+                </mat-form-field>
+              }
 
-            <app-copy-code id="command-line" [text]="curlCmd()" />
-          </div>
+              <app-copy-code id="command-line" [text]="curlCmd()" />
+            </div>
+          }
         }
-      }
-    </mat-card-content>
-  } @else {
-    <mat-card-content class="api-access__message">
-      @switch (subscription?.status) {
-        @case ('PENDING') {
-          <div class="next-gen-h5 api-access__message__content" i18n="@@subscriptionDetailsPendingHeader">Subscription in progress</div>
-          <div class="next-gen-body" i18n="@@subscriptionDetailsPendingContent">
-            Your subscription request is being validated. Come back later.
-          </div>
+      </mat-card-content>
+    } @else {
+      <mat-card-content class="api-access__message">
+        @switch (subscription?.status) {
+          @case ('PENDING') {
+            <div class="next-gen-h5 api-access__message__content" i18n="@@subscriptionDetailsPendingHeader">Subscription in progress</div>
+            <div class="next-gen-body" i18n="@@subscriptionDetailsPendingContent">
+              Your subscription request is being validated. Come back later.
+            </div>
+          }
+          @case ('REJECTED') {
+            <div class="next-gen-h5 api-access__message__content" i18n="@@subscriptionDetailsRejectedHeader">Subscription rejected</div>
+          }
+          @case ('PAUSED') {
+            <div class="next-gen-h5 api-access__message__content" i18n="@@subscriptionDetailsPasueddHeader">Subscription paused</div>
+          }
+          @case ('CLOSED') {
+            <div class="next-gen-h5 api-access__message__content" i18n="@@subscriptionDetailsClosedHeader">Subscription closed</div>
+          }
         }
-        @case ('REJECTED') {
-          <div class="next-gen-h5 api-access__message__content" i18n="@@subscriptionDetailsRejectedHeader">Subscription rejected</div>
-        }
-        @case ('PAUSED') {
-          <div class="next-gen-h5 api-access__message__content" i18n="@@subscriptionDetailsPasueddHeader">Subscription paused</div>
-        }
-        @case ('CLOSED') {
-          <div class="next-gen-h5 api-access__message__content" i18n="@@subscriptionDetailsClosedHeader">Subscription closed</div>
-        }
-      }
-    </mat-card-content>
-  }
-</mat-card>
+      </mat-card-content>
+    }
+  </mat-card>
+}

--- a/gravitee-apim-portal-webui-next/src/components/api-access/api-access.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/components/api-access/api-access.component.spec.ts
@@ -106,6 +106,45 @@ describe('ApiAccessComponent', () => {
     });
   });
 
+  describe('Federated API (empty entrypoints)', () => {
+    it('should hide the whole API access card for a keyless plan with empty entrypoints', async () => {
+      component.planSecurity = 'KEY_LESS';
+      component.entrypointUrls = [];
+
+      fixture.detectChanges();
+
+      expect(apiAccessCardShown()).toBeFalsy();
+      expect(apiAccessShellShown()).toBeFalsy();
+      expect(await commandLineShown()).toBeFalsy();
+    });
+
+    it('should hide the whole API access card for a keyless plan with undefined entrypoints', async () => {
+      component.planSecurity = 'KEY_LESS';
+      component.entrypointUrls = undefined;
+
+      fixture.detectChanges();
+
+      expect(apiAccessCardShown()).toBeFalsy();
+      expect(apiAccessShellShown()).toBeFalsy();
+      expect(await commandLineShown()).toBeFalsy();
+    });
+
+    it('should still show api keys but hide calling the API content for an api key plan with empty entrypoints', async () => {
+      component.planSecurity = 'API_KEY';
+      component.subscription = { status: 'ACCEPTED' } as Subscription;
+      component.entrypointUrls = [];
+      component.apiKeys = [{ key: 'api-key', application: { id: 'app-id', name: 'app-name' } }];
+
+      fixture.detectChanges();
+
+      expect(apiAccessCardShown()).toBeTruthy();
+      expect(apiAccessShellShown()).toBeTruthy();
+      expect(await apiKeysTableShown()).toBeTruthy();
+      expect(await baseUrlShown()).toBeFalsy();
+      expect(await commandLineShown()).toBeFalsy();
+    });
+  });
+
   describe('Accepted', () => {
     describe('HTTP API', () => {
       describe('API Key', () => {
@@ -875,6 +914,9 @@ describe('ApiAccessComponent', () => {
   }
   function apiAccessShellShown() {
     return !!fixture.debugElement.query(By.css('.api-access__copy-code-content'));
+  }
+  function apiAccessCardShown() {
+    return !!fixture.debugElement.query(By.css('.api-access'));
   }
   async function getRevokeApiKeyButton() {
     return await harnessLoader.getHarnessOrNull(MatButtonHarness.with({ selector: '[data-testid="api-key-revoke-button"]' }));

--- a/gravitee-apim-portal-webui-next/src/components/api-access/api-access.component.ts
+++ b/gravitee-apim-portal-webui-next/src/components/api-access/api-access.component.ts
@@ -220,8 +220,24 @@ export class ApiAccessComponent {
   protected readonly primaryApiKey = computed(() => this.activeApiKey()?.key ?? '');
   protected readonly resolvedApiKeyConfigUsername = computed(() => this.apiKeyConfigUsernameInput() ?? this.activeApiKey()?.hash ?? '');
   protected readonly shouldShowApiAccessContent = computed(
-    () => this.planSecurityInput() !== 'API_KEY' || this.subscriptionInput()?.status !== 'ACCEPTED' || this.hasActiveApiKey(),
+    () =>
+      this.entrypointUrlValues().length > 0 &&
+      (this.planSecurityInput() !== 'API_KEY' || this.subscriptionInput()?.status !== 'ACCEPTED' || this.hasActiveApiKey()),
   );
+  protected readonly hasApiAccessContent = computed(() => {
+    if (this.apiTypeInput() === 'NATIVE') {
+      return true;
+    }
+    const security = this.planSecurityInput();
+    if (security === 'OAUTH2' || security === 'JWT' || security === 'API_KEY') {
+      return true;
+    }
+    return this.shouldShowApiAccessContent();
+  });
+  protected readonly shouldRenderApiAccessCard = computed(() => {
+    const isAccessVisible = this.subscriptionInput()?.status === 'ACCEPTED' || this.planSecurityInput() === 'KEY_LESS';
+    return isAccessVisible ? this.hasApiAccessContent() : true;
+  });
   protected isRevokingApiKey = false;
   protected isRevokeApiKeyDialogOpen = false;
   private readonly defaultSnackBarOptions: MatSnackBarConfig = {


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-14165

## Description

- Hide the empty "API access" card for federated APIs with no entrypoints (KEY_LESS plans)
- Hide the "Calling the API" / curl section when entrypoints are empty (all plans)
- API keys and OAuth credentials remain visible when available

## Additional context
<img width="1496" height="727" alt="Capture d’écran 2026-06-08 à 08 19 32" src="https://github.com/user-attachments/assets/65d9585e-7b9c-47d4-96af-7bab6ad229f4" />
<img width="1496" height="631" alt="Capture d’écran 2026-06-08 à 08 19 51" src="https://github.com/user-attachments/assets/faeccf28-c684-4aa2-ac2f-4f8e275a6953" />


