### PR TITLE
fix(deps): bump gravitee-policy-kafka-acl to 3.0.2 (APIM-13860)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -325,7 +325,7 @@
         <gravitee-policy-interops.version>1.1.3</gravitee-policy-interops.version>
         <gravitee-policy-kafka-quota.version>1.2.1</gravitee-policy-kafka-quota.version>
         <gravitee-policy-kafka-topic-mapping.version>2.0.1</gravitee-policy-kafka-topic-mapping.version>
-        <gravitee-policy-kafka-acl.version>3.0.1</gravitee-policy-kafka-acl.version>
+        <gravitee-policy-kafka-acl.version>3.0.2</gravitee-policy-kafka-acl.version>
         <gravitee-policy-kafka-transform-key.version>1.0.0</gravitee-policy-kafka-transform-key.version>
         <gravitee-policy-kafka-message-filtering.version>1.0.0</gravitee-policy-kafka-message-filtering.version>
         <gravitee-policy-kafka-message-encryption-decryption.version>1.0.0</gravitee-policy-kafka-message-encryption-decryption.version>


### PR DESCRIPTION
https://gravitee.atlassian.net/browse/APIM-14373
## Summary
- Bumps `gravitee-policy-kafka-acl` from 3.0.1 to 3.0.2 on the 4.12.x line.
- Picks up [PR #63 on gravitee-policy-kafka-acl](https://github.com/gravitee-io/gravitee-policy-kafka-acl/pull/63) — fix for [APIM-13860](https://gravitee.atlassian.net/browse/APIM-13860).

## Customer context
Zendesk #16339 (Blue Yonder). A native-Kafka consumer subscribing to several topics via a wildcard regex, whose ACL grants READ on some topics but not all, was seeing its **auto-commit fail for every topic** with `TOPIC_AUTHORIZATION_FAILED` — including the ones with legitimate READ access — and **no offsets were committed**, so on restart the consumer re-read the same messages.

## Root cause (in the policy)
`Resource.getEvaluatedResourcePattern` caches the EL resolution of resource patterns (e.g. `{#subscription?.metadata?.readTopics?:""}`) per connection for 60 s. When the EL transiently resolved to an empty string — or threw — the cache pinned that broken value for the full TTL: every subsequent request on that connection rebuilt an empty `ActionFilter`, denying every resource for up to 60 s.

`OffsetCommitAuthorizeStrategy` then saw every topic as unauthorized (`unauthorizedTopics.equals(topics)`) and short-circuited the whole request with all topics marked failed — nothing was forwarded to the broker, so even readable topics never committed.

## Fix in 3.0.2
The cache is now updated only when the resolution is non-blank and non-throwing. Empty / null / errored resolutions are returned for the current request without being cached, so the next request re-evaluates and self-heals as soon as the upstream condition clears. A legitimately-empty `readTopics` still denies — it is just re-evaluated each request instead of being pinned.

[APIM-13860]: https://gravitee.atlassian.net/browse/APIM-13860?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ