### PR TITLE
fix(rest-api): serialization failure in api export returs empty 

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiExportServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiExportServiceImpl.java
@@ -102,8 +102,8 @@ public class ApiExportServiceImpl extends AbstractService implements ApiExportSe
             return objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(apiEntity);
         } catch (final Exception e) {
             log.error("An error occurs while trying to JSON serialize the API {}", apiEntity, e);
+            throw new TechnicalManagementException(e);
         }
-        return "";
     }
 
     @Override

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiExportService_ExportAsJsonTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiExportService_ExportAsJsonTest.java
@@ -16,6 +16,8 @@
 package io.gravitee.rest.api.service.impl;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
 
 import com.google.common.base.Charsets;
 import com.google.common.io.Resources;
@@ -23,12 +25,15 @@ import io.gravitee.definition.model.*;
 import io.gravitee.rest.api.model.api.ApiEntity;
 import io.gravitee.rest.api.model.permissions.SystemRole;
 import io.gravitee.rest.api.service.common.GraviteeContext;
+import io.gravitee.rest.api.service.exceptions.GroupsNotFoundException;
+import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
 import io.gravitee.rest.api.service.jackson.ser.api.ApiSerializer;
 import java.io.IOException;
 import java.net.URL;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.Set;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -82,5 +87,17 @@ public class ApiExportService_ExportAsJsonTest extends ApiExportService_ExportAs
     @Test
     public void shouldConvertAsJsonForExportWithExecutionMode_v4_emulation_engine() throws IOException {
         shouldConvertAsJsonForExportWithExecutionMode(ApiSerializer.Version.DEFAULT, ExecutionMode.V4_EMULATION_ENGINE);
+    }
+
+    @Test
+    public void exportAsJson_throwsTechnicalManagementException_whenSerializationFails() {
+        // API references a group that no longer exists: the serializer throws and must not be swallowed
+        when(groupService.findByIds(apiEntity.getGroups())).thenThrow(new GroupsNotFoundException(Set.of("my-group")));
+
+        assertThatThrownBy(() ->
+            apiExportService.exportAsJson(GraviteeContext.getExecutionContext(), API_ID, ApiSerializer.Version.DEFAULT.getVersion())
+        )
+            .isInstanceOf(TechnicalManagementException.class)
+            .hasMessageContaining("my-group");
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiExportService_ExportAsJsonTestSetup.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ApiExportService_ExportAsJsonTestSetup.java
@@ -93,7 +93,7 @@ public class ApiExportService_ExportAsJsonTestSetup {
     private PlanService planService;
 
     @Mock
-    private GroupService groupService;
+    protected GroupService groupService;
 
     @Mock
     private ApplicationContext applicationContext;


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-13453

## Description

- `ApiExportServiceImpl.exportAsJson()` caught any serialization exception, logged it, and returned an empty string. The export endpoint then shipped HTTP 200 with a 0-byte body, and `PromotionServiceImpl.create()` persisted that empty string as the promotion's `apiDefinition` (the promotion looked successful but the definition was gone).

- It now rethrows as `TechnicalManagementException` (HTTP 500 with the error message), mirroring the sibling `exportAsCustomResourceDefinition()`. Promotion creation fails fast before persisting, so no promotion record is stored with an empty definition.

## Additional context

- **Root cause:** an API referencing group IDs that no longer exist in the `groups` collection makes `ApiSerializer.serialize()` throw `Groups [...] cannot be found.`, which was silently swallowed.

**Reproduction:**
1. Create an API assigned to a group.
2. Delete the group (the API still references its ID).
3. Export the API (`GET .../export`) — before: HTTP 200 + empty body; after: HTTP 500 with the error message.

**Affected:** 
- All maintained branches (4.8.x → master).
