### PR TITLE
chore(deps): update gravitee-resource-ai-vector-store-redis to 2.0.0-alpha.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -314,7 +314,7 @@
         <gravitee-reactor-llm-proxy.version>3.0.0-alpha.6</gravitee-reactor-llm-proxy.version>
         <gravitee-reactor-a2a-proxy.version>1.0.0</gravitee-reactor-a2a-proxy.version>
         <gravitee-reactor-edge.version>1.0.0-alpha.9</gravitee-reactor-edge.version>
-        <gravitee-resource-ai-vector-store-redis.version>1.0.1</gravitee-resource-ai-vector-store-redis.version>
+        <gravitee-resource-ai-vector-store-redis.version>2.0.0-alpha.1</gravitee-resource-ai-vector-store-redis.version>
         <gravitee-resource-ai-vector-store-aws-s3.version>1.0.0</gravitee-resource-ai-vector-store-aws-s3.version>
         <gravitee-resource-ai-model-text-embedding.version>1.0.0</gravitee-resource-ai-model-text-embedding.version>
         <gravitee-policy-ai-semantic-caching.version>1.1.0</gravitee-policy-ai-semantic-caching.version>


### PR DESCRIPTION
## What

Bumps `gravitee-resource-ai-vector-store-redis` from `1.0.1` to `2.0.0-alpha.1` in the root `pom.xml` (consumed by `gravitee-apim-distribution`).

## Why

The 2.x line of the plugin targets the APIM **4.12 / Vert.x 5** baseline (1.x is for 4.11). `4.12.x` should ship the matching 2.x plugin.

| Plugin version | APIM version   |
|----------------|----------------|
| 1.x            | 4.11           |
| 2.x            | 4.12 to latest |

Plugin compatibility matrix: gravitee-io/gravitee-resource-ai-vector-store-redis#20