### PR TITLE
chore: bump gravitee-policy-ssl-enforcement to 1.7.0-alpha.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -229,7 +229,7 @@
         <gravitee-policy-rest-to-soap.version>1.14.1</gravitee-policy-rest-to-soap.version>
         <gravitee-policy-retry.version>4.1.1</gravitee-policy-retry.version>
         <gravitee-policy-role-based-access-control.version>2.1.0</gravitee-policy-role-based-access-control.version>
-        <gravitee-policy-ssl-enforcement.version>1.6.0</gravitee-policy-ssl-enforcement.version>
+        <gravitee-policy-ssl-enforcement.version>1.7.0-alpha.2</gravitee-policy-ssl-enforcement.version>
         <gravitee-policy-traffic-shadowing.version>3.0.0</gravitee-policy-traffic-shadowing.version>
         <gravitee-policy-transform-avro-json.version>5.1.1</gravitee-policy-transform-avro-json.version>
         <gravitee-policy-transform-avro-protobuf.version>1.0.9</gravitee-policy-transform-avro-protobuf.version>


### PR DESCRIPTION
Bumps `gravitee-policy-ssl-enforcement` from 1.6.0 to 1.7.0-alpha.2 on the 4.12.x branch.

The version is defined as the `gravitee-policy-ssl-enforcement.version` property in the root `pom.xml` and consumed by `gravitee-apim-distribution` and `gravitee-apim-integration-tests`.