### PR TITLE
fix: preserve label order in API-to-repository mapping

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/ApiServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/ApiServiceImpl.java
@@ -123,6 +123,7 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -512,7 +513,7 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
             }
 
             if (updateApiEntity.getLabels() == null && apiToUpdate.getLabels() != null) {
-                api.setLabels(new ArrayList<>(new HashSet<>(apiToUpdate.getLabels())));
+                api.setLabels(new ArrayList<>(new LinkedHashSet<>(apiToUpdate.getLabels())));
             }
             if (updateApiEntity.getCategories() == null) {
                 api.setCategories(apiToUpdate.getCategories());

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/mapper/ApiMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/mapper/ApiMapper.java
@@ -61,7 +61,7 @@ import io.gravitee.rest.api.service.v4.PlanService;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Date;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 import lombok.CustomLog;
@@ -446,7 +446,7 @@ public class ApiMapper {
         repoApi.setCategories(categoryMapper.toCategoryId(executionContext.getEnvironmentId(), updateApiEntity.getCategories()));
 
         if (updateApiEntity.getLabels() != null) {
-            repoApi.setLabels(new ArrayList<>(new HashSet<>(updateApiEntity.getLabels())));
+            repoApi.setLabels(new ArrayList<>(new LinkedHashSet<>(updateApiEntity.getLabels())));
         }
 
         repoApi.setGroups(updateApiEntity.getGroups());
@@ -524,7 +524,7 @@ public class ApiMapper {
         repoApi.setGroups(apiEntity.getGroups());
         repoApi.setId(apiEntity.getId());
         if (apiEntity.getLabels() != null) {
-            repoApi.setLabels(new ArrayList<>(new HashSet<>(apiEntity.getLabels())));
+            repoApi.setLabels(new ArrayList<>(new LinkedHashSet<>(apiEntity.getLabels())));
         }
         if (apiEntity.getState() != null) {
             repoApi.setLifecycleState(LifecycleState.valueOf(apiEntity.getState().name()));

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/ApiServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/impl/ApiServiceImplTest.java
@@ -944,6 +944,20 @@ public class ApiServiceImplTest {
     }
 
     @Test
+    public void shouldPreserveStoredLabelsOrderWhenUpdateLabelsAreNull() throws TechnicalException {
+        prepareUpdate();
+        api.setLabels(asList("z-label", "a-label", "m-label"));
+        updateApiEntity.setLabels(null);
+
+        final ApiEntity apiEntity = apiService.update(GraviteeContext.getExecutionContext(), API_ID, updateApiEntity, USER_NAME);
+
+        ArgumentCaptor<Api> repositoryApiCaptor = ArgumentCaptor.forClass(Api.class);
+        verify(apiRepository).update(repositoryApiCaptor.capture());
+        assertThat(repositoryApiCaptor.getValue().getLabels()).isEqualTo(asList("z-label", "a-label", "m-label"));
+        assertNotNull(apiEntity);
+    }
+
+    @Test
     public void update_shouldNotChangeImages() throws TechnicalException {
         prepareUpdate();
         updateApiEntity.setLabels(asList("label1", "label1"));

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/mapper/ApiMapperTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/v4/mapper/ApiMapperTest.java
@@ -530,6 +530,66 @@ public class ApiMapperTest {
     }
 
     @Test
+    public void shouldPreserveLabelsOrderWhenToRepositoryFromUpdateEntity() {
+        UpdateApiEntity updateApiEntity = new UpdateApiEntity();
+        updateApiEntity.setId("id");
+        updateApiEntity.setName("name");
+        updateApiEntity.setApiVersion("version");
+        updateApiEntity.setDefinitionVersion(DefinitionVersion.V4);
+        updateApiEntity.setType(ApiType.PROXY);
+        updateApiEntity.setLabels(List.of("tc-1601-b", "tc-1601-a"));
+
+        Api api = apiMapper.toRepository(GraviteeContext.getExecutionContext(), updateApiEntity);
+
+        assertThat(api.getLabels()).containsExactly("tc-1601-b", "tc-1601-a");
+    }
+
+    @Test
+    public void shouldDeduplicateLabelsPreservingFirstOccurrenceOrderWhenToRepositoryFromUpdateEntity() {
+        UpdateApiEntity updateApiEntity = new UpdateApiEntity();
+        updateApiEntity.setId("id");
+        updateApiEntity.setName("name");
+        updateApiEntity.setApiVersion("version");
+        updateApiEntity.setDefinitionVersion(DefinitionVersion.V4);
+        updateApiEntity.setType(ApiType.PROXY);
+        updateApiEntity.setLabels(List.of("a", "b", "a"));
+
+        Api api = apiMapper.toRepository(GraviteeContext.getExecutionContext(), updateApiEntity);
+
+        assertThat(api.getLabels()).containsExactly("a", "b");
+    }
+
+    @Test
+    public void shouldPreserveLabelsOrderWhenToRepositoryFromApiEntity() {
+        ApiEntity apiEntity = new ApiEntity();
+        apiEntity.setId("id");
+        apiEntity.setName("name");
+        apiEntity.setApiVersion("version");
+        apiEntity.setDefinitionVersion(DefinitionVersion.V4);
+        apiEntity.setType(ApiType.PROXY);
+        apiEntity.setLabels(List.of("tc-1601-b", "tc-1601-a"));
+
+        Api api = apiMapper.toRepository(GraviteeContext.getExecutionContext(), apiEntity);
+
+        assertThat(api.getLabels()).containsExactly("tc-1601-b", "tc-1601-a");
+    }
+
+    @Test
+    public void shouldDeduplicateLabelsPreservingFirstOccurrenceOrderWhenToRepositoryFromApiEntity() {
+        ApiEntity apiEntity = new ApiEntity();
+        apiEntity.setId("id");
+        apiEntity.setName("name");
+        apiEntity.setApiVersion("version");
+        apiEntity.setDefinitionVersion(DefinitionVersion.V4);
+        apiEntity.setType(ApiType.PROXY);
+        apiEntity.setLabels(List.of("a", "b", "a"));
+
+        Api api = apiMapper.toRepository(GraviteeContext.getExecutionContext(), apiEntity);
+
+        assertThat(api.getLabels()).containsExactly("a", "b");
+    }
+
+    @Test
     public void shouldCreateRepositoryApiFromApiEntity() throws JsonProcessingException {
         ApiEntity apiEntity = new ApiEntity();
         apiEntity.setId("id");


### PR DESCRIPTION
## Issue

[APIM-14377](https://gravitee.atlassian.net/browse/APIM-14377)

## Why

Applying an RFC 6902 `move` operation (or a merge-patch reorder) to the `labels` array of a v4 API returned `200 OK` but left the array in its original order — the reorder was silently lost in both the PATCH response and a follow-up GET. The cause: labels were round-tripped through an unordered `HashSet` while being mapped to the repository entity, discarding insertion order before persistence.

## What changed

Label de-duplication now flows through a `LinkedHashSet` instead of a `HashSet`, so insertion order is preserved while duplicates are still removed:

- `ApiMapper.toRepository(ExecutionContext, UpdateApiEntity)`
- `ApiMapper.toRepository(ExecutionContext, ApiEntity)`
- `ApiServiceImpl.update(...)` — the branch that retains stored labels when the update payload omits them

## User-facing impact

- **Behaviour change**: reordering an API's `labels` via PATCH (`move`, or a merge-patch that supplies the new order) now persists and is reflected in both the PATCH response and subsequent GETs. Duplicate labels continue to collapse to their first occurrence. No API signature, config, or default changed — not a breaking change.

## How to test

1. Create a v4 PROXY API (capture `apiId`).
2. `PATCH .../apis/{apiId}` with `Content-Type: application/merge-patch+json`, body `{"labels":["tc-1601-a","tc-1601-b"]}` → `200 OK`.
3. `PATCH .../apis/{apiId}` with `Content-Type: application/json-patch+json`, body `[{"op":"move","from":"/labels/0","path":"/labels/1"}]` → `200 OK`.
4. `GET .../apis/{apiId}` → `labels` is now `["tc-1601-b","tc-1601-a"]` (previously unchanged).

## Known Issues

- The same dedup-without-order idiom (`new ArrayList<>(new HashSet<>(labels))`) exists in the v2/v3 service at `gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiServiceImpl.java:1355` and `:2702`. This fix is scoped to the v4 path the bug reproduces on; the v2 sites are intentionally left untouched and would be addressed separately if the v2 update path is found to exhibit the same behaviour.


[APIM-14377]: https://gravitee.atlassian.net/browse/APIM-14377?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ