### PR TITLE
fix(portal): add missing bg-orange-600 CSS class to make AsyncAPI message ID visible

### DIFF
--- a/gravitee-apim-console-webui/src/assets/style/asyncapi-component.css
+++ b/gravitee-apim-console-webui/src/assets/style/asyncapi-component.css
@@ -1273,6 +1273,11 @@ video {
   background-color: rgba(128, 90, 213, var(--tw-bg-opacity));
 }
 
+.bg-orange-600 {
+  --tw-bg-opacity: 1;
+  background-color: rgba(221, 107, 32, var(--tw-bg-opacity));
+}
+
 .hover\:bg-orange-300:hover {
   --tw-bg-opacity: 1;
   background-color: rgba(251, 211, 141, var(--tw-bg-opacity));

--- a/gravitee-apim-portal-webui/src/assets/styles/asyncapi-component.css
+++ b/gravitee-apim-portal-webui/src/assets/styles/asyncapi-component.css
@@ -1259,6 +1259,11 @@ video {
   background-color: rgba(128, 90, 213, var(--tw-bg-opacity));
 }
 
+.bg-orange-600{
+  --tw-bg-opacity: 1;
+  background-color: rgba(221, 107, 32, var(--tw-bg-opacity));
+}
+
 .hover\:bg-orange-300:hover{
   --tw-bg-opacity: 1;
   background-color: rgba(251, 211, 141, var(--tw-bg-opacity));


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-14362

## Description

The @asyncapi/react-component library renders the Message ID (and Correlation ID) badge with the Tailwind class **_bg-orange-600_** text-white. 
Both the portal and console ship a hand-curated subset of Tailwind utilities to style the AsyncAPI web component, but **_bg-orange-600_** was missing from that subset. Without the background rule, the badge had no background color, leaving white text invisible against the white page background. 

The fix adds the missing **_.bg-orange-600_** rule to both asyncapi-component.css files (portal and console). 

## Additional context

**Before Fix:**

https://github.com/user-attachments/assets/ed090731-421b-4703-b104-05d79982b9b4

**After Fix:**

https://github.com/user-attachments/assets/815b674b-4dc4-4c28-af1f-cc79596e18f9


<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

