### PR TITLE
Apim 14369 frontend implement invitation resend

### DIFF
--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-invitations/application-tab-invitations.component.harness.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-invitations/application-tab-invitations.component.harness.ts
@@ -25,7 +25,8 @@ export class ApplicationTabInvitationsComponentHarness extends ComponentHarness 
   private readonly locateLoader = this.locatorForOptional(LoaderHarness);
   private readonly locateSectionTitle = this.locatorForOptional('[data-testid="invitations-section-title"]');
   private readonly locateErrorMessage = this.locatorForOptional('[data-testid="invitations-list-error"]');
-  private readonly locateDeleteErrorMessage = this.locatorForOptional('[data-testid="invitations-delete-error"]');
+  private readonly locateActionErrorMessage = this.locatorForOptional('[data-testid="invitations-action-error"]');
+  private readonly locateActionSuccessMessage = this.locatorForOptional('[data-testid="invitations-action-success"]');
   private readonly locateEmptyState = this.locatorForOptional('[data-testid="invitations-empty-state"]');
   private readonly locateSearchBar = this.locatorForOptional('app-search-bar');
   private readonly locateSearchNoMatch = this.locatorForOptional('[data-testid="invitations-search-no-match"]');
@@ -46,8 +47,12 @@ export class ApplicationTabInvitationsComponentHarness extends ComponentHarness 
     return this.locateErrorMessage();
   }
 
-  public async getDeleteErrorMessage(): Promise<TestElement | null> {
-    return this.locateDeleteErrorMessage();
+  public async getActionErrorMessage(): Promise<TestElement | null> {
+    return this.locateActionErrorMessage();
+  }
+
+  public async getActionSuccessMessage(): Promise<TestElement | null> {
+    return this.locateActionSuccessMessage();
   }
 
   public async getEmptyState(): Promise<TestElement | null> {
@@ -88,5 +93,13 @@ export class ApplicationTabInvitationsComponentHarness extends ComponentHarness 
 
   public async clickEditInvitation(): Promise<void> {
     return (await this.getEditInvitationButton())!.click();
+  }
+
+  public async getResendInvitationButton(): Promise<MatButtonHarness | null> {
+    return (await this.locatePaginatedTable())?.getActionButton('resend') ?? null;
+  }
+
+  public async clickResendInvitation(): Promise<void> {
+    return (await this.getResendInvitationButton())!.click();
   }
 }

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-invitations/application-tab-invitations.component.html
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-invitations/application-tab-invitations.component.html
@@ -37,8 +37,11 @@
   <h4 class="next-gen-h4 invitations__title" data-testid="invitations-section-title">
     {{ sectionTitle() }}
   </h4>
+  @if (successMessage(); as successText) {
+    <p class="invitations__success next-gen-small" data-testid="invitations-action-success" aria-live="polite">{{ successText }}</p>
+  }
   @if (error(); as errorText) {
-    <p class="invitations__error next-gen-small" data-testid="invitations-delete-error" role="alert">{{ errorText }}</p>
+    <p class="invitations__error next-gen-small" data-testid="invitations-action-error" role="alert">{{ errorText }}</p>
   }
   @if (invitationsResource.isLoading()) {
     <app-loader />

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-invitations/application-tab-invitations.component.scss
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-invitations/application-tab-invitations.component.scss
@@ -50,6 +50,11 @@ app-search-bar {
     color: app-theme.$error-main-color;
   }
 
+  &__success {
+    padding: 24px 0;
+    color: app-theme.$primary-main-color;
+  }
+
   &__email {
     display: flex;
     align-items: center;

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-invitations/application-tab-invitations.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-invitations/application-tab-invitations.component.spec.ts
@@ -384,6 +384,110 @@ describe('ApplicationTabInvitationsComponent', () => {
     });
   });
 
+  describe('resend action', () => {
+    it('should not show resend button when user lacks MEMBER[U] permission', async () => {
+      const harness = await flush(fakeApplicationInvitationsResponse([fakeApplicationInvitation()]));
+
+      expect(await harness.getResendInvitationButton()).toBeNull();
+    });
+
+    it('should show resend button when user has MEMBER[U] permission', async () => {
+      fixture.componentRef.setInput('userApplicationPermissions', fakeUserApplicationPermissions({ MEMBER: ['R', 'U'] }));
+
+      const harness = await flush(fakeApplicationInvitationsResponse([fakeApplicationInvitation()]));
+
+      expect(await harness.getResendInvitationButton()).not.toBeNull();
+    });
+
+    it('should open confirmation dialog on resend click', async () => {
+      fixture.componentRef.setInput('userApplicationPermissions', fakeUserApplicationPermissions({ MEMBER: ['R', 'U'] }));
+      const harness = await flush(fakeApplicationInvitationsResponse([fakeApplicationInvitation({ email: 'alice@example.com' })]));
+
+      await harness.clickResendInvitation();
+      fixture.detectChanges();
+
+      const dialog = await rootLoader.getHarnessOrNull(ConfirmDialogHarness);
+      expect(dialog).not.toBeNull();
+      expect(await dialog!.getTitle()).toBe('Resend invitation?');
+      expect(await dialog!.getContent()).toContain('alice@example.com');
+      expect(await dialog!.getConfirmText()).toBe('Resend');
+      expect(await dialog!.getCancelText()).toBe('Cancel');
+      await dialog!.cancel();
+    });
+
+    it('should not send resend request when dialog is cancelled', async () => {
+      fixture.componentRef.setInput('userApplicationPermissions', fakeUserApplicationPermissions({ MEMBER: ['R', 'U'] }));
+      const harness = await flush(fakeApplicationInvitationsResponse([fakeApplicationInvitation()]));
+
+      await harness.clickResendInvitation();
+      fixture.detectChanges();
+
+      const dialog = await rootLoader.getHarnessOrNull(ConfirmDialogHarness);
+      await dialog!.cancel();
+      fixture.detectChanges();
+
+      httpTestingController.expectNone(r => r.url.includes('_resend'));
+    });
+
+    it('should send resend request, disable row action, reload list and show success message on confirm', async () => {
+      fixture.componentRef.setInput('userApplicationPermissions', fakeUserApplicationPermissions({ MEMBER: ['R', 'U'] }));
+      const invitation = fakeApplicationInvitation({ id: 'invitation-1', email: 'alice@example.com' });
+      const harness = await flush(fakeApplicationInvitationsResponse([invitation]));
+
+      await harness.clickResendInvitation();
+      fixture.detectChanges();
+
+      const dialog = await rootLoader.getHarnessOrNull(ConfirmDialogHarness);
+      await dialog!.confirm();
+      fixture.detectChanges();
+
+      const request = httpTestingController.expectOne(
+        r => r.url === `${TESTING_BASE_URL}/applications/${applicationId}/invitations/${invitation.id}/_resend` && r.method === 'POST',
+      );
+      expect(request.request.body).toEqual({
+        confirmation_page_url: `${globalThis.location.origin}/user/invitation/confirm`,
+      });
+      expect(await (await harness.getResendInvitationButton())!.isDisabled()).toBe(true);
+      request.flush(null, { status: 204, statusText: 'No Content' });
+      fixture.detectChanges();
+
+      httpTestingController.expectOne(r => r.url.includes('invitations/_search')).flush(fakeApplicationInvitationsResponse([invitation]));
+      await fixture.whenStable();
+      fixture.detectChanges();
+
+      const success = await harness.getActionSuccessMessage();
+      expect(success).not.toBeNull();
+      expect(await success!.getAttribute('aria-live')).toBe('polite');
+      expect(await success!.text()).toContain('Invitation email resent to alice@example.com');
+    });
+
+    it('should show inline error when resend fails', async () => {
+      fixture.componentRef.setInput('userApplicationPermissions', fakeUserApplicationPermissions({ MEMBER: ['R', 'U'] }));
+      const invitation = fakeApplicationInvitation({ id: 'invitation-1' });
+      const harness = await flush(fakeApplicationInvitationsResponse([invitation]));
+
+      await harness.clickResendInvitation();
+      fixture.detectChanges();
+
+      const dialog = await rootLoader.getHarnessOrNull(ConfirmDialogHarness);
+      await dialog!.confirm();
+      fixture.detectChanges();
+
+      httpTestingController
+        .expectOne(
+          r => r.url === `${TESTING_BASE_URL}/applications/${applicationId}/invitations/${invitation.id}/_resend` && r.method === 'POST',
+        )
+        .flush({ error: 'Server error' }, { status: 500, statusText: 'Internal Server Error' });
+      await fixture.whenStable();
+      fixture.detectChanges();
+
+      const error = await harness.getActionErrorMessage();
+      expect(error).not.toBeNull();
+      expect(await error!.getAttribute('role')).toBe('alert');
+      expect(await error!.text()).toContain('An error occurred while resending the invitation');
+    });
+  });
+
   describe('delete action', () => {
     it('should not show delete button when user lacks MEMBER[D] permission', async () => {
       const harness = await flush(fakeApplicationInvitationsResponse([fakeApplicationInvitation()]));
@@ -496,7 +600,7 @@ describe('ApplicationTabInvitationsComponent', () => {
       await fixture.whenStable();
       fixture.detectChanges();
 
-      const error = await harness.getDeleteErrorMessage();
+      const error = await harness.getActionErrorMessage();
       expect(error).not.toBeNull();
       expect(await error!.getAttribute('role')).toBe('alert');
       expect(await error!.text()).toContain('An error occurred while deleting the invitation');

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-invitations/application-tab-invitations.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-invitations/application-tab-invitations.component.ts
@@ -13,12 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { PlatformLocation } from '@angular/common';
 import { Component, computed, DestroyRef, inject, input, signal } from '@angular/core';
 import { rxResource, takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { MatButtonModule } from '@angular/material/button';
 import { MatDialog, MatDialogModule } from '@angular/material/dialog';
 import { MatIcon } from '@angular/material/icon';
-import { EMPTY, filter, map, of, switchMap, tap } from 'rxjs';
+import { EMPTY, filter, finalize, map, of, switchMap, tap } from 'rxjs';
 
 import { ConfirmDialogComponent, ConfirmDialogData } from '../../../../components/confirm-dialog/confirm-dialog.component';
 import { LoaderComponent } from '../../../../components/loader/loader.component';
@@ -70,6 +71,7 @@ export class ApplicationTabInvitationsComponent {
   private readonly applicationInvitationService = inject(ApplicationInvitationService);
   private readonly destroyRef = inject(DestroyRef);
   private readonly matDialog = inject(MatDialog);
+  private readonly platformLocation = inject(PlatformLocation);
 
   readonly applicationId = input.required<string>();
   readonly userApplicationPermissions = input.required<UserApplicationPermissions>();
@@ -78,6 +80,8 @@ export class ApplicationTabInvitationsComponent {
   readonly pageSize = signal(10);
   readonly searchTerm = signal('');
   readonly error = signal<string | null>(null);
+  readonly successMessage = signal<string | null>(null);
+  readonly resendingInvitationId = signal<string | null>(null);
   readonly displayedTotalElements = signal<number | null>(null);
   readonly sectionTitle = computed(() => {
     const totalElements = this.displayedTotalElements();
@@ -103,26 +107,34 @@ export class ApplicationTabInvitationsComponent {
   });
 
   readonly actions = computed<TableAction<InvitationTableRow>[]>(() => {
-    const actions: TableAction<InvitationTableRow>[] = [];
+    const updateActions: TableAction<InvitationTableRow>[] = this.canUpdate()
+      ? [
+          {
+            id: 'resend',
+            icon: 'send',
+            ariaLabel: $localize`:@@resendApplicationInvitationAriaLabel:Resend invitation`,
+            isDisabled: invitation => this.resendingInvitationId() === invitation.id,
+          },
+          {
+            id: 'edit',
+            icon: 'edit',
+            ariaLabel: $localize`:@@editApplicationInvitationAriaLabel:Edit invitation role`,
+          },
+        ]
+      : [];
 
-    if (this.canUpdate()) {
-      actions.push({
-        id: 'edit',
-        icon: 'edit',
-        ariaLabel: $localize`:@@editApplicationInvitationAriaLabel:Edit invitation role`,
-      });
-    }
+    const deleteActions: TableAction<InvitationTableRow>[] = this.canDelete()
+      ? [
+          {
+            id: 'delete',
+            icon: 'delete_outline',
+            ariaLabel: $localize`:@@deleteApplicationInvitationAriaLabel:Delete invitation`,
+            color: 'warn',
+          },
+        ]
+      : [];
 
-    if (this.canDelete()) {
-      actions.push({
-        id: 'delete',
-        icon: 'delete_outline',
-        ariaLabel: $localize`:@@deleteApplicationInvitationAriaLabel:Delete invitation`,
-        color: 'warn',
-      });
-    }
-
-    return actions;
+    return [...updateActions, ...deleteActions];
   });
 
   readonly requestParams = computed<InvitationsRequestParams | null>(() =>
@@ -188,15 +200,21 @@ export class ApplicationTabInvitationsComponent {
   }
 
   onActionClick({ actionId, row }: { actionId: string; row: InvitationTableRow }): void {
-    if (actionId === 'edit') {
-      this.openEditInvitationDialog(row);
-    } else if (actionId === 'delete') {
-      this.openDeleteConfirmation(row);
+    switch (actionId) {
+      case 'resend':
+        this.openResendConfirmation(row);
+        break;
+      case 'edit':
+        this.openEditInvitationDialog(row);
+        break;
+      case 'delete':
+        this.openDeleteConfirmation(row);
+        break;
     }
   }
 
   openCreateInvitationDialog(): void {
-    this.error.set(null);
+    this.clearActionFeedback();
     this.matDialog
       .open<ApplicationInvitationCreateDialogComponent, ApplicationInvitationCreateDialogData, boolean>(
         ApplicationInvitationCreateDialogComponent,
@@ -215,7 +233,7 @@ export class ApplicationTabInvitationsComponent {
   }
 
   private openEditInvitationDialog(invitation: InvitationTableRow): void {
-    this.error.set(null);
+    this.clearActionFeedback();
     this.matDialog
       .open<ApplicationInvitationEditDialogComponent, ApplicationInvitationEditDialogData, boolean>(
         ApplicationInvitationEditDialogComponent,
@@ -237,8 +255,50 @@ export class ApplicationTabInvitationsComponent {
       .subscribe();
   }
 
+  private openResendConfirmation(invitation: InvitationTableRow): void {
+    this.clearActionFeedback();
+    this.matDialog
+      .open<ConfirmDialogComponent, ConfirmDialogData, boolean>(ConfirmDialogComponent, {
+        role: 'alertdialog',
+        data: {
+          title: $localize`:@@resendApplicationInvitationDialogTitle:Resend invitation?`,
+          content: $localize`:@@resendApplicationInvitationDialogContent:This will send a new invitation email to ${invitation.email}:invitationEmail: and refresh its validity period.`,
+          confirmLabel: $localize`:@@resendApplicationInvitationDialogConfirm:Resend`,
+          cancelLabel: $localize`:@@resendApplicationInvitationDialogCancel:Cancel`,
+        },
+      })
+      .afterClosed()
+      .pipe(
+        switchMap(confirmed => {
+          if (!confirmed) {
+            return EMPTY;
+          }
+
+          this.resendingInvitationId.set(invitation.id);
+          return this.applicationInvitationService
+            .resendApplicationInvitation(this.applicationId(), invitation.id, {
+              confirmation_page_url: this.buildRegistrationConfirmationPageUrl(),
+            })
+            .pipe(finalize(() => this.resendingInvitationId.set(null)));
+        }),
+        tap(() => {
+          this.successMessage.set(
+            $localize`:@@resendApplicationInvitationSuccess:Invitation email resent to ${invitation.email}:invitationEmail:.`,
+          );
+          this.invitationsResource.reload();
+        }),
+        takeUntilDestroyed(this.destroyRef),
+      )
+      .subscribe({
+        error: () =>
+          this.error.set(
+            $localize`:@@resendApplicationInvitationError:An error occurred while resending the invitation. Please try again.`,
+          ),
+      });
+  }
+
   private openDeleteConfirmation(invitation: InvitationTableRow): void {
-    this.error.set(null);
+    this.clearActionFeedback();
     this.matDialog
       .open<ConfirmDialogComponent, ConfirmDialogData, boolean>(ConfirmDialogComponent, {
         role: 'alertdialog',
@@ -261,6 +321,18 @@ export class ApplicationTabInvitationsComponent {
         error: () =>
           this.error.set($localize`:@@deleteApplicationInvitationError:An error occurred while deleting the invitation. Please try again.`),
       });
+  }
+
+  private clearActionFeedback(): void {
+    this.error.set(null);
+    this.successMessage.set(null);
+  }
+
+  private buildRegistrationConfirmationPageUrl(): string {
+    const baseHref = this.platformLocation.getBaseHrefFromDOM() || '/';
+    const normalizedBaseHref = baseHref.endsWith('/') ? baseHref : `${baseHref}/`;
+
+    return new URL(`${normalizedBaseHref}user/invitation/confirm`, globalThis.location.origin).toString();
   }
 
   private reloadInvitationsAfterDelete(): void {

--- a/gravitee-apim-portal-webui-next/src/entities/application/application-invitation.ts
+++ b/gravitee-apim-portal-webui-next/src/entities/application/application-invitation.ts
@@ -34,6 +34,10 @@ export interface ApplicationInvitationUpdateInput {
   role: string;
 }
 
+export interface ApplicationInvitationResendInput {
+  confirmation_page_url: string;
+}
+
 export interface ApplicationInvitationsSearchFilters {
   email?: string;
 }

--- a/gravitee-apim-portal-webui-next/src/services/application-invitation.service.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/services/application-invitation.service.spec.ts
@@ -114,4 +114,17 @@ describe('ApplicationInvitationService', () => {
     expect(req.request.body).toEqual(input);
     req.flush(response);
   });
+
+  it('should resend application invitation', done => {
+    const invitationId = 'invitation-1';
+    const input = { confirmation_page_url: 'http://example.local/user/invitation/confirm' };
+
+    service.resendApplicationInvitation(applicationId, invitationId, input).subscribe(() => done());
+
+    const req = httpTestingController.expectOne(
+      r => r.url === `${TESTING_BASE_URL}/applications/${applicationId}/invitations/${invitationId}/_resend` && r.method === 'POST',
+    );
+    expect(req.request.body).toEqual(input);
+    req.flush(null, { status: 204, statusText: 'No Content' });
+  });
 });

--- a/gravitee-apim-portal-webui-next/src/services/application-invitation.service.ts
+++ b/gravitee-apim-portal-webui-next/src/services/application-invitation.service.ts
@@ -20,6 +20,7 @@ import { Observable } from 'rxjs';
 import { ConfigService } from './config.service';
 import {
   ApplicationInvitation,
+  ApplicationInvitationResendInput,
   ApplicationInvitationsCreateInput,
   ApplicationInvitationsResponse,
   ApplicationInvitationsSearchFilters,
@@ -68,5 +69,9 @@ export class ApplicationInvitationService {
       `${this.configService.baseURL}/applications/${applicationId}/invitations/${invitationId}`,
       input,
     );
+  }
+
+  resendApplicationInvitation(applicationId: string, invitationId: string, input: ApplicationInvitationResendInput): Observable<void> {
+    return this.http.post<void>(`${this.configService.baseURL}/applications/${applicationId}/invitations/${invitationId}/_resend`, input);
   }
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-14369

## Description
Implements the frontend resend invitation action for application invitations.

Changes:
- Added a Resend invitation row action gated by MEMBER[U].
- Added confirmation dialog before resending.
- Calls POST /applications/{applicationId}/invitations/{invitationId}/_resend.
- Sends required confirmation_page_url using /user/invitation/confirm.



https://github.com/user-attachments/assets/77a3eb51-72cb-4357-8bd3-8bdc41eecddd

