### PR TITLE
fix(gateway): bound XML start-element scan to prevent event-loop hang

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/el/ContentTemplateVariableProvider.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/el/ContentTemplateVariableProvider.java
@@ -159,7 +159,15 @@ public class ContentTemplateVariableProvider implements ExecutionContextTemplate
      */
     private String sanitizeContent(HttpExecutionContext ctx, Buffer buffer) throws XMLStreamException {
         XMLStreamReader sr = XML_INPUT_FACTORY.createXMLStreamReader(new ByteArrayInputStream(buffer.getBytes()));
+        // A malformed body can make next() throw at the same offset without ever advancing,
+        // so the swallow-and-retry loop would spin the event-loop thread forever. Bound the scan to the
+        // input length: a productive scan can't need more steps than there are bytes to read.
+        int maxSteps = buffer.length();
+        int steps = 0;
         while (!sr.isStartElement() && sr.hasNext()) {
+            if (++steps > maxSteps) {
+                break;
+            }
             try {
                 sr.next();
             } catch (Exception e) {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/el/ContentTemplateVariableProviderTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/el/ContentTemplateVariableProviderTest.java
@@ -26,6 +26,7 @@ import static io.gravitee.gateway.reactive.handlers.api.el.ContentTemplateVariab
 import static java.util.Map.entry;
 import static java.util.Map.ofEntries;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.lenient;
@@ -43,6 +44,7 @@ import io.gravitee.gateway.reactive.api.el.EvaluableResponse;
 import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.Single;
 import io.reactivex.rxjava3.observers.TestObserver;
+import java.time.Duration;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -304,6 +306,26 @@ class ContentTemplateVariableProviderTest {
             obs.assertComplete();
 
             // An empty map is expected if the content isn't a valid xml.
+            verify(evaluableRequest).setXmlContent(Collections.emptyMap());
+        }
+
+        @Test
+        void should_provide_empty_xml_content_without_blocking_on_unquoted_root_attribute() {
+            // '<a b=c/>' makes the real StAX parser throw on next() at a fixed offset forever:
+            // the unbounded scan spun the event-loop thread. The bounded scan must terminate quickly and
+            // yield an empty map. assertTimeoutPreemptively turns a regression (re-introduced spin) into a
+            // failure instead of a hung build.
+            when(request.bodyOrEmpty()).thenReturn(Single.just(Buffer.buffer("<a b=c/>")));
+            when(templateContext.lookupVariable(TEMPLATE_ATTRIBUTE_REQUEST)).thenReturn(evaluableRequest);
+
+            cut.provide(ctx);
+
+            ArgumentCaptor<Completable> completableCaptor = ArgumentCaptor.forClass(Completable.class);
+            verify(templateContext).setDeferredVariable(eq(TEMPLATE_ATTRIBUTE_REQUEST_CONTENT_XML), completableCaptor.capture());
+
+            final Completable contentCompletable = completableCaptor.getValue();
+            assertTimeoutPreemptively(Duration.ofSeconds(5), () -> contentCompletable.test().assertComplete());
+
             verify(evaluableRequest).setXmlContent(Collections.emptyMap());
         }
 


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-14350

## Description

Bounds the XML start-element scan so a malformed `#request.xmlContent` / `#response.xmlContent` body can no longer spin the Vert.x event-loop thread. An unparseable body now terminates and returns an empty map. Adds a regression test that drives the real parser through `provide()` with a timeout guard.

## Additional context

**Root cause (APIM-14280):** StAX parser throws on `next()` at a fixed offset without advancing, so the unbounded swallow-and-retry scan never terminates. Empirically the trigger is an unquoted / value-less attribute on the root element (e.g. `<a b=c/>`); the SOAP example in the report actually recovers.

**Reproduction:** POST a body of `<a b=c/>` to an API whose request phase reads `#request.xmlContent` — before the fix the request never returns and the event-loop thread stays blocked.

One commit covers every affected version: base **4.11.x**, applied to **4.9.x, 4.10.x, 4.12.x and master** via the `apply-on-*` labels. Supersedes #17574 (consolidated into this single PR).