### PR TITLE
feat(authz): granular entityType — definition-model helpers + gateway sync

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/authz/AuthzEntityMapper.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/authz/AuthzEntityMapper.java
@@ -22,6 +22,7 @@ import io.gravitee.gamma.definition.authz.AuthzEntityKind;
 import io.gravitee.gateway.services.sync.process.common.model.SyncAction;
 import io.gravitee.repository.management.model.Event;
 import io.reactivex.rxjava3.core.Maybe;
+import java.util.List;
 import lombok.CustomLog;
 import lombok.RequiredArgsConstructor;
 
@@ -46,7 +47,7 @@ public class AuthzEntityMapper {
                     .kind(kind)
                     .entityType(wire.getEntityType())
                     .attributes(wire.getAttributes())
-                    .parents(wire.getParents())
+                    .parents(normalizeParents(wire.getParents()))
                     .syncAction(SyncAction.DEPLOY)
                     .build();
             } catch (Exception e) {
@@ -85,6 +86,14 @@ public class AuthzEntityMapper {
 
     private static AuthzEntityReactorDeployable.Kind toGatewayKind(AuthzEntityKind wireKind) {
         return AuthzEntityReactorDeployable.Kind.valueOf(wireKind.name());
+    }
+
+    // Emit parents in the engine's canonical quoted form Type::"id" so the PDP can parse them directly.
+    private static List<String> normalizeParents(List<String> parents) {
+        if (parents == null) {
+            return null;
+        }
+        return parents.stream().map(AuthzEntityIdConstants::normalizeParentUid).toList();
     }
 
     /**

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/authz/AuthzEntityMapperTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/authz/AuthzEntityMapperTest.java
@@ -102,7 +102,30 @@ class AuthzEntityMapperTest {
         assertThat(d).isNotNull();
         assertThat(d.engineUid()).isEqualTo("Principal::\"idp.am.alice\"");
         assertThat(d.kind()).isEqualTo(AuthzEntityReactorDeployable.Kind.PRINCIPAL);
+        // A typeless bare-id parent passes through untouched.
         assertThat(d.parents()).containsExactly("idp.am.admins");
+    }
+
+    @Test
+    void toDeploy_normalizes_typed_parent_uids_to_the_canonical_quoted_form() {
+        Event event = event(
+            "evt-parents",
+            """
+            {
+              "entityId": "alice",
+              "entityType": "User",
+              "kind": "PRINCIPAL",
+              "attributes": {},
+              "parents": ["Group::engineering", "Role::\\"admin\\"", "bare-id"]
+            }
+            """
+        );
+
+        AuthzEntityReactorDeployable d = mapper.toDeploy(event).blockingGet();
+
+        assertThat(d).isNotNull();
+        // Unquoted typed parent is re-quoted; already-quoted stays; bare id passes through.
+        assertThat(d.parents()).containsExactly("Group::\"engineering\"", "Role::\"admin\"", "bare-id");
     }
 
     @Test

--- a/gravitee-gamma/gravitee-gamma-definition-model/src/main/java/io/gravitee/gamma/definition/authz/AuthzEntityIdConstants.java
+++ b/gravitee-gamma/gravitee-gamma-definition-model/src/main/java/io/gravitee/gamma/definition/authz/AuthzEntityIdConstants.java
@@ -15,6 +15,9 @@
  */
 package io.gravitee.gamma.definition.authz;
 
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
 import java.util.Set;
 
 public final class AuthzEntityIdConstants {
@@ -49,6 +52,71 @@ public final class AuthzEntityIdConstants {
             }
         }
         return false;
+    }
+
+    // Transitional bridge: maps a _kind attribute value (principals) or an entityId prefix segment
+    // (resources) to the canonical engine type name. Mirrors the FE entity-kind-registry.ts. The
+    // schema is the source of truth for which types are valid; this only types legacy/sync data
+    // that carries _kind/prefix rather than an explicit entityType.
+    private static final Map<String, String> ENGINE_TYPE_BY_HINT = new HashMap<>();
+
+    static {
+        registerEngineType("User", "user");
+        registerEngineType("Group", "group");
+        registerEngineType("Role", "role");
+        registerEngineType("ServiceAccount", "serviceaccount", "service-account", "service_account");
+        registerEngineType("AgentIdentity", "agent-identity", "agentidentity");
+        registerEngineType("MCPServer", "mcp", "mcpserver");
+        registerEngineType("MCPTool", "mcptool");
+        registerEngineType("Model", "model", "llm", "llmmodel", "llmroute");
+        registerEngineType("Agent", "agent", "a2a", "a2aagent");
+        registerEngineType("API", "api");
+        registerEngineType("Event", "event");
+        registerEngineType("Resource", "resource");
+        registerEngineType("Action", "action");
+    }
+
+    private static void registerEngineType(String engineType, String... hints) {
+        for (String hint : hints) {
+            ENGINE_TYPE_BY_HINT.put(hint.toLowerCase(Locale.ROOT), engineType);
+        }
+    }
+
+    /** A {@code _kind} value or entityId prefix segment → canonical engine type, or {@code null} when unknown. */
+    public static String engineTypeForHint(String hint) {
+        if (hint == null || hint.isBlank()) {
+            return null;
+        }
+        return ENGINE_TYPE_BY_HINT.get(hint.toLowerCase(Locale.ROOT));
+    }
+
+    /**
+     * Canonical engine UID wire form: {@code Type::"id"} (the quoted form the engine's parser expects).
+     * No escaping is applied: entityIds are constrained by {@link #FORMAT_REGEX} (lowercase, digits,
+     * {@code _ : - .}) and types are canonical names, so neither can contain a quote/backslash.
+     */
+    public static String toEngineUid(String entityType, String entityId) {
+        return entityType + "::\"" + entityId + "\"";
+    }
+
+    /**
+     * Normalize a reference UID to the canonical quoted form {@code Type::"id"} so the engine parser
+     * accepts it directly. Re-quotes the unquoted legacy {@code Type::id}; leaves an already-quoted
+     * UID, a typeless bare id (no {@code ::}), and null untouched. The type/id split is the last
+     * {@code ::}, mirroring the engine's own parse (a namespaced type keeps its inner {@code ::}).
+     */
+    public static String normalizeParentUid(String uid) {
+        if (uid == null || uid.contains("::\"") || !uid.contains("::")) {
+            return uid;
+        }
+        int sep = uid.lastIndexOf("::");
+        String type = uid.substring(0, sep);
+        String id = uid.substring(sep + 2);
+        if (type.isBlank() || id.isBlank()) {
+            // Not a normalizable Type::id (e.g. "Type::" or "::id") — leave it for the parser to reject.
+            return uid;
+        }
+        return toEngineUid(type, id);
     }
 
     private AuthzEntityIdConstants() {}

--- a/gravitee-gamma/gravitee-gamma-definition-model/src/test/java/io/gravitee/gamma/definition/authz/AuthzEntityIdConstantsTest.java
+++ b/gravitee-gamma/gravitee-gamma-definition-model/src/test/java/io/gravitee/gamma/definition/authz/AuthzEntityIdConstantsTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gamma.definition.authz;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class AuthzEntityIdConstantsTest {
+
+    @Test
+    void maps_principal_kind_hints_to_engine_types() {
+        assertThat(AuthzEntityIdConstants.engineTypeForHint("user")).isEqualTo("User");
+        assertThat(AuthzEntityIdConstants.engineTypeForHint("group")).isEqualTo("Group");
+        assertThat(AuthzEntityIdConstants.engineTypeForHint("role")).isEqualTo("Role");
+        assertThat(AuthzEntityIdConstants.engineTypeForHint("agent-identity")).isEqualTo("AgentIdentity");
+    }
+
+    @Test
+    void maps_resource_prefixes_to_engine_types() {
+        assertThat(AuthzEntityIdConstants.engineTypeForHint("mcp")).isEqualTo("MCPServer");
+        assertThat(AuthzEntityIdConstants.engineTypeForHint("mcptool")).isEqualTo("MCPTool");
+        assertThat(AuthzEntityIdConstants.engineTypeForHint("model")).isEqualTo("Model");
+        assertThat(AuthzEntityIdConstants.engineTypeForHint("api")).isEqualTo("API");
+        assertThat(AuthzEntityIdConstants.engineTypeForHint("agent")).isEqualTo("Agent");
+    }
+
+    @Test
+    void accepts_aliases_and_is_case_insensitive() {
+        assertThat(AuthzEntityIdConstants.engineTypeForHint("service-account")).isEqualTo("ServiceAccount");
+        assertThat(AuthzEntityIdConstants.engineTypeForHint("LLM")).isEqualTo("Model");
+        assertThat(AuthzEntityIdConstants.engineTypeForHint("MCPServer")).isEqualTo("MCPServer");
+    }
+
+    @Test
+    void returns_null_for_unknown_or_blank_hint() {
+        assertThat(AuthzEntityIdConstants.engineTypeForHint("dupa")).isNull();
+        assertThat(AuthzEntityIdConstants.engineTypeForHint("")).isNull();
+        assertThat(AuthzEntityIdConstants.engineTypeForHint(null)).isNull();
+    }
+
+    @Test
+    void toEngineUid_builds_the_canonical_quoted_form() {
+        assertThat(AuthzEntityIdConstants.toEngineUid("User", "alice")).isEqualTo("User::\"alice\"");
+        assertThat(AuthzEntityIdConstants.toEngineUid("API", "api.payments")).isEqualTo("API::\"api.payments\"");
+    }
+
+    @Test
+    void normalizeParentUid_requotes_unquoted_typed_uids() {
+        assertThat(AuthzEntityIdConstants.normalizeParentUid("Group::engineering")).isEqualTo("Group::\"engineering\"");
+        // Namespaced type: split on the LAST '::' so the type keeps its inner '::'.
+        assertThat(AuthzEntityIdConstants.normalizeParentUid("myapp::Report::r1")).isEqualTo("myapp::Report::\"r1\"");
+    }
+
+    @Test
+    void normalizeParentUid_leaves_canonical_bare_and_null_untouched() {
+        assertThat(AuthzEntityIdConstants.normalizeParentUid("Group::\"engineering\"")).isEqualTo("Group::\"engineering\"");
+        assertThat(AuthzEntityIdConstants.normalizeParentUid("bare-id")).isEqualTo("bare-id");
+        assertThat(AuthzEntityIdConstants.normalizeParentUid(null)).isNull();
+    }
+
+    @Test
+    void normalizeParentUid_does_not_manufacture_empty_component_uids() {
+        // Malformed Type::/::id must pass through unchanged, not become Type::"" / ::"id".
+        assertThat(AuthzEntityIdConstants.normalizeParentUid("Group::")).isEqualTo("Group::");
+        assertThat(AuthzEntityIdConstants.normalizeParentUid("::engineering")).isEqualTo("::engineering");
+    }
+}


### PR DESCRIPTION
APIM-side half of the granular-entityType change (splitting #17513). The authz-module half (write-time `entityType` derive + FE read path) moves to the standalone **gravitee-gamma-module-authz** repo in a separate PR.

## What this adds
- **`AuthzEntityIdConstants`** (shared `gamma-definition-model` artifact):
  - `engineTypeForHint(hint)` — maps a kind/source hint to the engine entity type.
  - `toEngineUid(entityType, entityId)` — builds the engine's canonical `Type::"id"` UID.
  - `normalizeParentUid(uid)` — normalizes a parent UID into that canonical form.
- **Gateway sync** (`AuthzEntityMapper`): normalizes parent UIDs via `normalizeParentUid` so the published entities carry engine-canonical parents.

## Why split
The module consumes these helpers as a **published artifact**, so they must land + release in APIM first; the standalone module PR then bumps `gravitee-apim.version` to pick them up.

## Tests
`AuthzEntityIdConstantsTest` — 8 tests, green locally (`mvn -pl gravitee-gamma/gravitee-gamma-definition-model test`). Gateway `AuthzEntityMapperTest` validated by CI.