### PR TITLE
feat(observability): add extensible shared observability filter socle

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-container/src/main/java/io/gravitee/rest/api/standalone/spring/StandaloneConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-container/src/main/java/io/gravitee/rest/api/standalone/spring/StandaloneConfiguration.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.rest.api.standalone.spring;
 
+import io.gravitee.gamma.rest.infra.config.GammaObservabilityFilterConfiguration;
 import io.gravitee.gamma.rest.infra.config.GammaTracingConfiguration;
 import io.gravitee.integration.controller.spring.IntegrationControllerConfiguration;
 import io.gravitee.node.api.Node;
@@ -45,6 +46,7 @@ import org.springframework.context.annotation.Import;
         IntegrationControllerConfiguration.class,
         RestPortalConfiguration.class,
         GammaTracingConfiguration.class,
+        GammaObservabilityFilterConfiguration.class,
     }
 )
 public class StandaloneConfiguration {

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/filter/exception/UnsupportedObservabilityFilterException.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/filter/exception/UnsupportedObservabilityFilterException.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gamma.rest.core.observability.filter.exception;
+
+import io.gravitee.apim.core.exception.ValidationDomainException;
+
+/**
+ * Raised when an observability query receives a {@code FilterCondition} that references an unknown
+ * filter name or an unsupported operator. Maps to HTTP 400 via the apim
+ * {@code ValidationDomainExceptionMapper}.
+ *
+ * @author GraviteeSource Team
+ */
+public class UnsupportedObservabilityFilterException extends ValidationDomainException {
+
+    public static UnsupportedObservabilityFilterException unknownName(String name) {
+        return new UnsupportedObservabilityFilterException(
+            "Filter '" + name + "' is not supported by this backend",
+            "observability.filter.unknown_name"
+        );
+    }
+
+    public static UnsupportedObservabilityFilterException unsupportedOperator(String filterName, String operator) {
+        return new UnsupportedObservabilityFilterException(
+            "Operator '" + operator + "' is not supported yet for filter '" + filterName + "'",
+            "observability.filter.unsupported_operator"
+        );
+    }
+
+    private UnsupportedObservabilityFilterException(String message, String technicalCode) {
+        super(message, technicalCode);
+    }
+}

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/filter/model/ApiType.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/filter/model/ApiType.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gamma.rest.core.observability.filter.model;
+
+import java.util.Set;
+
+/**
+ * Observability-curated API kind. Second discriminating axis of a {@link FilterSpec} (alongside
+ * {@link Signal}): a filter declares the API kinds it is relevant to, so a consumer can ask for
+ * only the filters that make sense for the kind of API it observes (e.g. a native-kafka logs table
+ * asks for {@code signal=LOGS&apiType=NATIVE}).
+ *
+ * <p>This vocabulary mirrors the canonical {@code API_TYPE} filter values already used by the v4
+ * analytics/logs engines ({@code HTTP_PROXY, LLM, MESSAGE, MCP, NATIVE, EDGE}) — {@code NATIVE}
+ * covers native-kafka APIs. The backend owns the mapping from indexed data to these kinds. It
+ * doubles as the authoritative {@code enumValues} of the built-in {@code API_TYPE} filter — single
+ * source of truth for both the discriminant and the filter values.
+ *
+ * @author GraviteeSource Team
+ */
+public enum ApiType {
+    HTTP_PROXY("HTTP Proxy"),
+    LLM("LLM"),
+    MESSAGE("Message"),
+    MCP("MCP"),
+    NATIVE("Kafka (native)"),
+    EDGE("Edge");
+
+    private final String label;
+
+    ApiType(String label) {
+        this.label = label;
+    }
+
+    /** Human-readable display label for this API kind (e.g. {@code NATIVE} → "Kafka (native)"). */
+    public String label() {
+        return label;
+    }
+
+    /**
+     * Every API kind. Use for truly cross-cutting filters (e.g. {@code API}, {@code API_TYPE}) so
+     * they automatically apply to API kinds added later, while a filter declaring an explicit
+     * subset (e.g. {@code {LLM, MCP}}) never widens on its own.
+     */
+    public static final Set<ApiType> ALL = Set.of(values());
+}

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/filter/model/CommonFilters.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/filter/model/CommonFilters.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gamma.rest.core.observability.filter.model;
+
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * The union of all host-owned filter names: {@link StaticFilters} ∪ {@link ExtensibleFilters}.
+ *
+ * <p>Java enums can't be unioned into a third enum, so this is a small aggregator rather than an
+ * enum. Its job is the **collision guard**: the registry rejects any module-contributed filter
+ * whose name is host-owned (a module must not redefine {@code API}, {@code API_TYPE}, …).
+ *
+ * @author GraviteeSource Team
+ */
+public final class CommonFilters {
+
+    private CommonFilters() {}
+
+    /** Names owned by the host (static + extensible) — modules cannot ship a filter with these names. */
+    public static Set<String> names() {
+        return Stream.concat(
+            Arrays.stream(StaticFilters.values()).map(StaticFilters::filterName),
+            Arrays.stream(ExtensibleFilters.values()).map(ExtensibleFilters::filterName)
+        ).collect(Collectors.toUnmodifiableSet());
+    }
+}

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/filter/model/ExtensibleFilters.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/filter/model/ExtensibleFilters.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gamma.rest.core.observability.filter.model;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Host-owned {@link FilterType#ENUM} filters whose **values are open**: modules extend them by
+ * contributing additional {@link FilterSpec.EnumValue}s (see
+ * {@code FilterContributor.enumValues()}). This is the **module-facing** part of the catalog — a
+ * module references one of these constants to declare which values it adds, and cannot touch
+ * anything else (the contribution map is keyed by this enum).
+ *
+ * <p>Each constant owns its filter shell (label, signals, apiTypes, operators) so the host is the
+ * single owner of the definition; modules only add values. The final {@code enumValues} of a filter
+ * is {@link #baselineValues()} (host) ∪ module contributions, deduplicated by value.
+ *
+ * <p><b>Temporary baseline.</b> Until each owning module becomes a real contributor, the host seeds
+ * the values itself (e.g. {@code API_TYPE} = the full {@link ApiType} vocabulary). As a module takes
+ * ownership of its API kinds, its values must be removed from the host baseline here (they will then
+ * come from the module). See GMA-421 note.
+ *
+ * @author GraviteeSource Team
+ */
+public enum ExtensibleFilters {
+    API_TYPE("API type", Signal.ALL, ApiType.ALL);
+
+    private final String label;
+    private final Set<Signal> signals;
+    private final Set<ApiType> apiTypes;
+
+    ExtensibleFilters(String label, Set<Signal> signals, Set<ApiType> apiTypes) {
+        this.label = label;
+        this.signals = signals;
+        this.apiTypes = apiTypes;
+    }
+
+    /** Stable filter name echoed on the wire (the enum constant name). */
+    public String filterName() {
+        return name();
+    }
+
+    /**
+     * Host-provided default values for this filter, merged (union, dedup by value) with module
+     * contributions. Temporary for {@code API_TYPE} — see the class note.
+     */
+    public List<FilterSpec.EnumValue> baselineValues() {
+        return switch (this) {
+            // TODO(GMA-421): remove API kinds here as their owning module becomes a contributor.
+            case API_TYPE -> Arrays.stream(ApiType.values())
+                .map(t -> new FilterSpec.EnumValue(t.name(), t.label()))
+                .toList();
+        };
+    }
+
+    /** Builds the {@link FilterSpec} shell for this filter with the given (already merged) values. */
+    public FilterSpec toSpec(List<FilterSpec.EnumValue> values) {
+        return new FilterSpec(
+            name(),
+            label,
+            FilterType.ENUM,
+            List.of(FilterOperator.EQ, FilterOperator.IN),
+            values,
+            null,
+            signals,
+            apiTypes
+        );
+    }
+}

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/filter/model/FilterCondition.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/filter/model/FilterCondition.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gamma.rest.core.observability.filter.model;
+
+import java.util.List;
+
+/**
+ * One filter the caller wants applied to an observability query — references a {@link FilterSpec}
+ * by {@link #name} and pairs it with an {@link #operator} + values to match.
+ *
+ * <p>{@link #values} is always a list — single-value operators like {@code EQ} pass a one-element
+ * list, while {@code IN} / {@code NOT_IN} carry multiple entries natively.
+ *
+ * @author GraviteeSource Team
+ */
+public record FilterCondition(String name, FilterOperator operator, List<String> values) {}

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/filter/model/FilterOperator.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/filter/model/FilterOperator.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gamma.rest.core.observability.filter.model;
+
+/**
+ * Comparison operator a filter supports. Mirrors the tracing-side {@code FilterOperator} and the
+ * {@code FILTER_OPERATORS} union from {@code @gravitee/gamma-lib-observability}'s {@code domain.ts}
+ * so a {@code FilterCondition} built by the UI flows straight to the backend without translation.
+ *
+ * @author GraviteeSource Team
+ */
+public enum FilterOperator {
+    EQ,
+    NEQ,
+    CONTAINS,
+    NOT_CONTAINS,
+    STARTS_WITH,
+    ENDS_WITH,
+    GT,
+    GTE,
+    LT,
+    LTE,
+    IN,
+    NOT_IN,
+    EXISTS,
+    NOT_EXISTS,
+}

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/filter/model/FilterSpec.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/filter/model/FilterSpec.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gamma.rest.core.observability.filter.model;
+
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Self-describing specification of one filterable field in the observability domain. The UI
+ * introspects the list returned by the filter-definitions endpoint and renders a generic chip /
+ * multi-select / range input depending on {@link #type} and {@link #operators}.
+ *
+ * <p>{@code name} is the stable id sent back as {@code FilterCondition.name} when the UI submits a
+ * filtered query. Contributors should namespace their filters to avoid collisions — the registry
+ * uses a simple last-wins union, no explicit override mechanism.
+ *
+ * @param name        Stable identifier echoed by the UI on filter submission.
+ * @param label       Human-readable display label.
+ * @param type        Data shape — see {@link FilterType}.
+ * @param operators   Supported comparison operators — see {@link FilterOperator}. Always non-empty.
+ * @param enumValues  Allowed {@link EnumValue}s (stable value + display label) when {@link #type}
+ *                    is {@link FilterType#ENUM} — otherwise null.
+ * @param range       Inclusive min / max bounds when {@link #type} is {@link FilterType#NUMBER} and
+ *                    a finite range applies — otherwise null.
+ * @param signals     Observability signals this filter applies to. A filter with
+ *                    {@code signals = {LOGS, TRACES}} appears in both log and trace queries.
+ * @param apiTypes    API kinds this filter is relevant to. A filter with {@code apiTypes = {LLM}}
+ *                    only surfaces for LLM APIs; use {@link ApiType#ALL} for cross-cutting filters.
+ *                    The two axes are independent: applicability is the rectangle
+ *                    {@code signals × apiTypes}.
+ *
+ * @author GraviteeSource Team
+ */
+public record FilterSpec(
+    String name,
+    String label,
+    FilterType type,
+    List<FilterOperator> operators,
+    List<EnumValue> enumValues,
+    Range range,
+    Set<Signal> signals,
+    Set<ApiType> apiTypes
+) {
+    /** Inclusive numeric bounds for {@link FilterType#NUMBER} filters. */
+    public record Range(Number min, Number max) {}
+
+    /**
+     * One allowed value of an {@link FilterType#ENUM} filter: a stable {@code value} sent on the
+     * wire and a human-readable {@code label} for display (e.g. {@code value="NATIVE"},
+     * {@code label="Kafka (native)"}).
+     */
+    public record EnumValue(String value, String label) {}
+}

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/filter/model/FilterType.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/filter/model/FilterType.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gamma.rest.core.observability.filter.model;
+
+/**
+ * The data shape of an observability filter, used by the UI to pick the right input renderer
+ * (single-value chip, multi-select, numeric range, free-text). Mirrors the tracing-side
+ * {@code FilterType} vocabulary so both APIs can share the same UI renderer logic.
+ *
+ * @author GraviteeSource Team
+ */
+public enum FilterType {
+    KEYWORD,
+    STRING,
+    NUMBER,
+    ENUM,
+    BOOLEAN,
+}

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/filter/model/Signal.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/filter/model/Signal.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gamma.rest.core.observability.filter.model;
+
+import java.util.Set;
+
+/**
+ * Observability signal kind. A {@link FilterSpec} declares which signals it applies to so the
+ * {@link io.gravitee.gamma.rest.core.observability.filter.port.service_provider.FilterRegistry}
+ * can return only the relevant filters for a given consumer (logs UI, analytics dashboard, trace
+ * explorer, or a combination).
+ *
+ * @author GraviteeSource Team
+ */
+public enum Signal {
+    LOGS,
+    ANALYTICS,
+    TRACES;
+
+    public static final Set<Signal> ALL = Set.of(values());
+}

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/filter/model/StaticFilters.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/filter/model/StaticFilters.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gamma.rest.core.observability.filter.model;
+
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Host-owned filters with a **fixed definition** that modules cannot extend (unlike
+ * {@link ExtensibleFilters}). These are the cross-cutting filters the host always ships
+ * (e.g. {@code API}, {@code HTTP_STATUS}).
+ *
+ * <p>Conceptually host-internal: although the enum is public (the registry, in the infra layer,
+ * needs it), modules have no way to contribute to these — the contribution map is keyed by
+ * {@link ExtensibleFilters}, and the registry rejects any module filter whose name collides with a
+ * host-owned name (see {@link CommonFilters}).
+ *
+ * @author GraviteeSource Team
+ */
+public enum StaticFilters {
+    API("API", FilterType.KEYWORD, List.of(FilterOperator.EQ, FilterOperator.IN), null, Signal.ALL, ApiType.ALL),
+    HTTP_STATUS(
+        "HTTP status",
+        FilterType.NUMBER,
+        List.of(FilterOperator.EQ, FilterOperator.GTE, FilterOperator.LTE),
+        new FilterSpec.Range(100, 599),
+        Signal.ALL,
+        Set.of(ApiType.HTTP_PROXY, ApiType.LLM, ApiType.MCP)
+    );
+
+    private final String label;
+    private final FilterType type;
+    private final List<FilterOperator> operators;
+    private final FilterSpec.Range range;
+    private final Set<Signal> signals;
+    private final Set<ApiType> apiTypes;
+
+    StaticFilters(
+        String label,
+        FilterType type,
+        List<FilterOperator> operators,
+        FilterSpec.Range range,
+        Set<Signal> signals,
+        Set<ApiType> apiTypes
+    ) {
+        this.label = label;
+        this.type = type;
+        this.operators = operators;
+        this.range = range;
+        this.signals = signals;
+        this.apiTypes = apiTypes;
+    }
+
+    /** Stable filter name echoed on the wire (the enum constant name). */
+    public String filterName() {
+        return name();
+    }
+
+    public FilterSpec toSpec() {
+        return new FilterSpec(name(), label, type, operators, null, range, signals, apiTypes);
+    }
+}

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/filter/port/service_provider/FilterContributor.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/filter/port/service_provider/FilterContributor.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gamma.rest.core.observability.filter.port.service_provider;
+
+import io.gravitee.gamma.rest.core.observability.filter.model.ExtensibleFilters;
+import io.gravitee.gamma.rest.core.observability.filter.model.FilterSpec;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Module-facing extension point for the observability filter catalog. A module contributes in two
+ * additive ways, both optional (default no-op):
+ *
+ * <ul>
+ *   <li>{@link #filters()} — brand-new filters owned by the module (e.g. {@code LLM_MODEL}). Names
+ *       must not collide with host-owned filters ({@code CommonFilters}); such collisions are
+ *       rejected by the registry.</li>
+ *   <li>{@link #enumValues()} — additional allowed values for a host-owned {@link ExtensibleFilters}
+ *       (e.g. add {@code LLM}/{@code MCP} to {@code API_TYPE}). The key is the {@link ExtensibleFilters}
+ *       enum, so a module can only add values to filters that are explicitly extensible — it can
+ *       never modify a static filter's definition.</li>
+ * </ul>
+ *
+ * <p>Implementations are pure data (no host internals). <b>Note:</b> runtime discovery of module
+ * contributions across the isolated gamma plugin classloaders is NOT handled here — that registration
+ * mechanism (plugin handler + {@code GammaModule} extension) is delivered separately. Today only
+ * host-classpath contributors are wired.
+ *
+ * @author GraviteeSource Team
+ */
+public interface FilterContributor {
+    /** New filters owned by the contributing module. */
+    default List<FilterSpec> filters() {
+        return List.of();
+    }
+
+    /** Additive values for host-owned {@link ExtensibleFilters} (e.g. {@code API_TYPE}). */
+    default Map<ExtensibleFilters, List<FilterSpec.EnumValue>> enumValues() {
+        return Map.of();
+    }
+}

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/filter/port/service_provider/FilterRegistry.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/filter/port/service_provider/FilterRegistry.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gamma.rest.core.observability.filter.port.service_provider;
+
+import io.gravitee.gamma.rest.core.observability.filter.model.ApiType;
+import io.gravitee.gamma.rest.core.observability.filter.model.FilterSpec;
+import io.gravitee.gamma.rest.core.observability.filter.model.Signal;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Core-side port that returns the aggregated, deduplicated filter specs for observability queries.
+ * The infra adapter discovers {@link FilterContributor} implementations (typically via
+ * {@link java.util.ServiceLoader}); consumers stay unaware of how contributors are wired.
+ *
+ * @author GraviteeSource Team
+ */
+public interface FilterRegistry {
+    /**
+     * Returns the deduplicated union of all contributor filter specs, narrowed on two independent
+     * axes: kept specs are those whose {@link FilterSpec#signals()} intersects {@code signals}
+     * <strong>and</strong> whose {@link FilterSpec#apiTypes()} intersects {@code apiTypes}. An axis
+     * passed as {@code null} or empty is unconstrained.
+     *
+     * @param signals  The signal set to filter by; {@code null}/empty → any signal.
+     * @param apiTypes The API-kind set to filter by; {@code null}/empty → any API kind.
+     */
+    List<FilterSpec> getFilters(Set<Signal> signals, Set<ApiType> apiTypes);
+}

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/infra/adapter/SpiFilterRegistry.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/infra/adapter/SpiFilterRegistry.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gamma.rest.infra.adapter;
+
+import io.gravitee.gamma.rest.core.observability.filter.model.ApiType;
+import io.gravitee.gamma.rest.core.observability.filter.model.CommonFilters;
+import io.gravitee.gamma.rest.core.observability.filter.model.ExtensibleFilters;
+import io.gravitee.gamma.rest.core.observability.filter.model.FilterSpec;
+import io.gravitee.gamma.rest.core.observability.filter.model.Signal;
+import io.gravitee.gamma.rest.core.observability.filter.model.StaticFilters;
+import io.gravitee.gamma.rest.core.observability.filter.port.service_provider.FilterContributor;
+import io.gravitee.gamma.rest.core.observability.filter.port.service_provider.FilterRegistry;
+import io.gravitee.node.logging.NodeLoggerFactory;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.EnumMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.ServiceLoader;
+import java.util.Set;
+import org.slf4j.Logger;
+
+/**
+ * {@link FilterRegistry} adapter that assembles the catalog from two sources:
+ * <ol>
+ *   <li>the <b>host catalog</b> — {@link StaticFilters} (fixed) + {@link ExtensibleFilters} (shells
+ *       seeded with their baseline values), built from the enums directly;</li>
+ *   <li>the <b>contributors</b> — each adds new {@link FilterContributor#filters()} and/or extra
+ *       values for extensible filters via {@link FilterContributor#enumValues()}.</li>
+ * </ol>
+ *
+ * <p>Merge rules: a contributor filter whose name is host-owned ({@link CommonFilters#names()}) is
+ * rejected (warn); two contributors shipping the same name → last-write-wins with a descriptive warn
+ * on differing definitions; extensible filter values are the union (dedup by value) of baseline +
+ * contributions; an extensible filter that ends up with no values is omitted.
+ *
+ * <p>Query-time filtering applies two independent axes ({@link FilterSpec#signals()} and
+ * {@link FilterSpec#apiTypes()}) by set intersection; an absent/empty axis is unconstrained.
+ *
+ * <p>The no-arg constructor sources contributors via {@link ServiceLoader} (host classpath only).
+ * Cross-plugin module contributions require the separate plugin-handler registration mechanism.
+ *
+ * @author GraviteeSource Team
+ */
+public class SpiFilterRegistry implements FilterRegistry {
+
+    private static final Logger LOGGER = NodeLoggerFactory.getLogger(SpiFilterRegistry.class);
+
+    private final Map<String, FilterSpec> specsByName;
+
+    public SpiFilterRegistry() {
+        this(ServiceLoader.load(FilterContributor.class).stream().map(ServiceLoader.Provider::get).toList());
+    }
+
+    /** Test seam — inject a fixed contributor list without touching the classpath. */
+    public SpiFilterRegistry(List<FilterContributor> contributors) {
+        this.specsByName = assemble(contributors);
+    }
+
+    private static Map<String, FilterSpec> assemble(List<FilterContributor> contributors) {
+        Map<String, FilterSpec> byName = new LinkedHashMap<>();
+
+        // 1. Host static filters.
+        for (StaticFilters staticFilter : StaticFilters.values()) {
+            byName.put(staticFilter.filterName(), staticFilter.toSpec());
+        }
+
+        // 2. Host extensible filters, seeded with their baseline values (re-assembled in step 4).
+        Map<ExtensibleFilters, LinkedHashMap<String, FilterSpec.EnumValue>> extensibleValues = new EnumMap<>(ExtensibleFilters.class);
+        for (ExtensibleFilters extensible : ExtensibleFilters.values()) {
+            LinkedHashMap<String, FilterSpec.EnumValue> values = new LinkedHashMap<>();
+            for (FilterSpec.EnumValue value : extensible.baselineValues()) {
+                values.put(value.value(), value);
+            }
+            extensibleValues.put(extensible, values);
+            byName.put(extensible.filterName(), extensible.toSpec(List.copyOf(values.values())));
+        }
+
+        // 3. Contributors: new filters + extra values for extensible filters.
+        Set<String> hostOwned = CommonFilters.names();
+        for (FilterContributor contributor : contributors) {
+            addContributorFilters(byName, hostOwned, contributor);
+            mergeContributorValues(extensibleValues, contributor);
+        }
+
+        // 4. Re-assemble extensible filters with their merged values (omit if empty).
+        for (ExtensibleFilters extensible : ExtensibleFilters.values()) {
+            LinkedHashMap<String, FilterSpec.EnumValue> values = extensibleValues.get(extensible);
+            if (values.isEmpty()) {
+                byName.remove(extensible.filterName());
+            } else {
+                byName.put(extensible.filterName(), extensible.toSpec(List.copyOf(values.values())));
+            }
+        }
+
+        return Collections.unmodifiableMap(byName);
+    }
+
+    private static void addContributorFilters(Map<String, FilterSpec> byName, Set<String> hostOwned, FilterContributor contributor) {
+        for (FilterSpec spec : contributor.filters()) {
+            if (hostOwned.contains(spec.name())) {
+                LOGGER.warn("A filter contributor tried to (re)define host-owned filter '{}'; ignored.", spec.name());
+                continue;
+            }
+            FilterSpec previous = byName.put(spec.name(), spec);
+            if (previous != null && !previous.equals(spec)) {
+                LOGGER.warn(
+                    "Duplicate filter '{}' from multiple contributors with differing definitions (signals {} vs {}, apiTypes {} vs {}, operators {} vs {}); last one wins, coverage from the dropped one is lost.",
+                    spec.name(),
+                    previous.signals(),
+                    spec.signals(),
+                    previous.apiTypes(),
+                    spec.apiTypes(),
+                    previous.operators(),
+                    spec.operators()
+                );
+            }
+        }
+    }
+
+    private static void mergeContributorValues(
+        Map<ExtensibleFilters, LinkedHashMap<String, FilterSpec.EnumValue>> extensibleValues,
+        FilterContributor contributor
+    ) {
+        contributor
+            .enumValues()
+            .forEach((extensible, values) -> {
+                if (values == null) {
+                    return;
+                }
+                LinkedHashMap<String, FilterSpec.EnumValue> target = extensibleValues.get(extensible);
+                for (FilterSpec.EnumValue value : values) {
+                    target.putIfAbsent(value.value(), value); // union, first label wins
+                }
+            });
+    }
+
+    @Override
+    public List<FilterSpec> getFilters(Set<Signal> signals, Set<ApiType> apiTypes) {
+        return specsByName
+            .values()
+            .stream()
+            .filter(spec -> matches(spec.signals(), signals))
+            .filter(spec -> matches(spec.apiTypes(), apiTypes))
+            .toList();
+    }
+
+    /** An axis matches when no values are requested, or when the spec's non-empty set intersects the requested one. */
+    private static boolean matches(Collection<?> specAxis, Collection<?> requested) {
+        if (requested == null || requested.isEmpty()) {
+            return true;
+        }
+        return specAxis != null && !Collections.disjoint(specAxis, requested);
+    }
+}

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/infra/config/GammaObservabilityFilterConfiguration.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/infra/config/GammaObservabilityFilterConfiguration.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gamma.rest.infra.config;
+
+import io.gravitee.gamma.rest.core.observability.filter.port.service_provider.FilterRegistry;
+import io.gravitee.gamma.rest.infra.adapter.SpiFilterRegistry;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Spring wiring for the shared observability filter engine. The registry discovers
+ * {@link io.gravitee.gamma.rest.core.observability.filter.port.service_provider.FilterContributor}
+ * implementations via {@link java.util.ServiceLoader} at construction — runs once when the rest-api
+ * context starts.
+ *
+ * @author GraviteeSource Team
+ */
+@Configuration
+public class GammaObservabilityFilterConfiguration {
+
+    @Bean
+    public FilterRegistry gammaFilterRegistry() {
+        return new SpiFilterRegistry();
+    }
+}

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/test/java/io/gravitee/gamma/rest/core/observability/filter/CommonFiltersTest.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/test/java/io/gravitee/gamma/rest/core/observability/filter/CommonFiltersTest.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gamma.rest.core.observability.filter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.gamma.rest.core.observability.filter.model.CommonFilters;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class CommonFiltersTest {
+
+    @Test
+    void should_union_static_and_extensible_host_filter_names() {
+        assertThat(CommonFilters.names()).containsExactlyInAnyOrder("API", "HTTP_STATUS", "API_TYPE");
+    }
+}

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/test/java/io/gravitee/gamma/rest/core/observability/filter/SpiFilterRegistryTest.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/test/java/io/gravitee/gamma/rest/core/observability/filter/SpiFilterRegistryTest.java
@@ -1,0 +1,207 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gamma.rest.core.observability.filter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+
+import io.gravitee.gamma.rest.core.observability.filter.model.ApiType;
+import io.gravitee.gamma.rest.core.observability.filter.model.ExtensibleFilters;
+import io.gravitee.gamma.rest.core.observability.filter.model.FilterOperator;
+import io.gravitee.gamma.rest.core.observability.filter.model.FilterSpec;
+import io.gravitee.gamma.rest.core.observability.filter.model.FilterType;
+import io.gravitee.gamma.rest.core.observability.filter.model.Signal;
+import io.gravitee.gamma.rest.core.observability.filter.port.service_provider.FilterContributor;
+import io.gravitee.gamma.rest.core.observability.filter.port.service_provider.FilterRegistry;
+import io.gravitee.gamma.rest.infra.adapter.SpiFilterRegistry;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class SpiFilterRegistryTest {
+
+    @Test
+    void should_expose_the_host_catalog_by_default() {
+        FilterRegistry registry = registryWith();
+
+        List<FilterSpec> result = registry.getFilters(null, null);
+
+        assertThat(result).extracting(FilterSpec::name).containsExactly("API", "HTTP_STATUS", "API_TYPE");
+    }
+
+    @Test
+    void should_seed_api_type_with_the_api_type_baseline() {
+        FilterRegistry registry = registryWith();
+
+        FilterSpec apiType = byName(registry, "API_TYPE");
+
+        assertThat(apiType.type()).isEqualTo(FilterType.ENUM);
+        assertThat(apiType.operators()).containsExactly(FilterOperator.EQ, FilterOperator.IN);
+        assertThat(apiType.enumValues())
+            .extracting(FilterSpec.EnumValue::value)
+            .containsExactly(Arrays.stream(ApiType.values()).map(Enum::name).toArray(String[]::new));
+        assertThat(apiType.enumValues())
+            .filteredOn(v -> v.value().equals("NATIVE"))
+            .singleElement()
+            .extracting(FilterSpec.EnumValue::label)
+            .isEqualTo("Kafka (native)");
+    }
+
+    @Test
+    void should_scope_http_status_to_http_based_api_kinds() {
+        FilterRegistry registry = registryWith();
+
+        // NATIVE (Kafka) context: API + API_TYPE are cross-cutting; HTTP_STATUS is HTTP-only.
+        List<FilterSpec> result = registry.getFilters(null, Set.of(ApiType.NATIVE));
+
+        assertThat(result).extracting(FilterSpec::name).containsExactly("API", "API_TYPE");
+    }
+
+    @Test
+    void should_add_a_contributor_filter() {
+        FilterRegistry registry = registryWith(filtersContributor(llmModel()));
+
+        List<FilterSpec> result = registry.getFilters(null, null);
+
+        assertThat(result).extracting(FilterSpec::name).containsExactly("API", "HTTP_STATUS", "API_TYPE", "LLM_MODEL");
+    }
+
+    @Test
+    void should_reject_a_module_filter_that_redefines_a_host_owned_name() {
+        FilterSpec rogueApi = new FilterSpec(
+            "API",
+            "Rogue API",
+            FilterType.KEYWORD,
+            List.of(FilterOperator.EQ),
+            null,
+            null,
+            Set.of(Signal.LOGS),
+            Set.of(ApiType.LLM)
+        );
+        FilterRegistry registry = registryWith(filtersContributor(rogueApi));
+
+        FilterSpec api = byName(registry, "API");
+
+        // Host definition wins (cross-cutting), the module's is ignored.
+        assertThat(api.label()).isEqualTo("API");
+        assertThat(api.apiTypes()).isEqualTo(ApiType.ALL);
+        assertThat(registry.getFilters(null, null)).extracting(FilterSpec::name).filteredOn("API"::equals).hasSize(1);
+    }
+
+    @Test
+    void should_reject_a_module_filter_that_redefines_an_extensible_host_filter() {
+        FilterSpec rogueApiType = new FilterSpec(
+            "API_TYPE",
+            "Rogue",
+            FilterType.ENUM,
+            List.of(FilterOperator.EQ),
+            List.of(new FilterSpec.EnumValue("X", "X")),
+            null,
+            Signal.ALL,
+            ApiType.ALL
+        );
+        FilterRegistry registry = registryWith(filtersContributor(rogueApiType));
+
+        // API_TYPE stays the host extensible filter (baseline values), the module's is ignored.
+        assertThat(byName(registry, "API_TYPE").enumValues()).hasSize(ApiType.values().length);
+    }
+
+    @Test
+    void should_extend_api_type_with_contributed_values() {
+        FilterRegistry registry = registryWith(
+            valuesContributor(ExtensibleFilters.API_TYPE, new FilterSpec.EnumValue("CUSTOM", "Custom kind"))
+        );
+
+        assertThat(byName(registry, "API_TYPE").enumValues())
+            .extracting(FilterSpec.EnumValue::value, FilterSpec.EnumValue::label)
+            .contains(tuple("NATIVE", "Kafka (native)"), tuple("CUSTOM", "Custom kind"));
+    }
+
+    @Test
+    void should_deduplicate_a_contributed_value_already_in_the_baseline() {
+        FilterRegistry registry = registryWith(
+            valuesContributor(ExtensibleFilters.API_TYPE, new FilterSpec.EnumValue("LLM", "duplicate label"))
+        );
+
+        FilterSpec apiType = byName(registry, "API_TYPE");
+
+        assertThat(apiType.enumValues()).hasSize(ApiType.values().length); // no duplicate added
+        assertThat(apiType.enumValues())
+            .filteredOn(v -> v.value().equals("LLM"))
+            .singleElement()
+            .extracting(FilterSpec.EnumValue::label)
+            .isEqualTo("LLM"); // baseline label wins
+    }
+
+    @Test
+    void should_apply_both_axes_to_host_and_contributor_filters() {
+        FilterRegistry registry = registryWith(filtersContributor(llmModel()));
+
+        // LOGS + NATIVE: only the cross-cutting host filters; HTTP_STATUS (HTTP-only) and LLM_MODEL (LLM-only) are excluded.
+        List<FilterSpec> result = registry.getFilters(Set.of(Signal.LOGS), Set.of(ApiType.NATIVE));
+
+        assertThat(result).extracting(FilterSpec::name).containsExactly("API", "API_TYPE");
+    }
+
+    private static FilterRegistry registryWith(FilterContributor... contributors) {
+        return new SpiFilterRegistry(List.of(contributors));
+    }
+
+    private static FilterSpec byName(FilterRegistry registry, String name) {
+        return registry
+            .getFilters(null, null)
+            .stream()
+            .filter(spec -> spec.name().equals(name))
+            .findFirst()
+            .orElseThrow(() -> new AssertionError("Filter '" + name + "' not found"));
+    }
+
+    private static FilterSpec llmModel() {
+        return new FilterSpec(
+            "LLM_MODEL",
+            "LLM model",
+            FilterType.KEYWORD,
+            List.of(FilterOperator.EQ, FilterOperator.IN),
+            null,
+            null,
+            Set.of(Signal.LOGS, Signal.ANALYTICS),
+            Set.of(ApiType.LLM)
+        );
+    }
+
+    private static FilterContributor filtersContributor(FilterSpec... filters) {
+        return new FilterContributor() {
+            @Override
+            public List<FilterSpec> filters() {
+                return List.of(filters);
+            }
+        };
+    }
+
+    private static FilterContributor valuesContributor(ExtensibleFilters key, FilterSpec.EnumValue... values) {
+        return new FilterContributor() {
+            @Override
+            public Map<ExtensibleFilters, List<FilterSpec.EnumValue>> enumValues() {
+                return Map.of(key, List.of(values));
+            }
+        };
+    }
+}

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/test/java/io/gravitee/gamma/rest/core/observability/filter/UnsupportedObservabilityFilterExceptionTest.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/test/java/io/gravitee/gamma/rest/core/observability/filter/UnsupportedObservabilityFilterExceptionTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gamma.rest.core.observability.filter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.gamma.rest.core.observability.filter.exception.UnsupportedObservabilityFilterException;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class UnsupportedObservabilityFilterExceptionTest {
+
+    @Test
+    void unknown_name_should_carry_the_correct_technical_code() {
+        var exception = UnsupportedObservabilityFilterException.unknownName("BOGUS");
+
+        assertThat(exception.getTechnicalCode()).isEqualTo("observability.filter.unknown_name");
+        assertThat(exception.getMessage()).contains("BOGUS");
+    }
+
+    @Test
+    void unsupported_operator_should_carry_the_correct_technical_code() {
+        var exception = UnsupportedObservabilityFilterException.unsupportedOperator("API", "REGEX");
+
+        assertThat(exception.getTechnicalCode()).isEqualTo("observability.filter.unsupported_operator");
+        assertThat(exception.getMessage()).contains("API").contains("REGEX");
+    }
+}


### PR DESCRIPTION
## Summary

Introduce an **extensible, self-describing observability filter socle** in `gravitee-gamma-rest-api` (Lot 1 of [GMA-420](https://gravitee.atlassian.net/browse/GMA-420)). It gives logs, analytics (and later traces) a single filter vocabulary, discriminated on two independent axes (observability **signal** × **API type**), with host-owned filters plus a per-module extension contract.

Refs [GMA-421](https://gravitee.atlassian.net/browse/GMA-421)

## Changes

- **Domain model** (`core.observability.filter.model`): `FilterSpec` (with `EnumValue{value,label}` + `Range`), `FilterCondition`, and enums `Signal` (LOGS/ANALYTICS/TRACES), `ApiType` (HTTP_PROXY/LLM/MESSAGE/MCP/NATIVE/EDGE, with display labels), `FilterType`, `FilterOperator`.
- **Two discriminating axes** on every `FilterSpec`: `signals` and `apiTypes` (applicability = `signals × apiTypes`; `Signal.ALL`/`ApiType.ALL` for cross-cutting).
- **Host catalog from enums**: `StaticFilters` (fixed: `API`, `HTTP_STATUS`) + `ExtensibleFilters` (host ENUM filters open to module values: `API_TYPE`, seeded with a temporary baseline) + `CommonFilters` (union → collision guard).
- **SPI** `FilterContributor` = `filters()` + `enumValues(Map<ExtensibleFilters, …>)` (typed key, additive only).
- **`SpiFilterRegistry`**: assembles host catalog + contributor merge — host-name collision rejected (descriptive warn), enum-value union/dedup, extensible-empty omitted, two-axis intersection query.
- **`UnsupportedObservabilityFilterException`** (400 + `technicalCode`).
- Spring wiring `GammaObservabilityFilterConfiguration` `@Import`ed from `StandaloneConfiguration`.

## Test plan

- [x] Unit tests: `SpiFilterRegistryTest` (host catalog, two-axis, collision guard, enum-value union/dedup, baseline), `CommonFiltersTest`, `UnsupportedObservabilityFilterExceptionTest`.
- [x] ArchUnit (naming, onion, core purity) green; tracing untouched and its tests stay green.
- [x] `mvn -pl gravitee-gamma/gravitee-gamma-rest-api test` → 76 tests, 0 failures.

## Reviewer notes

- **Scope boundary**: this PR is the **host socle** only. Cross-plugin **module contribution discovery** (gamma modules load in isolated classloaders → `ServiceLoader` can't reach them) is delivered separately in [GMA-628](https://gravitee.atlassian.net/browse/GMA-628); AIM becomes the first contributor in [GMA-629](https://gravitee.atlassian.net/browse/GMA-629). The contract (`FilterContributor`) is in place and unit-tested with in-memory contributors but not yet wired to plugins — intentional.
- **`API_TYPE` values are a temporary host baseline** (`ExtensibleFilters.baselineValues()`); they move to their owning modules as contributors land (note in code).
- Tracing (`core.tracing.*`) is intentionally left untouched; it collapses onto this engine in Lot 2 ([GMA-587](https://gravitee.atlassian.net/browse/GMA-587)).
- Most relevant files: `SpiFilterRegistry`, `ExtensibleFilters`/`StaticFilters`/`CommonFilters`, `FilterContributor`, `FilterSpec`.

[GMA-420]: https://gravitee.atlassian.net/browse/GMA-420?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[GMA-421]: https://gravitee.atlassian.net/browse/GMA-421?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[GMA-628]: https://gravitee.atlassian.net/browse/GMA-628?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ