### PR TITLE
fix: preserve metadata when auto-accepting on create

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/subscription/model/SubscriptionEntity.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/subscription/model/SubscriptionEntity.java
@@ -157,7 +157,7 @@ public class SubscriptionEntity {
                     .processedAt(now)
                     .status(Status.ACCEPTED)
                     .reasonMessage(reasonMessage)
-                    .metadata(metadata)
+                    .metadata(metadata != null ? metadata : this.metadata)
                     .build();
             }
             case ACCEPTED -> this;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/subscription/model/SubscriptionEntityTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/subscription/model/SubscriptionEntityTest.java
@@ -24,6 +24,7 @@ import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
+import java.util.Map;
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -142,6 +143,30 @@ class SubscriptionEntityTest {
             var closedSubscription = subscription.acceptBy("user-id", STARTING_AT, ENDING_AT, "my reason");
 
             assertThat(closedSubscription).isSameAs(subscription).isEqualTo(subscription);
+        }
+
+        @Test
+        void should_preserve_existing_metadata_when_accepting_without_metadata() {
+            var metadata = Map.of("key", "value");
+            var subscription = aSubscription().toBuilder().status(SubscriptionEntity.Status.PENDING).metadata(metadata).build();
+
+            var acceptedSubscription = subscription.acceptBy("user-id", STARTING_AT, ENDING_AT, "my reason");
+
+            assertThat(acceptedSubscription.getMetadata()).isEqualTo(metadata);
+        }
+
+        @Test
+        void should_override_existing_metadata_when_accepting_with_metadata() {
+            var subscription = aSubscription()
+                .toBuilder()
+                .status(SubscriptionEntity.Status.PENDING)
+                .metadata(Map.of("key", "value"))
+                .build();
+            var newMetadata = Map.of("integration-key", "integration-value");
+
+            var acceptedSubscription = subscription.acceptBy("user-id", STARTING_AT, ENDING_AT, "my reason", newMetadata);
+
+            assertThat(acceptedSubscription.getMetadata()).isEqualTo(newMetadata);
         }
     }
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-14329

## Description

Subscription metadata sent in POST /management/v2/.../subscriptions was cleared during acceptBy() because null metadata overwrote existing values on auto-accept. Preserve existing metadata when none is provided explicitly.

## Additional context
 ### Before Fix:
https://github.com/user-attachments/assets/c8810d2c-6250-4acd-8175-18ea6c3c9166

### After Fix:
https://github.com/user-attachments/assets/a983154e-1520-48d7-a06c-43efe784a5b6

