### PR TITLE
feat(portal-settings): add toggles for member mapping, transfer owner…

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/parameters/Key.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/parameters/Key.java
@@ -145,6 +145,17 @@ public enum Key {
     PORTAL_NEXT_CATALOG_VIEW_MODE("portal.next.catalog.viewMode", new HashSet<>(singletonList(ENVIRONMENT))),
     PORTAL_NEXT_MTLS_ENABLED("portal.next.mtls.enabled", new HashSet<>(singletonList(ENVIRONMENT))),
     PORTAL_NEXT_ANALYTICS_ENABLED("portal.next.analytics.enabled", Boolean.FALSE.toString(), new HashSet<>(singletonList(ENVIRONMENT))),
+    PORTAL_NEXT_MEMBER_MAPPING_ENABLED(
+        "portal.next.memberMapping.enabled",
+        Boolean.FALSE.toString(),
+        new HashSet<>(singletonList(ENVIRONMENT))
+    ),
+    PORTAL_NEXT_TRANSFER_OWNERSHIP_ENABLED(
+        "portal.next.transferOwnership.enabled",
+        Boolean.FALSE.toString(),
+        new HashSet<>(singletonList(ENVIRONMENT))
+    ),
+    PORTAL_NEXT_INVITATIONS_ENABLED("portal.next.invitations.enabled", Boolean.FALSE.toString(), new HashSet<>(singletonList(ENVIRONMENT))),
 
     MANAGEMENT_TITLE("management.title", "Gravitee.io Management", new HashSet<>(Arrays.asList(ORGANIZATION, SYSTEM))),
     MANAGEMENT_URL("management.url", new HashSet<>(Arrays.asList(ORGANIZATION, SYSTEM))),

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/settings/PortalNext.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/settings/PortalNext.java
@@ -43,6 +43,15 @@ public class PortalNext {
     @ParameterKey(Key.PORTAL_NEXT_ANALYTICS_ENABLED)
     private Enabled analytics;
 
+    @ParameterKey(Key.PORTAL_NEXT_MEMBER_MAPPING_ENABLED)
+    private Enabled memberMapping;
+
+    @ParameterKey(Key.PORTAL_NEXT_TRANSFER_OWNERSHIP_ENABLED)
+    private Enabled transferOwnership;
+
+    @ParameterKey(Key.PORTAL_NEXT_INVITATIONS_ENABLED)
+    private Enabled invitations;
+
     private Banner banner;
 
     private Catalog catalog;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/mapper/ConfigurationMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/mapper/ConfigurationMapper.java
@@ -61,6 +61,15 @@ public class ConfigurationMapper {
         if (portalNext.getAnalytics() != null) {
             configuration.setAnalytics(convert(portalNext.getAnalytics()));
         }
+        if (portalNext.getMemberMapping() != null) {
+            configuration.setMemberMapping(convert(portalNext.getMemberMapping()));
+        }
+        if (portalNext.getTransferOwnership() != null) {
+            configuration.setTransferOwnership(convert(portalNext.getTransferOwnership()));
+        }
+        if (portalNext.getInvitations() != null) {
+            configuration.setInvitations(convert(portalNext.getInvitations()));
+        }
         return configuration;
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/resources/portal-openapi.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/resources/portal-openapi.yaml
@@ -6930,6 +6930,12 @@ components:
                     $ref: "#/components/schemas/Enabled"
                 analytics:
                     $ref: "#/components/schemas/Enabled"
+                memberMapping:
+                    $ref: "#/components/schemas/Enabled"
+                transferOwnership:
+                    $ref: "#/components/schemas/Enabled"
+                invitations:
+                    $ref: "#/components/schemas/Enabled"
         ConfigurationPortalNextBanner:
             type: object
             description: Configuration of the banner for Portal Next

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/mapper/ConfigurationMapperTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/mapper/ConfigurationMapperTest.java
@@ -230,4 +230,64 @@ public class ConfigurationMapperTest {
         result = configurationMapper.convert(portalNext);
         Assertions.assertNull(result.getAnalytics());
     }
+
+    @Test
+    public void convertPortalNextShouldMapMemberMappingEnabled() {
+        PortalNext portalNext = new PortalNext();
+        portalNext.setAccess(new Enabled(false));
+
+        portalNext.setMemberMapping(new Enabled(true));
+        ConfigurationPortalNext result = configurationMapper.convert(portalNext);
+        Assertions.assertNotNull(result.getMemberMapping());
+        Assertions.assertEquals(Boolean.TRUE, result.getMemberMapping().getEnabled());
+
+        portalNext.setMemberMapping(new Enabled(false));
+        result = configurationMapper.convert(portalNext);
+        Assertions.assertNotNull(result.getMemberMapping());
+        Assertions.assertEquals(Boolean.FALSE, result.getMemberMapping().getEnabled());
+
+        portalNext.setMemberMapping(null);
+        result = configurationMapper.convert(portalNext);
+        Assertions.assertNull(result.getMemberMapping());
+    }
+
+    @Test
+    public void convertPortalNextShouldMapTransferOwnershipEnabled() {
+        PortalNext portalNext = new PortalNext();
+        portalNext.setAccess(new Enabled(false));
+
+        portalNext.setTransferOwnership(new Enabled(true));
+        ConfigurationPortalNext result = configurationMapper.convert(portalNext);
+        Assertions.assertNotNull(result.getTransferOwnership());
+        Assertions.assertEquals(Boolean.TRUE, result.getTransferOwnership().getEnabled());
+
+        portalNext.setTransferOwnership(new Enabled(false));
+        result = configurationMapper.convert(portalNext);
+        Assertions.assertNotNull(result.getTransferOwnership());
+        Assertions.assertEquals(Boolean.FALSE, result.getTransferOwnership().getEnabled());
+
+        portalNext.setTransferOwnership(null);
+        result = configurationMapper.convert(portalNext);
+        Assertions.assertNull(result.getTransferOwnership());
+    }
+
+    @Test
+    public void convertPortalNextShouldMapInvitationsEnabled() {
+        PortalNext portalNext = new PortalNext();
+        portalNext.setAccess(new Enabled(false));
+
+        portalNext.setInvitations(new Enabled(true));
+        ConfigurationPortalNext result = configurationMapper.convert(portalNext);
+        Assertions.assertNotNull(result.getInvitations());
+        Assertions.assertEquals(Boolean.TRUE, result.getInvitations().getEnabled());
+
+        portalNext.setInvitations(new Enabled(false));
+        result = configurationMapper.convert(portalNext);
+        Assertions.assertNotNull(result.getInvitations());
+        Assertions.assertEquals(Boolean.FALSE, result.getInvitations().getEnabled());
+
+        portalNext.setInvitations(null);
+        result = configurationMapper.convert(portalNext);
+        Assertions.assertNull(result.getInvitations());
+    }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ConfigServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ConfigServiceTest.java
@@ -45,6 +45,9 @@ import static io.gravitee.rest.api.model.parameters.Key.LOGGING_USER_DISPLAYED;
 import static io.gravitee.rest.api.model.parameters.Key.OPEN_API_DOC_TYPE_SWAGGER_ENABLED;
 import static io.gravitee.rest.api.model.parameters.Key.PORTAL_ANALYTICS_ENABLED;
 import static io.gravitee.rest.api.model.parameters.Key.PORTAL_AUTHENTICATION_FORCELOGIN_ENABLED;
+import static io.gravitee.rest.api.model.parameters.Key.PORTAL_NEXT_INVITATIONS_ENABLED;
+import static io.gravitee.rest.api.model.parameters.Key.PORTAL_NEXT_MEMBER_MAPPING_ENABLED;
+import static io.gravitee.rest.api.model.parameters.Key.PORTAL_NEXT_TRANSFER_OWNERSHIP_ENABLED;
 import static io.gravitee.rest.api.model.parameters.Key.PORTAL_SCHEDULER_NOTIFICATIONS;
 import static io.gravitee.rest.api.model.parameters.Key.PORTAL_URL;
 import static io.gravitee.rest.api.model.parameters.Key.USER_GROUP_REQUIRED_ENABLED;
@@ -270,6 +273,89 @@ class ConfigServiceTest {
             GraviteeContext.getExecutionContext(),
             PORTAL_URL,
             "ACME",
+            "DEFAULT",
+            ParameterReferenceType.ENVIRONMENT
+        );
+    }
+
+    @Test
+    void shouldGetPortalSettingsWithPortalNextTogglesEnabled() {
+        Map<String, List<String>> params = new HashMap<>();
+        params.put(PORTAL_NEXT_MEMBER_MAPPING_ENABLED.key(), singletonList("true"));
+        params.put(PORTAL_NEXT_TRANSFER_OWNERSHIP_ENABLED.key(), singletonList("true"));
+        params.put(PORTAL_NEXT_INVITATIONS_ENABLED.key(), singletonList("true"));
+
+        when(
+            mockParameterService.findAll(
+                eq(GraviteeContext.getExecutionContext()),
+                any(List.class),
+                any(Function.class),
+                eq("DEFAULT"),
+                eq(ParameterReferenceType.ENVIRONMENT)
+            )
+        ).thenReturn(params);
+        when(reCaptchaService.getSiteKey()).thenReturn("my-site-key");
+        when(reCaptchaService.isEnabled()).thenReturn(false);
+
+        PortalSettingsEntity portalSettings = configService.getPortalSettings(GraviteeContext.getExecutionContext());
+
+        assertThat(portalSettings.getPortalNext().getMemberMapping().isEnabled()).as("portalNext memberMapping enabled").isTrue();
+        assertThat(portalSettings.getPortalNext().getTransferOwnership().isEnabled()).as("portalNext transferOwnership enabled").isTrue();
+        assertThat(portalSettings.getPortalNext().getInvitations().isEnabled()).as("portalNext invitations enabled").isTrue();
+    }
+
+    @Test
+    void shouldGetPortalSettingsWithPortalNextTogglesDefaultedToDisabled() {
+        when(
+            mockParameterService.findAll(
+                eq(GraviteeContext.getExecutionContext()),
+                any(List.class),
+                any(Function.class),
+                eq("DEFAULT"),
+                eq(ParameterReferenceType.ENVIRONMENT)
+            )
+        ).thenReturn(new HashMap<>());
+        when(reCaptchaService.getSiteKey()).thenReturn("my-site-key");
+        when(reCaptchaService.isEnabled()).thenReturn(false);
+
+        PortalSettingsEntity portalSettings = configService.getPortalSettings(GraviteeContext.getExecutionContext());
+
+        assertThat(portalSettings.getPortalNext().getMemberMapping().isEnabled())
+            .as("portalNext memberMapping disabled by default")
+            .isFalse();
+        assertThat(portalSettings.getPortalNext().getTransferOwnership().isEnabled())
+            .as("portalNext transferOwnership disabled by default")
+            .isFalse();
+        assertThat(portalSettings.getPortalNext().getInvitations().isEnabled()).as("portalNext invitations disabled by default").isFalse();
+    }
+
+    @Test
+    void shouldSavePortalNextToggles() {
+        PortalSettingsEntity portalSettingsEntity = new PortalSettingsEntity();
+        portalSettingsEntity.getPortalNext().setMemberMapping(new Enabled(true));
+        portalSettingsEntity.getPortalNext().setTransferOwnership(new Enabled(false));
+        portalSettingsEntity.getPortalNext().setInvitations(new Enabled(true));
+
+        configService.save(GraviteeContext.getExecutionContext(), portalSettingsEntity);
+
+        verify(mockParameterService, times(1)).save(
+            GraviteeContext.getExecutionContext(),
+            PORTAL_NEXT_MEMBER_MAPPING_ENABLED,
+            "true",
+            "DEFAULT",
+            ParameterReferenceType.ENVIRONMENT
+        );
+        verify(mockParameterService, times(1)).save(
+            GraviteeContext.getExecutionContext(),
+            PORTAL_NEXT_TRANSFER_OWNERSHIP_ENABLED,
+            "false",
+            "DEFAULT",
+            ParameterReferenceType.ENVIRONMENT
+        );
+        verify(mockParameterService, times(1)).save(
+            GraviteeContext.getExecutionContext(),
+            PORTAL_NEXT_INVITATIONS_ENABLED,
+            "true",
             "DEFAULT",
             ParameterReferenceType.ENVIRONMENT
         );

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ParameterServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ParameterServiceTest.java
@@ -889,6 +889,98 @@ public class ParameterServiceTest {
     }
 
     @Test
+    public void shouldAuditPortalNextToggleOnFirstCreate() throws TechnicalException {
+        final Parameter savedParameter = new Parameter();
+        savedParameter.setKey(PORTAL_NEXT_MEMBER_MAPPING_ENABLED.key());
+        savedParameter.setReferenceId("DEFAULT");
+        savedParameter.setReferenceType(ParameterReferenceType.ENVIRONMENT);
+        savedParameter.setValue("true");
+
+        when(
+            parameterRepository.findById(PORTAL_NEXT_MEMBER_MAPPING_ENABLED.key(), "DEFAULT", ParameterReferenceType.ENVIRONMENT)
+        ).thenReturn(empty());
+        when(parameterRepository.create(savedParameter)).thenReturn(savedParameter);
+
+        parameterService.save(
+            GraviteeContext.getExecutionContext(),
+            PORTAL_NEXT_MEMBER_MAPPING_ENABLED,
+            "true",
+            io.gravitee.rest.api.model.parameters.ParameterReferenceType.ENVIRONMENT
+        );
+
+        verify(auditService).createAuditLog(
+            eq(GraviteeContext.getExecutionContext()),
+            argThat(
+                auditLogData ->
+                    auditLogData.getProperties().equals(singletonMap(PARAMETER, PORTAL_NEXT_MEMBER_MAPPING_ENABLED.key())) &&
+                    auditLogData.getEvent().equals(PARAMETER_CREATED) &&
+                    auditLogData.getOldValue() == null &&
+                    auditLogData.getNewValue().equals(savedParameter)
+            )
+        );
+    }
+
+    @Test
+    public void shouldAuditPortalNextToggleOnUpdate() throws TechnicalException {
+        final Parameter oldParameter = new Parameter();
+        oldParameter.setKey(PORTAL_NEXT_INVITATIONS_ENABLED.key());
+        oldParameter.setReferenceId("DEFAULT");
+        oldParameter.setReferenceType(ParameterReferenceType.ENVIRONMENT);
+        oldParameter.setValue("false");
+
+        final Parameter updatedParameter = new Parameter();
+        updatedParameter.setKey(PORTAL_NEXT_INVITATIONS_ENABLED.key());
+        updatedParameter.setReferenceId("DEFAULT");
+        updatedParameter.setReferenceType(ParameterReferenceType.ENVIRONMENT);
+        updatedParameter.setValue("true");
+
+        when(parameterRepository.findById(PORTAL_NEXT_INVITATIONS_ENABLED.key(), "DEFAULT", ParameterReferenceType.ENVIRONMENT)).thenReturn(
+            of(oldParameter)
+        );
+        when(parameterRepository.update(updatedParameter)).thenReturn(updatedParameter);
+
+        parameterService.save(
+            GraviteeContext.getExecutionContext(),
+            PORTAL_NEXT_INVITATIONS_ENABLED,
+            "true",
+            io.gravitee.rest.api.model.parameters.ParameterReferenceType.ENVIRONMENT
+        );
+
+        verify(auditService).createAuditLog(
+            eq(GraviteeContext.getExecutionContext()),
+            argThat(
+                auditLogData ->
+                    auditLogData.getProperties().equals(singletonMap(PARAMETER, PORTAL_NEXT_INVITATIONS_ENABLED.key())) &&
+                    auditLogData.getEvent().equals(PARAMETER_UPDATED) &&
+                    auditLogData.getOldValue().equals(oldParameter) &&
+                    auditLogData.getNewValue().equals(updatedParameter)
+            )
+        );
+    }
+
+    @Test
+    public void shouldNotAuditPortalNextToggleWhenValueUnchanged() throws TechnicalException {
+        final Parameter existingParameter = new Parameter();
+        existingParameter.setKey(PORTAL_NEXT_TRANSFER_OWNERSHIP_ENABLED.key());
+        existingParameter.setReferenceId("DEFAULT");
+        existingParameter.setReferenceType(ParameterReferenceType.ENVIRONMENT);
+        existingParameter.setValue("false");
+
+        when(
+            parameterRepository.findById(PORTAL_NEXT_TRANSFER_OWNERSHIP_ENABLED.key(), "DEFAULT", ParameterReferenceType.ENVIRONMENT)
+        ).thenReturn(of(existingParameter));
+
+        parameterService.save(
+            GraviteeContext.getExecutionContext(),
+            PORTAL_NEXT_TRANSFER_OWNERSHIP_ENABLED,
+            "false",
+            io.gravitee.rest.api.model.parameters.ParameterReferenceType.ENVIRONMENT
+        );
+
+        verify(auditService, never()).createAuditLog(eq(GraviteeContext.getExecutionContext()), any());
+    }
+
+    @Test
     public void shouldSendInvalidateCacheCommandOnDelete() throws TechnicalException {
         // given
         final Parameter parameter = new Parameter();


### PR DESCRIPTION
…ship, and invitations in Portal Next configuration and auditing

## Issue

https://gravitee.atlassian.net/browse/APIM-14393
https://gravitee.atlassian.net/browse/APIM-14394
https://gravitee.atlassian.net/browse/APIM-14401

## Description

This PR adds the backend foundation for three new Next Gen Portal feature toggles that administrators will control from Console Portal Settings:

Team Member Mapping (portal.next.memberMapping.enabled)
Transfer of Ownership (portal.next.transferOwnership.enabled)
Team Invitation Sending (portal.next.invitations.enabled)
All three settings are environment-scoped, default to disabled, persist via the existing parameters table, and are exposed through the portal configuration API so the Next Gen Portal can read them at bootstrap.

What changed

- Added three new keys in Key.java:
     - portal.next.memberMapping.enabled
     - portal.next.transferOwnership.enabled
     - portal.next.invitations.enabled
- Added corresponding Enabled fields on PortalNext.java with @ParameterKey annotations.
- Extended ConfigServiceTest to verify:
     - defaults are false when no parameter exists
     - values load correctly when enabled
     - values are persisted via ParameterService.save()

 Expose toggles via portal configuration API

- Extended ConfigurationPortalNext in portal-openapi.yaml with memberMapping, transferOwnership, and invitations.
- Updated ConfigurationMapper to map the three new fields from PortalSettingsEntity.portalNext.
- Added mapper tests covering enabled, disabled, and null cases.

GET /portal/environments/{envId}/configuration now returns:

```
{
  "portalNext": {
    "memberMapping": { "enabled": false },
    "transferOwnership": { "enabled": false },
    "invitations": { "enabled": false }
  }
}
```

Audit trail verification

- Added ParameterServiceTest coverage to confirm existing audit behavior for the new keys:
- PARAMETER_CREATED on first save
- PARAMETER_UPDATED when value changes
- no audit entry when value is unchanged
- No new audit code was required; ParameterServiceImpl already audits parameter changes.

Design notes

- Follows the existing PORTAL_NEXT_ANALYTICS_ENABLED pattern.
- No DB migration needed; parameters are created on first save.
- Settings take effect without restart via existing parameter cache invalidation.
- Server-side API gating was intentionally not included in this PR, since the classic portal shares the same member/invitation endpoints. UI-only gating will be handled in frontend follow-up PRs.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

