### PR TITLE
test: replace jsonassert with json-unit-assertj

### DIFF
--- a/gravitee-apim-bom/pom.xml
+++ b/gravitee-apim-bom/pom.xml
@@ -340,11 +340,6 @@
             </dependency>
 
             <dependency>
-                <groupId>org.skyscreamer</groupId>
-                <artifactId>jsonassert</artifactId>
-                <version>${jsonassert.version}</version>
-            </dependency>
-            <dependency>
                 <groupId>net.javacrumbs.json-unit</groupId>
                 <artifactId>json-unit-assertj</artifactId>
                 <version>${json-unit.version}</version>

--- a/gravitee-apim-definition/gravitee-apim-definition-jackson/pom.xml
+++ b/gravitee-apim-definition/gravitee-apim-definition-jackson/pom.xml
@@ -39,8 +39,8 @@
 
         <!-- Tests -->
         <dependency>
-            <groupId>org.skyscreamer</groupId>
-            <artifactId>jsonassert</artifactId>
+            <groupId>net.javacrumbs.json-unit</groupId>
+            <artifactId>json-unit-assertj</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/gravitee-apim-definition/gravitee-apim-definition-jackson/src/test/java/io/gravitee/definition/jackson/api/ApiSerializerTest.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-jackson/src/test/java/io/gravitee/definition/jackson/api/ApiSerializerTest.java
@@ -21,16 +21,12 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.gravitee.definition.jackson.AbstractTest;
 import io.gravitee.definition.model.Api;
-import io.gravitee.definition.model.Policy;
 import java.io.IOException;
 import java.util.stream.Stream;
 import org.apache.commons.io.IOUtils;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.skyscreamer.jsonassert.JSONAssert;
-import org.skyscreamer.jsonassert.JSONCompareMode;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)

--- a/gravitee-apim-definition/gravitee-apim-definition-jackson/src/test/java/io/gravitee/definition/jackson/api/PropertySerializerTest.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-jackson/src/test/java/io/gravitee/definition/jackson/api/PropertySerializerTest.java
@@ -15,11 +15,11 @@
  */
 package io.gravitee.definition.jackson.api;
 
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
+
 import io.gravitee.definition.jackson.AbstractTest;
 import io.gravitee.definition.model.Property;
 import org.junit.jupiter.api.Test;
-import org.skyscreamer.jsonassert.JSONAssert;
-import org.skyscreamer.jsonassert.JSONCompareMode;
 
 /**
  * @author GraviteeSource Team
@@ -30,10 +30,6 @@ public class PropertySerializerTest extends AbstractTest {
     public void serialize() throws Exception {
         Property property = new Property("key1", "myvalue", true);
         String generatedJsonDefinition = objectMapper().writeValueAsString(property);
-        JSONAssert.assertEquals(
-            "{\"key\" : \"key1\", \"value\" : \"myvalue\", \"encrypted\" : true}",
-            generatedJsonDefinition,
-            JSONCompareMode.STRICT
-        );
+        assertThatJson(generatedJsonDefinition).isEqualTo("{\"key\" : \"key1\", \"value\" : \"myvalue\", \"encrypted\" : true}");
     }
 }

--- a/gravitee-apim-definition/gravitee-apim-definition-jackson/src/test/java/io/gravitee/definition/jackson/datatype/SslOptionsMapperTest.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-jackson/src/test/java/io/gravitee/definition/jackson/datatype/SslOptionsMapperTest.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.definition.jackson.datatype;
 
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -25,7 +26,6 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
-import org.skyscreamer.jsonassert.JSONAssert;
 
 class SslOptionsMapperTest {
 
@@ -73,7 +73,7 @@ class SslOptionsMapperTest {
 
             var result = mapper.writeValueAsString(sslOptions);
 
-            JSONAssert.assertEquals("{\"hostnameVerifier\":true,\"trustAll\":false,\"trustStore\":{\"type\":\"NONE\"}}", result, true);
+            assertThatJson(result).isEqualTo("{\"hostnameVerifier\":true,\"trustAll\":false,\"trustStore\":{\"type\":\"NONE\"}}");
         }
 
         @Test
@@ -83,7 +83,7 @@ class SslOptionsMapperTest {
 
             var result = mapper.writeValueAsString(sslOptions);
 
-            JSONAssert.assertEquals("{\"hostnameVerifier\":true,\"trustAll\":false,\"keyStore\":{\"type\":\"NONE\"}}", result, true);
+            assertThatJson(result).isEqualTo("{\"hostnameVerifier\":true,\"trustAll\":false,\"keyStore\":{\"type\":\"NONE\"}}");
         }
     }
 }

--- a/gravitee-apim-definition/gravitee-apim-definition-jackson/src/test/java/io/gravitee/definition/jackson/services/ServicesSerializerTest.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-jackson/src/test/java/io/gravitee/definition/jackson/services/ServicesSerializerTest.java
@@ -15,12 +15,15 @@
  */
 package io.gravitee.definition.jackson.services;
 
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
+import static net.javacrumbs.jsonunit.core.Option.IGNORING_ARRAY_ORDER;
+import static net.javacrumbs.jsonunit.core.Option.IGNORING_EXTRA_FIELDS;
+
 import io.gravitee.definition.jackson.AbstractTest;
 import io.gravitee.definition.model.Api;
 import org.apache.commons.io.IOUtils;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.skyscreamer.jsonassert.JSONAssert;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
@@ -38,7 +41,7 @@ public class ServicesSerializerTest extends AbstractTest {
         Assertions.assertNotNull(generatedJsonDefinition);
 
         String expected = IOUtils.toString(read(expectedDefinition));
-        JSONAssert.assertEquals(expected, generatedJsonDefinition, false);
+        assertThatJson(generatedJsonDefinition).when(IGNORING_ARRAY_ORDER, IGNORING_EXTRA_FIELDS).isEqualTo(expected);
     }
 
     @Test
@@ -51,7 +54,7 @@ public class ServicesSerializerTest extends AbstractTest {
         Assertions.assertNotNull(generatedJsonDefinition);
 
         String expected = IOUtils.toString(read(expectedDefinition));
-        JSONAssert.assertEquals(expected, generatedJsonDefinition, false);
+        assertThatJson(generatedJsonDefinition).when(IGNORING_ARRAY_ORDER, IGNORING_EXTRA_FIELDS).isEqualTo(expected);
     }
 
     @Test
@@ -64,6 +67,6 @@ public class ServicesSerializerTest extends AbstractTest {
         Assertions.assertNotNull(generatedJsonDefinition);
 
         String expected = IOUtils.toString(read(expectedDefinition));
-        JSONAssert.assertEquals(expected, generatedJsonDefinition, false);
+        assertThatJson(generatedJsonDefinition).when(IGNORING_ARRAY_ORDER, IGNORING_EXTRA_FIELDS).isEqualTo(expected);
     }
 }

--- a/gravitee-apim-definition/gravitee-apim-definition-jackson/src/test/java/io/gravitee/definition/jackson/services/discovery/EndpointDiscoveryServiceSerializerTest.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-jackson/src/test/java/io/gravitee/definition/jackson/services/discovery/EndpointDiscoveryServiceSerializerTest.java
@@ -15,6 +15,10 @@
  */
 package io.gravitee.definition.jackson.services.discovery;
 
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
+import static net.javacrumbs.jsonunit.core.Option.IGNORING_ARRAY_ORDER;
+import static net.javacrumbs.jsonunit.core.Option.IGNORING_EXTRA_FIELDS;
+
 import io.gravitee.definition.jackson.AbstractTest;
 import io.gravitee.definition.model.Api;
 import io.gravitee.definition.model.services.discovery.EndpointDiscoveryService;
@@ -22,7 +26,6 @@ import org.apache.commons.io.IOUtils;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
-import org.skyscreamer.jsonassert.JSONAssert;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
@@ -40,7 +43,7 @@ public class EndpointDiscoveryServiceSerializerTest extends AbstractTest {
         Assertions.assertNotNull(generatedJsonDefinition);
 
         String expected = IOUtils.toString(read(expectedDefinition));
-        JSONAssert.assertEquals(expected, generatedJsonDefinition, false);
+        assertThatJson(generatedJsonDefinition).when(IGNORING_ARRAY_ORDER, IGNORING_EXTRA_FIELDS).isEqualTo(expected);
 
         EndpointDiscoveryService endpointDiscoveryService = api.getService(EndpointDiscoveryService.class);
         Assertions.assertNull(endpointDiscoveryService);
@@ -58,6 +61,6 @@ public class EndpointDiscoveryServiceSerializerTest extends AbstractTest {
         Assertions.assertNotNull(generatedJsonDefinition);
 
         String expected = IOUtils.toString(read(expectedDefinition));
-        JSONAssert.assertEquals(expected, generatedJsonDefinition, false);
+        assertThatJson(generatedJsonDefinition).when(IGNORING_ARRAY_ORDER, IGNORING_EXTRA_FIELDS).isEqualTo(expected);
     }
 }

--- a/gravitee-apim-definition/gravitee-apim-definition-jackson/src/test/java/io/gravitee/definition/jackson/services/dynamicproperty/DynamicPropertyServiceSerializerTest.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-jackson/src/test/java/io/gravitee/definition/jackson/services/dynamicproperty/DynamicPropertyServiceSerializerTest.java
@@ -15,12 +15,15 @@
  */
 package io.gravitee.definition.jackson.services.dynamicproperty;
 
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
+import static net.javacrumbs.jsonunit.core.Option.IGNORING_ARRAY_ORDER;
+import static net.javacrumbs.jsonunit.core.Option.IGNORING_EXTRA_FIELDS;
+
 import io.gravitee.definition.jackson.AbstractTest;
 import io.gravitee.definition.model.Api;
 import org.apache.commons.io.IOUtils;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.skyscreamer.jsonassert.JSONAssert;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
@@ -39,7 +42,7 @@ public class DynamicPropertyServiceSerializerTest extends AbstractTest {
         Assertions.assertNotNull(generatedJsonDefinition);
 
         String expected = IOUtils.toString(read(expectedDefinition));
-        JSONAssert.assertEquals(expected, generatedJsonDefinition, false);
+        assertThatJson(generatedJsonDefinition).when(IGNORING_ARRAY_ORDER, IGNORING_EXTRA_FIELDS).isEqualTo(expected);
     }
 
     @Test
@@ -53,7 +56,7 @@ public class DynamicPropertyServiceSerializerTest extends AbstractTest {
         Assertions.assertNotNull(generatedJsonDefinition);
 
         String expected = IOUtils.toString(read(expectedDefinition));
-        JSONAssert.assertEquals(expected, generatedJsonDefinition, false);
+        assertThatJson(generatedJsonDefinition).when(IGNORING_ARRAY_ORDER, IGNORING_EXTRA_FIELDS).isEqualTo(expected);
     }
 
     @Test
@@ -67,6 +70,6 @@ public class DynamicPropertyServiceSerializerTest extends AbstractTest {
         Assertions.assertNotNull(generatedJsonDefinition);
 
         String expected = IOUtils.toString(read(expectedDefinition));
-        JSONAssert.assertEquals(expected, generatedJsonDefinition, false);
+        assertThatJson(generatedJsonDefinition).when(IGNORING_ARRAY_ORDER, IGNORING_EXTRA_FIELDS).isEqualTo(expected);
     }
 }

--- a/gravitee-apim-definition/gravitee-apim-definition-jackson/src/test/java/io/gravitee/definition/jackson/services/healthcheck/HealthCheckServiceSerializerTest.java
+++ b/gravitee-apim-definition/gravitee-apim-definition-jackson/src/test/java/io/gravitee/definition/jackson/services/healthcheck/HealthCheckServiceSerializerTest.java
@@ -15,12 +15,15 @@
  */
 package io.gravitee.definition.jackson.services.healthcheck;
 
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
+import static net.javacrumbs.jsonunit.core.Option.IGNORING_ARRAY_ORDER;
+import static net.javacrumbs.jsonunit.core.Option.IGNORING_EXTRA_FIELDS;
+
 import io.gravitee.definition.jackson.AbstractTest;
 import io.gravitee.definition.model.Api;
 import org.apache.commons.io.IOUtils;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.skyscreamer.jsonassert.JSONAssert;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
@@ -38,7 +41,7 @@ public class HealthCheckServiceSerializerTest extends AbstractTest {
         Assertions.assertNotNull(generatedJsonDefinition);
 
         String expected = IOUtils.toString(read(expectedDefinition));
-        JSONAssert.assertEquals(expected, generatedJsonDefinition, false);
+        assertThatJson(generatedJsonDefinition).when(IGNORING_ARRAY_ORDER, IGNORING_EXTRA_FIELDS).isEqualTo(expected);
     }
 
     @Test
@@ -51,7 +54,7 @@ public class HealthCheckServiceSerializerTest extends AbstractTest {
         Assertions.assertNotNull(generatedJsonDefinition);
 
         String expected = IOUtils.toString(read(expectedDefinition));
-        JSONAssert.assertEquals(expected, generatedJsonDefinition, false);
+        assertThatJson(generatedJsonDefinition).when(IGNORING_ARRAY_ORDER, IGNORING_EXTRA_FIELDS).isEqualTo(expected);
     }
 
     @Test
@@ -64,7 +67,7 @@ public class HealthCheckServiceSerializerTest extends AbstractTest {
         Assertions.assertNotNull(generatedJsonDefinition);
 
         String expected = IOUtils.toString(read(expectedDefinition));
-        JSONAssert.assertEquals(expected, generatedJsonDefinition, false);
+        assertThatJson(generatedJsonDefinition).when(IGNORING_ARRAY_ORDER, IGNORING_EXTRA_FIELDS).isEqualTo(expected);
     }
 
     @Test
@@ -78,7 +81,7 @@ public class HealthCheckServiceSerializerTest extends AbstractTest {
         Assertions.assertNotNull(generatedJsonDefinition);
 
         String expected = IOUtils.toString(read(expectedDefinition));
-        JSONAssert.assertEquals(expected, generatedJsonDefinition, false);
+        assertThatJson(generatedJsonDefinition).when(IGNORING_ARRAY_ORDER, IGNORING_EXTRA_FIELDS).isEqualTo(expected);
     }
 
     @Test
@@ -92,7 +95,7 @@ public class HealthCheckServiceSerializerTest extends AbstractTest {
         Assertions.assertNotNull(generatedJsonDefinition);
 
         String expected = IOUtils.toString(read(expectedDefinition));
-        JSONAssert.assertEquals(expected, generatedJsonDefinition, false);
+        assertThatJson(generatedJsonDefinition).when(IGNORING_ARRAY_ORDER, IGNORING_EXTRA_FIELDS).isEqualTo(expected);
     }
 
     @Test
@@ -105,6 +108,6 @@ public class HealthCheckServiceSerializerTest extends AbstractTest {
         Assertions.assertNotNull(generatedJsonDefinition);
 
         String expected = IOUtils.toString(read(expectedDefinition));
-        JSONAssert.assertEquals(expected, generatedJsonDefinition, false);
+        assertThatJson(generatedJsonDefinition).when(IGNORING_ARRAY_ORDER, IGNORING_EXTRA_FIELDS).isEqualTo(expected);
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -124,7 +124,6 @@
         <jmh.version>1.37</jmh.version>
         <jna.version>5.16.0</jna.version>
         <jolt.version>0.1.8</jolt.version>
-        <jsonassert.version>1.5.3</jsonassert.version>
         <json-patch.version>1.13</json-patch.version>
         <json-path.version>2.9.0</json-path.version>
         <json-smart.version>2.5.2</json-smart.version>


### PR DESCRIPTION
## Description

jsonassert was only used in 7 test files while json-unit-assertj is the standard across 21+ other test files in the project. Also jsonassert seems less maintained than json-unit-assertj. Removes jsonassert dependency entirely (BOM + version property).


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

