### PR TITLE
fix(gamma): disable nx daemon and cap node heap for maven builds

### DIFF
--- a/gravitee-gamma/gravitee-gamma-module-apim/pom.xml
+++ b/gravitee-gamma/gravitee-gamma-module-apim/pom.xml
@@ -112,6 +112,10 @@
                         <configuration>
                             <executable>yarn</executable>
                             <workingDirectory>${project.basedir}/../..</workingDirectory>
+                            <environmentVariables>
+                                <NX_DAEMON>false</NX_DAEMON>
+                                <NODE_OPTIONS>--max-old-space-size=4096</NODE_OPTIONS>
+                            </environmentVariables>
                             <arguments>
                                 <argument>nx</argument>
                                 <argument>build</argument>

--- a/gravitee-gamma/gravitee-gamma-module-apim/pom.xml
+++ b/gravitee-gamma/gravitee-gamma-module-apim/pom.xml
@@ -115,6 +115,7 @@
                             <environmentVariables>
                                 <NX_DAEMON>false</NX_DAEMON>
                                 <NODE_OPTIONS>--max-old-space-size=4096</NODE_OPTIONS>
+                                <NX_CACHE_DIRECTORY>${project.build.directory}/.nx/cache</NX_CACHE_DIRECTORY>
                             </environmentVariables>
                             <arguments>
                                 <argument>nx</argument>

--- a/gravitee-gamma/gravitee-gamma-module-platform/pom.xml
+++ b/gravitee-gamma/gravitee-gamma-module-platform/pom.xml
@@ -217,6 +217,10 @@
                         <configuration>
                             <executable>yarn</executable>
                             <workingDirectory>${project.basedir}/../..</workingDirectory>
+                            <environmentVariables>
+                                <NX_DAEMON>false</NX_DAEMON>
+                                <NODE_OPTIONS>--max-old-space-size=4096</NODE_OPTIONS>
+                            </environmentVariables>
                             <arguments>
                                 <argument>nx</argument>
                                 <argument>build</argument>

--- a/gravitee-gamma/gravitee-gamma-module-platform/pom.xml
+++ b/gravitee-gamma/gravitee-gamma-module-platform/pom.xml
@@ -220,6 +220,7 @@
                             <environmentVariables>
                                 <NX_DAEMON>false</NX_DAEMON>
                                 <NODE_OPTIONS>--max-old-space-size=4096</NODE_OPTIONS>
+                                <NX_CACHE_DIRECTORY>${project.build.directory}/.nx/cache</NX_CACHE_DIRECTORY>
                             </environmentVariables>
                             <arguments>
                                 <argument>nx</argument>


### PR DESCRIPTION
## Issue

_No JIRA ticket for this change._

## Description

The `gravitee-gamma-module-apim` and `gravitee-gamma-module-platform` modules both run `yarn nx build` against the same workspace root during the `generate-resources` phase. Under a parallel Maven reactor they share a single NX daemon running with the default Node heap, which gets OOM-killed and surfaces as:

```
NX Daemon process terminated and closed the connection
```

This PR makes each build run daemon-less (`NX_DAEMON=false`) with an explicit `--max-old-space-size=4096`, so the two parallel rspack builds no longer contend on one Node process.

## Additional context

- Affects only the Maven build configuration (`pom.xml`) of the two gamma modules — no runtime/product code change.
