### PR TITLE
fix: bump gravitee-policy-json-to-toon version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -203,7 +203,7 @@
         <gravitee-policy-js.version>1.0.0-alpha.7</gravitee-policy-js.version>
         <gravitee-policy-json-threat-protection.version>2.1.0</gravitee-policy-json-threat-protection.version>
         <gravitee-policy-json-to-json.version>3.0.1</gravitee-policy-json-to-json.version>
-        <gravitee-policy-json-to-toon.version>1.0.0</gravitee-policy-json-to-toon.version>
+        <gravitee-policy-json-to-toon.version>1.0.2</gravitee-policy-json-to-toon.version>
         <gravitee-policy-json-validation.version>2.1.4</gravitee-policy-json-validation.version>
         <gravitee-policy-json-xml.version>3.0.3</gravitee-policy-json-xml.version>
         <gravitee-policy-jws.version>2.0.0</gravitee-policy-jws.version>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-13243

## Description

Bump gravitee-policy-json-to-toon version to 1.0.2 to fix a vuln.

