### PR TITLE
chore(4.11.x): bump gravitee-reactor-native-kafka from 6.2.0 to 6.3.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -306,7 +306,7 @@
         <gravitee-resource-schema-registry-confluent.version>4.1.0</gravitee-resource-schema-registry-confluent.version>
         <gravitee-resource-storage-azure-blob.version>1.1.0</gravitee-resource-storage-azure-blob.version>
         <gravitee-reactor-message.version>10.0.1</gravitee-reactor-message.version>
-        <gravitee-reactor-native-kafka.version>6.2.0</gravitee-reactor-native-kafka.version>
+        <gravitee-reactor-native-kafka.version>6.3.0</gravitee-reactor-native-kafka.version>
         <gravitee-reactor-mcp-proxy.version>1.1.2</gravitee-reactor-mcp-proxy.version>
         <gravitee-reactor-llm-proxy.version>2.10.1</gravitee-reactor-llm-proxy.version>
         <gravitee-reactor-a2a-proxy.version>1.0.0</gravitee-reactor-a2a-proxy.version>


### PR DESCRIPTION
## Summary

Bumps **[gravitee-io/gravitee-reactor-native-kafka](https://github.com/gravitee-io/gravitee-reactor-native-kafka)** from `6.2.0` to `6.3.0` on branch `4.11.x`.

## Changelog

See the [releases](https://github.com/gravitee-io/gravitee-reactor-native-kafka/releases) page for details.

## Jira

[APIM-13511](https://gravitee.atlassian.net/browse/APIM-13511), [APIM-13860](https://gravitee.atlassian.net/browse/APIM-13860), [APIM-14373](https://gravitee.atlassian.net/browse/APIM-14373)

[APIM-13511]: https://gravitee.atlassian.net/browse/APIM-13511?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[APIM-13860]: https://gravitee.atlassian.net/browse/APIM-13860?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[APIM-14373]: https://gravitee.atlassian.net/browse/APIM-14373?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ