### PR TITLE
fix: retain primary-owner own group on v4 API groups sanitization

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/validation/GroupValidationServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/validation/GroupValidationServiceImpl.java
@@ -112,7 +112,10 @@ public class GroupValidationServiceImpl extends TransactionalService implements 
                     group -> StringUtils.isEmpty(group.getApiPrimaryOwner()) || group.getId().equals(primaryOwner.getMemberId())
                 );
             } else {
-                groupEntityStream = groupEntityStream.filter(group -> StringUtils.isEmpty(group.getApiPrimaryOwner()));
+                groupEntityStream = groupEntityStream.filter(
+                    group ->
+                        StringUtils.isEmpty(group.getApiPrimaryOwner()) || group.getApiPrimaryOwner().equals(primaryOwner.getMemberId())
+                );
             }
         } else {
             groupEntityStream = groupEntityStream.filter(group -> StringUtils.isEmpty(group.getApiPrimaryOwner()));

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/validation/GroupValidationServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/validation/GroupValidationServiceImpl.java
@@ -114,7 +114,8 @@ public class GroupValidationServiceImpl extends TransactionalService implements 
             } else {
                 groupEntityStream = groupEntityStream.filter(
                     group ->
-                        StringUtils.isEmpty(group.getApiPrimaryOwner()) || group.getApiPrimaryOwner().equals(primaryOwner.getMemberId())
+                        StringUtils.isEmpty(group.getApiPrimaryOwner()) ||
+                        StringUtils.equals(group.getApiPrimaryOwner(), primaryOwner.getMemberId())
                 );
             }
         } else {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/validation/GroupValidationServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/validation/GroupValidationServiceImpl.java
@@ -109,19 +109,21 @@ public class GroupValidationServiceImpl extends TransactionalService implements 
             if (primaryOwner.getMemberType() == MembershipMemberType.GROUP) {
                 // don't remove the primary owner group of this API.
                 groupEntityStream = groupEntityStream.filter(
-                    group -> StringUtils.isEmpty(group.getApiPrimaryOwner()) || group.getId().equals(primaryOwner.getMemberId())
+                    group -> isNotPrimaryOwnerGroup(group) || group.getId().equals(primaryOwner.getMemberId())
                 );
             } else {
                 groupEntityStream = groupEntityStream.filter(
-                    group ->
-                        StringUtils.isEmpty(group.getApiPrimaryOwner()) ||
-                        StringUtils.equals(group.getApiPrimaryOwner(), primaryOwner.getMemberId())
+                    group -> isNotPrimaryOwnerGroup(group) || StringUtils.equals(group.getApiPrimaryOwner(), primaryOwner.getMemberId())
                 );
             }
         } else {
-            groupEntityStream = groupEntityStream.filter(group -> StringUtils.isEmpty(group.getApiPrimaryOwner()));
+            groupEntityStream = groupEntityStream.filter(this::isNotPrimaryOwnerGroup);
         }
 
         return groupEntityStream.map(GroupEntity::getId).collect(Collectors.toSet());
+    }
+
+    private boolean isNotPrimaryOwnerGroup(GroupEntity group) {
+        return StringUtils.isEmpty(group.getApiPrimaryOwner());
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/validation/GroupValidationServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/validation/GroupValidationServiceImplTest.java
@@ -423,6 +423,50 @@ public class GroupValidationServiceImplTest {
     }
 
     @Test
+    public void shouldRetainPrimaryOwnerOwnGroupWhenApiPrimaryOwnerIsUser() {
+        // Given
+        ExecutionContext executionContext = GraviteeContext.getExecutionContext();
+        String apiId = "apiId";
+
+        String poGroupId = "po-group";
+        GroupEntity poGroupEntity = new GroupEntity();
+        poGroupEntity.setId(poGroupId);
+        poGroupEntity.setApiPrimaryOwner("user");
+
+        String foreignGroupId = "foreign-group";
+        GroupEntity foreignGroupEntity = new GroupEntity();
+        foreignGroupEntity.setId(foreignGroupId);
+        foreignGroupEntity.setApiPrimaryOwner("other");
+
+        Set<String> groups = Set.of(poGroupId, foreignGroupId);
+        when(groupService.findByIds(groups)).thenReturn(Set.of(poGroupEntity, foreignGroupEntity));
+
+        MembershipEntity membershipEntity = new MembershipEntity();
+        membershipEntity.setMemberType(MembershipMemberType.USER);
+        membershipEntity.setMemberId("user");
+        when(membershipService.getPrimaryOwner(executionContext.getOrganizationId(), MembershipReferenceType.API, apiId)).thenReturn(
+            membershipEntity
+        );
+
+        UserEntity userEntity = new UserEntity();
+        userEntity.setId("user");
+
+        // When
+        Set<String> validatedGroups = groupValidationService.validateAndSanitize(
+            executionContext,
+            apiId,
+            groups,
+            null,
+            new PrimaryOwnerEntity(userEntity),
+            false
+        );
+
+        // Then
+        Assertions.assertThat(validatedGroups).contains(poGroupId);
+        Assertions.assertThat(validatedGroups).doesNotContain(foreignGroupId);
+    }
+
+    @Test
     public void shouldReturnExistingGroupsWhenGroupsIsNull() {
         Set<String> existingGroups = Set.of("existing1", "existing2");
 


### PR DESCRIPTION
## Issue

[APIM-14376](https://gravitee.atlassian.net/browse/APIM-14376)

## Why

When a v4 PROXY API is PATCHed with a `groups` list that contains both the primary owner's own group and a foreign group, the groups sanitization logic drops all groups instead of retaining the primary owner's group. The bug is in the `else` branch of the USER primary-owner path: it filtered out every group whose `apiPrimaryOwner` field is non-empty, which inadvertently discards the primary owner's own group. This causes silent data loss — all group memberships are cleared after a PATCH, potentially breaking visibility and subscription rules.

## What changed

- `GroupValidationServiceImpl`: In the USER primary-owner branch, the filter condition now also passes through any group whose `apiPrimaryOwner` matches the API's primary owner member ID, so the primary owner's own group is retained while unrelated primary-owner groups are still discarded.
- `GroupValidationServiceImplTest`: Added a test covering the case where the PATCH payload includes both the primary owner's own group and a foreign group, asserting the primary owner's group is kept and the foreign group is dropped.

## User-facing impact

APIs PATCHed with a groups list that includes the primary owner's own group will now correctly retain that group in the response and on subsequent GETs. Previously those groups were silently cleared.

[APIM-14376]: https://gravitee.atlassian.net/browse/APIM-14376?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ