### PR TITLE
feat: implement application invitation resend

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/mapper/ApplicationInvitationMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/mapper/ApplicationInvitationMapper.java
@@ -29,6 +29,8 @@ import org.mapstruct.factory.Mappers;
 public interface ApplicationInvitationMapper {
     ApplicationInvitationMapper INSTANCE = Mappers.getMapper(ApplicationInvitationMapper.class);
 
+    @Mapping(target = "id", expression = "java(map(invitation.id()))")
+    @Mapping(target = "email", expression = "java(invitation.email())")
     @Mapping(target = "role", source = "roleName")
     Invitation toInvitation(ApplicationInvitation invitation);
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/mapper/ApplicationInvitationResendInputMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/mapper/ApplicationInvitationResendInputMapper.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.portal.rest.mapper;
+
+import io.gravitee.rest.api.portal.rest.model.InvitationResendInput;
+import java.net.URI;
+import org.mapstruct.Mapper;
+import org.mapstruct.factory.Mappers;
+
+@Mapper
+public interface ApplicationInvitationResendInputMapper {
+    ApplicationInvitationResendInputMapper INSTANCE = Mappers.getMapper(ApplicationInvitationResendInputMapper.class);
+
+    default URI toConfirmationPageUrl(InvitationResendInput input) {
+        return input.getConfirmationPageUrl();
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/ApplicationInvitationsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/ApplicationInvitationsResource.java
@@ -18,6 +18,7 @@ package io.gravitee.rest.api.portal.rest.resource;
 import io.gravitee.apim.core.invitation.model.InvitationId;
 import io.gravitee.apim.core.invitation.use_case.CreateApplicationInvitationsUseCase;
 import io.gravitee.apim.core.invitation.use_case.DeleteApplicationInvitationUseCase;
+import io.gravitee.apim.core.invitation.use_case.ResendApplicationInvitationUseCase;
 import io.gravitee.apim.core.invitation.use_case.SearchApplicationInvitationsUseCase;
 import io.gravitee.apim.core.invitation.use_case.UpdateApplicationInvitationUseCase;
 import io.gravitee.common.http.MediaType;
@@ -25,11 +26,13 @@ import io.gravitee.rest.api.model.common.PageableImpl;
 import io.gravitee.rest.api.model.permissions.RolePermission;
 import io.gravitee.rest.api.model.permissions.RolePermissionAction;
 import io.gravitee.rest.api.portal.rest.mapper.ApplicationInvitationMapper;
+import io.gravitee.rest.api.portal.rest.mapper.ApplicationInvitationResendInputMapper;
 import io.gravitee.rest.api.portal.rest.mapper.ApplicationInvitationUpdateInputMapper;
 import io.gravitee.rest.api.portal.rest.mapper.ApplicationInvitationsCreateInputMapper;
 import io.gravitee.rest.api.portal.rest.mapper.ApplicationInvitationsSearchCriteriaMapper;
 import io.gravitee.rest.api.portal.rest.model.ApplicationInvitationsSearchInput;
 import io.gravitee.rest.api.portal.rest.model.InvitationCreateInput;
+import io.gravitee.rest.api.portal.rest.model.InvitationResendInput;
 import io.gravitee.rest.api.portal.rest.model.InvitationUpdateInput;
 import io.gravitee.rest.api.portal.rest.model.InvitationsResponse;
 import io.gravitee.rest.api.portal.rest.resource.param.PaginationParam;
@@ -68,6 +71,9 @@ public class ApplicationInvitationsResource extends AbstractResource {
 
     @Inject
     private UpdateApplicationInvitationUseCase updateApplicationInvitationUseCase;
+
+    @Inject
+    private ResendApplicationInvitationUseCase resendApplicationInvitationUseCase;
 
     @POST
     @Consumes(MediaType.APPLICATION_JSON)
@@ -159,5 +165,29 @@ public class ApplicationInvitationsResource extends AbstractResource {
         );
 
         return Response.ok(INVITATION_MAPPER.toInvitation(output.invitation())).build();
+    }
+
+    @POST
+    @Path("/{invitationId}/_resend")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    @Permissions({ @Permission(value = RolePermission.APPLICATION_MEMBER, acls = RolePermissionAction.UPDATE) })
+    public Response resendApplicationInvitation(
+        @PathParam("applicationId") String applicationId,
+        @PathParam("invitationId") String invitationId,
+        @Valid @NotNull(message = "Input must not be null.") InvitationResendInput input
+    ) {
+        var executionContext = GraviteeContext.getExecutionContext();
+        resendApplicationInvitationUseCase.execute(
+            new ResendApplicationInvitationUseCase.Input(
+                executionContext.getOrganizationId(),
+                executionContext.getEnvironmentId(),
+                applicationId,
+                InvitationId.of(invitationId),
+                ApplicationInvitationResendInputMapper.INSTANCE.toConfirmationPageUrl(input)
+            )
+        );
+
+        return Response.noContent().build();
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/resources/portal-openapi.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/resources/portal-openapi.yaml
@@ -1527,6 +1527,13 @@ paths:
         post:
             tags:
                 - Application
+            requestBody:
+                description: Use to configure the resent application invitation email.
+                required: true
+                content:
+                    application/json:
+                        schema:
+                            $ref: "#/components/schemas/InvitationResendInput"
             summary: Resend an application invitation
             description: |
                 Resend an application invitation.
@@ -7331,6 +7338,15 @@ components:
                     default: true
                 confirmation_page_url:
                     description: URL of the confirmation page to be used in the application invitation email.
+                    type: string
+                    format: uri
+        InvitationResendInput:
+            type: object
+            required:
+                - confirmation_page_url
+            properties:
+                confirmation_page_url:
+                    description: URL of the confirmation page to be used in the resent application invitation email.
                     type: string
                     format: uri
         InvitationRecipientInput:

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/mapper/ApplicationInvitationMapperTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/mapper/ApplicationInvitationMapperTest.java
@@ -30,7 +30,7 @@ class ApplicationInvitationMapperTest {
     @Test
     void should_map_application_invitation_item() {
         var invitationId = "00000000-0000-0000-0000-000000000001";
-        var invitationItem = new ApplicationInvitation(
+        var invitationItem = ApplicationInvitation.of(
             InvitationId.of(invitationId),
             "application-id",
             "alice@example.com",

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/ApplicationInvitationsResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/ApplicationInvitationsResourceTest.java
@@ -42,6 +42,7 @@ import io.gravitee.rest.api.portal.rest.model.ApplicationInvitationsSearchFilter
 import io.gravitee.rest.api.portal.rest.model.ApplicationInvitationsSearchInput;
 import io.gravitee.rest.api.portal.rest.model.InvitationCreateInput;
 import io.gravitee.rest.api.portal.rest.model.InvitationRecipientInput;
+import io.gravitee.rest.api.portal.rest.model.InvitationResendInput;
 import io.gravitee.rest.api.portal.rest.model.InvitationUpdateInput;
 import io.gravitee.rest.api.portal.rest.model.InvitationsResponse;
 import jakarta.ws.rs.client.Entity;
@@ -317,6 +318,87 @@ class ApplicationInvitationsResourceTest extends AbstractResourceTest {
     }
 
     @Test
+    void should_resend_invitation() {
+        var invitationId = InvitationId.of(INVITATION_ID_1);
+        when(invitationCrudService.findApplicationInvitationById(invitationId)).thenReturn(
+            Optional.of(anInvitation(INVITATION_ID_1, "alice@example.com"))
+        );
+        when(invitationCrudService.update(any(ApplicationInvitation.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        var response = target(APPLICATION)
+            .path("invitations")
+            .path(INVITATION_ID_1)
+            .path("_resend")
+            .request()
+            .post(Entity.json(new InvitationResendInput().confirmationPageUrl(CONFIRMATION_PAGE_URL)));
+
+        assertThat(response.getStatus()).isEqualTo(HttpStatusCode.NO_CONTENT_204);
+        verify(invitationCrudService).update(
+            argThat(
+                updatedInvitation ->
+                    updatedInvitation.id().equals(invitationId) &&
+                    updatedInvitation.applicationId().equals(APPLICATION) &&
+                    updatedInvitation.email().equals("alice@example.com") &&
+                    updatedInvitation.roleName().equals(ROLE_NAME)
+            )
+        );
+        verify(applicationInvitationNotificationDomainService).dispatchAsync(
+            anyString(),
+            anyString(),
+            eq(APPLICATION),
+            argThat(invitations -> invitations.size() == 1 && invitations.get(0).email().equals("alice@example.com")),
+            eq(CONFIRMATION_PAGE_URL)
+        );
+    }
+
+    @Test
+    void should_return_bad_request_when_resending_invitation_without_confirmation_page_url() {
+        var response = target(APPLICATION)
+            .path("invitations")
+            .path(INVITATION_ID_1)
+            .path("_resend")
+            .request()
+            .post(Entity.json(new InvitationResendInput()));
+
+        assertThat(response.getStatus()).isEqualTo(HttpStatusCode.BAD_REQUEST_400);
+        verify(invitationCrudService, never()).findApplicationInvitationById(any());
+        verify(invitationCrudService, never()).update(any());
+        verifyNoInvitationNotificationDispatch();
+    }
+
+    @Test
+    void should_return_not_found_when_resending_invitation_for_unknown_application() {
+        var response = target(UNKNOWN_APPLICATION)
+            .path("invitations")
+            .path(INVITATION_ID_1)
+            .path("_resend")
+            .request()
+            .post(Entity.json(new InvitationResendInput().confirmationPageUrl(CONFIRMATION_PAGE_URL)));
+
+        assertThat(response.getStatus()).isEqualTo(HttpStatusCode.NOT_FOUND_404);
+        verify(invitationCrudService, never()).findApplicationInvitationById(any());
+        verify(invitationCrudService, never()).update(any());
+        verifyNoInvitationNotificationDispatch();
+    }
+
+    @Test
+    void should_return_not_found_when_resending_unknown_invitation() {
+        var invitationId = InvitationId.of(INVITATION_ID_1);
+        when(invitationCrudService.findApplicationInvitationById(invitationId)).thenReturn(Optional.empty());
+
+        var response = target(APPLICATION)
+            .path("invitations")
+            .path(INVITATION_ID_1)
+            .path("_resend")
+            .request()
+            .post(Entity.json(new InvitationResendInput().confirmationPageUrl(CONFIRMATION_PAGE_URL)));
+
+        assertThat(response.getStatus()).isEqualTo(HttpStatusCode.NOT_FOUND_404);
+        verify(invitationCrudService, never()).update(any());
+        verifyNoInvitationNotificationDispatch();
+    }
+
+    @Test
     void should_update_invitation_role() {
         var invitationId = InvitationId.of(INVITATION_ID_1);
         when(invitationCrudService.findApplicationInvitationById(invitationId)).thenReturn(
@@ -430,7 +512,7 @@ class ApplicationInvitationsResourceTest extends AbstractResourceTest {
     }
 
     private ApplicationInvitation anInvitation(String id, String applicationId, String email) {
-        return new ApplicationInvitation(
+        return ApplicationInvitation.of(
             InvitationId.of(id),
             applicationId,
             email,
@@ -446,6 +528,10 @@ class ApplicationInvitationsResourceTest extends AbstractResourceTest {
             .role(ROLE_NAME)
             .notify(notify)
             .confirmationPageUrl(CONFIRMATION_PAGE_URL);
+    }
+
+    private void verifyNoInvitationNotificationDispatch() {
+        verify(applicationInvitationNotificationDomainService, never()).dispatchAsync(anyString(), anyString(), anyString(), any(), any());
     }
 
     private Role applicationRole(String roleName) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/invitation/domain_service/ResendApplicationInvitationDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/invitation/domain_service/ResendApplicationInvitationDomainService.java
@@ -20,32 +20,41 @@ import io.gravitee.apim.core.invitation.crud_service.InvitationCrudService;
 import io.gravitee.apim.core.invitation.exception.ApplicationInvitationNotFoundException;
 import io.gravitee.apim.core.invitation.model.ApplicationInvitation;
 import io.gravitee.apim.core.invitation.model.InvitationId;
-import io.gravitee.apim.core.invitation.model.UpdateApplicationInvitation;
 import jakarta.annotation.Nonnull;
+import java.net.URI;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 
 @DomainService
 @RequiredArgsConstructor
-public class UpdateApplicationInvitationDomainService {
+public class ResendApplicationInvitationDomainService {
 
     private final InvitationCrudService invitationCrudService;
-    private final ValidateApplicationInvitationRoleDomainService validateApplicationInvitationRoleDomainService;
+    private final ApplicationInvitationNotificationDomainService applicationInvitationNotificationDomainService;
 
-    public ApplicationInvitation update(
+    public ApplicationInvitation resend(
         @Nonnull String organizationId,
+        @Nonnull String environmentId,
         @Nonnull String applicationId,
         @Nonnull InvitationId invitationId,
-        @Nonnull UpdateApplicationInvitation updateApplicationInvitation
+        URI confirmationPageUrl
     ) {
         var invitation = invitationCrudService
             .findApplicationInvitationById(invitationId)
             .filter(applicationInvitation -> applicationId.equals(applicationInvitation.applicationId()))
             .orElseThrow(() -> new ApplicationInvitationNotFoundException(invitationId.toString()));
 
-        validateApplicationInvitationRoleDomainService.validate(organizationId, updateApplicationInvitation.roleName());
+        invitation.markResendAttempted();
 
-        invitation.updateRole(updateApplicationInvitation.roleName());
+        var resentInvitation = invitationCrudService.update(invitation);
+        applicationInvitationNotificationDomainService.dispatchAsync(
+            organizationId,
+            environmentId,
+            applicationId,
+            List.of(resentInvitation),
+            confirmationPageUrl
+        );
 
-        return invitationCrudService.update(invitation);
+        return resentInvitation;
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/invitation/model/ApplicationInvitation.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/invitation/model/ApplicationInvitation.java
@@ -17,21 +17,130 @@ package io.gravitee.apim.core.invitation.model;
 
 import io.gravitee.common.utils.TimeProvider;
 import java.time.ZonedDateTime;
+import java.util.Objects;
+import lombok.Getter;
 
-public record ApplicationInvitation(
-    InvitationId id,
-    String applicationId,
-    String email,
-    String roleName,
-    ZonedDateTime createdAt,
-    ZonedDateTime updatedAt
-) implements Invitation {
+public final class ApplicationInvitation implements Invitation {
+
+    private final InvitationId id;
+
+    @Getter
+    private final String applicationId;
+
+    private final String email;
+
+    @Getter
+    private String roleName;
+
+    @Getter
+    private final ZonedDateTime createdAt;
+
+    @Getter
+    private ZonedDateTime updatedAt;
+
+    private ApplicationInvitation(
+        InvitationId id,
+        String applicationId,
+        String email,
+        String roleName,
+        ZonedDateTime createdAt,
+        ZonedDateTime updatedAt
+    ) {
+        this.id = id;
+        this.applicationId = applicationId;
+        this.email = email;
+        this.roleName = roleName;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+    }
+
     public static ApplicationInvitation create(String applicationId, String email, String roleName) {
         var now = TimeProvider.now();
         return new ApplicationInvitation(InvitationId.random(), applicationId, email, roleName, now, now);
     }
 
-    public ApplicationInvitation updateRole(String roleName) {
-        return new ApplicationInvitation(id, applicationId, email, roleName, createdAt, TimeProvider.now());
+    public static ApplicationInvitation of(
+        InvitationId id,
+        String applicationId,
+        String email,
+        String roleName,
+        ZonedDateTime createdAt,
+        ZonedDateTime updatedAt
+    ) {
+        return new ApplicationInvitation(id, applicationId, email, roleName, createdAt, updatedAt);
+    }
+
+    public void updateRole(String roleName) {
+        this.roleName = roleName;
+        this.updatedAt = TimeProvider.now();
+    }
+
+    public void markResendAttempted() {
+        this.updatedAt = TimeProvider.now();
+    }
+
+    @Override
+    public InvitationId id() {
+        return id;
+    }
+
+    public String applicationId() {
+        return applicationId;
+    }
+
+    @Override
+    public String email() {
+        return email;
+    }
+
+    public String roleName() {
+        return roleName;
+    }
+
+    public ZonedDateTime createdAt() {
+        return createdAt;
+    }
+
+    public ZonedDateTime updatedAt() {
+        return updatedAt;
+    }
+
+    @Override
+    public boolean equals(Object object) {
+        if (this == object) {
+            return true;
+        }
+        if (!(object instanceof ApplicationInvitation that)) {
+            return false;
+        }
+        return Objects.equals(id, that.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
+    }
+
+    @Override
+    public String toString() {
+        return (
+            "ApplicationInvitation{" +
+            "id=" +
+            id +
+            ", applicationId='" +
+            applicationId +
+            '\'' +
+            ", email='" +
+            email +
+            '\'' +
+            ", roleName='" +
+            roleName +
+            '\'' +
+            ", createdAt=" +
+            createdAt +
+            ", updatedAt=" +
+            updatedAt +
+            '}'
+        );
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/invitation/use_case/ResendApplicationInvitationUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/invitation/use_case/ResendApplicationInvitationUseCase.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.invitation.use_case;
+
+import io.gravitee.apim.core.UseCase;
+import io.gravitee.apim.core.application.crud_service.ApplicationCrudService;
+import io.gravitee.apim.core.invitation.domain_service.ResendApplicationInvitationDomainService;
+import io.gravitee.apim.core.invitation.model.ApplicationInvitation;
+import io.gravitee.apim.core.invitation.model.InvitationId;
+import java.net.URI;
+import lombok.RequiredArgsConstructor;
+
+@UseCase
+@RequiredArgsConstructor
+public class ResendApplicationInvitationUseCase {
+
+    private final ApplicationCrudService applicationCrudService;
+    private final ResendApplicationInvitationDomainService resendApplicationInvitationDomainService;
+
+    public Output execute(Input input) {
+        applicationCrudService.findById(input.applicationId(), input.environmentId());
+        return new Output(
+            resendApplicationInvitationDomainService.resend(
+                input.organizationId(),
+                input.environmentId(),
+                input.applicationId(),
+                input.invitationId(),
+                input.confirmationPageUrl()
+            )
+        );
+    }
+
+    public record Input(
+        String organizationId,
+        String environmentId,
+        String applicationId,
+        InvitationId invitationId,
+        URI confirmationPageUrl
+    ) {}
+
+    public record Output(ApplicationInvitation invitation) {}
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/InvitationAdapter.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/InvitationAdapter.java
@@ -32,9 +32,19 @@ import org.mapstruct.factory.Mappers;
 public interface InvitationAdapter {
     InvitationAdapter INSTANCE = Mappers.getMapper(InvitationAdapter.class);
 
-    @Mapping(target = "roleName", source = "applicationRole")
-    @Mapping(target = "applicationId", source = "referenceId")
-    ApplicationInvitation toApplicationInvitation(io.gravitee.repository.management.model.Invitation invitation);
+    default ApplicationInvitation toApplicationInvitation(io.gravitee.repository.management.model.Invitation invitation) {
+        if (invitation == null) {
+            return null;
+        }
+        return ApplicationInvitation.of(
+            map(invitation.getId()),
+            invitation.getReferenceId(),
+            invitation.getEmail(),
+            invitation.getApplicationRole(),
+            map(invitation.getCreatedAt()),
+            map(invitation.getUpdatedAt())
+        );
+    }
 
     @Mapping(target = "id", source = "id")
     @Mapping(target = "referenceId", source = "referenceId")
@@ -44,9 +54,11 @@ public interface InvitationAdapter {
     @Mapping(target = "applicationRole", source = "applicationRole")
     GroupInvitation toGroupInvitation(io.gravitee.repository.management.model.Invitation invitation);
 
-    @Mapping(target = "applicationRole", source = "roleName")
+    @Mapping(target = "id", expression = "java(map(invitation.id()))")
     @Mapping(target = "referenceId", source = "applicationId")
     @Mapping(target = "referenceType", constant = "APPLICATION")
+    @Mapping(target = "email", expression = "java(invitation.email())")
+    @Mapping(target = "applicationRole", source = "roleName")
     @Mapping(target = "apiRole", ignore = true)
     io.gravitee.repository.management.model.Invitation toRepository(ApplicationInvitation invitation);
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/fixtures/core/model/ApplicationInvitationFixtures.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/fixtures/core/model/ApplicationInvitationFixtures.java
@@ -37,7 +37,7 @@ public class ApplicationInvitationFixtures {
     }
 
     public static ApplicationInvitation anApplicationInvitation(String id, String applicationId, String email, String role) {
-        return new ApplicationInvitation(InvitationId.of(id), applicationId, email, role, date(), date());
+        return ApplicationInvitation.of(InvitationId.of(id), applicationId, email, role, date(), date());
     }
 
     private static ZonedDateTime date() {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/invitation/domain_service/ResendApplicationInvitationDomainServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/invitation/domain_service/ResendApplicationInvitationDomainServiceTest.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.invitation.domain_service;
+
+import static fixtures.core.model.ApplicationInvitationFixtures.anApplicationInvitation;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.apim.core.invitation.crud_service.InvitationCrudService;
+import io.gravitee.apim.core.invitation.exception.ApplicationInvitationNotFoundException;
+import io.gravitee.apim.core.invitation.model.ApplicationInvitation;
+import io.gravitee.apim.core.invitation.model.InvitationId;
+import io.gravitee.common.utils.TimeProvider;
+import java.net.URI;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.Optional;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ResendApplicationInvitationDomainServiceTest {
+
+    private static final String ORGANIZATION_ID = "organization-id";
+    private static final String ENVIRONMENT_ID = "environment-id";
+    private static final String APPLICATION_ID = "application-id";
+    private static final String OTHER_APPLICATION_ID = "other-application-id";
+    private static final String INVITATION_ID = "00000000-0000-0000-0000-000000000001";
+    private static final URI CONFIRMATION_PAGE_URL = URI.create("https://portal.example.com/user/registration/confirm");
+    private static final Instant RESEND_TIME = Instant.parse("2026-06-09T09:15:00Z");
+
+    @Mock
+    private InvitationCrudService invitationCrudService;
+
+    @Mock
+    private ApplicationInvitationNotificationDomainService applicationInvitationNotificationDomainService;
+
+    private ResendApplicationInvitationDomainService cut;
+
+    @BeforeEach
+    void setUp() {
+        TimeProvider.overrideClock(Clock.fixed(RESEND_TIME, ZoneId.systemDefault()));
+        cut = new ResendApplicationInvitationDomainService(invitationCrudService, applicationInvitationNotificationDomainService);
+    }
+
+    @AfterEach
+    void tearDown() {
+        TimeProvider.overrideClock(Clock.systemDefaultZone());
+    }
+
+    @Test
+    void should_resend_application_invitation() {
+        var invitationId = InvitationId.of(INVITATION_ID);
+        var invitation = anApplicationInvitation(INVITATION_ID, APPLICATION_ID, "alice@example.com", "USER");
+        when(invitationCrudService.findApplicationInvitationById(invitationId)).thenReturn(Optional.of(invitation));
+        when(invitationCrudService.update(any(ApplicationInvitation.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        var result = cut.resend(ORGANIZATION_ID, ENVIRONMENT_ID, APPLICATION_ID, invitationId, CONFIRMATION_PAGE_URL);
+
+        assertThat(result.id()).isEqualTo(invitation.id());
+        assertThat(result.applicationId()).isEqualTo(APPLICATION_ID);
+        assertThat(result.email()).isEqualTo("alice@example.com");
+        assertThat(result.roleName()).isEqualTo("USER");
+        assertThat(result.createdAt()).isEqualTo(invitation.createdAt());
+        assertThat(result.updatedAt()).isEqualTo(RESEND_TIME.atZone(ZoneId.systemDefault()));
+
+        var invitationCaptor = ArgumentCaptor.forClass(ApplicationInvitation.class);
+        verify(invitationCrudService).update(invitationCaptor.capture());
+        assertThat(invitationCaptor.getValue().updatedAt()).isEqualTo(RESEND_TIME.atZone(ZoneId.systemDefault()));
+        verify(applicationInvitationNotificationDomainService).dispatchAsync(
+            eq(ORGANIZATION_ID),
+            eq(ENVIRONMENT_ID),
+            eq(APPLICATION_ID),
+            argThat(invitations -> invitations.size() == 1 && invitations.get(0).updatedAt().equals(result.updatedAt())),
+            eq(CONFIRMATION_PAGE_URL)
+        );
+    }
+
+    @Test
+    void should_throw_when_invitation_does_not_exist() {
+        var invitationId = InvitationId.of(INVITATION_ID);
+        when(invitationCrudService.findApplicationInvitationById(invitationId)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() ->
+            cut.resend(ORGANIZATION_ID, ENVIRONMENT_ID, APPLICATION_ID, invitationId, CONFIRMATION_PAGE_URL)
+        ).isInstanceOf(ApplicationInvitationNotFoundException.class);
+
+        verify(invitationCrudService, never()).update(any());
+        verifyNoInteractions(applicationInvitationNotificationDomainService);
+    }
+
+    @Test
+    void should_throw_when_invitation_belongs_to_another_application() {
+        var invitationId = InvitationId.of(INVITATION_ID);
+        when(invitationCrudService.findApplicationInvitationById(invitationId)).thenReturn(
+            Optional.of(anApplicationInvitation(INVITATION_ID, OTHER_APPLICATION_ID, "alice@example.com", "USER"))
+        );
+
+        assertThatThrownBy(() ->
+            cut.resend(ORGANIZATION_ID, ENVIRONMENT_ID, APPLICATION_ID, invitationId, CONFIRMATION_PAGE_URL)
+        ).isInstanceOf(ApplicationInvitationNotFoundException.class);
+
+        verify(invitationCrudService, never()).update(any());
+        verifyNoInteractions(applicationInvitationNotificationDomainService);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/invitation/use_case/ResendApplicationInvitationUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/invitation/use_case/ResendApplicationInvitationUseCaseTest.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.invitation.use_case;
+
+import static fixtures.core.model.ApplicationInvitationFixtures.anApplicationInvitation;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.apim.core.application.crud_service.ApplicationCrudService;
+import io.gravitee.apim.core.invitation.domain_service.ResendApplicationInvitationDomainService;
+import io.gravitee.apim.core.invitation.model.InvitationId;
+import io.gravitee.rest.api.model.BaseApplicationEntity;
+import io.gravitee.rest.api.service.exceptions.ApplicationNotFoundException;
+import java.net.URI;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ResendApplicationInvitationUseCaseTest {
+
+    private static final String ORGANIZATION_ID = "organization-id";
+    private static final String ENVIRONMENT_ID = "environment-id";
+    private static final String APPLICATION_ID = "application-id";
+    private static final String INVITATION_ID = "00000000-0000-0000-0000-000000000001";
+    private static final URI CONFIRMATION_PAGE_URL = URI.create("https://portal.example.com/user/registration/confirm");
+
+    @Mock
+    private ApplicationCrudService applicationCrudService;
+
+    @Mock
+    private ResendApplicationInvitationDomainService resendApplicationInvitationDomainService;
+
+    private ResendApplicationInvitationUseCase cut;
+
+    @BeforeEach
+    void setUp() {
+        cut = new ResendApplicationInvitationUseCase(applicationCrudService, resendApplicationInvitationDomainService);
+    }
+
+    @Test
+    void should_validate_application_existence_before_resending_invitation() {
+        var invitationId = InvitationId.of(INVITATION_ID);
+        when(applicationCrudService.findById(APPLICATION_ID, ENVIRONMENT_ID)).thenThrow(new ApplicationNotFoundException(APPLICATION_ID));
+
+        assertThatThrownBy(() ->
+            cut.execute(
+                new ResendApplicationInvitationUseCase.Input(
+                    ORGANIZATION_ID,
+                    ENVIRONMENT_ID,
+                    APPLICATION_ID,
+                    invitationId,
+                    CONFIRMATION_PAGE_URL
+                )
+            )
+        ).isInstanceOf(ApplicationNotFoundException.class);
+
+        verifyNoInteractions(resendApplicationInvitationDomainService);
+    }
+
+    @Test
+    void should_resend_application_invitation() {
+        var invitationId = InvitationId.of(INVITATION_ID);
+        var invitation = anApplicationInvitation(INVITATION_ID, APPLICATION_ID, "alice@example.com", "USER");
+        when(applicationCrudService.findById(APPLICATION_ID, ENVIRONMENT_ID)).thenReturn(
+            BaseApplicationEntity.builder().id(APPLICATION_ID).environmentId(ENVIRONMENT_ID).build()
+        );
+        when(
+            resendApplicationInvitationDomainService.resend(
+                ORGANIZATION_ID,
+                ENVIRONMENT_ID,
+                APPLICATION_ID,
+                invitationId,
+                CONFIRMATION_PAGE_URL
+            )
+        ).thenReturn(invitation);
+
+        var output = cut.execute(
+            new ResendApplicationInvitationUseCase.Input(
+                ORGANIZATION_ID,
+                ENVIRONMENT_ID,
+                APPLICATION_ID,
+                invitationId,
+                CONFIRMATION_PAGE_URL
+            )
+        );
+
+        assertThat(output.invitation()).isEqualTo(invitation);
+        verify(resendApplicationInvitationDomainService).resend(
+            ORGANIZATION_ID,
+            ENVIRONMENT_ID,
+            APPLICATION_ID,
+            invitationId,
+            CONFIRMATION_PAGE_URL
+        );
+    }
+}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-14370

## Description

Summary
- Add backend support for resending application invitations.
- Extend the resend contract with optional confirmation_page_url.
- Update invitation updatedAt to record resend attempts.
- Dispatch resend notifications asynchronously.
