### PR TITLE
feat(rest-api): grant default roles to users created from an invitation

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/user/domain_service/AssignUserDefaultRolesDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/user/domain_service/AssignUserDefaultRolesDomainService.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.user.domain_service;
+
+import io.gravitee.rest.api.service.common.ExecutionContext;
+
+/**
+ * Grants a user the default {@code ORGANIZATION} and {@code ENVIRONMENT} roles of the organization,
+ * so they can actually use the platform (e.g. list applications in the portal).
+ */
+public interface AssignUserDefaultRolesDomainService {
+    void assignDefaultRoles(ExecutionContext executionContext, String userId);
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/user/AssignUserDefaultRolesDomainServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/user/AssignUserDefaultRolesDomainServiceImpl.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.infra.domain_service.user;
+
+import io.gravitee.apim.core.user.domain_service.AssignUserDefaultRolesDomainService;
+import io.gravitee.rest.api.model.MembershipMemberType;
+import io.gravitee.rest.api.model.MembershipReferenceType;
+import io.gravitee.rest.api.model.RoleEntity;
+import io.gravitee.rest.api.model.permissions.RoleScope;
+import io.gravitee.rest.api.service.MembershipService;
+import io.gravitee.rest.api.service.RoleService;
+import io.gravitee.rest.api.service.common.ExecutionContext;
+import io.gravitee.rest.api.service.common.GraviteeContext;
+import io.gravitee.rest.api.service.exceptions.DefaultRoleNotFoundException;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AssignUserDefaultRolesDomainServiceImpl implements AssignUserDefaultRolesDomainService {
+
+    private final RoleService roleService;
+    private final MembershipService membershipService;
+
+    @Override
+    public void assignDefaultRoles(ExecutionContext executionContext, String userId) {
+        RoleScope[] scopes = { RoleScope.ORGANIZATION, RoleScope.ENVIRONMENT };
+        List<RoleEntity> defaultRoleByScopes = roleService.findDefaultRoleByScopes(executionContext.getOrganizationId(), scopes);
+        if (defaultRoleByScopes == null || defaultRoleByScopes.isEmpty()) {
+            throw new DefaultRoleNotFoundException(scopes);
+        }
+        for (RoleEntity defaultRoleByScope : defaultRoleByScopes) {
+            switch (defaultRoleByScope.getScope()) {
+                case ORGANIZATION -> membershipService.addRoleToMemberOnReference(
+                    executionContext,
+                    new MembershipService.MembershipReference(MembershipReferenceType.ORGANIZATION, executionContext.getOrganizationId()),
+                    new MembershipService.MembershipMember(userId, null, MembershipMemberType.USER),
+                    new MembershipService.MembershipRole(RoleScope.ORGANIZATION, defaultRoleByScope.getName())
+                );
+                case ENVIRONMENT -> membershipService.addRoleToMemberOnReference(
+                    executionContext,
+                    new MembershipService.MembershipReference(
+                        MembershipReferenceType.ENVIRONMENT,
+                        executionContext.hasEnvironmentId() ? executionContext.getEnvironmentId() : GraviteeContext.getDefaultEnvironment()
+                    ),
+                    new MembershipService.MembershipMember(userId, null, MembershipMemberType.USER),
+                    new MembershipService.MembershipRole(RoleScope.ENVIRONMENT, defaultRoleByScope.getName())
+                );
+            }
+        }
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/user/CreateUserDomainServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/user/CreateUserDomainServiceImpl.java
@@ -16,6 +16,7 @@
 package io.gravitee.apim.infra.domain_service.user;
 
 import io.gravitee.apim.core.user.crud_service.UserCrudService;
+import io.gravitee.apim.core.user.domain_service.AssignUserDefaultRolesDomainService;
 import io.gravitee.apim.core.user.domain_service.CreateUserDomainService;
 import io.gravitee.apim.core.user.model.BaseUserEntity;
 import io.gravitee.common.utils.TimeProvider;
@@ -30,6 +31,7 @@ import org.springframework.stereotype.Service;
 public class CreateUserDomainServiceImpl implements CreateUserDomainService {
 
     private final UserCrudService userCrudService;
+    private final AssignUserDefaultRolesDomainService assignUserDefaultRolesDomainService;
 
     @Override
     public BaseUserEntity createGraviteeUser(
@@ -39,8 +41,10 @@ public class CreateUserDomainServiceImpl implements CreateUserDomainService {
         Optional<String> lastname
     ) {
         var now = Date.from(TimeProvider.now().toInstant());
-        return userCrudService.create(
+        var created = userCrudService.create(
             BaseUserEntity.createGraviteeUser(executionContext.getOrganizationId(), email, firstname, lastname, now)
         );
+        assignUserDefaultRolesDomainService.assignDefaultRoles(executionContext, created.getId());
+        return created;
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/UserServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/UserServiceImpl.java
@@ -44,6 +44,7 @@ import com.auth0.jwt.interfaces.DecodedJWT;
 import com.jayway.jsonpath.JsonPath;
 import com.jayway.jsonpath.ReadContext;
 import io.gravitee.apim.core.installation.query_service.InstallationAccessQueryService;
+import io.gravitee.apim.core.user.domain_service.AssignUserDefaultRolesDomainService;
 import io.gravitee.common.data.domain.MetadataPage;
 import io.gravitee.common.data.domain.Page;
 import io.gravitee.el.TemplateEngine;
@@ -123,7 +124,6 @@ import io.gravitee.rest.api.service.common.UuidString;
 import io.gravitee.rest.api.service.configuration.identity.IdentityProviderService;
 import io.gravitee.rest.api.service.converter.UserConverter;
 import io.gravitee.rest.api.service.exceptions.AbstractManagementException;
-import io.gravitee.rest.api.service.exceptions.DefaultRoleNotFoundException;
 import io.gravitee.rest.api.service.exceptions.EmailFormatInvalidException;
 import io.gravitee.rest.api.service.exceptions.EmailRequiredException;
 import io.gravitee.rest.api.service.exceptions.GroupNotFoundException;
@@ -224,6 +224,9 @@ public class UserServiceImpl extends AbstractService implements UserService, Ini
 
     @Autowired
     private MembershipService membershipService;
+
+    @Autowired
+    private AssignUserDefaultRolesDomainService assignUserDefaultRolesDomainService;
 
     @Lazy
     @Autowired
@@ -816,41 +819,7 @@ public class UserServiceImpl extends AbstractService implements UserService, Ini
     }
 
     private void addDefaultMembership(ExecutionContext executionContext, User user) {
-        RoleScope[] scopes = { RoleScope.ORGANIZATION, RoleScope.ENVIRONMENT };
-        List<RoleEntity> defaultRoleByScopes = roleService.findDefaultRoleByScopes(executionContext.getOrganizationId(), scopes);
-        if (defaultRoleByScopes == null || defaultRoleByScopes.isEmpty()) {
-            throw new DefaultRoleNotFoundException(scopes);
-        }
-        for (RoleEntity defaultRoleByScope : defaultRoleByScopes) {
-            switch (defaultRoleByScope.getScope()) {
-                case ORGANIZATION:
-                    membershipService.addRoleToMemberOnReference(
-                        executionContext,
-                        new MembershipService.MembershipReference(
-                            MembershipReferenceType.ORGANIZATION,
-                            executionContext.getOrganizationId()
-                        ),
-                        new MembershipService.MembershipMember(user.getId(), null, MembershipMemberType.USER),
-                        new MembershipService.MembershipRole(RoleScope.ORGANIZATION, defaultRoleByScope.getName())
-                    );
-                    break;
-                case ENVIRONMENT:
-                    membershipService.addRoleToMemberOnReference(
-                        executionContext,
-                        new MembershipService.MembershipReference(
-                            MembershipReferenceType.ENVIRONMENT,
-                            executionContext.hasEnvironmentId()
-                                ? executionContext.getEnvironmentId()
-                                : GraviteeContext.getDefaultEnvironment()
-                        ),
-                        new MembershipService.MembershipMember(user.getId(), null, MembershipMemberType.USER),
-                        new MembershipService.MembershipRole(RoleScope.ENVIRONMENT, defaultRoleByScope.getName())
-                    );
-                    break;
-                default:
-                    break;
-            }
-        }
+        assignUserDefaultRolesDomainService.assignDefaultRoles(executionContext, user.getId());
     }
 
     @Override

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/invitation/use_case/AcceptUserInvitationUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/invitation/use_case/AcceptUserInvitationUseCaseTest.java
@@ -57,6 +57,7 @@ import io.gravitee.rest.api.service.exceptions.UserNotFoundException;
 import io.gravitee.rest.api.service.exceptions.UserRegistrationUnavailableException;
 import io.gravitee.rest.api.service.notification.PortalHook;
 import java.time.ZoneId;
+import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
@@ -81,6 +82,7 @@ class AcceptUserInvitationUseCaseTest extends AbstractUseCaseTest {
 
     private final InvitationCrudServiceInMemory invitationCrudService = new InvitationCrudServiceInMemory();
     private final MembershipDomainServiceInMemory membershipDomainService = new MembershipDomainServiceInMemory();
+    private final List<String> assignedDefaultRoleUserIds = new ArrayList<>();
 
     @Mock
     private ParameterService parameterService;
@@ -100,7 +102,7 @@ class AcceptUserInvitationUseCaseTest extends AbstractUseCaseTest {
         auditDomainService = new AuditDomainService(auditCrudService, userCrudService, new JacksonJsonDiffProcessor());
         cut = new AcceptUserInvitationUseCase(
             userCrudService,
-            new CreateUserDomainServiceImpl(userCrudService),
+            new CreateUserDomainServiceImpl(userCrudService, (ctx, userId) -> assignedDefaultRoleUserIds.add(userId)),
             invitationCrudService,
             new AcceptInvitationDomainServiceImpl(membershipDomainService),
             new UserRegistrationEnabledServiceImpl(parameterService),
@@ -113,6 +115,7 @@ class AcceptUserInvitationUseCaseTest extends AbstractUseCaseTest {
         userCrudService.reset();
         auditCrudService.reset();
         membershipDomainService.reset();
+        assignedDefaultRoleUserIds.clear();
     }
 
     @Nested
@@ -143,6 +146,7 @@ class AcceptUserInvitationUseCaseTest extends AbstractUseCaseTest {
             assertThat(output.user().getId()).isEqualTo(GENERATED_UUID);
             assertThat(output.user().getUpdatedAt()).isEqualTo(Date.from(INSTANT_NOW));
             assertThat(userCrudService.getStoredPassword(GENERATED_UUID)).isPresent();
+            assertThat(assignedDefaultRoleUserIds).containsExactly(GENERATED_UUID);
             verify(notifierService).trigger(eq(executionContext), eq(PortalHook.USER_REGISTERED), any());
         }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/user/AssignUserDefaultRolesDomainServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/user/AssignUserDefaultRolesDomainServiceImplTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.infra.domain_service.user;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.rest.api.model.MembershipReferenceType;
+import io.gravitee.rest.api.model.RoleEntity;
+import io.gravitee.rest.api.model.permissions.RoleScope;
+import io.gravitee.rest.api.service.MembershipService;
+import io.gravitee.rest.api.service.RoleService;
+import io.gravitee.rest.api.service.common.ExecutionContext;
+import io.gravitee.rest.api.service.exceptions.DefaultRoleNotFoundException;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@ExtendWith(MockitoExtension.class)
+class AssignUserDefaultRolesDomainServiceImplTest {
+
+    private static final ExecutionContext EXECUTION_CONTEXT = new ExecutionContext("org-id", "env-id");
+
+    @Mock
+    private RoleService roleService;
+
+    @Mock
+    private MembershipService membershipService;
+
+    private AssignUserDefaultRolesDomainServiceImpl service;
+
+    @BeforeEach
+    void setUp() {
+        service = new AssignUserDefaultRolesDomainServiceImpl(roleService, membershipService);
+    }
+
+    @Test
+    void should_assign_default_organization_and_environment_roles_to_the_user() {
+        var orgRole = RoleEntity.builder().scope(RoleScope.ORGANIZATION).name("ORG_USER").build();
+        var envRole = RoleEntity.builder().scope(RoleScope.ENVIRONMENT).name("ENV_USER").build();
+        when(roleService.findDefaultRoleByScopes("org-id", RoleScope.ORGANIZATION, RoleScope.ENVIRONMENT)).thenReturn(
+            List.of(orgRole, envRole)
+        );
+
+        service.assignDefaultRoles(EXECUTION_CONTEXT, "user-1");
+
+        var referenceCaptor = ArgumentCaptor.forClass(MembershipService.MembershipReference.class);
+        verify(membershipService, times(2)).addRoleToMemberOnReference(eq(EXECUTION_CONTEXT), referenceCaptor.capture(), any(), any());
+        assertThat(referenceCaptor.getAllValues())
+            .extracting(MembershipService.MembershipReference::getType)
+            .containsExactlyInAnyOrder(MembershipReferenceType.ORGANIZATION, MembershipReferenceType.ENVIRONMENT);
+    }
+
+    @Test
+    void should_throw_when_no_default_role_is_found() {
+        when(roleService.findDefaultRoleByScopes("org-id", RoleScope.ORGANIZATION, RoleScope.ENVIRONMENT)).thenReturn(List.of());
+
+        assertThatThrownBy(() -> service.assignDefaultRoles(EXECUTION_CONTEXT, "user-1")).isInstanceOf(DefaultRoleNotFoundException.class);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/user/CreateUserDomainServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/user/CreateUserDomainServiceImplTest.java
@@ -18,6 +18,7 @@ package io.gravitee.apim.infra.domain_service.user;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import inmemory.UserCrudServiceInMemory;
+import io.gravitee.apim.core.user.domain_service.AssignUserDefaultRolesDomainService;
 import io.gravitee.apim.core.user.model.BaseUserEntity;
 import io.gravitee.apim.core.user.model.IdpSource;
 import io.gravitee.common.utils.TimeProvider;
@@ -25,7 +26,9 @@ import io.gravitee.rest.api.service.common.ExecutionContext;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneId;
+import java.util.ArrayList;
 import java.util.Date;
+import java.util.List;
 import java.util.Optional;
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.AfterAll;
@@ -40,6 +43,7 @@ class CreateUserDomainServiceImplTest {
     private static final ExecutionContext EXECUTION_CONTEXT = new ExecutionContext("org-id", "env-id");
 
     UserCrudServiceInMemory userCrudService = new UserCrudServiceInMemory();
+    RecordingAssignUserDefaultRoles assignUserDefaultRoles = new RecordingAssignUserDefaultRoles();
     CreateUserDomainServiceImpl service;
 
     @BeforeAll
@@ -54,7 +58,7 @@ class CreateUserDomainServiceImplTest {
 
     @BeforeEach
     void setUp() {
-        service = new CreateUserDomainServiceImpl(userCrudService);
+        service = new CreateUserDomainServiceImpl(userCrudService, assignUserDefaultRoles);
     }
 
     @AfterEach
@@ -93,5 +97,25 @@ class CreateUserDomainServiceImplTest {
         service.createGraviteeUser(EXECUTION_CONTEXT, "stored@example.com", Optional.empty(), Optional.empty());
 
         assertThat(userCrudService.storage()).hasSize(1).extracting(BaseUserEntity::getEmail).containsExactly("stored@example.com");
+    }
+
+    @Test
+    void should_assign_default_roles_to_the_created_user() {
+        var result = service.createGraviteeUser(EXECUTION_CONTEXT, "jane@example.com", Optional.of("Jane"), Optional.of("Doe"));
+
+        assertThat(assignUserDefaultRoles.assignedUserIds).containsExactly(result.getId());
+        assertThat(assignUserDefaultRoles.lastOrganizationId).isEqualTo("org-id");
+    }
+
+    private static class RecordingAssignUserDefaultRoles implements AssignUserDefaultRolesDomainService {
+
+        final List<String> assignedUserIds = new ArrayList<>();
+        String lastOrganizationId;
+
+        @Override
+        public void assignDefaultRoles(ExecutionContext executionContext, String userId) {
+            this.lastOrganizationId = executionContext.getOrganizationId();
+            this.assignedUserIds.add(userId);
+        }
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/UserServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/UserServiceTest.java
@@ -30,6 +30,7 @@ import static org.springframework.test.util.ReflectionTestUtils.setField;
 import com.auth0.jwt.JWT;
 import com.auth0.jwt.algorithms.Algorithm;
 import io.gravitee.apim.core.installation.query_service.InstallationAccessQueryService;
+import io.gravitee.apim.core.user.domain_service.AssignUserDefaultRolesDomainService;
 import io.gravitee.common.data.domain.MetadataPage;
 import io.gravitee.common.util.Maps;
 import io.gravitee.repository.exceptions.TechnicalException;
@@ -123,6 +124,9 @@ public class UserServiceTest {
 
     @Mock
     private MembershipService membershipService;
+
+    @Mock
+    private AssignUserDefaultRolesDomainService assignUserDefaultRolesDomainService;
 
     @Mock
     private MembershipRepository membershipRepository;
@@ -489,11 +493,6 @@ public class UserServiceTest {
         when(user.getCreatedAt()).thenReturn(date);
         when(user.getOrganizationId()).thenReturn(ORGANIZATION);
         when(userRepository.create(any(User.class))).thenReturn(user);
-        RoleEntity roleEnvironmentAdmin = mockRoleEntity(RoleScope.ENVIRONMENT, "ADMIN");
-        RoleEntity roleOrganizationAdmin = mockRoleEntity(RoleScope.ORGANIZATION, "ADMIN");
-        when(roleService.findDefaultRoleByScopes(ORGANIZATION, RoleScope.ORGANIZATION, RoleScope.ENVIRONMENT)).thenReturn(
-            Arrays.asList(roleOrganizationAdmin, roleEnvironmentAdmin)
-        );
         RoleEntity roleEnv = mock(RoleEntity.class);
         when(roleEnv.getScope()).thenReturn(RoleScope.ENVIRONMENT);
         when(roleEnv.getName()).thenReturn("USER");
@@ -514,6 +513,7 @@ public class UserServiceTest {
         verify(newPreRegisterUserEntity, times(1)).setSourceId(EMAIL);
         verify(emailService, times(1)).sendAsyncEmailNotification(eq(EXECUTION_CONTEXT), any());
         verify(notifierService, times(1)).trigger(eq(EXECUTION_CONTEXT), eq(PortalHook.USER_CREATED), any());
+        verify(assignUserDefaultRolesDomainService, times(1)).assignDefaultRoles(eq(EXECUTION_CONTEXT), eq(USER_NAME));
     }
 
     @Test
@@ -550,11 +550,6 @@ public class UserServiceTest {
         when(user.getUpdatedAt()).thenReturn(date);
         when(user.getOrganizationId()).thenReturn(ORGANIZATION);
         when(userRepository.create(any(User.class))).thenReturn(user);
-        RoleEntity roleEnvironmentAdmin = mockRoleEntity(RoleScope.ENVIRONMENT, "ADMIN");
-        RoleEntity roleOrganizationAdmin = mockRoleEntity(RoleScope.ORGANIZATION, "ADMIN");
-        when(roleService.findDefaultRoleByScopes(ORGANIZATION, RoleScope.ORGANIZATION, RoleScope.ENVIRONMENT)).thenReturn(
-            Arrays.asList(roleOrganizationAdmin, roleEnvironmentAdmin)
-        );
         RoleEntity roleEnv = mock(RoleEntity.class);
         when(roleEnv.getScope()).thenReturn(RoleScope.ENVIRONMENT);
         when(roleEnv.getName()).thenReturn("USER");
@@ -599,11 +594,6 @@ public class UserServiceTest {
         when(user.getUpdatedAt()).thenReturn(date);
         when(user.getOrganizationId()).thenReturn(ORGANIZATION);
         when(userRepository.create(any(User.class))).thenReturn(user);
-        RoleEntity roleEnvironmentAdmin = mockRoleEntity(RoleScope.ENVIRONMENT, "ADMIN");
-        RoleEntity roleOrganizationAdmin = mockRoleEntity(RoleScope.ORGANIZATION, "ADMIN");
-        when(roleService.findDefaultRoleByScopes(ORGANIZATION, RoleScope.ORGANIZATION, RoleScope.ENVIRONMENT)).thenReturn(
-            Arrays.asList(roleOrganizationAdmin, roleEnvironmentAdmin)
-        );
         RoleEntity roleEnv = mock(RoleEntity.class);
         when(roleEnv.getScope()).thenReturn(RoleScope.ENVIRONMENT);
         when(roleEnv.getName()).thenReturn("USER");
@@ -2638,11 +2628,6 @@ public class UserServiceTest {
         when(user.getUpdatedAt()).thenReturn(date);
         when(user.getOrganizationId()).thenReturn(ORGANIZATION);
         when(userRepository.create(any(User.class))).thenReturn(user);
-        RoleEntity roleEnvironmentAdmin = mockRoleEntity(RoleScope.ENVIRONMENT, "ADMIN");
-        RoleEntity roleOrganizationAdmin = mockRoleEntity(RoleScope.ORGANIZATION, "ADMIN");
-        when(roleService.findDefaultRoleByScopes(ORGANIZATION, RoleScope.ORGANIZATION, RoleScope.ENVIRONMENT)).thenReturn(
-            Arrays.asList(roleOrganizationAdmin, roleEnvironmentAdmin)
-        );
         RoleEntity roleEnv = mock(RoleEntity.class);
         when(roleEnv.getScope()).thenReturn(RoleScope.ENVIRONMENT);
         when(roleEnv.getName()).thenReturn("USER");
@@ -2688,11 +2673,6 @@ public class UserServiceTest {
         when(user.getUpdatedAt()).thenReturn(date);
         when(user.getOrganizationId()).thenReturn(ORGANIZATION);
         when(userRepository.create(any(User.class))).thenReturn(user);
-        RoleEntity roleEnvironmentAdmin = mockRoleEntity(RoleScope.ENVIRONMENT, "ADMIN");
-        RoleEntity roleOrganizationAdmin = mockRoleEntity(RoleScope.ORGANIZATION, "ADMIN");
-        when(roleService.findDefaultRoleByScopes(ORGANIZATION, RoleScope.ORGANIZATION, RoleScope.ENVIRONMENT)).thenReturn(
-            Arrays.asList(roleOrganizationAdmin, roleEnvironmentAdmin)
-        );
         RoleEntity roleEnv = mock(RoleEntity.class);
         when(roleEnv.getScope()).thenReturn(RoleScope.ENVIRONMENT);
         when(roleEnv.getName()).thenReturn("USER");


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-14396

## Description

Users created when accepting an application invitation got no default `ORGANIZATION`/`ENVIRONMENT` role, so the portal returned **403** (e.g. on `GET /applications`). They could log in but couldn't use it.

Extract the default-role assignment from `UserServiceImpl.addDefaultMembership` into a shared `AssignUserDefaultRolesDomainService`, now called by both:

- classic registration
- the invitation flow (`CreateUserDomainServiceImpl`)

