### PR TITLE
chore(deps): bump avro-json policy and kafka endpoint for binary-safe key decoding (APIM-14299)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -231,7 +231,7 @@
         <gravitee-policy-role-based-access-control.version>2.1.0</gravitee-policy-role-based-access-control.version>
         <gravitee-policy-ssl-enforcement.version>1.6.0</gravitee-policy-ssl-enforcement.version>
         <gravitee-policy-traffic-shadowing.version>3.0.0</gravitee-policy-traffic-shadowing.version>
-        <gravitee-policy-transform-avro-json.version>5.1.1</gravitee-policy-transform-avro-json.version>
+        <gravitee-policy-transform-avro-json.version>5.2.0</gravitee-policy-transform-avro-json.version>
         <gravitee-policy-transform-avro-protobuf.version>1.0.9</gravitee-policy-transform-avro-protobuf.version>
         <gravitee-policy-transform-protobuf-json.version>2.0.1</gravitee-policy-transform-protobuf-json.version>
         <gravitee-policy-transformheaders.version>5.2.0</gravitee-policy-transformheaders.version>
@@ -296,7 +296,7 @@
         <gravitee-entrypoint-agent-to-agent.version>2.0.0</gravitee-entrypoint-agent-to-agent.version>
         <gravitee-entrypoint-mcp-tool-server.version>2.0.1</gravitee-entrypoint-mcp-tool-server.version>
         <gravitee-endpoint-jms.version>2.0.0</gravitee-endpoint-jms.version>
-        <gravitee-endpoint-kafka.version>6.0.2</gravitee-endpoint-kafka.version>
+        <gravitee-endpoint-kafka.version>6.1.0</gravitee-endpoint-kafka.version>
         <gravitee-endpoint-mqtt5.version>5.0.0</gravitee-endpoint-mqtt5.version>
         <gravitee-endpoint-rabbitmq.version>4.0.0</gravitee-endpoint-rabbitmq.version>
         <gravitee-endpoint-solace.version>4.0.1</gravitee-endpoint-solace.version>


### PR DESCRIPTION
## Summary

Cherry-pick of #17579 (master) onto the `4.11.x` maintenance line. Same diff, same dependency versions — both branches pin the same policy / endpoint versions today so no backport adjustment is required.

- `gravitee-policy-transform-avro-json` 5.1.1 → 5.2.0
- `gravitee-endpoint-kafka` 6.0.2 → 6.1.0

See #17579 for the full rationale (binary-safe Kafka record key decoding via new `metadata["keyBytes"]` entry).

## Companion PRs

- APIM master: #17579
- APIM 4.10.x: #17578
- `gravitee-policy-transform-avro-json` PR #90 (release 5.2.0)
- `gravitee-endpoint-kafka` PR #170 (master, release 6.1.0)

## Test plan

- [ ] CI green
