### PR TITLE
Feat/portal listing persistence

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/PortalListingRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/PortalListingRepository.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.management.api;
+
+import io.gravitee.repository.exceptions.TechnicalException;
+import io.gravitee.repository.management.model.PortalListing;
+import java.util.Optional;
+
+/**
+ * @author GraviteeSource Team
+ */
+public interface PortalListingRepository extends CrudRepository<PortalListing, String> {
+    Optional<PortalListing> findByIdAndEnvironmentId(final String portalListingId, final String environmentId) throws TechnicalException;
+    void deleteByEnvironmentId(final String environmentId) throws TechnicalException;
+    void deleteByOrganizationId(final String organizationId) throws TechnicalException;
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/PortalListing.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/PortalListing.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.management.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+/**
+ * @author GraviteeSource Team
+ */
+@Data
+@EqualsAndHashCode(of = "id")
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PortalListing {
+
+    private String id;
+    private String environmentId;
+    private String organizationId;
+    private String portalId;
+    private String apis;
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcPortalListingRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcPortalListingRepository.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.jdbc.management;
+
+import io.gravitee.repository.exceptions.TechnicalException;
+import io.gravitee.repository.jdbc.orm.JdbcObjectMapper;
+import io.gravitee.repository.management.api.PortalListingRepository;
+import io.gravitee.repository.management.model.PortalListing;
+import java.sql.Types;
+import java.util.Optional;
+import lombok.CustomLog;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Repository;
+
+/**
+ * @author GraviteeSource Team
+ */
+@CustomLog
+@Repository
+public class JdbcPortalListingRepository extends JdbcAbstractCrudRepository<PortalListing, String> implements PortalListingRepository {
+
+    JdbcPortalListingRepository(@Value("${management.jdbc.prefix:}") String tablePrefix) {
+        super(tablePrefix, "portal_listings");
+    }
+
+    @Override
+    protected JdbcObjectMapper<PortalListing> buildOrm() {
+        return JdbcObjectMapper.builder(PortalListing.class, this.tableName, "id")
+            .addColumn("id", Types.NVARCHAR, String.class)
+            .addColumn("environment_id", Types.NVARCHAR, String.class)
+            .addColumn("organization_id", Types.NVARCHAR, String.class)
+            .addColumn("portal_id", Types.NVARCHAR, String.class)
+            .addColumn("apis", Types.NCLOB, String.class)
+            .build();
+    }
+
+    @Override
+    protected String getId(final PortalListing item) {
+        return item.getId();
+    }
+
+    @Override
+    public Optional<PortalListing> findByIdAndEnvironmentId(String portalListingId, String environmentId) throws TechnicalException {
+        log.debug("JdbcPortalListingRepository.findByIdAndEnvironmentId({}, {})", portalListingId, environmentId);
+        try {
+            return jdbcTemplate
+                .query(
+                    getOrm().getSelectAllSql() + " WHERE id = ? and environment_id = ?",
+                    getOrm().getRowMapper(),
+                    portalListingId,
+                    environmentId
+                )
+                .stream()
+                .findFirst();
+        } catch (final Exception ex) {
+            final String error = String.format(
+                "Failed to find portal listing by id (%s) and environment id (%s)",
+                portalListingId,
+                environmentId
+            );
+            log.error(error, ex);
+            throw new TechnicalException(error, ex);
+        }
+    }
+
+    @Override
+    public void deleteByEnvironmentId(String environmentId) throws TechnicalException {
+        log.debug("JdbcPortalListingRepository.deleteByEnvironmentId({})", environmentId);
+        try {
+            jdbcTemplate.update("delete from " + this.tableName + " where environment_id = ?", environmentId);
+        } catch (final Exception ex) {
+            final String error = "Failed to delete portal listings by environment id: " + environmentId;
+            log.error(error, ex);
+            throw new TechnicalException(error, ex);
+        }
+    }
+
+    @Override
+    public void deleteByOrganizationId(String organizationId) throws TechnicalException {
+        log.debug("JdbcPortalListingRepository.deleteByOrganizationId({})", organizationId);
+        try {
+            jdbcTemplate.update("delete from " + this.tableName + " where organization_id = ?", organizationId);
+        } catch (final Exception ex) {
+            final String error = "Failed to delete portal listings by organization id: " + organizationId;
+            log.error(error, ex);
+            throw new TechnicalException(error, ex);
+        }
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_12_0/14_add_portal_listings_table.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_12_0/14_add_portal_listings_table.yml
@@ -1,0 +1,29 @@
+databaseChangeLog:
+  - changeSet:
+      id: 4.12.0_add_portal_listings
+      author: GraviteeSource Team
+      changes:
+        - createTable:
+            tableName: ${gravitee_prefix}portal_listings
+            columns:
+              - column: {name: id, type: nvarchar(64), constraints: { nullable: false, primaryKey: true, primaryKeyName: pk_portal_listings } }
+              - column: {name: environment_id, type: nvarchar(64), constraints: { nullable: false } }
+              - column: {name: organization_id, type: nvarchar(64), constraints: { nullable: false } }
+              - column: {name: portal_id, type: nvarchar(64), constraints: { nullable: false } }
+              - column: {name: apis, type: nclob, constraints: { nullable: false } }
+
+        - createIndex:
+            indexName: idx_${gravitee_prefix}portal_listings_environment_id
+            columns:
+              - column:
+                  name: environment_id
+                  type: nvarchar(64)
+            tableName: ${gravitee_prefix}portal_listings
+
+        - createIndex:
+            indexName: idx_${gravitee_prefix}portal_listings_organization_id
+            columns:
+              - column:
+                  name: organization_id
+                  type: nvarchar(64)
+            tableName: ${gravitee_prefix}portal_listings

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/master.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/master.yml
@@ -371,3 +371,5 @@ databaseChangeLog:
         - file: liquibase/changelogs/v4_12_0/12_add_root_id_index_to_portal_navigation_items.yml
     - include:
         - file: liquibase/changelogs/v4_12_0/13_add_segment_to_portal_navigation_items.yml
+    - include:
+        - file: liquibase/changelogs/v4_12_0/14_add_portal_listings_table.yml

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/test/java/io/gravitee/repository/jdbc/JdbcTestRepositoryInitializer.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/test/java/io/gravitee/repository/jdbc/JdbcTestRepositoryInitializer.java
@@ -164,7 +164,8 @@ public class JdbcTestRepositoryInitializer implements TestRepositoryInitializer 
         "subscription_forms",
         "kafka_port_ranges",
         "am_connections",
-        "portals"
+        "portals",
+        "portal_listings"
     );
     private static final List<String> tablesToDrop = concatenate(tablesToTruncate, List.of("databasechangelog", "databasechangeloglock"));
     private final DataSource dataSource;

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoPortalListingRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoPortalListingRepository.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.mongodb.management;
+
+import io.gravitee.repository.exceptions.TechnicalException;
+import io.gravitee.repository.management.api.PortalListingRepository;
+import io.gravitee.repository.management.model.PortalListing;
+import io.gravitee.repository.mongodb.management.internal.model.PortalListingMongo;
+import io.gravitee.repository.mongodb.management.internal.portallisting.PortalListingMongoRepository;
+import io.gravitee.repository.mongodb.management.mapper.GraviteeMapper;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import lombok.CustomLog;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+/**
+ * @author GraviteeSource Team
+ */
+@CustomLog
+@Component
+public class MongoPortalListingRepository implements PortalListingRepository {
+
+    @Autowired
+    private PortalListingMongoRepository internalPortalListingRepo;
+
+    @Autowired
+    private GraviteeMapper mapper;
+
+    @Override
+    public Optional<PortalListing> findByIdAndEnvironmentId(String portalListingId, String environmentId) throws TechnicalException {
+        log.debug("Find portal listing by ID [{}] and environment [{}]", portalListingId, environmentId);
+        PortalListingMongo listing = internalPortalListingRepo.findByIdAndEnvironmentId(portalListingId, environmentId).orElse(null);
+        return Optional.ofNullable(mapper.map(listing));
+    }
+
+    @Override
+    public void deleteByEnvironmentId(String environmentId) throws TechnicalException {
+        try {
+            internalPortalListingRepo.deleteByEnvironmentId(environmentId);
+        } catch (Exception e) {
+            throw new TechnicalException("An error occurred when deleting portal listings by environment [" + environmentId + "]", e);
+        }
+    }
+
+    @Override
+    public void deleteByOrganizationId(String organizationId) throws TechnicalException {
+        try {
+            internalPortalListingRepo.deleteByOrganizationId(organizationId);
+        } catch (Exception e) {
+            throw new TechnicalException("An error occurred when deleting portal listings by organization [" + organizationId + "]", e);
+        }
+    }
+
+    @Override
+    public Optional<PortalListing> findById(String portalListingId) throws TechnicalException {
+        log.debug("Find portal listing by ID [{}]", portalListingId);
+        PortalListingMongo listing = internalPortalListingRepo.findById(portalListingId).orElse(null);
+        return Optional.ofNullable(mapper.map(listing));
+    }
+
+    @Override
+    public PortalListing create(PortalListing portalListing) throws TechnicalException {
+        log.debug("Create portal listing [{}]", portalListing.getId());
+        PortalListingMongo listingMongo = mapper.map(portalListing);
+        PortalListingMongo created = internalPortalListingRepo.insert(listingMongo);
+        return mapper.map(created);
+    }
+
+    @Override
+    public PortalListing update(PortalListing portalListing) throws TechnicalException {
+        if (portalListing == null) {
+            throw new IllegalStateException("Portal listing must not be null");
+        }
+
+        PortalListingMongo existing = internalPortalListingRepo.findById(portalListing.getId()).orElse(null);
+        if (existing == null) {
+            throw new IllegalStateException(String.format("No portal listing found with id [%s]", portalListing.getId()));
+        }
+
+        try {
+            PortalListingMongo updated = internalPortalListingRepo.save(mapper.map(portalListing));
+            return mapper.map(updated);
+        } catch (Exception e) {
+            throw new TechnicalException("An error occurred when updating portal listing [" + portalListing.getId() + "]", e);
+        }
+    }
+
+    @Override
+    public void delete(String portalListingId) throws TechnicalException {
+        try {
+            internalPortalListingRepo.deleteById(portalListingId);
+        } catch (Exception e) {
+            throw new TechnicalException("An error occurred when deleting portal listing [" + portalListingId + "]", e);
+        }
+    }
+
+    @Override
+    public Set<PortalListing> findAll() throws TechnicalException {
+        return internalPortalListingRepo.findAll().stream().map(mapper::map).collect(Collectors.toSet());
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/model/PortalListingMongo.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/model/PortalListingMongo.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.mongodb.management.internal.model;
+
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+/**
+ * @author GraviteeSource Team
+ */
+@Document(collection = "#{@environment.getProperty('management.mongodb.prefix')}portal_listings")
+@Data
+@EqualsAndHashCode(of = "id")
+public class PortalListingMongo {
+
+    @Id
+    private String id;
+
+    private String environmentId;
+    private String organizationId;
+    private String portalId;
+    private String apis;
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/portallisting/PortalListingMongoRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/portallisting/PortalListingMongoRepository.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.mongodb.management.internal.portallisting;
+
+import io.gravitee.repository.mongodb.management.internal.model.PortalListingMongo;
+import java.util.Optional;
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.data.mongodb.repository.Query;
+import org.springframework.stereotype.Repository;
+
+/**
+ * @author GraviteeSource Team
+ */
+@Repository
+public interface PortalListingMongoRepository extends MongoRepository<PortalListingMongo, String> {
+    @Query("{ '_id': ?0, 'environmentId': ?1 }")
+    Optional<PortalListingMongo> findByIdAndEnvironmentId(String portalListingId, String environmentId);
+
+    @Query(value = "{ 'environmentId': ?0 }", delete = true)
+    void deleteByEnvironmentId(String environmentId);
+
+    @Query(value = "{ 'organizationId': ?0 }", delete = true)
+    void deleteByOrganizationId(String organizationId);
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/mapper/GraviteeMapper.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/mapper/GraviteeMapper.java
@@ -265,6 +265,10 @@ public interface GraviteeMapper {
     PortalMongo map(Portal toMap);
     List<Portal> mapPortals(Collection<PortalMongo> toMap);
 
+    // Portal listing mapping
+    PortalListing map(PortalListingMongo toMap);
+    PortalListingMongo map(PortalListing toMap);
+
     // Portal menu links mapping
     PortalMenuLink map(PortalMenuLinkMongo toMap);
     PortalMenuLinkMongo map(PortalMenuLink toMap);

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/index/portallistings/EnvironmentIdIndexUpgrader.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/index/portallistings/EnvironmentIdIndexUpgrader.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.mongodb.management.upgrade.upgrader.index.portallistings;
+
+import io.gravitee.repository.mongodb.management.upgrade.upgrader.index.Index;
+import io.gravitee.repository.mongodb.management.upgrade.upgrader.index.IndexUpgrader;
+import org.springframework.stereotype.Component;
+
+/**
+ * Mirrors the JDBC {@code idx_portal_listings_environment_id} index on the {@code portal_listings} collection.
+ * Used by {@code deleteByEnvironmentId}; without this index MongoDB falls back to a collection scan.
+ */
+@Component("PortalListingsEnvironmentIdIndexUpgrader")
+public class EnvironmentIdIndexUpgrader extends IndexUpgrader {
+
+    @Override
+    protected Index buildIndex() {
+        return Index.builder()
+            .collection("portal_listings")
+            .name("ei1")
+            .key("environmentId", ascending())
+            .build();
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/index/portallistings/OrganizationIdIndexUpgrader.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/index/portallistings/OrganizationIdIndexUpgrader.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.mongodb.management.upgrade.upgrader.index.portallistings;
+
+import io.gravitee.repository.mongodb.management.upgrade.upgrader.index.Index;
+import io.gravitee.repository.mongodb.management.upgrade.upgrader.index.IndexUpgrader;
+import org.springframework.stereotype.Component;
+
+/**
+ * Mirrors the JDBC {@code idx_portal_listings_organization_id} index on the {@code portal_listings} collection.
+ * Used by {@code deleteByOrganizationId}; without this index MongoDB falls back to a collection scan.
+ */
+@Component("PortalListingsOrganizationIdIndexUpgrader")
+public class OrganizationIdIndexUpgrader extends IndexUpgrader {
+
+    @Override
+    protected Index buildIndex() {
+        return Index.builder()
+            .collection("portal_listings")
+            .name("oi1")
+            .key("organizationId", ascending())
+            .build();
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/AbstractManagementRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/AbstractManagementRepositoryTest.java
@@ -234,6 +234,9 @@ public abstract class AbstractManagementRepositoryTest extends AbstractRepositor
     protected PortalRepository portalRepository;
 
     @Inject
+    protected PortalListingRepository portalListingRepository;
+
+    @Inject
     protected ClusterRepository clusterRepository;
 
     @Inject
@@ -335,6 +338,7 @@ public abstract class AbstractManagementRepositoryTest extends AbstractRepositor
             case SharedPolicyGroup sharedPolicyGroup -> sharedPolicyGroupRepository.create(sharedPolicyGroup);
             case PortalMenuLink portalMenuLink -> portalMenuLinkRepository.create(portalMenuLink);
             case Portal portal -> portalRepository.create(portal);
+            case PortalListing portalListing -> portalListingRepository.create(portalListing);
             case Cluster cluster -> clusterRepository.create(cluster);
             case PortalPage portalPage -> portalPageRepository.create(portalPage);
             case PortalPageContext portalPageContext -> portalPageContextRepository.create(portalPageContext);

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/PortalListingRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/PortalListingRepositoryTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.management;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.repository.management.model.PortalListing;
+import java.util.Optional;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author GraviteeSource Team
+ */
+public class PortalListingRepositoryTest extends AbstractManagementRepositoryTest {
+
+    @Override
+    protected String getTestCasesPath() {
+        return "/data/portallisting-tests/";
+    }
+
+    @Test
+    public void should_find_by_id_and_environment() throws Exception {
+        Optional<PortalListing> listing = portalListingRepository.findByIdAndEnvironmentId("portal-listing-1", "environment1");
+
+        assertThat(listing).isPresent();
+        assertThat(listing.get().getPortalId()).isEqualTo("portal1");
+        assertThat(listing.get().getOrganizationId()).isEqualTo("organization1");
+        assertThat(listing.get().getApis()).contains("pets-api").contains("/projects/alpha");
+    }
+
+    @Test
+    public void should_not_find_by_id_when_environment_differs() throws Exception {
+        Optional<PortalListing> listing = portalListingRepository.findByIdAndEnvironmentId("portal-listing-1", "environment2");
+
+        assertThat(listing).isNotPresent();
+    }
+
+    @Test
+    public void should_create() throws Exception {
+        PortalListing toCreate = PortalListing.builder()
+            .id("new-listing")
+            .environmentId("environment1")
+            .organizationId("organization1")
+            .portalId("portal1")
+            .apis("[{\"apiHrid\":\"new-api\",\"location\":\"/projects/new\",\"order\":1}]")
+            .build();
+
+        PortalListing created = portalListingRepository.create(toCreate);
+
+        assertThat(created).isEqualTo(toCreate);
+        assertThat(portalListingRepository.findById("new-listing")).hasValue(toCreate);
+    }
+
+    @Test
+    public void should_update() throws Exception {
+        PortalListing toUpdate = PortalListing.builder()
+            .id("portal-listing-1")
+            .environmentId("environment1")
+            .organizationId("organization1")
+            .portalId("portal1")
+            .apis("[{\"apiHrid\":\"pets-api\",\"location\":\"/projects/alpha\",\"order\":2}]")
+            .build();
+
+        PortalListing updated = portalListingRepository.update(toUpdate);
+
+        assertThat(updated.getApis()).contains("\"order\":2");
+        assertThat(portalListingRepository.findById("portal-listing-1")).hasValue(toUpdate);
+    }
+
+    @Test
+    public void should_delete() throws Exception {
+        portalListingRepository.delete("portal-listing-1");
+
+        assertThat(portalListingRepository.findById("portal-listing-1")).isNotPresent();
+    }
+
+    @Test
+    public void should_delete_by_environment() throws Exception {
+        portalListingRepository.deleteByEnvironmentId("environment1");
+
+        Set<PortalListing> remaining = portalListingRepository.findAll();
+        assertThat(remaining).extracting(PortalListing::getId).containsExactlyInAnyOrder("portal-listing-4", "portal-listing-5");
+    }
+
+    @Test
+    public void should_delete_by_organization() throws Exception {
+        portalListingRepository.deleteByOrganizationId("organization1");
+
+        Set<PortalListing> remaining = portalListingRepository.findAll();
+        assertThat(remaining).extracting(PortalListing::getId).containsExactly("portal-listing-5");
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/resources/data/portallisting-tests/portalListings.json
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/resources/data/portallisting-tests/portalListings.json
@@ -1,0 +1,37 @@
+[
+  {
+    "id": "portal-listing-1",
+    "environmentId": "environment1",
+    "organizationId": "organization1",
+    "portalId": "portal1",
+    "apis": "[{\"apiHrid\":\"pets-api\",\"location\":\"/projects/alpha\",\"order\":1}]"
+  },
+  {
+    "id": "portal-listing-2",
+    "environmentId": "environment1",
+    "organizationId": "organization1",
+    "portalId": "portal1",
+    "apis": "[{\"apiHrid\":\"shop-api\",\"location\":\"/projects/beta\",\"order\":1},{\"apiHrid\":\"store-api\",\"location\":\"/projects/beta\",\"order\":2}]"
+  },
+  {
+    "id": "portal-listing-3",
+    "environmentId": "environment1",
+    "organizationId": "organization1",
+    "portalId": "portal2",
+    "apis": "[]"
+  },
+  {
+    "id": "portal-listing-4",
+    "environmentId": "environment2",
+    "organizationId": "organization1",
+    "portalId": "portal3",
+    "apis": "[]"
+  },
+  {
+    "id": "portal-listing-5",
+    "environmentId": "environment3",
+    "organizationId": "organization2",
+    "portalId": "portal4",
+    "apis": "[]"
+  }
+]

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal/validation/NavigationPathValidator.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal/validation/NavigationPathValidator.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal.validation;
+
+import io.gravitee.apim.core.validation.Validator;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Format-only checks on a portal navigation path. Stateless utility — no DI, no I/O.
+ *
+ * <p>Shared by portal-navigation-bearing resources (PortalListing entries, ApiSpec.portalNavigation, etc.)
+ * so the path conventions stay aligned. Caller passes the field name (e.g. {@code "apis[0].location"})
+ * which gets interpolated into the error message for clear pointing.
+ *
+ * @author GraviteeSource Team
+ */
+public final class NavigationPathValidator {
+
+    private NavigationPathValidator() {}
+
+    /** Returns severe errors found in the path. Empty list if the path is well-formed. */
+    public static List<Validator.Error> validate(String path, String fieldName) {
+        var errors = new ArrayList<Validator.Error>();
+        if (path == null || path.isBlank()) {
+            errors.add(Validator.Error.severe("%s must not be empty", fieldName));
+            return errors;
+        }
+        if (!path.startsWith("/")) {
+            errors.add(Validator.Error.severe("%s must start with '/' (was: %s)", fieldName, path));
+        }
+        if (path.contains("//")) {
+            errors.add(Validator.Error.severe("%s must not contain consecutive '/' (was: %s)", fieldName, path));
+        }
+        if (path.contains("..")) {
+            errors.add(Validator.Error.severe("%s must not contain '..' (was: %s)", fieldName, path));
+        }
+        if (path.length() > 1 && path.endsWith("/")) {
+            errors.add(Validator.Error.severe("%s must not end with '/' (was: %s)", fieldName, path));
+        }
+        return errors;
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_listing/crud_service/PortalListingCrudService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_listing/crud_service/PortalListingCrudService.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal_listing.crud_service;
+
+import io.gravitee.apim.core.portal_listing.model.PortalListing;
+import io.gravitee.apim.core.portal_listing.model.PortalListingId;
+import java.util.Optional;
+
+public interface PortalListingCrudService {
+    PortalListing create(PortalListing portalListing);
+
+    PortalListing update(PortalListing portalListing);
+
+    Optional<PortalListing> findByIdAndEnvironmentId(PortalListingId portalListingId, String environmentId);
+
+    void delete(PortalListingId portalListingId);
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_listing/domain_service/ValidatePortalListingDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_listing/domain_service/ValidatePortalListingDomainService.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal_listing.domain_service;
+
+import io.gravitee.apim.core.audit.model.AuditInfo;
+import io.gravitee.apim.core.portal.model.PortalId;
+import io.gravitee.apim.core.portal_listing.model.PortalListingApiEntry;
+import io.gravitee.apim.core.portal_listing.model.PortalListingId;
+import io.gravitee.apim.core.validation.Validator;
+import java.util.List;
+
+/**
+ * @author GraviteeSource Team
+ */
+public interface ValidatePortalListingDomainService extends Validator<ValidatePortalListingDomainService.Input> {
+    record Input(AuditInfo auditInfo, PortalListingId listingId, PortalId portalId, List<PortalListingApiEntry> apis) implements
+        Validator.Input {}
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_listing/exception/PortalListingNotFoundException.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_listing/exception/PortalListingNotFoundException.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal_listing.exception;
+
+import io.gravitee.apim.core.exception.NotFoundDomainException;
+
+/**
+ * @author GraviteeSource Team
+ */
+public class PortalListingNotFoundException extends NotFoundDomainException {
+
+    public PortalListingNotFoundException(String portalListingId) {
+        super("Portal Listing [ " + portalListingId + " ] not found", portalListingId);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_listing/model/PortalListing.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_listing/model/PortalListing.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal_listing.model;
+
+import io.gravitee.apim.core.portal.model.PortalId;
+import jakarta.annotation.Nonnull;
+import java.util.List;
+import lombok.Getter;
+
+@Getter
+public class PortalListing {
+
+    @Nonnull
+    private final PortalListingId id;
+
+    @Nonnull
+    private final String environmentId;
+
+    @Nonnull
+    private final String organizationId;
+
+    @Nonnull
+    private final PortalId portalId;
+
+    @Nonnull
+    private final List<PortalListingApiEntry> apis;
+
+    private PortalListing(
+        PortalListingId id,
+        String environmentId,
+        String organizationId,
+        PortalId portalId,
+        List<PortalListingApiEntry> apis
+    ) {
+        this.id = id;
+        this.environmentId = environmentId;
+        this.organizationId = organizationId;
+        this.portalId = portalId;
+        this.apis = List.copyOf(apis);
+    }
+
+    public static PortalListing of(
+        PortalListingId id,
+        String environmentId,
+        String organizationId,
+        PortalId portalId,
+        List<PortalListingApiEntry> apis
+    ) {
+        return new PortalListing(id, environmentId, organizationId, portalId, apis);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        PortalListing that = (PortalListing) o;
+        return id.equals(that.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return id.hashCode();
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_listing/model/PortalListingApiEntry.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_listing/model/PortalListingApiEntry.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal_listing.model;
+
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
+
+public record PortalListingApiEntry(@Nonnull String apiHrid, @Nonnull String location, @Nullable Integer order) {}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_listing/model/PortalListingId.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_listing/model/PortalListingId.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal_listing.model;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+import jakarta.annotation.Nonnull;
+import java.util.UUID;
+
+public record PortalListingId(@Nonnull UUID id) {
+    public static PortalListingId random() {
+        return new PortalListingId(UUID.randomUUID());
+    }
+
+    public static PortalListingId of(String value) {
+        return new PortalListingId(UUID.fromString(value));
+    }
+
+    @JsonValue
+    @Override
+    public String toString() {
+        return id.toString();
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_listing/use_case/CreateOrUpdatePortalListingUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_listing/use_case/CreateOrUpdatePortalListingUseCase.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal_listing.use_case;
+
+import io.gravitee.apim.core.audit.model.AuditInfo;
+import io.gravitee.apim.core.exception.ValidationDomainException;
+import io.gravitee.apim.core.portal.model.PortalId;
+import io.gravitee.apim.core.portal_listing.crud_service.PortalListingCrudService;
+import io.gravitee.apim.core.portal_listing.domain_service.ValidatePortalListingDomainService;
+import io.gravitee.apim.core.portal_listing.model.PortalListing;
+import io.gravitee.apim.core.portal_listing.model.PortalListingApiEntry;
+import io.gravitee.apim.core.portal_listing.model.PortalListingId;
+import io.gravitee.apim.core.validation.Validator;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class CreateOrUpdatePortalListingUseCase {
+
+    private final ValidatePortalListingDomainService validator;
+    private final PortalListingCrudService portalListingCrudService;
+
+    public record Input(AuditInfo auditInfo, PortalListingId listingId, PortalId portalId, List<PortalListingApiEntry> apis) {}
+
+    public record Output(PortalListingId id, List<Validator.Error> errors) {}
+
+    public Output execute(Input input) {
+        var validation = validator.validateAndSanitize(
+            new ValidatePortalListingDomainService.Input(input.auditInfo(), input.listingId(), input.portalId(), input.apis())
+        );
+
+        validation
+            .severe()
+            .ifPresent(errors -> {
+                throw new ValidationDomainException(errors.stream().map(Validator.Error::getMessage).collect(Collectors.joining(", ")));
+            });
+
+        var warnings = validation.warning().orElseGet(List::of);
+
+        var listing = PortalListing.of(
+            input.listingId(),
+            input.auditInfo().environmentId(),
+            input.auditInfo().organizationId(),
+            input.portalId(),
+            input.apis() == null ? List.of() : input.apis()
+        );
+
+        var existing = portalListingCrudService.findByIdAndEnvironmentId(input.listingId(), input.auditInfo().environmentId());
+        var saved = existing.isPresent() ? portalListingCrudService.update(listing) : portalListingCrudService.create(listing);
+
+        return new Output(saved.getId(), warnings);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_listing/use_case/DeletePortalListingUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_listing/use_case/DeletePortalListingUseCase.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal_listing.use_case;
+
+import io.gravitee.apim.core.audit.model.AuditInfo;
+import io.gravitee.apim.core.portal_listing.crud_service.PortalListingCrudService;
+import io.gravitee.apim.core.portal_listing.exception.PortalListingNotFoundException;
+import io.gravitee.apim.core.portal_listing.model.PortalListingId;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class DeletePortalListingUseCase {
+
+    private final PortalListingCrudService portalListingCrudService;
+
+    public record Input(AuditInfo auditInfo, PortalListingId listingId) {}
+
+    public void execute(Input input) {
+        portalListingCrudService
+            .findByIdAndEnvironmentId(input.listingId(), input.auditInfo().environmentId())
+            .orElseThrow(() -> new PortalListingNotFoundException(input.listingId().toString()));
+        portalListingCrudService.delete(input.listingId());
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_listing/use_case/GetPortalListingUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_listing/use_case/GetPortalListingUseCase.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal_listing.use_case;
+
+import io.gravitee.apim.core.audit.model.AuditInfo;
+import io.gravitee.apim.core.portal_listing.crud_service.PortalListingCrudService;
+import io.gravitee.apim.core.portal_listing.exception.PortalListingNotFoundException;
+import io.gravitee.apim.core.portal_listing.model.PortalListing;
+import io.gravitee.apim.core.portal_listing.model.PortalListingId;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class GetPortalListingUseCase {
+
+    private final PortalListingCrudService portalListingCrudService;
+
+    public record Input(AuditInfo auditInfo, PortalListingId listingId) {}
+
+    public record Output(PortalListing portalListing) {}
+
+    public Output execute(Input input) {
+        var listing = portalListingCrudService
+            .findByIdAndEnvironmentId(input.listingId(), input.auditInfo().environmentId())
+            .orElseThrow(() -> new PortalListingNotFoundException(input.listingId().toString()));
+        return new Output(listing);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_listing/use_case/ValidatePortalListingUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_listing/use_case/ValidatePortalListingUseCase.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal_listing.use_case;
+
+import io.gravitee.apim.core.portal_listing.domain_service.ValidatePortalListingDomainService;
+import io.gravitee.apim.core.validation.Validator;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class ValidatePortalListingUseCase {
+
+    private final ValidatePortalListingDomainService validator;
+
+    public CreateOrUpdatePortalListingUseCase.Output execute(CreateOrUpdatePortalListingUseCase.Input input) {
+        var result = validator.validateAndSanitize(
+            new ValidatePortalListingDomainService.Input(input.auditInfo(), input.listingId(), input.portalId(), input.apis())
+        );
+        List<Validator.Error> errors = result.errors().orElseGet(List::of);
+        return new CreateOrUpdatePortalListingUseCase.Output(input.listingId(), errors);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/PortalListingAdapter.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/PortalListingAdapter.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.infra.adapter;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import io.gravitee.apim.core.portal.model.PortalId;
+import io.gravitee.apim.core.portal_listing.model.PortalListing;
+import io.gravitee.apim.core.portal_listing.model.PortalListingApiEntry;
+import io.gravitee.apim.core.portal_listing.model.PortalListingId;
+import java.util.List;
+import org.mapstruct.Mapper;
+import org.mapstruct.factory.Mappers;
+
+@Mapper
+public interface PortalListingAdapter {
+    PortalListingAdapter INSTANCE = Mappers.getMapper(PortalListingAdapter.class);
+
+    TypeReference<List<PortalListingApiEntry>> APIS_TYPE = new TypeReference<>() {};
+
+    default PortalListing toEntity(io.gravitee.repository.management.model.PortalListing portalListing) {
+        if (portalListing == null) {
+            return null;
+        }
+        return PortalListing.of(
+            PortalListingId.of(portalListing.getId()),
+            portalListing.getEnvironmentId(),
+            portalListing.getOrganizationId(),
+            PortalId.of(portalListing.getPortalId()),
+            deserializeApis(portalListing.getApis())
+        );
+    }
+
+    default io.gravitee.repository.management.model.PortalListing toRepository(PortalListing portalListing) {
+        if (portalListing == null) {
+            return null;
+        }
+        return io.gravitee.repository.management.model.PortalListing.builder()
+            .id(portalListing.getId().toString())
+            .environmentId(portalListing.getEnvironmentId())
+            .organizationId(portalListing.getOrganizationId())
+            .portalId(portalListing.getPortalId().toString())
+            .apis(serializeApis(portalListing.getApis()))
+            .build();
+    }
+
+    static String serializeApis(List<PortalListingApiEntry> apis) {
+        try {
+            return GraviteeJacksonMapper.getInstance().writeValueAsString(apis == null ? List.of() : apis);
+        } catch (JsonProcessingException e) {
+            throw new IllegalStateException("Failed to serialize PortalListing apis", e);
+        }
+    }
+
+    static List<PortalListingApiEntry> deserializeApis(String apis) {
+        if (apis == null || apis.isBlank()) {
+            return List.of();
+        }
+        try {
+            return GraviteeJacksonMapper.getInstance().readValue(apis, APIS_TYPE);
+        } catch (JsonProcessingException e) {
+            throw new IllegalStateException("Failed to deserialize PortalListing apis", e);
+        }
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/crud_service/portal_listing/PortalListingCrudServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/crud_service/portal_listing/PortalListingCrudServiceImpl.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.infra.crud_service.portal_listing;
+
+import io.gravitee.apim.core.exception.TechnicalDomainException;
+import io.gravitee.apim.core.portal_listing.crud_service.PortalListingCrudService;
+import io.gravitee.apim.core.portal_listing.model.PortalListing;
+import io.gravitee.apim.core.portal_listing.model.PortalListingId;
+import io.gravitee.apim.infra.adapter.PortalListingAdapter;
+import io.gravitee.repository.exceptions.TechnicalException;
+import io.gravitee.repository.management.api.PortalListingRepository;
+import java.util.Optional;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.stereotype.Component;
+
+@Component
+public class PortalListingCrudServiceImpl implements PortalListingCrudService {
+
+    private final PortalListingRepository portalListingRepository;
+    private static final PortalListingAdapter portalListingAdapter = PortalListingAdapter.INSTANCE;
+
+    public PortalListingCrudServiceImpl(@Lazy PortalListingRepository portalListingRepository) {
+        this.portalListingRepository = portalListingRepository;
+    }
+
+    @Override
+    public PortalListing create(PortalListing portalListing) {
+        try {
+            var result = portalListingRepository.create(portalListingAdapter.toRepository(portalListing));
+            return portalListingAdapter.toEntity(result);
+        } catch (TechnicalException e) {
+            throw new TechnicalDomainException(
+                String.format("An error occurred while trying to create a Portal Listing with id: %s", portalListing.getId()),
+                e
+            );
+        }
+    }
+
+    @Override
+    public PortalListing update(PortalListing portalListing) {
+        try {
+            var result = portalListingRepository.update(portalListingAdapter.toRepository(portalListing));
+            return portalListingAdapter.toEntity(result);
+        } catch (TechnicalException e) {
+            throw new TechnicalDomainException(
+                String.format("An error occurred while trying to update a Portal Listing with id: %s", portalListing.getId()),
+                e
+            );
+        }
+    }
+
+    @Override
+    public Optional<PortalListing> findByIdAndEnvironmentId(PortalListingId portalListingId, String environmentId) {
+        try {
+            return portalListingRepository
+                .findByIdAndEnvironmentId(portalListingId.toString(), environmentId)
+                .map(portalListingAdapter::toEntity);
+        } catch (TechnicalException e) {
+            throw new TechnicalDomainException(
+                String.format(
+                    "An error occurred while trying to find a Portal Listing with id (%s) in environment (%s)",
+                    portalListingId,
+                    environmentId
+                ),
+                e
+            );
+        }
+    }
+
+    @Override
+    public void delete(PortalListingId portalListingId) {
+        try {
+            portalListingRepository.delete(portalListingId.toString());
+        } catch (TechnicalException e) {
+            throw new TechnicalDomainException(
+                String.format("An error occurred while trying to delete the Portal Listing with id: %s", portalListingId),
+                e
+            );
+        }
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/portal_listing/ValidatePortalListingDomainServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/portal_listing/ValidatePortalListingDomainServiceImpl.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.infra.domain_service.portal_listing;
+
+import io.gravitee.apim.core.portal.validation.NavigationPathValidator;
+import io.gravitee.apim.core.portal_listing.domain_service.ValidatePortalListingDomainService;
+import io.gravitee.apim.core.portal_listing.model.PortalListingApiEntry;
+import java.util.ArrayList;
+import java.util.List;
+import org.springframework.stereotype.Component;
+
+/**
+ * Validates Portal Listing input. Format checks only — no reference-existence checks (parent portal,
+ * referenced APIs). Missing parent / API entities are tolerated as orphans per the orphan-tolerance
+ * design; they materialize once the missing CRD applies.
+ *
+ * @author GraviteeSource Team
+ */
+@Component
+public class ValidatePortalListingDomainServiceImpl implements ValidatePortalListingDomainService {
+
+    @Override
+    public Result<Input> validateAndSanitize(Input input) {
+        var errors = new ArrayList<Error>();
+        List<PortalListingApiEntry> apis = input.apis() == null ? List.of() : input.apis();
+        for (int i = 0; i < apis.size(); i++) {
+            errors.addAll(NavigationPathValidator.validate(apis.get(i).location(), "apis[" + i + "].location"));
+        }
+        return Result.ofBoth(input, errors);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/cockpit/command/handler/DeleteEnvironmentCommandHandler.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/cockpit/command/handler/DeleteEnvironmentCommandHandler.java
@@ -57,6 +57,7 @@ import io.gravitee.repository.management.api.PageRepository;
 import io.gravitee.repository.management.api.PageRevisionRepository;
 import io.gravitee.repository.management.api.ParameterRepository;
 import io.gravitee.repository.management.api.PlanRepository;
+import io.gravitee.repository.management.api.PortalListingRepository;
 import io.gravitee.repository.management.api.PortalMenuLinkRepository;
 import io.gravitee.repository.management.api.PortalNavigationItemRepository;
 import io.gravitee.repository.management.api.PortalNotificationConfigRepository;
@@ -171,6 +172,7 @@ public class DeleteEnvironmentCommandHandler implements CommandHandler<DeleteEnv
     private final PortalNavigationItemRepository portalNavigationItemRepository;
     private final PortalPageContentRepository portalPageContentRepository;
     private final PortalRepository portalRepository;
+    private final PortalListingRepository portalListingRepository;
     private final PromotionRepository promotionRepository;
     private final QualityRuleRepository qualityRuleRepository;
     private final RatingAnswerRepository ratingAnswerRepository;
@@ -230,6 +232,7 @@ public class DeleteEnvironmentCommandHandler implements CommandHandler<DeleteEnv
         @Lazy PortalNavigationItemRepository portalNavigationItemRepository,
         @Lazy PortalPageContentRepository portalPageContentRepository,
         @Lazy PortalRepository portalRepository,
+        @Lazy PortalListingRepository portalListingRepository,
         @Lazy PromotionRepository promotionRepository,
         @Lazy QualityRuleRepository qualityRuleRepository,
         @Lazy RatingAnswerRepository ratingAnswerRepository,
@@ -302,6 +305,7 @@ public class DeleteEnvironmentCommandHandler implements CommandHandler<DeleteEnv
         this.portalNavigationItemRepository = portalNavigationItemRepository;
         this.portalPageContentRepository = portalPageContentRepository;
         this.portalRepository = portalRepository;
+        this.portalListingRepository = portalListingRepository;
         this.promotionRepository = promotionRepository;
         this.qualityRuleRepository = qualityRuleRepository;
         this.ratingAnswerRepository = ratingAnswerRepository;
@@ -408,6 +412,7 @@ public class DeleteEnvironmentCommandHandler implements CommandHandler<DeleteEnv
         portalPageRepository.deleteByEnvironmentId(environment.getId());
         deletePortalNavigationItems(environment);
         portalNavigationItemRepository.deleteByEnvironmentId(environment.getId());
+        portalListingRepository.deleteByEnvironmentId(environment.getId());
         portalRepository.deleteByEnvironmentId(environment.getId());
         customUserFieldsRepository.deleteByReferenceIdAndReferenceType(environment.getId(), CustomUserFieldReferenceType.ENVIRONMENT);
         groupRepository

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/common/HRIDToUUID.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/common/HRIDToUUID.java
@@ -22,11 +22,13 @@ import io.gravitee.apim.core.audit.model.AuditInfo;
  * <p>
  * Top-level resources (API, Application, SharedPolicyGroup, Group) produce both {@code id()} and {@code crossId()}.
  * Sub-resources (Plan, Page, Subscription) are scoped to a parent API and only produce {@code id()}.
+ * Portal sub-resources (Portal Listing) are scoped to a parent Portal and only produce {@code id()}.
  * <p>
  * Examples:
  * <pre>
  * HRIDToUUID.api().context(audit).hrid("my-api").id()
  * HRIDToUUID.plan().context(audit).api("my-api").plan("my-plan").id()
+ * HRIDToUUID.portalListing().context(audit).portal("my-portal").hrid("my-listing").id()
  * </pre>
  *
  * @author Benoit BORDIGONI (benoit.bordigoni at graviteesource.com)
@@ -74,6 +76,10 @@ public final class HRIDToUUID {
 
     public static NavigationBuilder navigation() {
         return new NavigationBuilder();
+    }
+
+    public static PortalSubResourceBuilder portalListing() {
+        return new PortalSubResourceBuilder();
     }
 
     public static class TopLevelBuilder {
@@ -169,6 +175,35 @@ public final class HRIDToUUID {
     public record NavigationItemResult(String organizationId, String environmentId, String portalId, String kind, String identifier) {
         public String id() {
             return UuidString.generateFrom(organizationId, environmentId, portalId, kind, identifier);
+        }
+    }
+
+    public static class PortalSubResourceBuilder {
+
+        public PortalSubResourceWithContext context(AuditInfo audit) {
+            return new PortalSubResourceWithContext(audit.organizationId(), audit.environmentId());
+        }
+
+        public PortalSubResourceWithContext context(ExecutionContext ctx) {
+            return new PortalSubResourceWithContext(ctx.getOrganizationId(), ctx.getEnvironmentId());
+        }
+    }
+
+    public record PortalSubResourceWithContext(String organizationId, String environmentId) {
+        public PortalSubResourceWithPortal portal(String portalHrid) {
+            return new PortalSubResourceWithPortal(UuidString.generateFrom(organizationId, "portal", portalHrid), environmentId);
+        }
+    }
+
+    public record PortalSubResourceWithPortal(String portalCrossId, String environmentId) {
+        public PortalSubResourceResult hrid(String hrid) {
+            return new PortalSubResourceResult(portalCrossId, environmentId, hrid);
+        }
+    }
+
+    public record PortalSubResourceResult(String portalCrossId, String environmentId, String hrid) {
+        public String id() {
+            return UuidString.generateFrom(portalCrossId, environmentId, hrid);
         }
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/fixtures/core/model/PortalListingFixtures.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/fixtures/core/model/PortalListingFixtures.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package fixtures.core.model;
+
+import io.gravitee.apim.core.portal_listing.model.PortalListing;
+import io.gravitee.apim.core.portal_listing.model.PortalListingApiEntry;
+import io.gravitee.apim.core.portal_listing.model.PortalListingId;
+import java.util.List;
+
+public class PortalListingFixtures {
+
+    private PortalListingFixtures() {}
+
+    public static final PortalListingId PORTAL_LISTING_ID = PortalListingId.of("00000000-0000-0000-0000-0000000000b1");
+
+    public static PortalListing aPortalListing() {
+        return PortalListing.of(
+            PORTAL_LISTING_ID,
+            "environment-id",
+            "organization-id",
+            PortalFixtures.PORTAL_ID,
+            List.of(new PortalListingApiEntry("pets-api", "/projects/alpha", 1))
+        );
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/PortalListingCrudServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/PortalListingCrudServiceInMemory.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package inmemory;
+
+import io.gravitee.apim.core.portal_listing.crud_service.PortalListingCrudService;
+import io.gravitee.apim.core.portal_listing.exception.PortalListingNotFoundException;
+import io.gravitee.apim.core.portal_listing.model.PortalListing;
+import io.gravitee.apim.core.portal_listing.model.PortalListingId;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.OptionalInt;
+
+public class PortalListingCrudServiceInMemory implements PortalListingCrudService, InMemoryAlternative<PortalListing> {
+
+    final ArrayList<PortalListing> storage = new ArrayList<>();
+
+    @Override
+    public PortalListing create(PortalListing portalListing) {
+        storage.add(portalListing);
+        return portalListing;
+    }
+
+    @Override
+    public PortalListing update(PortalListing portalListing) {
+        OptionalInt index = this.findIndex(this.storage, p -> p.getId().equals(portalListing.getId()));
+        if (index.isPresent()) {
+            storage.set(index.getAsInt(), portalListing);
+            return portalListing;
+        }
+        throw new PortalListingNotFoundException(portalListing.getId().toString());
+    }
+
+    @Override
+    public Optional<PortalListing> findByIdAndEnvironmentId(PortalListingId portalListingId, String environmentId) {
+        return storage
+            .stream()
+            .filter(p -> portalListingId.equals(p.getId()) && environmentId.equals(p.getEnvironmentId()))
+            .findFirst();
+    }
+
+    @Override
+    public void delete(PortalListingId portalListingId) {
+        storage.removeIf(p -> portalListingId.equals(p.getId()));
+    }
+
+    @Override
+    public void initWith(List<PortalListing> items) {
+        storage.clear();
+        storage.addAll(items);
+    }
+
+    @Override
+    public void reset() {
+        storage.clear();
+    }
+
+    @Override
+    public List<PortalListing> storage() {
+        return Collections.unmodifiableList(storage);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/ValidatePortalListingDomainServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/ValidatePortalListingDomainServiceInMemory.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package inmemory;
+
+import io.gravitee.apim.core.portal.validation.NavigationPathValidator;
+import io.gravitee.apim.core.portal_listing.domain_service.ValidatePortalListingDomainService;
+import io.gravitee.apim.core.portal_listing.model.PortalListingApiEntry;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Mirrors {@code ValidatePortalListingDomainServiceImpl}. Uses the same shared
+ * {@link NavigationPathValidator} so the test path stays aligned with production.
+ */
+public class ValidatePortalListingDomainServiceInMemory implements ValidatePortalListingDomainService {
+
+    @Override
+    public Result<Input> validateAndSanitize(Input input) {
+        var errors = new ArrayList<Error>();
+        List<PortalListingApiEntry> apis = input.apis() == null ? List.of() : input.apis();
+        for (int i = 0; i < apis.size(); i++) {
+            errors.addAll(NavigationPathValidator.validate(apis.get(i).location(), "apis[" + i + "].location"));
+        }
+        return Result.ofBoth(input, errors);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/spring/InMemoryConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/spring/InMemoryConfiguration.java
@@ -559,6 +559,16 @@ public class InMemoryConfiguration {
     }
 
     @Bean
+    public PortalListingCrudServiceInMemory portalListingCrudService() {
+        return new PortalListingCrudServiceInMemory();
+    }
+
+    @Bean
+    public ValidatePortalListingDomainServiceInMemory validatePortalListingDomainService() {
+        return new ValidatePortalListingDomainServiceInMemory();
+    }
+
+    @Bean
     public ApiProductCrudServiceInMemory apiProductCrudService() {
         return new ApiProductCrudServiceInMemory();
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal/validation/NavigationPathValidatorTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal/validation/NavigationPathValidatorTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal.validation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.apim.core.validation.Validator;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class NavigationPathValidatorTest {
+
+    @Test
+    void should_accept_root_path() {
+        assertThat(NavigationPathValidator.validate("/", "f")).isEmpty();
+    }
+
+    @Test
+    void should_accept_nested_path() {
+        assertThat(NavigationPathValidator.validate("/projects/alpha", "f")).isEmpty();
+    }
+
+    @Test
+    void should_reject_null() {
+        var errors = NavigationPathValidator.validate(null, "f");
+        assertThat(errors).hasSize(1);
+        assertThat(errors.get(0).isSevere()).isTrue();
+        assertThat(errors.get(0).getMessage()).contains("f").contains("must not be empty");
+    }
+
+    @Test
+    void should_reject_blank() {
+        var errors = NavigationPathValidator.validate("  ", "f");
+        assertThat(errors).anyMatch(e -> e.getMessage().contains("must not be empty"));
+    }
+
+    @Test
+    void should_reject_path_not_starting_with_slash() {
+        var errors = NavigationPathValidator.validate("projects/alpha", "f");
+        assertThat(errors).anyMatch(e -> e.getMessage().contains("must start with '/'"));
+    }
+
+    @Test
+    void should_reject_path_with_consecutive_slashes() {
+        var errors = NavigationPathValidator.validate("/projects//alpha", "f");
+        assertThat(errors).anyMatch(e -> e.getMessage().contains("consecutive"));
+    }
+
+    @Test
+    void should_reject_path_with_parent_traversal() {
+        var errors = NavigationPathValidator.validate("/projects/../alpha", "f");
+        assertThat(errors).anyMatch(e -> e.getMessage().contains(".."));
+    }
+
+    @Test
+    void should_reject_path_with_trailing_slash() {
+        var errors = NavigationPathValidator.validate("/projects/alpha/", "f");
+        assertThat(errors).anyMatch(e -> e.getMessage().contains("end with"));
+    }
+
+    @Test
+    void should_only_emit_severe_errors() {
+        var errors = NavigationPathValidator.validate("bad", "f");
+        assertThat(errors).allMatch(Validator.Error::isSevere);
+    }
+
+    @Test
+    void should_interpolate_field_name_into_messages() {
+        var errors = NavigationPathValidator.validate("bad", "apis[2].location");
+        assertThat(errors).allMatch(e -> e.getMessage().startsWith("apis[2].location"));
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_listing/use_case/CreateOrUpdatePortalListingUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_listing/use_case/CreateOrUpdatePortalListingUseCaseTest.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal_listing.use_case;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+
+import inmemory.PortalListingCrudServiceInMemory;
+import inmemory.ValidatePortalListingDomainServiceInMemory;
+import io.gravitee.apim.core.audit.model.AuditActor;
+import io.gravitee.apim.core.audit.model.AuditInfo;
+import io.gravitee.apim.core.exception.ValidationDomainException;
+import io.gravitee.apim.core.portal.model.PortalId;
+import io.gravitee.apim.core.portal_listing.model.PortalListingApiEntry;
+import io.gravitee.apim.core.portal_listing.model.PortalListingId;
+import io.gravitee.rest.api.service.common.HRIDToUUID;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class CreateOrUpdatePortalListingUseCaseTest {
+
+    private static final AuditInfo AUDIT_INFO = AuditInfo.builder()
+        .organizationId("organization-id")
+        .environmentId("environment-id")
+        .actor(AuditActor.builder().userId("user-id").build())
+        .build();
+    private static final String PORTAL_HRID = "default-portal";
+    private static final String LISTING_HRID = "default-listing";
+    private static final PortalId PORTAL_ID = PortalId.of(HRIDToUUID.portal().context(AUDIT_INFO).hrid(PORTAL_HRID).id());
+    private static final PortalListingId LISTING_ID = PortalListingId.of(
+        HRIDToUUID.portalListing().context(AUDIT_INFO).portal(PORTAL_HRID).hrid(LISTING_HRID).id()
+    );
+
+    private final PortalListingCrudServiceInMemory portalListingCrudService = new PortalListingCrudServiceInMemory();
+    private final ValidatePortalListingDomainServiceInMemory validator = new ValidatePortalListingDomainServiceInMemory();
+    private CreateOrUpdatePortalListingUseCase useCase;
+
+    @BeforeEach
+    void setUp() {
+        useCase = new CreateOrUpdatePortalListingUseCase(validator, portalListingCrudService);
+    }
+
+    @AfterEach
+    void tearDown() {
+        portalListingCrudService.reset();
+    }
+
+    @Test
+    void should_create_when_not_existing() {
+        var apis = List.of(new PortalListingApiEntry("pets-api", "/projects/alpha", 1));
+
+        var output = useCase.execute(new CreateOrUpdatePortalListingUseCase.Input(AUDIT_INFO, LISTING_ID, PORTAL_ID, apis));
+
+        assertThat(output.id()).isEqualTo(LISTING_ID);
+        assertThat(output.errors()).isEmpty();
+        assertThat(portalListingCrudService.storage()).hasSize(1);
+        assertThat(portalListingCrudService.storage().get(0).getApis()).isEqualTo(apis);
+    }
+
+    @Test
+    void should_update_when_existing() {
+        useCase.execute(
+            new CreateOrUpdatePortalListingUseCase.Input(
+                AUDIT_INFO,
+                LISTING_ID,
+                PORTAL_ID,
+                List.of(new PortalListingApiEntry("pets-api", "/projects/alpha", 1))
+            )
+        );
+
+        var updatedApis = List.of(
+            new PortalListingApiEntry("pets-api", "/projects/alpha", 1),
+            new PortalListingApiEntry("shop-api", "/projects/beta", 2)
+        );
+        var output = useCase.execute(new CreateOrUpdatePortalListingUseCase.Input(AUDIT_INFO, LISTING_ID, PORTAL_ID, updatedApis));
+
+        assertThat(output.id()).isEqualTo(LISTING_ID);
+        assertThat(portalListingCrudService.storage()).hasSize(1);
+        assertThat(portalListingCrudService.storage().get(0).getApis()).isEqualTo(updatedApis);
+    }
+
+    @Test
+    void should_be_idempotent_when_put_twice() {
+        var input = new CreateOrUpdatePortalListingUseCase.Input(
+            AUDIT_INFO,
+            LISTING_ID,
+            PORTAL_ID,
+            List.of(new PortalListingApiEntry("pets-api", "/projects/alpha", 1))
+        );
+
+        var first = useCase.execute(input);
+        var second = useCase.execute(input);
+
+        assertThat(first.id()).isEqualTo(second.id());
+        assertThat(portalListingCrudService.storage()).hasSize(1);
+    }
+
+    @Test
+    void should_persist_listing_under_the_provided_id() {
+        useCase.execute(
+            new CreateOrUpdatePortalListingUseCase.Input(
+                AUDIT_INFO,
+                LISTING_ID,
+                PORTAL_ID,
+                List.of(new PortalListingApiEntry("pets-api", "/projects/alpha", 1))
+            )
+        );
+
+        var persisted = portalListingCrudService.storage().get(0);
+        assertThat(persisted.getId()).isEqualTo(LISTING_ID);
+        assertThat(persisted.getPortalId()).isEqualTo(PORTAL_ID);
+    }
+
+    @Test
+    void should_persist_even_when_parent_portal_does_not_exist() {
+        // Orphan tolerance: no portal-existence check; the listing is written and waits for its parent.
+        var apis = List.of(new PortalListingApiEntry("pets-api", "/projects/alpha", 1));
+
+        var output = useCase.execute(new CreateOrUpdatePortalListingUseCase.Input(AUDIT_INFO, LISTING_ID, PORTAL_ID, apis));
+
+        assertThat(output.errors()).isEmpty();
+        assertThat(portalListingCrudService.storage()).hasSize(1);
+    }
+
+    @Test
+    void should_throw_validation_error_when_location_is_malformed() {
+        var apis = List.of(new PortalListingApiEntry("pets-api", "projects/alpha", 1));
+
+        var throwable = catchThrowable(() ->
+            useCase.execute(new CreateOrUpdatePortalListingUseCase.Input(AUDIT_INFO, LISTING_ID, PORTAL_ID, apis))
+        );
+
+        assertThat(throwable).isInstanceOf(ValidationDomainException.class);
+        assertThat(throwable.getMessage()).contains("apis[0].location");
+        assertThat(portalListingCrudService.storage()).isEmpty();
+    }
+
+    @Test
+    void should_accept_empty_apis_list() {
+        var output = useCase.execute(new CreateOrUpdatePortalListingUseCase.Input(AUDIT_INFO, LISTING_ID, PORTAL_ID, List.of()));
+
+        assertThat(output.errors()).isEmpty();
+        assertThat(portalListingCrudService.storage()).hasSize(1);
+        assertThat(portalListingCrudService.storage().get(0).getApis()).isEmpty();
+    }
+
+    @Test
+    void should_treat_null_apis_as_empty() {
+        var output = useCase.execute(new CreateOrUpdatePortalListingUseCase.Input(AUDIT_INFO, LISTING_ID, PORTAL_ID, null));
+
+        assertThat(output.errors()).isEmpty();
+        assertThat(portalListingCrudService.storage().get(0).getApis()).isEmpty();
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_listing/use_case/DeletePortalListingUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_listing/use_case/DeletePortalListingUseCaseTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal_listing.use_case;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+
+import inmemory.PortalListingCrudServiceInMemory;
+import io.gravitee.apim.core.audit.model.AuditActor;
+import io.gravitee.apim.core.audit.model.AuditInfo;
+import io.gravitee.apim.core.portal.model.PortalId;
+import io.gravitee.apim.core.portal_listing.exception.PortalListingNotFoundException;
+import io.gravitee.apim.core.portal_listing.model.PortalListing;
+import io.gravitee.apim.core.portal_listing.model.PortalListingApiEntry;
+import io.gravitee.apim.core.portal_listing.model.PortalListingId;
+import io.gravitee.rest.api.service.common.HRIDToUUID;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class DeletePortalListingUseCaseTest {
+
+    private static final AuditInfo AUDIT_INFO = AuditInfo.builder()
+        .organizationId("organization-id")
+        .environmentId("environment-id")
+        .actor(AuditActor.builder().userId("user-id").build())
+        .build();
+    private static final String PORTAL_HRID = "default-portal";
+    private static final String LISTING_HRID = "default-listing";
+    private static final PortalListingId LISTING_ID = PortalListingId.of(
+        HRIDToUUID.portalListing().context(AUDIT_INFO).portal(PORTAL_HRID).hrid(LISTING_HRID).id()
+    );
+
+    private final PortalListingCrudServiceInMemory portalListingCrudService = new PortalListingCrudServiceInMemory();
+    private DeletePortalListingUseCase useCase;
+
+    @BeforeEach
+    void setUp() {
+        useCase = new DeletePortalListingUseCase(portalListingCrudService);
+    }
+
+    @AfterEach
+    void tearDown() {
+        portalListingCrudService.reset();
+    }
+
+    @Test
+    void should_delete() {
+        portalListingCrudService.initWith(List.of(aListing()));
+
+        useCase.execute(new DeletePortalListingUseCase.Input(AUDIT_INFO, LISTING_ID));
+
+        assertThat(portalListingCrudService.storage()).isEmpty();
+    }
+
+    @Test
+    void should_throw_when_missing() {
+        var throwable = catchThrowable(() -> useCase.execute(new DeletePortalListingUseCase.Input(AUDIT_INFO, LISTING_ID)));
+
+        assertThat(throwable).isInstanceOf(PortalListingNotFoundException.class);
+    }
+
+    @Test
+    void should_throw_when_id_exists_in_different_environment() {
+        portalListingCrudService.initWith(List.of(aListing()));
+
+        var otherEnvAudit = AuditInfo.builder()
+            .organizationId("organization-id")
+            .environmentId("other-env")
+            .actor(AuditActor.builder().userId("user-id").build())
+            .build();
+
+        var throwable = catchThrowable(() -> useCase.execute(new DeletePortalListingUseCase.Input(otherEnvAudit, LISTING_ID)));
+
+        assertThat(throwable).isInstanceOf(PortalListingNotFoundException.class);
+        assertThat(portalListingCrudService.storage()).hasSize(1);
+    }
+
+    private static PortalListing aListing() {
+        var portalId = PortalId.of(HRIDToUUID.portal().context(AUDIT_INFO).hrid(PORTAL_HRID).id());
+        return PortalListing.of(
+            LISTING_ID,
+            AUDIT_INFO.environmentId(),
+            AUDIT_INFO.organizationId(),
+            portalId,
+            List.of(new PortalListingApiEntry("pets-api", "/projects/alpha", 1))
+        );
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_listing/use_case/GetPortalListingUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_listing/use_case/GetPortalListingUseCaseTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal_listing.use_case;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+
+import inmemory.PortalListingCrudServiceInMemory;
+import io.gravitee.apim.core.audit.model.AuditActor;
+import io.gravitee.apim.core.audit.model.AuditInfo;
+import io.gravitee.apim.core.portal.model.PortalId;
+import io.gravitee.apim.core.portal_listing.exception.PortalListingNotFoundException;
+import io.gravitee.apim.core.portal_listing.model.PortalListing;
+import io.gravitee.apim.core.portal_listing.model.PortalListingApiEntry;
+import io.gravitee.apim.core.portal_listing.model.PortalListingId;
+import io.gravitee.rest.api.service.common.HRIDToUUID;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class GetPortalListingUseCaseTest {
+
+    private static final AuditInfo AUDIT_INFO = AuditInfo.builder()
+        .organizationId("organization-id")
+        .environmentId("environment-id")
+        .actor(AuditActor.builder().userId("user-id").build())
+        .build();
+    private static final String PORTAL_HRID = "default-portal";
+    private static final String LISTING_HRID = "default-listing";
+    private static final PortalListingId LISTING_ID = PortalListingId.of(
+        HRIDToUUID.portalListing().context(AUDIT_INFO).portal(PORTAL_HRID).hrid(LISTING_HRID).id()
+    );
+
+    private final PortalListingCrudServiceInMemory portalListingCrudService = new PortalListingCrudServiceInMemory();
+    private GetPortalListingUseCase useCase;
+
+    @BeforeEach
+    void setUp() {
+        useCase = new GetPortalListingUseCase(portalListingCrudService);
+    }
+
+    @AfterEach
+    void tearDown() {
+        portalListingCrudService.reset();
+    }
+
+    @Test
+    void should_return_listing() {
+        var stored = aListing();
+        portalListingCrudService.initWith(List.of(stored));
+
+        var output = useCase.execute(new GetPortalListingUseCase.Input(AUDIT_INFO, LISTING_ID));
+
+        assertThat(output.portalListing()).isEqualTo(stored);
+    }
+
+    @Test
+    void should_throw_when_missing() {
+        var throwable = catchThrowable(() -> useCase.execute(new GetPortalListingUseCase.Input(AUDIT_INFO, LISTING_ID)));
+
+        assertThat(throwable).isInstanceOf(PortalListingNotFoundException.class);
+    }
+
+    @Test
+    void should_throw_when_id_exists_in_different_environment() {
+        portalListingCrudService.initWith(List.of(aListing()));
+
+        var otherEnvAudit = AuditInfo.builder()
+            .organizationId("organization-id")
+            .environmentId("other-env")
+            .actor(AuditActor.builder().userId("user-id").build())
+            .build();
+
+        var throwable = catchThrowable(() -> useCase.execute(new GetPortalListingUseCase.Input(otherEnvAudit, LISTING_ID)));
+
+        assertThat(throwable).isInstanceOf(PortalListingNotFoundException.class);
+    }
+
+    private static PortalListing aListing() {
+        var portalId = PortalId.of(HRIDToUUID.portal().context(AUDIT_INFO).hrid(PORTAL_HRID).id());
+        return PortalListing.of(
+            LISTING_ID,
+            AUDIT_INFO.environmentId(),
+            AUDIT_INFO.organizationId(),
+            portalId,
+            List.of(new PortalListingApiEntry("pets-api", "/projects/alpha", 1))
+        );
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_listing/use_case/ValidatePortalListingUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_listing/use_case/ValidatePortalListingUseCaseTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal_listing.use_case;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import inmemory.ValidatePortalListingDomainServiceInMemory;
+import io.gravitee.apim.core.audit.model.AuditActor;
+import io.gravitee.apim.core.audit.model.AuditInfo;
+import io.gravitee.apim.core.portal.model.PortalId;
+import io.gravitee.apim.core.portal_listing.model.PortalListingApiEntry;
+import io.gravitee.apim.core.portal_listing.model.PortalListingId;
+import io.gravitee.rest.api.service.common.HRIDToUUID;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class ValidatePortalListingUseCaseTest {
+
+    private static final AuditInfo AUDIT_INFO = AuditInfo.builder()
+        .organizationId("organization-id")
+        .environmentId("environment-id")
+        .actor(AuditActor.builder().userId("user-id").build())
+        .build();
+    private static final String PORTAL_HRID = "default-portal";
+    private static final String LISTING_HRID = "default-listing";
+    private static final PortalId PORTAL_ID = PortalId.of(HRIDToUUID.portal().context(AUDIT_INFO).hrid(PORTAL_HRID).id());
+    private static final PortalListingId LISTING_ID = PortalListingId.of(
+        HRIDToUUID.portalListing().context(AUDIT_INFO).portal(PORTAL_HRID).hrid(LISTING_HRID).id()
+    );
+
+    private final ValidatePortalListingDomainServiceInMemory validator = new ValidatePortalListingDomainServiceInMemory();
+    private ValidatePortalListingUseCase useCase;
+
+    @BeforeEach
+    void setUp() {
+        useCase = new ValidatePortalListingUseCase(validator);
+    }
+
+    @Test
+    void should_return_listing_id_and_no_errors_for_well_formed_input() {
+        var output = useCase.execute(
+            new CreateOrUpdatePortalListingUseCase.Input(
+                AUDIT_INFO,
+                LISTING_ID,
+                PORTAL_ID,
+                List.of(new PortalListingApiEntry("pets-api", "/projects/alpha", 1))
+            )
+        );
+
+        assertThat(output.id()).isEqualTo(LISTING_ID);
+        assertThat(output.errors()).isEmpty();
+    }
+
+    @Test
+    void should_not_block_when_referenced_portal_does_not_exist() {
+        // Orphan tolerance — no parent-existence check.
+        var output = useCase.execute(
+            new CreateOrUpdatePortalListingUseCase.Input(
+                AUDIT_INFO,
+                LISTING_ID,
+                PORTAL_ID,
+                List.of(new PortalListingApiEntry("pets-api", "/projects/alpha", 1))
+            )
+        );
+
+        assertThat(output.errors()).isEmpty();
+    }
+
+    @Test
+    void should_surface_location_format_errors_with_indexed_field_name() {
+        var output = useCase.execute(
+            new CreateOrUpdatePortalListingUseCase.Input(
+                AUDIT_INFO,
+                LISTING_ID,
+                PORTAL_ID,
+                List.of(new PortalListingApiEntry("pets-api", "/projects/alpha", 1), new PortalListingApiEntry("shop-api", "bad", 2))
+            )
+        );
+
+        assertThat(output.errors()).anyMatch(e -> e.getMessage().contains("apis[1].location"));
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/adapter/PortalListingAdapterTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/adapter/PortalListingAdapterTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.infra.adapter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.apim.core.portal.model.PortalId;
+import io.gravitee.apim.core.portal_listing.model.PortalListing;
+import io.gravitee.apim.core.portal_listing.model.PortalListingApiEntry;
+import io.gravitee.apim.core.portal_listing.model.PortalListingId;
+import java.util.List;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class PortalListingAdapterTest {
+
+    private static final PortalListingId LISTING_ID = PortalListingId.of("00000000-0000-0000-0000-0000000000b1");
+    private static final PortalId PORTAL_ID = PortalId.of("00000000-0000-0000-0000-0000000000a1");
+
+    @Test
+    void should_round_trip_through_repository_and_back() {
+        var apis = List.of(
+            new PortalListingApiEntry("pets-api", "/projects/alpha", 1),
+            new PortalListingApiEntry("shop-api", "/projects/beta", 2)
+        );
+        var listing = PortalListing.of(LISTING_ID, "environment-id", "organization-id", PORTAL_ID, apis);
+
+        var repo = PortalListingAdapter.INSTANCE.toRepository(listing);
+        var back = PortalListingAdapter.INSTANCE.toEntity(repo);
+
+        SoftAssertions.assertSoftly(soft -> {
+            soft.assertThat(back.getId()).isEqualTo(listing.getId());
+            soft.assertThat(back.getEnvironmentId()).isEqualTo(listing.getEnvironmentId());
+            soft.assertThat(back.getOrganizationId()).isEqualTo(listing.getOrganizationId());
+            soft.assertThat(back.getPortalId()).isEqualTo(listing.getPortalId());
+            soft.assertThat(back.getApis()).isEqualTo(apis);
+        });
+    }
+
+    @Test
+    void should_serialize_apis_as_json_array() {
+        var listing = PortalListing.of(
+            LISTING_ID,
+            "environment-id",
+            "organization-id",
+            PORTAL_ID,
+            List.of(new PortalListingApiEntry("pets-api", "/projects/alpha", 1))
+        );
+
+        var repo = PortalListingAdapter.INSTANCE.toRepository(listing);
+
+        assertThat(repo.getApis()).isEqualTo("[{\"apiHrid\":\"pets-api\",\"location\":\"/projects/alpha\",\"order\":1}]");
+    }
+
+    @Test
+    void should_return_empty_list_when_apis_field_is_null() {
+        var repo = io.gravitee.repository.management.model.PortalListing.builder()
+            .id(LISTING_ID.toString())
+            .environmentId("environment-id")
+            .organizationId("organization-id")
+            .portalId(PORTAL_ID.toString())
+            .apis(null)
+            .build();
+
+        var entity = PortalListingAdapter.INSTANCE.toEntity(repo);
+
+        assertThat(entity.getApis()).isEmpty();
+    }
+
+    @Test
+    void should_return_empty_list_when_apis_field_is_blank() {
+        var repo = io.gravitee.repository.management.model.PortalListing.builder()
+            .id(LISTING_ID.toString())
+            .environmentId("environment-id")
+            .organizationId("organization-id")
+            .portalId(PORTAL_ID.toString())
+            .apis("")
+            .build();
+
+        var entity = PortalListingAdapter.INSTANCE.toEntity(repo);
+
+        assertThat(entity.getApis()).isEmpty();
+    }
+
+    @Test
+    void should_accept_null_input() {
+        assertThat(PortalListingAdapter.INSTANCE.toEntity(null)).isNull();
+        assertThat(PortalListingAdapter.INSTANCE.toRepository(null)).isNull();
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/crud_service/portal_listing/PortalListingCrudServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/crud_service/portal_listing/PortalListingCrudServiceImplTest.java
@@ -1,0 +1,177 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.infra.crud_service.portal_listing;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import fixtures.core.model.PortalListingFixtures;
+import io.gravitee.apim.core.exception.TechnicalDomainException;
+import io.gravitee.apim.infra.adapter.PortalListingAdapter;
+import io.gravitee.repository.exceptions.TechnicalException;
+import io.gravitee.repository.management.api.PortalListingRepository;
+import java.util.Optional;
+import lombok.SneakyThrows;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+class PortalListingCrudServiceImplTest {
+
+    PortalListingRepository repository;
+    PortalListingCrudServiceImpl service;
+
+    @BeforeEach
+    void setUp() {
+        repository = mock(PortalListingRepository.class);
+        service = new PortalListingCrudServiceImpl(repository);
+    }
+
+    @Nested
+    class Create {
+
+        @Test
+        @SneakyThrows
+        void should_create_a_portal_listing() {
+            var listing = PortalListingFixtures.aPortalListing();
+            when(repository.create(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+            var result = service.create(listing);
+
+            SoftAssertions.assertSoftly(soft -> {
+                soft.assertThat(result.getId()).isEqualTo(listing.getId());
+                soft.assertThat(result.getEnvironmentId()).isEqualTo(listing.getEnvironmentId());
+                soft.assertThat(result.getOrganizationId()).isEqualTo(listing.getOrganizationId());
+                soft.assertThat(result.getPortalId()).isEqualTo(listing.getPortalId());
+                soft.assertThat(result.getApis()).isEqualTo(listing.getApis());
+            });
+        }
+
+        @Test
+        @SneakyThrows
+        void should_throw_when_technical_exception_occurs() {
+            var listing = PortalListingFixtures.aPortalListing();
+            when(repository.create(any())).thenThrow(TechnicalException.class);
+
+            var throwable = catchThrowable(() -> service.create(listing));
+
+            assertThat(throwable)
+                .isInstanceOf(TechnicalDomainException.class)
+                .hasMessage("An error occurred while trying to create a Portal Listing with id: " + listing.getId());
+        }
+    }
+
+    @Nested
+    class FindByIdAndEnvironmentId {
+
+        @Test
+        @SneakyThrows
+        void should_return_listing_and_adapt_it() {
+            var listing = PortalListingFixtures.aPortalListing();
+            when(repository.findByIdAndEnvironmentId(listing.getId().toString(), listing.getEnvironmentId())).thenReturn(
+                Optional.of(PortalListingAdapter.INSTANCE.toRepository(listing))
+            );
+
+            var result = service.findByIdAndEnvironmentId(listing.getId(), listing.getEnvironmentId());
+
+            assertThat(result).isPresent();
+            assertThat(result.get()).isEqualTo(listing);
+        }
+
+        @Test
+        @SneakyThrows
+        void should_return_empty_when_not_found() {
+            when(repository.findByIdAndEnvironmentId(any(), any())).thenReturn(Optional.empty());
+
+            assertThat(service.findByIdAndEnvironmentId(PortalListingFixtures.PORTAL_LISTING_ID, "environment-id")).isEmpty();
+        }
+
+        @Test
+        @SneakyThrows
+        void should_throw_when_technical_exception_occurs() {
+            when(repository.findByIdAndEnvironmentId(any(), any())).thenThrow(TechnicalException.class);
+
+            var listingId = PortalListingFixtures.PORTAL_LISTING_ID;
+            var throwable = catchThrowable(() -> service.findByIdAndEnvironmentId(listingId, "environment-id"));
+
+            assertThat(throwable)
+                .isInstanceOf(TechnicalDomainException.class)
+                .hasMessage(
+                    "An error occurred while trying to find a Portal Listing with id (" + listingId + ") in environment (environment-id)"
+                );
+        }
+    }
+
+    @Nested
+    class Update {
+
+        @Test
+        @SneakyThrows
+        void should_update_existing_listing() {
+            var listing = PortalListingFixtures.aPortalListing();
+            when(repository.update(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+            service.update(listing);
+
+            var captor = ArgumentCaptor.forClass(io.gravitee.repository.management.model.PortalListing.class);
+            verify(repository).update(captor.capture());
+            assertThat(captor.getValue()).isEqualTo(PortalListingAdapter.INSTANCE.toRepository(listing));
+        }
+
+        @Test
+        void should_throw_when_technical_exception_occurs() throws TechnicalException {
+            when(repository.update(any())).thenThrow(TechnicalException.class);
+
+            var listing = PortalListingFixtures.aPortalListing();
+            var throwable = catchThrowable(() -> service.update(listing));
+
+            assertThat(throwable)
+                .isInstanceOf(TechnicalDomainException.class)
+                .hasMessage("An error occurred while trying to update a Portal Listing with id: " + listing.getId());
+        }
+    }
+
+    @Nested
+    class Delete {
+
+        @Test
+        void should_delete_listing() throws TechnicalException {
+            var listingId = PortalListingFixtures.PORTAL_LISTING_ID;
+
+            service.delete(listingId);
+
+            verify(repository).delete(listingId.toString());
+        }
+
+        @Test
+        void should_throw_when_technical_exception_occurs() throws TechnicalException {
+            var listingId = PortalListingFixtures.PORTAL_LISTING_ID;
+            doThrow(new TechnicalException("boom")).when(repository).delete(listingId.toString());
+
+            assertThatThrownBy(() -> service.delete(listingId))
+                .isInstanceOf(TechnicalDomainException.class)
+                .hasMessage("An error occurred while trying to delete the Portal Listing with id: " + listingId);
+        }
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/cockpit/command/handler/DeleteEnvironmentCommandHandlerTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/cockpit/command/handler/DeleteEnvironmentCommandHandlerTest.java
@@ -61,6 +61,7 @@ import io.gravitee.repository.management.api.PageRepository;
 import io.gravitee.repository.management.api.PageRevisionRepository;
 import io.gravitee.repository.management.api.ParameterRepository;
 import io.gravitee.repository.management.api.PlanRepository;
+import io.gravitee.repository.management.api.PortalListingRepository;
 import io.gravitee.repository.management.api.PortalMenuLinkRepository;
 import io.gravitee.repository.management.api.PortalNavigationItemRepository;
 import io.gravitee.repository.management.api.PortalNotificationConfigRepository;
@@ -319,6 +320,9 @@ public class DeleteEnvironmentCommandHandlerTest {
     private PortalRepository portalRepository;
 
     @Mock
+    private PortalListingRepository portalListingRepository;
+
+    @Mock
     private PromotionRepository promotionRepository;
 
     @Mock
@@ -477,6 +481,7 @@ public class DeleteEnvironmentCommandHandlerTest {
             portalNavigationItemRepository,
             portalPageContentRepository,
             portalRepository,
+            portalListingRepository,
             promotionRepository,
             qualityRuleRepository,
             ratingAnswerRepository,

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/common/HRIDToUUIDTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/common/HRIDToUUIDTest.java
@@ -157,6 +157,45 @@ class HRIDToUUIDTest {
     }
 
     @Nested
+    class PortalListing {
+
+        @Test
+        void should_generate_same_id_for_same_inputs() {
+            assertThat(HRIDToUUID.portalListing().context(AUDIT).portal("my-portal").hrid("my-listing").id()).isEqualTo(
+                HRIDToUUID.portalListing().context(AUDIT).portal("my-portal").hrid("my-listing").id()
+            );
+        }
+
+        @Test
+        void should_generate_different_id_for_different_listing_hrid() {
+            assertThat(HRIDToUUID.portalListing().context(AUDIT).portal("my-portal").hrid("listing-a").id()).isNotEqualTo(
+                HRIDToUUID.portalListing().context(AUDIT).portal("my-portal").hrid("listing-b").id()
+            );
+        }
+
+        @Test
+        void should_generate_different_id_for_different_portal_hrid() {
+            assertThat(HRIDToUUID.portalListing().context(AUDIT).portal("portal-a").hrid("listing").id()).isNotEqualTo(
+                HRIDToUUID.portalListing().context(AUDIT).portal("portal-b").hrid("listing").id()
+            );
+        }
+
+        @Test
+        void should_produce_same_result_from_audit_info_and_execution_context() {
+            assertThat(HRIDToUUID.portalListing().context(AUDIT).portal("portal").hrid("listing").id()).isEqualTo(
+                HRIDToUUID.portalListing().context(EXEC_CTX).portal("portal").hrid("listing").id()
+            );
+        }
+
+        @Test
+        void should_not_collide_with_portal_top_level_id() {
+            String portalId = HRIDToUUID.portal().context(AUDIT).hrid("my-portal").id();
+            String listingId = HRIDToUUID.portalListing().context(AUDIT).portal("my-portal").hrid("my-portal").id();
+            assertThat(portalId).isNotEqualTo(listingId);
+        }
+    }
+
+    @Nested
     class CrossResourceConsistency {
 
         @Test


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/EXT-134

## Description

Part of the Next-Gen Portal Automation API initiative, Slice 3: Portal Listing. This PR lays down only the data and domain layer.

  Scope is deliberately narrow: CRUD persistence only, no portal navigation tree side effect. A `PortalListing` row carries the spec (hrid + APIs) but does not yet materialize any `PortalNavigationApi` leaves in the portal nav tree — that depends on Slice 2 (portal navigation sync) and will be addressed in a separate follow-up PR once Slice 2 merges.
  
  ### Introduced

  - New `PortalListing` entity with persistence across JDBC, Mongo, and TCK, plus a Liquibase migration; unique constraint on `(environmentId, portalId, hrid)`
  keeps deterministic re-PUT idempotent.
  - Core domain layer (model, crud service, exception, infra adapter handling JSON serialization at the repository boundary).
  - Extension of `HRIDToUUID` with a portal-scoped sub-resource builder so the listing id is derived deterministically from `(portalHrid, listingHrid)`.
  - Create / Get / Delete use cases — intentionally not Spring-wired here; the REST PR turns them on.
  - Cascade cleanup wired into the existing environment-deletion command handler so the org-deletion arch test stays green.

