### PR TITLE
fix(rest-api): ApiMapper drops resources field for HTTP and native v4 APIs

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/ApiMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/ApiMapper.java
@@ -301,6 +301,7 @@ public interface ApiMapper {
         expression = "java(source != null && source.getApiDefinitionHttpV4() != null ? responseTemplateMapper.mapResponseTemplateToApiModel(source.getApiDefinitionHttpV4().getResponseTemplates()) : null)"
     )
     @Mapping(target = "properties", source = "source.apiDefinitionHttpV4.properties")
+    @Mapping(target = "resources", source = "source.apiDefinitionHttpV4.resources")
     @Mapping(target = "services", source = "source.apiDefinitionHttpV4.services")
     @Mapping(target = "state", source = "source.lifecycleState")
     ApiV4 mapToHttpV4(io.gravitee.apim.core.api.model.Api source, UriInfo uriInfo, GenericApi.DeploymentStateEnum deploymentState);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/ApiMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/ApiMapper.java
@@ -316,6 +316,7 @@ public interface ApiMapper {
     @Mapping(target = "listeners", source = "source.apiDefinitionNativeV4.listeners", qualifiedByName = "fromNativeListeners")
     @Mapping(target = "state", source = "source.lifecycleState")
     @Mapping(target = "analytics", source = "source.apiDefinitionNativeV4.analytics")
+    @Mapping(target = "resources", source = "source.apiDefinitionNativeV4.resources")
     ApiV4 mapToNativeV4(io.gravitee.apim.core.api.model.Api source, UriInfo uriInfo, GenericApi.DeploymentStateEnum deploymentState);
 
     @Mapping(target = "definitionContext", source = "source.originContext")

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/mapper/ApiMapperTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/mapper/ApiMapperTest.java
@@ -255,6 +255,25 @@ public class ApiMapperTest {
     }
 
     @Test
+    void map_to_native_v4_preserves_resources_from_definition() {
+        var uriInfo = Mockito.mock(UriInfo.class);
+        Mockito.when(uriInfo.getBaseUriBuilder()).thenReturn(UriBuilder.fromUri("http://localhost/"));
+
+        var resource = Resource.builder().name("cache-resource").type("cache").enabled(true).build();
+
+        var baseApi = fixtures.core.model.ApiFixtures.aNativeApi();
+        var api = baseApi
+            .toBuilder()
+            .apiDefinitionValue(baseApi.getApiDefinitionNativeV4().toBuilder().resources(List.of(resource)).build())
+            .build();
+
+        var apiV4 = apiMapper.mapToNativeV4(api, uriInfo, null);
+
+        Assertions.assertThat(apiV4.getResources()).isNotNull().hasSize(1);
+        assertThat(apiV4.getResources().get(0).getName()).isEqualTo("cache-resource");
+    }
+
+    @Test
     void map_to_http_v4_propagates_null_resources() {
         var uriInfo = Mockito.mock(UriInfo.class);
         Mockito.when(uriInfo.getBaseUriBuilder()).thenReturn(UriBuilder.fromUri("http://localhost/"));

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/mapper/ApiMapperTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/mapper/ApiMapperTest.java
@@ -26,6 +26,7 @@ import io.gravitee.definition.model.DefinitionVersion;
 import io.gravitee.definition.model.Plugin;
 import io.gravitee.definition.model.v4.failover.Failover;
 import io.gravitee.definition.model.v4.listener.ListenerType;
+import io.gravitee.definition.model.v4.resource.Resource;
 import io.gravitee.definition.model.v4.service.ApiServices;
 import io.gravitee.rest.api.management.v2.rest.model.Analytics;
 import io.gravitee.rest.api.management.v2.rest.model.ApiType;
@@ -44,8 +45,11 @@ import jakarta.ws.rs.core.UriBuilder;
 import jakarta.ws.rs.core.UriInfo;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Stream;
+import org.assertj.core.api.Assertions;
+import org.assertj.core.api.InstanceOfAssertFactories;
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
@@ -208,6 +212,59 @@ public class ApiMapperTest {
         assertThat(apiV4.getFailover().getEnabled()).isTrue();
         assertThat(apiV4.getServices()).isNotNull();
         assertThat(apiV4.getAllowedInApiProducts()).isTrue();
+    }
+
+    @Test
+    void map_to_http_v4_preserves_resources_from_definition() {
+        var uriInfo = Mockito.mock(UriInfo.class);
+        Mockito.when(uriInfo.getBaseUriBuilder()).thenReturn(UriBuilder.fromUri("http://localhost/"));
+
+        var resource = Resource.builder().name("cache-resource").type("cache").enabled(true).build();
+
+        var baseApi = fixtures.core.model.ApiFixtures.aProxyApiV4();
+        var api = baseApi
+            .toBuilder()
+            .apiDefinitionValue(baseApi.getApiDefinitionHttpV4().toBuilder().resources(List.of(resource)).build())
+            .build();
+
+        var apiV4 = apiMapper.mapToHttpV4(api, uriInfo, null);
+
+        Assertions.assertThat(apiV4.getResources()).isNotNull().hasSize(1);
+        assertThat(apiV4.getResources().get(0).getName()).isEqualTo("cache-resource");
+    }
+
+    @Test
+    void map_to_http_v4_deserializes_resource_configuration() {
+        var uriInfo = Mockito.mock(UriInfo.class);
+        Mockito.when(uriInfo.getBaseUriBuilder()).thenReturn(UriBuilder.fromUri("http://localhost/"));
+
+        var resource = Resource.builder().name("cache-resource").type("cache").enabled(true).configuration("{\"key\":\"value\"}").build();
+
+        var baseApi = fixtures.core.model.ApiFixtures.aProxyApiV4();
+        var api = baseApi
+            .toBuilder()
+            .apiDefinitionValue(baseApi.getApiDefinitionHttpV4().toBuilder().resources(List.of(resource)).build())
+            .build();
+
+        var apiV4 = apiMapper.mapToHttpV4(api, uriInfo, null);
+
+        Assertions.assertThat(apiV4.getResources()).hasSize(1);
+        var configuration = apiV4.getResources().get(0).getConfiguration();
+        assertThat(configuration).isInstanceOf(Map.class);
+        Assertions.assertThat(configuration).asInstanceOf(InstanceOfAssertFactories.MAP).containsEntry("key", "value");
+    }
+
+    @Test
+    void map_to_http_v4_propagates_null_resources() {
+        var uriInfo = Mockito.mock(UriInfo.class);
+        Mockito.when(uriInfo.getBaseUriBuilder()).thenReturn(UriBuilder.fromUri("http://localhost/"));
+
+        var baseApi = fixtures.core.model.ApiFixtures.aProxyApiV4();
+        var api = baseApi.toBuilder().apiDefinitionValue(baseApi.getApiDefinitionHttpV4().toBuilder().resources(null).build()).build();
+
+        var apiV4 = apiMapper.mapToHttpV4(api, uriInfo, null);
+
+        assertThat(apiV4.getResources()).isNull();
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource_PatchApiResourcesTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource_PatchApiResourcesTest.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.management.v2.rest.resource.api;
+
+import static assertions.MAPIAssertions.assertThat;
+import static io.gravitee.common.http.HttpStatusCode.OK_200;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.when;
+
+import fixtures.core.model.ApiFixtures;
+import inmemory.InMemoryAlternative;
+import io.gravitee.apim.core.api.domain_service.UpdateApiDomainService;
+import io.gravitee.apim.core.membership.model.Membership;
+import io.gravitee.apim.core.membership.model.PrimaryOwnerEntity;
+import io.gravitee.definition.model.DefinitionVersion;
+import io.gravitee.definition.model.v4.ApiType;
+import io.gravitee.definition.model.v4.resource.Resource;
+import io.gravitee.rest.api.management.v2.rest.model.ApiV4;
+import io.gravitee.rest.api.model.v4.api.ApiEntity;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.client.Entity;
+import java.time.Instant;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+import org.assertj.core.api.Assertions;
+import org.assertj.core.api.InstanceOfAssertFactories;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+public class ApiResource_PatchApiResourcesTest extends ApiResourceTest {
+
+    private static final String MERGE_PATCH_TYPE = "application/merge-patch+json";
+    private static final String JSON_PATCH_TYPE = "application/json-patch+json";
+
+    @Inject
+    UpdateApiDomainService updateApiDomainService;
+
+    @Override
+    protected String contextPath() {
+        return "/environments/" + ENVIRONMENT + "/apis";
+    }
+
+    @BeforeEach
+    void setUpApiAndPrimaryOwner() {
+        apiCrudService.initWith(List.of(ApiFixtures.aProxyApiV4().toBuilder().id(API).build()));
+
+        var apiEntity = new ApiEntity();
+        apiEntity.setId(API);
+        apiEntity.setDefinitionVersion(DefinitionVersion.V4);
+        apiEntity.setType(ApiType.PROXY);
+        apiEntity.setUpdatedAt(Date.from(Instant.ofEpochMilli(1000)));
+        when(apiSearchServiceV4.findGenericById(any(), eq(API), any(boolean.class), any(boolean.class), any(boolean.class))).thenReturn(
+            apiEntity
+        );
+
+        roleQueryService.resetSystemRoles(ORGANIZATION);
+        primaryOwnerDomainService.initWith(
+            List.of(Map.entry(API, PrimaryOwnerEntity.builder().id(USER_NAME).type(PrimaryOwnerEntity.Type.USER).build()))
+        );
+        membershipQueryServiceInMemory.initWith(
+            List.of(
+                Membership.builder()
+                    .memberId(USER_NAME)
+                    .referenceId(API)
+                    .roleId("api-po-id-" + ORGANIZATION)
+                    .referenceType(Membership.ReferenceType.API)
+                    .memberType(Membership.Type.USER)
+                    .build()
+            )
+        );
+
+        doAnswer(inv -> inv.getArgument(0))
+            .when(updateApiDomainService)
+            .updateV4(any(), any());
+        doAnswer(inv -> inv.getArgument(0))
+            .when(updateApiDomainService)
+            .validateV4(any(), any());
+    }
+
+    @AfterEach
+    public void tearDown() {
+        Stream.of(apiCrudService, membershipQueryServiceInMemory, primaryOwnerDomainService).forEach(InMemoryAlternative::reset);
+        reset(updateApiDomainService, apiSearchServiceV4);
+    }
+
+    @Test
+    void merge_patch_resources_returns_them_in_response_body() {
+        var body =
+            "{\"resources\":[{\"name\":\"my-cache\",\"type\":\"cache\",\"enabled\":true,\"configuration\":{\"timeToIdleSeconds\":0,\"timeToLiveSeconds\":0,\"maxEntriesLocalHeap\":1000}}]}";
+
+        var response = rootTarget(API).request().method("PATCH", Entity.entity(body, MERGE_PATCH_TYPE));
+
+        var apiV4 = assertThat(response).hasStatus(OK_200).asEntity(ApiV4.class).actual();
+        Assertions.assertThat(apiV4.getResources()).hasSize(1);
+        Assertions.assertThat(apiV4.getResources().getFirst().getName()).isEqualTo("my-cache");
+        Assertions.assertThat(apiV4.getResources().getFirst().getType()).isEqualTo("cache");
+    }
+
+    @Test
+    void json_patch_tests_and_replaces_existing_resource_configuration() {
+        var resource = Resource.builder().name("my-cache").type("cache").enabled(true).configuration("{\"timeToLiveSeconds\":10}").build();
+        var baseApi = ApiFixtures.aProxyApiV4();
+        apiCrudService.initWith(
+            List.of(
+                baseApi
+                    .toBuilder()
+                    .id(API)
+                    .apiDefinitionValue(baseApi.getApiDefinitionHttpV4().toBuilder().resources(List.of(resource)).build())
+                    .build()
+            )
+        );
+
+        var body =
+            "[" +
+            "{\"op\":\"test\",\"path\":\"/resources/0/configuration\",\"value\":{\"timeToLiveSeconds\":10}}," +
+            "{\"op\":\"replace\",\"path\":\"/resources/0/configuration\",\"value\":{\"timeToLiveSeconds\":60}}" +
+            "]";
+
+        var response = rootTarget(API).request().method("PATCH", Entity.entity(body, JSON_PATCH_TYPE));
+
+        var apiV4 = assertThat(response).hasStatus(OK_200).asEntity(ApiV4.class).actual();
+        Assertions.assertThat(apiV4.getResources()).hasSize(1);
+        Assertions.assertThat(apiV4.getResources().getFirst().getConfiguration())
+            .asInstanceOf(InstanceOfAssertFactories.MAP)
+            .containsEntry("timeToLiveSeconds", 60);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource_UpdateApiFromSwaggerTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource_UpdateApiFromSwaggerTest.java
@@ -29,6 +29,7 @@ import io.gravitee.apim.core.api.exception.InvalidApiDefinitionException;
 import io.gravitee.apim.core.api.exception.InvalidPathsException;
 import io.gravitee.apim.core.api.model.ApiWithFlows;
 import io.gravitee.apim.core.api.use_case.OAIToUpdateApiUseCase;
+import io.gravitee.definition.model.v4.resource.Resource;
 import io.gravitee.rest.api.management.v2.rest.model.ApiV4;
 import io.gravitee.rest.api.management.v2.rest.model.ImportSwaggerDescriptor;
 import io.gravitee.rest.api.model.permissions.RolePermission;
@@ -37,6 +38,7 @@ import io.gravitee.rest.api.service.common.GraviteeContext;
 import jakarta.ws.rs.client.Entity;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 
 class ApiResource_UpdateApiFromSwaggerTest extends ApiResourceTest {
@@ -87,6 +89,31 @@ class ApiResource_UpdateApiFromSwaggerTest extends ApiResourceTest {
         var body = response.readEntity(ApiV4.class);
         assertThat(body).isNotNull();
         assertThat(body.getId()).isEqualTo(API);
+    }
+
+    @Test
+    void should_return_resources_in_response_on_success() {
+        var resource = Resource.builder().name("cache-resource").type("cache").enabled(true).configuration("{\"key\":\"value\"}").build();
+        var baseApi = ApiFixtures.aProxyApiV4();
+        var existingApi = baseApi
+            .toBuilder()
+            .id(API)
+            .environmentId(ENVIRONMENT)
+            .apiDefinitionValue(baseApi.getApiDefinitionHttpV4().toBuilder().resources(List.of(resource)).build())
+            .build();
+        var apiWithFlows = new ApiWithFlows(existingApi, List.of());
+
+        when(oaiToUpdateApiUseCase.execute(any())).thenReturn(new OAIToUpdateApiUseCase.Output(apiWithFlows));
+        when(apiSearchServiceV4.findById(GraviteeContext.getExecutionContext(), API)).thenReturn(
+            io.gravitee.rest.api.model.v4.api.ApiEntity.builder().id(API).name("Test API").apiVersion("1.0").build()
+        );
+
+        Response response = rootTarget().request().put(Entity.entity(buildDescriptor("{}"), MediaType.APPLICATION_JSON));
+
+        assertThat(response.getStatus()).isEqualTo(OK_200);
+        var body = response.readEntity(ApiV4.class);
+        assertThat(body.getResources()).isNotNull().hasSize(1);
+        assertThat(body.getResources().getFirst().getName()).isEqualTo("cache-resource");
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource_UpdateApiFromWsdlTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource_UpdateApiFromWsdlTest.java
@@ -30,6 +30,7 @@ import io.gravitee.apim.core.api.exception.InvalidApiDefinitionException;
 import io.gravitee.apim.core.api.exception.InvalidPathsException;
 import io.gravitee.apim.core.api.model.ApiWithFlows;
 import io.gravitee.apim.core.api.use_case.WsdlToUpdateApiUseCase;
+import io.gravitee.definition.model.v4.resource.Resource;
 import io.gravitee.rest.api.management.v2.rest.model.ApiV4;
 import io.gravitee.rest.api.management.v2.rest.model.ImportWsdlDescriptor;
 import io.gravitee.rest.api.model.permissions.RolePermission;
@@ -91,6 +92,31 @@ class ApiResource_UpdateApiFromWsdlTest extends ApiResourceTest {
         var body = response.readEntity(ApiV4.class);
         assertThat(body).isNotNull();
         assertThat(body.getId()).isEqualTo(API);
+    }
+
+    @Test
+    void should_return_resources_in_response_on_success() {
+        var resource = Resource.builder().name("cache-resource").type("cache").enabled(true).configuration("{\"key\":\"value\"}").build();
+        var baseApi = ApiFixtures.aProxyApiV4();
+        var existingApi = baseApi
+            .toBuilder()
+            .id(API)
+            .environmentId(ENVIRONMENT)
+            .apiDefinitionValue(baseApi.getApiDefinitionHttpV4().toBuilder().resources(List.of(resource)).build())
+            .build();
+        var apiWithFlows = new ApiWithFlows(existingApi, List.of());
+
+        when(wsdlToUpdateApiUseCase.execute(any())).thenReturn(new WsdlToUpdateApiUseCase.Output(apiWithFlows));
+        when(apiSearchServiceV4.findById(GraviteeContext.getExecutionContext(), API)).thenReturn(
+            io.gravitee.rest.api.model.v4.api.ApiEntity.builder().id(API).name("CalculatorService").apiVersion("1.0").build()
+        );
+
+        Response response = rootTarget().request().put(Entity.entity(buildDescriptor("<definitions/>"), MediaType.APPLICATION_JSON));
+
+        assertThat(response.getStatus()).isEqualTo(OK_200);
+        var body = response.readEntity(ApiV4.class);
+        assertThat(body.getResources()).isNotNull().hasSize(1);
+        assertThat(body.getResources().getFirst().getName()).isEqualTo("cache-resource");
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource_UpdateApiWithDefinitionTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource_UpdateApiWithDefinitionTest.java
@@ -29,6 +29,7 @@ import io.gravitee.apim.core.api.exception.InvalidPathsException;
 import io.gravitee.apim.core.api.model.ApiWithFlows;
 import io.gravitee.apim.core.api.use_case.UpdateApiDefinitionFromImportUseCase;
 import io.gravitee.definition.model.DefinitionVersion;
+import io.gravitee.definition.model.v4.resource.Resource;
 import io.gravitee.rest.api.management.v2.rest.model.ApiV4;
 import io.gravitee.rest.api.management.v2.rest.model.ExportApiV4;
 import io.gravitee.rest.api.model.permissions.RolePermission;
@@ -38,6 +39,7 @@ import io.gravitee.rest.api.service.exceptions.ApiDefinitionVersionNotSupportedE
 import jakarta.ws.rs.client.Entity;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 
 class ApiResource_UpdateApiWithDefinitionTest extends ApiResourceTest {
@@ -104,6 +106,31 @@ class ApiResource_UpdateApiWithDefinitionTest extends ApiResourceTest {
         var body = response.readEntity(ApiV4.class);
         assertThat(body).isNotNull();
         assertThat(body.getId()).isEqualTo(API);
+    }
+
+    @Test
+    void should_return_resources_in_response_on_success() {
+        var resource = Resource.builder().name("cache-resource").type("cache").enabled(true).configuration("{\"key\":\"value\"}").build();
+        var baseApi = ApiFixtures.aProxyApiV4();
+        var existingApi = baseApi
+            .toBuilder()
+            .id(API)
+            .environmentId(ENVIRONMENT)
+            .apiDefinitionValue(baseApi.getApiDefinitionHttpV4().toBuilder().resources(List.of(resource)).build())
+            .build();
+        var apiWithFlows = new ApiWithFlows(existingApi, List.of());
+
+        when(updateApiDefinitionUseCase.execute(any())).thenReturn(new UpdateApiDefinitionFromImportUseCase.Output(apiWithFlows));
+        when(apiSearchServiceV4.findById(GraviteeContext.getExecutionContext(), API)).thenReturn(
+            io.gravitee.rest.api.model.v4.api.ApiEntity.builder().id(API).name("Test API").apiVersion("1.0").build()
+        );
+
+        Response response = rootTarget().request().put(Entity.entity(buildMinimalExportApiV4(), MediaType.APPLICATION_JSON));
+
+        assertThat(response.getStatus()).isEqualTo(OK_200);
+        var body = response.readEntity(ApiV4.class);
+        assertThat(body.getResources()).isNotNull().hasSize(1);
+        assertThat(body.getResources().getFirst().getName()).isEqualTo("cache-resource");
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApisResource_CreateApiFromSwagger.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApisResource_CreateApiFromSwagger.java
@@ -16,6 +16,7 @@
 package io.gravitee.rest.api.management.v2.rest.resource.api;
 
 import static io.gravitee.common.http.HttpStatusCode.BAD_REQUEST_400;
+import static io.gravitee.common.http.HttpStatusCode.CREATED_201;
 import static io.gravitee.common.http.HttpStatusCode.FORBIDDEN_403;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -25,18 +26,22 @@ import static org.mockito.Mockito.when;
 
 import com.google.common.base.Charsets;
 import com.google.common.io.Resources;
+import fixtures.core.model.ApiFixtures;
 import io.gravitee.apim.core.api.domain_service.CreateApiDomainService;
 import io.gravitee.apim.core.api.domain_service.OAIDomainService;
 import io.gravitee.apim.core.api.exception.InvalidPathsException;
+import io.gravitee.apim.core.api.model.ApiWithFlows;
 import io.gravitee.apim.core.api.model.import_definition.ApiExport;
 import io.gravitee.apim.core.api.model.import_definition.ImportDefinition;
 import io.gravitee.apim.core.user.model.BaseUserEntity;
 import io.gravitee.definition.model.DefinitionVersion;
 import io.gravitee.definition.model.v4.listener.http.HttpListener;
 import io.gravitee.definition.model.v4.listener.http.Path;
+import io.gravitee.definition.model.v4.resource.Resource;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.model.Parameter;
 import io.gravitee.repository.management.model.ParameterReferenceType;
+import io.gravitee.rest.api.management.v2.rest.model.ApiV4;
 import io.gravitee.rest.api.management.v2.rest.model.Error;
 import io.gravitee.rest.api.management.v2.rest.model.ImportSwaggerDescriptor;
 import io.gravitee.rest.api.management.v2.rest.resource.AbstractResourceTest;
@@ -111,6 +116,46 @@ public class ApisResource_CreateApiFromSwagger extends AbstractResourceTest {
 
         // Then
         assertThat(response.getStatus()).isEqualTo(FORBIDDEN_403);
+    }
+
+    @Test
+    @SneakyThrows
+    public void should_return_resources_in_response_on_success() {
+        // Given
+        when(oaiDomainService.convert(any(), any(), any(), anyBoolean(), anyBoolean())).thenReturn(
+            ImportDefinition.builder()
+                .apiExport(
+                    ApiExport.builder()
+                        .definitionVersion(DefinitionVersion.V4)
+                        .listeners(List.of(HttpListener.builder().paths(List.of(Path.builder().path("/path").build())).build()))
+                        .build()
+                )
+                .build()
+        );
+
+        var resource = Resource.builder().name("cache-resource").type("cache").enabled(true).configuration("{\"key\":\"value\"}").build();
+        var baseApi = ApiFixtures.aProxyApiV4();
+        var createdApi = baseApi
+            .toBuilder()
+            .id("imported-api-id")
+            .environmentId(ENVIRONMENT_ID)
+            .apiDefinitionValue(baseApi.getApiDefinitionHttpV4().toBuilder().resources(List.of(resource)).build())
+            .build();
+        var apiWithFlows = new ApiWithFlows(createdApi, List.of());
+        when(createApiDomainService.create(any(), any(), any(), any(), any())).thenReturn(apiWithFlows);
+
+        var swagger = Resources.getResource("io/gravitee/rest/api/management/service/openapi-withExtensions.json");
+
+        // When
+        var response = rootTarget()
+            .request()
+            .post(Entity.json(new ImportSwaggerDescriptor().payload(Resources.toString(swagger, Charsets.UTF_8))));
+
+        // Then
+        assertThat(response.getStatus()).isEqualTo(CREATED_201);
+        var body = response.readEntity(ApiV4.class);
+        assertThat(body.getResources()).isNotNull().hasSize(1);
+        assertThat(body.getResources().getFirst().getName()).isEqualTo("cache-resource");
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApisResource_CreateApiFromSwaggerTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApisResource_CreateApiFromSwaggerTest.java
@@ -58,7 +58,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
-public class ApisResource_CreateApiFromSwagger extends AbstractResourceTest {
+public class ApisResource_CreateApiFromSwaggerTest extends AbstractResourceTest {
 
     private static final String ENVIRONMENT_ID = "my-env";
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApisResource_CreateApiFromWsdlTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApisResource_CreateApiFromWsdlTest.java
@@ -23,12 +23,14 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.when;
 
+import fixtures.core.model.ApiFixtures;
 import io.gravitee.apim.core.api.exception.InvalidPathsException;
 import io.gravitee.apim.core.api.model.Api;
 import io.gravitee.apim.core.api.model.ApiWithFlows;
 import io.gravitee.apim.core.api.use_case.WsdlToImportApiUseCase;
 import io.gravitee.definition.model.DefinitionVersion;
 import io.gravitee.definition.model.v4.ApiType;
+import io.gravitee.definition.model.v4.resource.Resource;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.rest.api.management.v2.rest.model.ApiV4;
 import io.gravitee.rest.api.management.v2.rest.model.Error;
@@ -105,6 +107,28 @@ public class ApisResource_CreateApiFromWsdlTest extends AbstractResourceTest {
         var api = response.readEntity(ApiV4.class);
         assertThat(api.getId()).isEqualTo("wsdl-api-id");
         assertThat(api.getName()).isEqualTo("CalculatorService");
+    }
+
+    @Test
+    public void should_return_resources_in_response_on_success() {
+        var resource = Resource.builder().name("cache-resource").type("cache").enabled(true).configuration("{\"key\":\"value\"}").build();
+        var baseApi = ApiFixtures.aProxyApiV4();
+        var createdApi = baseApi
+            .toBuilder()
+            .id("wsdl-api-id")
+            .environmentId(ENVIRONMENT_ID)
+            .apiDefinitionValue(baseApi.getApiDefinitionHttpV4().toBuilder().resources(List.of(resource)).build())
+            .build();
+        when(wsdlToImportApiUseCase.execute(any())).thenReturn(new WsdlToImportApiUseCase.Output(new ApiWithFlows(createdApi, List.of())));
+
+        var descriptor = new ImportWsdlDescriptor().payload("<definitions/>").withDocumentation(false).withOASValidationPolicy(false);
+
+        var response = rootTarget().request().post(Entity.json(descriptor));
+
+        assertThat(response.getStatus()).isEqualTo(CREATED_201);
+        var api = response.readEntity(ApiV4.class);
+        assertThat(api.getResources()).isNotNull().hasSize(1);
+        assertThat(api.getResources().getFirst().getName()).isEqualTo("cache-resource");
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApisResource_CreateApiWithDefinitionTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApisResource_CreateApiWithDefinitionTest.java
@@ -15,24 +15,39 @@
  */
 package io.gravitee.rest.api.management.v2.rest.resource.api;
 
+import static io.gravitee.common.http.HttpStatusCode.CREATED_201;
 import static io.gravitee.common.http.HttpStatusCode.FORBIDDEN_403;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.when;
 
+import fixtures.core.model.ApiFixtures;
+import io.gravitee.apim.core.api.model.ApiWithFlows;
+import io.gravitee.apim.core.api.use_case.ImportApiDefinitionUseCase;
+import io.gravitee.definition.model.v4.resource.Resource;
 import io.gravitee.repository.exceptions.TechnicalException;
+import io.gravitee.rest.api.management.v2.rest.model.ApiV4;
+import io.gravitee.rest.api.management.v2.rest.model.ExportApiV4;
 import io.gravitee.rest.api.management.v2.rest.resource.AbstractResourceTest;
 import io.gravitee.rest.api.model.EnvironmentEntity;
 import io.gravitee.rest.api.model.permissions.RolePermission;
 import io.gravitee.rest.api.model.permissions.RolePermissionAction;
 import io.gravitee.rest.api.service.common.GraviteeContext;
+import jakarta.ws.rs.client.Entity;
 import jakarta.ws.rs.core.Response;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 
 public class ApisResource_CreateApiWithDefinitionTest extends AbstractResourceTest {
 
     private static final String ENVIRONMENT_ID = "my-env";
+
+    @Autowired
+    private ImportApiDefinitionUseCase importApiDefinitionUseCase;
 
     @Override
     protected String contextPath() {
@@ -41,7 +56,7 @@ public class ApisResource_CreateApiWithDefinitionTest extends AbstractResourceTe
 
     @BeforeEach
     public void init() throws TechnicalException {
-        reset(apiServiceV4);
+        reset(apiServiceV4, importApiDefinitionUseCase);
         GraviteeContext.cleanContext();
         GraviteeContext.setCurrentEnvironment(ENVIRONMENT_ID);
         GraviteeContext.setCurrentOrganization(ORGANIZATION);
@@ -65,5 +80,40 @@ public class ApisResource_CreateApiWithDefinitionTest extends AbstractResourceTe
         ).thenReturn(false);
         Response response = rootTarget().request().post(null);
         assertEquals(FORBIDDEN_403, response.getStatus());
+    }
+
+    @Test
+    public void should_return_resources_in_response_on_success() {
+        var resource = Resource.builder().name("cache-resource").type("cache").enabled(true).configuration("{\"key\":\"value\"}").build();
+        var baseApi = ApiFixtures.aProxyApiV4();
+        var createdApi = baseApi
+            .toBuilder()
+            .id("imported-api-id")
+            .environmentId(ENVIRONMENT_ID)
+            .apiDefinitionValue(baseApi.getApiDefinitionHttpV4().toBuilder().resources(List.of(resource)).build())
+            .build();
+        var apiWithFlows = new ApiWithFlows(createdApi, List.of());
+
+        when(importApiDefinitionUseCase.execute(any())).thenReturn(new ImportApiDefinitionUseCase.Output(apiWithFlows));
+
+        Response response = rootTarget().request().post(Entity.json(buildMinimalExportApiV4()));
+
+        assertThat(response.getStatus()).isEqualTo(CREATED_201);
+        var body = response.readEntity(ApiV4.class);
+        assertThat(body.getResources()).isNotNull().hasSize(1);
+        assertThat(body.getResources().getFirst().getName()).isEqualTo("cache-resource");
+    }
+
+    private ExportApiV4 buildMinimalExportApiV4() {
+        var apiV4 = new ApiV4();
+        apiV4.setId("imported-api-id");
+        apiV4.setName("Test API");
+        apiV4.setApiVersion("1.0");
+        apiV4.setDefinitionVersion(io.gravitee.rest.api.management.v2.rest.model.DefinitionVersion.V4);
+        apiV4.setType(io.gravitee.rest.api.management.v2.rest.model.ApiType.PROXY);
+
+        var exportApiV4 = new ExportApiV4();
+        exportApiV4.setApi(apiV4);
+        return exportApiV4;
     }
 }


### PR DESCRIPTION
## Issue

[APIM-14375](https://gravitee.atlassian.net/browse/APIM-14375)

## Why

`ApiMapper.mapToHttpV4` (`ApiMapper.java:304`) was missing a mapping for the `resources` field. This projection is shared across eight endpoints, so the omission caused every one of them to return `"resources": []` in the response body even when resources were correctly persisted.

The most visible symptom was `PATCH /apis/{apiId}` returning an empty `resources` array. A less obvious but more damaging consequence was in the JSON-Patch engine: the current-state document built by `PatchApiV4Deserializer` goes through the same mapper, so JSON-Patch operations targeting `/resources/N/configuration/...` failed outright because the current state had no resources to match against.

The same omission existed in `mapToNativeV4` (`ApiMapper.java:319`): native (Kafka) v4 APIs inherit `resources` through `AbstractApi`, but the mapper lacked the symmetric mapping, so any resources stored on a native API were also silently dropped from responses.

## What changed

- `ApiMapper` — added `@Mapping(target = "resources", source = "source.apiDefinitionHttpV4.resources")` to `mapToHttpV4`, aligning it with the GET response projection.
- `ApiMapper` — added `@Mapping(target = "resources", source = "source.apiDefinitionNativeV4.resources")` to `mapToNativeV4`, applying the same fix symmetrically for native v4 APIs.

All eight HTTP v4 callers are fixed by the first change:

| Endpoint | Pre-fix symptom |
| --- | --- |
| `PATCH /apis/{apiId}` response | empty `resources` in response body |
| `PATCH /apis/{apiId}` JSON-Patch current state | `/resources/N/configuration/...` patch ops failed |
| `PUT /apis/{apiId}/_import/definition` | response dropped `resources` (persisted correctly) |
| `PUT /apis/{apiId}/_import/swagger` | same |
| `PUT /apis/{apiId}/_import/wsdl` | same |
| `POST /apis/_import/definition` | same |
| `POST /apis/_import/swagger` | same |
| `POST /apis/_import/wsdl` | same |

Native v4 API endpoints routing through `mapToNativeV4` are fixed by the second change.

Tests added for every caller path: `PATCH` response, JSON-Patch current-state round-trip, all six `_import` endpoints, and a native v4 round-trip using `ApiFixtures.aNativeApi()`.

## How to test

**HTTP v4 (Proxy/Message API)**

1. Create a v4 Proxy API with no resources (capture `{apiId}`).
2. `PATCH /management/v2/environments/DEFAULT/apis/{apiId}` with `Content-Type: application/merge-patch+json`:
   ```json
   {"resources":[{"name":"my-cache","type":"cache","enabled":true,"configuration":{"timeToIdleSeconds":0,"timeToLiveSeconds":0,"maxEntriesLocalHeap":1000}}]}
   ```
3. Verify the 200 response body includes the `resources` array with the cache entry (previously returned `[]`).
4. Confirm `GET /management/v2/environments/DEFAULT/apis/{apiId}` returns the same resources.

**Native v4 (Kafka API)**

1. Create a native (Kafka) v4 API with a resource defined.
2. `GET /management/v2/environments/DEFAULT/apis/{apiId}` — verify `resources` is populated in the response (previously returned `null`/`[]`).

## Gotchas / Follow-up

One related gap remains unaddressed (noted for follow-up, not a regression introduced here):

- `mapToV4(ApiWithFlows)` (`ApiMapper.java:332`, used by `POST /apis`) is missing `resources`, `properties`, `services`, `responseTemplates`, and `failover` — but `CreateApiV4` has no `resources` field, so this is a latent gap rather than an active defect.

[APIM-14375]: https://gravitee.atlassian.net/browse/APIM-14375