### PR TITLE
feat: send application invitation notifications

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/spring/ResourceContextConfiguration.java
@@ -115,6 +115,7 @@ import io.gravitee.apim.core.group.use_case.ImportGroupCRDUseCase;
 import io.gravitee.apim.core.group.use_case.ValidateGroupCRDUseCase;
 import io.gravitee.apim.core.invitation.crud_service.InvitationCrudService;
 import io.gravitee.apim.core.invitation.domain_service.AcceptInvitationDomainService;
+import io.gravitee.apim.core.invitation.domain_service.ApplicationInvitationNotificationDomainService;
 import io.gravitee.apim.core.invitation.query_service.InvitationQueryService;
 import io.gravitee.apim.core.json.JsonSchemaChecker;
 import io.gravitee.apim.core.json_patch.domain_service.JsonMergePatchService;
@@ -384,6 +385,11 @@ public class ResourceContextConfiguration {
     @Bean
     public InvitationCrudService invitationCrudService() {
         return mock(InvitationCrudService.class);
+    }
+
+    @Bean
+    public ApplicationInvitationNotificationDomainService applicationInvitationNotificationDomainService() {
+        return mock(ApplicationInvitationNotificationDomainService.class);
     }
 
     @Bean

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/spring/ResourceContextConfiguration.java
@@ -145,6 +145,7 @@ import io.gravitee.apim.core.group.query_service.GroupQueryService;
 import io.gravitee.apim.core.group.use_case.ImportGroupCRDUseCase;
 import io.gravitee.apim.core.invitation.crud_service.InvitationCrudService;
 import io.gravitee.apim.core.invitation.domain_service.AcceptInvitationDomainService;
+import io.gravitee.apim.core.invitation.domain_service.ApplicationInvitationNotificationDomainService;
 import io.gravitee.apim.core.invitation.query_service.InvitationQueryService;
 import io.gravitee.apim.core.json.JsonSchemaChecker;
 import io.gravitee.apim.core.json_patch.domain_service.JsonMergePatchService;
@@ -514,6 +515,11 @@ public class ResourceContextConfiguration {
     @Bean
     public InvitationCrudService invitationCrudService() {
         return mock(InvitationCrudService.class);
+    }
+
+    @Bean
+    public ApplicationInvitationNotificationDomainService applicationInvitationNotificationDomainService() {
+        return mock(ApplicationInvitationNotificationDomainService.class);
     }
 
     @Bean

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/spring/ResourceContextConfiguration.java
@@ -110,6 +110,7 @@ import io.gravitee.apim.core.installation.domain_service.InstallationTypeDomainS
 import io.gravitee.apim.core.installation.query_service.InstallationAccessQueryService;
 import io.gravitee.apim.core.invitation.crud_service.InvitationCrudService;
 import io.gravitee.apim.core.invitation.domain_service.AcceptInvitationDomainService;
+import io.gravitee.apim.core.invitation.domain_service.ApplicationInvitationNotificationDomainService;
 import io.gravitee.apim.core.invitation.query_service.InvitationQueryService;
 import io.gravitee.apim.core.json.JsonSchemaChecker;
 import io.gravitee.apim.core.json_patch.domain_service.JsonMergePatchService;
@@ -340,6 +341,11 @@ public class ResourceContextConfiguration {
     @Bean
     public InvitationCrudService invitationCrudService() {
         return mock(InvitationCrudService.class);
+    }
+
+    @Bean
+    public ApplicationInvitationNotificationDomainService applicationInvitationNotificationDomainService() {
+        return mock(ApplicationInvitationNotificationDomainService.class);
     }
 
     @Bean

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/mapper/ApplicationInvitationsCreateInputMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/mapper/ApplicationInvitationsCreateInputMapper.java
@@ -18,7 +18,6 @@ package io.gravitee.rest.api.portal.rest.mapper;
 import io.gravitee.apim.core.invitation.model.CreateApplicationInvitations;
 import io.gravitee.rest.api.portal.rest.model.InvitationCreateInput;
 import io.gravitee.rest.api.portal.rest.model.InvitationRecipientInput;
-import java.net.URI;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
@@ -35,7 +34,7 @@ public interface ApplicationInvitationsCreateInputMapper {
             toRecipientEmails(input.getRecipients()),
             normalizeRoleName(input.getRole()),
             input.getNotify() == null || input.getNotify(),
-            normalizeConfirmationPageUrl(input.getConfirmationPageUrl())
+            input.getConfirmationPageUrl()
         );
     }
 
@@ -55,9 +54,5 @@ public interface ApplicationInvitationsCreateInputMapper {
 
     private String normalizeRoleName(String roleName) {
         return roleName == null ? null : roleName.trim();
-    }
-
-    private String normalizeConfirmationPageUrl(URI confirmationPageUrl) {
-        return confirmationPageUrl == null || confirmationPageUrl.toString().isBlank() ? null : confirmationPageUrl.toString();
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/ApplicationInvitationsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/ApplicationInvitationsResource.java
@@ -80,7 +80,8 @@ public class ApplicationInvitationsResource extends AbstractResource {
         var executionContext = GraviteeContext.getExecutionContext();
         var output = createApplicationInvitationsUseCase.execute(
             new CreateApplicationInvitationsUseCase.Input(
-                executionContext,
+                executionContext.getOrganizationId(),
+                executionContext.getEnvironmentId(),
                 applicationId,
                 ApplicationInvitationsCreateInputMapper.INSTANCE.toCreateApplicationInvitations(input)
             )

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/mapper/ApplicationInvitationsCreateInputMapperTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/mapper/ApplicationInvitationsCreateInputMapperTest.java
@@ -25,6 +25,8 @@ import org.junit.jupiter.api.Test;
 
 class ApplicationInvitationsCreateInputMapperTest {
 
+    private static final URI CONFIRMATION_PAGE_URL = URI.create("https://portal.example.com/user/registration/confirm");
+
     private final ApplicationInvitationsCreateInputMapper cut = ApplicationInvitationsCreateInputMapper.INSTANCE;
 
     @Test
@@ -37,7 +39,7 @@ class ApplicationInvitationsCreateInputMapperTest {
                 )
             )
             .role(" USER ")
-            .confirmationPageUrl(URI.create("https://portal.example.com/user/registration/confirm"));
+            .confirmationPageUrl(CONFIRMATION_PAGE_URL);
         input.setNotify(null);
 
         var result = cut.toCreateApplicationInvitations(input);
@@ -45,7 +47,7 @@ class ApplicationInvitationsCreateInputMapperTest {
         assertThat(result.recipientEmails()).containsExactly("alice@example.com", "bob@example.com");
         assertThat(result.roleName()).isEqualTo("USER");
         assertThat(result.notifyUsers()).isTrue();
-        assertThat(result.confirmationPageUrl()).isEqualTo("https://portal.example.com/user/registration/confirm");
+        assertThat(result.confirmationPageUrl()).isEqualTo(CONFIRMATION_PAGE_URL);
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/ApplicationInvitationsResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/ApplicationInvitationsResourceTest.java
@@ -28,6 +28,7 @@ import static org.mockito.Mockito.when;
 import inmemory.ApplicationCrudServiceInMemory;
 import inmemory.RoleQueryServiceInMemory;
 import io.gravitee.apim.core.invitation.crud_service.InvitationCrudService;
+import io.gravitee.apim.core.invitation.domain_service.ApplicationInvitationNotificationDomainService;
 import io.gravitee.apim.core.invitation.model.ApplicationInvitation;
 import io.gravitee.apim.core.invitation.model.InvitationId;
 import io.gravitee.apim.core.invitation.model.SearchApplicationInvitationsCriteria;
@@ -45,6 +46,7 @@ import io.gravitee.rest.api.portal.rest.model.InvitationUpdateInput;
 import io.gravitee.rest.api.portal.rest.model.InvitationsResponse;
 import jakarta.ws.rs.client.Entity;
 import jakarta.ws.rs.core.Response;
+import java.net.URI;
 import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -61,12 +63,16 @@ class ApplicationInvitationsResourceTest extends AbstractResourceTest {
     private static final String INVITATION_ID_2 = "00000000-0000-0000-0000-000000000002";
     private static final String ROLE_NAME = "USER";
     private static final String UPDATED_ROLE_NAME = "OWNER";
+    private static final URI CONFIRMATION_PAGE_URL = URI.create("https://portal.example.com/user/registration/confirm");
 
     @Autowired
     private InvitationQueryService invitationQueryService;
 
     @Autowired
     private InvitationCrudService invitationCrudService;
+
+    @Autowired
+    private ApplicationInvitationNotificationDomainService applicationInvitationNotificationDomainService;
 
     @Autowired
     private ApplicationCrudServiceInMemory applicationCrudService;
@@ -84,6 +90,7 @@ class ApplicationInvitationsResourceTest extends AbstractResourceTest {
         resetAllMocks();
         reset(invitationQueryService);
         reset(invitationCrudService);
+        reset(applicationInvitationNotificationDomainService);
         applicationCrudService.reset();
         roleQueryService.reset();
         applicationCrudService.initWith(List.of(BaseApplicationEntity.builder().id(APPLICATION).environmentId("DEFAULT").build()));
@@ -167,11 +174,20 @@ class ApplicationInvitationsResourceTest extends AbstractResourceTest {
     }
 
     @Test
-    void should_return_internal_server_error_when_notify_is_not_supported_yet() {
+    void should_create_invitations_and_dispatch_notifications_when_notify_is_true() {
+        when(invitationQueryService.findByReference(any())).thenReturn(List.of());
+        when(invitationCrudService.create(any(ApplicationInvitation.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
         var response = target(APPLICATION).path("invitations").request().post(Entity.json(createInput(true)));
 
-        assertThat(response.getStatus()).isEqualTo(HttpStatusCode.INTERNAL_SERVER_ERROR_500);
-        verify(invitationCrudService, never()).create(any());
+        assertThat(response.getStatus()).isEqualTo(HttpStatusCode.CREATED_201);
+        verify(applicationInvitationNotificationDomainService).dispatchAsync(
+            anyString(),
+            anyString(),
+            eq(APPLICATION),
+            argThat(invitations -> invitations.size() == 1 && invitations.get(0).email().equals("alice@example.com")),
+            eq(CONFIRMATION_PAGE_URL)
+        );
     }
 
     @Test
@@ -428,7 +444,8 @@ class ApplicationInvitationsResourceTest extends AbstractResourceTest {
         return new InvitationCreateInput()
             .recipients(List.of(new InvitationRecipientInput().email("alice@example.com")))
             .role(ROLE_NAME)
-            .notify(notify);
+            .notify(notify)
+            .confirmationPageUrl(CONFIRMATION_PAGE_URL);
     }
 
     private Role applicationRole(String roleName) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/spring/ResourceContextConfiguration.java
@@ -117,6 +117,7 @@ import io.gravitee.apim.core.installation.domain_service.InstallationTypeDomainS
 import io.gravitee.apim.core.installation.query_service.InstallationAccessQueryService;
 import io.gravitee.apim.core.invitation.crud_service.InvitationCrudService;
 import io.gravitee.apim.core.invitation.domain_service.AcceptInvitationDomainService;
+import io.gravitee.apim.core.invitation.domain_service.ApplicationInvitationNotificationDomainService;
 import io.gravitee.apim.core.invitation.query_service.InvitationQueryService;
 import io.gravitee.apim.core.json.JsonSchemaChecker;
 import io.gravitee.apim.core.json_patch.domain_service.JsonMergePatchService;
@@ -483,6 +484,11 @@ public class ResourceContextConfiguration {
     @Bean
     public InvitationCrudService invitationCrudService() {
         return mock(InvitationCrudService.class);
+    }
+
+    @Bean
+    public ApplicationInvitationNotificationDomainService applicationInvitationNotificationDomainService() {
+        return mock(ApplicationInvitationNotificationDomainService.class);
     }
 
     @Bean

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/invitation/domain_service/ApplicationInvitationNotificationDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/invitation/domain_service/ApplicationInvitationNotificationDomainService.java
@@ -13,13 +13,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.apim.core.invitation.model;
+package io.gravitee.apim.core.invitation.domain_service;
 
+import io.gravitee.apim.core.invitation.model.ApplicationInvitation;
 import java.net.URI;
-import java.util.Set;
+import java.util.List;
 
-public record CreateApplicationInvitations(Set<String> recipientEmails, String roleName, boolean notifyUsers, URI confirmationPageUrl) {
-    public CreateApplicationInvitations(Set<String> recipientEmails, String roleName, boolean notifyUsers) {
-        this(recipientEmails, roleName, notifyUsers, null);
-    }
+public interface ApplicationInvitationNotificationDomainService {
+    void dispatchAsync(
+        String organizationId,
+        String environmentId,
+        String applicationId,
+        List<ApplicationInvitation> invitations,
+        URI confirmationPageUrl
+    );
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/invitation/domain_service/CreateApplicationInvitationsDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/invitation/domain_service/CreateApplicationInvitationsDomainService.java
@@ -25,6 +25,7 @@ import io.gravitee.apim.core.invitation.query_service.InvitationQueryService;
 import jakarta.annotation.Nonnull;
 import jakarta.mail.internet.AddressException;
 import jakarta.mail.internet.InternetAddress;
+import java.net.URI;
 import java.util.List;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
@@ -36,27 +37,38 @@ public class CreateApplicationInvitationsDomainService {
     private final InvitationQueryService invitationQueryService;
     private final InvitationCrudService invitationCrudService;
     private final ValidateApplicationInvitationRoleDomainService validateApplicationInvitationRoleDomainService;
+    private final ApplicationInvitationNotificationDomainService applicationInvitationNotificationDomainService;
 
     public List<ApplicationInvitation> create(
         @Nonnull String organizationId,
+        @Nonnull String environmentId,
         @Nonnull String applicationId,
         @Nonnull Set<String> recipientEmails,
         @Nonnull String roleName,
-        boolean notifyUsers
+        boolean notifyUsers,
+        URI confirmationPageUrl
     ) {
-        if (notifyUsers) {
-            throw new UnsupportedOperationException("Application invitation notifications are not implemented yet.");
-        }
-
         validateApplicationInvitationRoleDomainService.validate(organizationId, roleName);
         var emails = validateRecipients(recipientEmails);
 
         validateNoPendingInvitation(applicationId, emails);
-        return emails
+        var createdInvitations = emails
             .stream()
             .map(email -> ApplicationInvitation.create(applicationId, email, roleName))
             .map(invitationCrudService::create)
             .toList();
+
+        if (notifyUsers) {
+            applicationInvitationNotificationDomainService.dispatchAsync(
+                organizationId,
+                environmentId,
+                applicationId,
+                createdInvitations,
+                confirmationPageUrl
+            );
+        }
+
+        return createdInvitations;
     }
 
     private Set<String> validateRecipients(Set<String> recipients) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/invitation/use_case/CreateApplicationInvitationsUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/invitation/use_case/CreateApplicationInvitationsUseCase.java
@@ -20,7 +20,6 @@ import io.gravitee.apim.core.application.crud_service.ApplicationCrudService;
 import io.gravitee.apim.core.invitation.domain_service.CreateApplicationInvitationsDomainService;
 import io.gravitee.apim.core.invitation.model.ApplicationInvitation;
 import io.gravitee.apim.core.invitation.model.CreateApplicationInvitations;
-import io.gravitee.rest.api.service.common.ExecutionContext;
 import java.util.List;
 
 @UseCase
@@ -38,22 +37,25 @@ public class CreateApplicationInvitationsUseCase {
     }
 
     public Output execute(Input input) {
-        applicationCrudService.findById(input.applicationId(), input.executionContext().getEnvironmentId());
+        applicationCrudService.findById(input.applicationId(), input.environmentId());
         var createApplicationInvitations = input.createApplicationInvitations();
 
         return new Output(
             createApplicationInvitationsDomainService.create(
-                input.executionContext().getOrganizationId(),
+                input.organizationId(),
+                input.environmentId(),
                 input.applicationId(),
                 createApplicationInvitations.recipientEmails(),
                 createApplicationInvitations.roleName(),
-                createApplicationInvitations.notifyUsers()
+                createApplicationInvitations.notifyUsers(),
+                createApplicationInvitations.confirmationPageUrl()
             )
         );
     }
 
     public record Input(
-        ExecutionContext executionContext,
+        String organizationId,
+        String environmentId,
         String applicationId,
         CreateApplicationInvitations createApplicationInvitations
     ) {}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/invitation/ApplicationInvitationNotificationDomainServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/invitation/ApplicationInvitationNotificationDomainServiceImpl.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.infra.domain_service.invitation;
+
+import static io.gravitee.rest.api.service.common.JWTHelper.ACTION.APPLICATION_INVITATION;
+import static io.gravitee.rest.api.service.notification.NotificationParamsBuilder.PARAM_APPLICATION;
+import static io.gravitee.rest.api.service.notification.NotificationParamsBuilder.REGISTRATION_PATH;
+
+import io.gravitee.apim.core.application.crud_service.ApplicationCrudService;
+import io.gravitee.apim.core.invitation.domain_service.ApplicationInvitationNotificationDomainService;
+import io.gravitee.apim.core.invitation.model.ApplicationInvitation;
+import io.gravitee.rest.api.model.UserEntity;
+import io.gravitee.rest.api.service.EmailService;
+import io.gravitee.rest.api.service.UserService;
+import io.gravitee.rest.api.service.builder.EmailNotificationBuilder;
+import io.gravitee.rest.api.service.common.ExecutionContext;
+import java.net.URI;
+import java.util.HashMap;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ApplicationInvitationNotificationDomainServiceImpl implements ApplicationInvitationNotificationDomainService {
+
+    private static final String PARAM_ROLE = "role";
+
+    private final ApplicationCrudService applicationCrudService;
+    private final UserService userService;
+    private final EmailService emailService;
+
+    @Override
+    public void dispatchAsync(
+        String organizationId,
+        String environmentId,
+        String applicationId,
+        List<ApplicationInvitation> invitations,
+        URI confirmationPageUrl
+    ) {
+        if (invitations == null || invitations.isEmpty()) {
+            return;
+        }
+
+        var executionContext = new ExecutionContext(organizationId, environmentId);
+        var application = applicationCrudService.findById(applicationId, environmentId);
+
+        invitations.forEach(invitation -> {
+            var user = new UserEntity();
+            user.setEmail(invitation.email());
+
+            var params = new HashMap<>(
+                userService.getTokenRegistrationParams(
+                    executionContext,
+                    user,
+                    REGISTRATION_PATH,
+                    APPLICATION_INVITATION,
+                    confirmationPageUrl == null ? null : confirmationPageUrl.toString()
+                )
+            );
+            params.put(PARAM_APPLICATION, application);
+            params.put(PARAM_ROLE, invitation.roleName());
+
+            emailService.sendAsyncEmailNotification(
+                executionContext,
+                new EmailNotificationBuilder()
+                    .to(invitation.email())
+                    .template(EmailNotificationBuilder.EmailTemplate.TEMPLATES_FOR_ACTION_USER_APPLICATION_INVITATION)
+                    .params(params)
+                    .build()
+            );
+        });
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/builder/EmailNotificationBuilder.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/builder/EmailNotificationBuilder.java
@@ -253,6 +253,11 @@ public class EmailNotificationBuilder {
             "groupInvitation.html",
             "Group invitation - ${group.name}"
         ),
+        TEMPLATES_FOR_ACTION_USER_APPLICATION_INVITATION(
+            ActionHook.USER_APPLICATION_INVITATION,
+            "applicationInvitation.html",
+            "Application invitation - ${application.name}"
+        ),
         TEMPLATES_FOR_ACTION_USER_PASSWORD_RESET(
             ActionHook.USER_PASSWORD_RESET,
             "passwordReset.html",

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/notification/ActionHook.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/notification/ActionHook.java
@@ -40,6 +40,7 @@ public enum ActionHook implements Hook {
     ),
     GENERIC_MESSAGE("Generic message", "Email sent when using the messaging service.", "SUPPORT", true),
     USER_GROUP_INVITATION("User group invitation", "Email sent when using the messaging service.", "USER"),
+    USER_APPLICATION_INVITATION("User application invitation", "Email sent to a user invited to an application.", "USER"),
     USER_PASSWORD_RESET("User password reset", "Email sent to a user which password has been reset.", "USER"),
     SUBSCRIPTION_PRE_EXPIRATION(
         "Subscription pre-expiration notification",

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/invitation/domain_service/CreateApplicationInvitationsDomainServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/invitation/domain_service/CreateApplicationInvitationsDomainServiceTest.java
@@ -36,6 +36,7 @@ import io.gravitee.apim.core.invitation.query_service.InvitationQueryService;
 import io.gravitee.apim.core.membership.exception.RoleNotFoundException;
 import io.gravitee.apim.core.membership.query_service.RoleQueryService;
 import io.gravitee.rest.api.service.common.ReferenceContext;
+import java.net.URI;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Optional;
@@ -51,11 +52,13 @@ import org.mockito.junit.jupiter.MockitoExtension;
 class CreateApplicationInvitationsDomainServiceTest {
 
     private static final String ORGANIZATION_ID = "organization-id";
+    private static final String ENVIRONMENT_ID = "environment-id";
     private static final String APPLICATION_ID = "application-id";
     private static final String ROLE_NAME = "USER";
     private static final String INVITATION_ID_1 = "00000000-0000-0000-0000-000000000001";
     private static final String INVITATION_ID_2 = "00000000-0000-0000-0000-000000000002";
     private static final String EXISTING_INVITATION_ID = "00000000-0000-0000-0000-000000000003";
+    private static final URI CONFIRMATION_PAGE_URL = URI.create("https://portal.example.com/user/registration/confirm");
 
     @Mock
     private InvitationQueryService invitationQueryService;
@@ -66,6 +69,9 @@ class CreateApplicationInvitationsDomainServiceTest {
     @Mock
     private RoleQueryService roleQueryService;
 
+    @Mock
+    private ApplicationInvitationNotificationDomainService applicationInvitationNotificationDomainService;
+
     private CreateApplicationInvitationsDomainService cut;
 
     @BeforeEach
@@ -73,7 +79,8 @@ class CreateApplicationInvitationsDomainServiceTest {
         cut = new CreateApplicationInvitationsDomainService(
             invitationQueryService,
             invitationCrudService,
-            new ValidateApplicationInvitationRoleDomainService(roleQueryService)
+            new ValidateApplicationInvitationRoleDomainService(roleQueryService),
+            applicationInvitationNotificationDomainService
         );
     }
 
@@ -86,7 +93,15 @@ class CreateApplicationInvitationsDomainServiceTest {
             anApplicationInvitation(INVITATION_ID_2, "bob@example.com")
         );
 
-        var result = cut.create(ORGANIZATION_ID, APPLICATION_ID, recipients("alice@example.com", "bob@example.com"), ROLE_NAME, false);
+        var result = cut.create(
+            ORGANIZATION_ID,
+            ENVIRONMENT_ID,
+            APPLICATION_ID,
+            recipients("alice@example.com", "bob@example.com"),
+            ROLE_NAME,
+            false,
+            null
+        );
 
         assertThat(result).extracting(ApplicationInvitation::email).containsExactly("alice@example.com", "bob@example.com");
 
@@ -97,13 +112,16 @@ class CreateApplicationInvitationsDomainServiceTest {
             .extracting(ApplicationInvitation::email)
             .containsExactly("alice@example.com", "bob@example.com");
         assertThat(invitationCaptor.getAllValues()).extracting(ApplicationInvitation::roleName).containsOnly(ROLE_NAME);
+        verifyNoInteractions(applicationInvitationNotificationDomainService);
     }
 
     @Test
     void should_reject_invalid_email_before_creating_any_invitation() {
         givenExistingRole();
 
-        var throwable = catchThrowable(() -> cut.create(ORGANIZATION_ID, APPLICATION_ID, Set.of("not-an-email"), ROLE_NAME, false));
+        var throwable = catchThrowable(() ->
+            cut.create(ORGANIZATION_ID, ENVIRONMENT_ID, APPLICATION_ID, Set.of("not-an-email"), ROLE_NAME, false, null)
+        );
 
         assertThat(throwable).isInstanceOf(ValidationDomainException.class).hasMessageContaining("email is invalid");
         verifyNoInteractions(invitationCrudService);
@@ -111,11 +129,31 @@ class CreateApplicationInvitationsDomainServiceTest {
     }
 
     @Test
-    void should_reject_notify_true_before_creating_any_invitation() {
-        var throwable = catchThrowable(() -> cut.create(ORGANIZATION_ID, APPLICATION_ID, Set.of("alice@example.com"), ROLE_NAME, true));
+    void should_create_invitations_and_dispatch_notification_when_notify_is_true() {
+        givenExistingRole();
+        when(invitationQueryService.findByReference(InvitationReference.application(APPLICATION_ID))).thenReturn(List.of());
+        when(invitationCrudService.create(any(ApplicationInvitation.class))).thenReturn(
+            anApplicationInvitation(INVITATION_ID_1, "alice@example.com")
+        );
 
-        assertThat(throwable).isInstanceOf(UnsupportedOperationException.class).hasMessageContaining("not implemented yet");
-        verifyNoInteractions(roleQueryService, invitationQueryService, invitationCrudService);
+        var result = cut.create(
+            ORGANIZATION_ID,
+            ENVIRONMENT_ID,
+            APPLICATION_ID,
+            Set.of("alice@example.com"),
+            ROLE_NAME,
+            true,
+            CONFIRMATION_PAGE_URL
+        );
+
+        assertThat(result).extracting(ApplicationInvitation::email).containsExactly("alice@example.com");
+        verify(applicationInvitationNotificationDomainService).dispatchAsync(
+            ORGANIZATION_ID,
+            ENVIRONMENT_ID,
+            APPLICATION_ID,
+            result,
+            CONFIRMATION_PAGE_URL
+        );
     }
 
     @Test
@@ -125,7 +163,9 @@ class CreateApplicationInvitationsDomainServiceTest {
             List.of(anApplicationInvitation(EXISTING_INVITATION_ID, "alice@example.com"))
         );
 
-        var throwable = catchThrowable(() -> cut.create(ORGANIZATION_ID, APPLICATION_ID, Set.of("alice@example.com"), ROLE_NAME, false));
+        var throwable = catchThrowable(() ->
+            cut.create(ORGANIZATION_ID, ENVIRONMENT_ID, APPLICATION_ID, Set.of("alice@example.com"), ROLE_NAME, false, null)
+        );
 
         assertThat(throwable).isInstanceOf(ConflictDomainException.class).hasMessageContaining("pending application invitation");
         verifyNoInteractions(invitationCrudService);
@@ -135,7 +175,9 @@ class CreateApplicationInvitationsDomainServiceTest {
     void should_reject_unknown_application_role() {
         when(roleQueryService.findApplicationRole(eq(ROLE_NAME), any(ReferenceContext.class))).thenReturn(Optional.empty());
 
-        var throwable = catchThrowable(() -> cut.create(ORGANIZATION_ID, APPLICATION_ID, Set.of("alice@example.com"), ROLE_NAME, false));
+        var throwable = catchThrowable(() ->
+            cut.create(ORGANIZATION_ID, ENVIRONMENT_ID, APPLICATION_ID, Set.of("alice@example.com"), ROLE_NAME, false, null)
+        );
 
         assertThat(throwable).isInstanceOf(RoleNotFoundException.class);
         verifyNoInteractions(invitationQueryService, invitationCrudService);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/invitation/use_case/CreateApplicationInvitationsUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/invitation/use_case/CreateApplicationInvitationsUseCaseTest.java
@@ -26,8 +26,8 @@ import io.gravitee.apim.core.invitation.domain_service.CreateApplicationInvitati
 import io.gravitee.apim.core.invitation.model.ApplicationInvitation;
 import io.gravitee.apim.core.invitation.model.CreateApplicationInvitations;
 import io.gravitee.rest.api.model.BaseApplicationEntity;
-import io.gravitee.rest.api.service.common.ExecutionContext;
 import io.gravitee.rest.api.service.exceptions.ApplicationNotFoundException;
+import java.net.URI;
 import java.util.List;
 import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
@@ -43,6 +43,7 @@ class CreateApplicationInvitationsUseCaseTest {
     private static final String ENVIRONMENT_ID = "environment-id";
     private static final String ORGANIZATION_ID = "organization-id";
     private static final String ROLE_NAME = "USER";
+    private static final URI CONFIRMATION_PAGE_URL = URI.create("https://portal.example.com/user/registration/confirm");
 
     @Mock
     private ApplicationCrudService applicationCrudService;
@@ -59,15 +60,15 @@ class CreateApplicationInvitationsUseCaseTest {
 
     @Test
     void should_validate_application_existence_before_creating_invitations() {
-        var executionContext = new ExecutionContext(ORGANIZATION_ID, ENVIRONMENT_ID);
         when(applicationCrudService.findById(APPLICATION_ID, ENVIRONMENT_ID)).thenThrow(new ApplicationNotFoundException(APPLICATION_ID));
 
         Throwable throwable = catchThrowable(() ->
             cut.execute(
                 new CreateApplicationInvitationsUseCase.Input(
-                    executionContext,
+                    ORGANIZATION_ID,
+                    ENVIRONMENT_ID,
                     APPLICATION_ID,
-                    new CreateApplicationInvitations(Set.of("alice@example.com"), ROLE_NAME, false)
+                    new CreateApplicationInvitations(Set.of("alice@example.com"), ROLE_NAME, false, null)
                 )
             )
         );
@@ -78,48 +79,80 @@ class CreateApplicationInvitationsUseCaseTest {
 
     @Test
     void should_create_application_invitations() {
-        var executionContext = new ExecutionContext(ORGANIZATION_ID, ENVIRONMENT_ID);
         var recipients = Set.of("alice@example.com", "bob@example.com");
         var application = BaseApplicationEntity.builder().id(APPLICATION_ID).environmentId(ENVIRONMENT_ID).build();
         var invitations = List.of(anInvitation("alice@example.com"), anInvitation("bob@example.com"));
         when(applicationCrudService.findById(APPLICATION_ID, ENVIRONMENT_ID)).thenReturn(application);
-        when(createApplicationInvitationsDomainService.create(ORGANIZATION_ID, APPLICATION_ID, recipients, ROLE_NAME, false)).thenReturn(
-            invitations
-        );
+        when(
+            createApplicationInvitationsDomainService.create(
+                ORGANIZATION_ID,
+                ENVIRONMENT_ID,
+                APPLICATION_ID,
+                recipients,
+                ROLE_NAME,
+                false,
+                CONFIRMATION_PAGE_URL
+            )
+        ).thenReturn(invitations);
 
         var result = cut.execute(
             new CreateApplicationInvitationsUseCase.Input(
-                executionContext,
+                ORGANIZATION_ID,
+                ENVIRONMENT_ID,
                 APPLICATION_ID,
-                new CreateApplicationInvitations(recipients, ROLE_NAME, false)
+                new CreateApplicationInvitations(recipients, ROLE_NAME, false, CONFIRMATION_PAGE_URL)
             )
         );
 
         assertThat(result.invitations()).isEqualTo(invitations);
-        verify(createApplicationInvitationsDomainService).create(ORGANIZATION_ID, APPLICATION_ID, recipients, ROLE_NAME, false);
+        verify(createApplicationInvitationsDomainService).create(
+            ORGANIZATION_ID,
+            ENVIRONMENT_ID,
+            APPLICATION_ID,
+            recipients,
+            ROLE_NAME,
+            false,
+            CONFIRMATION_PAGE_URL
+        );
     }
 
     @Test
-    void should_propagate_notify_not_implemented_exception() {
-        var executionContext = new ExecutionContext(ORGANIZATION_ID, ENVIRONMENT_ID);
+    void should_create_application_invitations_with_notifications() {
         var recipients = Set.of("alice@example.com");
         var application = BaseApplicationEntity.builder().id(APPLICATION_ID).environmentId(ENVIRONMENT_ID).build();
+        var invitations = List.of(anInvitation("alice@example.com"));
         when(applicationCrudService.findById(APPLICATION_ID, ENVIRONMENT_ID)).thenReturn(application);
-        when(createApplicationInvitationsDomainService.create(ORGANIZATION_ID, APPLICATION_ID, recipients, ROLE_NAME, true)).thenThrow(
-            new UnsupportedOperationException("Application invitation notifications are not implemented yet.")
-        );
+        when(
+            createApplicationInvitationsDomainService.create(
+                ORGANIZATION_ID,
+                ENVIRONMENT_ID,
+                APPLICATION_ID,
+                recipients,
+                ROLE_NAME,
+                true,
+                CONFIRMATION_PAGE_URL
+            )
+        ).thenReturn(invitations);
 
-        Throwable throwable = catchThrowable(() ->
-            cut.execute(
-                new CreateApplicationInvitationsUseCase.Input(
-                    executionContext,
-                    APPLICATION_ID,
-                    new CreateApplicationInvitations(recipients, ROLE_NAME, true)
-                )
+        var result = cut.execute(
+            new CreateApplicationInvitationsUseCase.Input(
+                ORGANIZATION_ID,
+                ENVIRONMENT_ID,
+                APPLICATION_ID,
+                new CreateApplicationInvitations(recipients, ROLE_NAME, true, CONFIRMATION_PAGE_URL)
             )
         );
 
-        assertThat(throwable).isInstanceOf(UnsupportedOperationException.class).hasMessageContaining("not implemented yet");
+        assertThat(result.invitations()).isEqualTo(invitations);
+        verify(createApplicationInvitationsDomainService).create(
+            ORGANIZATION_ID,
+            ENVIRONMENT_ID,
+            APPLICATION_ID,
+            recipients,
+            ROLE_NAME,
+            true,
+            CONFIRMATION_PAGE_URL
+        );
     }
 
     private ApplicationInvitation anInvitation(String email) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/invitation/ApplicationInvitationNotificationDomainServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/invitation/ApplicationInvitationNotificationDomainServiceImplTest.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.infra.domain_service.invitation;
+
+import static fixtures.core.model.ApplicationInvitationFixtures.anApplicationInvitation;
+import static io.gravitee.rest.api.service.common.JWTHelper.ACTION.APPLICATION_INVITATION;
+import static io.gravitee.rest.api.service.notification.NotificationParamsBuilder.PARAM_APPLICATION;
+import static io.gravitee.rest.api.service.notification.NotificationParamsBuilder.PARAM_REGISTRATION_URL;
+import static io.gravitee.rest.api.service.notification.NotificationParamsBuilder.REGISTRATION_PATH;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.apim.core.application.crud_service.ApplicationCrudService;
+import io.gravitee.rest.api.model.BaseApplicationEntity;
+import io.gravitee.rest.api.model.UserEntity;
+import io.gravitee.rest.api.service.EmailNotification;
+import io.gravitee.rest.api.service.EmailService;
+import io.gravitee.rest.api.service.UserService;
+import io.gravitee.rest.api.service.builder.EmailNotificationBuilder;
+import io.gravitee.rest.api.service.common.ExecutionContext;
+import java.net.URI;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ApplicationInvitationNotificationDomainServiceImplTest {
+
+    private static final String ORGANIZATION_ID = "organization-id";
+    private static final String ENVIRONMENT_ID = "environment-id";
+    private static final String APPLICATION_ID = "application-id";
+    private static final String ROLE_NAME = "USER";
+    private static final String INVITATION_ID_1 = "00000000-0000-0000-0000-000000000001";
+    private static final String INVITATION_ID_2 = "00000000-0000-0000-0000-000000000002";
+    private static final String PARAM_ROLE = "role";
+    private static final URI CONFIRMATION_PAGE_URL = URI.create("https://portal.example.com/user/registration/confirm");
+
+    @Mock
+    private ApplicationCrudService applicationCrudService;
+
+    @Mock
+    private UserService userService;
+
+    @Mock
+    private EmailService emailService;
+
+    private ApplicationInvitationNotificationDomainServiceImpl cut;
+
+    @BeforeEach
+    void setUp() {
+        cut = new ApplicationInvitationNotificationDomainServiceImpl(applicationCrudService, userService, emailService);
+    }
+
+    @Test
+    void should_dispatch_application_invitation_email_for_each_invitation() {
+        var executionContext = new ExecutionContext(ORGANIZATION_ID, ENVIRONMENT_ID);
+        var application = BaseApplicationEntity.builder().id(APPLICATION_ID).name("My Application").environmentId(ENVIRONMENT_ID).build();
+        var invitations = List.of(
+            anApplicationInvitation(INVITATION_ID_1, APPLICATION_ID, "alice@example.com", ROLE_NAME),
+            anApplicationInvitation(INVITATION_ID_2, APPLICATION_ID, "bob@example.com", ROLE_NAME)
+        );
+        when(applicationCrudService.findById(APPLICATION_ID, ENVIRONMENT_ID)).thenReturn(application);
+        when(
+            userService.getTokenRegistrationParams(
+                eq(executionContext),
+                any(UserEntity.class),
+                eq(REGISTRATION_PATH),
+                eq(APPLICATION_INVITATION),
+                eq(CONFIRMATION_PAGE_URL.toString())
+            )
+        ).thenAnswer(invocation -> {
+            var user = invocation.getArgument(1, UserEntity.class);
+            return Map.of(PARAM_REGISTRATION_URL, "https://example.com/registration/" + user.getEmail());
+        });
+
+        cut.dispatchAsync(ORGANIZATION_ID, ENVIRONMENT_ID, APPLICATION_ID, invitations, CONFIRMATION_PAGE_URL);
+
+        verify(applicationCrudService).findById(APPLICATION_ID, ENVIRONMENT_ID);
+        verify(userService, times(2)).getTokenRegistrationParams(
+            eq(executionContext),
+            any(UserEntity.class),
+            eq(REGISTRATION_PATH),
+            eq(APPLICATION_INVITATION),
+            eq(CONFIRMATION_PAGE_URL.toString())
+        );
+        var notificationCaptor = ArgumentCaptor.forClass(EmailNotification.class);
+        verify(emailService, times(2)).sendAsyncEmailNotification(eq(executionContext), notificationCaptor.capture());
+        assertThat(notificationCaptor.getAllValues())
+            .extracting(notification -> notification.getTo()[0])
+            .containsExactly("alice@example.com", "bob@example.com");
+        assertThat(notificationCaptor.getAllValues())
+            .extracting(EmailNotification::getTemplate)
+            .containsOnly(
+                EmailNotificationBuilder.EmailTemplate.TEMPLATES_FOR_ACTION_USER_APPLICATION_INVITATION.getLinkedHook().getTemplate()
+            );
+        assertThat(notificationCaptor.getAllValues()).allSatisfy(notification -> {
+            assertThat(notification.getParams()).containsEntry(PARAM_APPLICATION, application).containsEntry(PARAM_ROLE, ROLE_NAME);
+            assertThat(notification.getParams()).containsKey(PARAM_REGISTRATION_URL);
+        });
+    }
+
+    @Test
+    void should_do_nothing_when_invitations_are_empty() {
+        cut.dispatchAsync(ORGANIZATION_ID, ENVIRONMENT_ID, APPLICATION_ID, List.of(), null);
+
+        verifyNoInteractions(applicationCrudService, userService, emailService);
+    }
+
+    @Test
+    void should_do_nothing_when_invitations_are_null() {
+        cut.dispatchAsync(ORGANIZATION_ID, ENVIRONMENT_ID, APPLICATION_ID, null, null);
+
+        verifyNoInteractions(applicationCrudService, userService, emailService);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/src/main/resources/templates/applicationInvitation.html
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/src/main/resources/templates/applicationInvitation.html
@@ -1,0 +1,12 @@
+<html>
+	<body style="text-align: center;">
+		<header>
+			<#include "header.html" />
+		</header>
+		<div style="margin-top: 50px; color: #424e5a;">
+			<h3>Hi,</h3>
+			<p>You have been invited to join the application <b>${application.name}</b> as <b>${role}</b>.</p>
+			<p><a href="${registrationUrl}">Click here</a> to accept the invitation.</p>
+		</div>
+	</body>
+</html>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-14143

Implements backend support for sending application invitation email notifications when `notify=true`.

## Changes

- Adds application invitation notification dispatch from the invitation creation flow.
- Sends notifications asynchronously using `EmailService.sendAsyncEmailNotification`.
- Builds registration token parameters through legacy `UserService`.
- Passes `confirmation_page_url` through the backend flow as `URI` 
- Adds application and role template parameters for the invitation email.

