### PR TITLE
feat(portal): add application invitation acceptance flow

### DIFF
--- a/gravitee-apim-portal-webui-next/src/app/app.routes.ts
+++ b/gravitee-apim-portal-webui-next/src/app/app.routes.ts
@@ -39,6 +39,7 @@ import { ApplicationTabMembersComponent } from './dashboard/application-details/
 import { ApplicationTabSettingsComponent } from './dashboard/application-details/application-tab-settings/application-tab-settings.component';
 import { DashboardComponent } from './dashboard/dashboard.component';
 import { DocumentationSubscribeComponent } from './documentation/components/documentation-subscribe/documentation-subscribe.component';
+import { InvitationConfirmationComponent } from './registration/invitation-confirmation/invitation-confirmation.component';
 import { RegistrationConfirmationComponent } from './registration/registration-confirmation/registration-confirmation.component';
 import { ServiceUnavailableComponent } from './service-unavailable/service-unavailable.component';
 import { NavigationPageFullWidthComponent } from '../components/navigation-page-full-width/navigation-page-full-width.component';
@@ -307,6 +308,11 @@ export const routes: Routes = [
       {
         path: 'registration/confirm/:token',
         component: RegistrationConfirmationComponent,
+        canActivate: [anonymousGuard],
+      },
+      {
+        path: 'invitation/confirm/:token',
+        component: InvitationConfirmationComponent,
         canActivate: [anonymousGuard],
       },
     ],

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-invitation-create-dialog/application-invitation-create-dialog.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-invitation-create-dialog/application-invitation-create-dialog.component.spec.ts
@@ -194,7 +194,7 @@ describe('ApplicationInvitationCreateDialogComponent', () => {
       recipients: [{ email: 'alice@example.com' }, { email: 'bob@example.com' }],
       role: 'USER',
       notify: true,
-      confirmation_page_url: `${globalThis.location.origin}/user/registration/confirm`,
+      confirmation_page_url: `${globalThis.location.origin}/user/invitation/confirm`,
     });
     request.flush(fakeApplicationInvitationsResponse());
     await fixture.whenStable();
@@ -215,7 +215,7 @@ describe('ApplicationInvitationCreateDialogComponent', () => {
       recipients: [{ email: 'alice@example.com' }],
       role: 'USER',
       notify: false,
-      confirmation_page_url: `${globalThis.location.origin}/user/registration/confirm`,
+      confirmation_page_url: `${globalThis.location.origin}/user/invitation/confirm`,
     });
     request.flush(fakeApplicationInvitationsResponse());
     await fixture.whenStable();

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-invitation-create-dialog/application-invitation-create-dialog.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-invitation-create-dialog/application-invitation-create-dialog.component.ts
@@ -154,7 +154,7 @@ export class ApplicationInvitationCreateDialogComponent {
         recipients: this.selectedEmails().map(selectedEmail => ({ email: selectedEmail.email })),
         role: this.roleControl.value,
         notify: this.notifyControl.value,
-        confirmation_page_url: this.buildRegistrationConfirmationUrl(),
+        confirmation_page_url: this.buildInvitationConfirmationUrl(),
       })
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe({
@@ -217,11 +217,11 @@ export class ApplicationInvitationCreateDialogComponent {
     return value.trim().toLowerCase();
   }
 
-  private buildRegistrationConfirmationUrl(): string {
+  private buildInvitationConfirmationUrl(): string {
     const baseHref = this.platformLocation.getBaseHrefFromDOM() || '/';
     const normalizedBaseHref = baseHref.endsWith('/') ? baseHref : `${baseHref}/`;
 
-    return new URL(`${normalizedBaseHref}user/registration/confirm`, globalThis.location.origin).toString();
+    return new URL(`${normalizedBaseHref}user/invitation/confirm`, globalThis.location.origin).toString();
   }
 
   private handleSubmitError(error: HttpErrorResponse): void {

--- a/gravitee-apim-portal-webui-next/src/app/registration/invitation-confirmation/invitation-confirmation.component.html
+++ b/gravitee-apim-portal-webui-next/src/app/registration/invitation-confirmation/invitation-confirmation.component.html
@@ -1,0 +1,131 @@
+<!--
+
+    Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+
+<mat-card appearance="outlined" class="invitation-confirmation invitation-confirmation__form__container content">
+  @if (tokenInvalid()) {
+    <mat-card-header class="invitation-confirmation__form__header">
+      <mat-card-title class="invitation-confirmation__form__title m3-headline-small" i18n="@@invitationConfirmationTokenErrorTitle">
+        Invalid token
+      </mat-card-title>
+    </mat-card-header>
+    <mat-card-content class="invitation-confirmation__form__content">
+      <mat-error i18n="@@invitationConfirmationBadToken">Invalid token value</mat-error>
+    </mat-card-content>
+  } @else if (!submitted() && invitationConfirmationForm) {
+    <mat-card-header class="invitation-confirmation__form__header">
+      <mat-card-title class="invitation-confirmation__form__title m3-headline-small" i18n="@@invitationConfirmationTitle"
+        >Accept your invitation
+      </mat-card-title>
+    </mat-card-header>
+    <mat-card-content class="invitation-confirmation__form__content">
+      <form
+        [formGroup]="invitationConfirmationForm"
+        (ngSubmit)="confirmInvitation()"
+        [appIsMobile]="'invitation-confirmation__form__container--mobile'"
+      >
+        <div class="invitation-confirmation__form">
+          <div class="invitation-confirmation__form__section">
+            <div class="invitation-confirmation__form__section-title m3-title-small" i18n="@@invitationConfirmationDetailsTitle">
+              Your details
+            </div>
+            <div class="invitation-confirmation__form__fields">
+              <mat-form-field appearance="outline" class="invitation-confirmation__form__input">
+                <mat-label i18n="@@invitationConfirmationFirstname">First name</mat-label>
+                <input type="text" matInput formControlName="firstname" />
+                @if (invitationConfirmationForm.controls.firstname.hasError('required')) {
+                  <mat-error i18n="@@invitationConfirmationFirstnameErrorRequired">First name is required</mat-error>
+                }
+              </mat-form-field>
+              <mat-form-field appearance="outline" class="invitation-confirmation__form__input">
+                <mat-label i18n="@@invitationConfirmationLastname">Last name</mat-label>
+                <input type="text" matInput formControlName="lastname" />
+                @if (invitationConfirmationForm.controls.lastname.hasError('required')) {
+                  <mat-error i18n="@@invitationConfirmationLastnameErrorRequired">Last name is required</mat-error>
+                }
+              </mat-form-field>
+              <mat-form-field appearance="outline" class="invitation-confirmation__form__input">
+                <mat-label i18n="@@invitationConfirmationEmail">Email</mat-label>
+                <input type="email" matInput formControlName="email" />
+              </mat-form-field>
+            </div>
+          </div>
+          <div class="invitation-confirmation__form__section">
+            <div class="invitation-confirmation__form__section-title m3-title-small" i18n="@@invitationConfirmationPasswordTitle">
+              Create your password
+            </div>
+            <div class="invitation-confirmation__form__fields">
+              <mat-form-field appearance="outline" class="invitation-confirmation__form__input">
+                <mat-label i18n="@@invitationConfirmationChoosePassword">Password</mat-label>
+                <input type="password" matInput formControlName="password" />
+                @if (invitationConfirmationForm.controls.password.hasError('required')) {
+                  <mat-error i18n="@@invitationConfirmationPasswordErrorRequired">Password is required</mat-error>
+                }
+              </mat-form-field>
+              <mat-form-field appearance="outline" class="invitation-confirmation__form__input">
+                <mat-label i18n="@@invitationConfirmationConfirmPassword">Confirm password</mat-label>
+                <input type="password" matInput formControlName="confirmedPassword" />
+                @if (invitationConfirmationForm.controls.confirmedPassword.hasError('required')) {
+                  <mat-error i18n="@@invitationConfirmationPasswordErrorRequired">Password is required</mat-error>
+                }
+                @if (invitationConfirmationForm.controls.confirmedPassword.hasError('passwordMismatch')) {
+                  <mat-error i18n="@@invitationConfirmationPasswordErrorMismatch">Passwords do not match</mat-error>
+                }
+              </mat-form-field>
+            </div>
+          </div>
+          @if (submitFailed()) {
+            <mat-error i18n="@@invitationConfirmationSubmitError">Unable to accept the invitation. Please try again.</mat-error>
+          }
+          <div class="invitation-confirmation__form__buttons">
+            <button
+              [disabled]="invitationConfirmationForm.invalid"
+              type="submit"
+              mat-flat-button
+              i18n="@@invitationConfirmationAction"
+              class="invitation-confirmation__form__submit"
+            >
+              Accept invitation
+            </button>
+            <div class="invitation-confirmation__form__login m3-label-large">
+              <span i18n="@@invitationConfirmationLoginLabel">Already have an account?</span>
+              <a routerLink="/log-in" class="internal-link" i18n="@@invitationConfirmationLoginAction">Login</a>
+            </div>
+          </div>
+        </div>
+      </form>
+    </mat-card-content>
+  } @else if (submitted()) {
+    <mat-card-header class="invitation-confirmation__form__header">
+      <mat-card-title class="invitation-confirmation__form__title m3-headline-small" i18n="@@invitationConfirmationSuccessTitle"
+        >Invitation accepted
+      </mat-card-title>
+    </mat-card-header>
+    <mat-card-content class="invitation-confirmation__success__content">
+      <div class="invitation-confirmation__success__text m3-body-medium" i18n="@@invitationConfirmationSuccessMessage">
+        Your account has been successfully activated. You can now sign in using your email address and password.
+      </div>
+      <a
+        i18n="@@invitationConfirmationSuccessAction"
+        class="invitation-confirmation__success__action internal-link m3-label-large"
+        routerLink="/log-in"
+      >
+        Back to login
+      </a>
+    </mat-card-content>
+  }
+</mat-card>

--- a/gravitee-apim-portal-webui-next/src/app/registration/invitation-confirmation/invitation-confirmation.component.scss
+++ b/gravitee-apim-portal-webui-next/src/app/registration/invitation-confirmation/invitation-confirmation.component.scss
@@ -1,0 +1,93 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@use '../../../scss/theme';
+@use '../../../scss/layout' as layout;
+
+:host {
+  @include layout.small-container-legacy();
+}
+
+.invitation-confirmation {
+  display: flex;
+  flex-flow: column;
+  gap: 16px;
+
+  &__success {
+    &__content {
+      display: flex;
+      flex-flow: column;
+      align-items: flex-start;
+      gap: 16px;
+      text-align: left;
+    }
+
+    &__text {
+      margin-top: 6px;
+      color: theme.$paragraph-color;
+    }
+
+    &__action {
+      align-self: center;
+      color: theme.$primary-main-color;
+    }
+  }
+
+  &__form {
+    display: flex;
+    flex-flow: column;
+    gap: 20px;
+
+    &__container {
+      border-radius: 8px;
+
+      &--mobile {
+        max-width: 75vw;
+      }
+    }
+
+    &__section {
+      display: flex;
+      flex-flow: column;
+      gap: 12px;
+    }
+
+    &__section-title {
+      color: theme.$paragraph-color;
+    }
+
+    &__fields {
+      display: flex;
+      flex-flow: column;
+      gap: 12px;
+    }
+
+    &__buttons {
+      display: flex;
+      flex-flow: column;
+      gap: 12px;
+    }
+
+    &__submit {
+      width: 100%;
+    }
+
+    &__login {
+      display: inline-flex;
+      justify-content: center;
+      gap: 6px;
+    }
+  }
+}

--- a/gravitee-apim-portal-webui-next/src/app/registration/invitation-confirmation/invitation-confirmation.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/app/registration/invitation-confirmation/invitation-confirmation.component.spec.ts
@@ -1,0 +1,164 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { HarnessLoader } from '@angular/cdk/testing';
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { HttpTestingController } from '@angular/common/http/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MatButtonHarness } from '@angular/material/button/testing';
+import { MatCardHarness } from '@angular/material/card/testing';
+import { MatErrorHarness } from '@angular/material/form-field/testing';
+import { MatInputHarness } from '@angular/material/input/testing';
+import { throwError } from 'rxjs';
+import { of } from 'rxjs/internal/observable/of';
+
+import { InvitationConfirmationComponent } from './invitation-confirmation.component';
+import { TokenService } from '../../../services/token.service';
+import { UsersService } from '../../../services/users.service';
+import { AppTestingModule } from '../../../testing/app-testing.module';
+
+describe('InvitationConfirmationComponent', () => {
+  let fixture: ComponentFixture<InvitationConfirmationComponent>;
+  let harnessLoader: HarnessLoader;
+  let httpTestingController: HttpTestingController;
+
+  const invitationParsed = { email: 'invited@example.com' };
+
+  const init = async (params?: { token?: string; parsedToken?: { firstname?: string; lastname?: string; email: string } | null }) => {
+    const token = params?.token ?? 'token-123';
+    const parsedToken = params && 'parsedToken' in params ? params.parsedToken : invitationParsed;
+
+    const tokenServiceMock = {
+      parseToken: jest.fn().mockReturnValue(parsedToken),
+    };
+    const usersServiceMock = {
+      finalizeRegistration: jest.fn().mockReturnValue(of({})),
+    };
+
+    await TestBed.configureTestingModule({
+      imports: [InvitationConfirmationComponent, AppTestingModule],
+      providers: [
+        { provide: TokenService, useValue: tokenServiceMock },
+        { provide: UsersService, useValue: usersServiceMock },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(InvitationConfirmationComponent);
+    harnessLoader = TestbedHarnessEnvironment.loader(fixture);
+    httpTestingController = TestBed.inject(HttpTestingController);
+
+    fixture.componentRef.setInput('token', token);
+    fixture.detectChanges();
+    fixture.detectChanges();
+    return { tokenServiceMock, usersServiceMock };
+  };
+
+  afterEach(() => {
+    httpTestingController.verify();
+    jest.restoreAllMocks();
+  });
+
+  it('should display invalid token view when token cannot be parsed', async () => {
+    await init({ parsedToken: null });
+
+    const card = await harnessLoader.getHarness(MatCardHarness.with({ selector: 'mat-card.invitation-confirmation__form__container' }));
+    expect(await card.getTitleText()).toContain('Invalid token');
+
+    const errorEl = await harnessLoader.getHarness(MatErrorHarness);
+    expect(await errorEl.getText()).toContain('Invalid token value');
+  });
+
+  it('should display the invitation form with editable, empty name fields and a prefilled disabled email', async () => {
+    const { tokenServiceMock } = await init({ token: 'token-abc', parsedToken: invitationParsed });
+
+    expect(tokenServiceMock.parseToken).toHaveBeenCalledWith('token-abc');
+
+    const card = await harnessLoader.getHarness(MatCardHarness.with({ selector: 'mat-card.invitation-confirmation__form__container' }));
+    expect(await card.getTitleText()).toContain('Accept your invitation');
+
+    const firstnameInput = await harnessLoader.getHarness(MatInputHarness.with({ selector: '[formControlName="firstname"]' }));
+    const lastnameInput = await harnessLoader.getHarness(MatInputHarness.with({ selector: '[formControlName="lastname"]' }));
+    const emailInput = await harnessLoader.getHarness(MatInputHarness.with({ selector: '[formControlName="email"]' }));
+
+    expect(await firstnameInput.isDisabled()).toBe(false);
+    expect(await lastnameInput.isDisabled()).toBe(false);
+    expect(await firstnameInput.getValue()).toBe('');
+    expect(await lastnameInput.getValue()).toBe('');
+
+    expect(await emailInput.isDisabled()).toBe(true);
+    expect(await emailInput.getValue()).toBe('invited@example.com');
+
+    const submitBtn = await harnessLoader.getHarness(MatButtonHarness.with({ selector: 'button.invitation-confirmation__form__submit' }));
+    expect(await submitBtn.isDisabled()).toBe(true);
+  });
+
+  it('should finalize the invitation with the user-provided name and show the success view', async () => {
+    const { usersServiceMock } = await init({ token: 'token-123', parsedToken: invitationParsed });
+
+    const firstnameInput = await harnessLoader.getHarness(MatInputHarness.with({ selector: '[formControlName="firstname"]' }));
+    const lastnameInput = await harnessLoader.getHarness(MatInputHarness.with({ selector: '[formControlName="lastname"]' }));
+    const passwordInput = await harnessLoader.getHarness(MatInputHarness.with({ selector: '[formControlName="password"]' }));
+    const confirmInput = await harnessLoader.getHarness(MatInputHarness.with({ selector: '[formControlName="confirmedPassword"]' }));
+
+    await firstnameInput.setValue('Jane');
+    await lastnameInput.setValue('Doe');
+    await passwordInput.setValue('P@ssw0rd!');
+    await confirmInput.setValue('P@ssw0rd!');
+
+    const submitBtn = await harnessLoader.getHarness(MatButtonHarness.with({ text: 'Accept invitation' }));
+    await submitBtn.click();
+    fixture.detectChanges();
+
+    expect(usersServiceMock.finalizeRegistration).toHaveBeenCalledTimes(1);
+    expect(usersServiceMock.finalizeRegistration).toHaveBeenCalledWith({
+      firstname: 'Jane',
+      lastname: 'Doe',
+      token: 'token-123',
+      password: 'P@ssw0rd!',
+    });
+
+    const card = await harnessLoader.getHarness(MatCardHarness.with({ selector: 'mat-card.invitation-confirmation__form__container' }));
+    expect(await card.getTitleText()).toContain('Invitation accepted');
+    const cardText = await card.getText();
+    expect(cardText).toContain('Your account has been successfully activated.');
+    expect(cardText).toContain('Back to login');
+  });
+
+  it('should keep the form and show a generic error when finalize fails', async () => {
+    const { usersServiceMock } = await init({ token: 'token-123', parsedToken: invitationParsed });
+    usersServiceMock.finalizeRegistration.mockReturnValue(throwError(() => new Error('finalize failed')));
+
+    const firstnameInput = await harnessLoader.getHarness(MatInputHarness.with({ selector: '[formControlName="firstname"]' }));
+    const lastnameInput = await harnessLoader.getHarness(MatInputHarness.with({ selector: '[formControlName="lastname"]' }));
+    const passwordInput = await harnessLoader.getHarness(MatInputHarness.with({ selector: '[formControlName="password"]' }));
+    const confirmInput = await harnessLoader.getHarness(MatInputHarness.with({ selector: '[formControlName="confirmedPassword"]' }));
+
+    await firstnameInput.setValue('Jane');
+    await lastnameInput.setValue('Doe');
+    await passwordInput.setValue('P@ssw0rd!');
+    await confirmInput.setValue('P@ssw0rd!');
+
+    const submitBtn = await harnessLoader.getHarness(MatButtonHarness.with({ text: 'Accept invitation' }));
+    await submitBtn.click();
+    fixture.detectChanges();
+
+    // The form stays visible (no success view) and a generic, non-misleading error is shown.
+    const card = await harnessLoader.getHarness(MatCardHarness.with({ selector: 'mat-card.invitation-confirmation__form__container' }));
+    expect(await card.getTitleText()).toContain('Accept your invitation');
+
+    const errorEl = await harnessLoader.getHarness(MatErrorHarness);
+    expect(await errorEl.getText()).toContain('Unable to accept the invitation');
+  });
+});

--- a/gravitee-apim-portal-webui-next/src/app/registration/invitation-confirmation/invitation-confirmation.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/registration/invitation-confirmation/invitation-confirmation.component.ts
@@ -1,0 +1,113 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Component, computed, DestroyRef, effect, inject, input, signal } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
+import { MatButtonModule } from '@angular/material/button';
+import { MatCardModule } from '@angular/material/card';
+import { MatInputModule } from '@angular/material/input';
+import { RouterLink } from '@angular/router';
+import { catchError, EMPTY, tap } from 'rxjs';
+
+import { MobileClassDirective } from '../../../directives/mobile-class.directive';
+import { TokenService } from '../../../services/token.service';
+import { UsersService } from '../../../services/users.service';
+import { passwordMatchValidator } from '../../validators/password-match.validator';
+
+type InvitationConfirmationFormType = FormGroup<{
+  firstname: FormControl<string | null>;
+  lastname: FormControl<string | null>;
+  email: FormControl<string | null>;
+  password: FormControl<string | null>;
+  confirmedPassword: FormControl<string | null>;
+}>;
+
+interface InvitationToken {
+  email: string;
+}
+
+interface InvitationConfirmationFormValue {
+  firstname: string;
+  lastname: string;
+  password: string;
+}
+
+@Component({
+  selector: 'app-invitation-confirmation',
+  imports: [MatCardModule, MatInputModule, MatButtonModule, ReactiveFormsModule, RouterLink, MobileClassDirective],
+  templateUrl: './invitation-confirmation.component.html',
+  styleUrl: './invitation-confirmation.component.scss',
+})
+export class InvitationConfirmationComponent {
+  private readonly tokenService = inject(TokenService);
+  private readonly usersService = inject(UsersService);
+  private readonly destroyRef = inject(DestroyRef);
+
+  token = input.required<string>();
+
+  invitationConfirmationForm?: InvitationConfirmationFormType;
+  submitted = signal(false);
+  submitFailed = signal(false);
+
+  invitedUser = computed<InvitationToken | null>(() => this.tokenService.parseToken(this.token()));
+  tokenInvalid = computed(() => !this.invitedUser());
+
+  constructor() {
+    effect(() => {
+      const user = this.invitedUser();
+
+      if (!user) {
+        return;
+      }
+
+      this.invitationConfirmationForm = new FormGroup(
+        {
+          firstname: new FormControl('', Validators.required),
+          lastname: new FormControl('', Validators.required),
+          email: new FormControl({ value: user.email, disabled: true }),
+          password: new FormControl('', Validators.required),
+          confirmedPassword: new FormControl('', Validators.required),
+        },
+        { validators: passwordMatchValidator('password', 'confirmedPassword') },
+      );
+    });
+  }
+
+  confirmInvitation(): void {
+    if (!this.invitationConfirmationForm) {
+      return;
+    }
+    this.submitFailed.set(false);
+    const value = this.invitationConfirmationForm.getRawValue() as InvitationConfirmationFormValue;
+
+    this.usersService
+      .finalizeRegistration({
+        firstname: value.firstname,
+        lastname: value.lastname,
+        token: this.token(),
+        password: value.password,
+      })
+      .pipe(
+        tap(() => this.submitted.set(true)),
+        catchError(() => {
+          this.submitFailed.set(true);
+          return EMPTY;
+        }),
+        takeUntilDestroyed(this.destroyRef),
+      )
+      .subscribe();
+  }
+}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-14131

## Description

Adds the screen an invited user lands on from the invitation email (route `user/invitation/confirm/:token`).

The user enters their own first/last name (the invitation only carries an email) and a password, then submits to `/_finalize`. The create-invitation dialog now points its `confirmation_page_url` to this screen.

## Additional context

<img width="1213" height="745" alt="Capture d’écran 2026-06-09 à 17 37 52" src="https://github.com/user-attachments/assets/02bab79f-659f-4047-ab01-727e0abe4f67" />
<img width="1214" height="428" alt="Capture d’écran 2026-06-09 à 17 39 06" src="https://github.com/user-attachments/assets/41e3b106-8b84-466a-b29f-5be9ff3e1365" />


