### PR TITLE
fix(otel): keep hyphens in namespace-position placeholders

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/utils/OtelDataStreamIndexUtils.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/utils/OtelDataStreamIndexUtils.java
@@ -17,35 +17,40 @@ package io.gravitee.repository.elasticsearch.utils;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
-import java.util.regex.Matcher;
 
 /**
  * Resolves an OTel ES data stream index template by substituting {@code {placeholder}} tokens with
- * their caller-supplied values, applying the same dataset normalisation the OpenTelemetry
- * collector's {@code elasticsearchexporter} applies before writing.
+ * their caller-supplied values, applying the same normalisation the OpenTelemetry collector's
+ * {@code elasticsearchexporter} applies before writing.
  *
  * <p>Why this isn't {@code IndexNameUtils.format}: that utility lowercases substituted values but
  * leaves their other characters intact, which is the right behaviour for legacy analytics indices
- * that the gateway writes directly. The OTel collector ES exporter, in contrast, runs each dataset
- * component through {@code sanitizeDataStreamField} — replacing characters in a "disallowed runes"
- * set with {@code _} and then lowercasing — before forming the final data stream name. The
- * disallowed set for dataset components is a superset of the namespace set; notably it includes the
- * hyphen, so a Gravitee org id of {@code "my-org-1"} is stored under
- * {@code traces-gamma_my_org_1.otel-<namespace>} but a naive {@code IndexNameUtils.format}
- * substitution would query for {@code traces-gamma_my-org-1.otel-<namespace>} — every result
- * misses.
+ * that the gateway writes directly. The OTel collector ES exporter, in contrast, runs each data
+ * stream component through {@code sanitizeDataStreamField} — replacing characters in a "disallowed
+ * runes" set with {@code _} and then lowercasing — before forming the final data stream name.
+ *
+ * <p><strong>Position matters.</strong> The exporter uses two different disallowed sets:
+ * <ul>
+ *   <li><b>Dataset</b>: {@code DISALLOWED_DATASET_RUNES = "-\\/*?\"<>| ,#:"} — hyphen included.
+ *   So an org id like {@code my-org-1} stored as the dataset becomes {@code my_org_1}.</li>
+ *   <li><b>Namespace</b>: {@code DISALLOWED_NAMESPACE_RUNES = "\\/*?\"<>| ,#:"} — hyphen <em>not</em>
+ *   included. The same {@code my-org-1} stored as the namespace stays {@code my-org-1}.</li>
+ * </ul>
+ *
+ * <p>Templates follow the OTel ES exporter shape {@code <type>-<dataset>.otel-<namespace>}. The
+ * literal {@code .otel-} marker splits the two halves: placeholders appearing before it land in the
+ * dataset slot (strict rule, hyphens stripped); placeholders after it land in the namespace slot
+ * (looser rule, hyphens preserved). Applying the dataset rule uniformly would silently strip hyphens
+ * from namespace-position placeholders, producing index names that don't match what the collector
+ * actually writes — every look-up misses.
+ *
+ * <p>Templates with no {@code .otel-} marker fall back to the dataset rule. Same-placeholder-in-both-
+ * slots (unusual but possible) uses the stricter dataset rule so the value is safe everywhere.
  *
  * <p>Source of the rune sets + algorithm:
  * {@code https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/exporter/elasticsearchexporter/data_stream_router.go}
  * — see {@code sanitizeDataStreamField}, {@code disallowedDatasetRunes},
  * {@code disallowedNamespaceRunes}, and {@code maxDataStreamBytes}.
- *
- * <p>Design note: we apply the dataset rule (the stricter superset) to every placeholder, not just
- * those in dataset position within the template. Templates for the OTel scopes always target OTel
- * data streams by construction, and a placeholder in namespace position has hyphens preserved by
- * the namespace rule but they'd just be cosmetic — the look-up still works once both sides agree
- * on the substitution. The trade-off (losing potential hyphens in namespace-position placeholders)
- * is preferable to the risk of getting the position detection wrong.
  *
  * @author GraviteeSource Team
  */
@@ -57,28 +62,56 @@ public final class OtelDataStreamIndexUtils {
      */
     private static final String DISALLOWED_DATASET_RUNES = "-\\/*?\"<>| ,#:";
 
+    /**
+     * Characters disallowed in OTel data stream namespace components — same set as dataset minus the
+     * hyphen. Lets per-tenant ids that contain hyphens (Cockpit-style HRIDs, UUIDs) survive the
+     * substitution and match what the exporter actually writes.
+     */
+    private static final String DISALLOWED_NAMESPACE_RUNES = "\\/*?\"<>| ,#:";
+
     /** Max byte length of a sanitised dataset / namespace component, matching the exporter constant. */
     private static final int MAX_DATA_STREAM_BYTES = 100;
+
+    /** Literal marker separating the dataset (left) and namespace (right) halves of an OTel template. */
+    private static final String OTEL_TEMPLATE_MARKER = ".otel-";
 
     private OtelDataStreamIndexUtils() {}
 
     /**
      * Substitutes {@code {placeholder}} tokens in {@code template}, sanitising each replacement
-     * value per OTel data stream dataset rules (disallowed runes → {@code _}, others lowercased,
-     * truncated to {@value #MAX_DATA_STREAM_BYTES} bytes). The template's own structural characters
-     * are left untouched — only the substituted values are sanitised.
+     * value with the OTel rule that matches the placeholder's position in the template — dataset for
+     * placeholders left of {@code .otel-}, namespace for placeholders right of it. Both rules
+     * lowercase the result and truncate to {@value #MAX_DATA_STREAM_BYTES} bytes; the difference is
+     * whether the hyphen survives.
      */
     public static String format(String template, Map<String, String> parameters) {
+        int markerAt = template.indexOf(OTEL_TEMPLATE_MARKER);
+        String datasetSlot = markerAt >= 0 ? template.substring(0, markerAt) : template;
+
         var resolved = template;
         for (var entry : parameters.entrySet()) {
-            var sanitised = sanitiseDatasetComponent(entry.getValue());
-            resolved = resolved.replaceAll(String.format("\\{%s}", entry.getKey()), Matcher.quoteReplacement(sanitised));
+            var placeholder = "{" + entry.getKey() + "}";
+            // A placeholder living in both slots is unusual but legal — use the stricter dataset rule
+            // so the substituted value is also safe in the dataset slot (a hyphen would otherwise be
+            // illegal there). Pure namespace-only placeholders keep their hyphens.
+            boolean inDataset = datasetSlot.contains(placeholder);
+            var sanitised = inDataset ? sanitiseDatasetComponent(entry.getValue()) : sanitiseNamespaceComponent(entry.getValue());
+            resolved = resolved.replace(placeholder, sanitised);
         }
         return resolved;
     }
 
     /** Visible for test. Mirrors the OTel exporter's {@code sanitizeDataStreamField} for dataset components. */
     static String sanitiseDatasetComponent(String value) {
+        return sanitiseAgainst(value, DISALLOWED_DATASET_RUNES);
+    }
+
+    /** Visible for test. Mirrors the OTel exporter's {@code sanitizeDataStreamField} for namespace components. */
+    static String sanitiseNamespaceComponent(String value) {
+        return sanitiseAgainst(value, DISALLOWED_NAMESPACE_RUNES);
+    }
+
+    private static String sanitiseAgainst(String value, String disallowedRunes) {
         if (value == null || value.isEmpty()) {
             return value;
         }
@@ -86,7 +119,7 @@ public final class OtelDataStreamIndexUtils {
         int idx = 0;
         while (idx < value.length()) {
             int cp = value.codePointAt(idx);
-            if (cp < 128 && DISALLOWED_DATASET_RUNES.indexOf(cp) >= 0) {
+            if (cp < 128 && disallowedRunes.indexOf(cp) >= 0) {
                 sb.append('_');
             } else {
                 sb.appendCodePoint(Character.toLowerCase(cp));

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/otel/log/ElasticsearchOtelLogRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/otel/log/ElasticsearchOtelLogRepositoryTest.java
@@ -64,9 +64,10 @@ class ElasticsearchOtelLogRepositoryTest {
         ArgumentCaptor<String> bodyCaptor = ArgumentCaptor.forClass(String.class);
         Mockito.verify(client).search(indexCaptor.capture(), eq(null), bodyCaptor.capture());
 
-        // Hyphen in orgId converted to underscore by the OTel-mode dataset normalisation — matches
-        // the data stream the collector wrote (see OtelDataStreamIndexUtils javadoc).
-        assertThat(indexCaptor.getValue()).isEqualTo("logs-apim.otel-test_org");
+        // Hyphen in orgId preserved: the {orgId} placeholder lives in the namespace slot of the
+        // shipped template (logs-apim.otel-{orgId}), and the OTel namespace rule keeps hyphens —
+        // matches what the collector writes (see OtelDataStreamIndexUtils javadoc).
+        assertThat(indexCaptor.getValue()).isEqualTo("logs-apim.otel-test-org");
 
         JsonNode body = MAPPER.readTree(bodyCaptor.getValue());
         JsonNode filter = body.path("query").path("bool").path("filter");
@@ -420,9 +421,9 @@ class ElasticsearchOtelLogRepositoryTest {
 
         ArgumentCaptor<String> indexCaptor = ArgumentCaptor.forClass(String.class);
         Mockito.verify(client).search(indexCaptor.capture(), eq(null), any());
-        // Both placeholders go through the same dataset normalisation, so hyphens in either
-        // value become underscores.
-        assertThat(indexCaptor.getValue()).isEqualTo("logs-apim.otel-test_org-test_env");
+        // Both placeholders live in namespace position (right of .otel-) so the namespace rule
+        // applies — hyphens in either value are preserved, matching what the OTel exporter writes.
+        assertThat(indexCaptor.getValue()).isEqualTo("logs-apim.otel-test-org-test-env");
     }
 
     @Test

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/tracing/ElasticsearchTracingRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/tracing/ElasticsearchTracingRepositoryTest.java
@@ -81,9 +81,10 @@ class ElasticsearchTracingRepositoryTest {
         ArgumentCaptor<String> bodyCaptor = ArgumentCaptor.forClass(String.class);
         Mockito.verify(client).search(indexCaptor.capture(), eq(null), bodyCaptor.capture());
 
-        // Hyphen in orgId converted to underscore by the OTel-mode dataset normalisation — matches
-        // the data stream the collector wrote (see OtelDataStreamIndexUtils javadoc).
-        assertThat(indexCaptor.getValue()).isEqualTo("traces-apim.otel-test_org");
+        // Hyphen in orgId preserved: the {orgId} placeholder lives in the namespace slot of the
+        // shipped template (traces-apim.otel-{orgId}), and the OTel namespace rule keeps hyphens —
+        // matches what the collector writes (see OtelDataStreamIndexUtils javadoc).
+        assertThat(indexCaptor.getValue()).isEqualTo("traces-apim.otel-test-org");
 
         JsonNode body = MAPPER.readTree(bodyCaptor.getValue());
         JsonNode filter = body.path("query").path("bool").path("filter");

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/utils/OtelDataStreamIndexUtilsTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/utils/OtelDataStreamIndexUtilsTest.java
@@ -27,11 +27,49 @@ import org.junit.jupiter.api.Test;
 class OtelDataStreamIndexUtilsTest {
 
     @Test
-    void should_replace_hyphens_in_substituted_values_with_underscore() {
-        // Original bug: orgId "my-org-1" against a Gravitee-side template stays "my-org-1", but the
-        // OTel collector wrote the data stream with hyphens converted to underscores — query misses.
+    void should_replace_hyphens_in_dataset_position_with_underscore() {
+        // Dataset-position placeholder: the OTel exporter strips hyphens from the dataset component,
+        // so we must do the same on the read side or every query misses.
         String result = OtelDataStreamIndexUtils.format("traces-gamma_{orgId}.otel-dev_apim_master", Map.of("orgId", "my-org-1"));
         assertThat(result).isEqualTo("traces-gamma_my_org_1.otel-dev_apim_master");
+    }
+
+    @Test
+    void should_keep_hyphens_in_namespace_position() {
+        // Namespace-position placeholder: the OTel exporter's namespace rule keeps hyphens, so
+        // stripping them on the read side would query an index the collector never wrote (this is
+        // the bug the position-aware fix addresses for the shipped logs-apim.otel-{orgId} default).
+        String result = OtelDataStreamIndexUtils.format("traces-apim.otel-{orgId}", Map.of("orgId", "my-super-org"));
+        assertThat(result).isEqualTo("traces-apim.otel-my-super-org");
+    }
+
+    @Test
+    void should_apply_namespace_rule_to_every_placeholder_right_of_the_otel_marker() {
+        // Multi-segment namespace (e.g. "{orgId}-{envId}") — each placeholder lands right of .otel-
+        // and keeps its hyphens. The structural hyphen between the two placeholders is part of the
+        // template, not a value, so it's preserved untouched.
+        var params = new LinkedHashMap<String, String>();
+        params.put("orgId", "my-org");
+        params.put("envId", "my-env");
+        String result = OtelDataStreamIndexUtils.format("logs-apim.otel-{orgId}-{envId}", params);
+        assertThat(result).isEqualTo("logs-apim.otel-my-org-my-env");
+    }
+
+    @Test
+    void should_apply_dataset_rule_when_placeholder_lives_in_both_slots() {
+        // Same placeholder used in both dataset and namespace position — pick the stricter rule so
+        // the substituted value is legal in the dataset slot too (hyphens are disallowed there).
+        // Unusual shape but legal — the namespace ends up with the stripped form too, which is fine.
+        String result = OtelDataStreamIndexUtils.format("traces-gamma_{orgId}.otel-{orgId}", Map.of("orgId", "my-org"));
+        assertThat(result).isEqualTo("traces-gamma_my_org.otel-my_org");
+    }
+
+    @Test
+    void should_fall_back_to_dataset_rule_when_template_has_no_otel_marker() {
+        // Legacy or custom template without the .otel- separator — no position info, so apply the
+        // stricter rule. Conservative: never produce an index name the exporter would reject.
+        String result = OtelDataStreamIndexUtils.format("custom-{orgId}", Map.of("orgId", "my-org"));
+        assertThat(result).isEqualTo("custom-my_org");
     }
 
     @Test
@@ -63,17 +101,17 @@ class OtelDataStreamIndexUtilsTest {
     }
 
     @Test
-    void should_apply_multiple_substitutions_in_one_pass() {
+    void should_apply_multiple_substitutions_in_one_pass_with_position_aware_rules() {
         // LinkedHashMap to make the ordering explicit — substitution order doesn't matter functionally
         // (no value contains another placeholder pattern), but pinning it makes the assertion stable.
+        // Dataset-position placeholders ({module}, {orgId}) get the strict rule; namespace-position
+        // ({namespace}) gets the looser rule that preserves hyphens.
         var params = new LinkedHashMap<String, String>();
         params.put("module", "gamma");
         params.put("orgId", "DEFAULT");
         params.put("namespace", "prod-eu");
         String result = OtelDataStreamIndexUtils.format("traces-{module}_{orgId}.otel-{namespace}", params);
-        // namespace placeholder goes through the dataset rule too — hyphens in user-supplied values
-        // are universally converted, per the always-strict design choice.
-        assertThat(result).isEqualTo("traces-gamma_default.otel-prod_eu");
+        assertThat(result).isEqualTo("traces-gamma_default.otel-prod-eu");
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/src/main/resources/config/gravitee.yml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-distribution/src/main/resources/config/gravitee.yml
@@ -266,16 +266,24 @@ repositories:
 # OTel traces repository — feeds the gamma APIM tracing resource. Defaults to "none" so a dev install
 # bootstraps without OTel infra; the NoOpTracingRepository returns empty results so any consumer code
 # stays bean-resolvable. Set type to "elasticsearch" and fill in the block below to wire the real
-# ES-backed TracingRepository. Configuration is fully independent from analytics (same per-scope
-# pattern as ratelimit.redis / distributed-sync.redis). When enabled, the ES cluster declared below
+# ES-backed TracingRepository. When enabled, the ES cluster declared below
 # must be the one the OTel collector / Elastic Cloud OTLP endpoint writes traces to.
   otel-traces:
     type: none # or "elasticsearch" to enable the block below
 #    elasticsearch:
-#      # Index/data-stream template — {orgId} / {envId} placeholders are substituted (lowercased) from the
-#      # caller's QueryContext at query time, matching the analytics IndexNameUtils.format convention.
-#      # Should match the data-stream name the OTel collector elasticsearch exporter (mapping.mode: otel)
-#      # writes to.
+#      # Index/data-stream template — must follow the OTel data-stream shape:
+#      #     <type>-<dataset>.otel-<namespace>
+#      # `<type>` is fixed by the signal (`traces` here), and the literal `.otel-` segment is part of
+#      # the OTel naming convention — neither is configurable. Only the dataset and namespace halves
+#      # are yours to shape; the template needs both halves around the `.otel-` separator or the
+#      # reader can't match what the OTel exporter writes.
+#      # {orgId} / {envId} placeholders are substituted (lowercased) from the caller's QueryContext
+#      # at query time, then sanitised position-aware to mirror the OTel collector's two disallowed-
+#      # runes sets:
+#      #   - Placeholders left of `.otel-` (dataset slot)   strip `-\/*?"<>| ,#:` to `_`
+#      #   - Placeholders right of `.otel-` (namespace slot) strip `\/*?"<>| ,#:` to `_` (hyphen kept)
+#      # So an org id like `my-org-1` becomes `my_org_1` in dataset position and stays `my-org-1` in
+#      # namespace position — matching what the exporter writes on either side.
 #      index: traces-apim.otel-{orgId}
 #      endpoints:
 #        - http://${ds.elastic.host}:${ds.elastic.port}
@@ -315,9 +323,19 @@ repositories:
   otel-logs:
     type: none # or "elasticsearch" to enable the block below
 #    elasticsearch:
-#      # Index/data-stream template — {orgId} / {envId} placeholders are substituted (lowercased) from the
-#      # caller's QueryContext at query time. Should match the data-stream name the OTel collector
-#      # elasticsearch exporter (mapping.mode: otel) writes to AND the one gravitee-reporter-otel ships to.
+#      # Index/data-stream template — must follow the OTel data-stream shape:
+#      #     <type>-<dataset>.otel-<namespace>
+#      # `<type>` is fixed by the signal (`logs` here), and the literal `.otel-` segment is part of
+#      # the OTel naming convention — neither is configurable. Only the dataset and namespace halves
+#      # are yours to shape; the template needs both halves around the `.otel-` separator or the
+#      # reader can't match what the OTel exporter (and gravitee-reporter-otel) writes.
+#      # {orgId} / {envId} placeholders are substituted (lowercased) from the caller's QueryContext
+#      # at query time, then sanitised position-aware to mirror the OTel collector's two disallowed-
+#      # runes sets:
+#      #   - Placeholders left of `.otel-` (dataset slot)   strip `-\/*?"<>| ,#:` to `_`
+#      #   - Placeholders right of `.otel-` (namespace slot) strip `\/*?"<>| ,#:` to `_` (hyphen kept)
+#      # So an org id like `my-org-1` becomes `my_org_1` in dataset position and stays `my-org-1` in
+#      # namespace position — matching what the writers produce on either side.
 #      index: logs-apim.otel-{orgId}
 #      endpoints:
 #        - http://${ds.elastic.host}:${ds.elastic.port}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -1137,9 +1137,18 @@ api:
   otelTraces:
     type: none # or elasticsearch
     elasticsearch:
-      # Index/data-stream name template. {orgId} / {envId} are substituted (lowercased) from the caller's
-      # QueryContext at query time, matching the analytics IndexNameUtils.format convention. Should match the
-      # data-stream name the OTel collector elasticsearch exporter (mapping.mode: otel) writes to.
+      # Index/data-stream template — must follow the OTel data-stream shape:
+      #     <type>-<dataset>.otel-<namespace>
+      # `<type>` is fixed by the signal (`traces` here), and the literal `.otel-` segment is part of the OTel
+      # naming convention — neither is configurable. Only the dataset and namespace halves are yours to shape;
+      # the template needs both halves around the `.otel-` separator or the reader can't match what the OTel
+      # exporter writes.
+      # {orgId} / {envId} placeholders are substituted (lowercased) from the caller's QueryContext at query
+      # time, then sanitised position-aware to mirror the OTel collector's two disallowed-runes sets:
+      #   - Placeholders left of `.otel-` (dataset slot)   strip `-\/*?"<>| ,#:` to `_`
+      #   - Placeholders right of `.otel-` (namespace slot) strip `\/*?"<>| ,#:` to `_` (hyphen kept)
+      # So an org id like `my-org-1` becomes `my_org_1` in dataset position and stays `my-org-1` in namespace
+      # position — matching what the exporter writes on either side.
       index: traces-apim.otel-{orgId}
       endpoints:
         - http://elasticsearch:9200
@@ -1164,9 +1173,18 @@ api:
   otelLogs:
     type: none # or elasticsearch
     elasticsearch:
-      # Index/data-stream template — {orgId} / {envId} are substituted (lowercased) from the caller's
-      # QueryContext at query time. Should match the data-stream name the OTel collector elasticsearch
-      # exporter (mapping.mode: otel) writes to AND the one gravitee-reporter-otel ships to.
+      # Index/data-stream template — must follow the OTel data-stream shape:
+      #     <type>-<dataset>.otel-<namespace>
+      # `<type>` is fixed by the signal (`logs` here), and the literal `.otel-` segment is part of the OTel
+      # naming convention — neither is configurable. Only the dataset and namespace halves are yours to shape;
+      # the template needs both halves around the `.otel-` separator or the reader can't match what the OTel
+      # exporter (and gravitee-reporter-otel) writes.
+      # {orgId} / {envId} placeholders are substituted (lowercased) from the caller's QueryContext at query
+      # time, then sanitised position-aware to mirror the OTel collector's two disallowed-runes sets:
+      #   - Placeholders left of `.otel-` (dataset slot)   strip `-\/*?"<>| ,#:` to `_`
+      #   - Placeholders right of `.otel-` (namespace slot) strip `\/*?"<>| ,#:` to `_` (hyphen kept)
+      # So an org id like `my-org-1` becomes `my_org_1` in dataset position and stays `my-org-1` in namespace
+      # position — matching what the writers produce on either side.
       index: logs-apim.otel-{orgId}
       endpoints:
         - http://elasticsearch:9200


### PR DESCRIPTION
## Summary
`OtelDataStreamIndexUtils.format` applied the dataset sanitisation rule (hyphen → `_`) to every placeholder regardless of slot. Shipped defaults put `{orgId}` in **namespace** position (`logs-apim.otel-{orgId}`, `traces-apim.otel-{orgId}`) where the OTel collector keeps hyphens — so the reader queried an index the writer never wrote. Any hyphenated org / env id (UUIDs, Cockpit HRIDs) silently returned **zero results**.

Position-aware fix: split the template on `.otel-` — left of it uses the dataset rule (hyphen stripped), right of it uses the namespace rule (hyphen kept). Same-placeholder-in-both-slots and no-marker templates fall back to the stricter dataset rule.

## Changes
- `OtelDataStreamIndexUtils`: add `DISALLOWED_NAMESPACE_RUNES` + `sanitiseNamespaceComponent`, make `format()` position-aware, rewrite javadoc.
- `OtelDataStreamIndexUtilsTest`: add namespace-keeps-hyphens, both-slots, and no-marker tests.
- `ElasticsearchOtelLogRepositoryTest:69/425` + `ElasticsearchTracingRepositoryTest:86`: flip assertions that encoded the bug (`test_org` → `test-org`).
- `gravitee.yml` and `helm/values.yaml`: document the data-stream shape contract and which characters get stripped where.

## Affected versions
- `master` — fixes the bug introduced by #17246.
- `4.12.x` — at risk via open backport #17405; this fix should be carried into that backport before it merges.
- `4.11.x` and earlier — not affected (no #17246 backport).

🤖 Generated with [Claude Code](https://claude.com/claude-code)