### PR TITLE
feat(portal): accept confirmation page url in invitation creation

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/mapper/ApplicationInvitationsCreateInputMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/mapper/ApplicationInvitationsCreateInputMapper.java
@@ -18,6 +18,7 @@ package io.gravitee.rest.api.portal.rest.mapper;
 import io.gravitee.apim.core.invitation.model.CreateApplicationInvitations;
 import io.gravitee.rest.api.portal.rest.model.InvitationCreateInput;
 import io.gravitee.rest.api.portal.rest.model.InvitationRecipientInput;
+import java.net.URI;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
@@ -56,7 +57,7 @@ public interface ApplicationInvitationsCreateInputMapper {
         return roleName == null ? null : roleName.trim();
     }
 
-    private String normalizeConfirmationPageUrl(String confirmationPageUrl) {
-        return confirmationPageUrl == null || confirmationPageUrl.isBlank() ? null : confirmationPageUrl.trim();
+    private String normalizeConfirmationPageUrl(URI confirmationPageUrl) {
+        return confirmationPageUrl == null || confirmationPageUrl.toString().isBlank() ? null : confirmationPageUrl.toString();
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/mapper/ApplicationInvitationsCreateInputMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/mapper/ApplicationInvitationsCreateInputMapper.java
@@ -33,7 +33,8 @@ public interface ApplicationInvitationsCreateInputMapper {
         return new CreateApplicationInvitations(
             toRecipientEmails(input.getRecipients()),
             normalizeRoleName(input.getRole()),
-            input.getNotify() == null || input.getNotify()
+            input.getNotify() == null || input.getNotify(),
+            normalizeConfirmationPageUrl(input.getConfirmationPageUrl())
         );
     }
 
@@ -53,5 +54,9 @@ public interface ApplicationInvitationsCreateInputMapper {
 
     private String normalizeRoleName(String roleName) {
         return roleName == null ? null : roleName.trim();
+    }
+
+    private String normalizeConfirmationPageUrl(String confirmationPageUrl) {
+        return confirmationPageUrl == null || confirmationPageUrl.isBlank() ? null : confirmationPageUrl.trim();
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/resources/portal-openapi.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/resources/portal-openapi.yaml
@@ -7329,6 +7329,9 @@ components:
                     description: Whether invitation notifications should be sent when invitations are created.
                     type: boolean
                     default: true
+                confirmation_page_url:
+                    description: URL of the confirmation page to be used in the application invitation email.
+                    type: string
         InvitationRecipientInput:
             type: object
             required:

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/resources/portal-openapi.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/resources/portal-openapi.yaml
@@ -7332,6 +7332,7 @@ components:
                 confirmation_page_url:
                     description: URL of the confirmation page to be used in the application invitation email.
                     type: string
+                    format: uri
         InvitationRecipientInput:
             type: object
             required:

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/mapper/ApplicationInvitationsCreateInputMapperTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/mapper/ApplicationInvitationsCreateInputMapperTest.java
@@ -19,6 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.gravitee.rest.api.portal.rest.model.InvitationCreateInput;
 import io.gravitee.rest.api.portal.rest.model.InvitationRecipientInput;
+import java.net.URI;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 
@@ -36,7 +37,7 @@ class ApplicationInvitationsCreateInputMapperTest {
                 )
             )
             .role(" USER ")
-            .confirmationPageUrl(" https://portal.example.com/user/registration/confirm ");
+            .confirmationPageUrl(URI.create("https://portal.example.com/user/registration/confirm"));
         input.setNotify(null);
 
         var result = cut.toCreateApplicationInvitations(input);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/mapper/ApplicationInvitationsCreateInputMapperTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/mapper/ApplicationInvitationsCreateInputMapperTest.java
@@ -35,7 +35,8 @@ class ApplicationInvitationsCreateInputMapperTest {
                     new InvitationRecipientInput().email("BOB@example.com")
                 )
             )
-            .role(" USER ");
+            .role(" USER ")
+            .confirmationPageUrl(" https://portal.example.com/user/registration/confirm ");
         input.setNotify(null);
 
         var result = cut.toCreateApplicationInvitations(input);
@@ -43,6 +44,7 @@ class ApplicationInvitationsCreateInputMapperTest {
         assertThat(result.recipientEmails()).containsExactly("alice@example.com", "bob@example.com");
         assertThat(result.roleName()).isEqualTo("USER");
         assertThat(result.notifyUsers()).isTrue();
+        assertThat(result.confirmationPageUrl()).isEqualTo("https://portal.example.com/user/registration/confirm");
     }
 
     @Test
@@ -56,6 +58,7 @@ class ApplicationInvitationsCreateInputMapperTest {
 
         assertThat(result.recipientEmails()).containsExactly("alice@example.com");
         assertThat(result.notifyUsers()).isFalse();
+        assertThat(result.confirmationPageUrl()).isNull();
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/invitation/model/CreateApplicationInvitations.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/invitation/model/CreateApplicationInvitations.java
@@ -17,4 +17,4 @@ package io.gravitee.apim.core.invitation.model;
 
 import java.util.Set;
 
-public record CreateApplicationInvitations(Set<String> recipientEmails, String roleName, boolean notifyUsers) {}
+public record CreateApplicationInvitations(Set<String> recipientEmails, String roleName, boolean notifyUsers, String confirmationPageUrl) {}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/invitation/model/CreateApplicationInvitations.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/invitation/model/CreateApplicationInvitations.java
@@ -17,4 +17,8 @@ package io.gravitee.apim.core.invitation.model;
 
 import java.util.Set;
 
-public record CreateApplicationInvitations(Set<String> recipientEmails, String roleName, boolean notifyUsers, String confirmationPageUrl) {}
+public record CreateApplicationInvitations(Set<String> recipientEmails, String roleName, boolean notifyUsers, String confirmationPageUrl) {
+    public CreateApplicationInvitations(Set<String> recipientEmails, String roleName, boolean notifyUsers) {
+        this(recipientEmails, roleName, notifyUsers, null);
+    }
+}


### PR DESCRIPTION
https://gravitee.atlassian.net/browse/APIM-14143

## Issue

https://gravitee.atlassian.net/browse/APIM-14143

## Description
Adds confirmation_page_url to the Portal API invitation creation contract and maps it into the backend create-invitations command.

Changes:
- Added optional confirmation_page_url to InvitationCreateInput in portal-openapi.yaml.
- Extended CreateApplicationInvitations with confirmationPageUrl.
- Updated Portal mapper to trim the value and normalize blank strings to null.
- Updated mapper/use-case tests for the extended command.
 
This PR only makes the backend accept and carry the new field. It does not yet use confirmation_page_url to generate the invitation email link.

