### PR TITLE
fix(crd-export): preserve DEPRECATED and ARCHIVED lifecycle states in CRD export

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/ApiCRDMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/ApiCRDMapper.java
@@ -101,7 +101,10 @@ public interface ApiCRDMapper {
 
     @Named("mapLifecycleState")
     default ApiLifecycleState mapLifecycleState(String lifecycleState) {
-        return ApiLifecycleState.PUBLISHED.name().equals(lifecycleState) ? ApiLifecycleState.PUBLISHED : ApiLifecycleState.UNPUBLISHED;
+        if (lifecycleState == null) {
+            return null;
+        }
+        return ApiLifecycleState.fromValue(lifecycleState);
     }
 
     @Named("mapPlanTypeCoreToRest")

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/mapper/ApiCRDMapperTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/mapper/ApiCRDMapperTest.java
@@ -15,6 +15,9 @@
  */
 package io.gravitee.rest.api.management.v2.rest.mapper;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import fixtures.AnalyticsFixtures;
 import fixtures.definition.FlowFixtures;
 import io.gravitee.apim.core.api.model.crd.ApiCRDSpec;
@@ -46,7 +49,7 @@ import org.junit.jupiter.api.Test;
 class ApiCRDMapperTest {
 
     @Test
-    void should_map_to_rest_model_unpublished() {
+    void should_map_to_rest_model_created() {
         var restModel = ApiCRDMapper.INSTANCE.map(aCoreCRD().build());
 
         SoftAssertions.assertSoftly(soft -> {
@@ -58,9 +61,44 @@ class ApiCRDMapperTest {
             soft.assertThat(restModel.getEndpointGroups()).hasSize(1);
             soft.assertThat(restModel.getPlans()).hasSize(1);
             soft.assertThat(restModel.getPlans()).containsKey("keyless-key");
-            soft.assertThat(restModel.getLifecycleState()).isEqualTo(ApiLifecycleState.UNPUBLISHED);
+            soft.assertThat(restModel.getLifecycleState()).isEqualTo(ApiLifecycleState.CREATED);
             soft.assertThat(restModel.getTags()).contains("tag");
         });
+    }
+
+    @Test
+    void should_map_to_rest_model_unpublished() {
+        var restModel = ApiCRDMapper.INSTANCE.map(aCoreCRD().lifecycleState("UNPUBLISHED").build());
+
+        assertThat(restModel.getLifecycleState()).isEqualTo(ApiLifecycleState.UNPUBLISHED);
+    }
+
+    @Test
+    void should_map_to_rest_model_deprecated() {
+        var restModel = ApiCRDMapper.INSTANCE.map(aCoreCRD().lifecycleState("DEPRECATED").build());
+
+        assertThat(restModel.getLifecycleState()).isEqualTo(ApiLifecycleState.DEPRECATED);
+    }
+
+    @Test
+    void should_map_to_rest_model_archived() {
+        var restModel = ApiCRDMapper.INSTANCE.map(aCoreCRD().lifecycleState("ARCHIVED").build());
+
+        assertThat(restModel.getLifecycleState()).isEqualTo(ApiLifecycleState.ARCHIVED);
+    }
+
+    @Test
+    void should_map_null_lifecycle_state_to_null() {
+        var restModel = ApiCRDMapper.INSTANCE.map(aCoreCRD().lifecycleState(null).build());
+
+        assertThat(restModel.getLifecycleState()).isNull();
+    }
+
+    @Test
+    void should_throw_when_lifecycle_state_is_unknown() {
+        var spec = aCoreCRD().lifecycleState("UNKNOWN_STATE").build();
+
+        assertThatThrownBy(() -> ApiCRDMapper.INSTANCE.map(spec)).isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-14236

## Description

When exporting a v4 API as a CRD (/_export/crd), the spec.lifecycleState field was always serialized as either **_PUBLISHED_** or **_UNPUBLISHED_**. APIs in **_DEPRECATED_** or **_ARCHIVED_** state were silently downgraded to **_UNPUBLISHED_**, making the CRD export unsafe for backup or GitOps roundtrips.

**Root cause:** ApiCRDMapper.mapLifecycleState() had a hardcoded binary check **_PUBLISHED_** or else **_UNPUBLISHED_**  instead of a proper enum lookup. 
The REST model already declared all 5 states (_CREATED, PUBLISHED, UNPUBLISHED, DEPRECATED, ARCHIVED_).

**Fix:** Replace the binary check with ApiLifecycleState.fromValue(lifecycleState). This single change covers both the Management v2 API and the Automation API (which reuses the same mapper).


## Additional context

**Before Fix:**

https://github.com/user-attachments/assets/4ba16444-9969-423f-be77-838e35c2ea69

**After Fix:**

https://github.com/user-attachments/assets/5700adbb-5d11-4a93-b9be-77df89f85a2e


<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

