### PR TITLE
fix(gateway): render requestMethod MDC entry as String to avoid ClassCastException

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/SyncApiReactor.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/SyncApiReactor.java
@@ -106,7 +106,9 @@ public class SyncApiReactor extends AbstractLifecycleComponent<ReactorHandler> i
 
     private static final Set<LogEntry<? extends HttpExecutionContextInternal>> DEFAULT_EXECUTION_CONTEXT_LOG_ENTRIES = Set.of(
         LogEntryFactory.refreshable("contextPath", DefaultExecutionContext.class, context -> context.getAttribute(ATTR_CONTEXT_PATH)),
-        LogEntryFactory.refreshable("requestMethod", DefaultExecutionContext.class, context -> context.getAttribute(ATTR_REQUEST_METHOD))
+        LogEntryFactory.refreshable("requestMethod", DefaultExecutionContext.class, context ->
+            Objects.toString(context.getAttribute(ATTR_REQUEST_METHOD), null)
+        )
     );
 
     protected final Api api;

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/DefaultApiReactor.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/DefaultApiReactor.java
@@ -117,7 +117,9 @@ public class DefaultApiReactor extends AbstractApiReactor {
     private static final Set<LogEntry<? extends HttpExecutionContextInternal>> DEFAULT_EXECUTION_CONTEXT_LOG_ENTRIES = Set.of(
         LogEntryFactory.cached("serverId", DefaultExecutionContext.class, context -> context.getInternalAttribute(ATTR_INTERNAL_SERVER_ID)),
         LogEntryFactory.refreshable("contextPath", DefaultExecutionContext.class, context -> context.getAttribute(ATTR_CONTEXT_PATH)),
-        LogEntryFactory.refreshable("requestMethod", DefaultExecutionContext.class, context -> context.getAttribute(ATTR_REQUEST_METHOD))
+        LogEntryFactory.refreshable("requestMethod", DefaultExecutionContext.class, context ->
+            Objects.toString(context.getAttribute(ATTR_REQUEST_METHOD), null)
+        )
     );
 
     public static final String API_VALIDATE_SUBSCRIPTION_PROPERTY = "api.validateSubscription";

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/SyncApiReactorTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/SyncApiReactorTest.java
@@ -18,8 +18,10 @@ package io.gravitee.gateway.reactive.handlers.api;
 import static io.gravitee.common.http.HttpStatusCode.UNAUTHORIZED_401;
 import static io.gravitee.gateway.handlers.api.ApiReactorHandlerFactory.PENDING_REQUESTS_TIMEOUT_PROPERTY;
 import static io.gravitee.gateway.reactive.api.ExecutionPhase.RESPONSE;
+import static io.gravitee.gateway.reactive.api.context.ContextAttributes.ATTR_REQUEST_METHOD;
 import static io.gravitee.gateway.reactive.api.context.InternalContextAttributes.ATTR_INTERNAL_INVOKER;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.inOrder;
@@ -32,6 +34,7 @@ import static org.mockito.Mockito.when;
 
 import io.gravitee.common.component.Lifecycle;
 import io.gravitee.common.event.EventManager;
+import io.gravitee.common.http.HttpMethod;
 import io.gravitee.definition.model.Logging;
 import io.gravitee.definition.model.LoggingMode;
 import io.gravitee.definition.model.Proxy;
@@ -50,6 +53,7 @@ import io.gravitee.gateway.reactive.api.ExecutionPhase;
 import io.gravitee.gateway.reactive.api.context.ExecutionContext;
 import io.gravitee.gateway.reactive.api.context.http.HttpExecutionContext;
 import io.gravitee.gateway.reactive.api.invoker.Invoker;
+import io.gravitee.gateway.reactive.core.context.DefaultExecutionContext;
 import io.gravitee.gateway.reactive.core.context.MutableExecutionContext;
 import io.gravitee.gateway.reactive.core.context.MutableRequest;
 import io.gravitee.gateway.reactive.core.context.MutableResponse;
@@ -70,6 +74,7 @@ import io.gravitee.gateway.report.guard.LogGuardService;
 import io.gravitee.gateway.resource.ResourceLifecycleManager;
 import io.gravitee.node.api.Node;
 import io.gravitee.node.api.configuration.Configuration;
+import io.gravitee.node.logging.LogEntry;
 import io.gravitee.node.opentelemetry.tracer.noop.NoOpTracer;
 import io.gravitee.reporter.api.v4.metric.Metrics;
 import io.netty.handler.codec.http.HttpResponseStatus;
@@ -83,13 +88,18 @@ import io.reactivex.rxjava3.schedulers.Timed;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InOrder;
@@ -372,6 +382,39 @@ class SyncApiReactorTest {
         assertThat(cut.httpSecurityChain).isNotNull();
         assertThat(cut.invokerHooks).hasSize(1);
         assertThat(cut.invokerHooks.get(0)).isInstanceOf(LoggingHook.class);
+    }
+
+    private static LogEntry<?> requestMethodLogEntry;
+
+    @BeforeAll
+    @SuppressWarnings("unchecked")
+    static void extractRequestMethodLogEntry() {
+        Set<LogEntry<?>> logEntries = (Set<LogEntry<?>>) ReflectionTestUtils.getField(
+            SyncApiReactor.class,
+            "DEFAULT_EXECUTION_CONTEXT_LOG_ENTRIES"
+        );
+        requestMethodLogEntry = logEntries
+            .stream()
+            .filter(entry -> "requestMethod".equals(entry.getKey()))
+            .findFirst()
+            .orElseThrow();
+    }
+
+    static Stream<Arguments> requestMethodAttributeShapes() {
+        return Stream.of(
+            arguments(HttpMethod.POST, "POST"),
+            arguments(io.vertx.core.http.HttpMethod.PUT, "PUT"),
+            arguments("GET", "GET"),
+            arguments(null, null)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("requestMethodAttributeShapes")
+    void shouldRenderRequestMethodMdcEntryAsString(Object attributeValue, String expectedMdcValue) {
+        DefaultExecutionContext context = new DefaultExecutionContext(null, null);
+        context.setAttribute(ATTR_REQUEST_METHOD, attributeValue);
+        assertThat(requestMethodLogEntry.resolve(context)).isEqualTo(expectedMdcValue);
     }
 
     @Test

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/v4/DefaultApiReactorTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/v4/DefaultApiReactorTest.java
@@ -26,6 +26,7 @@ import static io.gravitee.gateway.reactive.handlers.api.v4.DefaultApiReactor.REQ
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.atLeastOnce;
@@ -42,6 +43,7 @@ import static org.mockito.Mockito.when;
 import io.gravitee.common.component.Lifecycle;
 import io.gravitee.common.event.EventListener;
 import io.gravitee.common.event.EventManager;
+import io.gravitee.common.http.HttpMethod;
 import io.gravitee.definition.model.v4.analytics.Analytics;
 import io.gravitee.definition.model.v4.listener.http.HttpListener;
 import io.gravitee.definition.model.v4.listener.http.Path;
@@ -66,6 +68,7 @@ import io.gravitee.gateway.reactive.api.context.ContextAttributes;
 import io.gravitee.gateway.reactive.api.context.InternalContextAttributes;
 import io.gravitee.gateway.reactive.api.context.http.HttpExecutionContext;
 import io.gravitee.gateway.reactive.core.context.DefaultDeploymentContext;
+import io.gravitee.gateway.reactive.core.context.DefaultExecutionContext;
 import io.gravitee.gateway.reactive.core.context.MutableExecutionContext;
 import io.gravitee.gateway.reactive.core.context.MutableRequest;
 import io.gravitee.gateway.reactive.core.context.MutableResponse;
@@ -90,6 +93,7 @@ import io.gravitee.gateway.report.guard.LogGuardService;
 import io.gravitee.gateway.resource.ResourceLifecycleManager;
 import io.gravitee.node.api.Node;
 import io.gravitee.node.api.configuration.Configuration;
+import io.gravitee.node.logging.LogEntry;
 import io.gravitee.plugin.apiservice.ApiServicePluginManager;
 import io.gravitee.plugin.entrypoint.EntrypointConnectorPluginManager;
 import io.gravitee.reporter.api.v4.metric.Metrics;
@@ -103,12 +107,18 @@ import io.reactivex.rxjava3.schedulers.TestScheduler;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Stream;
 import org.assertj.core.groups.Tuple;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.platform.commons.function.Try;
 import org.junit.platform.commons.util.ReflectionUtils;
 import org.mockito.ArgumentCaptor;
@@ -441,6 +451,39 @@ class DefaultApiReactorTest {
         verify(ctx).setAttribute(ContextAttributes.ATTR_API, API_ID);
         verify(ctx).setAttribute(ContextAttributes.ATTR_ORGANIZATION, ORGANIZATION_ID);
         verify(ctx).setAttribute(ContextAttributes.ATTR_ENVIRONMENT, ENVIRONMENT_ID);
+    }
+
+    private static LogEntry<?> requestMethodLogEntry;
+
+    @BeforeAll
+    @SuppressWarnings("unchecked")
+    static void extractRequestMethodLogEntry() {
+        Set<LogEntry<?>> logEntries = (Set<LogEntry<?>>) ReflectionTestUtils.getField(
+            DefaultApiReactor.class,
+            "DEFAULT_EXECUTION_CONTEXT_LOG_ENTRIES"
+        );
+        requestMethodLogEntry = logEntries
+            .stream()
+            .filter(entry -> "requestMethod".equals(entry.getKey()))
+            .findFirst()
+            .orElseThrow();
+    }
+
+    static Stream<Arguments> requestMethodAttributeShapes() {
+        return Stream.of(
+            arguments(HttpMethod.POST, "POST"),
+            arguments(io.vertx.core.http.HttpMethod.PUT, "PUT"),
+            arguments("GET", "GET"),
+            arguments(null, null)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("requestMethodAttributeShapes")
+    void shouldRenderRequestMethodMdcEntryAsString(Object attributeValue, String expectedMdcValue) {
+        DefaultExecutionContext context = new DefaultExecutionContext(null, null);
+        context.setAttribute(ContextAttributes.ATTR_REQUEST_METHOD, attributeValue);
+        assertThat(requestMethodLogEntry.resolve(context)).isEqualTo(expectedMdcValue);
     }
 
     @Test


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-14386

## Description

Both `DefaultApiReactor` (v4) and `SyncApiReactor` (v2) registered the `requestMethod` MDC log entry with a lambda `context -> context.getAttribute(ATTR_REQUEST_METHOD)`. Because `LogEntryFactory.refreshable` requires `Function<T, String>`, javac infers `T=String` and emits a `checkcast String` inside the lambda. The `rest-to-soap` policy sets `ATTR_REQUEST_METHOD` to `io.gravitee.common.http.HttpMethod` (an enum), so when MDC is resolved the cast throws `ClassCastException`, masking the real error with a 500.

Fix: use `Objects.toString(context.getAttribute(ATTR_REQUEST_METHOD), null)` in both reactors — handles Gravitee `HttpMethod`, Vert.x `HttpMethod`, `String`, and `null` safely.

## Additional context

Regression tests use `@ParameterizedTest` with four attribute shapes (Gravitee `HttpMethod`, Vert.x `HttpMethod`, `String`, `null`) via `ReflectionTestUtils.getField` on `DEFAULT_EXECUTION_CONTEXT_LOG_ENTRIES`, driven against a real `DefaultExecutionContext`. Red→green proven; full 896-test module suite passes.

Backport labels: `apply-on-4-12-x`, `apply-on-master`