### PR TITLE
feat(portal-settings): add toggles for member mapping, transfer owner…

### DIFF
--- a/gravitee-apim-console-webui/src/entities/portal/portalSettings.fixture.ts
+++ b/gravitee-apim-console-webui/src/entities/portal/portalSettings.fixture.ts
@@ -228,14 +228,12 @@ export function fakePortalConfiguration(attributes?: Partial<PortalConfiguration
       analytics: {
         enabled: false,
       },
-      memberMapping: {
-        enabled: false,
-      },
-      transferOwnership: {
-        enabled: false,
-      },
-      invitations: {
-        enabled: false,
+      applications: {
+        membership: {
+          enabled: { enabled: false },
+          transferOwnership: { enabled: false },
+          invitations: { enabled: false },
+        },
       },
       banner: {
         enabled: true,

--- a/gravitee-apim-console-webui/src/entities/portal/portalSettings.fixture.ts
+++ b/gravitee-apim-console-webui/src/entities/portal/portalSettings.fixture.ts
@@ -228,6 +228,15 @@ export function fakePortalConfiguration(attributes?: Partial<PortalConfiguration
       analytics: {
         enabled: false,
       },
+      memberMapping: {
+        enabled: false,
+      },
+      transferOwnership: {
+        enabled: false,
+      },
+      invitations: {
+        enabled: false,
+      },
       banner: {
         enabled: true,
         title: 'testTitle',

--- a/gravitee-apim-console-webui/src/entities/portal/portalSettings.ts
+++ b/gravitee-apim-console-webui/src/entities/portal/portalSettings.ts
@@ -258,6 +258,15 @@ export interface PortalSettingsPortalNext {
   analytics?: {
     enabled?: boolean;
   };
+  memberMapping?: {
+    enabled?: boolean;
+  };
+  transferOwnership?: {
+    enabled?: boolean;
+  };
+  invitations?: {
+    enabled?: boolean;
+  };
   banner?: {
     title?: string;
     subtitle?: string;

--- a/gravitee-apim-console-webui/src/entities/portal/portalSettings.ts
+++ b/gravitee-apim-console-webui/src/entities/portal/portalSettings.ts
@@ -258,14 +258,12 @@ export interface PortalSettingsPortalNext {
   analytics?: {
     enabled?: boolean;
   };
-  memberMapping?: {
-    enabled?: boolean;
-  };
-  transferOwnership?: {
-    enabled?: boolean;
-  };
-  invitations?: {
-    enabled?: boolean;
+  applications?: {
+    membership?: {
+      enabled?: { enabled?: boolean };
+      transferOwnership?: { enabled?: boolean };
+      invitations?: { enabled?: boolean };
+    };
   };
   banner?: {
     title?: string;

--- a/gravitee-apim-console-webui/src/management/settings/portal-settings/portal-settings.component.html
+++ b/gravitee-apim-console-webui/src/management/settings/portal-settings/portal-settings.component.html
@@ -489,6 +489,33 @@
                 aria-label="Analytics Enabled"
               ></mat-slide-toggle>
             </gio-form-slide-toggle>
+            <gio-form-slide-toggle formGroupName="memberMapping" class="portal__form__card__form-field">
+              <gio-form-label>Enable Team Member Mapping</gio-form-label>
+              <mat-slide-toggle
+                id="enable-portal-next-member-mapping"
+                formControlName="enabled"
+                gioFormSlideToggle
+                aria-label="Team Member Mapping Enabled"
+              ></mat-slide-toggle>
+            </gio-form-slide-toggle>
+            <gio-form-slide-toggle formGroupName="transferOwnership" class="portal__form__card__form-field">
+              <gio-form-label>Enable Transfer of Ownership</gio-form-label>
+              <mat-slide-toggle
+                id="enable-portal-next-transfer-ownership"
+                formControlName="enabled"
+                gioFormSlideToggle
+                aria-label="Transfer of Ownership Enabled"
+              ></mat-slide-toggle>
+            </gio-form-slide-toggle>
+            <gio-form-slide-toggle formGroupName="invitations" class="portal__form__card__form-field">
+              <gio-form-label>Enable Team Invitation Sending</gio-form-label>
+              <mat-slide-toggle
+                id="enable-portal-next-invitations"
+                formControlName="enabled"
+                gioFormSlideToggle
+                aria-label="Team Invitation Sending Enabled"
+              ></mat-slide-toggle>
+            </gio-form-slide-toggle>
             @if (!!settings.portalNext?.access?.enabled) {
               <div class="new-developer-portal-actions">
                 @if (portalUrl) {

--- a/gravitee-apim-console-webui/src/management/settings/portal-settings/portal-settings.component.html
+++ b/gravitee-apim-console-webui/src/management/settings/portal-settings/portal-settings.component.html
@@ -489,33 +489,37 @@
                 aria-label="Analytics Enabled"
               ></mat-slide-toggle>
             </gio-form-slide-toggle>
-            <gio-form-slide-toggle formGroupName="memberMapping" class="portal__form__card__form-field">
-              <gio-form-label>Enable Team Member Mapping</gio-form-label>
-              <mat-slide-toggle
-                id="enable-portal-next-member-mapping"
-                formControlName="enabled"
-                gioFormSlideToggle
-                aria-label="Team Member Mapping Enabled"
-              ></mat-slide-toggle>
-            </gio-form-slide-toggle>
-            <gio-form-slide-toggle formGroupName="transferOwnership" class="portal__form__card__form-field">
-              <gio-form-label>Enable Transfer of Ownership</gio-form-label>
-              <mat-slide-toggle
-                id="enable-portal-next-transfer-ownership"
-                formControlName="enabled"
-                gioFormSlideToggle
-                aria-label="Transfer of Ownership Enabled"
-              ></mat-slide-toggle>
-            </gio-form-slide-toggle>
-            <gio-form-slide-toggle formGroupName="invitations" class="portal__form__card__form-field">
-              <gio-form-label>Enable Team Invitation Sending</gio-form-label>
-              <mat-slide-toggle
-                id="enable-portal-next-invitations"
-                formControlName="enabled"
-                gioFormSlideToggle
-                aria-label="Team Invitation Sending Enabled"
-              ></mat-slide-toggle>
-            </gio-form-slide-toggle>
+            <div formGroupName="applications">
+              <div formGroupName="membership">
+                <gio-form-slide-toggle formGroupName="enabled" class="portal__form__card__form-field">
+                  <gio-form-label>Enable Application Membership Settings</gio-form-label>
+                  <mat-slide-toggle
+                    id="enable-portal-next-member-mapping"
+                    formControlName="enabled"
+                    gioFormSlideToggle
+                    aria-label="Application Membership Settings Enabled"
+                  ></mat-slide-toggle>
+                </gio-form-slide-toggle>
+                <gio-form-slide-toggle formGroupName="transferOwnership" class="portal__form__card__form-field">
+                  <gio-form-label>Enable Transfer of Application Ownership</gio-form-label>
+                  <mat-slide-toggle
+                    id="enable-portal-next-transfer-ownership"
+                    formControlName="enabled"
+                    gioFormSlideToggle
+                    aria-label="Transfer of Application Ownership Enabled"
+                  ></mat-slide-toggle>
+                </gio-form-slide-toggle>
+                <gio-form-slide-toggle formGroupName="invitations" class="portal__form__card__form-field">
+                  <gio-form-label>Enable Application Membership Invitation</gio-form-label>
+                  <mat-slide-toggle
+                    id="enable-portal-next-invitations"
+                    formControlName="enabled"
+                    gioFormSlideToggle
+                    aria-label="Application Membership Invitation Enabled"
+                  ></mat-slide-toggle>
+                </gio-form-slide-toggle>
+              </div>
+            </div>
             @if (!!settings.portalNext?.access?.enabled) {
               <div class="new-developer-portal-actions">
                 @if (portalUrl) {

--- a/gravitee-apim-console-webui/src/management/settings/portal-settings/portal-settings.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/settings/portal-settings/portal-settings.component.spec.ts
@@ -204,6 +204,15 @@ describe('PortalSettingsComponent', () => {
           analytics: {
             enabled: false,
           },
+          memberMapping: {
+            enabled: false,
+          },
+          transferOwnership: {
+            enabled: false,
+          },
+          invitations: {
+            enabled: false,
+          },
           banner: {
             ...portalSettingsMock.portalNext.banner,
             enabled: true,
@@ -228,6 +237,57 @@ describe('PortalSettingsComponent', () => {
       const req = httpTestingController.expectOne(`${CONSTANTS_TESTING.env.baseURL}/settings`);
       expect(req.request.method).toEqual('POST');
       expect(req.request.body.portalNext.analytics.enabled).toEqual(true);
+    });
+
+    it('display settings form and edit Portal Next member mapping toggle', async () => {
+      portalSettingsMock = fakePortalSettings();
+      expectPortalSettingsGetRequest(portalSettingsMock);
+      const saveBar = await loader.getHarness(GioSaveBarHarness);
+      expect(await saveBar.isVisible()).toBe(false);
+
+      const toggle = await loader.getHarness(MatSlideToggleHarness.with({ selector: '#enable-portal-next-member-mapping' }));
+      expect(await toggle.isChecked()).toBe(false);
+      await toggle.toggle();
+      expect(await saveBar.isSubmitButtonInvalid()).toEqual(false);
+      await saveBar.clickSubmit();
+
+      const req = httpTestingController.expectOne(`${CONSTANTS_TESTING.env.baseURL}/settings`);
+      expect(req.request.method).toEqual('POST');
+      expect(req.request.body.portalNext.memberMapping.enabled).toEqual(true);
+    });
+
+    it('display settings form and edit Portal Next transfer of ownership toggle', async () => {
+      portalSettingsMock = fakePortalSettings();
+      expectPortalSettingsGetRequest(portalSettingsMock);
+      const saveBar = await loader.getHarness(GioSaveBarHarness);
+      expect(await saveBar.isVisible()).toBe(false);
+
+      const toggle = await loader.getHarness(MatSlideToggleHarness.with({ selector: '#enable-portal-next-transfer-ownership' }));
+      expect(await toggle.isChecked()).toBe(false);
+      await toggle.toggle();
+      expect(await saveBar.isSubmitButtonInvalid()).toEqual(false);
+      await saveBar.clickSubmit();
+
+      const req = httpTestingController.expectOne(`${CONSTANTS_TESTING.env.baseURL}/settings`);
+      expect(req.request.method).toEqual('POST');
+      expect(req.request.body.portalNext.transferOwnership.enabled).toEqual(true);
+    });
+
+    it('display settings form and edit Portal Next invitations toggle', async () => {
+      portalSettingsMock = fakePortalSettings();
+      expectPortalSettingsGetRequest(portalSettingsMock);
+      const saveBar = await loader.getHarness(GioSaveBarHarness);
+      expect(await saveBar.isVisible()).toBe(false);
+
+      const toggle = await loader.getHarness(MatSlideToggleHarness.with({ selector: '#enable-portal-next-invitations' }));
+      expect(await toggle.isChecked()).toBe(false);
+      await toggle.toggle();
+      expect(await saveBar.isSubmitButtonInvalid()).toEqual(false);
+      await saveBar.clickSubmit();
+
+      const req = httpTestingController.expectOne(`${CONSTANTS_TESTING.env.baseURL}/settings`);
+      expect(req.request.method).toEqual('POST');
+      expect(req.request.body.portalNext.invitations.enabled).toEqual(true);
     });
 
     it('display settings form and edit CORS fields', async () => {

--- a/gravitee-apim-console-webui/src/management/settings/portal-settings/portal-settings.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/settings/portal-settings/portal-settings.component.spec.ts
@@ -204,14 +204,12 @@ describe('PortalSettingsComponent', () => {
           analytics: {
             enabled: false,
           },
-          memberMapping: {
-            enabled: false,
-          },
-          transferOwnership: {
-            enabled: false,
-          },
-          invitations: {
-            enabled: false,
+          applications: {
+            membership: {
+              enabled: { enabled: false },
+              transferOwnership: { enabled: false },
+              invitations: { enabled: false },
+            },
           },
           banner: {
             ...portalSettingsMock.portalNext.banner,
@@ -253,7 +251,7 @@ describe('PortalSettingsComponent', () => {
 
       const req = httpTestingController.expectOne(`${CONSTANTS_TESTING.env.baseURL}/settings`);
       expect(req.request.method).toEqual('POST');
-      expect(req.request.body.portalNext.memberMapping.enabled).toEqual(true);
+      expect(req.request.body.portalNext.applications.membership.enabled.enabled).toEqual(true);
     });
 
     it('display settings form and edit Portal Next transfer of ownership toggle', async () => {
@@ -270,7 +268,7 @@ describe('PortalSettingsComponent', () => {
 
       const req = httpTestingController.expectOne(`${CONSTANTS_TESTING.env.baseURL}/settings`);
       expect(req.request.method).toEqual('POST');
-      expect(req.request.body.portalNext.transferOwnership.enabled).toEqual(true);
+      expect(req.request.body.portalNext.applications.membership.transferOwnership.enabled).toEqual(true);
     });
 
     it('display settings form and edit Portal Next invitations toggle', async () => {
@@ -287,7 +285,7 @@ describe('PortalSettingsComponent', () => {
 
       const req = httpTestingController.expectOne(`${CONSTANTS_TESTING.env.baseURL}/settings`);
       expect(req.request.method).toEqual('POST');
-      expect(req.request.body.portalNext.invitations.enabled).toEqual(true);
+      expect(req.request.body.portalNext.applications.membership.invitations.enabled).toEqual(true);
     });
 
     it('display settings form and edit CORS fields', async () => {

--- a/gravitee-apim-console-webui/src/management/settings/portal-settings/portal-settings.component.ts
+++ b/gravitee-apim-console-webui/src/management/settings/portal-settings/portal-settings.component.ts
@@ -115,9 +115,13 @@ interface PortalForm {
     access: FormGroup<{ enabled: FormControl<boolean> }>;
     mtls: FormGroup<{ enabled: FormControl<boolean> }>;
     analytics: FormGroup<{ enabled: FormControl<boolean> }>;
-    memberMapping: FormGroup<{ enabled: FormControl<boolean> }>;
-    transferOwnership: FormGroup<{ enabled: FormControl<boolean> }>;
-    invitations: FormGroup<{ enabled: FormControl<boolean> }>;
+    applications: FormGroup<{
+      membership: FormGroup<{
+        enabled: FormGroup<{ enabled: FormControl<boolean> }>;
+        transferOwnership: FormGroup<{ enabled: FormControl<boolean> }>;
+        invitations: FormGroup<{ enabled: FormControl<boolean> }>;
+      }>;
+    }>;
   }>;
   scheduler: FormGroup<{
     tasks: FormControl<number>;
@@ -436,22 +440,26 @@ export class PortalSettingsComponent implements OnInit {
             disabled: this.isReadonly('portal.next.analytics.enabled'),
           }),
         }),
-        memberMapping: new FormGroup({
-          enabled: new FormControl({
-            value: !!this.settings.portalNext?.memberMapping?.enabled,
-            disabled: this.isReadonly('portal.next.memberMapping.enabled'),
-          }),
-        }),
-        transferOwnership: new FormGroup({
-          enabled: new FormControl({
-            value: !!this.settings.portalNext?.transferOwnership?.enabled,
-            disabled: this.isReadonly('portal.next.transferOwnership.enabled'),
-          }),
-        }),
-        invitations: new FormGroup({
-          enabled: new FormControl({
-            value: !!this.settings.portalNext?.invitations?.enabled,
-            disabled: this.isReadonly('portal.next.invitations.enabled'),
+        applications: new FormGroup({
+          membership: new FormGroup({
+            enabled: new FormGroup({
+              enabled: new FormControl({
+                value: !!this.settings.portalNext?.applications?.membership?.enabled?.enabled,
+                disabled: this.isReadonly('portal.next.memberMapping.enabled'),
+              }),
+            }),
+            transferOwnership: new FormGroup({
+              enabled: new FormControl({
+                value: !!this.settings.portalNext?.applications?.membership?.transferOwnership?.enabled,
+                disabled: this.isReadonly('portal.next.transferOwnership.enabled'),
+              }),
+            }),
+            invitations: new FormGroup({
+              enabled: new FormControl({
+                value: !!this.settings.portalNext?.applications?.membership?.invitations?.enabled,
+                disabled: this.isReadonly('portal.next.invitations.enabled'),
+              }),
+            }),
           }),
         }),
       }),
@@ -713,9 +721,14 @@ export class PortalSettingsComponent implements OnInit {
         },
         mtls: this.portalForm.controls.portalNext.controls.mtls.value,
         analytics: this.portalForm.controls.portalNext.controls.analytics.value,
-        memberMapping: this.portalForm.controls.portalNext.controls.memberMapping.value,
-        transferOwnership: this.portalForm.controls.portalNext.controls.transferOwnership.value,
-        invitations: this.portalForm.controls.portalNext.controls.invitations.value,
+        applications: {
+          membership: {
+            enabled: this.portalForm.controls.portalNext.controls.applications.controls.membership.controls.enabled.value,
+            transferOwnership:
+              this.portalForm.controls.portalNext.controls.applications.controls.membership.controls.transferOwnership.value,
+            invitations: this.portalForm.controls.portalNext.controls.applications.controls.membership.controls.invitations.value,
+          },
+        },
       },
     };
 

--- a/gravitee-apim-console-webui/src/management/settings/portal-settings/portal-settings.component.ts
+++ b/gravitee-apim-console-webui/src/management/settings/portal-settings/portal-settings.component.ts
@@ -115,6 +115,9 @@ interface PortalForm {
     access: FormGroup<{ enabled: FormControl<boolean> }>;
     mtls: FormGroup<{ enabled: FormControl<boolean> }>;
     analytics: FormGroup<{ enabled: FormControl<boolean> }>;
+    memberMapping: FormGroup<{ enabled: FormControl<boolean> }>;
+    transferOwnership: FormGroup<{ enabled: FormControl<boolean> }>;
+    invitations: FormGroup<{ enabled: FormControl<boolean> }>;
   }>;
   scheduler: FormGroup<{
     tasks: FormControl<number>;
@@ -418,19 +421,37 @@ export class PortalSettingsComponent implements OnInit {
         access: new FormGroup({
           enabled: new FormControl({
             value: !!this.settings.portalNext?.access?.enabled,
-            disabled: this.isReadonly('portalNext.access.enabled'),
+            disabled: this.isReadonly('portal.next.access.enabled'),
           }),
         }),
         mtls: new FormGroup({
           enabled: new FormControl({
             value: !!this.settings.portalNext?.mtls?.enabled,
-            disabled: this.isReadonly('portalNext.mtls.enabled'),
+            disabled: this.isReadonly('portal.next.mtls.enabled'),
           }),
         }),
         analytics: new FormGroup({
           enabled: new FormControl({
             value: !!this.settings.portalNext?.analytics?.enabled,
-            disabled: this.isReadonly('portalNext.analytics.enabled'),
+            disabled: this.isReadonly('portal.next.analytics.enabled'),
+          }),
+        }),
+        memberMapping: new FormGroup({
+          enabled: new FormControl({
+            value: !!this.settings.portalNext?.memberMapping?.enabled,
+            disabled: this.isReadonly('portal.next.memberMapping.enabled'),
+          }),
+        }),
+        transferOwnership: new FormGroup({
+          enabled: new FormControl({
+            value: !!this.settings.portalNext?.transferOwnership?.enabled,
+            disabled: this.isReadonly('portal.next.transferOwnership.enabled'),
+          }),
+        }),
+        invitations: new FormGroup({
+          enabled: new FormControl({
+            value: !!this.settings.portalNext?.invitations?.enabled,
+            disabled: this.isReadonly('portal.next.invitations.enabled'),
           }),
         }),
       }),
@@ -690,8 +711,11 @@ export class PortalSettingsComponent implements OnInit {
           ...this.settings.portalNext.access,
           ...this.portalForm.get('portalNext.access').value,
         },
-        mtls: this.portalForm.get('portalNext.mtls').value,
-        analytics: this.portalForm.get('portalNext.analytics').value,
+        mtls: this.portalForm.controls.portalNext.controls.mtls.value,
+        analytics: this.portalForm.controls.portalNext.controls.analytics.value,
+        memberMapping: this.portalForm.controls.portalNext.controls.memberMapping.value,
+        transferOwnership: this.portalForm.controls.portalNext.controls.transferOwnership.value,
+        invitations: this.portalForm.controls.portalNext.controls.invitations.value,
       },
     };
 

--- a/gravitee-apim-portal-webui-next/src/app/app.routes.ts
+++ b/gravitee-apim-portal-webui-next/src/app/app.routes.ts
@@ -44,6 +44,7 @@ import { RegistrationConfirmationComponent } from './registration/registration-c
 import { ServiceUnavailableComponent } from './service-unavailable/service-unavailable.component';
 import { NavigationPageFullWidthComponent } from '../components/navigation-page-full-width/navigation-page-full-width.component';
 import { analyticsEnabledGuard } from '../guards/analytics-enabled.guard';
+import { applicationInvitationsEnabledGuard, applicationMembershipEnabledGuard } from '../guards/application-membership-enabled.guard';
 import { redirectGuard } from '../guards/redirect.guard';
 import { apiResolver } from '../resolvers/api.resolver';
 import { applicationPermissionResolver, applicationResolver, applicationTypeResolver } from '../resolvers/application.resolver';
@@ -215,10 +216,12 @@ export const routes: Routes = [
           {
             path: 'members',
             component: ApplicationTabMembersComponent,
+            canActivate: [applicationMembershipEnabledGuard],
           },
           {
             path: 'invitations',
             component: ApplicationTabInvitationsComponent,
+            canActivate: [applicationInvitationsEnabledGuard],
           },
         ],
       },

--- a/gravitee-apim-portal-webui-next/src/entities/configuration/configuration-portal-next.ts
+++ b/gravitee-apim-portal-webui-next/src/entities/configuration/configuration-portal-next.ts
@@ -34,6 +34,13 @@ export class ConfigurationPortalNext {
   analytics?: {
     enabled?: boolean;
   };
+  applications?: {
+    membership?: {
+      enabled?: { enabled?: boolean };
+      transferOwnership?: { enabled?: boolean };
+      invitations?: { enabled?: boolean };
+    };
+  };
 }
 
 export interface BannerButton {

--- a/gravitee-apim-portal-webui-next/src/guards/application-membership-enabled.guard.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/guards/application-membership-enabled.guard.spec.ts
@@ -1,0 +1,189 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { TestBed } from '@angular/core/testing';
+import { ActivatedRouteSnapshot, Router, RouterStateSnapshot } from '@angular/router';
+
+import {
+  applicationInvitationsEnabledGuard,
+  applicationMembershipEnabledGuard,
+  applicationTransferOwnershipEnabledGuard,
+} from './application-membership-enabled.guard';
+import { ConfigService } from '../services/config.service';
+
+const dummyRoute = {} as ActivatedRouteSnapshot;
+const dummyState = {} as RouterStateSnapshot;
+
+describe('applicationMembershipEnabledGuard', () => {
+  it('should allow navigation when member mapping is enabled', () => {
+    TestBed.configureTestingModule({
+      providers: [
+        {
+          provide: ConfigService,
+          useValue: {
+            configuration: { portalNext: { applications: { membership: { enabled: { enabled: true } } } } },
+          },
+        },
+        { provide: Router, useValue: { parseUrl: jest.fn() } },
+      ],
+    });
+
+    const result = TestBed.runInInjectionContext(() => applicationMembershipEnabledGuard(dummyRoute, dummyState));
+
+    expect(result).toBe(true);
+  });
+
+  it('should redirect to home when member mapping is disabled', () => {
+    const parseUrl = jest.fn().mockReturnValue('PARSED');
+    TestBed.configureTestingModule({
+      providers: [
+        {
+          provide: ConfigService,
+          useValue: {
+            configuration: { portalNext: { applications: { membership: { enabled: { enabled: false } } } } },
+          },
+        },
+        { provide: Router, useValue: { parseUrl } },
+      ],
+    });
+
+    const result = TestBed.runInInjectionContext(() => applicationMembershipEnabledGuard(dummyRoute, dummyState));
+
+    expect(parseUrl).toHaveBeenCalledWith('/');
+    expect(result).toBe('PARSED');
+  });
+
+  it('should redirect to home when member mapping configuration is missing', () => {
+    const parseUrl = jest.fn().mockReturnValue('PARSED');
+    TestBed.configureTestingModule({
+      providers: [
+        { provide: ConfigService, useValue: { configuration: {} } },
+        { provide: Router, useValue: { parseUrl } },
+      ],
+    });
+
+    TestBed.runInInjectionContext(() => applicationMembershipEnabledGuard(dummyRoute, dummyState));
+
+    expect(parseUrl).toHaveBeenCalledWith('/');
+  });
+});
+
+describe('applicationTransferOwnershipEnabledGuard', () => {
+  it('should allow navigation when transfer ownership is enabled', () => {
+    TestBed.configureTestingModule({
+      providers: [
+        {
+          provide: ConfigService,
+          useValue: {
+            configuration: { portalNext: { applications: { membership: { transferOwnership: { enabled: true } } } } },
+          },
+        },
+        { provide: Router, useValue: { parseUrl: jest.fn() } },
+      ],
+    });
+
+    const result = TestBed.runInInjectionContext(() => applicationTransferOwnershipEnabledGuard(dummyRoute, dummyState));
+
+    expect(result).toBe(true);
+  });
+
+  it('should redirect to home when transfer ownership is disabled', () => {
+    const parseUrl = jest.fn().mockReturnValue('PARSED');
+    TestBed.configureTestingModule({
+      providers: [
+        {
+          provide: ConfigService,
+          useValue: {
+            configuration: { portalNext: { applications: { membership: { transferOwnership: { enabled: false } } } } },
+          },
+        },
+        { provide: Router, useValue: { parseUrl } },
+      ],
+    });
+
+    const result = TestBed.runInInjectionContext(() => applicationTransferOwnershipEnabledGuard(dummyRoute, dummyState));
+
+    expect(parseUrl).toHaveBeenCalledWith('/');
+    expect(result).toBe('PARSED');
+  });
+
+  it('should redirect to home when transfer ownership configuration is missing', () => {
+    const parseUrl = jest.fn().mockReturnValue('PARSED');
+    TestBed.configureTestingModule({
+      providers: [
+        { provide: ConfigService, useValue: { configuration: {} } },
+        { provide: Router, useValue: { parseUrl } },
+      ],
+    });
+
+    TestBed.runInInjectionContext(() => applicationTransferOwnershipEnabledGuard(dummyRoute, dummyState));
+
+    expect(parseUrl).toHaveBeenCalledWith('/');
+  });
+});
+
+describe('applicationInvitationsEnabledGuard', () => {
+  it('should allow navigation when invitations are enabled', () => {
+    TestBed.configureTestingModule({
+      providers: [
+        {
+          provide: ConfigService,
+          useValue: {
+            configuration: { portalNext: { applications: { membership: { invitations: { enabled: true } } } } },
+          },
+        },
+        { provide: Router, useValue: { parseUrl: jest.fn() } },
+      ],
+    });
+
+    const result = TestBed.runInInjectionContext(() => applicationInvitationsEnabledGuard(dummyRoute, dummyState));
+
+    expect(result).toBe(true);
+  });
+
+  it('should redirect to home when invitations are disabled', () => {
+    const parseUrl = jest.fn().mockReturnValue('PARSED');
+    TestBed.configureTestingModule({
+      providers: [
+        {
+          provide: ConfigService,
+          useValue: {
+            configuration: { portalNext: { applications: { membership: { invitations: { enabled: false } } } } },
+          },
+        },
+        { provide: Router, useValue: { parseUrl } },
+      ],
+    });
+
+    const result = TestBed.runInInjectionContext(() => applicationInvitationsEnabledGuard(dummyRoute, dummyState));
+
+    expect(parseUrl).toHaveBeenCalledWith('/');
+    expect(result).toBe('PARSED');
+  });
+
+  it('should redirect to home when invitations configuration is missing', () => {
+    const parseUrl = jest.fn().mockReturnValue('PARSED');
+    TestBed.configureTestingModule({
+      providers: [
+        { provide: ConfigService, useValue: { configuration: {} } },
+        { provide: Router, useValue: { parseUrl } },
+      ],
+    });
+
+    TestBed.runInInjectionContext(() => applicationInvitationsEnabledGuard(dummyRoute, dummyState));
+
+    expect(parseUrl).toHaveBeenCalledWith('/');
+  });
+});

--- a/gravitee-apim-portal-webui-next/src/guards/application-membership-enabled.guard.ts
+++ b/gravitee-apim-portal-webui-next/src/guards/application-membership-enabled.guard.ts
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { inject } from '@angular/core';
+import { CanActivateFn, Router } from '@angular/router';
+
+import { ConfigService } from '../services/config.service';
+
+export const applicationMembershipEnabledGuard: CanActivateFn = () => {
+  const enabled = inject(ConfigService).configuration.portalNext?.applications?.membership?.enabled?.enabled === true;
+  if (enabled) {
+    return true;
+  }
+  return inject(Router).parseUrl('/');
+};
+
+export const applicationTransferOwnershipEnabledGuard: CanActivateFn = () => {
+  const enabled = inject(ConfigService).configuration.portalNext?.applications?.membership?.transferOwnership?.enabled === true;
+  if (enabled) {
+    return true;
+  }
+  return inject(Router).parseUrl('/');
+};
+
+export const applicationInvitationsEnabledGuard: CanActivateFn = () => {
+  const enabled = inject(ConfigService).configuration.portalNext?.applications?.membership?.invitations?.enabled === true;
+  if (enabled) {
+    return true;
+  }
+  return inject(Router).parseUrl('/');
+};

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/settings/PortalNext.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/settings/PortalNext.java
@@ -43,22 +43,41 @@ public class PortalNext {
     @ParameterKey(Key.PORTAL_NEXT_ANALYTICS_ENABLED)
     private Enabled analytics;
 
-    @ParameterKey(Key.PORTAL_NEXT_MEMBER_MAPPING_ENABLED)
-    private Enabled memberMapping;
-
-    @ParameterKey(Key.PORTAL_NEXT_TRANSFER_OWNERSHIP_ENABLED)
-    private Enabled transferOwnership;
-
-    @ParameterKey(Key.PORTAL_NEXT_INVITATIONS_ENABLED)
-    private Enabled invitations;
+    private Applications applications;
 
     private Banner banner;
 
     private Catalog catalog;
 
     public PortalNext() {
+        this.applications = new Applications();
         this.banner = new Banner();
         this.catalog = new Catalog();
+    }
+
+    @Data
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class Applications {
+
+        private Membership membership;
+
+        public Applications() {
+            this.membership = new Membership();
+        }
+
+        @Data
+        @JsonIgnoreProperties(ignoreUnknown = true)
+        public static class Membership {
+
+            @ParameterKey(Key.PORTAL_NEXT_MEMBER_MAPPING_ENABLED)
+            private Enabled enabled;
+
+            @ParameterKey(Key.PORTAL_NEXT_TRANSFER_OWNERSHIP_ENABLED)
+            private Enabled transferOwnership;
+
+            @ParameterKey(Key.PORTAL_NEXT_INVITATIONS_ENABLED)
+            private Enabled invitations;
+        }
     }
 
     @Data

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/mapper/ConfigurationMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/mapper/ConfigurationMapper.java
@@ -61,16 +61,40 @@ public class ConfigurationMapper {
         if (portalNext.getAnalytics() != null) {
             configuration.setAnalytics(convert(portalNext.getAnalytics()));
         }
-        if (portalNext.getMemberMapping() != null) {
-            configuration.setMemberMapping(convert(portalNext.getMemberMapping()));
-        }
-        if (portalNext.getTransferOwnership() != null) {
-            configuration.setTransferOwnership(convert(portalNext.getTransferOwnership()));
-        }
-        if (portalNext.getInvitations() != null) {
-            configuration.setInvitations(convert(portalNext.getInvitations()));
+        if (portalNext.getApplications() != null) {
+            configuration.setApplications(convert(portalNext.getApplications()));
         }
         return configuration;
+    }
+
+    private ConfigurationPortalNextApplications convert(PortalNext.Applications applications) {
+        if (applications.getMembership() == null) {
+            return null;
+        }
+        ConfigurationPortalNextApplicationsMembership membership = convert(applications.getMembership());
+        if (membership == null) {
+            return null;
+        }
+        ConfigurationPortalNextApplications config = new ConfigurationPortalNextApplications();
+        config.setMembership(membership);
+        return config;
+    }
+
+    private ConfigurationPortalNextApplicationsMembership convert(PortalNext.Applications.Membership membership) {
+        if (membership.getEnabled() == null && membership.getTransferOwnership() == null && membership.getInvitations() == null) {
+            return null;
+        }
+        ConfigurationPortalNextApplicationsMembership config = new ConfigurationPortalNextApplicationsMembership();
+        if (membership.getEnabled() != null) {
+            config.setEnabled(convert(membership.getEnabled()));
+        }
+        if (membership.getTransferOwnership() != null) {
+            config.setTransferOwnership(convert(membership.getTransferOwnership()));
+        }
+        if (membership.getInvitations() != null) {
+            config.setInvitations(convert(membership.getInvitations()));
+        }
+        return config;
     }
 
     private ConfigurationPortalNextBanner convert(PortalNext.Banner banner) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/resources/portal-openapi.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/resources/portal-openapi.yaml
@@ -6930,7 +6930,19 @@ components:
                     $ref: "#/components/schemas/Enabled"
                 analytics:
                     $ref: "#/components/schemas/Enabled"
-                memberMapping:
+                applications:
+                    $ref: "#/components/schemas/ConfigurationPortalNextApplications"
+        ConfigurationPortalNextApplications:
+            type: object
+            description: Configuration of application-level features for Portal Next
+            properties:
+                membership:
+                    $ref: "#/components/schemas/ConfigurationPortalNextApplicationsMembership"
+        ConfigurationPortalNextApplicationsMembership:
+            type: object
+            description: Configuration of membership-related features for Portal Next applications
+            properties:
+                enabled:
                     $ref: "#/components/schemas/Enabled"
                 transferOwnership:
                     $ref: "#/components/schemas/Enabled"

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/mapper/ConfigurationMapperTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/mapper/ConfigurationMapperTest.java
@@ -232,62 +232,62 @@ public class ConfigurationMapperTest {
     }
 
     @Test
-    public void convertPortalNextShouldMapMemberMappingEnabled() {
+    public void convertPortalNextShouldMapApplicationsMembershipEnabled() {
         PortalNext portalNext = new PortalNext();
         portalNext.setAccess(new Enabled(false));
 
-        portalNext.setMemberMapping(new Enabled(true));
+        portalNext.getApplications().getMembership().setEnabled(new Enabled(true));
         ConfigurationPortalNext result = configurationMapper.convert(portalNext);
-        Assertions.assertNotNull(result.getMemberMapping());
-        Assertions.assertEquals(Boolean.TRUE, result.getMemberMapping().getEnabled());
+        Assertions.assertNotNull(result.getApplications().getMembership().getEnabled());
+        Assertions.assertEquals(Boolean.TRUE, result.getApplications().getMembership().getEnabled().getEnabled());
 
-        portalNext.setMemberMapping(new Enabled(false));
+        portalNext.getApplications().getMembership().setEnabled(new Enabled(false));
         result = configurationMapper.convert(portalNext);
-        Assertions.assertNotNull(result.getMemberMapping());
-        Assertions.assertEquals(Boolean.FALSE, result.getMemberMapping().getEnabled());
+        Assertions.assertNotNull(result.getApplications().getMembership().getEnabled());
+        Assertions.assertEquals(Boolean.FALSE, result.getApplications().getMembership().getEnabled().getEnabled());
 
-        portalNext.setMemberMapping(null);
+        portalNext.getApplications().getMembership().setEnabled(null);
         result = configurationMapper.convert(portalNext);
-        Assertions.assertNull(result.getMemberMapping());
+        Assertions.assertNull(result.getApplications());
     }
 
     @Test
-    public void convertPortalNextShouldMapTransferOwnershipEnabled() {
+    public void convertPortalNextShouldMapApplicationsMembershipTransferOwnershipEnabled() {
         PortalNext portalNext = new PortalNext();
         portalNext.setAccess(new Enabled(false));
 
-        portalNext.setTransferOwnership(new Enabled(true));
+        portalNext.getApplications().getMembership().setTransferOwnership(new Enabled(true));
         ConfigurationPortalNext result = configurationMapper.convert(portalNext);
-        Assertions.assertNotNull(result.getTransferOwnership());
-        Assertions.assertEquals(Boolean.TRUE, result.getTransferOwnership().getEnabled());
+        Assertions.assertNotNull(result.getApplications().getMembership().getTransferOwnership());
+        Assertions.assertEquals(Boolean.TRUE, result.getApplications().getMembership().getTransferOwnership().getEnabled());
 
-        portalNext.setTransferOwnership(new Enabled(false));
+        portalNext.getApplications().getMembership().setTransferOwnership(new Enabled(false));
         result = configurationMapper.convert(portalNext);
-        Assertions.assertNotNull(result.getTransferOwnership());
-        Assertions.assertEquals(Boolean.FALSE, result.getTransferOwnership().getEnabled());
+        Assertions.assertNotNull(result.getApplications().getMembership().getTransferOwnership());
+        Assertions.assertEquals(Boolean.FALSE, result.getApplications().getMembership().getTransferOwnership().getEnabled());
 
-        portalNext.setTransferOwnership(null);
+        portalNext.getApplications().getMembership().setTransferOwnership(null);
         result = configurationMapper.convert(portalNext);
-        Assertions.assertNull(result.getTransferOwnership());
+        Assertions.assertNull(result.getApplications());
     }
 
     @Test
-    public void convertPortalNextShouldMapInvitationsEnabled() {
+    public void convertPortalNextShouldMapApplicationsMembershipInvitationsEnabled() {
         PortalNext portalNext = new PortalNext();
         portalNext.setAccess(new Enabled(false));
 
-        portalNext.setInvitations(new Enabled(true));
+        portalNext.getApplications().getMembership().setInvitations(new Enabled(true));
         ConfigurationPortalNext result = configurationMapper.convert(portalNext);
-        Assertions.assertNotNull(result.getInvitations());
-        Assertions.assertEquals(Boolean.TRUE, result.getInvitations().getEnabled());
+        Assertions.assertNotNull(result.getApplications().getMembership().getInvitations());
+        Assertions.assertEquals(Boolean.TRUE, result.getApplications().getMembership().getInvitations().getEnabled());
 
-        portalNext.setInvitations(new Enabled(false));
+        portalNext.getApplications().getMembership().setInvitations(new Enabled(false));
         result = configurationMapper.convert(portalNext);
-        Assertions.assertNotNull(result.getInvitations());
-        Assertions.assertEquals(Boolean.FALSE, result.getInvitations().getEnabled());
+        Assertions.assertNotNull(result.getApplications().getMembership().getInvitations());
+        Assertions.assertEquals(Boolean.FALSE, result.getApplications().getMembership().getInvitations().getEnabled());
 
-        portalNext.setInvitations(null);
+        portalNext.getApplications().getMembership().setInvitations(null);
         result = configurationMapper.convert(portalNext);
-        Assertions.assertNull(result.getInvitations());
+        Assertions.assertNull(result.getApplications());
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ConfigServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ConfigServiceImpl.java
@@ -465,6 +465,7 @@ public class ConfigServiceImpl extends AbstractService implements ConfigService 
             portalConfigEntity.getPortal().getUploadMedia(),
             portalConfigEntity.getPortal().getUserCreation(),
             portalConfigEntity.getPortalNext(),
+            portalConfigEntity.getPortalNext().getApplications().getMembership(),
             portalConfigEntity.getPortalNext().getBanner(),
             portalConfigEntity.getPortalNext().getBanner().getPrimaryButton(),
             portalConfigEntity.getPortalNext().getBanner().getSecondaryButton(),

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ConfigServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ConfigServiceTest.java
@@ -299,9 +299,15 @@ class ConfigServiceTest {
 
         PortalSettingsEntity portalSettings = configService.getPortalSettings(GraviteeContext.getExecutionContext());
 
-        assertThat(portalSettings.getPortalNext().getMemberMapping().isEnabled()).as("portalNext memberMapping enabled").isTrue();
-        assertThat(portalSettings.getPortalNext().getTransferOwnership().isEnabled()).as("portalNext transferOwnership enabled").isTrue();
-        assertThat(portalSettings.getPortalNext().getInvitations().isEnabled()).as("portalNext invitations enabled").isTrue();
+        assertThat(portalSettings.getPortalNext().getApplications().getMembership().getEnabled().isEnabled())
+            .as("portalNext applications.membership.enabled enabled")
+            .isTrue();
+        assertThat(portalSettings.getPortalNext().getApplications().getMembership().getTransferOwnership().isEnabled())
+            .as("portalNext applications.membership.transferOwnership enabled")
+            .isTrue();
+        assertThat(portalSettings.getPortalNext().getApplications().getMembership().getInvitations().isEnabled())
+            .as("portalNext applications.membership.invitations enabled")
+            .isTrue();
     }
 
     @Test
@@ -320,21 +326,23 @@ class ConfigServiceTest {
 
         PortalSettingsEntity portalSettings = configService.getPortalSettings(GraviteeContext.getExecutionContext());
 
-        assertThat(portalSettings.getPortalNext().getMemberMapping().isEnabled())
-            .as("portalNext memberMapping disabled by default")
+        assertThat(portalSettings.getPortalNext().getApplications().getMembership().getEnabled().isEnabled())
+            .as("portalNext applications.membership.enabled disabled by default")
             .isFalse();
-        assertThat(portalSettings.getPortalNext().getTransferOwnership().isEnabled())
-            .as("portalNext transferOwnership disabled by default")
+        assertThat(portalSettings.getPortalNext().getApplications().getMembership().getTransferOwnership().isEnabled())
+            .as("portalNext applications.membership.transferOwnership disabled by default")
             .isFalse();
-        assertThat(portalSettings.getPortalNext().getInvitations().isEnabled()).as("portalNext invitations disabled by default").isFalse();
+        assertThat(portalSettings.getPortalNext().getApplications().getMembership().getInvitations().isEnabled())
+            .as("portalNext applications.membership.invitations disabled by default")
+            .isFalse();
     }
 
     @Test
     void shouldSavePortalNextToggles() {
         PortalSettingsEntity portalSettingsEntity = new PortalSettingsEntity();
-        portalSettingsEntity.getPortalNext().setMemberMapping(new Enabled(true));
-        portalSettingsEntity.getPortalNext().setTransferOwnership(new Enabled(false));
-        portalSettingsEntity.getPortalNext().setInvitations(new Enabled(true));
+        portalSettingsEntity.getPortalNext().getApplications().getMembership().setEnabled(new Enabled(true));
+        portalSettingsEntity.getPortalNext().getApplications().getMembership().setTransferOwnership(new Enabled(false));
+        portalSettingsEntity.getPortalNext().getApplications().getMembership().setInvitations(new Enabled(true));
 
         configService.save(GraviteeContext.getExecutionContext(), portalSettingsEntity);
 


### PR DESCRIPTION
…ship, and invitations

## Issue

https://gravitee.atlassian.net/browse/APIM-14395
https://gravitee.atlassian.net/browse/APIM-14397

## Summary

Adds admin-console toggles for three Next Gen Portal application membership features and wires them through to Portal Next configuration and route guards.

Parameter keys are unchanged (`portal.next.memberMapping.enabled`, `portal.next.transferOwnership.enabled`, `portal.next.invitations.enabled`); settings are nested under `portalNext.applications.membership` for clearer scope.

Gating is **UI-only** at this stage (route guards). Portal REST endpoints remain governed by existing RBAC so the classic portal is unaffected.

---

## What's included

### Console — Portal Settings toggles
- Three slide toggles in **Settings → Portal → New Developer Portal**, default **OFF**
- Labels per review feedback:
  - **Enable Application Membership Settings**
  - **Enable Transfer of Application Ownership**
  - **Enable Application Membership Invitation**
- Toggles persist via `GET/POST /settings` and respect `metadata.readonly` + `environment-settings-u`
- Uses typed `controls` chain in `onSubmit()` for type safety
- Fixes `isReadonly` keys for `access`, `mtls`, and `analytics` to use dot-separated backend keys (`portal.next.*.enabled`)

### `applications.membership` nesting (backend + console + portal API)
Restructures flat fields under a scoped object:

```json
"portalNext": {
  "applications": {
    "membership": {
      "enabled": { "enabled": false },
      "transferOwnership": { "enabled": false },
      "invitations": { "enabled": false }
    }
  }
}
```

Backend

- PortalNext.java — Applications.Membership inner classes; member mapping maps to membership.enabled
- ConfigServiceImpl.java — registers applications.membership in getObjectArray()
- portal-openapi.yaml — ConfigurationPortalNextApplications / ConfigurationPortalNextApplicationsMembership schemas
- ConfigurationMapper.java — maps nested structure; omits applications when all membership fields are unset

Console

- portalSettings.ts, fixture, form, HTML, and specs updated to nested structure
- Portal Next — config + route guards
- configuration-portal-next.ts — exposes applications.membership flags


New guards in application-membership-enabled.guard.ts:

- applicationMembershipEnabledGuard → members route
- applicationInvitationsEnabledGuard → invitations route
- applicationTransferOwnershipEnabledGuard — implemented + tested, not wired to routes (transfer ownership is a dialog, not a route)

Missing or false config is treated as disabled; direct navigation redirects to / (same pattern as analyticsEnabledGuard)

Notes for reviewers

- membership.enabled.enabled is intentional: Membership.enabled is an Enabled object bound to PORTAL_NEXT_MEMBER_MAPPING_ENABLED, matching existing Gravitee settings patterns.


## Additional context


https://github.com/user-attachments/assets/81a2c65d-b762-4089-83b5-a9968ce27d7a



<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

