### PR TITLE
feat(portal): add portal navigation sync domain layer

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/spring/ResourceContextConfiguration.java
@@ -31,8 +31,6 @@ import inmemory.GroupQueryServiceInMemory;
 import inmemory.PageCrudServiceInMemory;
 import inmemory.PageSourceDomainServiceInMemory;
 import inmemory.ParametersQueryServiceInMemory;
-import inmemory.PortalNavigationItemsCrudServiceInMemory;
-import inmemory.PortalNavigationItemsQueryServiceInMemory;
 import inmemory.PortalPageContentQueryServiceInMemory;
 import inmemory.SharedPolicyGroupCrudServiceInMemory;
 import inmemory.SharedPolicyGroupHistoryCrudServiceInMemory;
@@ -146,7 +144,6 @@ import io.gravitee.apim.core.policy.domain_service.PolicyValidationDomainService
 import io.gravitee.apim.core.portal.use_case.CreateOrUpdatePortalUseCase;
 import io.gravitee.apim.core.portal.use_case.DeletePortalUseCase;
 import io.gravitee.apim.core.portal.use_case.GetPortalUseCase;
-import io.gravitee.apim.core.portal_page.crud_service.PortalNavigationItemCrudService;
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemDomainService;
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemValidatorService;
 import io.gravitee.apim.core.portal_page.query_service.PortalNavigationItemsQueryService;
@@ -1135,16 +1132,6 @@ public class ResourceContextConfiguration {
         PortalNavigationItemDomainService domainService
     ) {
         return new UpdatePortalNavigationItemUseCase(portalNavigationItemsQueryService, validatorService, domainService);
-    }
-
-    @Bean
-    public PortalNavigationItemCrudService portalNavigationItemCrudService() {
-        return new PortalNavigationItemsCrudServiceInMemory();
-    }
-
-    @Bean
-    public PortalNavigationItemsQueryService portalNavigationItemsQueryService() {
-        return new PortalNavigationItemsQueryServiceInMemory();
     }
 
     @Bean

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/spring/ResourceContextConfiguration.java
@@ -37,7 +37,6 @@ import inmemory.NewtAIProviderInMemory;
 import inmemory.PageCrudServiceInMemory;
 import inmemory.PageSourceDomainServiceInMemory;
 import inmemory.ParametersQueryServiceInMemory;
-import inmemory.PortalNavigationItemsCrudServiceInMemory;
 import inmemory.RoleQueryServiceInMemory;
 import inmemory.SharedPolicyGroupCrudServiceInMemory;
 import inmemory.UserDomainServiceInMemory;
@@ -1370,11 +1369,6 @@ public class ResourceContextConfiguration {
             portalNavigationItemValidatorService,
             domainService
         );
-    }
-
-    @Bean
-    public PortalNavigationItemCrudService portalNavigationItemCrudService() {
-        return new PortalNavigationItemsCrudServiceInMemory();
     }
 
     @Bean

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/spring/ResourceContextConfiguration.java
@@ -27,7 +27,6 @@ import inmemory.ApplicationCrudServiceInMemory;
 import inmemory.CRDMembersDomainServiceInMemory;
 import inmemory.GroupCrudServiceInMemory;
 import inmemory.PageSourceDomainServiceInMemory;
-import inmemory.PortalNavigationItemsCrudServiceInMemory;
 import inmemory.PortalNavigationItemsQueryServiceInMemory;
 import inmemory.PortalPageContentQueryServiceInMemory;
 import inmemory.SharedPolicyGroupCrudServiceInMemory;
@@ -136,7 +135,6 @@ import io.gravitee.apim.core.plan.use_case.PatchPlanUseCase.PlanFlowsConverter;
 import io.gravitee.apim.core.plugin.crud_service.PolicyPluginCrudService;
 import io.gravitee.apim.core.plugin.domain_service.EndpointConnectorPluginDomainService;
 import io.gravitee.apim.core.policy.domain_service.PolicyValidationDomainService;
-import io.gravitee.apim.core.portal_page.crud_service.PortalNavigationItemCrudService;
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemDomainService;
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemValidatorService;
 import io.gravitee.apim.core.portal_page.query_service.PortalNavigationItemsQueryService;
@@ -1342,11 +1340,6 @@ public class ResourceContextConfiguration {
         PortalNavigationItemDomainService domainService
     ) {
         return new UpdatePortalNavigationItemUseCase(portalNavigationItemsQueryService, validatorService, domainService);
-    }
-
-    @Bean
-    public PortalNavigationItemCrudService portalNavigationItemCrudService() {
-        return new PortalNavigationItemsCrudServiceInMemory();
     }
 
     @Bean

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/spring/ResourceContextConfiguration.java
@@ -28,7 +28,6 @@ import inmemory.CRDMembersDomainServiceInMemory;
 import inmemory.GroupCrudServiceInMemory;
 import inmemory.MembershipQueryServiceInMemory;
 import inmemory.PageSourceDomainServiceInMemory;
-import inmemory.PortalNavigationItemsCrudServiceInMemory;
 import inmemory.PortalPageContentQueryServiceInMemory;
 import inmemory.SharedPolicyGroupCrudServiceInMemory;
 import inmemory.SubscriptionQueryServiceInMemory;
@@ -145,7 +144,6 @@ import io.gravitee.apim.core.plan.use_case.PatchPlanUseCase.PlanFlowsConverter;
 import io.gravitee.apim.core.plugin.crud_service.PolicyPluginCrudService;
 import io.gravitee.apim.core.plugin.domain_service.EndpointConnectorPluginDomainService;
 import io.gravitee.apim.core.policy.domain_service.PolicyValidationDomainService;
-import io.gravitee.apim.core.portal_page.crud_service.PortalNavigationItemCrudService;
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationApiVisibilityDomainService;
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemDomainService;
 import io.gravitee.apim.core.portal_page.domain_service.PortalNavigationItemValidatorService;
@@ -1249,11 +1247,6 @@ public class ResourceContextConfiguration {
         PortalNavigationItemDomainService domainService
     ) {
         return new UpdatePortalNavigationItemUseCase(portalNavigationItemsQueryService, validatorService, domainService);
-    }
-
-    @Bean
-    public PortalNavigationItemCrudService portalNavigationItemCrudService() {
-        return new PortalNavigationItemsCrudServiceInMemory();
     }
 
     @Bean

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal/domain_service/PortalNavigationListingDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal/domain_service/PortalNavigationListingDomainService.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal.domain_service;
+
+import io.gravitee.apim.core.DomainService;
+import io.gravitee.apim.core.portal.domain_service.navigation.PortalNavigationTreeWalker;
+import io.gravitee.apim.core.portal.domain_service.navigation.PortalNavigationVisitor;
+import io.gravitee.apim.core.portal.model.NavigationPath;
+import io.gravitee.apim.core.portal_page.model.PortalArea;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationFolder;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItemQueryCriteria;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItemType;
+import io.gravitee.apim.core.portal_page.query_service.PortalNavigationItemsQueryService;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+
+@DomainService
+@RequiredArgsConstructor
+public class PortalNavigationListingDomainService {
+
+    private final PortalNavigationItemsQueryService queryService;
+
+    public List<NavigationPath> listAsNavigationPaths(String environmentId) {
+        final var folders = queryService.search(
+            PortalNavigationItemQueryCriteria.builder()
+                .environmentId(environmentId)
+                .area(PortalArea.TOP_NAVBAR)
+                .type(PortalNavigationItemType.FOLDER)
+                .build()
+        );
+        final var collector = new PathCollector();
+        PortalNavigationTreeWalker.walk(folders, collector);
+        return collector.paths;
+    }
+
+    private static final class PathCollector implements PortalNavigationVisitor {
+
+        private final List<NavigationPath> paths = new ArrayList<>();
+
+        @Override
+        public void visitFolder(PortalNavigationFolder folder, NavigationPath parentPath) {
+            final var nodePath = parentPath.descend(folder.getEffectiveSegment());
+            final var displayName = !folder.getEffectiveSegment().equals(folder.getTitle()) ? folder.getTitle() : null;
+            paths.add(new NavigationPath(nodePath.path(), Optional.ofNullable(displayName)));
+        }
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal/domain_service/PortalNavigationSyncDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal/domain_service/PortalNavigationSyncDomainService.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal.domain_service;
+
+import io.gravitee.apim.core.DomainService;
+import io.gravitee.apim.core.audit.model.AuditInfo;
+import io.gravitee.apim.core.portal.domain_service.navigation.NavigationFolderMapper;
+import io.gravitee.apim.core.portal.domain_service.navigation.actions.FolderActions;
+import io.gravitee.apim.core.portal.domain_service.navigation.actions.NavigationAction;
+import io.gravitee.apim.core.portal.domain_service.navigation.plan.NavigationSyncPlan;
+import io.gravitee.apim.core.portal.domain_service.navigation.plan.NavigationSyncPlanner;
+import io.gravitee.apim.core.portal.model.NavigationPath;
+import io.gravitee.apim.core.portal.model.PortalId;
+import io.gravitee.apim.core.portal_page.crud_service.PortalNavigationItemCrudService;
+import io.gravitee.apim.core.portal_page.crud_service.PortalPageContentCrudService;
+import io.gravitee.apim.core.portal_page.model.CreatePortalNavigationItem;
+import io.gravitee.apim.core.portal_page.model.PortalArea;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationFolder;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItem;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItemContainer;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItemQueryCriteria;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItemType;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationPage;
+import io.gravitee.apim.core.portal_page.model.PortalVisibility;
+import io.gravitee.apim.core.portal_page.query_service.PortalNavigationItemsQueryService;
+import io.gravitee.rest.api.service.common.HRIDToUUID;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+
+@DomainService
+@RequiredArgsConstructor
+public class PortalNavigationSyncDomainService {
+
+    private static final PortalArea AREA = PortalArea.TOP_NAVBAR;
+    private static final int MAX_CASCADE_DEPTH = 50;
+
+    private final PortalNavigationItemCrudService crudService;
+    private final PortalNavigationItemsQueryService queryService;
+    private final PortalPageContentCrudService pageContentCrudService;
+
+    public void sync(AuditInfo auditInfo, PortalId portalId, List<NavigationPath> desired) {
+        final var currentFolders = queryService.search(
+            PortalNavigationItemQueryCriteria.builder()
+                .environmentId(auditInfo.environmentId())
+                .area(AREA)
+                .type(PortalNavigationItemType.FOLDER)
+                .build()
+        );
+        final var plan = NavigationSyncPlanner.plan(desired == null ? List.of() : desired, currentFolders);
+        execute(plan, auditInfo, portalId);
+    }
+
+    private void execute(NavigationSyncPlan plan, AuditInfo auditInfo, PortalId portalId) {
+        final var byPath = new HashMap<String, PortalNavigationItemContainer>();
+        plan.actions().forEach(action -> applyAction(action, byPath, auditInfo, portalId));
+    }
+
+    private void applyAction(
+        NavigationAction action,
+        Map<String, PortalNavigationItemContainer> byPath,
+        AuditInfo auditInfo,
+        PortalId portalId
+    ) {
+        switch (action) {
+            case FolderActions.FolderMutation m -> applyMutation(m, byPath, auditInfo, portalId);
+            case FolderActions.DeleteFolder d -> cascadeDelete(d.item(), auditInfo.environmentId(), 0);
+        }
+    }
+
+    private void applyMutation(
+        FolderActions.FolderMutation mutation,
+        Map<String, PortalNavigationItemContainer> byPath,
+        AuditInfo auditInfo,
+        PortalId portalId
+    ) {
+        final var df = mutation.desired();
+        final var parent = df.parentPath() == null ? null : byPath.get(df.parentPath());
+        final PortalNavigationFolder result = switch (mutation) {
+            case FolderActions.CreateFolder c -> createFolder(c.desired(), parent, auditInfo, portalId);
+            case FolderActions.UpdateFolder u -> applyUpdate(u.existing(), u.desired(), parent);
+        };
+        byPath.put(df.path(), result);
+    }
+
+    private PortalNavigationFolder createFolder(
+        FolderActions.DesiredFolder df,
+        PortalNavigationItemContainer parent,
+        AuditInfo auditInfo,
+        PortalId portalId
+    ) {
+        final var folderId = PortalNavigationItemId.of(
+            HRIDToUUID.navigation().context(auditInfo).portal(portalId.toString()).folder(df.path()).id()
+        );
+        final var create = CreatePortalNavigationItem.builder()
+            .id(folderId)
+            .title(df.title())
+            .segment(df.segment().value())
+            .area(AREA)
+            .type(PortalNavigationItemType.FOLDER)
+            .order(df.order())
+            .visibility(PortalVisibility.PUBLIC)
+            .published(true)
+            .build();
+        return (PortalNavigationFolder) crudService.create(
+            PortalNavigationItem.from(create, auditInfo.organizationId(), auditInfo.environmentId(), parent)
+        );
+    }
+
+    private PortalNavigationFolder applyUpdate(
+        PortalNavigationFolder existing,
+        FolderActions.DesiredFolder desired,
+        PortalNavigationItemContainer parent
+    ) {
+        if (NavigationFolderMapper.matches(existing, desired, parent == null ? null : parent.getId())) return existing;
+        NavigationFolderMapper.apply(desired, parent, existing);
+        return (PortalNavigationFolder) crudService.update(existing);
+    }
+
+    private void cascadeDelete(PortalNavigationItem item, String environmentId, int depth) {
+        if (depth > MAX_CASCADE_DEPTH) throw new IllegalStateException(
+            "Maximum portal navigation nesting level of %d exceeded".formatted(MAX_CASCADE_DEPTH)
+        );
+        queryService
+            .findByParentIdAndEnvironmentId(environmentId, item.getId())
+            .forEach(child -> cascadeDelete(child, environmentId, depth + 1));
+        if (item instanceof PortalNavigationPage page && page.getPortalPageContentId() != null) pageContentCrudService.delete(
+            page.getPortalPageContentId()
+        );
+        crudService.delete(item.getId());
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal/domain_service/navigation/NavigationFolderMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal/domain_service/navigation/NavigationFolderMapper.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal.domain_service.navigation;
+
+import io.gravitee.apim.core.portal.domain_service.navigation.actions.FolderActions;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationFolder;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItemContainer;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
+import jakarta.annotation.Nullable;
+import java.util.Objects;
+
+public final class NavigationFolderMapper {
+
+    private NavigationFolderMapper() {}
+
+    public static boolean matches(
+        PortalNavigationFolder existing,
+        FolderActions.DesiredFolder desired,
+        @Nullable PortalNavigationItemId parentId
+    ) {
+        return (
+            Objects.equals(existing.getTitle(), desired.title()) &&
+            Objects.equals(existing.getSegment(), desired.segment().value()) &&
+            existing.getOrder() == desired.order() &&
+            Objects.equals(existing.getParentId(), parentId)
+        );
+    }
+
+    public static void apply(FolderActions.DesiredFolder source, PortalNavigationItemContainer parent, PortalNavigationFolder target) {
+        target.setTitle(source.title());
+        target.setSegment(source.segment().value());
+        target.setOrder(source.order());
+        if (parent == null) {
+            target.markAsRoot();
+        } else {
+            target.updateParent(parent);
+        }
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal/domain_service/navigation/PortalNavigationTreeWalker.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal/domain_service/navigation/PortalNavigationTreeWalker.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal.domain_service.navigation;
+
+import io.gravitee.apim.core.portal.model.NavigationPath;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationApi;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationFolder;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItem;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationLink;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationPage;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+/** Pre-order traversal, children sorted by {@code order}. */
+public final class PortalNavigationTreeWalker {
+
+    private static final NavigationPath ROOT = new NavigationPath("", Optional.empty());
+
+    private PortalNavigationTreeWalker() {}
+
+    public static void walk(List<PortalNavigationItem> items, PortalNavigationVisitor visitor) {
+        final Comparator<PortalNavigationItem> byOrder = Comparator.comparingInt(PortalNavigationItem::getOrder);
+        final var childrenByParent = items
+            .stream()
+            .filter(i -> i.getParentId() != null)
+            .sorted(byOrder)
+            .collect(Collectors.groupingBy(PortalNavigationItem::getParentId));
+
+        items
+            .stream()
+            .filter(i -> i.getParentId() == null)
+            .sorted(byOrder)
+            .forEach(root -> traverse(root, ROOT, childrenByParent, visitor));
+    }
+
+    private static void traverse(
+        PortalNavigationItem node,
+        NavigationPath parentPath,
+        Map<PortalNavigationItemId, List<PortalNavigationItem>> childrenByParent,
+        PortalNavigationVisitor visitor
+    ) {
+        dispatch(node, parentPath, visitor);
+        final var nodePath = parentPath.descend(node.getEffectiveSegment());
+        childrenByParent.getOrDefault(node.getId(), List.of()).forEach(child -> traverse(child, nodePath, childrenByParent, visitor));
+    }
+
+    private static void dispatch(PortalNavigationItem node, NavigationPath parentPath, PortalNavigationVisitor visitor) {
+        switch (node) {
+            case PortalNavigationFolder f -> visitor.visitFolder(f, parentPath);
+            case PortalNavigationPage p -> visitor.visitPage(p, parentPath);
+            case PortalNavigationApi a -> visitor.visitApi(a, parentPath);
+            case PortalNavigationLink l -> visitor.visitLink(l, parentPath);
+        }
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal/domain_service/navigation/PortalNavigationVisitor.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal/domain_service/navigation/PortalNavigationVisitor.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal.domain_service.navigation;
+
+import io.gravitee.apim.core.portal.model.NavigationPath;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationApi;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationFolder;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationLink;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationPage;
+
+/** Override only the node kinds you care about; defaults are no-ops. */
+public interface PortalNavigationVisitor {
+    default void visitFolder(PortalNavigationFolder folder, NavigationPath parentPath) {}
+
+    default void visitPage(PortalNavigationPage page, NavigationPath parentPath) {}
+
+    default void visitApi(PortalNavigationApi api, NavigationPath parentPath) {}
+
+    default void visitLink(PortalNavigationLink link, NavigationPath parentPath) {}
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal/domain_service/navigation/actions/FolderActions.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal/domain_service/navigation/actions/FolderActions.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal.domain_service.navigation.actions;
+
+import io.gravitee.apim.core.portal_page.model.PortalNavigationFolder;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItem;
+import io.gravitee.apim.core.portal_page.model.Slug;
+
+public final class FolderActions {
+
+    private FolderActions() {}
+
+    public sealed interface FolderAction extends NavigationAction permits FolderMutation, DeleteFolder {}
+
+    public sealed interface FolderMutation extends FolderAction permits CreateFolder, UpdateFolder {
+        DesiredFolder desired();
+    }
+
+    public record CreateFolder(DesiredFolder desired) implements FolderMutation {}
+
+    public record UpdateFolder(PortalNavigationFolder existing, DesiredFolder desired) implements FolderMutation {}
+
+    public record DeleteFolder(PortalNavigationItem item) implements FolderAction {}
+
+    public record DesiredFolder(String path, String parentPath, Slug segment, String title, int order) {}
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal/domain_service/navigation/actions/NavigationAction.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal/domain_service/navigation/actions/NavigationAction.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal.domain_service.navigation.actions;
+
+/** Extension point — future slices add {@code PageAction}, {@code ApiAction}, {@code LinkAction} to permits. */
+public sealed interface NavigationAction permits FolderActions.FolderAction {}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal/domain_service/navigation/plan/NavigationSyncPlan.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal/domain_service/navigation/plan/NavigationSyncPlan.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal.domain_service.navigation.plan;
+
+import io.gravitee.apim.core.portal.domain_service.navigation.actions.NavigationAction;
+import java.util.List;
+
+public record NavigationSyncPlan(List<NavigationAction> actions) {}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal/domain_service/navigation/plan/NavigationSyncPlanner.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal/domain_service/navigation/plan/NavigationSyncPlanner.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal.domain_service.navigation.plan;
+
+import io.gravitee.apim.core.portal.domain_service.navigation.actions.FolderActions.CreateFolder;
+import io.gravitee.apim.core.portal.domain_service.navigation.actions.FolderActions.DeleteFolder;
+import io.gravitee.apim.core.portal.domain_service.navigation.actions.FolderActions.DesiredFolder;
+import io.gravitee.apim.core.portal.domain_service.navigation.actions.FolderActions.FolderMutation;
+import io.gravitee.apim.core.portal.domain_service.navigation.actions.FolderActions.UpdateFolder;
+import io.gravitee.apim.core.portal.domain_service.navigation.actions.NavigationAction;
+import io.gravitee.apim.core.portal.model.NavigationPath;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationFolder;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItem;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/** Pure — no side effects, no I/O. Folders match by path, not by ID. */
+public final class NavigationSyncPlanner {
+
+    private static final String PATH_DELIMITER = "/";
+
+    private NavigationSyncPlanner() {}
+
+    public static NavigationSyncPlan plan(List<NavigationPath> desired, List<PortalNavigationItem> currentFolders) {
+        final var desiredFolders = computeDesiredFolders(desired);
+        final var currentByPath = indexByPath(currentFolders);
+        final var desiredPaths = desiredFolders.stream().map(DesiredFolder::path).collect(Collectors.toSet());
+        final var depthOrder = Comparator.comparingInt((FolderMutation m) -> PathExpander.depth(m.desired().path()));
+
+        final var mutations = desiredFolders
+            .stream()
+            .<FolderMutation>map(df ->
+                currentByPath.containsKey(df.path()) ? new UpdateFolder(currentByPath.get(df.path()), df) : new CreateFolder(df)
+            )
+            .sorted(depthOrder);
+
+        final var deletes = currentByPath
+            .entrySet()
+            .stream()
+            .filter(e -> !desiredPaths.contains(e.getKey()))
+            .map(Map.Entry::getValue)
+            .map(DeleteFolder::new);
+
+        return new NavigationSyncPlan(Stream.<NavigationAction>concat(mutations, deletes).toList());
+    }
+
+    /** Reconstructs the path of every current folder by walking from its root, using {@code segment} (fallback to {@code title}). */
+    private static Map<String, PortalNavigationFolder> indexByPath(List<PortalNavigationItem> currentFolders) {
+        final var byId = currentFolders
+            .stream()
+            .filter(PortalNavigationFolder.class::isInstance)
+            .map(PortalNavigationFolder.class::cast)
+            .collect(Collectors.toMap(PortalNavigationItem::getId, f -> f));
+        final var result = new HashMap<String, PortalNavigationFolder>();
+        for (PortalNavigationFolder folder : byId.values()) {
+            result.put(reconstructPath(folder, byId), folder);
+        }
+        return result;
+    }
+
+    private static String reconstructPath(PortalNavigationFolder folder, Map<PortalNavigationItemId, PortalNavigationFolder> byId) {
+        return PATH_DELIMITER + String.join(PATH_DELIMITER, walkSegmentChain(folder, byId));
+    }
+
+    /** Walks the parent chain from {@code folder} up to the root, returning segments in root-first order. */
+    private static Deque<String> walkSegmentChain(PortalNavigationFolder folder, Map<PortalNavigationItemId, PortalNavigationFolder> byId) {
+        List<String> segments = Stream.iterate(folder, Objects::nonNull, item -> item.hasParent() ? byId.get(item.getParentId()) : null)
+            .map(PortalNavigationItem::getEffectiveSegment)
+            .collect(Collectors.toCollection(ArrayList::new));
+        Collections.reverse(segments);
+        return new ArrayDeque<>(segments);
+    }
+
+    private static List<DesiredFolder> computeDesiredFolders(List<NavigationPath> input) {
+        final var displayNames = explicitDisplayNames(input);
+        final var uniqueEntries = deduplicateByPath(input);
+        final var orderByPath = assignSiblingOrder(uniqueEntries);
+        return uniqueEntries
+            .stream()
+            .map(pe -> buildDesiredFolder(pe, displayNames, orderByPath.get(pe.fullPath())))
+            .toList();
+    }
+
+    private static Map<String, String> explicitDisplayNames(List<NavigationPath> input) {
+        return input
+            .stream()
+            .filter(e -> e.displayName().isPresent())
+            .collect(Collectors.toMap(NavigationPath::path, e -> e.displayName().orElseThrow(), (first, second) -> first));
+    }
+
+    private static Collection<PathExpander.PathEntry> deduplicateByPath(List<NavigationPath> input) {
+        return input
+            .stream()
+            .flatMap(e -> PathExpander.expand(e.path()).stream())
+            .collect(Collectors.toMap(PathExpander.PathEntry::fullPath, pe -> pe, (first, second) -> first, LinkedHashMap::new))
+            .values();
+    }
+
+    private static Map<String, Integer> assignSiblingOrder(Collection<PathExpander.PathEntry> entries) {
+        final var counter = new HashMap<String, Integer>();
+        final var orderByPath = new HashMap<String, Integer>();
+        entries.forEach(pe -> {
+            final var parentKey = pe.parentPath() != null ? pe.parentPath() : "";
+            orderByPath.put(pe.fullPath(), counter.merge(parentKey, 1, Integer::sum) - 1);
+        });
+        return orderByPath;
+    }
+
+    private static DesiredFolder buildDesiredFolder(PathExpander.PathEntry pe, Map<String, String> displayNames, int order) {
+        return new DesiredFolder(
+            pe.fullPath(),
+            pe.parentPath(),
+            pe.segment(),
+            displayNames.getOrDefault(pe.fullPath(), pe.segment().value()),
+            order
+        );
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal/domain_service/navigation/plan/PathExpander.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal/domain_service/navigation/plan/PathExpander.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal.domain_service.navigation.plan;
+
+import io.gravitee.apim.core.portal_page.model.Slug;
+import java.util.ArrayList;
+import java.util.List;
+
+/** Assumes path is already validated by {@code NavigationPath}. */
+final class PathExpander {
+
+    private PathExpander() {}
+
+    record PathEntry(Slug segment, String parentPath, String fullPath) {}
+
+    static List<PathEntry> expand(String normalizedPath) {
+        final var entries = new ArrayList<PathEntry>();
+        String parent = null;
+        for (String segment : normalizedPath.substring(1).split("/")) {
+            final var fullPath = childPath(parent, segment);
+            entries.add(new PathEntry(Slug.from(segment), parent, fullPath));
+            parent = fullPath;
+        }
+        return entries;
+    }
+
+    static int depth(String path) {
+        return (int) path
+            .chars()
+            .filter(c -> c == '/')
+            .count();
+    }
+
+    private static String childPath(String parent, String segment) {
+        return (parent == null ? "" : parent) + "/" + segment;
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal/model/NavigationPath.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal/model/NavigationPath.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal.model;
+
+import io.gravitee.apim.core.portal_page.model.Slug;
+import jakarta.annotation.Nonnull;
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+public record NavigationPath(@Nonnull String path, Optional<String> displayName) {
+    public NavigationPath {
+        path = normalizePath(path);
+    }
+
+    public NavigationPath descend(String childSegment) {
+        return new NavigationPath(this.path + "/" + childSegment, Optional.empty());
+    }
+
+    private static String normalizePath(String p) {
+        String s = stripTrailingSlash(p);
+        if (s.isEmpty()) return s;
+        return Arrays.stream(s.split("/", -1))
+            .map(part -> part.isEmpty() ? part : slugify(part).value())
+            .collect(Collectors.joining("/"));
+    }
+
+    private static String stripTrailingSlash(String p) {
+        return p.length() > 1 && p.endsWith("/") ? p.substring(0, p.length() - 1) : p;
+    }
+
+    public static Slug slugify(String value) {
+        return Slug.from(value);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/common/HRIDToUUID.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/common/HRIDToUUID.java
@@ -72,6 +72,10 @@ public final class HRIDToUUID {
         return new SubResourceBuilder();
     }
 
+    public static NavigationBuilder navigation() {
+        return new NavigationBuilder();
+    }
+
     public static class TopLevelBuilder {
 
         public TopLevelWithContext context(AuditInfo audit) {
@@ -137,6 +141,34 @@ public final class HRIDToUUID {
 
         public String crossId() {
             return UuidString.generateFrom(apiCrossId, extraHrid);
+        }
+    }
+
+    public static class NavigationBuilder {
+
+        public NavigationWithContext context(AuditInfo audit) {
+            return new NavigationWithContext(audit.organizationId(), audit.environmentId());
+        }
+    }
+
+    public record NavigationWithContext(String organizationId, String environmentId) {
+        public NavigationInPortal portal(String portalId) {
+            return new NavigationInPortal(organizationId, environmentId, portalId);
+        }
+    }
+
+    public record NavigationInPortal(String organizationId, String environmentId, String portalId) {
+        public NavigationItemResult folder(String path) {
+            return new NavigationItemResult(organizationId, environmentId, portalId, "folder", path);
+        }
+        // Future:
+        // public NavigationItemResult documentation(String docHrid) { … }
+        // public NavigationItemResult listingApi(String apiHrid)    { … }
+    }
+
+    public record NavigationItemResult(String organizationId, String environmentId, String portalId, String kind, String identifier) {
+        public String id() {
+            return UuidString.generateFrom(organizationId, environmentId, portalId, kind, identifier);
         }
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal/domain_service/PortalNavigationListingDomainServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal/domain_service/PortalNavigationListingDomainServiceTest.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal.domain_service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import inmemory.PortalNavigationItemsCrudServiceInMemory;
+import inmemory.PortalNavigationItemsQueryServiceInMemory;
+import inmemory.PortalPageContentCrudServiceInMemory;
+import io.gravitee.apim.core.audit.model.AuditActor;
+import io.gravitee.apim.core.audit.model.AuditInfo;
+import io.gravitee.apim.core.portal.model.NavigationPath;
+import io.gravitee.apim.core.portal.model.PortalId;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class PortalNavigationListingDomainServiceTest {
+
+    private static final AuditInfo AUDIT_INFO = AuditInfo.builder()
+        .organizationId("organization-id")
+        .environmentId("environment-id")
+        .actor(AuditActor.builder().userId("user-id").build())
+        .build();
+
+    private static final PortalId PORTAL_ID = PortalId.of("11111111-1111-1111-1111-111111111111");
+
+    private final PortalNavigationItemsCrudServiceInMemory crud = new PortalNavigationItemsCrudServiceInMemory();
+    private final PortalNavigationItemsQueryServiceInMemory query = new PortalNavigationItemsQueryServiceInMemory(crud.storage());
+    private final PortalPageContentCrudServiceInMemory pageContentCrud = new PortalPageContentCrudServiceInMemory();
+    private PortalNavigationSyncDomainService syncService;
+    private PortalNavigationListingDomainService listingService;
+
+    @BeforeEach
+    void setUp() {
+        crud.reset();
+        pageContentCrud.reset();
+        syncService = new PortalNavigationSyncDomainService(crud, query, pageContentCrud);
+        listingService = new PortalNavigationListingDomainService(query);
+    }
+
+    @Test
+    void list_as_navigation_paths_round_trips_input_order() {
+        syncService.sync(
+            AUDIT_INFO,
+            PORTAL_ID,
+            List.of(
+                new NavigationPath("/a", Optional.empty()),
+                new NavigationPath("/a/b", Optional.empty()),
+                new NavigationPath("/c", Optional.empty()),
+                new NavigationPath("/c/d", Optional.empty())
+            )
+        );
+
+        var result = listingService.listAsNavigationPaths(AUDIT_INFO.environmentId());
+
+        assertThat(result).extracting(NavigationPath::path).containsExactly("/a", "/a/b", "/c", "/c/d");
+    }
+
+    @Test
+    void path_uses_segment_not_title_when_display_name_provided() {
+        syncService.sync(
+            AUDIT_INFO,
+            PORTAL_ID,
+            List.of(
+                new NavigationPath("/projects/alpha", Optional.of("Alpha")),
+                new NavigationPath("/projects/alpha/docs", Optional.empty())
+            )
+        );
+
+        var result = listingService.listAsNavigationPaths(AUDIT_INFO.environmentId());
+
+        assertThat(result).extracting(NavigationPath::path).containsExactly("/projects", "/projects/alpha", "/projects/alpha/docs");
+    }
+
+    @Test
+    void display_name_is_surfaced_when_title_differs_from_segment() {
+        syncService.sync(AUDIT_INFO, PORTAL_ID, List.of(new NavigationPath("/projects/alpha", Optional.of("Alpha"))));
+
+        var result = listingService.listAsNavigationPaths(AUDIT_INFO.environmentId());
+
+        assertThat(result)
+            .filteredOn(p -> "/projects/alpha".equals(p.path()))
+            .singleElement()
+            .extracting(NavigationPath::displayName)
+            .isEqualTo(Optional.of("Alpha"));
+    }
+
+    @Test
+    void display_name_is_null_when_title_equals_segment() {
+        syncService.sync(AUDIT_INFO, PORTAL_ID, List.of(new NavigationPath("/a", Optional.empty())));
+
+        var result = listingService.listAsNavigationPaths(AUDIT_INFO.environmentId());
+
+        assertThat(result).singleElement().extracting(NavigationPath::displayName).isEqualTo(Optional.empty());
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal/domain_service/PortalNavigationSyncDomainServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal/domain_service/PortalNavigationSyncDomainServiceTest.java
@@ -1,0 +1,414 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal.domain_service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import inmemory.PortalNavigationItemsCrudServiceInMemory;
+import inmemory.PortalNavigationItemsQueryServiceInMemory;
+import inmemory.PortalPageContentCrudServiceInMemory;
+import io.gravitee.apim.core.audit.model.AuditActor;
+import io.gravitee.apim.core.audit.model.AuditInfo;
+import io.gravitee.apim.core.gravitee_markdown.GraviteeMarkdown;
+import io.gravitee.apim.core.portal.model.NavigationPath;
+import io.gravitee.apim.core.portal.model.PortalId;
+import io.gravitee.apim.core.portal_page.model.GraviteeMarkdownPageContent;
+import io.gravitee.apim.core.portal_page.model.PortalArea;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationApi;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationFolder;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItem;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItemType;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationLink;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationPage;
+import io.gravitee.apim.core.portal_page.model.PortalPageContentId;
+import io.gravitee.apim.core.portal_page.model.PortalVisibility;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class PortalNavigationSyncDomainServiceTest {
+
+    private static final AuditInfo AUDIT_INFO = AuditInfo.builder()
+        .organizationId("organization-id")
+        .environmentId("environment-id")
+        .actor(AuditActor.builder().userId("user-id").build())
+        .build();
+
+    private static final PortalId PORTAL_ID = PortalId.of("11111111-1111-1111-1111-111111111111");
+
+    private final PortalNavigationItemsCrudServiceInMemory crud = new PortalNavigationItemsCrudServiceInMemory();
+    private final PortalNavigationItemsQueryServiceInMemory query = new PortalNavigationItemsQueryServiceInMemory(crud.storage());
+    private final PortalPageContentCrudServiceInMemory pageContentCrud = new PortalPageContentCrudServiceInMemory();
+    private PortalNavigationSyncDomainService syncService;
+
+    @BeforeEach
+    void setUp() {
+        crud.reset();
+        pageContentCrud.reset();
+        syncService = new PortalNavigationSyncDomainService(crud, query, pageContentCrud);
+    }
+
+    @Test
+    void empty_input_on_empty_db_is_a_noop() {
+        syncService.sync(AUDIT_INFO, PORTAL_ID, List.of());
+
+        assertThat(crud.storage()).isEmpty();
+    }
+
+    @Test
+    void single_root_path_creates_one_folder() {
+        syncService.sync(AUDIT_INFO, PORTAL_ID, List.of(new NavigationPath("/a", Optional.empty())));
+
+        assertThat(crud.storage()).hasSize(1);
+        var folder = (PortalNavigationFolder) crud.storage().get(0);
+        assertThat(folder.getTitle()).isEqualTo("a");
+        assertThat(folder.getOrder()).isZero();
+        assertThat(folder.getParentId()).isNull();
+        assertThat(folder.getRootId()).isEqualTo(folder.getId());
+        assertThat(folder.getArea()).isEqualTo(PortalArea.TOP_NAVBAR);
+        assertThat(folder.getVisibility()).isEqualTo(PortalVisibility.PUBLIC);
+        assertThat(folder.getPublished()).isTrue();
+        assertThat(folder.getType()).isEqualTo(PortalNavigationItemType.FOLDER);
+    }
+
+    @Test
+    void display_name_when_provided_becomes_the_title_and_segment_holds_the_path_piece() {
+        syncService.sync(AUDIT_INFO, PORTAL_ID, List.of(new NavigationPath("/a", Optional.of("Alpha"))));
+
+        assertThat(crud.storage()).hasSize(1);
+        var folder = crud.storage().get(0);
+        assertThat(folder.getTitle()).isEqualTo("Alpha");
+        assertThat(folder.getSegment()).isEqualTo("a");
+    }
+
+    @Test
+    void title_falls_back_to_segment_when_no_display_name_provided() {
+        syncService.sync(AUDIT_INFO, PORTAL_ID, List.of(new NavigationPath("/a", Optional.empty())));
+
+        assertThat(crud.storage()).hasSize(1);
+        var folder = crud.storage().get(0);
+        assertThat(folder.getTitle()).isEqualTo("a");
+        assertThat(folder.getSegment()).isEqualTo("a");
+    }
+
+    @Test
+    void implicit_ancestors_are_created_with_mkdir_p() {
+        syncService.sync(AUDIT_INFO, PORTAL_ID, List.of(new NavigationPath("/a/b/c", Optional.empty())));
+
+        assertThat(crud.storage()).hasSize(3);
+        var a = findByPath("/a").orElseThrow();
+        var b = findByPath("/a/b").orElseThrow();
+        var c = findByPath("/a/b/c").orElseThrow();
+        assertThat(a.getTitle()).isEqualTo("a");
+        assertThat(b.getTitle()).isEqualTo("b");
+        assertThat(c.getTitle()).isEqualTo("c");
+        assertThat(a.getParentId()).isNull();
+        assertThat(b.getParentId()).isEqualTo(a.getId());
+        assertThat(c.getParentId()).isEqualTo(b.getId());
+        assertThat(a.getRootId()).isEqualTo(a.getId());
+        assertThat(b.getRootId()).isEqualTo(a.getId());
+        assertThat(c.getRootId()).isEqualTo(a.getId());
+    }
+
+    @Test
+    void siblings_get_order_from_first_appearance_position() {
+        syncService.sync(
+            AUDIT_INFO,
+            PORTAL_ID,
+            List.of(
+                new NavigationPath("/a", Optional.empty()),
+                new NavigationPath("/a/b", Optional.empty()),
+                new NavigationPath("/a/c", Optional.empty())
+            )
+        );
+
+        var a = findByPath("/a").orElseThrow();
+        var b = findByPath("/a/b").orElseThrow();
+        var c = findByPath("/a/c").orElseThrow();
+        assertThat(a.getOrder()).isZero();
+        assertThat(b.getOrder()).isZero();
+        assertThat(c.getOrder()).isEqualTo(1);
+    }
+
+    @Test
+    void re_sync_with_same_input_is_idempotent() {
+        var input = List.of(
+            new NavigationPath("/a", Optional.of("Alpha")),
+            new NavigationPath("/a/b", Optional.empty()),
+            new NavigationPath("/c", Optional.empty())
+        );
+
+        syncService.sync(AUDIT_INFO, PORTAL_ID, input);
+        var snapshot = new ArrayList<>(crud.storage());
+
+        syncService.sync(AUDIT_INFO, PORTAL_ID, input);
+
+        assertThat(crud.storage()).hasSize(snapshot.size());
+        for (int i = 0; i < snapshot.size(); i++) {
+            assertThat(crud.storage().get(i)).isSameAs(snapshot.get(i));
+        }
+    }
+
+    @Test
+    void folder_ids_are_deterministic_from_audit_portal_and_path() {
+        syncService.sync(AUDIT_INFO, PORTAL_ID, List.of(new NavigationPath("/a/b", Optional.empty())));
+
+        var idsBefore = crud.storage().stream().map(PortalNavigationItem::getId).toList();
+
+        crud.reset();
+        syncService.sync(AUDIT_INFO, PORTAL_ID, List.of(new NavigationPath("/a/b", Optional.empty())));
+
+        var idsAfter = crud.storage().stream().map(PortalNavigationItem::getId).toList();
+        assertThat(idsAfter).isEqualTo(idsBefore);
+    }
+
+    @Test
+    void different_portals_produce_different_folder_ids_for_the_same_path() {
+        var otherPortal = PortalId.of("22222222-2222-2222-2222-222222222222");
+
+        syncService.sync(AUDIT_INFO, PORTAL_ID, List.of(new NavigationPath("/a", Optional.empty())));
+        var idForPortalOne = findByPath("/a").orElseThrow().getId();
+
+        crud.reset();
+        syncService.sync(AUDIT_INFO, otherPortal, List.of(new NavigationPath("/a", Optional.empty())));
+        var idForPortalTwo = findByPath("/a").orElseThrow().getId();
+
+        assertThat(idForPortalTwo).isNotEqualTo(idForPortalOne);
+    }
+
+    @Test
+    void reorder_updates_existing_folders() {
+        syncService.sync(
+            AUDIT_INFO,
+            PORTAL_ID,
+            List.of(new NavigationPath("/a/b", Optional.empty()), new NavigationPath("/a/c", Optional.empty()))
+        );
+
+        syncService.sync(
+            AUDIT_INFO,
+            PORTAL_ID,
+            List.of(new NavigationPath("/a/c", Optional.empty()), new NavigationPath("/a/b", Optional.empty()))
+        );
+
+        var b = findByPath("/a/b").orElseThrow();
+        var c = findByPath("/a/c").orElseThrow();
+        assertThat(c.getOrder()).isZero();
+        assertThat(b.getOrder()).isEqualTo(1);
+        assertThat(crud.storage()).hasSize(3);
+    }
+
+    @Test
+    void removed_path_is_deleted() {
+        syncService.sync(
+            AUDIT_INFO,
+            PORTAL_ID,
+            List.of(new NavigationPath("/a", Optional.empty()), new NavigationPath("/b", Optional.empty()))
+        );
+        assertThat(crud.storage()).hasSize(2);
+
+        syncService.sync(AUDIT_INFO, PORTAL_ID, List.of(new NavigationPath("/a", Optional.empty())));
+
+        assertThat(crud.storage()).hasSize(1);
+        assertThat(findByPath("/a")).isPresent();
+        assertThat(findByPath("/b")).isEmpty();
+    }
+
+    @Test
+    void rename_via_display_name_updates_title_without_changing_id() {
+        syncService.sync(AUDIT_INFO, PORTAL_ID, List.of(new NavigationPath("/a", Optional.of("Original"))));
+        var originalId = crud.storage().get(0).getId();
+
+        syncService.sync(AUDIT_INFO, PORTAL_ID, List.of(new NavigationPath("/a", Optional.of("Renamed"))));
+
+        assertThat(crud.storage()).hasSize(1);
+        var folder = crud.storage().get(0);
+        assertThat(folder.getId()).isEqualTo(originalId);
+        assertThat(folder.getTitle()).isEqualTo("Renamed");
+    }
+
+    @Test
+    void sync_does_not_touch_other_node_types_or_areas() {
+        var pageInTopNavbar = PortalNavigationPage.builder()
+            .id(PortalNavigationItemId.random())
+            .organizationId(AUDIT_INFO.organizationId())
+            .environmentId(AUDIT_INFO.environmentId())
+            .title("untouched-page")
+            .segment("untouched-page")
+            .area(PortalArea.TOP_NAVBAR)
+            .order(0)
+            .portalPageContentId(PortalPageContentId.random())
+            .published(true)
+            .visibility(PortalVisibility.PUBLIC)
+            .build();
+        pageInTopNavbar.markAsRoot();
+        var folderInHomepage = PortalNavigationFolder.builder()
+            .id(PortalNavigationItemId.random())
+            .organizationId(AUDIT_INFO.organizationId())
+            .environmentId(AUDIT_INFO.environmentId())
+            .title("untouched-homepage-folder")
+            .segment("untouched-homepage-folder")
+            .area(PortalArea.HOMEPAGE)
+            .order(0)
+            .published(true)
+            .visibility(PortalVisibility.PUBLIC)
+            .build();
+        folderInHomepage.markAsRoot();
+        crud.initWith(List.of(pageInTopNavbar, folderInHomepage));
+
+        syncService.sync(AUDIT_INFO, PORTAL_ID, List.of(new NavigationPath("/a", Optional.empty())));
+
+        assertThat(crud.storage()).hasSize(3);
+        assertThat(crud.storage()).contains(pageInTopNavbar, folderInHomepage);
+        assertThat(findByPath("/a")).isPresent();
+    }
+
+    @Test
+    void cascade_deletes_non_folder_descendants_of_removed_folder() {
+        var folder = folderRow("x", null, 0);
+        folder.markAsRoot();
+        var pageChild = pageRow("page-child", folder.getId(), 0, PortalPageContentId.random());
+        var linkChild = linkRow("link-child", folder.getId(), 1);
+        var apiChild = apiRow("api-child", folder.getId(), 2);
+        crud.initWith(List.of(folder, pageChild, linkChild, apiChild));
+
+        syncService.sync(AUDIT_INFO, PORTAL_ID, List.of());
+
+        assertThat(crud.storage()).isEmpty();
+    }
+
+    @Test
+    void cascade_deletes_associated_page_content_for_page_descendants() {
+        var contentId = PortalPageContentId.random();
+        var content = new GraviteeMarkdownPageContent(
+            contentId,
+            AUDIT_INFO.organizationId(),
+            AUDIT_INFO.environmentId(),
+            GraviteeMarkdown.of("hello")
+        );
+        pageContentCrud.initWith(List.of(content));
+        var folder = folderRow("x", null, 0);
+        folder.markAsRoot();
+        var pageChild = pageRow("page-child", folder.getId(), 0, contentId);
+        crud.initWith(List.of(folder, pageChild));
+
+        syncService.sync(AUDIT_INFO, PORTAL_ID, List.of());
+
+        assertThat(crud.storage()).isEmpty();
+        assertThat(pageContentCrud.storage()).isEmpty();
+    }
+
+    @Test
+    void cascade_deletes_nested_folder_chain() {
+        var a = folderRow("a", null, 0);
+        a.markAsRoot();
+        var b = folderRow("b", a.getId(), 0);
+        var c = folderRow("c", b.getId(), 0);
+        var leafPage = pageRow("leaf", c.getId(), 0, PortalPageContentId.random());
+        crud.initWith(List.of(a, b, c, leafPage));
+
+        syncService.sync(AUDIT_INFO, PORTAL_ID, List.of());
+
+        assertThat(crud.storage()).isEmpty();
+    }
+
+    private PortalNavigationFolder folderRow(String title, PortalNavigationItemId parentId, int order) {
+        return PortalNavigationFolder.builder()
+            .id(PortalNavigationItemId.random())
+            .organizationId(AUDIT_INFO.organizationId())
+            .environmentId(AUDIT_INFO.environmentId())
+            .title(title)
+            .segment(PortalNavigationItem.slugify(title).value())
+            .area(PortalArea.TOP_NAVBAR)
+            .order(order)
+            .parentId(parentId)
+            .published(true)
+            .visibility(PortalVisibility.PUBLIC)
+            .build();
+    }
+
+    private PortalNavigationPage pageRow(String title, PortalNavigationItemId parentId, int order, PortalPageContentId contentId) {
+        return PortalNavigationPage.builder()
+            .id(PortalNavigationItemId.random())
+            .organizationId(AUDIT_INFO.organizationId())
+            .environmentId(AUDIT_INFO.environmentId())
+            .title(title)
+            .segment(PortalNavigationItem.slugify(title).value())
+            .area(PortalArea.TOP_NAVBAR)
+            .order(order)
+            .parentId(parentId)
+            .portalPageContentId(contentId)
+            .published(true)
+            .visibility(PortalVisibility.PUBLIC)
+            .build();
+    }
+
+    private PortalNavigationLink linkRow(String title, PortalNavigationItemId parentId, int order) {
+        return PortalNavigationLink.builder()
+            .id(PortalNavigationItemId.random())
+            .organizationId(AUDIT_INFO.organizationId())
+            .environmentId(AUDIT_INFO.environmentId())
+            .title(title)
+            .segment(PortalNavigationItem.slugify(title).value())
+            .area(PortalArea.TOP_NAVBAR)
+            .order(order)
+            .parentId(parentId)
+            .url("https://example.com")
+            .published(true)
+            .visibility(PortalVisibility.PUBLIC)
+            .build();
+    }
+
+    private PortalNavigationApi apiRow(String title, PortalNavigationItemId parentId, int order) {
+        return PortalNavigationApi.builder()
+            .id(PortalNavigationItemId.random())
+            .organizationId(AUDIT_INFO.organizationId())
+            .environmentId(AUDIT_INFO.environmentId())
+            .title(title)
+            .segment(PortalNavigationItem.slugify(title).value())
+            .area(PortalArea.TOP_NAVBAR)
+            .order(order)
+            .parentId(parentId)
+            .apiId("api-id")
+            .published(true)
+            .visibility(PortalVisibility.PUBLIC)
+            .build();
+    }
+
+    private Optional<PortalNavigationItem> findByPath(String path) {
+        var segments = new ArrayList<String>();
+        for (String s : path.split("/")) if (!s.isEmpty()) segments.add(s);
+
+        PortalNavigationItem current = null;
+        for (String seg : segments) {
+            final PortalNavigationItemId parentId = current == null ? null : current.getId();
+            current = crud
+                .storage()
+                .stream()
+                .filter(it -> seg.equals(it.getTitle()))
+                .filter(it -> parentId == null ? it.getParentId() == null : parentId.equals(it.getParentId()))
+                .findFirst()
+                .orElse(null);
+            if (current == null) return Optional.empty();
+        }
+        return Optional.ofNullable(current);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal/model/NavigationPathTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal/model/NavigationPathTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class NavigationPathTest {
+
+    @Test
+    void accepts_single_segment() {
+        assertThat(new NavigationPath("/a", Optional.empty()).path()).isEqualTo("/a");
+    }
+
+    @Test
+    void accepts_multi_segment() {
+        assertThat(new NavigationPath("/a/b/c", Optional.empty()).path()).isEqualTo("/a/b/c");
+    }
+
+    @Test
+    void strips_trailing_slash() {
+        assertThat(new NavigationPath("/a/b/", Optional.empty()).path()).isEqualTo("/a/b");
+    }
+
+    @Test
+    void descend_appends_child_segment() {
+        assertThat(new NavigationPath("/docs", Optional.empty()).descend("getting-started").path()).isEqualTo("/docs/getting-started");
+    }
+
+    @Test
+    void descend_from_empty_root_produces_leading_slash_path() {
+        assertThat(new NavigationPath("", Optional.empty()).descend("docs").path()).isEqualTo("/docs");
+    }
+
+    @Test
+    void descend_clears_display_name() {
+        assertThat(new NavigationPath("/docs", Optional.of("Documentation")).descend("api").displayName()).isEmpty();
+    }
+
+    @Test
+    void normalizes_segment_casing_and_spaces() {
+        assertThat(new NavigationPath("/Docs/Getting Started", Optional.empty()).path()).isEqualTo("/docs/getting-started");
+    }
+}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/EXT-134

## Description

### What changed

  Introduces the domain layer that powers declarative navigation sync. The core idea: callers supply a flat list of hierarchical paths (e.g. ["`/getting-started`", "`/getting-started/quickstart`", "`/apis`"]) and the domain service reconciles that desired state against the current folder tree —  creating, updating, or deleting folders as needed.                                                                                                                                                                                                                       

  Sync planner (`NavigationSyncPlanner`) is a pure, side-effect-free diff engine. It expands the input paths into all implied ancestor folders, assigns sibling order, matches against current folders by reconstructed path (using the segment field from PR 1), and produces a typed plan of
  mutations. PathExpander slugifies each path component during expansion, so the planner always works with clean segments.                                                                                                                                                 

  Sync executor (`PortalNavigationSyncDomainService`) applies the plan — creating/updating folders and cascade-deleting removed ones along with all their descendants (including associated PortalPageContent for PAGE-type children).

  Listing service (`PortalNavigationListingDomainService`) reads the current folder tree back as a flat list of NavigationPath records, preserving displayName where the title differs from the segment. This is what GET returns.

  Also fixes a dormant Spring bean conflict in 4 test configs triggered by registering the new @DomainService beans.

###  Why it's needed
  
  This layer has no REST caller yet — PR 3 wires it into the use cases and resources. Keeping it separate makes the algorithmic logic reviewable on its own.
