### PR TITLE
feat: api product, plan sharding tag changes

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/ReactableApiProduct.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/ReactableApiProduct.java
@@ -58,6 +58,7 @@ public class ReactableApiProduct implements Reactable, Serializable {
     private Date deployedAt;
 
     private List<Plan> plans;
+    private Set<String> tags;
 
     @Override
     public boolean enabled() {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/manager/impl/ApiManagerImpl.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/manager/impl/ApiManagerImpl.java
@@ -24,6 +24,8 @@ import io.gravitee.definition.model.DefinitionVersion;
 import io.gravitee.definition.model.Plugin;
 import io.gravitee.gateway.env.GatewayConfiguration;
 import io.gravitee.gateway.handlers.api.definition.Api;
+import io.gravitee.gateway.handlers.api.event.ApiProductChangedEvent;
+import io.gravitee.gateway.handlers.api.event.ApiProductEventType;
 import io.gravitee.gateway.handlers.api.manager.ActionOnApi;
 import io.gravitee.gateway.handlers.api.manager.ApiManager;
 import io.gravitee.gateway.handlers.api.manager.Deployer;
@@ -38,16 +40,20 @@ import io.gravitee.secrets.api.discovery.Definition;
 import io.gravitee.secrets.api.discovery.DefinitionMetadata;
 import io.gravitee.secrets.api.event.SecretDiscoveryEvent;
 import io.gravitee.secrets.api.event.SecretDiscoveryEventType;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.stream.Collectors;
 import lombok.CustomLog;
 import org.slf4j.MDC;
@@ -61,10 +67,13 @@ public class ApiManagerImpl implements ApiManager {
 
     private static final int PARALLELISM = Runtime.getRuntime().availableProcessors() * 2;
 
+    private static final Set<String> SUPPORTED_SECRET_DEFINITION_KINDS = Set.of(API_V4_DEFINITION_KIND, NATIVE_API_V4_DEFINITION_KIND);
+
     private final EventManager eventManager;
     private final GatewayConfiguration gatewayConfiguration;
     private final LicenseManager licenseManager;
     private final Map<String, ReactableApi<?>> apis = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<String, Lock> apiLocks = new ConcurrentHashMap<>();
     private final Map<Class<? extends ReactableApi<?>>, ? extends Deployer<?>> deployers;
     private final ApiProductRegistry apiProductRegistry;
 
@@ -104,45 +113,86 @@ public class ApiManagerImpl implements ApiManager {
             )
         );
 
-        // Listen to secret discovery events to update APIs when secrets change
+        subscribeToSecretDiscoveryEvents();
+        subscribeToApiProductEventsIfNeeded();
+    }
+
+    private void subscribeToSecretDiscoveryEvents() {
         eventManager.subscribeForEvents(
             event -> {
                 if (event.content() instanceof SecretDiscoveryEvent secretDiscoveryEvent) {
-                    if (secretDiscoveryEvent.definition() instanceof Definition definition) {
-                        if (!List.of(API_V4_DEFINITION_KIND, NATIVE_API_V4_DEFINITION_KIND).contains(definition.kind())) {
-                            // We only handle API V4 and Native API definitions
-                            log.debug(
-                                "Received SecretDiscoveryEvent for definition {} with kind {}, but we only handle API V4 and Native API definitions",
-                                definition.id(),
-                                definition.kind()
-                            );
-                            return;
-                        }
-
-                        ReactableApi<?> api = apis.get(definition.id());
-                        if (api != null) {
-                            MDC.put("api", api.getId());
-
-                            log.info("Secret value changed for API {}, updating it", definition.id());
-                            eventManager.publishEvent(ReactorEvent.UPDATE, api);
-
-                            log.info("{} has been updated", api);
-                            MDC.remove("api");
-                        } else {
-                            log.trace(
-                                "Received SecretDiscoveryEvent for API {}, but it is not found in the API manager. Unable to update it",
-                                definition.id()
-                            );
-                        }
-                    }
+                    onSecretDiscoveryValueChanged(secretDiscoveryEvent);
                 }
             },
             SecretDiscoveryEventType.VALUE_CHANGED
         );
     }
 
+    private void onSecretDiscoveryValueChanged(SecretDiscoveryEvent secretDiscoveryEvent) {
+        if (!(secretDiscoveryEvent.definition() instanceof Definition definition)) {
+            return;
+        }
+        if (!SUPPORTED_SECRET_DEFINITION_KINDS.contains(definition.kind())) {
+            log.debug(
+                "Received SecretDiscoveryEvent for definition {} with kind {}, but we only handle API V4 and Native API definitions",
+                definition.id(),
+                definition.kind()
+            );
+            return;
+        }
+        updateApiOnSecretChange(definition);
+    }
+
+    private void updateApiOnSecretChange(Definition definition) {
+        ReactableApi<?> api = apis.get(definition.id());
+        if (api == null) {
+            log.trace(
+                "Received SecretDiscoveryEvent for API {}, but it is not found in the API manager. Unable to update it",
+                definition.id()
+            );
+            return;
+        }
+        MDC.put("api", api.getId());
+        log.info("Secret value changed for API {}, updating it", definition.id());
+        eventManager.publishEvent(ReactorEvent.UPDATE, api);
+        log.info("{} has been updated", api);
+        MDC.remove("api");
+    }
+
+    private void subscribeToApiProductEventsIfNeeded() {
+        if (apiProductRegistry == null) {
+            return;
+        }
+        eventManager.subscribeForEvents(
+            event -> {
+                if (event.content() instanceof ApiProductChangedEvent productEvent) {
+                    onApiProductChanged(productEvent);
+                }
+            },
+            ApiProductEventType.DEPLOY,
+            ApiProductEventType.UNDEPLOY,
+            ApiProductEventType.UPDATE
+        );
+    }
+
+    private void onApiProductChanged(ApiProductChangedEvent productEvent) {
+        if (productEvent.getApiIds() == null) {
+            return;
+        }
+        reEvaluateApisAfterProductChange(productEvent);
+    }
+
     private boolean register(ReactableApi<?> api, boolean force) {
-        // Get deployed API
+        Lock lock = apiLocks.computeIfAbsent(api.getId(), k -> new ReentrantLock());
+        lock.lock();
+        try {
+            return doRegister(api, force);
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    private boolean doRegister(ReactableApi<?> api, boolean force) {
         ReactableApi<?> deployedApi = get(api.getId());
 
         List<Plugin> plugins;
@@ -165,34 +215,27 @@ public class ApiManagerImpl implements ApiManager {
             return false;
         }
 
-        // Keep the check of Sharding Tags for io.gravitee.gateway.services.localregistry.LocalApiDefinitionRegistry
-        if (gatewayConfiguration.hasMatchingTags(api.getTags())) {
+        if (isApiShardEligible(api)) {
             boolean apiToDeploy = deployedApi == null || force;
             boolean apiToUpdate =
                 !apiToDeploy &&
                 (deployedApi.getDeployedAt().before(api.getDeployedAt()) && !Objects.equals(deployedApi.getRevision(), api.getRevision()));
 
-            // if API will be deployed or updated
             if (apiToDeploy || apiToUpdate) {
                 Deployer deployer = deployers.get(api.getClass());
                 deployer.initialize(api);
             }
 
-            // API is not yet deployed, so let's do it
             if (apiToDeploy) {
                 deploy(api);
                 return true;
-            }
-            // API has to be updated, so update it
-            else if (apiToUpdate) {
+            } else if (apiToUpdate) {
                 update(api);
                 return true;
             }
         } else {
             log.debug("The API {} has been ignored because not in configured tags {}", api.getName(), api.getTags());
 
-            // Check that the API was not previously deployed with other tags
-            // In that case, we must undeploy it
             if (deployedApi != null) {
                 undeploy(api.getId());
             }
@@ -205,25 +248,38 @@ public class ApiManagerImpl implements ApiManager {
     public ActionOnApi requiredActionFor(final ReactableApi<?> reactableApi) {
         ReactableApi<?> deployedApi = get(reactableApi.getId());
         if (!reactableApi.enabled()) {
+            log.debug("requiredActionFor [{}]: UNDEPLOY (disabled)", reactableApi.getId());
             return ActionOnApi.UNDEPLOY;
         }
 
-        if (gatewayConfiguration.hasMatchingTags(reactableApi.getTags())) {
+        if (isApiShardEligible(reactableApi)) {
             boolean apiToDeploy = deployedApi == null;
             boolean apiToUpdate =
                 !apiToDeploy &&
                 (deployedApi.getDeployedAt().before(reactableApi.getDeployedAt()) &&
                     !Objects.equals(deployedApi.getRevision(), reactableApi.getRevision()));
 
-            // API will be deployed or updated
             if (apiToDeploy || apiToUpdate) {
+                log.debug(
+                    "requiredActionFor [{}]: DEPLOY (shard-eligible, toDeploy={}, toUpdate={})",
+                    reactableApi.getId(),
+                    apiToDeploy,
+                    apiToUpdate
+                );
                 return ActionOnApi.DEPLOY;
             }
+            log.debug("requiredActionFor [{}]: NONE (shard-eligible but already up-to-date)", reactableApi.getId());
         } else if (deployedApi != null) {
-            // Undeploy if previously deployed with other tags
+            log.debug("requiredActionFor [{}]: UNDEPLOY (no longer eligible)", reactableApi.getId());
             return ActionOnApi.UNDEPLOY;
+        } else {
+            log.debug(
+                "requiredActionFor [{}]: NONE — not shard-eligible (tags={}, env={})",
+                reactableApi.getId(),
+                reactableApi.getTags(),
+                reactableApi.getEnvironmentId()
+            );
         }
-        // Nothing to do
         return ActionOnApi.NONE;
     }
 
@@ -234,38 +290,45 @@ public class ApiManagerImpl implements ApiManager {
 
     @Override
     public void unregister(String apiId) {
+        apiLocks.remove(apiId);
         undeploy(apiId);
     }
 
     @Override
     public void refresh() {
-        if (!apis.isEmpty()) {
-            final long begin = System.currentTimeMillis();
-
-            log.info("Starting apis refresh. {} apis to be refreshed.", apis.size());
-
-            // Create an executor to parallelize a refresh for all the apis.
-            final ExecutorService refreshAllExecutor = createExecutor(Math.min(PARALLELISM, apis.size()));
-
-            final List<Callable<Boolean>> toInvoke = apis
-                .values()
-                .stream()
-                .map(api -> ((Callable<Boolean>) () -> register(api, true)))
-                .collect(Collectors.toList());
-
-            try {
-                refreshAllExecutor.invokeAll(toInvoke);
-                refreshAllExecutor.shutdown();
-                while (!refreshAllExecutor.awaitTermination(100, TimeUnit.MILLISECONDS));
-            } catch (InterruptedException e) {
-                log.error("Unable to refresh apis", e);
-                Thread.currentThread().interrupt();
-            } finally {
-                refreshAllExecutor.shutdown();
-            }
-
-            log.info("Apis refresh done in {}ms", (System.currentTimeMillis() - begin));
+        if (apis.isEmpty()) {
+            return;
         }
+
+        final long begin = System.currentTimeMillis();
+
+        List<ReactableApi<?>> allApis = new ArrayList<>(apis.values());
+
+        log.info("Starting apis refresh. {} deployed apis to be refreshed.", apis.size());
+
+        if (allApis.isEmpty()) {
+            return;
+        }
+
+        final ExecutorService refreshAllExecutor = createExecutor(Math.min(PARALLELISM, allApis.size()));
+
+        final List<Callable<Boolean>> toInvoke = allApis
+            .stream()
+            .map(api -> ((Callable<Boolean>) () -> register(api, true)))
+            .collect(Collectors.toList());
+
+        try {
+            refreshAllExecutor.invokeAll(toInvoke);
+            refreshAllExecutor.shutdown();
+            while (!refreshAllExecutor.awaitTermination(100, TimeUnit.MILLISECONDS));
+        } catch (InterruptedException e) {
+            log.error("Unable to refresh apis", e);
+            Thread.currentThread().interrupt();
+        } finally {
+            refreshAllExecutor.shutdown();
+        }
+
+        log.info("Apis refresh done in {}ms", (System.currentTimeMillis() - begin));
     }
 
     private void deploy(ReactableApi api) {
@@ -354,6 +417,22 @@ public class ApiManagerImpl implements ApiManager {
         MDC.remove("api");
     }
 
+    private boolean isApiShardEligible(ReactableApi<?> api) {
+        if (gatewayConfiguration.hasMatchingTags(api.getTags())) {
+            return true;
+        }
+        boolean productMatch = isIncludedInApiProductWithPlans(api);
+        if (!productMatch) {
+            log.debug(
+                "API [{}] (tags={}) not shard-eligible: no matching gateway tags and no API Product plan entries found (env={})",
+                api.getId(),
+                api.getTags(),
+                api.getEnvironmentId()
+            );
+        }
+        return productMatch;
+    }
+
     private boolean isIncludedInApiProductWithPlans(ReactableApi<?> api) {
         if (apiProductRegistry == null || api.getEnvironmentId() == null) {
             return false;
@@ -363,6 +442,17 @@ public class ApiManagerImpl implements ApiManager {
             api.getEnvironmentId()
         );
         return apiProductPlanEntries != null && !apiProductPlanEntries.isEmpty();
+    }
+
+    private void reEvaluateApisAfterProductChange(ApiProductChangedEvent productEvent) {
+        log.debug("Re-evaluating {} API(s) after API Product [{}] change", productEvent.getApiIds().size(), productEvent.getProductId());
+        for (String apiId : productEvent.getApiIds()) {
+            ReactableApi<?> deployedApi = apis.get(apiId);
+            if (deployedApi != null && !isApiShardEligible(deployedApi)) {
+                log.info("API [{}] no longer eligible after API Product [{}] change — undeploying", apiId, productEvent.getProductId());
+                undeploy(apiId);
+            }
+        }
     }
 
     private void undeploy(String apiId) {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/manager/impl/ApiProductManagerImpl.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/manager/impl/ApiProductManagerImpl.java
@@ -16,16 +16,20 @@
 package io.gravitee.gateway.handlers.api.manager.impl;
 
 import io.gravitee.common.event.EventManager;
+import io.gravitee.gateway.env.GatewayConfiguration;
 import io.gravitee.gateway.handlers.api.ReactableApiProduct;
 import io.gravitee.gateway.handlers.api.event.ApiProductChangedEvent;
 import io.gravitee.gateway.handlers.api.event.ApiProductEventType;
 import io.gravitee.gateway.handlers.api.manager.ApiProductManager;
 import io.gravitee.gateway.handlers.api.registry.ApiProductRegistry;
+import io.gravitee.gateway.handlers.api.sharding.ApiProductShardingFilter;
 import io.gravitee.node.api.license.LicenseManager;
 import io.reactivex.rxjava3.core.Completable;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import lombok.CustomLog;
 
@@ -39,12 +43,19 @@ public class ApiProductManagerImpl implements ApiProductManager {
     private final ApiProductRegistry apiProductRegistry;
     private final EventManager eventManager;
     private final LicenseManager licenseManager;
+    private final GatewayConfiguration gatewayConfiguration;
     private final Map<String, ReactableApiProduct> apiProducts = new ConcurrentHashMap<>();
 
-    public ApiProductManagerImpl(ApiProductRegistry apiProductRegistry, EventManager eventManager, LicenseManager licenseManager) {
+    public ApiProductManagerImpl(
+        ApiProductRegistry apiProductRegistry,
+        EventManager eventManager,
+        LicenseManager licenseManager,
+        GatewayConfiguration gatewayConfiguration
+    ) {
         this.apiProductRegistry = apiProductRegistry;
         this.eventManager = eventManager;
         this.licenseManager = licenseManager;
+        this.gatewayConfiguration = gatewayConfiguration;
     }
 
     @Override
@@ -80,6 +91,18 @@ public class ApiProductManagerImpl implements ApiProductManager {
                 "The API Product [{}] can not be deployed because it is not allowed by the current license (universe tier)",
                 apiProduct.getName()
             );
+            return Completable.complete();
+        }
+
+        if (!ApiProductShardingFilter.matchesProductTags(gatewayConfiguration, apiProduct.getTags())) {
+            log.debug(
+                "The API Product [{}] has been ignored because not in configured gateway tags {}",
+                apiProduct.getName(),
+                apiProduct.getTags()
+            );
+            if (get(apiProduct.getId()) != null) {
+                undeploy(apiProduct.getId());
+            }
             return Completable.complete();
         }
 
@@ -124,16 +147,28 @@ public class ApiProductManagerImpl implements ApiProductManager {
     private Completable update(ReactableApiProduct apiProduct, Completable doBeforeEmit) {
         log.debug("Updating API Product [{}]", apiProduct.getId());
 
+        ReactableApiProduct previousProduct = apiProducts.get(apiProduct.getId());
+        Set<String> previousApiIds = previousProduct != null && previousProduct.getApiIds() != null
+            ? previousProduct.getApiIds()
+            : Set.of();
+
         apiProducts.put(apiProduct.getId(), apiProduct);
         apiProductRegistry.register(apiProduct);
 
-        Completable emit = Completable.fromRunnable(() -> {
-            if (apiProduct.getApiIds() != null && !apiProduct.getApiIds().isEmpty()) {
-                emitApiProductChangedEvent(ApiProductEventType.UPDATE, apiProduct);
-            }
-            log.info("API Product [{}] has been updated", apiProduct.getId());
-        });
+        Completable emit = Completable.fromRunnable(() -> publishApiProductUpdateEvent(apiProduct, previousApiIds));
         return (doBeforeEmit != null ? doBeforeEmit : Completable.complete()).andThen(emit);
+    }
+
+    private void publishApiProductUpdateEvent(ReactableApiProduct apiProduct, Set<String> previousApiIds) {
+        Set<String> allAffectedApiIds = new HashSet<>(previousApiIds);
+        if (apiProduct.getApiIds() != null) {
+            allAffectedApiIds.addAll(apiProduct.getApiIds());
+        }
+        if (!allAffectedApiIds.isEmpty()) {
+            ApiProductChangedEvent event = new ApiProductChangedEvent(apiProduct.getId(), apiProduct.getEnvironmentId(), allAffectedApiIds);
+            eventManager.publishEvent(ApiProductEventType.UPDATE, event);
+        }
+        log.info("API Product [{}] has been updated", apiProduct.getId());
     }
 
     private void undeploy(String apiProductId) {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/registry/ApiProductRegistryKey.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/registry/ApiProductRegistryKey.java
@@ -13,25 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.apim.core.api_product.model;
+package io.gravitee.gateway.handlers.api.registry;
 
-import java.util.List;
-import java.util.Set;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
-import lombok.experimental.SuperBuilder;
-
-@Data
-@Builder
-@NoArgsConstructor
-@AllArgsConstructor
-public class CreateApiProduct {
-
-    private String name;
-    private String description;
-    private String version;
-    private List<String> apiIds;
-    private Set<String> tags;
-}
+/**
+ * Registry key combining API Product ID and Environment ID for scoping.
+ */
+public record ApiProductRegistryKey(String apiProductId, String environmentId) {}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/registry/impl/ApiProductRegistryImpl.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/registry/impl/ApiProductRegistryImpl.java
@@ -18,13 +18,19 @@ package io.gravitee.gateway.handlers.api.registry.impl;
 import com.google.common.annotations.VisibleForTesting;
 import io.gravitee.definition.model.v4.plan.Plan;
 import io.gravitee.definition.model.v4.plan.PlanStatus;
+import io.gravitee.gateway.env.GatewayConfiguration;
 import io.gravitee.gateway.handlers.api.ReactableApiProduct;
 import io.gravitee.gateway.handlers.api.registry.ApiProductRegistry;
+import io.gravitee.gateway.handlers.api.registry.ApiProductRegistryKey;
+import io.gravitee.gateway.handlers.api.sharding.ApiProductShardingFilter;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 import lombok.CustomLog;
 
 /**
@@ -34,8 +40,19 @@ import lombok.CustomLog;
 @CustomLog
 public class ApiProductRegistryImpl implements ApiProductRegistry {
 
+    private record ApiEnvironmentKey(String environmentId, String apiId) {}
+
     @VisibleForTesting
     protected final Map<ApiProductRegistryKey, ReactableApiProduct> registry = new ConcurrentHashMap<>();
+
+    private volatile Map<ApiEnvironmentKey, List<ApiProductPlanEntry>> planEntriesByApi = Map.of();
+
+    private final ReadWriteLock indexLock = new ReentrantReadWriteLock();
+    private final GatewayConfiguration gatewayConfiguration;
+
+    public ApiProductRegistryImpl(GatewayConfiguration gatewayConfiguration) {
+        this.gatewayConfiguration = gatewayConfiguration;
+    }
 
     @Override
     public ReactableApiProduct get(String apiProductId, String environmentId) {
@@ -52,15 +69,8 @@ public class ApiProductRegistryImpl implements ApiProductRegistry {
         log.debug("Registering API Product [{}] for environment [{}]", apiProduct.getId(), apiProduct.getEnvironmentId());
 
         ApiProductRegistryKey key = new ApiProductRegistryKey(apiProduct.getId(), apiProduct.getEnvironmentId());
-        ReactableApiProduct previousApiProduct = registry.put(key, apiProduct);
-
-        if (previousApiProduct != null) {
-            log.debug(
-                "API Product [{}] was already registered for environment [{}]; replaced with new version",
-                apiProduct.getId(),
-                apiProduct.getEnvironmentId()
-            );
-        }
+        ReactableApiProduct previous = registry.put(key, apiProduct);
+        updateIndexForProduct(previous, apiProduct);
     }
 
     @Override
@@ -72,49 +82,120 @@ public class ApiProductRegistryImpl implements ApiProductRegistry {
 
         if (removed != null) {
             log.debug("API Product [{}] removed from environment [{}]", apiProductId, environmentId);
+            removeIndexForProduct(removed);
         } else {
             log.debug("API Product [{}] was not found in registry for environment [{}]", apiProductId, environmentId);
         }
     }
 
-    /**
-     * Clear all API Products from the registry.
-     * Used for cleanup during shutdown or testing.
-     */
     public void clear() {
         log.debug("Clearing all API Products from registry");
         registry.clear();
+        indexLock.writeLock().lock();
+        try {
+            planEntriesByApi = Map.of();
+        } finally {
+            indexLock.writeLock().unlock();
+        }
     }
 
     @Override
     public List<ApiProductPlanEntry> getApiProductPlanEntriesForApi(String apiId, String environmentId) {
-        List<ApiProductPlanEntry> entries = new ArrayList<>();
-
         if (apiId == null || environmentId == null) {
-            return entries;
+            return List.of();
         }
+        return planEntriesByApi.getOrDefault(new ApiEnvironmentKey(environmentId, apiId), List.of());
+    }
 
-        for (ReactableApiProduct product : registry.values()) {
-            if (
-                product.getEnvironmentId() != null &&
-                product.getEnvironmentId().equals(environmentId) &&
-                product.getApiIds() != null &&
-                product.getApiIds().contains(apiId) &&
-                product.getPlans() != null
-            ) {
-                for (Plan plan : product.getPlans()) {
-                    if (plan.getStatus() == PlanStatus.PUBLISHED || plan.getStatus() == PlanStatus.DEPRECATED) {
-                        entries.add(new ApiProductPlanEntry(product.getId(), plan));
-                    }
+    private void updateIndexForProduct(ReactableApiProduct previous, ReactableApiProduct current) {
+        indexLock.writeLock().lock();
+        try {
+            Map<ApiEnvironmentKey, List<ApiProductPlanEntry>> mutable = new HashMap<>(planEntriesByApi);
+            if (previous != null) {
+                removeProductFromMutableIndex(mutable, previous);
+            }
+            addProductToMutableIndex(mutable, current);
+            planEntriesByApi = Map.copyOf(mutable);
+        } finally {
+            indexLock.writeLock().unlock();
+        }
+        log.debug("API Product registry index updated for product [{}]: {} API entries total", current.getId(), planEntriesByApi.size());
+    }
+
+    private void removeIndexForProduct(ReactableApiProduct product) {
+        indexLock.writeLock().lock();
+        try {
+            Map<ApiEnvironmentKey, List<ApiProductPlanEntry>> mutable = new HashMap<>(planEntriesByApi);
+            removeProductFromMutableIndex(mutable, product);
+            planEntriesByApi = Map.copyOf(mutable);
+        } finally {
+            indexLock.writeLock().unlock();
+        }
+        log.debug(
+            "API Product registry index updated after removing product [{}]: {} API entries total",
+            product.getId(),
+            planEntriesByApi.size()
+        );
+    }
+
+    private void addProductToMutableIndex(Map<ApiEnvironmentKey, List<ApiProductPlanEntry>> index, ReactableApiProduct product) {
+        if (!ApiProductShardingFilter.matchesProductTags(gatewayConfiguration, product.getTags())) {
+            log.debug(
+                "API Product [{}] skipped during indexing: product tags {} do not match gateway sharding tags",
+                product.getId(),
+                product.getTags()
+            );
+            return;
+        }
+        if (product.getEnvironmentId() == null || product.getApiIds() == null || product.getPlans() == null) {
+            return;
+        }
+        for (String apiId : product.getApiIds()) {
+            for (Plan plan : product.getPlans()) {
+                addPlanToIndexIfEligible(index, product, apiId, plan);
+            }
+        }
+    }
+
+    private void addPlanToIndexIfEligible(
+        Map<ApiEnvironmentKey, List<ApiProductPlanEntry>> index,
+        ReactableApiProduct product,
+        String apiId,
+        Plan plan
+    ) {
+        if (plan.getStatus() != PlanStatus.PUBLISHED && plan.getStatus() != PlanStatus.DEPRECATED) {
+            return;
+        }
+        if (!ApiProductShardingFilter.matchesPlanTags(gatewayConfiguration, plan.getTags())) {
+            log.debug(
+                "Plan [{}] of product [{}] skipped: plan tags {} do not match gateway tags",
+                plan.getId(),
+                product.getId(),
+                plan.getTags()
+            );
+            return;
+        }
+        ApiProductPlanEntry entry = new ApiProductPlanEntry(product.getId(), plan);
+        index.computeIfAbsent(new ApiEnvironmentKey(product.getEnvironmentId(), apiId), k -> new ArrayList<>()).add(entry);
+    }
+
+    private static void removeProductFromMutableIndex(
+        Map<ApiEnvironmentKey, List<ApiProductPlanEntry>> index,
+        ReactableApiProduct product
+    ) {
+        if (product.getEnvironmentId() == null || product.getApiIds() == null) {
+            return;
+        }
+        String productId = product.getId();
+        for (String apiId : product.getApiIds()) {
+            ApiEnvironmentKey key = new ApiEnvironmentKey(product.getEnvironmentId(), apiId);
+            List<ApiProductPlanEntry> entries = index.get(key);
+            if (entries != null) {
+                entries.removeIf(e -> productId.equals(e.apiProductId()));
+                if (entries.isEmpty()) {
+                    index.remove(key);
                 }
             }
         }
-
-        return entries;
     }
-
-    /**
-     * Registry key combining API Product ID and Environment ID for scoping.
-     */
-    record ApiProductRegistryKey(String apiProductId, String environmentId) {}
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/sharding/ApiProductShardingFilter.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/sharding/ApiProductShardingFilter.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.handlers.api.sharding;
+
+import io.gravitee.gateway.env.GatewayConfiguration;
+import java.util.Set;
+
+/**
+ * Sharding tag matching for API Products and API Product plans (aligned with API sharding in gateway).
+ *
+ * <p>Follows the same rules as APIs: tagless gateways retrieve everything; tagged gateways
+ * only retrieve entities whose tags match.
+ */
+public final class ApiProductShardingFilter {
+
+    private ApiProductShardingFilter() {}
+
+    public static boolean matchesProductTags(GatewayConfiguration gatewayConfiguration, Set<String> productTags) {
+        return gatewayConfiguration.hasMatchingTags(productTags);
+    }
+
+    public static boolean matchesPlanTags(GatewayConfiguration gatewayConfiguration, Set<String> planTags) {
+        if (planTags == null || planTags.isEmpty()) {
+            return true;
+        }
+        return gatewayConfiguration.hasMatchingTags(planTags);
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/spring/ApiProductConfiguration.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/spring/ApiProductConfiguration.java
@@ -16,6 +16,7 @@
 package io.gravitee.gateway.handlers.api.spring;
 
 import io.gravitee.common.event.EventManager;
+import io.gravitee.gateway.env.GatewayConfiguration;
 import io.gravitee.gateway.handlers.api.manager.ApiProductManager;
 import io.gravitee.gateway.handlers.api.manager.impl.ApiProductManagerImpl;
 import io.gravitee.gateway.handlers.api.registry.ApiProductRegistry;
@@ -32,16 +33,17 @@ import org.springframework.context.annotation.Configuration;
 public class ApiProductConfiguration {
 
     @Bean
-    public ApiProductRegistry apiProductRegistry() {
-        return new ApiProductRegistryImpl();
+    public ApiProductRegistry apiProductRegistry(GatewayConfiguration gatewayConfiguration) {
+        return new ApiProductRegistryImpl(gatewayConfiguration);
     }
 
     @Bean
     public ApiProductManager apiProductManager(
         ApiProductRegistry apiProductRegistry,
         EventManager eventManager,
-        LicenseManager licenseManager
+        LicenseManager licenseManager,
+        GatewayConfiguration gatewayConfiguration
     ) {
-        return new ApiProductManagerImpl(apiProductRegistry, eventManager, licenseManager);
+        return new ApiProductManagerImpl(apiProductRegistry, eventManager, licenseManager, gatewayConfiguration);
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/handlers/api/manager/ApiManagerImplTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/handlers/api/manager/ApiManagerImplTest.java
@@ -62,6 +62,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.SneakyThrows;
 import org.junit.jupiter.api.BeforeEach;

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/handlers/api/manager/impl/ApiManagerImplApiProductListenerTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/handlers/api/manager/impl/ApiManagerImplApiProductListenerTest.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.handlers.api.manager.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.common.event.EventListener;
+import io.gravitee.common.event.EventManager;
+import io.gravitee.common.event.impl.SimpleEvent;
+import io.gravitee.common.util.DataEncryptor;
+import io.gravitee.definition.model.v4.listener.http.HttpListener;
+import io.gravitee.definition.model.v4.listener.http.Path;
+import io.gravitee.definition.model.v4.plan.PlanStatus;
+import io.gravitee.gateway.env.GatewayConfiguration;
+import io.gravitee.gateway.handlers.api.event.ApiProductChangedEvent;
+import io.gravitee.gateway.handlers.api.event.ApiProductEventType;
+import io.gravitee.gateway.handlers.api.registry.ApiProductRegistry;
+import io.gravitee.gateway.reactor.ReactorEvent;
+import io.gravitee.node.api.license.LicenseManager;
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class ApiManagerImplApiProductListenerTest {
+
+    @Mock
+    private EventManager eventManager;
+
+    @Mock
+    private GatewayConfiguration gatewayConfiguration;
+
+    @Mock
+    private LicenseManager licenseManager;
+
+    @Mock
+    private DataEncryptor dataEncryptor;
+
+    @Mock
+    private ApiProductRegistry apiProductRegistry;
+
+    private ApiManagerImpl apiManager;
+    private ArgumentCaptor<EventListener<ApiProductEventType, ApiProductChangedEvent>> listenerCaptor;
+
+    @BeforeEach
+    void setUp() {
+        lenient().when(gatewayConfiguration.hasMatchingTags(any())).thenReturn(false);
+        apiManager = new ApiManagerImpl(eventManager, gatewayConfiguration, licenseManager, dataEncryptor, apiProductRegistry);
+        listenerCaptor = ArgumentCaptor.forClass(EventListener.class);
+        verify(eventManager).subscribeForEvents(
+            listenerCaptor.capture(),
+            eq(ApiProductEventType.DEPLOY),
+            eq(ApiProductEventType.UNDEPLOY),
+            eq(ApiProductEventType.UPDATE)
+        );
+    }
+
+    @Test
+    void should_undeploy_product_only_api_when_product_change_removes_registry_eligibility() {
+        var api = buildProductOnlyApi();
+
+        when(apiProductRegistry.getApiProductPlanEntriesForApi(eq("api-test"), eq("env-1"))).thenReturn(
+            List.of(
+                new ApiProductRegistry.ApiProductPlanEntry(
+                    "product-1",
+                    io.gravitee.definition.model.v4.plan.Plan.builder()
+                        .id("plan-test")
+                        .name("TestPlan")
+                        .status(PlanStatus.PUBLISHED)
+                        .build()
+                )
+            )
+        );
+        apiManager.register(api);
+        verify(eventManager).publishEvent(ReactorEvent.DEPLOY, api);
+
+        when(apiProductRegistry.getApiProductPlanEntriesForApi(eq("api-test"), eq("env-1"))).thenReturn(List.of());
+
+        listenerCaptor
+            .getValue()
+            .onEvent(new SimpleEvent<>(ApiProductEventType.UPDATE, new ApiProductChangedEvent("product-1", "env-1", Set.of("api-test"))));
+
+        verify(eventManager).publishEvent(ReactorEvent.UNDEPLOY, api);
+        assertThat(apiManager.apis()).isEmpty();
+    }
+
+    @Test
+    void should_ignore_product_change_event_with_null_api_ids() {
+        var api = buildProductOnlyApi();
+
+        when(apiProductRegistry.getApiProductPlanEntriesForApi(eq("api-test"), eq("env-1"))).thenReturn(
+            List.of(
+                new ApiProductRegistry.ApiProductPlanEntry(
+                    "product-1",
+                    io.gravitee.definition.model.v4.plan.Plan.builder().id("plan-test").status(PlanStatus.PUBLISHED).build()
+                )
+            )
+        );
+        apiManager.register(api);
+
+        listenerCaptor
+            .getValue()
+            .onEvent(new SimpleEvent<>(ApiProductEventType.UPDATE, new ApiProductChangedEvent("product-1", "env-1", null)));
+
+        assertThat(apiManager.apis()).hasSize(1);
+    }
+
+    private io.gravitee.gateway.reactive.handlers.api.v4.Api buildProductOnlyApi() {
+        HttpListener httpListener = new HttpListener();
+        httpListener.setPaths(List.of(mock(Path.class)));
+
+        var definition = new io.gravitee.definition.model.v4.Api();
+        definition.setId("api-test");
+        definition.setPlans(Collections.emptyList());
+
+        var api = new io.gravitee.gateway.reactive.handlers.api.v4.Api(definition);
+        api.setEnabled(true);
+        api.setEnvironmentId("env-1");
+        api.setDeployedAt(new Date());
+        api.setOrganizationId("org-id");
+        return api;
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/handlers/api/manager/impl/ApiProductManagerImplTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/handlers/api/manager/impl/ApiProductManagerImplTest.java
@@ -26,6 +26,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.gravitee.common.event.EventManager;
+import io.gravitee.gateway.env.GatewayConfiguration;
 import io.gravitee.gateway.handlers.api.ReactableApiProduct;
 import io.gravitee.gateway.handlers.api.event.ApiProductChangedEvent;
 import io.gravitee.gateway.handlers.api.event.ApiProductEventType;
@@ -35,6 +36,8 @@ import io.gravitee.node.api.license.LicenseManager;
 import io.reactivex.rxjava3.core.Completable;
 import java.util.Collection;
 import java.util.Date;
+import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
@@ -42,6 +45,7 @@ import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -66,13 +70,18 @@ class ApiProductManagerImplTest {
     @Mock
     private License license;
 
+    @Mock
+    private GatewayConfiguration gatewayConfiguration;
+
     private ApiProductManagerImpl manager;
 
     @BeforeEach
     void setUp() {
         lenient().when(licenseManager.getOrganizationLicenseOrPlatform(any())).thenReturn(license);
         lenient().when(license.getTier()).thenReturn("universe");
-        manager = new ApiProductManagerImpl(apiProductRegistry, eventManager, licenseManager);
+        lenient().when(gatewayConfiguration.shardingTags()).thenReturn(Optional.of(List.of("internal")));
+        lenient().when(gatewayConfiguration.hasMatchingTags(any())).thenReturn(true);
+        manager = new ApiProductManagerImpl(apiProductRegistry, eventManager, licenseManager, gatewayConfiguration);
     }
 
     @Nested
@@ -340,6 +349,26 @@ class ApiProductManagerImplTest {
         }
 
         @Test
+        void should_emit_update_event_with_union_of_previous_and_current_member_api_ids() {
+            Date oldDate = new Date(System.currentTimeMillis() - 10000);
+            Date newDate = new Date();
+
+            ReactableApiProduct oldProduct = createApiProduct("product-1", "env-1", oldDate);
+            oldProduct.setApiIds(Set.of("api-1", "api-2"));
+
+            ReactableApiProduct newProduct = createApiProduct("product-1", "env-1", newDate);
+            newProduct.setApiIds(Set.of("api-2", "api-3"));
+
+            manager.register(oldProduct);
+
+            ArgumentCaptor<ApiProductChangedEvent> eventCaptor = ArgumentCaptor.forClass(ApiProductChangedEvent.class);
+            manager.register(newProduct);
+
+            verify(eventManager).publishEvent(eq(ApiProductEventType.UPDATE), eventCaptor.capture());
+            assertThat(eventCaptor.getValue().getApiIds()).containsExactlyInAnyOrder("api-1", "api-2", "api-3");
+        }
+
+        @Test
         void should_deploy_successfully_when_no_op_beforeEmit() {
             ReactableApiProduct apiProduct = createApiProduct("product-1", "env-1", new Date());
 
@@ -426,6 +455,65 @@ class ApiProductManagerImplTest {
             thread2.join();
 
             assertThat(manager.getApiProducts()).hasSize(100);
+        }
+    }
+
+    @Nested
+    class ShardingTagFilterTest {
+
+        @Test
+        void should_not_deploy_when_product_tags_do_not_match_gateway() {
+            when(gatewayConfiguration.hasMatchingTags(Set.of("external"))).thenReturn(false);
+
+            ReactableApiProduct apiProduct = createApiProduct("product-1", "env-1", new Date());
+            apiProduct.setTags(Set.of("external"));
+
+            manager.register(apiProduct);
+
+            assertThat(manager.get("product-1")).isNull();
+            verify(apiProductRegistry, never()).register(any());
+        }
+
+        @Test
+        void should_deploy_when_product_tags_match_gateway() {
+            when(gatewayConfiguration.hasMatchingTags(Set.of("internal"))).thenReturn(true);
+
+            ReactableApiProduct apiProduct = createApiProduct("product-1", "env-1", new Date());
+            apiProduct.setTags(Set.of("internal"));
+
+            manager.register(apiProduct);
+
+            assertThat(manager.get("product-1")).isNotNull();
+            verify(apiProductRegistry).register(apiProduct);
+        }
+
+        @Test
+        void should_undeploy_previously_deployed_product_when_tags_change_to_non_matching() {
+            when(gatewayConfiguration.hasMatchingTags(Set.of("internal"))).thenReturn(true);
+            when(gatewayConfiguration.hasMatchingTags(Set.of("external"))).thenReturn(false);
+
+            ReactableApiProduct apiProduct = createApiProduct("product-1", "env-1", new Date(System.currentTimeMillis() - 10000));
+            apiProduct.setTags(Set.of("internal"));
+            manager.register(apiProduct);
+            assertThat(manager.get("product-1")).isNotNull();
+
+            ReactableApiProduct updatedProduct = createApiProduct("product-1", "env-1", new Date());
+            updatedProduct.setTags(Set.of("external"));
+            manager.register(updatedProduct);
+
+            assertThat(manager.get("product-1")).isNull();
+            verify(apiProductRegistry).remove("product-1", "env-1");
+        }
+
+        @Test
+        void should_deploy_product_with_empty_tags_regardless_of_gateway_tags() {
+            ReactableApiProduct apiProduct = createApiProduct("product-1", "env-1", new Date());
+            apiProduct.setTags(null);
+
+            manager.register(apiProduct);
+
+            assertThat(manager.get("product-1")).isNotNull();
+            verify(apiProductRegistry).register(apiProduct);
         }
     }
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/handlers/api/registry/impl/ApiProductRegistryImplTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/handlers/api/registry/impl/ApiProductRegistryImplTest.java
@@ -16,33 +16,46 @@
 package io.gravitee.gateway.handlers.api.registry.impl;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
 
 import io.gravitee.definition.model.v4.plan.Plan;
 import io.gravitee.definition.model.v4.plan.PlanStatus;
+import io.gravitee.gateway.env.GatewayConfiguration;
 import io.gravitee.gateway.handlers.api.ReactableApiProduct;
 import io.gravitee.gateway.handlers.api.registry.ApiProductRegistry;
 import java.util.Collection;
 import java.util.Date;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 /**
  * @author Arpit Mishra (arpit.mishra at graviteesource.com)
  * @author GraviteeSource Team
  */
+@ExtendWith(MockitoExtension.class)
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 class ApiProductRegistryImplTest {
+
+    @Mock
+    private GatewayConfiguration gatewayConfiguration;
 
     private ApiProductRegistryImpl registry;
 
     @BeforeEach
     void setUp() {
-        registry = new ApiProductRegistryImpl();
+        lenient().when(gatewayConfiguration.shardingTags()).thenReturn(Optional.of(List.of("internal")));
+        lenient().when(gatewayConfiguration.hasMatchingTags(any())).thenReturn(true);
+        registry = new ApiProductRegistryImpl(gatewayConfiguration);
     }
 
     @Nested
@@ -334,6 +347,103 @@ class ApiProductRegistryImplTest {
     }
 
     @Nested
+    class ShardingTagFilteringTest {
+
+        @Test
+        void should_exclude_product_when_product_tags_do_not_match_gateway() {
+            lenient().when(gatewayConfiguration.hasMatchingTags(Set.of("external"))).thenReturn(false);
+            lenient().when(gatewayConfiguration.hasMatchingTags(Set.of("internal"))).thenReturn(true);
+
+            ReactableApiProduct product = createApiProduct("product-1", "env-1");
+            product.setTags(Set.of("external"));
+            product.setPlans(List.of(createPlan("plan-1", PlanStatus.PUBLISHED)));
+            registry.register(product);
+
+            List<ApiProductRegistry.ApiProductPlanEntry> entries = registry.getApiProductPlanEntriesForApi("api-1", "env-1");
+            assertThat(entries).isEmpty();
+        }
+
+        @Test
+        void should_include_product_when_product_tags_match_gateway() {
+            lenient().when(gatewayConfiguration.hasMatchingTags(Set.of("internal"))).thenReturn(true);
+
+            ReactableApiProduct product = createApiProduct("product-1", "env-1");
+            product.setTags(Set.of("internal"));
+            product.setPlans(List.of(createPlan("plan-1", PlanStatus.PUBLISHED)));
+            registry.register(product);
+
+            List<ApiProductRegistry.ApiProductPlanEntry> entries = registry.getApiProductPlanEntriesForApi("api-1", "env-1");
+            assertThat(entries).hasSize(1);
+        }
+
+        @Test
+        void should_exclude_plan_when_plan_tags_do_not_match_gateway() {
+            lenient().when(gatewayConfiguration.hasMatchingTags(Set.of("internal"))).thenReturn(true);
+            lenient().when(gatewayConfiguration.hasMatchingTags(Set.of("external"))).thenReturn(false);
+
+            ReactableApiProduct product = createApiProduct("product-1", "env-1");
+            product.setTags(Set.of("internal"));
+
+            Plan planMatching = createPlan("plan-matching", PlanStatus.PUBLISHED);
+            planMatching.setTags(Set.of("internal"));
+            Plan planNotMatching = createPlan("plan-no-match", PlanStatus.PUBLISHED);
+            planNotMatching.setTags(Set.of("external"));
+
+            product.setPlans(List.of(planMatching, planNotMatching));
+            registry.register(product);
+
+            List<ApiProductRegistry.ApiProductPlanEntry> entries = registry.getApiProductPlanEntriesForApi("api-1", "env-1");
+            assertThat(entries).hasSize(1);
+            assertThat(entries.get(0).plan().getId()).isEqualTo("plan-matching");
+        }
+
+        @Test
+        void should_include_plan_with_no_tags_when_product_matches() {
+            lenient().when(gatewayConfiguration.hasMatchingTags(Set.of("internal"))).thenReturn(true);
+
+            ReactableApiProduct product = createApiProduct("product-1", "env-1");
+            product.setTags(Set.of("internal"));
+
+            Plan planNoTags = createPlan("plan-no-tags", PlanStatus.PUBLISHED);
+
+            product.setPlans(List.of(planNoTags));
+            registry.register(product);
+
+            List<ApiProductRegistry.ApiProductPlanEntry> entries = registry.getApiProductPlanEntriesForApi("api-1", "env-1");
+            assertThat(entries).hasSize(1);
+            assertThat(entries.get(0).plan().getId()).isEqualTo("plan-no-tags");
+        }
+
+        @Test
+        void should_handle_multi_product_overlap_for_same_api() {
+            ReactableApiProduct product1 = createApiProduct("product-1", "env-1");
+            product1.setApiIds(Set.of("api-shared"));
+            product1.setPlans(List.of(createPlan("plan-p1", PlanStatus.PUBLISHED)));
+
+            ReactableApiProduct product2 = createApiProduct("product-2", "env-1");
+            product2.setApiIds(Set.of("api-shared"));
+            product2.setPlans(List.of(createPlan("plan-p2", PlanStatus.PUBLISHED)));
+
+            registry.register(product1);
+            registry.register(product2);
+
+            List<ApiProductRegistry.ApiProductPlanEntry> entries = registry.getApiProductPlanEntriesForApi("api-shared", "env-1");
+            assertThat(entries).hasSize(2);
+            assertThat(entries)
+                .extracting(ApiProductRegistry.ApiProductPlanEntry::apiProductId)
+                .containsExactlyInAnyOrder("product-1", "product-2");
+        }
+
+        private Plan createPlan(String id, PlanStatus status) {
+            Plan plan = new Plan();
+            plan.setId(id);
+            plan.setName("Plan " + id);
+            plan.setStatus(status);
+            return plan;
+        }
+    }
+
+    @Nested
     class ConcurrencyTest {
 
         @Test
@@ -359,29 +469,42 @@ class ApiProductRegistryImplTest {
         }
 
         @Test
-        void should_handle_concurrent_reads() throws InterruptedException {
+        void should_handle_concurrent_reads_during_rebuild() throws InterruptedException {
             for (int i = 0; i < 10; i++) {
-                registry.register(createApiProduct("product-" + i, "env-1"));
+                ReactableApiProduct product = createApiProduct("product-" + i, "env-1");
+                product.setPlans(List.of(createPlan("plan-" + i, PlanStatus.PUBLISHED)));
+                registry.register(product);
             }
 
-            Thread thread1 = new Thread(() -> {
-                for (int i = 0; i < 100; i++) {
-                    registry.get("product-5", "env-1");
+            Thread reader = new Thread(() -> {
+                for (int i = 0; i < 1000; i++) {
+                    List<ApiProductRegistry.ApiProductPlanEntry> entries = registry.getApiProductPlanEntriesForApi("api-1", "env-1");
+                    assertThat(entries).isNotNull();
                 }
             });
 
-            Thread thread2 = new Thread(() -> {
-                for (int i = 0; i < 100; i++) {
-                    registry.getAll();
+            Thread writer = new Thread(() -> {
+                for (int i = 10; i < 20; i++) {
+                    ReactableApiProduct product = createApiProduct("product-" + i, "env-1");
+                    product.setPlans(List.of(createPlan("plan-" + i, PlanStatus.PUBLISHED)));
+                    registry.register(product);
                 }
             });
 
-            thread1.start();
-            thread2.start();
-            thread1.join();
-            thread2.join();
+            reader.start();
+            writer.start();
+            reader.join();
+            writer.join();
 
-            assertThat(registry.getAll()).hasSize(10);
+            assertThat(registry.getAll()).hasSize(20);
+        }
+
+        private Plan createPlan(String id, PlanStatus status) {
+            Plan plan = new Plan();
+            plan.setId(id);
+            plan.setName("Plan " + id);
+            plan.setStatus(status);
+            return plan;
         }
     }
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/handlers/api/sharding/ApiProductShardingFilterTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/handlers/api/sharding/ApiProductShardingFilterTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.handlers.api.sharding;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.gateway.env.GatewayConfiguration;
+import java.util.Set;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class ApiProductShardingFilterTest {
+
+    @Mock
+    private GatewayConfiguration gatewayConfiguration;
+
+    @Test
+    void should_match_product_tags_via_gateway_configuration() {
+        when(gatewayConfiguration.hasMatchingTags(Set.of("internal"))).thenReturn(true);
+
+        assertThat(ApiProductShardingFilter.matchesProductTags(gatewayConfiguration, Set.of("internal"))).isTrue();
+    }
+
+    @Test
+    void should_accept_plan_with_no_tags_on_any_matching_gateway() {
+        assertThat(ApiProductShardingFilter.matchesPlanTags(gatewayConfiguration, null)).isTrue();
+        assertThat(ApiProductShardingFilter.matchesPlanTags(gatewayConfiguration, Set.of())).isTrue();
+    }
+
+    @Test
+    void should_delegate_plan_tag_matching_to_gateway_configuration() {
+        when(gatewayConfiguration.hasMatchingTags(Set.of("external"))).thenReturn(false);
+
+        assertThat(ApiProductShardingFilter.matchesPlanTags(gatewayConfiguration, Set.of("external"))).isFalse();
+    }
+
+    @Test
+    void should_match_plan_when_gateway_has_matching_tags() {
+        when(gatewayConfiguration.hasMatchingTags(Set.of("internal"))).thenReturn(true);
+
+        assertThat(ApiProductShardingFilter.matchesPlanTags(gatewayConfiguration, Set.of("internal"))).isTrue();
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/fetcher/LatestEventFetcher.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/fetcher/LatestEventFetcher.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Set;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.CustomLog;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.experimental.Accessors;
@@ -33,6 +34,7 @@ import lombok.experimental.Accessors;
  * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
  * @author GraviteeSource Team
  */
+@CustomLog
 @RequiredArgsConstructor
 public class LatestEventFetcher {
 
@@ -78,6 +80,28 @@ public class LatestEventFetcher {
                 }
             }
         );
+    }
+
+    public List<Event> fetchLatestForApiIds(Set<String> apiIds, Set<String> environments, Set<EventType> eventTypes) {
+        if (apiIds == null || apiIds.isEmpty()) {
+            return List.of();
+        }
+        try {
+            List<Event> events = eventLatestRepository.search(
+                EventCriteria.builder()
+                    .types(eventTypes)
+                    .environments(environments)
+                    .property(Event.EventProperties.API_ID.getValue(), apiIds)
+                    .build(),
+                Event.EventProperties.API_ID,
+                null,
+                null
+            );
+            return events != null ? events : List.of();
+        } catch (Exception e) {
+            log.warn("Failed to batch-fetch latest events for {} API(s): {}", apiIds.size(), e.getMessage());
+            return List.of();
+        }
     }
 
     @Builder

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/mapper/ApiProductMapper.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/mapper/ApiProductMapper.java
@@ -80,6 +80,7 @@ public class ApiProductMapper {
                     .version(payload.getVersion())
                     .apiIds(payload.getApiIds())
                     .environmentId(payload.getEnvironmentId())
+                    .tags(payload.getTags())
                     .deployedAt(new Date(event.getCreatedAt().getTime()))
                     .plans(filteredPlans(payload.getPlans()))
                     .build();
@@ -122,6 +123,7 @@ public class ApiProductMapper {
         private String environmentHrid;
         private String organizationId;
         private String organizationHrid;
+        private Set<String> tags;
         private List<Plan> plans;
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/spring/RepositorySyncConfiguration.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/spring/RepositorySyncConfiguration.java
@@ -18,6 +18,7 @@ package io.gravitee.gateway.services.sync.process.repository.spring;
 import static io.gravitee.gateway.services.sync.SyncConfiguration.DEFAULT_BULK_ITEMS;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.gravitee.common.event.EventManager;
 import io.gravitee.gateway.api.service.ApiKeyService;
 import io.gravitee.gateway.api.service.SubscriptionService;
 import io.gravitee.gateway.env.GatewayConfiguration;
@@ -54,6 +55,7 @@ import io.gravitee.gateway.services.sync.process.repository.synchronizer.api.Api
 import io.gravitee.gateway.services.sync.process.repository.synchronizer.api.ApiSynchronizer;
 import io.gravitee.gateway.services.sync.process.repository.synchronizer.api.AuthzAppender;
 import io.gravitee.gateway.services.sync.process.repository.synchronizer.api.PlanAppender;
+import io.gravitee.gateway.services.sync.process.repository.synchronizer.api.RepositoryApiMemberResyncTrigger;
 import io.gravitee.gateway.services.sync.process.repository.synchronizer.api.SubscriptionAppender;
 import io.gravitee.gateway.services.sync.process.repository.synchronizer.apikey.ApiKeySynchronizer;
 import io.gravitee.gateway.services.sync.process.repository.synchronizer.apiproduct.ApiProductSynchronizer;
@@ -92,6 +94,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Lazy;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
@@ -232,6 +235,15 @@ public class RepositorySyncConfiguration {
             syncDeployerExecutor,
             appenderParallelism
         );
+    }
+
+    @Bean(destroyMethod = "dispose")
+    public RepositoryApiMemberResyncTrigger apiMemberResyncTrigger(
+        @Lazy ApiSynchronizer apiSynchronizer,
+        @Qualifier("syncDeployerExecutor") ThreadPoolExecutor syncDeployerExecutor,
+        EventManager eventManager
+    ) {
+        return new RepositoryApiMemberResyncTrigger(apiSynchronizer, syncDeployerExecutor, eventManager);
     }
 
     @Bean

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/api/ApiSynchronizer.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/api/ApiSynchronizer.java
@@ -23,10 +23,13 @@ import io.gravitee.gateway.services.sync.process.common.synchronizer.Order;
 import io.gravitee.gateway.services.sync.process.repository.RepositorySynchronizer;
 import io.gravitee.gateway.services.sync.process.repository.fetcher.LatestEventFetcher;
 import io.gravitee.gateway.services.sync.process.repository.mapper.ApiMapper;
+import io.gravitee.repository.management.model.Event;
 import io.gravitee.repository.management.model.EventType;
 import io.reactivex.rxjava3.core.Completable;
+import io.reactivex.rxjava3.core.Flowable;
 import io.reactivex.rxjava3.schedulers.Schedulers;
 import java.time.Instant;
+import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.atomic.AtomicLong;
@@ -46,6 +49,7 @@ public class ApiSynchronizer extends AbstractApiSynchronizer implements Reposito
         EventType.UNPUBLISH_API,
         EventType.STOP_API
     );
+    private static final Set<EventType> MEMBER_API_RESYNC_EVENT_TYPES = INCREMENTAL_EVENT_TYPES;
     private final LatestEventFetcher eventsFetcher;
 
     public ApiSynchronizer(
@@ -96,6 +100,21 @@ public class ApiSynchronizer extends AbstractApiSynchronizer implements Reposito
                 }
             })
             .ignoreElement();
+    }
+
+    public Completable resyncMemberApis(Set<String> apiIds, Set<String> environments) {
+        if (apiIds == null || apiIds.isEmpty()) {
+            return Completable.complete();
+        }
+        List<Event> events = eventsFetcher.fetchLatestForApiIds(apiIds, environments, MEMBER_API_RESYNC_EVENT_TYPES);
+        if (events.isEmpty()) {
+            log.debug("No API events found to resync member APIs {}", apiIds);
+            return Completable.complete();
+        }
+        log.debug("Resyncing {} member API(s) after API Product change", events.size());
+        return processEvents(false, Flowable.fromIterable(events).buffer(bulkEvents()), environments)
+            .ignoreElements()
+            .subscribeOn(Schedulers.from(syncFetcherExecutor));
     }
 
     @Override

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/api/RepositoryApiMemberResyncTrigger.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/api/RepositoryApiMemberResyncTrigger.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.services.sync.process.repository.synchronizer.api;
+
+import io.gravitee.common.event.EventManager;
+import io.gravitee.gateway.handlers.api.event.ApiProductChangedEvent;
+import io.gravitee.gateway.handlers.api.event.ApiProductEventType;
+import io.reactivex.rxjava3.core.Completable;
+import io.reactivex.rxjava3.disposables.CompositeDisposable;
+import io.reactivex.rxjava3.disposables.Disposable;
+import io.reactivex.rxjava3.schedulers.Schedulers;
+import java.util.Set;
+import java.util.concurrent.ThreadPoolExecutor;
+import lombok.CustomLog;
+
+/**
+ * Subscribes to API Product change events and triggers a re-sync of member APIs
+ * through the sync process. Lives in the sync plugin context which has visibility
+ * to both the parent gateway context (EventManager) and the sync infrastructure
+ * (ApiSynchronizer).
+ */
+@CustomLog
+public class RepositoryApiMemberResyncTrigger {
+
+    private final ApiSynchronizer apiSynchronizer;
+    private final ThreadPoolExecutor syncDeployerExecutor;
+    private final CompositeDisposable disposables = new CompositeDisposable();
+
+    public RepositoryApiMemberResyncTrigger(
+        ApiSynchronizer apiSynchronizer,
+        ThreadPoolExecutor syncDeployerExecutor,
+        EventManager eventManager
+    ) {
+        this.apiSynchronizer = apiSynchronizer;
+        this.syncDeployerExecutor = syncDeployerExecutor;
+
+        eventManager.subscribeForEvents(
+            event -> {
+                if (event.content() instanceof ApiProductChangedEvent productEvent) {
+                    resyncMemberApis(productEvent.getEnvironmentId(), productEvent.getApiIds());
+                }
+            },
+            ApiProductEventType.DEPLOY,
+            ApiProductEventType.UPDATE
+        );
+    }
+
+    private void resyncMemberApis(String environmentId, Set<String> apiIds) {
+        if (environmentId == null || apiIds == null || apiIds.isEmpty()) {
+            return;
+        }
+        Disposable d = Completable.fromAction(() ->
+            log.debug("Scheduling resync of {} member API(s) in environment [{}]", apiIds.size(), environmentId)
+        )
+            .andThen(apiSynchronizer.resyncMemberApis(apiIds, Set.of(environmentId)))
+            .subscribeOn(Schedulers.from(syncDeployerExecutor))
+            .subscribe(
+                () -> log.debug("Member API resync completed for environment [{}]", environmentId),
+                error -> log.error("Member API resync failed for environment [{}]: {}", environmentId, error.getMessage(), error)
+            );
+        disposables.add(d);
+    }
+
+    public void dispose() {
+        disposables.dispose();
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/fetcher/LatestEventFetcherTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/fetcher/LatestEventFetcherTest.java
@@ -25,6 +25,7 @@ import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Set;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
@@ -137,5 +138,29 @@ class LatestEventFetcherTest {
     void should_emit_on_error_when_repository_thrown_exception() {
         when(eventLatestRepository.search(any(), any(), any(), any())).thenThrow(new RuntimeException());
         cut.fetchLatest(null, null, Event.EventProperties.API_ID, Set.of(), Set.of()).test().assertError(RuntimeException.class);
+    }
+
+    @Test
+    void should_return_empty_list_when_fetching_events_for_empty_api_ids() {
+        Assertions.assertThat(cut.fetchLatestForApiIds(Set.of(), Set.of("env"), Set.of(EventType.PUBLISH_API))).isEmpty();
+        Assertions.assertThat(cut.fetchLatestForApiIds(null, Set.of("env"), Set.of(EventType.PUBLISH_API))).isEmpty();
+        verifyNoInteractions(eventLatestRepository);
+    }
+
+    @Test
+    void should_fetch_latest_events_for_specific_api_ids() {
+        Event event = new Event();
+        when(eventLatestRepository.search(any(), eq(Event.EventProperties.API_ID), isNull(), isNull())).thenReturn(List.of(event));
+
+        Assertions.assertThat(
+            cut.fetchLatestForApiIds(Set.of("api-1", "api-2"), Set.of("env"), Set.of(EventType.START_API))
+        ).containsExactly(event);
+    }
+
+    @Test
+    void should_return_empty_list_when_repository_search_fails_for_api_ids() {
+        when(eventLatestRepository.search(any(), any(), any(), any())).thenThrow(new RuntimeException("db down"));
+
+        Assertions.assertThat(cut.fetchLatestForApiIds(Set.of("api-1"), Set.of("env"), Set.of(EventType.PUBLISH_API))).isEmpty();
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/api/ApiSynchronizerTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/api/ApiSynchronizerTest.java
@@ -141,7 +141,7 @@ class ApiSynchronizerTest {
             new ThreadPoolExecutor(1, 1, 15L, TimeUnit.SECONDS, new LinkedBlockingQueue<>()),
             1 // appenderParallelism: sequential for test determinism
         );
-        when(eventsFetcher.bulkItems()).thenReturn(1);
+        lenient().when(eventsFetcher.bulkItems()).thenReturn(1);
         lenient().when(deployerFactory.createApiDeployer()).thenReturn(apiDeployer);
         lenient().when(apiDeployer.deploy(any())).thenReturn(Completable.complete());
         lenient().when(apiDeployer.doAfterDeployment(any())).thenReturn(Completable.complete());
@@ -350,6 +350,71 @@ class ApiSynchronizerTest {
             verify(apiDeployer).undeploy(any());
             verify(subscriptionDeployer).undeploy(any());
             verify(apiKeyDeployer).undeploy(any());
+        }
+    }
+
+    @Nested
+    class ResyncMemberApisTest {
+
+        @Test
+        void should_not_resync_when_api_ids_are_empty() throws InterruptedException {
+            cut.resyncMemberApis(Set.of(), Set.of("env")).test().await().assertComplete();
+
+            verifyNoInteractions(eventsFetcher);
+            verifyNoInteractions(apiDeployer);
+        }
+
+        @Test
+        void should_not_deploy_when_no_repository_events_found_for_member_apis() throws InterruptedException {
+            when(eventsFetcher.fetchLatestForApiIds(eq(Set.of("api-1")), eq(Set.of("env")), any())).thenReturn(List.of());
+
+            cut.resyncMemberApis(Set.of("api-1"), Set.of("env")).test().await().assertComplete();
+
+            verify(eventsFetcher).fetchLatestForApiIds(eq(Set.of("api-1")), eq(Set.of("env")), any());
+            verifyNoInteractions(apiDeployer);
+        }
+
+        @Test
+        void should_redeploy_member_api_from_repository_events() throws InterruptedException, JsonProcessingException {
+            Event event = new Event();
+            event.setId("api");
+            event.setPayload(objectMapper.writeValueAsString(repoApi));
+            event.setType(PUBLISH_API);
+
+            when(eventsFetcher.fetchLatestForApiIds(eq(Set.of("api")), eq(Set.of("env")), any())).thenReturn(List.of(event));
+            when(apiManager.requiredActionFor(argThat(argument -> argument.getId().equals("api")))).thenReturn(ActionOnApi.DEPLOY);
+
+            cut.resyncMemberApis(Set.of("api"), Set.of("env")).test().await().assertComplete();
+
+            verify(apiDeployer).deploy(any());
+            verify(apiDeployer).doAfterDeployment(any());
+        }
+
+        private io.gravitee.definition.model.v4.Api api;
+        private Api repoApi;
+
+        @BeforeEach
+        void init() throws JsonProcessingException {
+            api = new io.gravitee.definition.model.v4.Api();
+            api.setId("api");
+            api.setDefinitionVersion(DefinitionVersion.V4);
+            PlanSecurity planSecurity = new PlanSecurity();
+            planSecurity.setType("api-key");
+            io.gravitee.definition.model.v4.plan.Plan plan = io.gravitee.definition.model.v4.plan.Plan.builder()
+                .id("planId")
+                .security(planSecurity)
+                .status(PlanStatus.PUBLISHED)
+                .build();
+            api.setPlans(List.of(plan));
+
+            repoApi = new Api();
+            repoApi.setId("api");
+            repoApi.setName("name");
+            repoApi.setLifecycleState(LifecycleState.STARTED);
+            repoApi.setEnvironmentId("env");
+            repoApi.setDefinitionVersion(DefinitionVersion.V4);
+            repoApi.setType(ApiType.PROXY);
+            repoApi.setDefinition(objectMapper.writeValueAsString(api));
         }
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/api/RepositoryApiMemberResyncTriggerTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/api/RepositoryApiMemberResyncTriggerTest.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.services.sync.process.repository.synchronizer.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.common.event.Event;
+import io.gravitee.common.event.EventListener;
+import io.gravitee.common.event.EventManager;
+import io.gravitee.common.event.impl.SimpleEvent;
+import io.gravitee.gateway.handlers.api.event.ApiProductChangedEvent;
+import io.gravitee.gateway.handlers.api.event.ApiProductEventType;
+import io.reactivex.rxjava3.core.Completable;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class RepositoryApiMemberResyncTriggerTest {
+
+    @Mock
+    private ApiSynchronizer apiSynchronizer;
+
+    @Mock
+    private EventManager eventManager;
+
+    @Captor
+    private ArgumentCaptor<EventListener<ApiProductEventType, ApiProductChangedEvent>> listenerCaptor;
+
+    private ThreadPoolExecutor syncDeployerExecutor;
+    private RepositoryApiMemberResyncTrigger cut;
+
+    @BeforeEach
+    void setUp() {
+        syncDeployerExecutor = new ThreadPoolExecutor(1, 1, 15L, TimeUnit.SECONDS, new LinkedBlockingQueue<>());
+        cut = new RepositoryApiMemberResyncTrigger(apiSynchronizer, syncDeployerExecutor, eventManager);
+        verify(eventManager).subscribeForEvents(listenerCaptor.capture(), eq(ApiProductEventType.DEPLOY), eq(ApiProductEventType.UPDATE));
+    }
+
+    @AfterEach
+    void tearDown() {
+        cut.dispose();
+        syncDeployerExecutor.shutdown();
+    }
+
+    @Test
+    void should_resync_member_apis_on_product_update_event() throws Exception {
+        CountDownLatch resyncCompleted = new CountDownLatch(1);
+        when(apiSynchronizer.resyncMemberApis(Set.of("api-1", "api-2"), Set.of("env-1"))).thenReturn(
+            Completable.fromAction(resyncCompleted::countDown)
+        );
+
+        listenerCaptor
+            .getValue()
+            .onEvent(
+                new SimpleEvent<>(ApiProductEventType.UPDATE, new ApiProductChangedEvent("product-1", "env-1", Set.of("api-1", "api-2")))
+            );
+
+        assertThat(resyncCompleted.await(5, TimeUnit.SECONDS)).isTrue();
+        verify(apiSynchronizer).resyncMemberApis(Set.of("api-1", "api-2"), Set.of("env-1"));
+    }
+
+    @Test
+    void should_resync_member_apis_on_product_deploy_event() throws Exception {
+        CountDownLatch resyncCompleted = new CountDownLatch(1);
+        when(apiSynchronizer.resyncMemberApis(Set.of("api-1"), Set.of("env-1"))).thenReturn(
+            Completable.fromAction(resyncCompleted::countDown)
+        );
+
+        listenerCaptor
+            .getValue()
+            .onEvent(new SimpleEvent<>(ApiProductEventType.DEPLOY, new ApiProductChangedEvent("product-1", "env-1", Set.of("api-1"))));
+
+        assertThat(resyncCompleted.await(5, TimeUnit.SECONDS)).isTrue();
+        verify(apiSynchronizer).resyncMemberApis(Set.of("api-1"), Set.of("env-1"));
+    }
+
+    @Test
+    void should_not_resync_when_environment_or_api_ids_are_missing() {
+        listenerCaptor
+            .getValue()
+            .onEvent(new SimpleEvent<>(ApiProductEventType.UPDATE, new ApiProductChangedEvent("product-1", null, Set.of("api-1"))));
+        listenerCaptor
+            .getValue()
+            .onEvent(new SimpleEvent<>(ApiProductEventType.UPDATE, new ApiProductChangedEvent("product-1", "env-1", null)));
+        listenerCaptor
+            .getValue()
+            .onEvent(new SimpleEvent<>(ApiProductEventType.UPDATE, new ApiProductChangedEvent("product-1", "env-1", Set.of())));
+
+        verify(apiSynchronizer, never()).resyncMemberApis(any(), any());
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/apiproduct/ApiProductSynchronizerTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/apiproduct/ApiProductSynchronizerTest.java
@@ -463,6 +463,45 @@ class ApiProductSynchronizerTest {
             assertThat(deployable.reactableApiProduct().getPlans()).isNullOrEmpty();
         }
 
+        @Test
+        void should_deserialize_product_tags_and_plan_tags_from_payload() throws InterruptedException, JsonProcessingException {
+            Event event = new Event();
+            event.setId("event-tags");
+            event.setType(DEPLOY_API_PRODUCT);
+            event.setCreatedAt(new Date());
+            event.setPayload(
+                objectMapper.writeValueAsString(
+                    Map.of(
+                        "id",
+                        "api-product-tagged",
+                        "name",
+                        "Tagged Product",
+                        "version",
+                        "1.0",
+                        "apiIds",
+                        Set.of("api-1"),
+                        "environmentId",
+                        "env-id",
+                        "tags",
+                        Set.of("internal", "partner"),
+                        "plans",
+                        List.of(Map.of("id", "plan-tagged", "name", "Tagged Plan", "status", "PUBLISHED", "tags", List.of("internal")))
+                    )
+                )
+            );
+
+            when(latestEventFetcher.fetchLatest(any(), any(), any(), any(), any())).thenReturn(Flowable.just(List.of(event)));
+            cut.synchronize(-1L, Instant.now().toEpochMilli(), Set.of()).test().await().assertComplete();
+
+            ArgumentCaptor<ApiProductReactorDeployable> captor = ArgumentCaptor.forClass(ApiProductReactorDeployable.class);
+            verify(apiProductDeployer).deploy(captor.capture());
+
+            ApiProductReactorDeployable deployable = captor.getValue();
+            assertThat(deployable.reactableApiProduct().getTags()).containsExactlyInAnyOrder("internal", "partner");
+            assertThat(deployable.reactableApiProduct().getPlans()).hasSize(1);
+            assertThat(deployable.reactableApiProduct().getPlans().get(0).getTags()).containsExactly("internal");
+        }
+
         private Event createDeployEventWithPlans(String apiProductId, List<Map<String, String>> plans) throws JsonProcessingException {
             Event event = new Event();
             event.setId("event-" + apiProductId);

--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/ApiProductV4IntegrationTest.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/ApiProductV4IntegrationTest.java
@@ -334,15 +334,15 @@ class ApiProductV4IntegrationTest {
         )
         void should_register_and_resolve_api_product_plan_security_types_for_api_key_jwt_and_mtls() {
             final String productId = "plan-state-d3-product";
-            deployApiProduct(product(productId, Set.of(API_1_ID)));
-            registerProductPlans(
-                productId,
+            ReactableApiProduct apiProduct = product(productId, Set.of(API_1_ID));
+            apiProduct.setPlans(
                 List.of(
                     productPlan("plan-state-d3-apikey", "api-key", PlanStatus.PUBLISHED),
                     productPlan("plan-state-d3-jwt", "jwt", PlanStatus.PUBLISHED),
                     productPlan("plan-state-d3-mtls", "mtls", PlanStatus.PUBLISHED)
                 )
             );
+            deployApiProduct(apiProduct);
 
             ApiProductRegistry apiProductRegistry = getBean(ApiProductRegistry.class);
             List<ApiProductRegistry.ApiProductPlanEntry> entries = apiProductRegistry.getApiProductPlanEntriesForApi(API_1_ID, ENV_ID);

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/ApiProduct.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/ApiProduct.java
@@ -42,6 +42,7 @@ public class ApiProduct {
     private String version;
     private List<String> apiIds;
     private Set<String> groups;
+    private Set<String> tags;
     private Date createdAt;
     private Date updatedAt;
     private boolean disableMembershipNotifications;

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcApiProductRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcApiProductRepository.java
@@ -41,11 +41,13 @@ public class JdbcApiProductRepository extends JdbcAbstractCrudRepository<ApiProd
 
     private final String API_PRODUCT_APIS;
     private final String API_PRODUCT_GROUPS;
+    private final String API_PRODUCT_TAGS;
 
     JdbcApiProductRepository(@Value("${management.jdbc.prefix:}") String tablePrefix) {
         super(tablePrefix, "api_products");
         API_PRODUCT_APIS = getTableNameFor("api_product_apis");
         API_PRODUCT_GROUPS = getTableNameFor("api_product_groups");
+        API_PRODUCT_TAGS = getTableNameFor("api_product_tags");
     }
 
     @Override
@@ -74,6 +76,7 @@ public class JdbcApiProductRepository extends JdbcAbstractCrudRepository<ApiProd
             jdbcTemplate.update(getOrm().buildInsertPreparedStatementCreator(apiProduct));
             storeApiIds(apiProduct, false);
             storeGroupIds(apiProduct, false);
+            storeTags(apiProduct, false);
             return findById(apiProduct.getId()).orElse(null);
         } catch (final Exception ex) {
             throw new TechnicalException("Failed to create api product", ex);
@@ -87,6 +90,7 @@ public class JdbcApiProductRepository extends JdbcAbstractCrudRepository<ApiProd
             jdbcTemplate.update(getOrm().buildUpdatePreparedStatementCreator(apiProduct, apiProduct.getId()));
             storeApiIds(apiProduct, true);
             storeGroupIds(apiProduct, true);
+            storeTags(apiProduct, true);
             return findById(apiProduct.getId()).orElseThrow(() ->
                 new IllegalStateException(String.format("No api product found with id [%s]", apiProduct.getId()))
             );
@@ -114,6 +118,8 @@ public class JdbcApiProductRepository extends JdbcAbstractCrudRepository<ApiProd
                 id
             );
             apiProduct.setGroups(groupIds.isEmpty() ? null : new HashSet<>(groupIds));
+            List<String> tags = getTags(id);
+            apiProduct.setTags(tags.isEmpty() ? null : new HashSet<>(tags));
             return Optional.of(apiProduct);
         }
         return opt;
@@ -138,6 +144,7 @@ public class JdbcApiProductRepository extends JdbcAbstractCrudRepository<ApiProd
             );
             List<ApiProduct> aggregated = aggregateApiProducts(apiProducts);
             enrichWithGroupIds(aggregated);
+            enrichWithTags(aggregated);
             return new HashSet<>(aggregated);
         } catch (final Exception ex) {
             throw new TechnicalException("Failed to find all api products", ex);
@@ -165,6 +172,7 @@ public class JdbcApiProductRepository extends JdbcAbstractCrudRepository<ApiProd
             );
             List<ApiProduct> aggregated = aggregateApiProducts(apiProducts);
             enrichWithGroupIds(aggregated);
+            enrichWithTags(aggregated);
             return aggregated.isEmpty() ? Optional.empty() : Optional.of(aggregated.get(0));
         } catch (final Exception ex) {
             throw new TechnicalException("Failed to find api product by environment and name", ex);
@@ -192,6 +200,7 @@ public class JdbcApiProductRepository extends JdbcAbstractCrudRepository<ApiProd
             );
             List<ApiProduct> aggregatedByEnv = aggregateApiProducts(apiProducts);
             enrichWithGroupIds(aggregatedByEnv);
+            enrichWithTags(aggregatedByEnv);
             return new HashSet<>(aggregatedByEnv);
         } catch (final Exception ex) {
             throw new TechnicalException("Failed to find api products by environment", ex);
@@ -204,6 +213,7 @@ public class JdbcApiProductRepository extends JdbcAbstractCrudRepository<ApiProd
         try {
             jdbcTemplate.update("DELETE FROM " + API_PRODUCT_APIS + " WHERE api_product_id = ?", id);
             jdbcTemplate.update("DELETE FROM " + API_PRODUCT_GROUPS + " WHERE api_product_id = ?", id);
+            jdbcTemplate.update("DELETE FROM " + API_PRODUCT_TAGS + " WHERE api_product_id = ?", id);
             jdbcTemplate.update(getOrm().getDeleteSql(), id);
         } catch (final Exception ex) {
             throw new TechnicalException("Failed to delete api product", ex);
@@ -242,6 +252,7 @@ public class JdbcApiProductRepository extends JdbcAbstractCrudRepository<ApiProd
             );
             List<ApiProduct> aggregated = needApiJoin ? aggregateApiProducts(apiProducts) : apiProducts;
             enrichWithGroupIds(aggregated);
+            enrichWithTags(aggregated);
             return aggregated;
         } catch (final Exception ex) {
             throw new TechnicalException("Failed to search api products", ex);
@@ -271,6 +282,7 @@ public class JdbcApiProductRepository extends JdbcAbstractCrudRepository<ApiProd
             );
             List<ApiProduct> aggregatedByApiId = aggregateApiProducts(apiProducts);
             enrichWithGroupIds(aggregatedByApiId);
+            enrichWithTags(aggregatedByApiId);
             return new HashSet<>(aggregatedByApiId);
         } catch (final Exception ex) {
             throw new TechnicalException("Failed to find api products by apiId", ex);
@@ -317,6 +329,7 @@ public class JdbcApiProductRepository extends JdbcAbstractCrudRepository<ApiProd
             );
             List<ApiProduct> aggregatedByApiIds = aggregateApiProducts(apiProducts);
             enrichWithGroupIds(aggregatedByApiIds);
+            enrichWithTags(aggregatedByApiIds);
             return new HashSet<>(aggregatedByApiIds);
         } catch (final Exception ex) {
             throw new TechnicalException("Failed to find api products by api ids", ex);
@@ -351,6 +364,7 @@ public class JdbcApiProductRepository extends JdbcAbstractCrudRepository<ApiProd
             );
             List<ApiProduct> aggregatedByIds = aggregateApiProducts(apiProducts);
             enrichWithGroupIds(aggregatedByIds);
+            enrichWithTags(aggregatedByIds);
             return new HashSet<>(aggregatedByIds);
         } catch (final Exception ex) {
             throw new TechnicalException("Failed to find api products by ids", ex);
@@ -512,6 +526,50 @@ public class JdbcApiProductRepository extends JdbcAbstractCrudRepository<ApiProd
                 }
             );
         }
+    }
+
+    private List<String> getTags(String apiProductId) {
+        return jdbcTemplate.query(
+            "SELECT tag FROM " + API_PRODUCT_TAGS + " WHERE api_product_id = ?",
+            (ResultSet rs, int rowNum) -> rs.getString("tag"),
+            apiProductId
+        );
+    }
+
+    private void storeTags(ApiProduct apiProduct, boolean deleteFirst) throws TechnicalException {
+        try {
+            if (deleteFirst) {
+                jdbcTemplate.update("DELETE FROM " + API_PRODUCT_TAGS + " WHERE api_product_id = ?", apiProduct.getId());
+            }
+            List<String> filteredTags = getOrm().filterStrings(apiProduct.getTags());
+            if (!filteredTags.isEmpty()) {
+                jdbcTemplate.batchUpdate(
+                    "INSERT INTO " + API_PRODUCT_TAGS + " ( api_product_id, tag ) VALUES ( ?, ? )",
+                    getOrm().getBatchStringSetter(apiProduct.getId(), filteredTags)
+                );
+            }
+        } catch (final Exception ex) {
+            throw new TechnicalException("Failed to store api product tags", ex);
+        }
+    }
+
+    private void enrichWithTags(List<ApiProduct> products) {
+        if (products == null || products.isEmpty()) {
+            return;
+        }
+        List<String> productIds = products.stream().map(ApiProduct::getId).toList();
+        Map<String, Set<String>> tagsByProductId = new HashMap<>();
+        jdbcTemplate.query(
+            "SELECT api_product_id, tag FROM " + API_PRODUCT_TAGS + " WHERE api_product_id IN (" + getOrm().buildInClause(productIds) + ")",
+            rs -> {
+                tagsByProductId.computeIfAbsent(rs.getString("api_product_id"), k -> new HashSet<>()).add(rs.getString("tag"));
+            },
+            productIds.toArray()
+        );
+        products.forEach(p -> {
+            Set<String> tags = tagsByProductId.get(p.getId());
+            p.setTags(tags == null || tags.isEmpty() ? null : tags);
+        });
     }
 
     private void enrichWithGroupIds(List<ApiProduct> products) {

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_12_0/16_add_api_product_tags_table.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_12_0/16_add_api_product_tags_table.yml
@@ -1,0 +1,28 @@
+databaseChangeLog:
+  - changeSet:
+      id: 4.12.0_11_add_api_product_tags_table
+      author: GraviteeSource Team
+      changes:
+        - createTable:
+            tableName: ${gravitee_prefix}api_product_tags
+            columns:
+              - column:
+                  name: api_product_id
+                  type: nvarchar(64)
+                  constraints:
+                    nullable: false
+                    primaryKey: true
+                    primaryKeyName: pk_${gravitee_prefix}api_product_tags
+              - column:
+                  name: tag
+                  type: nvarchar(64)
+                  constraints:
+                    nullable: false
+                    primaryKey: true
+                    primaryKeyName: pk_${gravitee_prefix}api_product_tags
+        - createIndex:
+            indexName: idx_${gravitee_prefix}api_product_tags_tag
+            tableName: ${gravitee_prefix}api_product_tags
+            columns:
+              - column:
+                  name: tag

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/master.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/master.yml
@@ -375,3 +375,5 @@ databaseChangeLog:
         - file: liquibase/changelogs/v4_12_0/14_add_portal_listings_table.yml
     - include:
         - file: liquibase/changelogs/v4_12_0/15_add_environment_id_to_am_connections.yml
+    - include:
+        - file: liquibase/changelogs/v4_12_0/16_add_api_product_tags_table.yml

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/test/java/io/gravitee/repository/jdbc/JdbcTestRepositoryInitializer.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/test/java/io/gravitee/repository/jdbc/JdbcTestRepositoryInitializer.java
@@ -53,6 +53,7 @@ public class JdbcTestRepositoryInitializer implements TestRepositoryInitializer 
         "api_tags",
         "api_categories",
         "api_product_apis",
+        "api_product_tags",
         "api_products",
         "applications",
         "application_groups",

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/model/ApiProductMongo.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/model/ApiProductMongo.java
@@ -18,6 +18,7 @@ package io.gravitee.repository.mongodb.management.internal.model;
 import io.gravitee.repository.management.model.ApiProduct;
 import java.util.Date;
 import java.util.List;
+import java.util.Set;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
@@ -47,6 +48,7 @@ public class ApiProductMongo {
     private String version;
     private List<String> apiIds;
     private List<String> groups;
+    private Set<String> tags;
     private Date createdAt;
     private Date updatedAt;
     private boolean disableMembershipNotifications;

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/ApiProductRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/ApiProductRepositoryTest.java
@@ -88,7 +88,28 @@ public class ApiProductRepositoryTest extends AbstractManagementRepositoryTest {
             softly.assertThat(found.getCreatedAt().getTime()).isEqualTo(1_470_157_767_000L);
             softly.assertThat(found.getUpdatedAt()).isNotNull();
             softly.assertThat(found.getUpdatedAt().getTime()).isEqualTo(1_470_157_767_000L);
+            softly.assertThat(found.getTags()).isNull();
         });
+    }
+
+    @Test
+    public void shouldReturnConsistentTagsBetweenFindByIdAndFindByEnvironmentId() throws TechnicalException {
+        var date = new Date();
+        var uuid = UUID.random().toString();
+        ApiProduct apiProduct = createApiProduct(uuid, date, "my-env", "tagged-api-product", "1.0.0", List.of("api1"));
+        apiProduct.setTags(Set.of("internal", "external"));
+        apiProductsRepository.create(apiProduct);
+
+        ApiProduct byId = apiProductsRepository.findById(uuid).orElseThrow();
+        ApiProduct byEnvironment = apiProductsRepository
+            .findByEnvironmentId("my-env")
+            .stream()
+            .filter(p -> uuid.equals(p.getId()))
+            .findFirst()
+            .orElseThrow();
+
+        assertThat(byId.getTags()).containsExactlyInAnyOrder("internal", "external");
+        assertThat(byEnvironment.getTags()).isEqualTo(byId.getTags());
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/ApiProductPlanMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/ApiProductPlanMapper.java
@@ -26,14 +26,11 @@ import io.gravitee.rest.api.management.v2.rest.model.UpdateGenericApiProductPlan
 import io.gravitee.rest.api.model.v4.plan.GenericPlanEntity;
 import io.gravitee.rest.api.model.v4.plan.PlanEntity;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
-import org.mapstruct.AfterMapping;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
-import org.mapstruct.MappingTarget;
 import org.mapstruct.Named;
 import org.mapstruct.NullValueMappingStrategy;
 import org.mapstruct.factory.Mappers;
@@ -105,16 +102,4 @@ public interface ApiProductPlanMapper {
 
     @Mapping(target = "securityConfiguration", source = "security.configuration", qualifiedByName = "serializeConfiguration")
     PlanUpdates mapToPlanUpdates(UpdateGenericApiProductPlan updatePlanV4);
-
-    /**
-     * API Products don't send tags in update requests. Set tags to empty set so PlanUpdates.applyTo()
-     * receives non-null and sets result to empty (matching DB), avoiding false deploy banner on cosmetic changes.
-     */
-    @AfterMapping
-    @SuppressWarnings("unused")
-    default void setEmptyTagsForApiProductUpdate(UpdateGenericApiProductPlan source, @MappingTarget PlanUpdates target) {
-        if (target.getTags() == null) {
-            target.setTags(Collections.emptySet());
-        }
-    }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api_product/ApiProductResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api_product/ApiProductResource.java
@@ -30,6 +30,7 @@ import io.gravitee.rest.api.model.permissions.RolePermissionAction;
 import io.gravitee.rest.api.rest.annotation.Permission;
 import io.gravitee.rest.api.rest.annotation.Permissions;
 import io.gravitee.rest.api.service.common.GraviteeContext;
+import io.gravitee.rest.api.service.v4.validation.TagsValidationService;
 import jakarta.inject.Inject;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
@@ -45,6 +46,7 @@ import jakarta.ws.rs.container.ResourceContext;
 import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
+import java.util.Set;
 import lombok.CustomLog;
 
 @CustomLog
@@ -70,6 +72,9 @@ public class ApiProductResource extends AbstractResource {
 
     @Inject
     private VerifyApiProductDeployUseCase verifyApiProductDeployUseCase;
+
+    @Inject
+    private TagsValidationService tagsValidationService;
 
     @Context
     private ResourceContext resourceContext;
@@ -130,6 +135,18 @@ public class ApiProductResource extends AbstractResource {
     @Produces(MediaType.APPLICATION_JSON)
     @Permissions({ @Permission(value = RolePermission.API_PRODUCT_DEFINITION, acls = { RolePermissionAction.UPDATE }) })
     public Response updateApiProductById(@Valid @NotNull UpdateApiProduct updateApiProduct) {
+        if (updateApiProduct.getTags() != null) {
+            var executionContext = GraviteeContext.getExecutionContext();
+            var existingInput = GetApiProductsUseCase.Input.of(
+                executionContext.getEnvironmentId(),
+                apiProductId,
+                executionContext.getOrganizationId()
+            );
+            var existing = getApiProductByIdUseCase.execute(existingInput).apiProduct().orElse(null);
+            Set<String> oldTags = existing != null ? existing.getTags() : null;
+            tagsValidationService.validateAndSanitize(executionContext, oldTags, updateApiProduct.getTags());
+        }
+
         AuditInfo audit = getAuditInfo();
         var input = new UpdateApiProductUseCase.Input(apiProductId, updateApiProduct, audit);
         log.debug("Update API Product by id: {}", apiProductId);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api_product/ApiProductsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api_product/ApiProductsResource.java
@@ -39,6 +39,7 @@ import io.gravitee.rest.api.rest.annotation.Permission;
 import io.gravitee.rest.api.rest.annotation.Permissions;
 import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.notification.ApiProductHook;
+import io.gravitee.rest.api.service.v4.validation.TagsValidationService;
 import jakarta.inject.Inject;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
@@ -77,6 +78,9 @@ public class ApiProductsResource extends AbstractResource {
 
     @Inject
     private SearchApiProductsUseCase searchApiProductsUseCase;
+
+    @Inject
+    private TagsValidationService tagsValidationService;
 
     @Path("{apiProductId}")
     public ApiProductResource getApiProductResource() {
@@ -119,6 +123,11 @@ public class ApiProductsResource extends AbstractResource {
     @Produces(MediaType.APPLICATION_JSON)
     @Permissions({ @Permission(value = RolePermission.ENVIRONMENT_API_PRODUCT, acls = { RolePermissionAction.CREATE }) })
     public Response createApiProduct(@Valid @NotNull final CreateApiProduct createApiProduct) throws TechnicalException {
+        if (createApiProduct.getTags() != null && !createApiProduct.getTags().isEmpty()) {
+            var executionContext = GraviteeContext.getExecutionContext();
+            tagsValidationService.validateAndSanitize(executionContext, null, createApiProduct.getTags());
+        }
+
         AuditInfo audit = getAuditInfo();
         var input = new CreateApiProductUseCase.Input(createApiProduct, audit);
         log.debug("Creating API Product [{}]", createApiProduct.getName());

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-api-products.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-api-products.yaml
@@ -2039,6 +2039,14 @@ components:
           example:
             - "api-1"
             - "api-2"
+        tags:
+          type: array
+          description: The list of sharding tags associated with this API Product.
+          items:
+            type: string
+          example:
+            - "eu"
+            - "secured-edge"
       required:
         - name
         - version
@@ -2087,6 +2095,14 @@ components:
           type: boolean
           description: Disable membership notifications.
           default: false
+        tags:
+          type: array
+          description: The list of sharding tags associated with this API Product.
+          items:
+            type: string
+          example:
+            - "eu"
+            - "secured-edge"
       required:
         - name
         - version
@@ -2149,6 +2165,14 @@ components:
           type: boolean
           description: Disable membership notifications.
           default: false
+        tags:
+          type: array
+          description: The list of sharding tags associated with this API Product.
+          items:
+            type: string
+          example:
+            - "eu"
+            - "secured-edge"
 
     ApiProductDeploymentState:
       type: string
@@ -2532,6 +2556,13 @@ components:
         selectionRule:
           type: string
           description: An optional EL expression that will be evaluated at request time to select this plan.
+        tags:
+          type: array
+          description: The list of sharding tags associated with this plan.
+          items:
+            type: string
+          example:
+            - "eu"
         security:
           type: object
           properties:

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/mapper/ApiProductPlanMapperTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/mapper/ApiProductPlanMapperTest.java
@@ -26,9 +26,7 @@ class ApiProductPlanMapperTest {
     private final ApiProductPlanMapper apiProductPlanMapper = ApiProductPlanMapper.INSTANCE;
 
     @Test
-    void mapToPlanUpdates_should_set_empty_tags_when_source_has_null_tags() {
-        // API Products don't send tags in update requests - tags are null after mapping.
-        // @AfterMapping sets tags to empty set so PlanUpdates.applyTo() matches DB and deploy banner is correct.
+    void mapToPlanUpdates_should_leave_tags_empty_when_source_has_null_tags() {
         var updatePlan = new UpdateGenericApiProductPlan();
         updatePlan.setName("Updated Plan");
         updatePlan.setDescription("Updated description");
@@ -36,9 +34,18 @@ class ApiProductPlanMapperTest {
         PlanUpdates result = apiProductPlanMapper.mapToPlanUpdates(updatePlan);
 
         assertThat(result).isNotNull();
-        assertThat(result.getTags()).isNotNull();
         assertThat(result.getTags()).isEmpty();
         assertThat(result.getName()).isEqualTo("Updated Plan");
         assertThat(result.getDescription()).isEqualTo("Updated description");
+    }
+
+    @Test
+    void mapToPlanUpdates_should_map_tags_when_provided() {
+        var updatePlan = new UpdateGenericApiProductPlan();
+        updatePlan.setTags(java.util.List.of("eu", "secured-edge"));
+
+        PlanUpdates result = apiProductPlanMapper.mapToPlanUpdates(updatePlan);
+
+        assertThat(result.getTags()).containsExactlyInAnyOrder("eu", "secured-edge");
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api_product/ApiProductResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api_product/ApiProductResourceTest.java
@@ -48,10 +48,13 @@ import io.gravitee.rest.api.model.permissions.RolePermission;
 import io.gravitee.rest.api.model.permissions.RolePermissionAction;
 import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.exceptions.InvalidDataException;
+import io.gravitee.rest.api.service.exceptions.TagNotAllowedException;
+import io.gravitee.rest.api.service.v4.validation.TagsValidationService;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.core.Response;
 import java.time.ZonedDateTime;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -84,6 +87,9 @@ class ApiProductResourceTest extends AbstractResourceTest {
 
     @Inject
     private VerifyApiProductDeployUseCase verifyApiProductDeployUseCase;
+
+    @Inject
+    private TagsValidationService tagsValidationService;
 
     @Inject
     private LicenseManager licenseManager;
@@ -119,7 +125,8 @@ class ApiProductResourceTest extends AbstractResourceTest {
             deployApiProductUseCase,
             updateApiProductUseCase,
             verifyApiProductExistsUseCase,
-            verifyApiProductDeployUseCase
+            verifyApiProductDeployUseCase,
+            tagsValidationService
         );
         when(licenseManager.getOrganizationLicenseOrPlatform(any())).thenReturn(LicenseFixtures.anEnterpriseLicense());
     }
@@ -221,6 +228,19 @@ class ApiProductResourceTest extends AbstractResourceTest {
     @Nested
     class UpdateApiProductTest {
 
+        @BeforeEach
+        void initUpdateApiProductTests() {
+            // OpenAPI UpdateApiProduct serializes tags as [] by default; the resource loads the existing
+            // product for tag validation whenever tags are present in the request body.
+            when(getApiProductByIdUseCase.execute(any())).thenReturn(
+                GetApiProductsUseCase.Output.single(
+                    Optional.of(
+                        ApiProduct.builder().id(API_PRODUCT_ID).environmentId(ENV_ID).name("Existing Product").tags(Set.of()).build()
+                    )
+                )
+            );
+        }
+
         @Test
         void should_update_api_product() {
             ApiProduct updatedApiProduct = ApiProduct.builder()
@@ -316,6 +336,26 @@ class ApiProductResourceTest extends AbstractResourceTest {
             shouldReturn403(RolePermission.API_PRODUCT_DEFINITION, API_PRODUCT_ID, RolePermissionAction.UPDATE, () ->
                 rootTarget().request().put(json(""))
             );
+        }
+
+        @Test
+        void should_return_400_when_user_not_allowed_to_use_restricted_tag() {
+            when(getApiProductByIdUseCase.execute(any())).thenReturn(
+                GetApiProductsUseCase.Output.single(
+                    Optional.of(ApiProduct.builder().id(API_PRODUCT_ID).environmentId(ENV_ID).tags(Set.of()).build())
+                )
+            );
+            when(tagsValidationService.validateAndSanitize(any(), any(), any())).thenThrow(
+                new TagNotAllowedException(new String[] { "restricted-tag" })
+            );
+
+            var updatePayload = new io.gravitee.rest.api.management.v2.rest.model.UpdateApiProduct();
+            updatePayload.setName("Updated Product");
+            updatePayload.setTags(List.of("restricted-tag"));
+
+            try (Response response = rootTarget().request().put(json(updatePayload))) {
+                assertThat(response.getStatus()).isEqualTo(BAD_REQUEST_400);
+            }
         }
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api_product/ApiProductsResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api_product/ApiProductsResourceTest.java
@@ -47,7 +47,9 @@ import io.gravitee.rest.api.model.EnvironmentEntity;
 import io.gravitee.rest.api.model.permissions.RolePermission;
 import io.gravitee.rest.api.model.permissions.RolePermissionAction;
 import io.gravitee.rest.api.service.common.GraviteeContext;
+import io.gravitee.rest.api.service.exceptions.TagNotAllowedException;
 import io.gravitee.rest.api.service.notification.ApiProductHook;
+import io.gravitee.rest.api.service.v4.validation.TagsValidationService;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.core.GenericType;
 import jakarta.ws.rs.core.Response;
@@ -78,6 +80,9 @@ class ApiProductsResourceTest extends AbstractResourceTest {
     private SearchApiProductsUseCase searchApiProductsUseCase;
 
     @Inject
+    private TagsValidationService tagsValidationService;
+
+    @Inject
     private LicenseManager licenseManager;
 
     @Override
@@ -105,7 +110,7 @@ class ApiProductsResourceTest extends AbstractResourceTest {
     public void tearDown() {
         super.tearDown();
         GraviteeContext.cleanContext();
-        reset(createApiProductUseCase, getApiProductsUseCase, verifyApiProductNameUseCase, searchApiProductsUseCase);
+        reset(createApiProductUseCase, getApiProductsUseCase, verifyApiProductNameUseCase, searchApiProductsUseCase, tagsValidationService);
     }
 
     @Nested
@@ -262,6 +267,22 @@ class ApiProductsResourceTest extends AbstractResourceTest {
             shouldReturn403(RolePermission.ENVIRONMENT_API_PRODUCT, ENV_ID, RolePermissionAction.CREATE, () ->
                 rootTarget().request().post(json(new CreateApiProduct()))
             );
+        }
+
+        @Test
+        void should_return_400_when_user_not_allowed_to_use_restricted_tag() {
+            when(tagsValidationService.validateAndSanitize(any(), any(), any())).thenThrow(
+                new TagNotAllowedException(new String[] { "restricted-tag" })
+            );
+
+            CreateApiProduct createApiProduct = new CreateApiProduct();
+            createApiProduct.setName("My API Product");
+            createApiProduct.setVersion("1.0.0");
+            createApiProduct.setTags(List.of("restricted-tag"));
+
+            final Response response = rootTarget().request().post(json(createApiProduct));
+
+            assertThat(response.getStatus()).isEqualTo(BAD_REQUEST_400);
         }
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/spring/ResourceContextConfiguration.java
@@ -1684,4 +1684,9 @@ public class ResourceContextConfiguration {
     public ValidatePortalListingDomainService validatePortalListingDomainService() {
         return new ValidatePortalListingDomainService();
     }
+
+    @Bean
+    public io.gravitee.rest.api.service.v4.validation.TagsValidationService tagsValidationService() {
+        return mock(io.gravitee.rest.api.service.v4.validation.TagsValidationService.class);
+    }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/domain_service/ApiProductTagDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/domain_service/ApiProductTagDomainService.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.api_product.domain_service;
+
+import io.gravitee.apim.core.DomainService;
+import io.gravitee.apim.core.api_product.crud_service.ApiProductCrudService;
+import io.gravitee.apim.core.api_product.model.ApiProduct;
+import io.gravitee.apim.core.api_product.query_service.ApiProductQueryService;
+import io.gravitee.apim.core.plan.crud_service.PlanCrudService;
+import io.gravitee.apim.core.plan.query_service.PlanQueryService;
+import io.gravitee.rest.api.model.v4.plan.GenericPlanEntity;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+import lombok.CustomLog;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * Handles tag lifecycle operations for API Products and their plans.
+ */
+@DomainService
+@RequiredArgsConstructor
+@CustomLog
+public class ApiProductTagDomainService {
+
+    private final ApiProductQueryService apiProductQueryService;
+    private final ApiProductCrudService apiProductCrudService;
+    private final PlanQueryService planQueryService;
+    private final PlanCrudService planCrudService;
+
+    /**
+     * Remove a deleted tag key from all API Products and their plans in the given environment.
+     * Called when an organization-level tag is deleted.
+     */
+    public void deleteTagFromApiProducts(String environmentId, String tagKey) {
+        Set<ApiProduct> products = apiProductQueryService.findByEnvironmentId(environmentId);
+
+        for (ApiProduct product : products) {
+            boolean productHasTag = product.getTags() != null && product.getTags().contains(tagKey);
+            if (productHasTag) {
+                removeTagFromProduct(product, tagKey);
+                apiProductCrudService.update(product);
+                removeTagFromProductPlans(product.getId(), tagKey);
+            }
+        }
+    }
+
+    private void removeTagFromProduct(ApiProduct product, String tagKey) {
+        Set<String> updatedTags = new HashSet<>(product.getTags());
+        updatedTags.remove(tagKey);
+        log.info("Removing deleted tag [{}] from API Product [{}]", tagKey, product.getId());
+        product.setTags(updatedTags.isEmpty() ? null : updatedTags);
+    }
+
+    private void removeTagFromProductPlans(String productId, String tagKey) {
+        var plans = planQueryService.findAllByReferenceIdAndReferenceType(productId, GenericPlanEntity.ReferenceType.API_PRODUCT);
+
+        for (var plan : plans) {
+            var planDef = plan.getPlanDefinitionHttpV4();
+            if (planDef == null || planDef.getTags() == null || !planDef.getTags().contains(tagKey)) {
+                continue;
+            }
+            Set<String> updatedTags = planDef
+                .getTags()
+                .stream()
+                .filter(t -> !t.equals(tagKey))
+                .collect(Collectors.toSet());
+            log.info("Removing deleted tag [{}] from plan [{}] of API Product [{}]", tagKey, plan.getId(), productId);
+            planDef.setTags(updatedTags.isEmpty() ? null : updatedTags);
+            planCrudService.update(plan);
+        }
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/domain_service/DeployApiProductDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/domain_service/DeployApiProductDomainService.java
@@ -55,6 +55,7 @@ public class DeployApiProductDomainService {
             .version(apiProduct.getVersion())
             .apiIds(apiProduct.getApiIds())
             .environmentId(apiProduct.getEnvironmentId())
+            .tags(apiProduct.getTags())
             .plans(plans)
             .build();
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/model/ApiProduct.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/model/ApiProduct.java
@@ -43,6 +43,7 @@ public class ApiProduct {
     private String version;
     private Set<String> apiIds;
     private Set<String> groups;
+    private Set<String> tags;
     private ZonedDateTime createdAt;
     private ZonedDateTime updatedAt;
     private PrimaryOwnerEntity primaryOwner;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/model/ApiProductDeploymentPayload.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/model/ApiProductDeploymentPayload.java
@@ -36,5 +36,6 @@ public class ApiProductDeploymentPayload {
     private String version;
     private Set<String> apiIds;
     private String environmentId;
+    private Set<String> tags;
     private List<Plan> plans;
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/model/UpdateApiProduct.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/model/UpdateApiProduct.java
@@ -34,6 +34,7 @@ public class UpdateApiProduct {
     private String version;
     private Set<String> apiIds;
     private Set<String> groups;
+    private Set<String> tags;
     private ZonedDateTime updatedAt;
     private Boolean disableMembershipNotifications;
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/use_case/CreateApiProductUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/use_case/CreateApiProductUseCase.java
@@ -92,6 +92,7 @@ public class CreateApiProductUseCase {
             .description(payload.getDescription())
             .version(payload.getVersion())
             .apiIds(apiIds)
+            .tags(payload.getTags() != null ? Set.copyOf(payload.getTags()) : null)
             .createdAt(now)
             .updatedAt(now)
             .build();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/use_case/GetApiProductsUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/use_case/GetApiProductsUseCase.java
@@ -128,7 +128,12 @@ public class GetApiProductsUseCase {
                 return product;
             }
 
-            if (!apiIdsUnchanged(product.getApiIds(), deployedProduct.getApiIds())) {
+            if (!setsEqual(product.getApiIds(), deployedProduct.getApiIds())) {
+                product.setDeploymentState(ApiProduct.DeploymentState.NEED_REDEPLOY);
+                return product;
+            }
+
+            if (!setsEqual(product.getTags(), deployedProduct.getTags())) {
                 product.setDeploymentState(ApiProduct.DeploymentState.NEED_REDEPLOY);
                 return product;
             }
@@ -155,10 +160,9 @@ public class GetApiProductsUseCase {
     }
 
     /**
-     * True if the list of APIs in the product is unchanged compared to the deployed version.
-     * NEED_REDEPLOY when apiIds change (user must deploy to sync gateway).
+     * True when two sets carry the same elements (e.g. apiIds or sharding tags vs last deploy payload).
      */
-    private static boolean apiIdsUnchanged(Set<String> current, Set<String> deployed) {
+    private static boolean setsEqual(Set<String> current, Set<String> deployed) {
         if (current == null && deployed == null) return true;
         if (current == null || deployed == null) return false;
         return current.size() == deployed.size() && current.containsAll(deployed);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/use_case/UpdateApiProductUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/use_case/UpdateApiProductUseCase.java
@@ -21,7 +21,6 @@ import io.gravitee.apim.core.UseCase;
 import io.gravitee.apim.core.api.domain_service.ApiStateDomainService;
 import io.gravitee.apim.core.api_product.crud_service.ApiProductCrudService;
 import io.gravitee.apim.core.api_product.domain_service.ApiProductIndexerDomainService;
-import io.gravitee.apim.core.api_product.domain_service.DeployApiProductDomainService;
 import io.gravitee.apim.core.api_product.domain_service.ValidateApiProductService;
 import io.gravitee.apim.core.api_product.exception.ApiProductNotFoundException;
 import io.gravitee.apim.core.api_product.model.ApiProduct;
@@ -32,19 +31,23 @@ import io.gravitee.apim.core.audit.model.ApiProductAuditLogEntity;
 import io.gravitee.apim.core.audit.model.AuditInfo;
 import io.gravitee.apim.core.audit.model.AuditProperties;
 import io.gravitee.apim.core.audit.model.event.ApiProductAuditEvent;
-import io.gravitee.apim.core.exception.ValidationDomainException;
 import io.gravitee.apim.core.license.domain_service.LicenseDomainService;
 import io.gravitee.apim.core.membership.domain_service.ApiProductPrimaryOwnerDomainService;
 import io.gravitee.apim.core.membership.exception.ApiProductPrimaryOwnerNotFoundException;
 import io.gravitee.apim.core.membership.model.PrimaryOwnerEntity;
 import io.gravitee.apim.core.notification.domain_service.TriggerNotificationDomainService;
 import io.gravitee.apim.core.notification.model.hook.ApiProductUpdatedHookContext;
+import io.gravitee.apim.core.plan.crud_service.PlanCrudService;
+import io.gravitee.apim.core.plan.model.Plan;
+import io.gravitee.apim.core.plan.query_service.PlanQueryService;
 import io.gravitee.common.utils.TimeProvider;
+import io.gravitee.rest.api.model.v4.plan.GenericPlanEntity;
 import io.gravitee.rest.api.service.exceptions.ForbiddenFeatureException;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 import lombok.CustomLog;
 import lombok.RequiredArgsConstructor;
 
@@ -61,8 +64,9 @@ public class UpdateApiProductUseCase {
     private final LicenseDomainService licenseDomainService;
     private final ApiProductIndexerDomainService apiProductIndexerDomainService;
     private final ApiProductPrimaryOwnerDomainService apiProductPrimaryOwnerDomainService;
-    private final DeployApiProductDomainService deployApiProductDomainService;
     private final TriggerNotificationDomainService triggerNotificationDomainService;
+    private final PlanQueryService planQueryService;
+    private final PlanCrudService planCrudService;
 
     public Output execute(Input input) {
         if (!licenseDomainService.isApiProductDeploymentAllowed(input.auditInfo().organizationId())) {
@@ -101,9 +105,15 @@ public class UpdateApiProductUseCase {
             }
         }
 
+        if (updateApiProduct.getTags() != null) {
+            existingApiProduct.setTags(updateApiProduct.getTags().isEmpty() ? Set.of() : Set.copyOf(updateApiProduct.getTags()));
+        }
+
         existingApiProduct.update(updateApiProduct);
 
         ApiProduct updated = apiProductCrudService.update(existingApiProduct);
+
+        autoCleanOrphanedPlanTags(updated, beforeUpdate.getTags());
 
         PrimaryOwnerEntity primaryOwner = null;
         try {
@@ -116,16 +126,8 @@ public class UpdateApiProductUseCase {
         }
         apiProductIndexerDomainService.index(oneShotIndexation(input.auditInfo()), updated, primaryOwner);
 
-        try {
-            validateApiProductService.validateForDeploy(updated);
-            deployApiProductDomainService.deploy(input.auditInfo(), updated);
-        } catch (ValidationDomainException e) {
-            log.warn("API Product [{}] was updated but not deployed to the gateway. {}", updated.getId(), e.getMessage());
-        }
         createAuditLog(beforeUpdate, updated, input.auditInfo());
-        // The notification fires regardless of whether the subsequent re-deploy succeeded: the
-        // data update (name, description, API list, …) always completes before the deploy attempt,
-        // so "API Product Updated" accurately reflects that the stored record changed.
+        // Notification reflects the persisted record change; gateway deploy is explicit via DeployApiProductUseCase.
         triggerNotificationDomainService.triggerApiProductNotification(
             input.auditInfo().organizationId(),
             input.auditInfo().environmentId(),
@@ -141,6 +143,56 @@ public class UpdateApiProductUseCase {
     }
 
     public record Output(ApiProduct apiProduct) {}
+
+    /**
+     * When tags are removed from the product, strip plan tags that are no longer present
+     * in the product's tag set. Only triggers when at least one previously-existing tag
+     * was removed (i.e. the effective set shrank or shifted).
+     */
+    private void autoCleanOrphanedPlanTags(ApiProduct updatedProduct, Set<String> previousProductTags) {
+        Set<String> currentProductTags = updatedProduct.getTags();
+        if (!hasRemovedTags(previousProductTags, currentProductTags)) {
+            return;
+        }
+
+        planQueryService
+            .findAllByReferenceIdAndReferenceType(updatedProduct.getId(), GenericPlanEntity.ReferenceType.API_PRODUCT)
+            .forEach(plan -> removeOrphanedTagsFromPlan(plan, updatedProduct.getId(), currentProductTags));
+    }
+
+    private static boolean hasRemovedTags(Set<String> previousTags, Set<String> currentTags) {
+        if (previousTags == null || previousTags.isEmpty()) {
+            return false;
+        }
+        if (currentTags == null || currentTags.isEmpty()) {
+            return true;
+        }
+        return !currentTags.containsAll(previousTags);
+    }
+
+    private void removeOrphanedTagsFromPlan(Plan plan, String productId, Set<String> currentProductTags) {
+        var planDef = plan.getPlanDefinitionHttpV4();
+        if (planDef == null || planDef.getTags() == null || planDef.getTags().isEmpty()) {
+            return;
+        }
+
+        Set<String> cleanedTags = (currentProductTags == null || currentProductTags.isEmpty())
+            ? Set.of()
+            : planDef.getTags().stream().filter(currentProductTags::contains).collect(Collectors.toSet());
+        if (cleanedTags.size() >= planDef.getTags().size()) {
+            return;
+        }
+
+        log.info(
+            "Auto-cleaning orphaned tags from plan [{}] of API Product [{}]: {} -> {}",
+            plan.getId(),
+            productId,
+            planDef.getTags(),
+            cleanedTags
+        );
+        planDef.setTags(cleanedTags.isEmpty() ? null : cleanedTags);
+        planCrudService.update(plan);
+    }
 
     private void createAuditLog(ApiProduct before, ApiProduct after, AuditInfo auditInfo) {
         auditService.createApiProductAuditLog(

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/plan/domain_service/CreatePlanDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/plan/domain_service/CreatePlanDomainService.java
@@ -212,6 +212,7 @@ public class CreatePlanDomainService {
         }*/
 
         planValidatorDomainService.validatePlanSecurity(plan, auditInfo.organizationId(), auditInfo.environmentId(), null);
+        planValidatorDomainService.validatePlanTagsAgainstApiProductTags(plan.getTags(), apiProduct.getTags());
         planValidatorDomainService.validateGeneralConditionsPageStatus(plan);
         var createdPlan = planCrudService.create(
             plan

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/plan/domain_service/PlanValidatorDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/plan/domain_service/PlanValidatorDomainService.java
@@ -86,9 +86,24 @@ public class PlanValidatorDomainService {
 
             throw new ValidationDomainException(
                 "Plan tags mismatch the tags defined by the API",
-                Map.of("planTags", String.join(",", planTags), "apiTags", String.join(",", apiTags))
+                Map.of("planTags", joinTags(planTags), "apiTags", joinTags(apiTags))
             );
         }
+    }
+
+    public void validatePlanTagsAgainstApiProductTags(Set<String> planTags, Set<String> apiProductTags) {
+        if (!isEmpty(planTags) && (isEmpty(apiProductTags) || planTags.stream().anyMatch(tag -> !apiProductTags.contains(tag)))) {
+            log.debug("Plan rejected, tags {} mismatch the tags defined by the API Product ({})", planTags, apiProductTags);
+
+            throw new ValidationDomainException(
+                "Plan tags mismatch the tags defined by the API Product",
+                Map.of("planTags", joinTags(planTags), "apiProductTags", joinTags(apiProductTags))
+            );
+        }
+    }
+
+    private static String joinTags(Set<String> tags) {
+        return isEmpty(tags) ? "" : String.join(",", tags);
     }
 
     public void validateGeneralConditionsPage(Plan plan, List<Page> pages) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/plan/domain_service/UpdatePlanDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/plan/domain_service/UpdatePlanDomainService.java
@@ -348,7 +348,7 @@ public class UpdatePlanDomainService {
         if (existingPlanStatuses == null) {
             existingPlanStatuses = getPlanStatusMapForApiProduct(apiProduct);
         }
-        updatePreFlightChecksForApiProduct(planToUpdate, existingPlanStatuses, auditInfo);
+        updatePreFlightChecksForApiProduct(planToUpdate, existingPlanStatuses, apiProduct, auditInfo);
 
         Plan existingPlan = planCrudService.getById(planToUpdate.getId());
         Plan updatePlan = existingPlan.update(planToUpdate);
@@ -364,9 +364,15 @@ public class UpdatePlanDomainService {
         return updated;
     }
 
-    private void updatePreFlightChecksForApiProduct(Plan planToUpdate, Map<String, PlanStatus> existingPlanStatuses, AuditInfo auditInfo) {
+    private void updatePreFlightChecksForApiProduct(
+        Plan planToUpdate,
+        Map<String, PlanStatus> existingPlanStatuses,
+        ApiProduct apiProduct,
+        AuditInfo auditInfo
+    ) {
         assertNotClosedStatus(planToUpdate, existingPlanStatuses);
         planValidatorDomainService.validatePlanSecurity(planToUpdate, auditInfo.organizationId(), auditInfo.environmentId(), null);
+        planValidatorDomainService.validatePlanTagsAgainstApiProductTags(planToUpdate.getTags(), apiProduct.getTags());
         planValidatorDomainService.validateGeneralConditionsPageStatus(planToUpdate);
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/plan/model/PlanUpdates.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/plan/model/PlanUpdates.java
@@ -69,7 +69,9 @@ public class PlanUpdates {
             .referenceType(oldPlan.getReferenceType())
             .build();
 
-        result.setPlanTags(tags);
+        if (tags != null) {
+            result.setPlanTags(tags);
+        }
         var definition = result.getPlanDefinitionV4();
         definition.setSelectionRule(selectionRule);
         if (definition.getSecurity() != null) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/TagServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/TagServiceImpl.java
@@ -22,6 +22,7 @@ import static io.gravitee.repository.management.model.Tag.AuditEvent.TAG_UPDATED
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toSet;
 
+import io.gravitee.apim.core.api_product.domain_service.ApiProductTagDomainService;
 import io.gravitee.common.utils.IdGenerator;
 import io.gravitee.common.utils.UUID;
 import io.gravitee.repository.exceptions.TechnicalException;
@@ -33,6 +34,7 @@ import io.gravitee.rest.api.model.TagEntity;
 import io.gravitee.rest.api.model.TagReferenceType;
 import io.gravitee.rest.api.model.UpdateTagEntity;
 import io.gravitee.rest.api.service.AuditService;
+import io.gravitee.rest.api.service.EnvironmentService;
 import io.gravitee.rest.api.service.GroupService;
 import io.gravitee.rest.api.service.TagService;
 import io.gravitee.rest.api.service.common.ExecutionContext;
@@ -71,6 +73,12 @@ public class TagServiceImpl extends AbstractService implements TagService {
 
     @Autowired
     private GroupService groupService;
+
+    @Autowired
+    private EnvironmentService environmentService;
+
+    @Autowired
+    private ApiProductTagDomainService apiProductTagDomainService;
 
     @Override
     public List<TagEntity> findByReference(String referenceId, TagReferenceType referenceType) {
@@ -212,18 +220,24 @@ public class TagServiceImpl extends AbstractService implements TagService {
             Optional<Tag> tagOptional = tagRepository.findByKeyAndReference(key, referenceId, repoTagReferenceType(referenceType));
 
             if (tagOptional.isPresent()) {
-                String actualTagId = tagOptional.get().getId();
-                tagRepository.delete(actualTagId);
+                Tag tag = tagOptional.get();
+                String tagId = tag.getId();
+                String tagKey = tag.getKey();
+                tagRepository.delete(tagId);
                 // delete all reference on APIs
-                apiTagService.deleteTagFromAPIs(executionContext, actualTagId);
+                apiTagService.deleteTagFromAPIs(executionContext, tagKey);
+                // delete all references on API Products and their plans
+                environmentService
+                    .findByOrganization(executionContext.getOrganizationId())
+                    .forEach(env -> apiProductTagDomainService.deleteTagFromApiProducts(env.getId(), tagKey));
                 auditService.createOrganizationAuditLog(
                     executionContext,
                     AuditService.AuditLogData.builder()
-                        .properties(Collections.singletonMap(TAG, actualTagId))
+                        .properties(Collections.singletonMap(TAG, tagKey))
                         .event(TAG_DELETED)
                         .createdAt(new Date())
                         .oldValue(null)
-                        .newValue(tagOptional.get())
+                        .newValue(tag)
                         .build()
                 );
             }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api_product/domain_service/ApiProductTagDomainServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api_product/domain_service/ApiProductTagDomainServiceTest.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.api_product.domain_service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import fixtures.core.model.PlanFixtures;
+import inmemory.ApiProductCrudServiceInMemory;
+import inmemory.ApiProductQueryServiceInMemory;
+import inmemory.PlanCrudServiceInMemory;
+import inmemory.PlanQueryServiceInMemory;
+import io.gravitee.apim.core.api_product.model.ApiProduct;
+import io.gravitee.apim.core.plan.model.Plan;
+import io.gravitee.definition.model.v4.plan.PlanStatus;
+import io.gravitee.rest.api.model.v4.plan.GenericPlanEntity;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class ApiProductTagDomainServiceTest {
+
+    private static final String ENV_ID = "DEFAULT";
+    private static final String PRODUCT_ID = "product-1";
+
+    private final ApiProductCrudServiceInMemory apiProductCrudService = new ApiProductCrudServiceInMemory();
+    private final ApiProductQueryServiceInMemory apiProductQueryService = new ApiProductQueryServiceInMemory();
+    private final PlanQueryServiceInMemory planQueryService = new PlanQueryServiceInMemory();
+    private final PlanCrudServiceInMemory planCrudService = new PlanCrudServiceInMemory();
+
+    private ApiProductTagDomainService apiProductTagDomainService;
+
+    @BeforeEach
+    void setUp() {
+        apiProductCrudService.reset();
+        apiProductQueryService.reset();
+        planQueryService.reset();
+        planCrudService.reset();
+        apiProductTagDomainService = new ApiProductTagDomainService(
+            apiProductQueryService,
+            apiProductCrudService,
+            planQueryService,
+            planCrudService
+        );
+    }
+
+    @Test
+    void should_remove_deleted_tag_from_product_and_its_plans() {
+        ApiProduct product = ApiProduct.builder()
+            .id(PRODUCT_ID)
+            .name("Product")
+            .environmentId(ENV_ID)
+            .tags(new HashSet<>(Set.of("internal", "external")))
+            .build();
+        apiProductCrudService.initWith(List.of(product));
+        apiProductQueryService.initWith(List.of(product));
+
+        Plan productPlan = productPlanWithTags("plan-1", Set.of("internal", "external"));
+        planQueryService.initWith(List.of(productPlan));
+        planCrudService.initWith(List.of(productPlan));
+
+        apiProductTagDomainService.deleteTagFromApiProducts(ENV_ID, "external");
+
+        assertThat(apiProductCrudService.get(PRODUCT_ID).getTags()).containsExactly("internal");
+        assertThat(planCrudService.getById("plan-1").getPlanDefinitionHttpV4().getTags()).containsExactly("internal");
+    }
+
+    @Test
+    void should_not_update_product_when_tag_is_not_present() {
+        ApiProduct product = ApiProduct.builder().id(PRODUCT_ID).name("Product").environmentId(ENV_ID).tags(Set.of("internal")).build();
+        apiProductCrudService.initWith(List.of(product));
+        apiProductQueryService.initWith(List.of(product));
+
+        apiProductTagDomainService.deleteTagFromApiProducts(ENV_ID, "external");
+
+        assertThat(apiProductCrudService.get(PRODUCT_ID).getTags()).containsExactly("internal");
+    }
+
+    @Test
+    void should_set_product_tags_to_null_when_last_tag_is_removed() {
+        ApiProduct product = ApiProduct.builder().id(PRODUCT_ID).name("Product").environmentId(ENV_ID).tags(Set.of("internal")).build();
+        apiProductCrudService.initWith(List.of(product));
+        apiProductQueryService.initWith(List.of(product));
+
+        apiProductTagDomainService.deleteTagFromApiProducts(ENV_ID, "internal");
+
+        assertThat(apiProductCrudService.get(PRODUCT_ID).getTags()).isNull();
+    }
+
+    @Test
+    void should_not_remove_tag_when_identifier_does_not_match_stored_tag_key() {
+        ApiProduct product = ApiProduct.builder().id(PRODUCT_ID).name("Product").environmentId(ENV_ID).tags(Set.of("internal")).build();
+        apiProductCrudService.initWith(List.of(product));
+        apiProductQueryService.initWith(List.of(product));
+
+        apiProductTagDomainService.deleteTagFromApiProducts(ENV_ID, "tag-uuid-not-key");
+
+        assertThat(apiProductCrudService.get(PRODUCT_ID).getTags()).containsExactly("internal");
+    }
+
+    private Plan productPlanWithTags(String planId, Set<String> tags) {
+        var planDefinition = PlanFixtures.aPlanHttpV4()
+            .getPlanDefinitionHttpV4()
+            .toBuilder()
+            .status(PlanStatus.PUBLISHED)
+            .tags(tags)
+            .build();
+        return PlanFixtures.aPlanHttpV4()
+            .toBuilder()
+            .id(planId)
+            .referenceId(PRODUCT_ID)
+            .referenceType(GenericPlanEntity.ReferenceType.API_PRODUCT)
+            .environmentId(ENV_ID)
+            .planDefinitionHttpV4(planDefinition)
+            .build();
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api_product/use_case/GetApiProductsUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api_product/use_case/GetApiProductsUseCaseTest.java
@@ -340,6 +340,30 @@ class GetApiProductsUseCaseTest extends AbstractUseCaseTest {
         }
 
         @Test
+        void should_be_need_redeploy_when_sharding_tags_changed() throws Exception {
+            ApiProduct currentProduct = ApiProduct.builder()
+                .id(API_PRODUCT_ID)
+                .name("Product")
+                .environmentId(ENV_ID)
+                .apiIds(Set.of("api-1"))
+                .tags(Set.of("tag1", "tag2"))
+                .build();
+            apiProductQueryService.initWith(List.of(currentProduct));
+            ApiProduct deployedProduct = ApiProduct.builder()
+                .id(API_PRODUCT_ID)
+                .name("Product")
+                .environmentId(ENV_ID)
+                .apiIds(Set.of("api-1"))
+                .tags(Set.of("tag1"))
+                .build();
+            eventLatestQueryService.initWith(List.of(aDeployApiProductEvent(API_PRODUCT_ID, DEPLOYED_AT, deployedProduct)));
+
+            var output = getApiProductsUseCase.execute(GetApiProductsUseCase.Input.of(ENV_ID, API_PRODUCT_ID, ORG_ID));
+
+            assertThat(output.apiProduct().get().getDeploymentState()).isEqualTo(ApiProduct.DeploymentState.NEED_REDEPLOY);
+        }
+
+        @Test
         void should_be_need_redeploy_when_list_of_apis_in_product_changed() throws Exception {
             ApiProduct currentProduct = ApiProduct.builder()
                 .id(API_PRODUCT_ID)

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api_product/use_case/UpdateApiProductUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api_product/use_case/UpdateApiProductUseCaseTest.java
@@ -35,19 +35,17 @@ import inmemory.ApiProductCrudServiceInMemory;
 import inmemory.ApiProductQueryServiceInMemory;
 import inmemory.ApiQueryServiceInMemory;
 import inmemory.LicenseCrudServiceInMemory;
+import inmemory.PlanCrudServiceInMemory;
 import inmemory.PlanQueryServiceInMemory;
 import inmemory.TriggerNotificationDomainServiceInMemory;
 import io.gravitee.apim.core.api.domain_service.ApiStateDomainService;
 import io.gravitee.apim.core.api.model.Api;
 import io.gravitee.apim.core.api_product.domain_service.ApiProductIndexerDomainService;
-import io.gravitee.apim.core.api_product.domain_service.DeployApiProductDomainService;
 import io.gravitee.apim.core.api_product.domain_service.ValidateApiProductService;
 import io.gravitee.apim.core.api_product.exception.ApiProductNotFoundException;
 import io.gravitee.apim.core.api_product.model.ApiProduct;
 import io.gravitee.apim.core.api_product.model.UpdateApiProduct;
 import io.gravitee.apim.core.audit.domain_service.AuditDomainService;
-import io.gravitee.apim.core.event.crud_service.EventCrudService;
-import io.gravitee.apim.core.event.crud_service.EventLatestCrudService;
 import io.gravitee.apim.core.exception.ValidationDomainException;
 import io.gravitee.apim.core.license.domain_service.LicenseDomainService;
 import io.gravitee.apim.core.membership.domain_service.ApiProductPrimaryOwnerDomainService;
@@ -72,8 +70,7 @@ class UpdateApiProductUseCaseTest extends AbstractUseCaseTest {
     private final ApiCrudServiceInMemory apiCrudService = new ApiCrudServiceInMemory();
     private final ApiQueryServiceInMemory apiQueryService = new ApiQueryServiceInMemory(apiCrudService);
     private final PlanQueryServiceInMemory planQueryService = new PlanQueryServiceInMemory();
-    private final EventCrudService eventCrudService = mock(EventCrudService.class);
-    private final EventLatestCrudService eventLatestCrudService = mock(EventLatestCrudService.class);
+    private final PlanCrudServiceInMemory planCrudService = new PlanCrudServiceInMemory();
     private final LicenseManager licenseManager = mock(LicenseManager.class);
     private final ApiStateDomainService apiStateDomainService = mock(ApiStateDomainService.class);
     private final ApiProductIndexerDomainService apiProductIndexerDomainService = mock(ApiProductIndexerDomainService.class);
@@ -86,6 +83,7 @@ class UpdateApiProductUseCaseTest extends AbstractUseCaseTest {
     @BeforeEach
     void setUp() {
         planQueryService.reset();
+        planCrudService.reset();
         triggerNotificationDomainService.reset();
         var auditService = new AuditDomainService(auditCrudService, userCrudService, new JacksonJsonDiffProcessor());
         var validateApiProductService = new ValidateApiProductService(
@@ -104,8 +102,9 @@ class UpdateApiProductUseCaseTest extends AbstractUseCaseTest {
             new LicenseDomainService(new LicenseCrudServiceInMemory(), licenseManager),
             apiProductIndexerDomainService,
             apiProductPrimaryOwnerDomainService,
-            new DeployApiProductDomainService(planQueryService, eventCrudService, eventLatestCrudService),
-            triggerNotificationDomainService
+            triggerNotificationDomainService,
+            planQueryService,
+            planCrudService
         );
     }
 
@@ -139,9 +138,6 @@ class UpdateApiProductUseCaseTest extends AbstractUseCaseTest {
             () -> assertThat(output.apiProduct().getApiIds()).containsExactly("api-2") // Replace, not merge
         );
 
-        // Verify DEPLOY event was published
-        verify(eventCrudService).createEvent(eq(ORG_ID), eq(ENV_ID), any(), any(), any(), any());
-        verify(eventLatestCrudService).createOrPatchLatestEvent(eq(ORG_ID), eq("api-product-id"), any());
         verify(apiProductIndexerDomainService).index(any(), eq(output.apiProduct()), any());
     }
 
@@ -525,8 +521,107 @@ class UpdateApiProductUseCaseTest extends AbstractUseCaseTest {
         var output = updateApiProductUseCase.execute(input);
 
         assertThat(output.apiProduct().getApiIds()).containsExactlyInAnyOrder("api-1", "api-2");
-        verify(eventCrudService, never()).createEvent(any(), any(), any(), any(), any(), any());
-        verify(eventLatestCrudService, never()).createOrPatchLatestEvent(any(), any(), any());
+    }
+
+    @Test
+    void should_update_api_product_tags() {
+        ApiProduct existing = ApiProduct.builder()
+            .id("api-product-id")
+            .name("API Product")
+            .version("1.0.0")
+            .tags(Set.of("internal"))
+            .environmentId(ENV_ID)
+            .build();
+        apiProductCrudService.initWith(List.of(existing));
+        apiProductQueryService.initWith(List.of(existing));
+
+        var toUpdate = UpdateApiProduct.builder().tags(Set.of("internal", "external")).build();
+        var output = updateApiProductUseCase.execute(new UpdateApiProductUseCase.Input("api-product-id", toUpdate, AUDIT_INFO));
+
+        assertThat(output.apiProduct().getTags()).containsExactlyInAnyOrder("internal", "external");
+    }
+
+    @Test
+    void should_remove_orphaned_plan_tags_when_product_tags_are_narrowed() {
+        Plan productPlan = productPlanWithTags("product-plan-1", Set.of("internal", "external"));
+        planQueryService.initWith(List.of(productPlan));
+        planCrudService.initWith(List.of(productPlan));
+
+        ApiProduct existing = ApiProduct.builder()
+            .id("api-product-id")
+            .name("API Product")
+            .version("1.0.0")
+            .tags(Set.of("internal", "external"))
+            .environmentId(ENV_ID)
+            .build();
+        apiProductCrudService.initWith(List.of(existing));
+        apiProductQueryService.initWith(List.of(existing));
+
+        var toUpdate = UpdateApiProduct.builder().tags(Set.of("internal")).build();
+        updateApiProductUseCase.execute(new UpdateApiProductUseCase.Input("api-product-id", toUpdate, AUDIT_INFO));
+
+        assertThat(planCrudService.getById("product-plan-1").getPlanDefinitionHttpV4().getTags()).containsExactly("internal");
+    }
+
+    @Test
+    void should_not_modify_plan_tags_when_product_tags_are_expanded() {
+        Plan productPlan = productPlanWithTags("product-plan-1", Set.of("internal"));
+        planQueryService.initWith(List.of(productPlan));
+        planCrudService.initWith(List.of(productPlan));
+
+        ApiProduct existing = ApiProduct.builder()
+            .id("api-product-id")
+            .name("API Product")
+            .version("1.0.0")
+            .tags(Set.of("internal"))
+            .environmentId(ENV_ID)
+            .build();
+        apiProductCrudService.initWith(List.of(existing));
+        apiProductQueryService.initWith(List.of(existing));
+
+        var toUpdate = UpdateApiProduct.builder().tags(Set.of("internal", "external")).build();
+        updateApiProductUseCase.execute(new UpdateApiProductUseCase.Input("api-product-id", toUpdate, AUDIT_INFO));
+
+        assertThat(planCrudService.getById("product-plan-1").getPlanDefinitionHttpV4().getTags()).containsExactly("internal");
+    }
+
+    @Test
+    void should_clear_all_plan_tags_when_product_tags_are_cleared() {
+        Plan productPlan = productPlanWithTags("product-plan-1", Set.of("internal", "external"));
+        planQueryService.initWith(List.of(productPlan));
+        planCrudService.initWith(List.of(productPlan));
+
+        ApiProduct existing = ApiProduct.builder()
+            .id("api-product-id")
+            .name("API Product")
+            .version("1.0.0")
+            .tags(Set.of("internal", "external"))
+            .environmentId(ENV_ID)
+            .build();
+        apiProductCrudService.initWith(List.of(existing));
+        apiProductQueryService.initWith(List.of(existing));
+
+        var toUpdate = UpdateApiProduct.builder().tags(Set.of()).build();
+        updateApiProductUseCase.execute(new UpdateApiProductUseCase.Input("api-product-id", toUpdate, AUDIT_INFO));
+
+        assertThat(planCrudService.getById("product-plan-1").getPlanDefinitionHttpV4().getTags()).isNull();
+    }
+
+    private Plan productPlanWithTags(String planId, Set<String> tags) {
+        var planDefinition = PlanFixtures.aPlanHttpV4()
+            .getPlanDefinitionHttpV4()
+            .toBuilder()
+            .status(PlanStatus.PUBLISHED)
+            .tags(tags)
+            .build();
+        return PlanFixtures.aPlanHttpV4()
+            .toBuilder()
+            .id(planId)
+            .referenceId("api-product-id")
+            .referenceType(GenericPlanEntity.ReferenceType.API_PRODUCT)
+            .environmentId(ENV_ID)
+            .planDefinitionHttpV4(planDefinition)
+            .build();
     }
 
     private void givenPublishedApiProductPlan() {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/plan/domain_service/CreatePlanDomainServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/plan/domain_service/CreatePlanDomainServiceTest.java
@@ -344,6 +344,18 @@ class CreatePlanDomainServiceTest {
         }
 
         @ParameterizedTest
+        @MethodSource("apiProductPlans")
+        void should_throw_when_plan_tags_mismatch_with_tags_defined_in_api_product(ApiProduct api, Plan plan, List<Flow> flows) {
+            var apiProductWithoutTags = api.toBuilder().tags(Set.of()).build();
+
+            var throwable = Assertions.catchThrowable(() -> service.createApiProductPlan(plan, apiProductWithoutTags, AUDIT_INFO));
+
+            assertThat(throwable)
+                .isInstanceOf(ValidationDomainException.class)
+                .hasMessage("Plan tags mismatch the tags defined by the API Product");
+        }
+
+        @ParameterizedTest
         @MethodSource("plans")
         void should_create_plan_with_generated_id_when_no_id_provided(Api api, Plan plan, List<Flow> flows) {
             // Given
@@ -549,6 +561,7 @@ class CreatePlanDomainServiceTest {
                 .environmentId("environment-id")
                 .description("api-product-description")
                 .version("1.0.0")
+                .tags(Set.of(TAG))
                 .createdAt(Instant.parse("2020-02-01T20:22:02.00Z").atZone(ZoneId.systemDefault()))
                 .updatedAt(Instant.parse("2020-02-02T20:22:02.00Z").atZone(ZoneId.systemDefault()));
         }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/plan/domain_service/PlanValidatorDomainServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/plan/domain_service/PlanValidatorDomainServiceTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.plan.domain_service;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+
+import inmemory.PageCrudServiceInMemory;
+import inmemory.ParametersQueryServiceInMemory;
+import io.gravitee.apim.core.exception.ValidationDomainException;
+import io.gravitee.apim.core.policy.domain_service.PolicyValidationDomainService;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class PlanValidatorDomainServiceTest {
+
+    private PlanValidatorDomainService cut;
+
+    @BeforeEach
+    void setUp() {
+        cut = new PlanValidatorDomainService(
+            new ParametersQueryServiceInMemory(),
+            mock(PolicyValidationDomainService.class),
+            new PageCrudServiceInMemory()
+        );
+    }
+
+    @Test
+    void should_accept_empty_plan_tags_for_tagless_api_product() {
+        assertThatCode(() -> cut.validatePlanTagsAgainstApiProductTags(Set.of(), null)).doesNotThrowAnyException();
+        assertThatCode(() -> cut.validatePlanTagsAgainstApiProductTags(Set.of(), Set.of())).doesNotThrowAnyException();
+    }
+
+    @Test
+    void should_accept_plan_tags_that_are_subset_of_api_product_tags() {
+        assertThatCode(() ->
+            cut.validatePlanTagsAgainstApiProductTags(Set.of("internal"), Set.of("internal", "external"))
+        ).doesNotThrowAnyException();
+    }
+
+    @Test
+    void should_reject_plan_tags_when_api_product_has_no_tags() {
+        assertThatThrownBy(() -> cut.validatePlanTagsAgainstApiProductTags(Set.of("internal"), null))
+            .isInstanceOf(ValidationDomainException.class)
+            .hasMessage("Plan tags mismatch the tags defined by the API Product");
+
+        assertThatThrownBy(() -> cut.validatePlanTagsAgainstApiProductTags(Set.of("internal"), Set.of()))
+            .isInstanceOf(ValidationDomainException.class)
+            .hasMessage("Plan tags mismatch the tags defined by the API Product");
+    }
+
+    @Test
+    void should_reject_plan_tags_not_defined_on_api_product() {
+        assertThatThrownBy(() -> cut.validatePlanTagsAgainstApiProductTags(Set.of("internal"), Set.of("external")))
+            .isInstanceOf(ValidationDomainException.class)
+            .hasMessage("Plan tags mismatch the tags defined by the API Product");
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/TagServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/TagServiceTest.java
@@ -24,15 +24,20 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
+import io.gravitee.apim.core.api_product.domain_service.ApiProductTagDomainService;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.TagRepository;
 import io.gravitee.repository.management.model.Tag;
+import io.gravitee.rest.api.model.EnvironmentEntity;
 import io.gravitee.rest.api.model.NewTagEntity;
 import io.gravitee.rest.api.model.TagReferenceType;
 import io.gravitee.rest.api.service.AuditService;
+import io.gravitee.rest.api.service.EnvironmentService;
 import io.gravitee.rest.api.service.common.ExecutionContext;
 import io.gravitee.rest.api.service.exceptions.DuplicateTagKeyException;
+import io.gravitee.rest.api.service.v4.ApiTagService;
 import java.util.Collections;
+import java.util.List;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -58,6 +63,15 @@ public class TagServiceTest {
 
     @Mock
     private AuditService auditService;
+
+    @Mock
+    private ApiTagService apiTagService;
+
+    @Mock
+    private EnvironmentService environmentService;
+
+    @Mock
+    private ApiProductTagDomainService apiProductTagDomainService;
 
     @Test
     public void should_create_tag_when_key_does_not_exist() throws TechnicalException {
@@ -122,5 +136,35 @@ public class TagServiceTest {
 
         verify(tagRepository, never()).create(any());
         verifyNoInteractions(auditService);
+    }
+
+    @Test
+    public void should_delete_tag_key_from_apis_and_api_products() throws TechnicalException {
+        var tagKey = "external";
+        var tagId = "tag-uuid";
+        var environmentId = "env-1";
+        var executionContext = new ExecutionContext(REFERENCE_ID, environmentId);
+
+        var tag = new Tag();
+        tag.setId(tagId);
+        tag.setKey(tagKey);
+        tag.setReferenceId(REFERENCE_ID);
+        tag.setReferenceType(io.gravitee.repository.management.model.TagReferenceType.ORGANIZATION);
+
+        var environment = new EnvironmentEntity();
+        environment.setId(environmentId);
+        environment.setOrganizationId(REFERENCE_ID);
+
+        when(
+            tagRepository.findByKeyAndReference(tagKey, REFERENCE_ID, io.gravitee.repository.management.model.TagReferenceType.ORGANIZATION)
+        ).thenReturn(java.util.Optional.of(tag));
+        when(environmentService.findByOrganization(REFERENCE_ID)).thenReturn(List.of(environment));
+
+        tagService.delete(executionContext, tagKey, REFERENCE_ID, REFERENCE_TYPE);
+
+        verify(tagRepository).delete(tagId);
+        verify(apiTagService).deleteTagFromAPIs(executionContext, tagKey);
+        verify(apiProductTagDomainService).deleteTagFromApiProducts(environmentId, tagKey);
+        verify(auditService).createOrganizationAuditLog(eq(executionContext), any());
     }
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-14341
https://gravitee.atlassian.net/browse/APIM-14342

## Description
Adds API Product & API Product Plan sharding tag changes

Layer | Area | Change | Behavior
-- | -- | -- | --
Repository | JDBC persistence | New api_product_tags table (Liquibase 16_add_api_product_tags_table.yml) | Product sharding tag keys stored per product
Repository | JdbcApiProductRepository | storeTags, getTags, enrichWithTags on all read paths | Tags loaded on create/update/find/list; empty → null
Repository | Mongo | tags field on ApiProductMongo + repository model | Parity with JDBC
Management API | Domain models | tags on ApiProduct, CreateApiProduct, UpdateApiProduct, ApiProductDeploymentPayload | Tags flow through CRUD and deploy payload
Management API | REST v2 | tags on create/update in ApiProductResource, ApiProductsResource, OpenAPI | TagsValidationService.validateAndSanitize on product tags
Management API | Deploy | DeployApiProductDomainService includes product tags in event | Gateways receive product tags on deploy
Management API | Deploy state | GetApiProductsUseCase | NEED_REDEPLOY when tags or apiIds differ from last deploy
Management API | Update | UpdateApiProductUseCase | Persists tags; auto-strips orphaned plan tags when product tags shrink; no auto-deploy on update
Management API | Plan validation | PlanValidatorDomainService.validatePlanTagsAgainstApiProductTags | Plan tags must be ⊆ product tags; non-empty plan tags rejected when product is tagless
Management API | Plan CRUD | CreatePlanDomainService, UpdatePlanDomainService | Product plan create/update wired to product tag validation
Management API | Plan mapper | ApiProductPlanMapper | Removed hack that wiped plan tags on PATCH
Management API | Org tag delete | ApiProductTagDomainService + TagServiceImpl | Deleting org tag removes key from all products and their plans; passes tag key (not UUID)
Gateway | Sharding | New ApiProductShardingFilter | Product/plan tag matching via hasMatchingTags; empty plan tags → match all gateways that got the product
Gateway | Product manager | ApiProductManagerImpl | Skip/undeploy products whose tags don't match gateway; UPDATE event includes union of previous + current member apiIds
Gateway | Registry | ApiProductRegistryImpl | Indexed plan lookup with product + plan tag filtering; pre-built planEntriesByApi map
Gateway | Sync model | ReactableApiProduct, ApiProductMapper | Product deploy event carries tags
Gateway | Member APIs | ApiManagerImpl | isApiShardEligible: deploy if API tags match or product registry has indexed plans; re-evaluate on product DEPLOY/UPDATE/UNDEPLOY
Gateway sync | Member resync | RepositoryApiMemberResyncTrigger | On product DEPLOY/UPDATE, resync member APIs from repository
Gateway sync | Batch fetch | LatestEventFetcher.fetchLatestForApiIds | Batch latest API events for member resync
Gateway sync | Resync path | ApiSynchronizer.resyncMemberApis | Redeploy member APIs after product membership/tag changes

