### PR TITLE
test(json-patch): cover out-of-bounds array-index add wrapping

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/json_patch/JsonPatchServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/json_patch/JsonPatchServiceImplTest.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.apim.infra.domain_service.json_patch;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -37,5 +38,15 @@ class JsonPatchServiceImplTest {
         var patch = objectMapper.readTree("[{\"op\":\"replace\",\"path\":\"/name\",\"value\":\"new\"}]");
 
         assertThatThrownBy(() -> cut.applyJsonPatch(patch, null)).isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void out_of_bounds_array_index_add_is_wrapped_as_validation_exception() throws Exception {
+        var target = objectMapper.readTree("{\"labels\":[\"a\"]}");
+        var patch = objectMapper.readTree("[{\"op\":\"add\",\"path\":\"/labels/5\",\"value\":\"x\"}]");
+
+        assertThatThrownBy(() -> cut.applyJsonPatch(patch, target)).isInstanceOf(ValidationDomainException.class);
+
+        assertThat(target.get("labels").size()).isEqualTo(1);
     }
 }


### PR DESCRIPTION
## Issue

[APIM-12009](https://gravitee.atlassian.net/browse/APIM-12009)

## Why

The `JsonPatchServiceImpl` wraps `JsonPatchException` into `ValidationDomainException` so callers receive a domain-level error rather than a raw library exception. An out-of-bounds array-index `add` operation (e.g. `/labels/5` on a single-element array) triggers that exception path, but it was not covered by any test — leaving a gap in the regression safety net for this wrapping contract.

## What changed

Added one test case to `JsonPatchServiceImplTest` that applies an out-of-bounds array-index `add` patch and asserts:
- the call throws `ValidationDomainException` (not a raw library or runtime exception), and
- the target node is left unmutated after the failed patch.

[APIM-12009]: https://gravitee.atlassian.net/browse/APIM-12009?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ