### PR TITLE
Improve distriubtion configuration

### DIFF
--- a/gravitee-apim-distribution/pom.xml
+++ b/gravitee-apim-distribution/pom.xml
@@ -268,6 +268,34 @@
             </exclusions>
         </dependency>
 
+        <!-- Gamma Modules -->
+        <dependency>
+            <groupId>io.gravitee.gamma.module</groupId>
+            <artifactId>gravitee-gamma-module-apim</artifactId>
+            <version>${project.version}</version>
+            <type>zip</type>
+            <scope>runtime</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.gravitee.gamma.module</groupId>
+            <artifactId>gravitee-gamma-module-platform</artifactId>
+            <version>${project.version}</version>
+            <type>zip</type>
+            <scope>runtime</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
         <!-- Notifiers -->
         <dependency>
             <groupId>io.gravitee.notifier</groupId>
@@ -1681,6 +1709,33 @@
                     </exclusions>
                 </dependency>
 
+                <!-- Gamma -->
+                <dependency>
+                    <groupId>com.graviteesource.gamma.module</groupId>
+                    <artifactId>gravitee-gamma-module-aim</artifactId>
+                    <version>${gravitee-gamma-module-aim.version}</version>
+                    <type>zip</type>
+                    <scope>runtime</scope>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>*</groupId>
+                            <artifactId>*</artifactId>
+                        </exclusion>
+                    </exclusions>
+                </dependency>
+                <dependency>
+                    <groupId>com.graviteesource.gamma.module</groupId>
+                    <artifactId>gravitee-gamma-module-authz</artifactId>
+                    <version>${gravitee-gamma-module-authz.version}</version>
+                    <type>zip</type>
+                    <scope>runtime</scope>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>*</groupId>
+                            <artifactId>*</artifactId>
+                        </exclusion>
+                    </exclusions>
+                </dependency>
 
                 <!-- Reporters -->
                 <dependency>

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/pom.xml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/pom.xml
@@ -123,20 +123,6 @@
             </exclusions>
         </dependency>
 
-        <dependency>
-            <groupId>io.gravitee.inference.service</groupId>
-            <artifactId>gravitee-inference-service</artifactId>
-            <version>${gravitee-inference-service.version}</version>
-            <scope>runtime</scope>
-            <type>zip</type>
-            <exclusions>
-                <exclusion>
-                    <groupId>*</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-
         <!-- Mapstruct -->
         <dependency>
             <groupId>org.mapstruct</groupId>

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/src/main/assembly/plugin-assembly-distribution.xml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/src/main/assembly/plugin-assembly-distribution.xml
@@ -152,7 +152,6 @@
             <useTransitiveDependencies>false</useTransitiveDependencies>
             <fileMode>644</fileMode>
         </dependencySet>
-
         <dependencySet>
             <outputDirectory>plugins</outputDirectory>
             <unpack>false</unpack>
@@ -164,6 +163,8 @@
                 <exclude>io.gravitee.notifier:*:zip</exclude>
                 <exclude>io.gravitee.apim.plugin.apiservice.dynamicproperties:gravitee-apim-plugin-apiservice-dynamicproperties-http:zip</exclude>
                 <exclude>com.graviteesource.connector:gravitee-*-native-kafka:zip</exclude>
+                <exclude>io.gravitee.gamma.module:*:zip</exclude>
+                <exclude>com.graviteesource.gamma.module:*:zip</exclude>
             </excludes>
             <useProjectArtifact>false</useProjectArtifact>
             <fileMode>755</fileMode>

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/pom.xml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/pom.xml
@@ -281,61 +281,6 @@
             <artifactId>logback-json-core</artifactId>
             <scope>runtime</scope>
         </dependency>
-
-        <!-- Gamma Modules -->
-        <dependency>
-            <groupId>io.gravitee.gamma.module</groupId>
-            <artifactId>gravitee-gamma-module-apim</artifactId>
-            <version>${project.version}</version>
-            <type>zip</type>
-            <scope>runtime</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>*</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>io.gravitee.gamma.module</groupId>
-            <artifactId>gravitee-gamma-module-platform</artifactId>
-            <version>${project.version}</version>
-            <type>zip</type>
-            <scope>runtime</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>*</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>com.graviteesource.gamma.module</groupId>
-            <artifactId>gravitee-gamma-module-aim</artifactId>
-            <version>${gravitee-gamma-module-aim.version}</version>
-            <type>zip</type>
-            <scope>runtime</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>*</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>com.graviteesource.gamma.module</groupId>
-            <artifactId>gravitee-gamma-module-authz</artifactId>
-            <version>${gravitee-gamma-module-authz.version}</version>
-            <type>zip</type>
-            <scope>runtime</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>*</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-
         <!-- Authz -->
         <dependency>
             <groupId>com.graviteesource.gamma</groupId>

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/pom.xml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/pom.xml
@@ -281,33 +281,6 @@
             <artifactId>logback-json-core</artifactId>
             <scope>runtime</scope>
         </dependency>
-        <!-- Authz -->
-        <dependency>
-            <groupId>com.graviteesource.gamma</groupId>
-            <artifactId>gravitee-service-authz-pdp</artifactId>
-            <version>${gravitee-service-authz-pdp.version}</version>
-            <type>zip</type>
-            <scope>runtime</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>*</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>com.graviteesource.gamma</groupId>
-            <artifactId>gravitee-policy-authz-pep</artifactId>
-            <version>${gravitee-policy-authz-pep.version}</version>
-            <type>zip</type>
-            <scope>runtime</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>*</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
## Description
- Move gamma modules to main distribution pom and exclude them from gateway assembly file.
- remove duplicated policies and services from gateway and rest-api distribution pom since they are already defined in main distribution.

By moving gamma modules in right maven profile, this should also fix the "check Community build" job in CircleCI.