### PR TITLE
chore(deps): bump cockpit-connectors-ws to 5.1.68 (CJ-4716)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -242,7 +242,7 @@
         <gravitee-resource-content-provider-inline.version>1.1.1</gravitee-resource-content-provider-inline.version>
         <gravitee-service-discovery-consul.version>1.3.0</gravitee-service-discovery-consul.version>
         <!-- Management API Only -->
-        <gravitee-cockpit-connectors-ws.version>5.1.65</gravitee-cockpit-connectors-ws.version>
+        <gravitee-cockpit-connectors-ws.version>5.1.68</gravitee-cockpit-connectors-ws.version>
         <gravitee-fetcher-bitbucket.version>2.1.1</gravitee-fetcher-bitbucket.version>
         <gravitee-fetcher-git.version>3.0.0</gravitee-fetcher-git.version>
         <gravitee-fetcher-github.version>2.2.1</gravitee-fetcher-github.version>


### PR DESCRIPTION
Bumps cockpit-connectors-ws to 5.1.68, bringing the `;;` separator fix (exchange 2.0.2) to this support line.

Ticket: https://gravitee.atlassian.net/browse/CJ-4716
