### PR TITLE
fix(api-search): exclude EDGE APIs from all search and listing endpoints

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/search/ApiCriteria.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/search/ApiCriteria.java
@@ -49,6 +49,7 @@ public class ApiCriteria {
     private List<DefinitionVersion> definitionVersion;
     private String integrationId;
     private List<ApiType> apiTypes;
+    private List<ApiType> notApiTypes;
     private Date updatedAtFrom;
 
     ApiCriteria(ApiCriteria.Builder builder) {
@@ -67,6 +68,7 @@ public class ApiCriteria {
         this.definitionVersion = builder.definitionVersion;
         this.integrationId = builder.integrationId;
         this.apiTypes = builder.apiTypes;
+        this.notApiTypes = builder.notApiTypes;
         this.updatedAtFrom = builder.updatedAtFrom;
     }
 
@@ -142,6 +144,10 @@ public class ApiCriteria {
         return apiTypes;
     }
 
+    public List<ApiType> getNotApiTypes() {
+        return notApiTypes;
+    }
+
     public Date getUpdatedAtFrom() {
         return updatedAtFrom;
     }
@@ -167,6 +173,7 @@ public class ApiCriteria {
             Objects.equals(definitionVersion, that.definitionVersion) &&
             Objects.equals(integrationId, that.integrationId) &&
             Objects.equals(apiTypes, that.apiTypes) &&
+            Objects.equals(notApiTypes, that.notApiTypes) &&
             Objects.equals(updatedAtFrom, that.updatedAtFrom)
         );
     }
@@ -189,6 +196,7 @@ public class ApiCriteria {
             definitionVersion,
             integrationId,
             apiTypes,
+            notApiTypes,
             updatedAtFrom
         );
     }
@@ -210,6 +218,7 @@ public class ApiCriteria {
         private List<DefinitionVersion> definitionVersion;
         private String integrationId;
         private List<ApiType> apiTypes;
+        private List<ApiType> notApiTypes;
         private Date updatedAtFrom;
 
         public ApiCriteria.Builder ids(final String... id) {
@@ -294,6 +303,11 @@ public class ApiCriteria {
 
         public ApiCriteria.Builder apiTypes(final List<ApiType> apiTypes) {
             this.apiTypes = apiTypes;
+            return this;
+        }
+
+        public ApiCriteria.Builder notApiTypes(final List<ApiType> notApiTypes) {
+            this.notApiTypes = notApiTypes;
             return this;
         }
 

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcApiRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcApiRepository.java
@@ -540,6 +540,9 @@ public class JdbcApiRepository extends JdbcAbstractPageableRepository<Api> imple
             if (!isEmpty(apiCriteria.getApiTypes())) {
                 lastIndex = getOrm().setArguments(ps, apiCriteria.getApiTypes(), lastIndex);
             }
+            if (!isEmpty(apiCriteria.getNotApiTypes())) {
+                lastIndex = getOrm().setArguments(ps, apiCriteria.getNotApiTypes(), lastIndex);
+            }
             if (apiCriteria.getUpdatedAtFrom() != null) {
                 ps.setTimestamp(lastIndex++, new java.sql.Timestamp(apiCriteria.getUpdatedAtFrom().getTime()));
             }
@@ -611,6 +614,9 @@ public class JdbcApiRepository extends JdbcAbstractPageableRepository<Api> imple
         }
         if (!isEmpty(apiCriteria.getApiTypes())) {
             clauses.add("a.type in (" + getOrm().buildInClause(apiCriteria.getApiTypes()) + ")");
+        }
+        if (!isEmpty(apiCriteria.getNotApiTypes())) {
+            clauses.add("a.type not in (" + getOrm().buildInClause(apiCriteria.getNotApiTypes()) + ")");
         }
         if (apiCriteria.getUpdatedAtFrom() != null) {
             clauses.add("a.updated_at >= ?");

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/api/ApiMongoRepositoryImpl.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/api/ApiMongoRepositoryImpl.java
@@ -176,6 +176,9 @@ public class ApiMongoRepositoryImpl implements ApiMongoRepositoryCustom {
                     if (apiCriteria.getApiTypes() != null && !apiCriteria.getApiTypes().isEmpty()) {
                         criteria.add(where("type").in(apiCriteria.getApiTypes()));
                     }
+                    if (apiCriteria.getNotApiTypes() != null && !apiCriteria.getNotApiTypes().isEmpty()) {
+                        criteria.add(where("type").not().in(apiCriteria.getNotApiTypes()));
+                    }
                     if (apiCriteria.getUpdatedAtFrom() != null) {
                         criteria.add(where("updatedAt").gte(apiCriteria.getUpdatedAtFrom()));
                     }

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/ApiRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/ApiRepositoryTest.java
@@ -292,7 +292,7 @@ public class ApiRepositoryTest extends AbstractManagementRepositoryTest {
             new ApiCriteria.Builder().definitionVersion(List.of(DefinitionVersion.V4)).build(),
             ApiFieldFilter.allFields()
         );
-        assertThat(v4Apis).hasSize(1);
+        assertThat(v4Apis).hasSize(2);
 
         List<Api> federatedApis = apiRepository.search(
             new ApiCriteria.Builder().definitionVersion(List.of(DefinitionVersion.FEDERATED)).build(),
@@ -362,8 +362,8 @@ public class ApiRepositoryTest extends AbstractManagementRepositoryTest {
         List<Api> apis = apiRepository.search(new ApiCriteria.Builder().environmentId("DEFAULT").build(), ApiFieldFilter.allFields());
         assertNotNull(apis);
         assertFalse(apis.isEmpty());
-        assertEquals(2, apis.size());
-        assertTrue(apis.stream().map(Api::getId).toList().containsAll(asList("grouped-api", "api-to-findById")));
+        assertEquals(3, apis.size());
+        assertTrue(apis.stream().map(Api::getId).toList().containsAll(asList("grouped-api", "api-to-findById", "edge-api")));
     }
 
     @Test
@@ -461,11 +461,16 @@ public class ApiRepositoryTest extends AbstractManagementRepositoryTest {
             ApiFieldFilter.allFields()
         );
         assertNotNull(apis);
-        assertEquals(1, apis.size());
-        assertEquals("async-api", apis.get(0).getId());
-        assertEquals(DefinitionVersion.V4, apis.get(0).getDefinitionVersion());
-        assertEquals(ApiType.MESSAGE, apis.get(0).getType());
-        assertEquals("async-searched-crossId", apis.get(0).getCrossId());
+        assertEquals(2, apis.size());
+        assertThat(apis.stream().map(Api::getId).toList()).containsExactlyInAnyOrder("async-api", "edge-api");
+        Api asyncApi = apis
+            .stream()
+            .filter(a -> "async-api".equals(a.getId()))
+            .findFirst()
+            .orElseThrow();
+        assertEquals(DefinitionVersion.V4, asyncApi.getDefinitionVersion());
+        assertEquals(ApiType.MESSAGE, asyncApi.getType());
+        assertEquals("async-searched-crossId", asyncApi.getCrossId());
         // Guard against a future regression that incorrectly broadens $in to always include null:
         // V4-only must NOT pull legacy null/missing-defVersion docs.
         assertThat(apis.stream().map(Api::getId).toList()).doesNotContain("legacy-explicit-null-defv-api");
@@ -491,9 +496,10 @@ public class ApiRepositoryTest extends AbstractManagementRepositoryTest {
             ApiFieldFilter.allFields()
         );
         assertNotNull(apis);
-        assertThat(apis).hasSize(12);
+        assertThat(apis).hasSize(13);
         assertThat(apis.stream().map(Api::getId).toList()).contains(
             "async-api",
+            "edge-api",
             "api-with-many-categories",
             "legacy-explicit-null-defv-api",
             "api-to-delete",
@@ -533,6 +539,17 @@ public class ApiRepositoryTest extends AbstractManagementRepositoryTest {
             ApiFieldFilter.allFields()
         );
         assertThat(mcpApis).isEmpty();
+    }
+
+    @Test
+    public void should_exclude_by_notApiTypes() {
+        List<Api> apisWithoutEdge = apiRepository.search(
+            new ApiCriteria.Builder().environmentId("DEFAULT").notApiTypes(List.of(ApiType.EDGE)).build(),
+            ApiFieldFilter.allFields()
+        );
+        assertThat(apisWithoutEdge).isNotEmpty();
+        assertThat(apisWithoutEdge.stream().map(Api::getType).toList()).doesNotContain(ApiType.EDGE);
+        assertThat(apisWithoutEdge.stream().map(Api::getId).toList()).doesNotContain("edge-api");
     }
 
     @Test
@@ -676,7 +693,7 @@ public class ApiRepositoryTest extends AbstractManagementRepositoryTest {
 
         assertNotNull(apis);
         assertFalse(apis.isEmpty());
-        assertEquals(13, apis.size());
+        assertEquals(14, apis.size());
     }
 
     @Test

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/resources/data/api-tests/apis.json
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/resources/data/api-tests/apis.json
@@ -223,5 +223,22 @@
         "lifecycleState": "STARTED",
         "apiLifecycleState": "CREATED",
         "disableMembershipNotifications": true
+    },
+    {
+        "id": "edge-api",
+        "environmentId": "DEFAULT",
+        "origin": "management",
+        "mode": "fully_managed",
+        "name": "edge api for test",
+        "definitionVersion": "4.0.0",
+        "type": "edge",
+        "version": "1.0",
+        "definition": "{\"id\":\"edge-api\",\"name\":\"edge api\",\"type\":\"edge\"}",
+        "visibility": "PRIVATE",
+        "createdAt": 1439022010883,
+        "updatedAt": 1439022010883,
+        "lifecycleState": "STARTED",
+        "apiLifecycleState": "CREATED",
+        "disableMembershipNotifications": false
     }
 ]

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/model/ApiSearchCriteria.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/model/ApiSearchCriteria.java
@@ -16,6 +16,7 @@
 package io.gravitee.apim.core.api.model;
 
 import io.gravitee.definition.model.DefinitionVersion;
+import io.gravitee.definition.model.v4.ApiType;
 import java.time.Instant;
 import java.util.Collection;
 import java.util.List;
@@ -40,5 +41,6 @@ public class ApiSearchCriteria {
     private String crossId;
     private Collection<DefinitionVersion> definitionVersion;
     private String integrationId;
+    private List<ApiType> notApiTypes;
     private Instant updatedAtFrom;
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/ApiSearchCriteriaAdapter.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/ApiSearchCriteriaAdapter.java
@@ -69,7 +69,8 @@ public class ApiSearchCriteriaAdapter {
                 .environmentId(criteria.getEnvironmentId())
                 .environments(criteria.getEnvironments())
                 .crossId(criteria.getCrossId())
-                .integrationId(criteria.getIntegrationId());
+                .integrationId(criteria.getIntegrationId())
+                .notApiTypes(criteria.getNotApiTypes());
             if (criteria.getUpdatedAtFrom() != null) {
                 builder.updatedAtFrom(Date.from(criteria.getUpdatedAtFrom()));
             }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/query_service/api/ApiPortalSearchQueryServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/query_service/api/ApiPortalSearchQueryServiceImpl.java
@@ -20,6 +20,7 @@ import io.gravitee.apim.core.api.model.ApiSearchCriteria;
 import io.gravitee.apim.core.api.query_service.ApiPortalSearchQueryService;
 import io.gravitee.apim.core.api.query_service.ApiQueryService;
 import io.gravitee.common.data.domain.Page;
+import io.gravitee.definition.model.v4.ApiType;
 import io.gravitee.rest.api.model.common.Pageable;
 import io.gravitee.rest.api.model.common.Sortable;
 import io.gravitee.rest.api.service.common.ExecutionContext;
@@ -61,7 +62,11 @@ public class ApiPortalSearchQueryServiceImpl implements ApiPortalSearchQueryServ
         if (queryText.isEmpty()) {
             // No text query: delegate sorting and pagination to the repository
             return apiQueryService.search(
-                ApiSearchCriteria.builder().ids(List.copyOf(allowedApiIds)).environmentId(query.environmentId()).build(),
+                ApiSearchCriteria.builder()
+                    .ids(List.copyOf(allowedApiIds))
+                    .environmentId(query.environmentId())
+                    .notApiTypes(List.of(ApiType.EDGE))
+                    .build(),
                 sortable.map(this::toCoreSortable).orElse(null),
                 pageable.orElse(null),
                 null
@@ -100,7 +105,12 @@ public class ApiPortalSearchQueryServiceImpl implements ApiPortalSearchQueryServ
 
         // Fetch by IDs then reorder to preserve Lucene relevance order
         Map<String, Api> apiById = apiQueryService
-            .search(ApiSearchCriteria.builder().ids(pageSubset).environmentId(query.environmentId()).build(), null, null, null)
+            .search(
+                ApiSearchCriteria.builder().ids(pageSubset).environmentId(query.environmentId()).notApiTypes(List.of(ApiType.EDGE)).build(),
+                null,
+                null,
+                null
+            )
             .getContent()
             .stream()
             .collect(Collectors.toMap(Api::getId, Function.identity()));

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/search/query/QueryBuilder.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/search/query/QueryBuilder.java
@@ -74,6 +74,11 @@ public class QueryBuilder<T extends Indexable> {
         return this;
     }
 
+    public QueryBuilder<T> addExcludedFilter(String name, Collection<String> values) {
+        query.getExcludedFilters().put(name, values);
+        return this;
+    }
+
     public QueryBuilder<T> setPage(Pageable pageable) {
         query.setPage(pageable);
         return this;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/ApiSearchServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/ApiSearchServiceImpl.java
@@ -17,6 +17,7 @@ package io.gravitee.rest.api.service.v4.impl;
 
 import static io.gravitee.apim.core.utils.CollectionUtils.isNotEmpty;
 import static io.gravitee.apim.core.utils.CollectionUtils.stream;
+import static io.gravitee.rest.api.service.impl.search.lucene.transformer.ApiDocumentTransformer.FIELD_API_TYPE;
 import static io.gravitee.rest.api.service.impl.search.lucene.transformer.ApiDocumentTransformer.FIELD_DEFINITION_VERSION;
 import static io.gravitee.rest.api.service.impl.search.lucene.transformer.PageDocumentTransformer.FIELD_PAGE_TYPE;
 import static java.util.stream.Collectors.toList;
@@ -28,6 +29,7 @@ import io.gravitee.apim.core.api.model.ApiMetadata;
 import io.gravitee.apim.core.api.query_service.ApiMetadataQueryService;
 import io.gravitee.common.data.domain.Page;
 import io.gravitee.definition.model.DefinitionVersion;
+import io.gravitee.definition.model.v4.ApiType;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.ApiRepository;
 import io.gravitee.repository.management.api.IntegrationRepository;
@@ -259,6 +261,8 @@ public class ApiSearchServiceImpl extends AbstractService implements ApiSearchSe
         final Boolean hasOpenApiDocumentation
     ) {
         // Step 1: find apiIds from lucene indexer from 'query' parameter without any pagination and sorting
+        // Lucene indexes api_type as "<definitionVersion>_<TYPE>" (e.g. "V4_EDGE"), not the raw label
+        apiQueryBuilder.addExcludedFilter(FIELD_API_TYPE, List.of(DefinitionVersion.V4.name() + "_" + ApiType.EDGE.name()));
         var apiQuery = apiQueryBuilder.build();
         SearchResult apiIdsResult = searchEngineService.search(GraviteeContext.getExecutionContext(), apiQuery);
 
@@ -306,7 +310,8 @@ public class ApiSearchServiceImpl extends AbstractService implements ApiSearchSe
 
         ApiCriteria.Builder apiCriteriaBuilder = new ApiCriteria.Builder()
             .environmentId(GraviteeContext.getExecutionContext().getEnvironmentId())
-            .ids(apiIdPageSubset);
+            .ids(apiIdPageSubset)
+            .notApiTypes(List.of(ApiType.EDGE));
 
         if (Objects.nonNull(apiQuery.getFilters())) {
             if (apiQuery.getFilters().getOrDefault(FIELD_DEFINITION_VERSION, List.of()) instanceof List<?> versions) {
@@ -458,7 +463,9 @@ public class ApiSearchServiceImpl extends AbstractService implements ApiSearchSe
     }
 
     private ApiCriteria.Builder queryToCriteria(final ExecutionContext executionContext, final ApiQuery query) {
-        final ApiCriteria.Builder builder = new ApiCriteria.Builder().environmentId(executionContext.getEnvironmentId());
+        final ApiCriteria.Builder builder = new ApiCriteria.Builder()
+            .environmentId(executionContext.getEnvironmentId())
+            .notApiTypes(List.of(ApiType.EDGE));
         if (query == null) {
             return builder;
         }
@@ -521,6 +528,7 @@ public class ApiSearchServiceImpl extends AbstractService implements ApiSearchSe
                 Map.of(FIELD_DEFINITION_VERSION, stream(excludeDefinitionVersions).map(DefinitionVersion::getLabel).toList())
             );
         }
+        searchEngineQueryBuilder.addExcludedFilter(FIELD_API_TYPE, List.of(DefinitionVersion.V4.name() + "_" + ApiType.EDGE.name()));
         if (!isBlank(query)) {
             searchEngineQueryBuilder.setQuery(query);
         }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/ApiServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/ApiServiceImpl.java
@@ -751,7 +751,9 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
         final Sortable sortable,
         final Pageable pageable
     ) {
-        ApiCriteria.Builder criteria = new ApiCriteria.Builder().environmentId(executionContext.getEnvironmentId());
+        ApiCriteria.Builder criteria = new ApiCriteria.Builder()
+            .environmentId(executionContext.getEnvironmentId())
+            .notApiTypes(List.of(ApiType.EDGE));
 
         // If user is not admin, get list of apiIds in their scope and add it to the criteria
         if (!isAdmin) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/ApiSearchServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/ApiSearchServiceImplTest.java
@@ -433,7 +433,11 @@ public class ApiSearchServiceImplTest {
         api2.setName("api2");
 
         when(
-            apiRepository.search(eq(new ApiCriteria.Builder().environmentId("DEFAULT").build()), isNull(), eq(ApiFieldFilter.allFields()))
+            apiRepository.search(
+                eq(new ApiCriteria.Builder().environmentId("DEFAULT").notApiTypes(List.of(ApiType.EDGE)).build()),
+                isNull(),
+                eq(ApiFieldFilter.allFields())
+            )
         ).thenReturn(Stream.of(api1));
 
         UserEntity admin = new UserEntity();
@@ -463,7 +467,13 @@ public class ApiSearchServiceImplTest {
 
         when(
             apiRepository.search(
-                eq(new ApiCriteria.Builder().environmentId("DEFAULT").definitionVersion(definitionList).build()),
+                eq(
+                    new ApiCriteria.Builder()
+                        .environmentId("DEFAULT")
+                        .notApiTypes(List.of(ApiType.EDGE))
+                        .definitionVersion(definitionList)
+                        .build()
+                ),
                 isNull(),
                 eq(ApiFieldFilter.allFields())
             )
@@ -505,6 +515,7 @@ public class ApiSearchServiceImplTest {
                 eq(
                     new ApiCriteria.Builder()
                         .environmentId("DEFAULT")
+                        .notApiTypes(List.of(ApiType.EDGE))
                         .category("cat1")
                         .groups(List.of("group1"))
                         .state(LifecycleState.STARTED)

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/ApiSearchService_SearchIdsTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/ApiSearchService_SearchIdsTest.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.rest.api.service.v4.impl;
 
+import static io.gravitee.rest.api.service.impl.search.lucene.transformer.ApiDocumentTransformer.FIELD_API_TYPE;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -24,6 +25,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.gravitee.apim.core.api.query_service.ApiMetadataQueryService;
 import io.gravitee.definition.jackson.datatype.GraviteeMapper;
 import io.gravitee.definition.model.DefinitionVersion;
+import io.gravitee.definition.model.v4.ApiType;
 import io.gravitee.repository.management.api.ApiRepository;
 import io.gravitee.repository.management.api.IntegrationRepository;
 import io.gravitee.rest.api.model.v4.api.GenericApiEntity;
@@ -156,6 +158,7 @@ public class ApiSearchService_SearchIdsTest {
         var filters = new HashMap<String, Object>();
         filters.put("api", ids);
         apiEntityQueryBuilder.setFilters(filters);
+        apiEntityQueryBuilder.addExcludedFilter(FIELD_API_TYPE, List.of(DefinitionVersion.V4.name() + "_" + ApiType.EDGE.name()));
 
         when(searchEngineService.search(eq(GraviteeContext.getExecutionContext()), eq(apiEntityQueryBuilder.build()))).thenReturn(
             new SearchResult(List.of())
@@ -181,6 +184,7 @@ public class ApiSearchService_SearchIdsTest {
         var filters = new HashMap<String, Object>();
         filters.put("api", ids);
         apiEntityQueryBuilder.setFilters(filters);
+        apiEntityQueryBuilder.addExcludedFilter(FIELD_API_TYPE, List.of(DefinitionVersion.V4.name() + "_" + ApiType.EDGE.name()));
 
         when(searchEngineService.search(eq(GraviteeContext.getExecutionContext()), eq(apiEntityQueryBuilder.build()))).thenReturn(
             new SearchResult(List.of("api-id"))
@@ -207,6 +211,7 @@ public class ApiSearchService_SearchIdsTest {
         var filters = new HashMap<String, Object>();
         filters.put("api", ids);
         apiEntityQueryBuilder.setFilters(filters);
+        apiEntityQueryBuilder.addExcludedFilter(FIELD_API_TYPE, List.of(DefinitionVersion.V4.name() + "_" + ApiType.EDGE.name()));
 
         when(searchEngineService.search(eq(GraviteeContext.getExecutionContext()), eq(apiEntityQueryBuilder.build()))).thenReturn(
             new SearchResult(List.of("api-id"))
@@ -233,6 +238,7 @@ public class ApiSearchService_SearchIdsTest {
         var filters = new HashMap<String, Object>();
         filters.put("api", ids);
         apiEntityQueryBuilder.setFilters(filters);
+        apiEntityQueryBuilder.addExcludedFilter(FIELD_API_TYPE, List.of(DefinitionVersion.V4.name() + "_" + ApiType.EDGE.name()));
 
         when(searchEngineService.search(eq(GraviteeContext.getExecutionContext()), eq(apiEntityQueryBuilder.build()))).thenReturn(
             new SearchResult(List.of("api-id"))

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/ApiServiceImpl_findAllTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/ApiServiceImpl_findAllTest.java
@@ -35,6 +35,7 @@ import io.gravitee.apim.core.api_product.domain_service.RemoveApiFromApiProducts
 import io.gravitee.apim.core.flow.crud_service.FlowCrudService;
 import io.gravitee.common.data.domain.Page;
 import io.gravitee.definition.jackson.datatype.GraviteeMapper;
+import io.gravitee.definition.model.v4.ApiType;
 import io.gravitee.repository.management.api.ApiQualityRuleRepository;
 import io.gravitee.repository.management.api.ApiRepository;
 import io.gravitee.repository.management.api.search.ApiCriteria;
@@ -302,7 +303,12 @@ public class ApiServiceImpl_findAllTest {
 
         when(
             apiRepository.search(
-                eq(new ApiCriteria.Builder().environmentId(GraviteeContext.getExecutionContext().getEnvironmentId()).build()),
+                eq(
+                    new ApiCriteria.Builder()
+                        .environmentId(GraviteeContext.getExecutionContext().getEnvironmentId())
+                        .notApiTypes(List.of(ApiType.EDGE))
+                        .build()
+                ),
                 isNull(),
                 eq(pageable),
                 eq(new ApiFieldFilter.Builder().excludePicture().build())
@@ -336,7 +342,12 @@ public class ApiServiceImpl_findAllTest {
 
         when(
             apiRepository.search(
-                eq(new ApiCriteria.Builder().environmentId(GraviteeContext.getExecutionContext().getEnvironmentId()).build()),
+                eq(
+                    new ApiCriteria.Builder()
+                        .environmentId(GraviteeContext.getExecutionContext().getEnvironmentId())
+                        .notApiTypes(List.of(ApiType.EDGE))
+                        .build()
+                ),
                 isNull(),
                 eq(pageable),
                 eq(new ApiFieldFilter.Builder().excludePicture().build())
@@ -378,6 +389,7 @@ public class ApiServiceImpl_findAllTest {
                     new ApiCriteria.Builder()
                         .environmentId(GraviteeContext.getExecutionContext().getEnvironmentId())
                         .ids(Set.of("API_1"))
+                        .notApiTypes(List.of(ApiType.EDGE))
                         .build()
                 ),
                 isNull(),
@@ -433,7 +445,12 @@ public class ApiServiceImpl_findAllTest {
 
         when(
             apiRepository.search(
-                eq(new ApiCriteria.Builder().environmentId(GraviteeContext.getExecutionContext().getEnvironmentId()).build()),
+                eq(
+                    new ApiCriteria.Builder()
+                        .environmentId(GraviteeContext.getExecutionContext().getEnvironmentId())
+                        .notApiTypes(List.of(ApiType.EDGE))
+                        .build()
+                ),
                 eq(sortable),
                 eq(pageable),
                 eq(new ApiFieldFilter.Builder().excludePicture().build())
@@ -471,7 +488,12 @@ public class ApiServiceImpl_findAllTest {
 
         when(
             apiRepository.search(
-                eq(new ApiCriteria.Builder().environmentId(GraviteeContext.getExecutionContext().getEnvironmentId()).build()),
+                eq(
+                    new ApiCriteria.Builder()
+                        .environmentId(GraviteeContext.getExecutionContext().getEnvironmentId())
+                        .notApiTypes(List.of(ApiType.EDGE))
+                        .build()
+                ),
                 eq(sortable),
                 eq(pageable),
                 eq(new ApiFieldFilter.Builder().excludePicture().build())
@@ -504,7 +526,12 @@ public class ApiServiceImpl_findAllTest {
 
         when(
             apiRepository.search(
-                eq(new ApiCriteria.Builder().environmentId(GraviteeContext.getExecutionContext().getEnvironmentId()).build()),
+                eq(
+                    new ApiCriteria.Builder()
+                        .environmentId(GraviteeContext.getExecutionContext().getEnvironmentId())
+                        .notApiTypes(List.of(ApiType.EDGE))
+                        .build()
+                ),
                 eq(sortable),
                 eq(pageable),
                 eq(new ApiFieldFilter.Builder().excludePicture().build())


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/GMA-499

## Description

EDGE APIs were being returned by all API search and listing endpoints (management v2, portal, management v1 via the v4 search service), causing bugs in the console since EDGE APIs lack required fields like primary owner.

The fix excludes EDGE APIs at two levels:

- **Repository level** (`ApiCriteria`): new `notApiTypes` exclusion field, applied in MongoDB and JDBC implementations. Used by `findAll` and all `queryToCriteria`-based paths.
- **Lucene level** (`QueryBuilder.addExcludedFilter`): EDGE excluded before the search engine query is fired, keeping pagination totals accurate. Applied in `ApiSearchServiceImpl.search(QueryBuilder)` and `searchIds`.

Paths covered:
- Management v2 `POST /apis/_search` and `GET /apis`
- Portal (ng portal via `SearchApisForPortalUseCase`, legacy portal via `FilteringService → searchIds`)
- Management v4 search via `ApiSearchServiceImpl.queryToCriteria`

Management v1 (`ApiServiceImpl` legacy) was already safe as it filters out V4 definition version by default.