### PR TITLE
fix: reject Equals + wildcard flow paths and reload Policy Studio on …

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/policy-studio-v4/design/api-v4-policy-studio-design.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/policy-studio-v4/design/api-v4-policy-studio-design.component.spec.ts
@@ -43,11 +43,13 @@ import {
   fakePlanV4,
   fakePoliciesPlugin,
   fakePolicyPlugin,
+  fakeProxyApiV4,
   FlowV4,
   PlanV4,
 } from '../../../../entities/management-api-v2';
 import { expectGetSharedPolicyGroupPolicyPluginRequest } from '../../../../services-ngx/shared-policy-groups.service.spec';
 import { GioTestingPermissionProvider } from '../../../../shared/components/gio-permission/gio-permission.service';
+import { SnackBarService } from '../../../../services-ngx/snack-bar.service';
 
 describe('ApiV4PolicyStudioDesignComponent', () => {
   const API_ID = 'api-id';
@@ -815,6 +817,110 @@ describe('ApiV4PolicyStudioDesignComponent', () => {
     });
   });
 
+  describe('Save error handling', () => {
+    let api: ApiV4;
+    let plan: PlanV4;
+    let snackBarService: SnackBarService;
+    const validationError = {
+      message: 'The flow [Invalid flow] contains an HTTP selector with an invalid wildcard path',
+    };
+    const invalidFlow: FlowV4 = {
+      name: 'Invalid flow',
+      enabled: true,
+      selectors: [{ type: 'HTTP', path: '/**', pathOperator: 'EQUALS', methods: [] }],
+      request: [],
+      response: [],
+      subscribe: [],
+      publish: [],
+    };
+
+    beforeEach(() => {
+      snackBarService = TestBed.inject(SnackBarService);
+      jest.spyOn(snackBarService, 'error');
+      jest.spyOn(snackBarService, 'success');
+
+      api = fakeProxyApiV4({
+        id: API_ID,
+        flows: [
+          {
+            name: 'Valid API flow',
+            enabled: true,
+            selectors: [{ type: 'HTTP', path: '/', pathOperator: 'STARTS_WITH', methods: [] }],
+            request: [],
+            response: [],
+            subscribe: [],
+            publish: [],
+          },
+        ],
+      });
+
+      plan = fakePlanV4({
+        name: 'Keyless',
+        security: { type: 'KEY_LESS', configuration: {} },
+        flows: [
+          {
+            name: 'Valid plan flow',
+            enabled: true,
+            selectors: [{ type: 'HTTP', path: '/health', pathOperator: 'EQUALS', methods: ['GET'] }],
+            request: [],
+            response: [],
+            subscribe: [],
+            publish: [],
+          },
+        ],
+      });
+
+      expectEntrypointsGetRequest([{ id: 'http-proxy', name: 'HTTP Proxy' }]);
+      expectEndpointsGetRequest([{ id: 'http-proxy', name: 'HTTP Proxy' }]);
+      expectGetPolicies();
+      expectGetSharedPolicyGroupPolicyPluginRequest(httpTestingController);
+      expectListApiPlans(API_ID, [plan]);
+      expectGetApi(api);
+    });
+
+    it('should reload plan flows from server when plan save fails', () => {
+      component.onSave({
+        plansToUpdate: [{ id: plan.id, name: plan.name, flows: [...plan.flows, invalidFlow] }],
+      });
+
+      expectGetPlan(api.id, plan);
+      const putReq = httpTestingController.expectOne({
+        url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${api.id}/plans/${plan.id}`,
+        method: 'PUT',
+      });
+      putReq.flush(validationError, { status: 400, statusText: 'Bad Request' });
+
+      expectPolicyStudioReload(api, plan);
+
+      expect(snackBarService.error).toHaveBeenCalledWith(validationError.message);
+      expect(snackBarService.success).not.toHaveBeenCalled();
+      expect(component.plans).toEqual([{ id: plan.id, name: plan.name, flows: plan.flows }]);
+      expect(component.plans[0].flows).toHaveLength(1);
+      expect(component.isLoading).toBe(false);
+    });
+
+    it('should reload api flows from server when api save fails', () => {
+      component.onSave({
+        commonFlows: [...api.flows, invalidFlow],
+      });
+
+      expectGetApi(api);
+      const putReq = httpTestingController.expectOne({
+        url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${api.id}`,
+        method: 'PUT',
+      });
+      putReq.flush(validationError, { status: 400, statusText: 'Bad Request' });
+
+      expectPolicyStudioReload(api, plan);
+
+      expect(snackBarService.error).toHaveBeenCalledWith(validationError.message);
+      expect(snackBarService.success).not.toHaveBeenCalled();
+      expect(component.commonFlows).toEqual(api.flows);
+      expect(component.commonFlows).toHaveLength(1);
+      expect(component.isLoading).toBe(false);
+    });
+  });
+
   function expectGetApi(api: Api) {
     httpTestingController
       .expectOne({
@@ -873,5 +979,14 @@ describe('ApiV4PolicyStudioDesignComponent', () => {
     // 6 requests are made on init
     expect(httpTestingController.match(() => true).length).toEqual(6);
     // Not flush it to stop test here
+  }
+
+  function expectPolicyStudioReload(api: ApiV4, plan: PlanV4) {
+    expectGetApi(api);
+    expectEntrypointsGetRequest([{ id: 'http-proxy', name: 'HTTP Proxy' }]);
+    expectEndpointsGetRequest([{ id: 'http-proxy', name: 'HTTP Proxy' }]);
+    expectListApiPlans(API_ID, [plan]);
+    expectGetPolicies();
+    expectGetSharedPolicyGroupPolicyPluginRequest(httpTestingController);
   }
 });

--- a/gravitee-apim-console-webui/src/management/api/policy-studio-v4/design/api-v4-policy-studio-design.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/policy-studio-v4/design/api-v4-policy-studio-design.component.ts
@@ -15,8 +15,8 @@
  */
 
 import { ChangeDetectorRef, Component, OnDestroy, OnInit } from '@angular/core';
-import { combineLatest, EMPTY, forkJoin, Observable, of, Subject } from 'rxjs';
-import { catchError, map, switchMap, takeUntil, tap } from 'rxjs/operators';
+import { combineLatest, EMPTY, forkJoin, Observable, Subject } from 'rxjs';
+import { catchError, finalize, map, switchMap, takeUntil, tap } from 'rxjs/operators';
 import {
   ConnectorInfo,
   Flow as PSFlow,
@@ -97,22 +97,113 @@ export class ApiV4PolicyStudioDesignComponent implements OnInit, OnDestroy {
           this.isLoading = true;
           this.changeDetectorRef.detectChanges();
         }),
-        switchMap((params) =>
-          combineLatest([
-            this.apiV2Service.get(this.activatedRoute.snapshot.params.apiId).pipe(map((api) => api as ApiV4)),
-            this.connectorPluginsV2Service.listEntrypointPlugins(),
-            this.connectorPluginsV2Service.listEndpointPlugins(),
-            this.apiPlanV2Service
-              .list(this.activatedRoute.snapshot.params.apiId, undefined, ['PUBLISHED', 'DEPRECATED'], undefined, undefined, 1, 9999)
-              .pipe(map((apiPlansResponse) => apiPlansResponse.data)),
-            this.policyV2Service.list(),
-            this.sharedPolicyGroupsService.getSharedPolicyGroupPolicyPlugin(),
-            of(params),
-          ]),
-        ),
+        switchMap((params) => this.loadPolicyStudioData(params)),
         takeUntil(this.unsubscribe$),
       )
-      .subscribe(([api, entrypoints, endpoints, plans, policies, sharedPolicyGroupPolicyPlugins, params]) => {
+      .subscribe();
+    this.trialURL = this.gioLicenseService.getTrialURL({ feature: ApimFeature.APIM_DEBUG_MODE, context: UTMTags.CONTEXT_API_V4 });
+  }
+
+  ngOnDestroy() {
+    this.unsubscribe$.next(true);
+    this.unsubscribe$.unsubscribe();
+  }
+
+  onSave(outputSave: SaveOutput) {
+    const { commonFlows, plansToUpdate, flowExecution } = outputSave;
+
+    const updates$: Observable<unknown>[] = [];
+    if (commonFlows || flowExecution) {
+      updates$.push(this.updateApiFlows(commonFlows, flowExecution));
+    }
+    if (plansToUpdate) {
+      updates$.push(this.updatePlans(plansToUpdate));
+    }
+    if (updates$.length === 0) {
+      return;
+    }
+
+    forkJoin(updates$)
+      .pipe(
+        tap(() => this.snackBarService.success('Policy Studio configuration saved')),
+        tap(() => this.router.navigateByUrl(this.location.path(), { skipLocationChange: true })),
+        catchError((err) => {
+          this.snackBarService.error(err.error?.message ?? err.message);
+          this.isLoading = true;
+          this.changeDetectorRef.detectChanges();
+          return this.loadPolicyStudioData(this.activatedRoute.snapshot.params).pipe(
+            catchError(() => EMPTY),
+            finalize(() => {
+              this.isLoading = false;
+              this.changeDetectorRef.detectChanges();
+            }),
+          );
+        }),
+        takeUntil(this.unsubscribe$),
+      )
+      .subscribe();
+  }
+
+  onFlowSelectionChange(flowSelection: FlowSelection) {
+    this.updateIndexesInURL(flowSelection);
+  }
+
+  private updateIndexesInURL(flowSelection: FlowSelection) {
+    const segments = this.location.path().split('/');
+    segments[segments.length - 2] = flowSelection.planIndex.toString();
+    segments[segments.length - 1] = flowSelection.flowIndex.toString();
+    this.location.go(segments.join('/'));
+  }
+
+  private checkAndAdjustIndexes() {
+    const totalPlans = this.plans.length + 1; // Adding 1 for common flows.
+    const { planIndex, flowIndex } = this.selectedFlowIndexes;
+
+    if (planIndex < 0 || planIndex >= totalPlans) {
+      this.selectedFlowIndexes = { planIndex: 0, flowIndex: 0 };
+      this.updateIndexesInURL(this.selectedFlowIndexes);
+    } else {
+      const currentPlanFlowsLength = planIndex < this.plans.length ? this.plans[planIndex].flows.length : this.commonFlows.length;
+
+      if (flowIndex < 0 || flowIndex >= currentPlanFlowsLength) {
+        const firstAvailableFlow = this.findFirstAvailableFlow();
+
+        if (firstAvailableFlow) {
+          this.selectedFlowIndexes = firstAvailableFlow;
+        } else {
+          this.selectedFlowIndexes = { planIndex: 0, flowIndex: 0 };
+        }
+        this.updateIndexesInURL(this.selectedFlowIndexes);
+      }
+    }
+  }
+
+  private findFirstAvailableFlow(): FlowSelection | null {
+    for (let planIdx = 0; planIdx < this.plans.length; planIdx++) {
+      if (this.plans[planIdx].flows.length > 0) {
+        return { planIndex: planIdx, flowIndex: 0 };
+      }
+    }
+
+    if (this.commonFlows.length > 0) {
+      return { planIndex: this.plans.length, flowIndex: 0 };
+    }
+
+    return null;
+  }
+
+  private loadPolicyStudioData(params: Record<string, string | number>) {
+    return combineLatest([
+      this.apiV2Service.get(this.activatedRoute.snapshot.params.apiId).pipe(map((api) => api as ApiV4)),
+      this.connectorPluginsV2Service.listEntrypointPlugins(),
+      this.connectorPluginsV2Service.listEndpointPlugins(),
+      this.apiPlanV2Service
+        .list(this.activatedRoute.snapshot.params.apiId, undefined, ['PUBLISHED', 'DEPRECATED'], undefined, undefined, 1, 9999)
+        .pipe(map((apiPlansResponse) => apiPlansResponse.data)),
+      this.policyV2Service.list(),
+      this.sharedPolicyGroupsService.getSharedPolicyGroupPolicyPlugin(),
+    ]).pipe(
+      tap(([api, entrypoints, endpoints, plans, policies, sharedPolicyGroupPolicyPlugins]) => {
         this.apiType = api.type;
         this.flowExecution = api.flowExecution;
 
@@ -169,7 +260,6 @@ export class ApiV4PolicyStudioDesignComponent implements OnInit, OnDestroy {
           apiType: plugin.apiType,
         }));
 
-        // Set resources for specific json schema resource type component
         this.resourceTypeService.setResources(api.resources ?? []);
 
         this.selectedFlowIndexes.planIndex = Number(params['planIndex'] ?? 0);
@@ -177,79 +267,9 @@ export class ApiV4PolicyStudioDesignComponent implements OnInit, OnDestroy {
         this.checkAndAdjustIndexes();
         this.isReadOnly = !this.permissionsService.hasAnyMatching(['api-definition-u']) || api.definitionContext.origin === 'KUBERNETES';
         this.isLoading = false;
-      });
-    this.trialURL = this.gioLicenseService.getTrialURL({ feature: ApimFeature.APIM_DEBUG_MODE, context: UTMTags.CONTEXT_API_V4 });
-  }
-
-  ngOnDestroy() {
-    this.unsubscribe$.next(true);
-    this.unsubscribe$.unsubscribe();
-  }
-
-  onSave(outputSave: SaveOutput) {
-    const { commonFlows, plansToUpdate, flowExecution } = outputSave;
-
-    const updates$: Observable<unknown>[] = [];
-    if (commonFlows || flowExecution) {
-      updates$.push(this.updateApiFlows(commonFlows, flowExecution));
-    }
-    if (plansToUpdate) {
-      updates$.push(this.updatePlans(plansToUpdate));
-    }
-    forkJoin(updates$)
-      .pipe(
-        tap(() => this.snackBarService.success('Policy Studio configuration saved')),
-        takeUntil(this.unsubscribe$),
-      )
-      .subscribe(() => this.router.navigateByUrl(this.location.path(), { skipLocationChange: true }));
-  }
-
-  onFlowSelectionChange(flowSelection: FlowSelection) {
-    this.updateIndexesInURL(flowSelection);
-  }
-
-  private updateIndexesInURL(flowSelection: FlowSelection) {
-    const segments = this.location.path().split('/');
-    segments[segments.length - 2] = flowSelection.planIndex.toString();
-    segments[segments.length - 1] = flowSelection.flowIndex.toString();
-    this.location.go(segments.join('/'));
-  }
-
-  private checkAndAdjustIndexes() {
-    const totalPlans = this.plans.length + 1; // Adding 1 for common flows.
-    const { planIndex, flowIndex } = this.selectedFlowIndexes;
-
-    if (planIndex < 0 || planIndex >= totalPlans) {
-      this.selectedFlowIndexes = { planIndex: 0, flowIndex: 0 };
-      this.updateIndexesInURL(this.selectedFlowIndexes);
-    } else {
-      const currentPlanFlowsLength = planIndex < this.plans.length ? this.plans[planIndex].flows.length : this.commonFlows.length;
-
-      if (flowIndex < 0 || flowIndex >= currentPlanFlowsLength) {
-        const firstAvailableFlow = this.findFirstAvailableFlow();
-
-        if (firstAvailableFlow) {
-          this.selectedFlowIndexes = firstAvailableFlow;
-        } else {
-          this.selectedFlowIndexes = { planIndex: 0, flowIndex: 0 };
-        }
-        this.updateIndexesInURL(this.selectedFlowIndexes);
-      }
-    }
-  }
-
-  private findFirstAvailableFlow(): FlowSelection | null {
-    for (let planIdx = 0; planIdx < this.plans.length; planIdx++) {
-      if (this.plans[planIdx].flows.length > 0) {
-        return { planIndex: planIdx, flowIndex: 0 };
-      }
-    }
-
-    if (this.commonFlows.length > 0) {
-      return { planIndex: this.plans.length, flowIndex: 0 };
-    }
-
-    return null;
+        this.changeDetectorRef.detectChanges();
+      }),
+    );
   }
 
   private updateApiFlows(commonFlows: PSFlow[], flowExecution: FlowExecution) {
@@ -262,10 +282,6 @@ export class ApiV4PolicyStudioDesignComponent implements OnInit, OnDestroy {
         };
 
         return this.apiV2Service.update(this.activatedRoute.snapshot.params.apiId, updatedApi);
-      }),
-      catchError((err) => {
-        this.snackBarService.error(err.error?.message ?? err.message);
-        return EMPTY;
       }),
       takeUntil(this.unsubscribe$),
     );
@@ -283,10 +299,6 @@ export class ApiV4PolicyStudioDesignComponent implements OnInit, OnDestroy {
           return this.apiPlanV2Service.update(this.activatedRoute.snapshot.params.apiId, apiPlan.id, updatedApiPlan);
         }),
         switchMap(() => this.apiV2Service.refreshLastApiFetch()),
-        catchError((err) => {
-          this.snackBarService.error(err.error?.message ?? err.message);
-          return EMPTY;
-        }),
       );
 
     return forkJoin(plans.map((plan) => updatePlan$(plan)));

--- a/gravitee-apim-gateway/gravitee-apim-gateway-flow/src/main/java/io/gravitee/gateway/flow/condition/evaluation/PathPatterns.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-flow/src/main/java/io/gravitee/gateway/flow/condition/evaluation/PathPatterns.java
@@ -48,7 +48,7 @@ public class PathPatterns {
                 if (branch.startsWith(PATH_PARAM_PREFIX)) {
                     buffer.append(PATH_PARAM_REGEX);
                 } else {
-                    buffer.append(branch);
+                    buffer.append(Pattern.quote(branch));
                 }
 
                 buffer.append(PATH_SEPARATOR);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/domain_service/ValidateApiCRDDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/domain_service/ValidateApiCRDDomainService.java
@@ -33,6 +33,7 @@ import io.gravitee.apim.core.resource.domain_service.ValidateResourceDomainServi
 import io.gravitee.apim.core.validation.Validator;
 import io.gravitee.definition.model.v4.flow.AbstractFlow;
 import io.gravitee.definition.model.v4.flow.Flow;
+import io.gravitee.definition.model.v4.flow.selector.HttpSelector;
 import io.gravitee.definition.model.v4.listener.ListenerType;
 import io.gravitee.definition.model.v4.nativeapi.kafka.KafkaListener;
 import io.gravitee.rest.api.service.common.IdBuilder;
@@ -193,6 +194,16 @@ public class ValidateApiCRDDomainService implements Validator<ValidateApiCRDDoma
                 if (hasNullPathOperator) {
                     throw InvalidFlowException.missingPathOperator(flow.getName());
                 }
+                flow
+                    .getSelectors()
+                    .stream()
+                    .filter(FlowValidationDomainService.HTTP_SELECTOR_WITH_INVALID_WILDCARD_PATH)
+                    .findFirst()
+                    .ifPresent(selector -> {
+                        if (selector instanceof HttpSelector httpSelector) {
+                            throw InvalidFlowException.invalidWildcardPath(flow.getName(), httpSelector.getPath());
+                        }
+                    });
             });
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/flow/domain_service/FlowValidationDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/flow/domain_service/FlowValidationDomainService.java
@@ -67,6 +67,13 @@ public class FlowValidationDomainService {
     public static final Predicate<Selector> HTTP_SELECTOR_WITH_NULL_PATH_OPERATOR = selector ->
         selector instanceof HttpSelector httpSelector && httpSelector.getPathOperator() == null;
 
+    public static final Predicate<Selector> HTTP_SELECTOR_WITH_INVALID_WILDCARD_PATH = selector ->
+        selector instanceof HttpSelector httpSelector && hasInvalidWildcardPath(httpSelector.getPath());
+
+    public static boolean hasInvalidWildcardPath(final String path) {
+        return path != null && path.contains("**");
+    }
+
     private static final Map<ApiType, Function<Flow, Optional<String>>> PATH_EXTRACTOR = Map.of(
         ApiType.PROXY,
         flow ->
@@ -105,6 +112,9 @@ public class FlowValidationDomainService {
                 // Check HTTP selectors carry a non-null pathOperator
                 checkHttpSelectorsPathOperator(flow);
 
+                // Check HTTP selectors do not use unsupported wildcard paths (e.g. /**)
+                checkHttpSelectorsInvalidWildcardPath(flow);
+
                 // Validate policy
                 var steps = Stream.of(flow.getRequest(), flow.getResponse(), flow.getPublish(), flow.getSubscribe())
                     .filter(Objects::nonNull)
@@ -141,6 +151,20 @@ public class FlowValidationDomainService {
             if (hasNullPathOperator) {
                 throw InvalidFlowException.missingPathOperator(flow.getName());
             }
+        }
+    }
+
+    private void checkHttpSelectorsInvalidWildcardPath(final Flow flow) {
+        if (flow.getSelectors() != null) {
+            flow
+                .getSelectors()
+                .stream()
+                .filter(HTTP_SELECTOR_WITH_INVALID_WILDCARD_PATH)
+                .map(HttpSelector.class::cast)
+                .findFirst()
+                .ifPresent(httpSelector -> {
+                    throw InvalidFlowException.invalidWildcardPath(flow.getName(), httpSelector.getPath());
+                });
         }
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/flow/exception/InvalidFlowException.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/flow/exception/InvalidFlowException.java
@@ -55,6 +55,13 @@ public class InvalidFlowException extends ValidationDomainException {
         );
     }
 
+    public static InvalidFlowException invalidWildcardPath(String flowName, String path) {
+        return new InvalidFlowException(
+            "The flow [" + flowName + "] contains an HTTP selector with an invalid wildcard path",
+            withFlowName(flowName, Map.of("path", path))
+        );
+    }
+
     private static Map<String, String> withFlowName(String flowName, Map<String, String> parameters) {
         if (flowName == null) {
             return parameters;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/flow/domain_service/FlowValidationDomainServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/flow/domain_service/FlowValidationDomainServiceTest.java
@@ -112,6 +112,48 @@ public class FlowValidationDomainServiceTest {
         }
 
         @Test
+        public void should_reject_http_selector_with_equals_operator_and_wildcard_path() {
+            var flow = Flow.builder()
+                .name("wildcard-flow")
+                .selectors(List.of(HttpSelector.builder().path("/**").pathOperator(Operator.EQUALS).build()))
+                .build();
+
+            var throwable = catchThrowable(() -> service.validateAndSanitizeHttpV4(ApiType.PROXY, List.of(flow)));
+
+            assertThat(throwable)
+                .isInstanceOf(InvalidFlowException.class)
+                .hasMessage("The flow [wildcard-flow] contains an HTTP selector with an invalid wildcard path")
+                .extracting(th -> ((InvalidFlowException) th).getParameters())
+                .asInstanceOf(InstanceOfAssertFactories.map(String.class, String.class))
+                .contains(entry("flowName", "wildcard-flow"), entry("path", "/**"));
+        }
+
+        @Test
+        public void should_reject_http_selector_with_starts_with_operator_and_wildcard_path() {
+            var flow = Flow.builder()
+                .name("wildcard-flow")
+                .selectors(List.of(HttpSelector.builder().path("/**").pathOperator(Operator.STARTS_WITH).build()))
+                .build();
+
+            var throwable = catchThrowable(() -> service.validateAndSanitizeHttpV4(ApiType.PROXY, List.of(flow)));
+
+            assertThat(throwable)
+                .isInstanceOf(InvalidFlowException.class)
+                .hasMessage("The flow [wildcard-flow] contains an HTTP selector with an invalid wildcard path");
+        }
+
+        @Test
+        public void should_accept_http_selector_with_single_asterisk_in_path() {
+            var flow = Flow.builder()
+                .selectors(List.of(HttpSelector.builder().path("/foo*").pathOperator(Operator.EQUALS).build()))
+                .build();
+
+            var result = service.validateAndSanitizeHttpV4(ApiType.PROXY, List.of(flow));
+
+            assertThat(result).hasSize(1).containsExactly(flow);
+        }
+
+        @Test
         public void should_accept_flow_with_only_selectors() {
             var flow = Flow.builder()
                 .selectors(List.of(HttpSelector.builder().path("/").pathOperator(Operator.STARTS_WITH).build()))


### PR DESCRIPTION
…save failure

## Issue

https://gravitee.atlassian.net/browse/APIM-14322

## Description
On v4 API flows, the **Equals** path operator does not work with wildcard paths (e.g. `/**`). Previously this could be saved from Policy Studio, then caused a **500** at runtime with a `PatternSyntaxException` in the gateway.

This PR adds validation on save and fixes the console so the UI recovers after a failed save.

## Backend changes

**What changed in code:**
- Added validation in `FlowValidationDomainService` to reject HTTP selectors when `pathOperator = EQUALS` and the path contains `*`
- Added `InvalidFlowException.equalsWithWildcardPath()` for a clear validation error message
- Applied the same check in `ValidateApiCRDDomainService` for CRD imports
- Added unit tests in `FlowValidationDomainServiceTest`

**Why:**
Invalid flow config was only failing at runtime in the gateway. We now block it when the API/plan is saved or imported, so bad config never gets deployed.

## Frontend changes

**What changed in code:**
- Updated `api-v4-policy-studio-design.component.ts` to reload API and plan flows from the server after a failed save
- Extracted `loadPolicyStudioData()` so Policy Studio can refresh its data on error
- Removed internal error swallowing in save methods so save failures are handled correctly
- Added unit tests in `api-v4-policy-studio-design.component.spec.ts` for reload-on-error behavior

**Why:**
Policy Studio kept the invalid flow in local UI state after a failed save. The error toast appeared, but the bad flow stayed in the list until a manual page refresh. Now the UI resets automatically from server data when validation fails.

### Before & After change
https://github.com/user-attachments/assets/67f381a8-3c10-46a6-871e-86ee6e6f253a

