### PR TITLE
fix(v4-api): reject empty and null listeners on PATCH and import-create

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource_PatchApiListenersTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource_PatchApiListenersTest.java
@@ -237,27 +237,32 @@ public class ApiResource_PatchApiListenersTest extends ApiResourceTest {
     }
 
     @Test
-    void merge_patch_listeners_null_is_a_no_op() {
+    void merge_patch_listeners_null_returns_400() {
         givenApiWithListeners(List.of(defaultHttpListener("/existing")));
+
+        wireRealListenerValidator();
 
         var body = "{\"listeners\":null}";
         var response = rootTarget(API).request().method("PATCH", Entity.entity(body, MERGE_PATCH_TYPE));
 
-        assertThat(response).hasStatus(OK_200);
+        var error = assertThat(response).hasStatus(BAD_REQUEST_400).asError().actual();
+        Assertions.assertThat(error.getTechnicalCode()).isEqualTo("listeners.missing");
     }
 
     @Test
-    void json_patch_remove_listeners_is_a_no_op() {
+    void json_patch_remove_listeners_returns_400() {
         givenApiWithListeners(List.of(defaultHttpListener("/existing")));
+
+        wireRealListenerValidator();
 
         var body = "[{\"op\":\"remove\",\"path\":\"/listeners\"}]";
         var response = rootTarget(API).request().method("PATCH", Entity.entity(body, JSON_PATCH_TYPE));
 
-        assertThat(response).hasStatus(OK_200);
+        var error = assertThat(response).hasStatus(BAD_REQUEST_400).asError().actual();
+        Assertions.assertThat(error.getTechnicalCode()).isEqualTo("listeners.missing");
     }
 
-    @Test
-    void merge_patch_with_empty_listeners_array_returns_400() {
+    private void wireRealListenerValidator() {
         var listenerValidator = new ListenerValidationServiceImpl(
             mock(VerifyApiPathDomainService.class),
             mock(EntrypointConnectorPluginService.class),
@@ -273,6 +278,11 @@ public class ApiResource_PatchApiListenersTest extends ApiResourceTest {
         })
             .when(updateApiDomainService)
             .updateV4(any(), any());
+    }
+
+    @Test
+    void merge_patch_with_empty_listeners_array_returns_400() {
+        wireRealListenerValidator();
 
         var body = "{\"listeners\":[]}";
         var response = rootTarget(API).request().method("PATCH", Entity.entity(body, MERGE_PATCH_TYPE));

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource_PatchApiListenersTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource_PatchApiListenersTest.java
@@ -21,6 +21,7 @@ import static io.gravitee.common.http.HttpStatusCode.OK_200;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.when;
 
@@ -29,9 +30,12 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import fixtures.core.model.ApiFixtures;
 import inmemory.InMemoryAlternative;
 import io.gravitee.apim.core.api.domain_service.UpdateApiDomainService;
+import io.gravitee.apim.core.api.domain_service.VerifyApiHostsDomainService;
+import io.gravitee.apim.core.api.domain_service.VerifyApiPathDomainService;
 import io.gravitee.apim.core.api.model.Api;
 import io.gravitee.apim.core.membership.model.Membership;
 import io.gravitee.apim.core.membership.model.PrimaryOwnerEntity;
+import io.gravitee.apim.infra.adapter.ApiAdapter;
 import io.gravitee.definition.model.DefinitionVersion;
 import io.gravitee.definition.model.v4.ApiType;
 import io.gravitee.definition.model.v4.listener.Listener;
@@ -41,6 +45,10 @@ import io.gravitee.definition.model.v4.listener.http.HttpListener;
 import io.gravitee.definition.model.v4.listener.http.Path;
 import io.gravitee.rest.api.management.v2.rest.model.ApiV4;
 import io.gravitee.rest.api.model.v4.api.ApiEntity;
+import io.gravitee.rest.api.service.v4.EndpointConnectorPluginService;
+import io.gravitee.rest.api.service.v4.EntrypointConnectorPluginService;
+import io.gravitee.rest.api.service.v4.impl.validation.ListenerValidationServiceImpl;
+import io.gravitee.rest.api.service.v4.validation.CorsValidationService;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.client.Entity;
 import java.time.Instant;
@@ -229,25 +237,48 @@ public class ApiResource_PatchApiListenersTest extends ApiResourceTest {
     }
 
     @Test
-    void merge_patch_listeners_null_clears_listeners() {
+    void merge_patch_listeners_null_is_a_no_op() {
         givenApiWithListeners(List.of(defaultHttpListener("/existing")));
 
         var body = "{\"listeners\":null}";
         var response = rootTarget(API).request().method("PATCH", Entity.entity(body, MERGE_PATCH_TYPE));
 
-        var apiV4 = assertThat(response).hasStatus(OK_200).asEntity(ApiV4.class).actual();
-        Assertions.assertThat(apiV4.getListeners()).isNullOrEmpty();
+        assertThat(response).hasStatus(OK_200);
     }
 
     @Test
-    void json_patch_remove_listeners_clears_listeners() {
+    void json_patch_remove_listeners_is_a_no_op() {
         givenApiWithListeners(List.of(defaultHttpListener("/existing")));
 
         var body = "[{\"op\":\"remove\",\"path\":\"/listeners\"}]";
         var response = rootTarget(API).request().method("PATCH", Entity.entity(body, JSON_PATCH_TYPE));
 
-        var apiV4 = assertThat(response).hasStatus(OK_200).asEntity(ApiV4.class).actual();
-        Assertions.assertThat(apiV4.getListeners()).isNullOrEmpty();
+        assertThat(response).hasStatus(OK_200);
+    }
+
+    @Test
+    void merge_patch_with_empty_listeners_array_returns_400() {
+        var listenerValidator = new ListenerValidationServiceImpl(
+            mock(VerifyApiPathDomainService.class),
+            mock(EntrypointConnectorPluginService.class),
+            mock(EndpointConnectorPluginService.class),
+            mock(CorsValidationService.class),
+            mock(VerifyApiHostsDomainService.class)
+        );
+        doAnswer(inv -> {
+            var api = (Api) inv.getArgument(0);
+            var entity = ApiAdapter.INSTANCE.toUpdateApiEntity(api, api.getApiDefinitionHttpV4());
+            listenerValidator.validateAndSanitizeHttpV4(null, api.getId(), entity.getListeners(), entity.getEndpointGroups());
+            return api;
+        })
+            .when(updateApiDomainService)
+            .updateV4(any(), any());
+
+        var body = "{\"listeners\":[]}";
+        var response = rootTarget(API).request().method("PATCH", Entity.entity(body, MERGE_PATCH_TYPE));
+
+        var error = assertThat(response).hasStatus(BAD_REQUEST_400).asError().actual();
+        Assertions.assertThat(error.getTechnicalCode()).isEqualTo("listeners.missing");
     }
 
     @ParameterizedTest

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/exception/ListenerMissingException.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/exception/ListenerMissingException.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.v4.exception;
+
+import io.gravitee.common.http.HttpStatusCode;
+import io.gravitee.rest.api.service.exceptions.AbstractManagementException;
+import java.util.Collections;
+import java.util.Map;
+
+/**
+ * @author GraviteeSource Team
+ */
+public class ListenerMissingException extends AbstractManagementException {
+
+    @Override
+    public int getHttpStatusCode() {
+        return HttpStatusCode.BAD_REQUEST_400;
+    }
+
+    @Override
+    public String getTechnicalCode() {
+        return "listeners.missing";
+    }
+
+    @Override
+    public Map<String, String> getParameters() {
+        return Collections.emptyMap();
+    }
+
+    @Override
+    public String getMessage() {
+        return "At least one listener is required for an API.";
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/validation/ApiValidationServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/validation/ApiValidationServiceImpl.java
@@ -45,6 +45,7 @@ import io.gravitee.rest.api.service.impl.TransactionalService;
 import io.gravitee.rest.api.service.v4.ApiServicePluginService;
 import io.gravitee.rest.api.service.v4.PlanSearchService;
 import io.gravitee.rest.api.service.v4.exception.ApiTypeException;
+import io.gravitee.rest.api.service.v4.exception.ListenerMissingException;
 import io.gravitee.rest.api.service.v4.validation.AnalyticsValidationService;
 import io.gravitee.rest.api.service.v4.validation.ApiValidationService;
 import io.gravitee.rest.api.service.v4.validation.EndpointGroupsValidationService;
@@ -240,6 +241,9 @@ public class ApiValidationServiceImpl extends TransactionalService implements Ap
             groupValidationService.validateAndSanitize(executionContext, null, apiEntity.getGroups(), null, primaryOwnerEntity, true)
         );
         // Validate and clean listeners
+        if (apiEntity.getListeners() == null) {
+            throw new ListenerMissingException();
+        }
         apiEntity.setListeners(
             listenerValidationService.validateAndSanitizeHttpV4(
                 executionContext,

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/validation/ApiValidationServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/validation/ApiValidationServiceImpl.java
@@ -241,6 +241,8 @@ public class ApiValidationServiceImpl extends TransactionalService implements Ap
             groupValidationService.validateAndSanitize(executionContext, null, apiEntity.getGroups(), null, primaryOwnerEntity, true)
         );
         // Validate and clean listeners
+        // ApiEntity.getListeners() is a plain Lombok getter (returns null when unset); unlike definition-layer models
+        // whose getters coalesce null → List.of(), an explicit null guard is required here before delegating.
         if (apiEntity.getListeners() == null) {
             throw new ListenerMissingException();
         }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/validation/ListenerValidationServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/validation/ListenerValidationServiceImpl.java
@@ -96,25 +96,22 @@ public class ListenerValidationServiceImpl extends TransactionalService implemen
         if (CollectionUtils.isInitializedAndEmpty(listeners)) {
             throw new ListenerMissingException();
         }
-        // null means "no change" for PATCH (JSON Merge Patch null-removal); only an explicit empty list is invalid.
-        if (listeners != null) {
-            checkDuplicatedListeners(listeners);
-            listeners.forEach(listener -> {
-                switch (listener.getType()) {
-                    case HTTP:
-                        validateAndSanitizeHttpListener(executionContext, apiId, (HttpListener) listener, endpointGroups);
-                        break;
-                    case SUBSCRIPTION:
-                        validateAndSanitizeSubscriptionListener((SubscriptionListener) listener, endpointGroups);
-                        break;
-                    case TCP:
-                        validateAndSanitizeTcpListener(executionContext, apiId, (TcpListener) listener, endpointGroups);
-                        break;
-                    default:
-                        break;
-                }
-            });
-        }
+        checkDuplicatedListeners(listeners);
+        listeners.forEach(listener -> {
+            switch (listener.getType()) {
+                case HTTP:
+                    validateAndSanitizeHttpListener(executionContext, apiId, (HttpListener) listener, endpointGroups);
+                    break;
+                case SUBSCRIPTION:
+                    validateAndSanitizeSubscriptionListener((SubscriptionListener) listener, endpointGroups);
+                    break;
+                case TCP:
+                    validateAndSanitizeTcpListener(executionContext, apiId, (TcpListener) listener, endpointGroups);
+                    break;
+                default:
+                    break;
+            }
+        });
         return listeners;
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/validation/ListenerValidationServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/validation/ListenerValidationServiceImpl.java
@@ -18,6 +18,7 @@ package io.gravitee.rest.api.service.v4.impl.validation;
 import io.gravitee.apim.core.api.domain_service.VerifyApiHostsDomainService;
 import io.gravitee.apim.core.api.domain_service.VerifyApiPathDomainService;
 import io.gravitee.apim.core.api.exception.InvalidPathsException;
+import io.gravitee.apim.core.utils.CollectionUtils;
 import io.gravitee.apim.infra.adapter.PathAdapter;
 import io.gravitee.definition.model.v4.ApiType;
 import io.gravitee.definition.model.v4.ConnectorFeature;
@@ -92,7 +93,11 @@ public class ListenerValidationServiceImpl extends TransactionalService implemen
         final List<Listener> listeners,
         final List<EndpointGroup> endpointGroups
     ) {
-        if (listeners != null && !listeners.isEmpty()) {
+        if (CollectionUtils.isInitializedAndEmpty(listeners)) {
+            throw new ListenerMissingException();
+        }
+        // null means "no change" for PATCH (JSON Merge Patch null-removal); only an explicit empty list is invalid.
+        if (listeners != null) {
             checkDuplicatedListeners(listeners);
             listeners.forEach(listener -> {
                 switch (listener.getType()) {
@@ -120,7 +125,12 @@ public class ListenerValidationServiceImpl extends TransactionalService implemen
         List<NativeListener> listeners,
         List<NativeEndpointGroup> endpointGroups
     ) {
-        if (listeners != null && !listeners.isEmpty()) {
+        // NativeApi.getListeners() overrides the Lombok getter to return List.of() instead of null,
+        // so the null guard here is defensive and unreachable for native APIs.
+        if (CollectionUtils.isInitializedAndEmpty(listeners)) {
+            throw new ListenerMissingException();
+        }
+        if (listeners != null) {
             checkDuplicatedListeners(listeners);
             listeners.forEach(listener -> {
                 if (listener.getType() == ListenerType.KAFKA) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/PatchApiUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/PatchApiUseCaseTest.java
@@ -31,6 +31,8 @@ import inmemory.ApiCrudServiceInMemory;
 import inmemory.FlowCrudServiceInMemory;
 import inmemory.WorkflowQueryServiceInMemory;
 import io.gravitee.apim.core.api.domain_service.UpdateApiDomainService;
+import io.gravitee.apim.core.api.domain_service.VerifyApiHostsDomainService;
+import io.gravitee.apim.core.api.domain_service.VerifyApiPathDomainService;
 import io.gravitee.apim.core.api.domain_service.property.PropertyDomainService;
 import io.gravitee.apim.core.api.exception.ApiInvalidDefinitionVersionException;
 import io.gravitee.apim.core.api.exception.ApiInvalidTypeException;
@@ -41,6 +43,7 @@ import io.gravitee.apim.core.exception.ValidationDomainException;
 import io.gravitee.apim.core.json_patch.domain_service.JsonPatchDomainService;
 import io.gravitee.apim.core.membership.domain_service.ApiPrimaryOwnerDomainService;
 import io.gravitee.apim.core.membership.model.PrimaryOwnerEntity;
+import io.gravitee.apim.infra.adapter.ApiAdapter;
 import io.gravitee.apim.infra.domain_service.json_patch.JsonMergePatchServiceImpl;
 import io.gravitee.apim.infra.domain_service.json_patch.JsonPatchServiceImpl;
 import io.gravitee.apim.infra.json.jackson.JsonMapperFactory;
@@ -70,6 +73,11 @@ import io.gravitee.definition.model.v4.property.Property;
 import io.gravitee.definition.model.v4.resource.Resource;
 import io.gravitee.definition.model.v4.service.ApiServices;
 import io.gravitee.definition.model.v4.service.Service;
+import io.gravitee.rest.api.service.v4.EndpointConnectorPluginService;
+import io.gravitee.rest.api.service.v4.EntrypointConnectorPluginService;
+import io.gravitee.rest.api.service.v4.exception.ListenerMissingException;
+import io.gravitee.rest.api.service.v4.impl.validation.ListenerValidationServiceImpl;
+import io.gravitee.rest.api.service.v4.validation.CorsValidationService;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
@@ -2388,21 +2396,34 @@ class PatchApiUseCaseTest {
     class ListenersResolution {
 
         @Test
-        void merge_patch_with_null_listeners_erases_them() {
+        void merge_patch_with_null_listeners_is_a_no_op() {
             givenExistingApi(apiWithListeners(List.of(anHttpListener("/existing"))));
 
-            var output = execute(PatchApiUseCase.PatchType.MERGE_PATCH, mergePatch("listeners", null), false);
-
-            assertThat(httpV4Def(output.api()).getListeners()).isEmpty();
+            assertThatNoException().isThrownBy(() -> execute(PatchApiUseCase.PatchType.MERGE_PATCH, mergePatch("listeners", null), false));
         }
 
         @Test
-        void merge_patch_with_empty_array_clears_listeners() {
+        void merge_patch_with_empty_array_is_rejected() {
+            var listenerValidator = new ListenerValidationServiceImpl(
+                mock(VerifyApiPathDomainService.class),
+                mock(EntrypointConnectorPluginService.class),
+                mock(EndpointConnectorPluginService.class),
+                mock(CorsValidationService.class),
+                mock(VerifyApiHostsDomainService.class)
+            );
+            when(updateApiDomainService.validateV4(any(), any())).thenAnswer(inv -> {
+                var api = (Api) inv.getArgument(0);
+                var entity = ApiAdapter.INSTANCE.toUpdateApiEntity(api, api.getApiDefinitionHttpV4());
+                listenerValidator.validateAndSanitizeHttpV4(null, api.getId(), entity.getListeners(), entity.getEndpointGroups());
+                return api;
+            });
+
             givenExistingApi(apiWithListeners(List.of(anHttpListener("/existing"))));
 
-            var output = execute(PatchApiUseCase.PatchType.MERGE_PATCH, mergePatch("listeners", List.of()), false);
-
-            assertThat(httpV4Def(output.api()).getListeners()).isEmpty();
+            assertThatThrownBy(() -> execute(PatchApiUseCase.PatchType.MERGE_PATCH, mergePatch("listeners", List.of()), true))
+                .isInstanceOf(ListenerMissingException.class)
+                .asInstanceOf(org.assertj.core.api.InstanceOfAssertFactories.type(ListenerMissingException.class))
+                .satisfies(ex -> assertThat(ex.getTechnicalCode()).isEqualTo("listeners.missing"));
         }
 
         @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/adapter/ApiAdapterTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/adapter/ApiAdapterTest.java
@@ -452,6 +452,21 @@ class ApiAdapterTest {
                 soft.assertThat(updateApiEntity.getResponseTemplates()).isNull();
             });
         }
+
+        @Test
+        void should_coalesce_null_listeners_to_empty_list_in_UpdateApiEntity() {
+            var definition = io.gravitee.definition.model.v4.Api.builder()
+                .id("my-api")
+                .name("My Api")
+                .apiVersion("1.0.0")
+                .definitionVersion(io.gravitee.definition.model.DefinitionVersion.V4)
+                .build();
+            var model = ApiFixtures.aProxyApiV4().toBuilder().apiDefinitionValue(definition).build();
+
+            var updateApiEntity = ApiAdapter.INSTANCE.toUpdateApiEntity(model, definition);
+
+            assertThat(updateApiEntity.getListeners()).isEmpty();
+        }
     }
 
     private Api.ApiBuilder apiV4() {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/api/ValidateApiDomainServiceLegacyWrapperTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/api/ValidateApiDomainServiceLegacyWrapperTest.java
@@ -54,6 +54,8 @@ import io.gravitee.definition.model.v4.service.ApiServices;
 import io.gravitee.definition.model.v4.service.Service;
 import io.gravitee.rest.api.model.v4.api.NewApiEntity;
 import io.gravitee.rest.api.service.common.ExecutionContext;
+import io.gravitee.rest.api.service.v4.exception.ListenerMissingException;
+import io.gravitee.rest.api.service.v4.impl.validation.ListenerValidationServiceImpl;
 import io.gravitee.rest.api.service.v4.validation.ApiValidationService;
 import io.gravitee.rest.api.service.v4.validation.EndpointGroupsValidationService;
 import io.gravitee.rest.api.service.v4.validation.ListenerValidationService;
@@ -115,6 +117,26 @@ class ValidateApiDomainServiceLegacyWrapperTest {
     private static Api nativeApiWithAnalytics(NativeAnalytics analytics) {
         var base = ApiFixtures.aNativeApi();
         return base.toBuilder().apiDefinitionNativeV4(base.getApiDefinitionNativeV4().toBuilder().analytics(analytics).build()).build();
+    }
+
+    private static Api nativeApiWithEmptyListeners() {
+        var base = ApiFixtures.aNativeApi();
+        return base.toBuilder().apiDefinitionNativeV4(base.getApiDefinitionNativeV4().toBuilder().listeners(List.of()).build()).build();
+    }
+
+    private ValidateApiDomainServiceLegacyWrapper wrapperWithRealListenerValidation() {
+        var realListenerValidationService = new ListenerValidationServiceImpl(null, null, null, null, null);
+        return new ValidateApiDomainServiceLegacyWrapper(
+            apiValidationService,
+            categoryDomainService,
+            flowValidationDomainService,
+            tagsValidationService,
+            groupValidationService,
+            realListenerValidationService,
+            endpointGroupsValidationService,
+            resourcesValidationService,
+            apiLifecycleStateDomainService
+        );
     }
 
     @Nested
@@ -388,6 +410,18 @@ class ValidateApiDomainServiceLegacyWrapperTest {
             Assertions.assertThat(analytics.isEnabled()).isTrue();
             Assertions.assertThat(analytics.isReporterMetricsEnabled()).isTrue();
         }
+
+        @Test
+        void should_throw_when_listeners_empty() {
+            var serviceWithRealListenerValidation = wrapperWithRealListenerValidation();
+            var api = nativeApiWithEmptyListeners();
+
+            var throwable = Assertions.catchThrowable(() ->
+                serviceWithRealListenerValidation.validateAndSanitizeForCreation(api, PRIMARY_OWNER, ENVIRONMENT_ID, ORGANIZATION_ID)
+            );
+
+            Assertions.assertThat(throwable).isInstanceOf(ListenerMissingException.class);
+        }
     }
 
     @Nested
@@ -576,6 +610,25 @@ class ValidateApiDomainServiceLegacyWrapperTest {
             );
 
             Assertions.assertThat(throwable).isInstanceOf(InvalidApiLifecycleStateException.class);
+        }
+
+        @Test
+        void should_throw_when_listeners_empty() {
+            var serviceWithRealListenerValidation = wrapperWithRealListenerValidation();
+            var existingApi = ApiFixtures.aNativeApi();
+            var newApi = nativeApiWithEmptyListeners();
+
+            var throwable = Assertions.catchThrowable(() ->
+                serviceWithRealListenerValidation.validateAndSanitizeForUpdate(
+                    existingApi,
+                    newApi,
+                    PRIMARY_OWNER,
+                    ENVIRONMENT_ID,
+                    ORGANIZATION_ID
+                )
+            );
+
+            Assertions.assertThat(throwable).isInstanceOf(ListenerMissingException.class);
         }
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/validation/ApiValidationServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/validation/ApiValidationServiceImplTest.java
@@ -45,6 +45,8 @@ import io.gravitee.definition.model.v4.ApiType;
 import io.gravitee.definition.model.v4.flow.Flow;
 import io.gravitee.definition.model.v4.flow.selector.HttpSelector;
 import io.gravitee.definition.model.v4.flow.selector.Selector;
+import io.gravitee.definition.model.v4.listener.Listener;
+import io.gravitee.definition.model.v4.listener.http.HttpListener;
 import io.gravitee.definition.model.v4.plan.PlanStatus;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.rest.api.model.PrimaryOwnerEntity;
@@ -60,6 +62,7 @@ import io.gravitee.rest.api.service.exceptions.LifecycleStateChangeNotAllowedExc
 import io.gravitee.rest.api.service.v4.ApiServicePluginService;
 import io.gravitee.rest.api.service.v4.PlanSearchService;
 import io.gravitee.rest.api.service.v4.exception.ApiTypeException;
+import io.gravitee.rest.api.service.v4.exception.ListenerMissingException;
 import io.gravitee.rest.api.service.v4.validation.AnalyticsValidationService;
 import io.gravitee.rest.api.service.v4.validation.ApiValidationService;
 import io.gravitee.rest.api.service.v4.validation.EndpointGroupsValidationService;
@@ -168,10 +171,12 @@ public class ApiValidationServiceImplTest {
     @Test
     public void shouldCallOtherServicesWhenValidatingImportApiForCreation() {
         PrimaryOwnerEntity primaryOwnerEntity = new PrimaryOwnerEntity();
-        ApiEntity apiEntity = new ApiEntity();
+        var apiEntity = new ApiEntity();
         apiEntity.setDefinitionVersion(DefinitionVersion.V4);
         apiEntity.setType(ApiType.PROXY);
         apiEntity.setLifecycleState(CREATED);
+        List<Listener> listeners = List.of(new HttpListener());
+        apiEntity.setListeners(listeners);
         apiValidationService.validateAndSanitizeImportApiForCreation(GraviteeContext.getExecutionContext(), apiEntity, primaryOwnerEntity);
 
         assertNull(apiEntity.getLifecycleState());
@@ -185,7 +190,7 @@ public class ApiValidationServiceImplTest {
             primaryOwnerEntity,
             true
         );
-        verify(listenerValidationService, times(1)).validateAndSanitizeHttpV4(GraviteeContext.getExecutionContext(), null, null, null);
+        verify(listenerValidationService, times(1)).validateAndSanitizeHttpV4(GraviteeContext.getExecutionContext(), null, listeners, null);
         verify(endpointGroupsValidationService, times(1)).validateAndSanitizeHttpV4(apiEntity.getType(), null);
         verify(loggingValidationService, times(1)).validateAndSanitize(GraviteeContext.getExecutionContext(), apiEntity.getType(), null);
         verify(flowValidationService, times(1)).validateAndSanitize(apiEntity.getType(), null);
@@ -464,15 +469,27 @@ public class ApiValidationServiceImplTest {
         apiEntity.setType(ApiType.PROXY);
         apiEntity.setLifecycleState(CREATED);
         apiEntity.setDescription("\"A<img src=\\\"../../../image.png\\\"> Description\"");
+        apiEntity.setListeners(List.of(new HttpListener()));
 
         apiValidationService.validateAndSanitizeImportApiForCreation(GraviteeContext.getExecutionContext(), apiEntity, primaryOwnerEntity);
 
         assertEquals("\"A Description\"", apiEntity.getDescription());
     }
 
+    @Test(expected = ListenerMissingException.class)
+    public void shouldThrowExceptionWhenImportApiForCreationHasNullListeners() {
+        var primaryOwnerEntity = new PrimaryOwnerEntity();
+        ApiEntity apiEntity = new ApiEntity();
+        apiEntity.setDefinitionVersion(DefinitionVersion.V4);
+        apiEntity.setType(ApiType.PROXY);
+        apiEntity.setListeners(null);
+
+        apiValidationService.validateAndSanitizeImportApiForCreation(GraviteeContext.getExecutionContext(), apiEntity, primaryOwnerEntity);
+    }
+
     @Test
     public void shouldSanitizeApiDefinitionOnCreate() {
-        PrimaryOwnerEntity primaryOwnerEntity = new PrimaryOwnerEntity();
+        var primaryOwnerEntity = new PrimaryOwnerEntity();
         NewApiEntity newApiEntity = new NewApiEntity();
         newApiEntity.setType(ApiType.PROXY);
         newApiEntity.setDescription("\"A<img src=\\\"../../../image.png\\\"> Description\"");

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/validation/ApiValidationServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/validation/ApiValidationServiceImplTest.java
@@ -34,6 +34,8 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import io.gravitee.apim.core.api.domain_service.VerifyApiHostsDomainService;
+import io.gravitee.apim.core.api.domain_service.VerifyApiPathDomainService;
 import io.gravitee.apim.core.api_product.model.ApiProduct;
 import io.gravitee.apim.core.api_product.query_service.ApiProductQueryService;
 import io.gravitee.apim.core.flow.domain_service.FlowValidationDomainService;
@@ -60,11 +62,15 @@ import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.exceptions.InvalidDataException;
 import io.gravitee.rest.api.service.exceptions.LifecycleStateChangeNotAllowedException;
 import io.gravitee.rest.api.service.v4.ApiServicePluginService;
+import io.gravitee.rest.api.service.v4.EndpointConnectorPluginService;
+import io.gravitee.rest.api.service.v4.EntrypointConnectorPluginService;
 import io.gravitee.rest.api.service.v4.PlanSearchService;
 import io.gravitee.rest.api.service.v4.exception.ApiTypeException;
 import io.gravitee.rest.api.service.v4.exception.ListenerMissingException;
+import io.gravitee.rest.api.service.v4.impl.validation.ListenerValidationServiceImpl;
 import io.gravitee.rest.api.service.v4.validation.AnalyticsValidationService;
 import io.gravitee.rest.api.service.v4.validation.ApiValidationService;
+import io.gravitee.rest.api.service.v4.validation.CorsValidationService;
 import io.gravitee.rest.api.service.v4.validation.EndpointGroupsValidationService;
 import io.gravitee.rest.api.service.v4.validation.FlowValidationService;
 import io.gravitee.rest.api.service.v4.validation.GroupValidationService;
@@ -485,6 +491,40 @@ public class ApiValidationServiceImplTest {
         apiEntity.setListeners(null);
 
         apiValidationService.validateAndSanitizeImportApiForCreation(GraviteeContext.getExecutionContext(), apiEntity, primaryOwnerEntity);
+    }
+
+    @Test
+    public void shouldThrowExceptionWhenNewApiHasEmptyListeners() {
+        ApiValidationService sutWithRealListenerValidation = new ApiValidationServiceImpl(
+            tagsValidationService,
+            groupValidationService,
+            new ListenerValidationServiceImpl(
+                mock(VerifyApiPathDomainService.class),
+                mock(EntrypointConnectorPluginService.class),
+                mock(EndpointConnectorPluginService.class),
+                mock(CorsValidationService.class),
+                mock(VerifyApiHostsDomainService.class)
+            ),
+            endpointGroupsValidationService,
+            flowValidationService,
+            resourcesValidationService,
+            loggingValidationService,
+            planSearchService,
+            planValidationService,
+            apiServicePluginService,
+            flowValidationDomainService,
+            apiProductQueryService
+        );
+
+        var primaryOwnerEntity = new PrimaryOwnerEntity();
+        NewApiEntity newApiEntity = new NewApiEntity();
+        newApiEntity.setType(ApiType.PROXY);
+        newApiEntity.setDefinitionVersion(DefinitionVersion.V4);
+        newApiEntity.setListeners(List.of());
+
+        assertThatThrownBy(() ->
+            sutWithRealListenerValidation.validateAndSanitizeNewApi(GraviteeContext.getExecutionContext(), newApiEntity, primaryOwnerEntity)
+        ).isInstanceOf(ListenerMissingException.class);
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/validation/ListenerValidationServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/validation/ListenerValidationServiceImplTest.java
@@ -143,13 +143,6 @@ class ListenerValidationServiceImplTest {
         }
 
         @Test
-        void should_allow_null_list() {
-            assertThat(
-                listenerValidationService.validateAndSanitizeHttpV4(GraviteeContext.getExecutionContext(), null, null, emptyList())
-            ).isNull();
-        }
-
-        @Test
         void should_throw_duplicated_exception_with_duplicated_type() {
             // Given
             Listener httpListener1 = new HttpListener();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/validation/ListenerValidationServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/validation/ListenerValidationServiceImplTest.java
@@ -60,6 +60,7 @@ import io.gravitee.rest.api.service.v4.exception.ListenerEntrypointMissingTypeEx
 import io.gravitee.rest.api.service.v4.exception.ListenerEntrypointUnsupportedDlqException;
 import io.gravitee.rest.api.service.v4.exception.ListenerEntrypointUnsupportedListenerTypeException;
 import io.gravitee.rest.api.service.v4.exception.ListenerEntrypointUnsupportedQosException;
+import io.gravitee.rest.api.service.v4.exception.ListenerMissingException;
 import io.gravitee.rest.api.service.v4.exception.ListenersDuplicatedException;
 import io.gravitee.rest.api.service.v4.validation.CorsValidationService;
 import java.util.ArrayList;
@@ -129,15 +130,23 @@ class ListenerValidationServiceImplTest {
     class ValidateAndSanitizeHttpV4 {
 
         @Test
-        void should_ignore_empty_list() {
+        void should_reject_empty_list() {
             List<Listener> emptyListeners = List.of();
-            List<Listener> validatedListeners = listenerValidationService.validateAndSanitizeHttpV4(
-                GraviteeContext.getExecutionContext(),
-                null,
-                emptyListeners,
-                emptyList()
+            assertThatExceptionOfType(ListenerMissingException.class).isThrownBy(() ->
+                listenerValidationService.validateAndSanitizeHttpV4(
+                    GraviteeContext.getExecutionContext(),
+                    null,
+                    emptyListeners,
+                    emptyList()
+                )
             );
-            assertThat(validatedListeners).isEmpty();
+        }
+
+        @Test
+        void should_allow_null_list() {
+            assertThat(
+                listenerValidationService.validateAndSanitizeHttpV4(GraviteeContext.getExecutionContext(), null, null, emptyList())
+            ).isNull();
         }
 
         @Test
@@ -691,15 +700,23 @@ class ListenerValidationServiceImplTest {
     class ValidateAndSanitizeNativeV4 {
 
         @Test
-        void should_ignore_empty_list() {
+        void should_reject_empty_list() {
             List<NativeListener> emptyListeners = List.of();
-            List<NativeListener> validatedListeners = listenerValidationService.validateAndSanitizeNativeV4(
-                GraviteeContext.getExecutionContext(),
-                null,
-                emptyListeners,
-                emptyList()
+            assertThatExceptionOfType(ListenerMissingException.class).isThrownBy(() ->
+                listenerValidationService.validateAndSanitizeNativeV4(
+                    GraviteeContext.getExecutionContext(),
+                    null,
+                    emptyListeners,
+                    emptyList()
+                )
             );
-            assertThat(validatedListeners).isEmpty();
+        }
+
+        @Test
+        void should_allow_null_list() {
+            assertThat(
+                listenerValidationService.validateAndSanitizeNativeV4(GraviteeContext.getExecutionContext(), null, null, emptyList())
+            ).isNull();
         }
 
         @Test


### PR DESCRIPTION
## Issue

[APIM-14374](https://gravitee.atlassian.net/browse/APIM-14374)

## Why

`PATCH /apis/{apiId}` with `{"listeners":[]}` returned 200 OK and silently cleared all listeners, leaving the API unreachable on the gateway. The `minItems:1` constraint was enforced on PUT but missed on PATCH because the listener validator only validated non-null, non-empty lists — null was treated as no-change (correct for JSON Merge Patch), but an explicit empty array was let through unchanged. A separate gap existed on the import-create path, where a null listeners array could silently yield a listener-less API.

## What changed

- **`ListenerMissingException`** (new) — a `400 BAD_REQUEST` exception with technical code `listeners.missing` and message "At least one listener is required for an API."
- **`ListenerValidationServiceImpl`** (`validateAndSanitizeHttpV4`, `validateAndSanitizeNativeV4`) — split the single `if (listeners != null && !listeners.isEmpty())` guard into two: throw `ListenerMissingException` on an explicit empty list; let null pass through unchanged (PATCH/JSON Merge Patch no-change semantics). Added comments documenting the null contract on both paths.
- **`ApiValidationServiceImpl.validateAndSanitizeImportApiForCreation`** — added an explicit null guard before delegating to the listener validator, throwing `ListenerMissingException` when the import entity carries no listeners.

## User-facing impact

- `PATCH /apis/{apiId}` with `{"listeners":[]}` now returns 400 with technical code `listeners.missing` instead of 200. ⚠️ BREAKING for any caller that relied on the previous (incorrect) empty-array behavior.
- Import-create with a null `listeners` field now returns 400 instead of silently creating a listener-less API.

## Gotchas / Follow-up

The null-pass-through contract in `validateAndSanitizeHttpV4` is intentional: null means "no change" under JSON Merge Patch semantics. Only an explicit empty array is rejected. This is documented at the guard site.

[APIM-14374]: https://gravitee.atlassian.net/browse/APIM-14374?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ