### PR TITLE
chore: bump gamma-module-authz plugin to 1.0.0-alpha.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -339,7 +339,7 @@
 
         <!-- Gamma plugins -->
         <gravitee-gamma-module-aim.version>1.0.0-alpha.130</gravitee-gamma-module-aim.version>
-        <gravitee-gamma-module-authz.version>1.0.0-alpha.4</gravitee-gamma-module-authz.version>
+        <gravitee-gamma-module-authz.version>1.0.0-alpha.8</gravitee-gamma-module-authz.version>
 
         <!-- Authz plugins -->
         <gravitee-service-authz-pdp.version>1.0.0-alpha.5</gravitee-service-authz-pdp.version>


### PR DESCRIPTION
## What

Bumps the `gravitee-gamma-module-authz` plugin version from `1.0.0-alpha.4` to `1.0.0-alpha.8` (latest released alpha).

## Why

alpha.8 of the authz module has been released. The other authz-family plugins are already pinned to their latest released alpha, so no change there:

| plugin | current | latest | action |
|---|---|---|---|
| gravitee-gamma-module-authz | alpha.4 | **alpha.8** | bumped |
| gravitee-service-authz-pdp | alpha.5 | alpha.5 | already latest |
| gravitee-policy-authz-pep | alpha.7 | alpha.7 | already latest |
| gravitee-policy-authz-pdp-authzen | alpha.1 | alpha.1 | already latest |

## Verification

- `1.0.0-alpha.8` resolves from the artifactory (`mvn dependency:get` on `com.graviteesource.gamma.module:gravitee-gamma-module-authz:1.0.0-alpha.8:zip`).
- Local Gamma stack boots with the authz module loaded.