### PR TITLE
chore(deps): update gravitee-resource-cache-redis to 5.0.0-alpha.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -279,7 +279,7 @@
         <gravitee-resource-auth-provider-http.version>2.0.0-alpha.1</gravitee-resource-auth-provider-http.version>
         <gravitee-resource-auth-provider-inline.version>1.4.0</gravitee-resource-auth-provider-inline.version>
         <gravitee-resource-auth-provider-ldap.version>2.0.1</gravitee-resource-auth-provider-ldap.version>
-        <gravitee-resource-cache-redis.version>5.0.0-alpha.3</gravitee-resource-cache-redis.version>
+        <gravitee-resource-cache-redis.version>5.0.0-alpha.4</gravitee-resource-cache-redis.version>
         <gravitee-resource-oauth2-provider-keycloak.version>4.0.0-alpha.1</gravitee-resource-oauth2-provider-keycloak.version>
         <gravitee-resource-ai-model-text-classification.version>2.2.1</gravitee-resource-ai-model-text-classification.version>
         <gravitee-service-geoip.version>3.0.0</gravitee-service-geoip.version>


### PR DESCRIPTION
## What

Bumps `gravitee-resource-cache-redis` from `5.0.0-alpha.3` to `5.0.0-alpha.4` in the root `pom.xml` (consumed by `gravitee-apim-distribution`).

## Verification

- `5.0.0-alpha.4` resolves from artifactory (`io.gravitee.resource:gravitee-resource-cache-redis:5.0.0-alpha.4`).

_Note: issues are disabled on plugin repos; no linked issue._