### PR TITLE
chore(deps): bump avro-json policy and kafka endpoint for binary-safe key decoding (APIM-14299)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -226,7 +226,7 @@
         <gravitee-policy-role-based-access-control.version>2.0.0</gravitee-policy-role-based-access-control.version>
         <gravitee-policy-ssl-enforcement.version>1.6.0</gravitee-policy-ssl-enforcement.version>
         <gravitee-policy-traffic-shadowing.version>3.0.0</gravitee-policy-traffic-shadowing.version>
-        <gravitee-policy-transform-avro-json.version>5.1.1</gravitee-policy-transform-avro-json.version>
+        <gravitee-policy-transform-avro-json.version>5.2.0</gravitee-policy-transform-avro-json.version>
         <gravitee-policy-transform-avro-protobuf.version>1.0.9</gravitee-policy-transform-avro-protobuf.version>
         <gravitee-policy-transform-protobuf-json.version>2.0.1</gravitee-policy-transform-protobuf-json.version>
         <gravitee-policy-transformheaders.version>5.1.0</gravitee-policy-transformheaders.version>
@@ -293,7 +293,7 @@
         <gravitee-entrypoint-agent-to-agent.version>1.0.1</gravitee-entrypoint-agent-to-agent.version>
         <gravitee-entrypoint-mcp.version>1.1.1</gravitee-entrypoint-mcp.version>
         <gravitee-endpoint-jms.version>1.0.1</gravitee-endpoint-jms.version>
-        <gravitee-endpoint-kafka.version>5.1.4</gravitee-endpoint-kafka.version>
+        <gravitee-endpoint-kafka.version>5.2.0</gravitee-endpoint-kafka.version>
         <gravitee-endpoint-mqtt5.version>4.0.1</gravitee-endpoint-mqtt5.version>
         <gravitee-endpoint-rabbitmq.version>3.0.2</gravitee-endpoint-rabbitmq.version>
         <gravitee-endpoint-solace.version>3.0.3</gravitee-endpoint-solace.version>


### PR DESCRIPTION
## Summary

Brings the binary-safe Avro Kafka record key decoding to the `4.10.x` maintenance line by bumping two dependencies:

- `gravitee-policy-transform-avro-json` 5.1.1 → 5.2.0
- `gravitee-endpoint-kafka` 5.1.4 → 5.2.0

## Why

The avro-json policy already decodes the message **value** on the subscribe path (Kafka → HTTP). The new policy release adds **key** decoding too, surfacing the decoded JSON on a dedicated `X-Gravitee-Kafka-Key` HTTP header for http-get / sse / webhook consumers.

The endpoint bump is required because policy 5.2.0 reads the raw key bytes from a new `metadata["keyBytes"]` entry that the endpoint populates only from 5.2.0 (5.x line) onwards. The legacy `metadata["key"]` String is UTF-8-decoded from the original bytes and is lossy as soon as a Confluent schema id ≥ 128 or any binary key field pushes a byte ≥ 0x80 — the policy needs the raw bytes to round-trip Avro decoding faithfully.

## Why a 5.x release and not 6.1.0

`gravitee-endpoint-kafka` 6.0.0 introduced a `BREAKING CHANGE` on the `gravitee-parent` version. Bumping APIM 4.10.x across that is risky. The 5.x backport (5.2.0) carries only the additive `metadata["keyBytes"]` entry, no parent change.

## Companion PRs

- `gravitee-policy-transform-avro-json` PR #90 (release 5.2.0)
- `gravitee-endpoint-kafka` PR #172 (5.x backport, release 5.2.0) — merged
- `gravitee-endpoint-kafka` PR #170 (master, release 6.1.0) — merged
- APIM master: #17579
- APIM 4.11.x: #17581

## Test plan

- [ ] CI green
- [ ] APIM 4.10.x integration test: a Kafka topic with Avro-encoded key+value, http-get entrypoint, avro-json policy in `subscribe[]` with `keyMapping` enabled — consumer sees decoded JSON in both `content` and `headers["X-Gravitee-Kafka-Key"]`