### PR TITLE
Apim 14339 frontend invitation creation enable notifications

### DIFF
--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-invitation-create-dialog/application-invitation-create-dialog.component.html
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-invitation-create-dialog/application-invitation-create-dialog.component.html
@@ -66,6 +66,14 @@
         placeholder="name@example.com"
         i18n-placeholder="@@createApplicationInvitationEmailPlaceholder"
       />
+      <mat-icon
+        matIconSuffix
+        class="application-invitation-create-dialog__email-enter-icon"
+        data-testid="create-invitation-email-enter-icon"
+        aria-hidden="true"
+      >
+        keyboard_return
+      </mat-icon>
       <mat-hint i18n="@@createApplicationInvitationEmailHint">Press Enter to add each email address.</mat-hint>
     </mat-form-field>
     @if (selectedEmails().length > 0) {

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-invitation-create-dialog/application-invitation-create-dialog.component.scss
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-invitation-create-dialog/application-invitation-create-dialog.component.scss
@@ -33,6 +33,12 @@
     width: 100%;
   }
 
+  &__email-enter-icon {
+    color: app-theme.$paragraph-color;
+    opacity: 0.72;
+    pointer-events: none;
+  }
+
   &__section:first-child &__field {
     margin-top: app-theme.$form-field-container-vertical-padding;
   }

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-invitation-create-dialog/application-invitation-create-dialog.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-invitation-create-dialog/application-invitation-create-dialog.component.spec.ts
@@ -138,11 +138,11 @@ describe('ApplicationInvitationCreateDialogComponent', () => {
     expect(await harness.getSubmitButtonText()).toBe('Send invitation');
   });
 
-  it('should keep notify unchecked and disabled while backend notifications are unavailable', async () => {
+  it('should enable notify checked by default when backend notifications are available', async () => {
     await init();
 
-    expect(await harness.isNotifyChecked()).toBe(false);
-    expect(await harness.isNotifyDisabled()).toBe(true);
+    expect(await harness.isNotifyChecked()).toBe(true);
+    expect(await harness.isNotifyDisabled()).toBe(false);
   });
 
   it('should reject invalid email address', async () => {
@@ -193,7 +193,8 @@ describe('ApplicationInvitationCreateDialogComponent', () => {
     expect(request.request.body).toEqual({
       recipients: [{ email: 'alice@example.com' }, { email: 'bob@example.com' }],
       role: 'USER',
-      notify: false,
+      notify: true,
+      confirmation_page_url: `${globalThis.location.origin}/user/registration/confirm`,
     });
     request.flush(fakeApplicationInvitationsResponse());
     await fixture.whenStable();
@@ -201,9 +202,10 @@ describe('ApplicationInvitationCreateDialogComponent', () => {
     expect(dialogRef.close).toHaveBeenCalledWith(true);
   });
 
-  it('should submit notify disabled default value', async () => {
+  it('should submit notify false when checkbox is unchecked', async () => {
     await init();
     await enterEmail('alice@example.com');
+    await harness.toggleNotify();
 
     await harness.clickSubmit();
     fixture.detectChanges();
@@ -213,6 +215,7 @@ describe('ApplicationInvitationCreateDialogComponent', () => {
       recipients: [{ email: 'alice@example.com' }],
       role: 'USER',
       notify: false,
+      confirmation_page_url: `${globalThis.location.origin}/user/registration/confirm`,
     });
     request.flush(fakeApplicationInvitationsResponse());
     await fixture.whenStable();

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-invitation-create-dialog/application-invitation-create-dialog.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-invitation-create-dialog/application-invitation-create-dialog.component.ts
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { PlatformLocation } from '@angular/common';
 import { HttpErrorResponse } from '@angular/common/http';
 import { Component, computed, DestroyRef, effect, inject, signal } from '@angular/core';
 import { rxResource, takeUntilDestroyed, toSignal } from '@angular/core/rxjs-interop';
@@ -64,10 +65,11 @@ export class ApplicationInvitationCreateDialogComponent {
   private readonly applicationService = inject(ApplicationService);
   private readonly destroyRef = inject(DestroyRef);
   private readonly dialogRef = inject(MatDialogRef<ApplicationInvitationCreateDialogComponent, boolean>);
+  private readonly platformLocation = inject(PlatformLocation);
   private readonly data: ApplicationInvitationCreateDialogData = inject(MAT_DIALOG_DATA);
 
   readonly emailControl = new FormControl('', { nonNullable: true, validators: [Validators.email] });
-  readonly notifyControl = new FormControl({ value: false, disabled: true }, { nonNullable: true });
+  readonly notifyControl = new FormControl(true, { nonNullable: true });
   readonly roleControl = new FormControl('', { nonNullable: true, validators: [Validators.required] });
 
   readonly selectedEmails = signal<SelectedInvitationEmail[]>([]);
@@ -152,6 +154,7 @@ export class ApplicationInvitationCreateDialogComponent {
         recipients: this.selectedEmails().map(selectedEmail => ({ email: selectedEmail.email })),
         role: this.roleControl.value,
         notify: this.notifyControl.value,
+        confirmation_page_url: this.buildRegistrationConfirmationUrl(),
       })
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe({
@@ -212,6 +215,13 @@ export class ApplicationInvitationCreateDialogComponent {
 
   private normalizeEmail(value: string): string {
     return value.trim().toLowerCase();
+  }
+
+  private buildRegistrationConfirmationUrl(): string {
+    const baseHref = this.platformLocation.getBaseHrefFromDOM() || '/';
+    const normalizedBaseHref = baseHref.endsWith('/') ? baseHref : `${baseHref}/`;
+
+    return new URL(`${normalizedBaseHref}user/registration/confirm`, globalThis.location.origin).toString();
   }
 
   private handleSubmitError(error: HttpErrorResponse): void {

--- a/gravitee-apim-portal-webui-next/src/entities/application/application-invitation.ts
+++ b/gravitee-apim-portal-webui-next/src/entities/application/application-invitation.ts
@@ -27,6 +27,7 @@ export interface ApplicationInvitationsCreateInput {
   recipients: ApplicationInvitationRecipientInput[];
   role: string;
   notify: boolean;
+  confirmation_page_url?: string;
 }
 
 export interface ApplicationInvitationsSearchFilters {


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-14339

## Description

Adds frontend support for sending application invitation notification data from the Portal Next invitation dialog.


Changes:
- Enables the Notify users when invitations are created option.
- Sends notify in the create invitations request.
- Sends confirmation_page_url so backend email templates can build the sign-up confirmation link.
- Adds an Enter hint icon to the email input to clarify how addresses are added.


<img width="745" height="465" alt="Zrzut ekranu 2026-06-9 o 10 20 03" src="https://github.com/user-attachments/assets/f5cbb202-6fa0-485b-b889-d130fefe5725" />