### PR TITLE
feat(portal): sync spec.navigation through automation API

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/java/io/gravitee/apim/rest/api/automation/mapper/PortalMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/java/io/gravitee/apim/rest/api/automation/mapper/PortalMapper.java
@@ -16,7 +16,11 @@
 package io.gravitee.apim.rest.api.automation.mapper;
 
 import io.gravitee.apim.core.portal.model.Portal;
+import io.gravitee.apim.rest.api.automation.model.NavigationPath;
 import io.gravitee.apim.rest.api.automation.model.PortalState;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.MappingTarget;
@@ -29,7 +33,7 @@ import org.mapstruct.factory.Mappers;
 public interface PortalMapper {
     PortalMapper INSTANCE = Mappers.getMapper(PortalMapper.class);
 
-    default PortalState toPortalState(Portal portal, String hrid) {
+    default PortalState toPortalState(Portal portal, String hrid, List<io.gravitee.apim.core.portal.model.NavigationPath> navigation) {
         var state = new PortalState(
             portal.getId() != null ? portal.getId().toString() : null,
             portal.getEnvironmentId(),
@@ -38,6 +42,7 @@ public interface PortalMapper {
         );
         state.setHrid(hrid);
         mapPortalToState(portal, state);
+        state.setNavigation(toApiNavigation(navigation));
         return state;
     }
 
@@ -48,4 +53,30 @@ public interface PortalMapper {
     @Mapping(target = "hrid", ignore = true)
     @Mapping(target = "navigation", ignore = true)
     void mapPortalToState(Portal portal, @MappingTarget PortalState state);
+
+    default List<io.gravitee.apim.core.portal.model.NavigationPath> toCoreNavigation(List<NavigationPath> navigation) {
+        if (navigation == null) {
+            return List.of();
+        }
+        return navigation
+            .stream()
+            .filter(PortalMapper::isValidNavigationPath)
+            .map(n -> new io.gravitee.apim.core.portal.model.NavigationPath(n.getPath(), Optional.ofNullable(n.getDisplayName())))
+            .toList();
+    }
+
+    default List<NavigationPath> toApiNavigation(List<io.gravitee.apim.core.portal.model.NavigationPath> navigation) {
+        if (navigation == null) {
+            return List.of();
+        }
+        return navigation
+            .stream()
+            .filter(Objects::nonNull)
+            .map(n -> new NavigationPath().path(n.path()).displayName(n.displayName().orElse(null)))
+            .toList();
+    }
+
+    private static boolean isValidNavigationPath(NavigationPath n) {
+        return n != null && n.getPath() != null && !n.getPath().isBlank();
+    }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/java/io/gravitee/apim/rest/api/automation/resource/PortalResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/java/io/gravitee/apim/rest/api/automation/resource/PortalResource.java
@@ -53,7 +53,7 @@ public class PortalResource extends AbstractResource {
         PortalId id = PortalId.of(HRIDToUUID.portal().context(auditInfo).hrid(hrid).id());
         try {
             var output = getPortalUseCase.execute(new GetPortalUseCase.Input(auditInfo, id));
-            return Response.ok(PortalMapper.INSTANCE.toPortalState(output.portal(), hrid)).build();
+            return Response.ok(PortalMapper.INSTANCE.toPortalState(output.portal(), hrid, output.navigation())).build();
         } catch (PortalNotFoundException e) {
             throw new HRIDNotFoundException(hrid);
         }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/java/io/gravitee/apim/rest/api/automation/resource/PortalsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/java/io/gravitee/apim/rest/api/automation/resource/PortalsResource.java
@@ -68,13 +68,14 @@ public class PortalsResource extends AbstractResource {
             auditInfo.organizationId(),
             spec.getName()
         );
+        var navigation = PortalMapper.INSTANCE.toCoreNavigation(spec.getNavigation());
 
         if (dryRun) {
-            return Response.ok(PortalMapper.INSTANCE.toPortalState(portal, spec.getHrid())).build();
+            return Response.ok(PortalMapper.INSTANCE.toPortalState(portal, spec.getHrid(), navigation)).build();
         }
 
-        var output = createOrUpdatePortalUseCase.execute(new CreateOrUpdatePortalUseCase.Input(auditInfo, portal));
+        var output = createOrUpdatePortalUseCase.execute(new CreateOrUpdatePortalUseCase.Input(auditInfo, portal, navigation));
 
-        return Response.ok(PortalMapper.INSTANCE.toPortalState(output.portal(), spec.getHrid())).build();
+        return Response.ok(PortalMapper.INSTANCE.toPortalState(output.portal(), spec.getHrid(), output.navigation())).build();
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/resource/PortalResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/resource/PortalResourceTest.java
@@ -22,6 +22,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.gravitee.apim.core.portal.exception.PortalNotFoundException;
+import io.gravitee.apim.core.portal.model.NavigationPath;
 import io.gravitee.apim.core.portal.model.Portal;
 import io.gravitee.apim.core.portal.model.PortalId;
 import io.gravitee.apim.core.portal.use_case.DeletePortalUseCase;
@@ -30,6 +31,8 @@ import io.gravitee.apim.rest.api.automation.model.PortalState;
 import io.gravitee.apim.rest.api.automation.resource.base.AbstractResourceTest;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.core.MediaType;
+import java.util.List;
+import java.util.Optional;
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Nested;
@@ -62,7 +65,7 @@ class PortalResourceTest extends AbstractResourceTest {
         @Test
         void should_return_portal_by_hrid() {
             var persisted = Portal.of(PORTAL_ID, ENVIRONMENT, ORGANIZATION, "Default Portal");
-            when(getPortalUseCase.execute(any())).thenReturn(new GetPortalUseCase.Output(persisted));
+            when(getPortalUseCase.execute(any())).thenReturn(new GetPortalUseCase.Output(persisted, List.of()));
 
             try (var response = rootTarget(HRID).request().accept(MediaType.APPLICATION_JSON_TYPE).get()) {
                 assertThat(response.getStatus()).isEqualTo(200);
@@ -73,7 +76,27 @@ class PortalResourceTest extends AbstractResourceTest {
                     soft.assertThat(state.getId()).isEqualTo(PORTAL_ID.toString());
                     soft.assertThat(state.getHrid()).isEqualTo(HRID);
                     soft.assertThat(state.getName()).isEqualTo("Default Portal");
+                    soft.assertThat(state.getNavigation()).isNullOrEmpty();
                 });
+            }
+        }
+
+        @Test
+        void should_return_navigation_alongside_portal() {
+            var persisted = Portal.of(PORTAL_ID, ENVIRONMENT, ORGANIZATION, "Default Portal");
+            var navigation = List.of(
+                new NavigationPath("/projects", Optional.empty()),
+                new NavigationPath("/projects/alpha", Optional.of("Alpha"))
+            );
+            when(getPortalUseCase.execute(any())).thenReturn(new GetPortalUseCase.Output(persisted, navigation));
+
+            try (var response = rootTarget(HRID).request().accept(MediaType.APPLICATION_JSON_TYPE).get()) {
+                assertThat(response.getStatus()).isEqualTo(200);
+                var state = response.readEntity(PortalState.class);
+                assertThat(state.getNavigation())
+                    .extracting(io.gravitee.apim.rest.api.automation.model.NavigationPath::getPath)
+                    .containsExactly("/projects", "/projects/alpha");
+                assertThat(state.getNavigation().get(1).getDisplayName()).isEqualTo("Alpha");
             }
         }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/resource/PortalsResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/resource/PortalsResourceTest.java
@@ -22,6 +22,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
+import io.gravitee.apim.core.portal.model.NavigationPath;
 import io.gravitee.apim.core.portal.model.Portal;
 import io.gravitee.apim.core.portal.model.PortalId;
 import io.gravitee.apim.core.portal.use_case.CreateOrUpdatePortalUseCase;
@@ -30,10 +31,13 @@ import io.gravitee.apim.rest.api.automation.resource.base.AbstractResourceTest;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.client.Entity;
 import jakarta.ws.rs.core.MediaType;
+import java.util.List;
+import java.util.Optional;
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 
 class PortalsResourceTest extends AbstractResourceTest {
 
@@ -77,6 +81,26 @@ class PortalsResourceTest extends AbstractResourceTest {
         }
 
         @Test
+        void should_echo_navigation_in_dry_run() {
+            try (
+                var response = rootTarget()
+                    .queryParam("dryRun", true)
+                    .request()
+                    .accept(MediaType.APPLICATION_JSON_TYPE)
+                    .put(Entity.json(readJSON("portal-with-navigation.json")))
+            ) {
+                assertThat(response.getStatus()).isEqualTo(200);
+                verifyNoInteractions(createOrUpdatePortalUseCase);
+
+                var state = response.readEntity(PortalState.class);
+                assertThat(state.getNavigation())
+                    .extracting(io.gravitee.apim.rest.api.automation.model.NavigationPath::getPath)
+                    .containsExactly("/projects/alpha", "/projects/alpha/docs");
+                assertThat(state.getNavigation().get(0).getDisplayName()).isEqualTo("Alpha");
+            }
+        }
+
+        @Test
         void should_return_400_when_hrid_is_missing() {
             try (
                 var response = rootTarget()
@@ -97,7 +121,7 @@ class PortalsResourceTest extends AbstractResourceTest {
         @Test
         void should_create_or_update_portal() {
             var persisted = Portal.of(PortalId.of("00000000-0000-0000-0000-0000000000a1"), ENVIRONMENT, ORGANIZATION, "Default Portal");
-            when(createOrUpdatePortalUseCase.execute(any())).thenReturn(new CreateOrUpdatePortalUseCase.Output(persisted));
+            when(createOrUpdatePortalUseCase.execute(any())).thenReturn(new CreateOrUpdatePortalUseCase.Output(persisted, List.of()));
 
             try (var response = rootTarget().request().accept(MediaType.APPLICATION_JSON_TYPE).put(Entity.json(readJSON("portal.json")))) {
                 assertThat(response.getStatus()).isEqualTo(200);
@@ -110,14 +134,20 @@ class PortalsResourceTest extends AbstractResourceTest {
                     soft.assertThat(state.getEnvironmentId()).isEqualTo(ENVIRONMENT);
                     soft.assertThat(state.getOrganizationId()).isEqualTo(ORGANIZATION);
                     soft.assertThat(state.getName()).isEqualTo("Default Portal");
+                    soft.assertThat(state.getNavigation()).isNullOrEmpty();
                 });
             }
         }
 
         @Test
-        void should_silently_ignore_navigation_field() {
+        void should_pass_navigation_to_use_case_and_echo_in_response() {
             var persisted = Portal.of(PortalId.of("00000000-0000-0000-0000-0000000000a1"), ENVIRONMENT, ORGANIZATION, "Default Portal");
-            when(createOrUpdatePortalUseCase.execute(any())).thenReturn(new CreateOrUpdatePortalUseCase.Output(persisted));
+            var echoed = List.of(
+                new NavigationPath("/projects", Optional.empty()),
+                new NavigationPath("/projects/alpha", Optional.of("Alpha")),
+                new NavigationPath("/projects/alpha/docs", Optional.empty())
+            );
+            when(createOrUpdatePortalUseCase.execute(any())).thenReturn(new CreateOrUpdatePortalUseCase.Output(persisted, echoed));
 
             try (
                 var response = rootTarget()
@@ -126,10 +156,19 @@ class PortalsResourceTest extends AbstractResourceTest {
                     .put(Entity.json(readJSON("portal-with-navigation.json")))
             ) {
                 assertThat(response.getStatus()).isEqualTo(200);
-                verify(createOrUpdatePortalUseCase).execute(any(CreateOrUpdatePortalUseCase.Input.class));
+
+                var inputCaptor = ArgumentCaptor.forClass(CreateOrUpdatePortalUseCase.Input.class);
+                verify(createOrUpdatePortalUseCase).execute(inputCaptor.capture());
+                assertThat(inputCaptor.getValue().navigation())
+                    .extracting(NavigationPath::path)
+                    .containsExactly("/projects/alpha", "/projects/alpha/docs");
+                assertThat(inputCaptor.getValue().navigation().get(0).displayName()).isEqualTo(Optional.of("Alpha"));
 
                 var state = response.readEntity(PortalState.class);
-                assertThat(state.getNavigation()).isNullOrEmpty();
+                assertThat(state.getNavigation())
+                    .extracting(io.gravitee.apim.rest.api.automation.model.NavigationPath::getPath)
+                    .containsExactly("/projects", "/projects/alpha", "/projects/alpha/docs");
+                assertThat(state.getNavigation().get(1).getDisplayName()).isEqualTo("Alpha");
             }
         }
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal/use_case/CreateOrUpdatePortalUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal/use_case/CreateOrUpdatePortalUseCase.java
@@ -18,7 +18,11 @@ package io.gravitee.apim.core.portal.use_case;
 import io.gravitee.apim.core.UseCase;
 import io.gravitee.apim.core.audit.model.AuditInfo;
 import io.gravitee.apim.core.portal.crud_service.PortalCrudService;
+import io.gravitee.apim.core.portal.domain_service.PortalNavigationListingDomainService;
+import io.gravitee.apim.core.portal.domain_service.PortalNavigationSyncDomainService;
+import io.gravitee.apim.core.portal.model.NavigationPath;
 import io.gravitee.apim.core.portal.model.Portal;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 
 @UseCase
@@ -26,15 +30,23 @@ import lombok.RequiredArgsConstructor;
 public class CreateOrUpdatePortalUseCase {
 
     private final PortalCrudService portalCrudService;
+    private final PortalNavigationSyncDomainService portalNavigationSyncDomainService;
+    private final PortalNavigationListingDomainService portalNavigationListingDomainService;
 
-    public record Input(AuditInfo auditInfo, Portal portal) {}
+    public record Input(AuditInfo auditInfo, Portal portal, List<NavigationPath> navigation) {
+        public Input(AuditInfo auditInfo, Portal portal) {
+            this(auditInfo, portal, List.of());
+        }
+    }
 
-    public record Output(Portal portal) {}
+    public record Output(Portal portal, List<NavigationPath> navigation) {}
 
     public Output execute(Input input) {
         var portal = input.portal();
         var existing = portalCrudService.findByIdAndEnvironmentId(portal.getId(), input.auditInfo().environmentId());
         var saved = existing.isPresent() ? portalCrudService.update(portal) : portalCrudService.create(portal);
-        return new Output(saved);
+        portalNavigationSyncDomainService.sync(input.auditInfo(), portal.getId(), input.navigation());
+        var navigation = portalNavigationListingDomainService.listAsNavigationPaths(input.auditInfo().environmentId());
+        return new Output(saved, navigation);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal/use_case/GetPortalUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal/use_case/GetPortalUseCase.java
@@ -18,9 +18,12 @@ package io.gravitee.apim.core.portal.use_case;
 import io.gravitee.apim.core.UseCase;
 import io.gravitee.apim.core.audit.model.AuditInfo;
 import io.gravitee.apim.core.portal.crud_service.PortalCrudService;
+import io.gravitee.apim.core.portal.domain_service.PortalNavigationListingDomainService;
 import io.gravitee.apim.core.portal.exception.PortalNotFoundException;
+import io.gravitee.apim.core.portal.model.NavigationPath;
 import io.gravitee.apim.core.portal.model.Portal;
 import io.gravitee.apim.core.portal.model.PortalId;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 
 @UseCase
@@ -28,15 +31,17 @@ import lombok.RequiredArgsConstructor;
 public class GetPortalUseCase {
 
     private final PortalCrudService portalCrudService;
+    private final PortalNavigationListingDomainService portalNavigationListingDomainService;
 
     public record Input(AuditInfo auditInfo, PortalId portalId) {}
 
-    public record Output(Portal portal) {}
+    public record Output(Portal portal, List<NavigationPath> navigation) {}
 
     public Output execute(Input input) {
         var portal = portalCrudService
             .findByIdAndEnvironmentId(input.portalId(), input.auditInfo().environmentId())
             .orElseThrow(() -> new PortalNotFoundException(input.portalId().toString()));
-        return new Output(portal);
+        var navigation = portalNavigationListingDomainService.listAsNavigationPaths(input.auditInfo().environmentId());
+        return new Output(portal, navigation);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal/use_case/CreateOrUpdatePortalUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal/use_case/CreateOrUpdatePortalUseCaseTest.java
@@ -19,9 +19,19 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import fixtures.core.model.PortalFixtures;
 import inmemory.PortalCrudServiceInMemory;
+import inmemory.PortalNavigationItemsCrudServiceInMemory;
+import inmemory.PortalNavigationItemsQueryServiceInMemory;
+import inmemory.PortalPageContentCrudServiceInMemory;
 import io.gravitee.apim.core.audit.model.AuditActor;
 import io.gravitee.apim.core.audit.model.AuditInfo;
+import io.gravitee.apim.core.portal.domain_service.PortalNavigationListingDomainService;
+import io.gravitee.apim.core.portal.domain_service.PortalNavigationSyncDomainService;
+import io.gravitee.apim.core.portal.model.NavigationPath;
 import io.gravitee.apim.core.portal.model.Portal;
+import io.gravitee.apim.core.portal_page.model.PortalArea;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItemType;
+import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
@@ -38,16 +48,27 @@ class CreateOrUpdatePortalUseCaseTest {
         .build();
 
     private final PortalCrudServiceInMemory portalCrudService = new PortalCrudServiceInMemory();
+    private final PortalNavigationItemsCrudServiceInMemory navCrudService = new PortalNavigationItemsCrudServiceInMemory();
+    private final PortalNavigationItemsQueryServiceInMemory navQueryService = new PortalNavigationItemsQueryServiceInMemory(
+        navCrudService.storage()
+    );
+    private final PortalPageContentCrudServiceInMemory pageContentCrudService = new PortalPageContentCrudServiceInMemory();
     private CreateOrUpdatePortalUseCase useCase;
 
     @BeforeEach
     void setUp() {
-        useCase = new CreateOrUpdatePortalUseCase(portalCrudService);
+        useCase = new CreateOrUpdatePortalUseCase(
+            portalCrudService,
+            new PortalNavigationSyncDomainService(navCrudService, navQueryService, pageContentCrudService),
+            new PortalNavigationListingDomainService(navQueryService)
+        );
     }
 
     @AfterEach
     void tearDown() {
         portalCrudService.reset();
+        navCrudService.reset();
+        pageContentCrudService.reset();
     }
 
     @Test
@@ -103,5 +124,29 @@ class CreateOrUpdatePortalUseCaseTest {
             "environment-id",
             "other-env"
         );
+    }
+
+    @Test
+    void should_sync_navigation_against_top_navbar_folders() {
+        var portal = PortalFixtures.aPortal();
+
+        useCase.execute(
+            new CreateOrUpdatePortalUseCase.Input(
+                AUDIT_INFO,
+                portal,
+                List.of(new NavigationPath("/projects/alpha", Optional.of("Alpha")), new NavigationPath("/projects/beta", Optional.empty()))
+            )
+        );
+
+        assertThat(navCrudService.storage()).hasSize(3);
+        assertThat(navCrudService.storage()).allMatch(item -> item.getArea() == PortalArea.TOP_NAVBAR);
+        assertThat(navCrudService.storage()).allMatch(item -> item.getType() == PortalNavigationItemType.FOLDER);
+        assertThat(
+            navCrudService
+                .storage()
+                .stream()
+                .map(it -> it.getTitle())
+                .toList()
+        ).containsExactlyInAnyOrder("projects", "Alpha", "beta");
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal/use_case/GetPortalUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal/use_case/GetPortalUseCaseTest.java
@@ -20,11 +20,18 @@ import static org.assertj.core.api.Assertions.catchThrowable;
 
 import fixtures.core.model.PortalFixtures;
 import inmemory.PortalCrudServiceInMemory;
+import inmemory.PortalNavigationItemsCrudServiceInMemory;
+import inmemory.PortalNavigationItemsQueryServiceInMemory;
+import inmemory.PortalPageContentCrudServiceInMemory;
 import io.gravitee.apim.core.audit.model.AuditActor;
 import io.gravitee.apim.core.audit.model.AuditInfo;
+import io.gravitee.apim.core.portal.domain_service.PortalNavigationListingDomainService;
+import io.gravitee.apim.core.portal.domain_service.PortalNavigationSyncDomainService;
 import io.gravitee.apim.core.portal.exception.PortalNotFoundException;
+import io.gravitee.apim.core.portal.model.NavigationPath;
 import io.gravitee.apim.core.portal.model.PortalId;
 import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
@@ -41,16 +48,28 @@ class GetPortalUseCaseTest {
         .build();
 
     private final PortalCrudServiceInMemory portalCrudService = new PortalCrudServiceInMemory();
+    private final PortalNavigationItemsCrudServiceInMemory navCrudService = new PortalNavigationItemsCrudServiceInMemory();
+    private final PortalNavigationItemsQueryServiceInMemory navQueryService = new PortalNavigationItemsQueryServiceInMemory(
+        navCrudService.storage()
+    );
+    private final PortalPageContentCrudServiceInMemory pageContentCrudService = new PortalPageContentCrudServiceInMemory();
+    private PortalNavigationSyncDomainService syncDomainService;
     private GetPortalUseCase useCase;
+
+    private PortalNavigationListingDomainService listingDomainService;
 
     @BeforeEach
     void setUp() {
-        useCase = new GetPortalUseCase(portalCrudService);
+        syncDomainService = new PortalNavigationSyncDomainService(navCrudService, navQueryService, pageContentCrudService);
+        listingDomainService = new PortalNavigationListingDomainService(navQueryService);
+        useCase = new GetPortalUseCase(portalCrudService, listingDomainService);
     }
 
     @AfterEach
     void tearDown() {
         portalCrudService.reset();
+        navCrudService.reset();
+        pageContentCrudService.reset();
     }
 
     @Test
@@ -61,6 +80,7 @@ class GetPortalUseCaseTest {
         var output = useCase.execute(new GetPortalUseCase.Input(AUDIT_INFO, portal.getId()));
 
         assertThat(output.portal()).isEqualTo(portal);
+        assertThat(output.navigation()).isEmpty();
     }
 
     @Test
@@ -85,5 +105,20 @@ class GetPortalUseCaseTest {
         var throwable = catchThrowable(() -> useCase.execute(new GetPortalUseCase.Input(otherEnvAudit, portal.getId())));
 
         assertThat(throwable).isInstanceOf(PortalNotFoundException.class);
+    }
+
+    @Test
+    void should_return_navigation_paths_from_stored_folders() {
+        var portal = PortalFixtures.aPortal();
+        portalCrudService.initWith(List.of(portal));
+        syncDomainService.sync(
+            AUDIT_INFO,
+            portal.getId(),
+            List.of(new NavigationPath("/a", Optional.empty()), new NavigationPath("/a/b", Optional.empty()))
+        );
+
+        var output = useCase.execute(new GetPortalUseCase.Input(AUDIT_INFO, portal.getId()));
+
+        assertThat(output.navigation()).extracting(NavigationPath::path).containsExactly("/a", "/a/b");
     }
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/EXT-134

## Description

### What changed

  Wires the domain layer from PR 2 into the Automation API. PUT `/portals` now accepts an `spec.navigation` array of path entries; GET `/portals/{hrid}` returns the synced navigation back.

  A navigation entry is a path defining a folder in the hierarchy, with an optional displayName for the human-readable label:

```
  { "path": "/getting-started", "displayName": "Getting Started" }
  { "path": "/getting-started/quickstart" }
```

  On PUT, the sync planner reconciles the desired paths against the current folder tree. On GET, the listing service reconstructs the paths from stored segments and returns them in the same format — making the round-trip idempotent.

###  Why it's needed
  
  This is the user-visible change. PRs 1 and 2 were pure groundwork with no behavioral effect on the API. This PR is the one that makes spec.navigation in a portal CRD actually do something.

### Demo


https://github.com/user-attachments/assets/f21ece08-77a6-42b7-a586-f00fd32e94d4

https://github.com/user-attachments/assets/ebbcf8b2-8a61-43e7-9789-dffe279c929b

https://github.com/user-attachments/assets/d180faf2-34d8-4540-9139-0faf42657657




