### PR TITLE
feat: map existing invitation users to app members

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/spring/ResourceContextConfiguration.java
@@ -160,6 +160,7 @@ import io.gravitee.apim.core.logs_engine.domain_service.LogNamesPostProcessor;
 import io.gravitee.apim.core.member.domain_service.CRDMembersDomainService;
 import io.gravitee.apim.core.member.domain_service.ValidateCRDMembersDomainService;
 import io.gravitee.apim.core.membership.domain_service.ApplicationPrimaryOwnerDomainService;
+import io.gravitee.apim.core.membership.domain_service.MembershipDomainService;
 import io.gravitee.apim.core.membership.domain_service.SearchApplicationMembersDomainService;
 import io.gravitee.apim.core.newtai.service_provider.NewtAIProvider;
 import io.gravitee.apim.core.notification.crud_service.NotificationConfigCrudService;
@@ -413,6 +414,11 @@ public class ResourceContextConfiguration {
     @Bean
     public MembershipService membershipService() {
         return mock(MembershipService.class);
+    }
+
+    @Bean
+    public MembershipDomainService membershipDomainService() {
+        return mock(MembershipDomainService.class);
     }
 
     @Bean

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/resources/portal-openapi.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/resources/portal-openapi.yaml
@@ -1390,16 +1390,19 @@ paths:
                             $ref: "#/components/schemas/InvitationCreateInput"
             summary: Create application invitations
             description: |
-                Create one or more invitations for an application.
+                Process one or more invitation recipients for an application.
 
                 User must be allowed to manage invitations for the application.
                 Planned permission key: APPLICATION_INVITATION[CREATE].
-                This operation is all-or-nothing: invitations are created for all recipients or for none.
+                Recipients matching existing users are added directly as application members with the requested role.
+                Recipients that do not match an existing user are created as pending invitations.
+                The response contains only the created pending invitations, so it may contain fewer entries than
+                the requested recipients, including none when all recipients matched existing users.
                 The API does not return per-recipient success or error entries and does not use `207 Multi-Status`.
             operationId: createApplicationInvitations
             responses:
                 201:
-                    description: Created invitations for all requested recipients
+                    description: Created pending invitations for recipients that did not match existing users
                     content:
                         application/json:
                             schema:
@@ -1411,7 +1414,7 @@ paths:
                 404:
                     $ref: "#/components/responses/ApplicationNotFoundError"
                 409:
-                    description: All-or-nothing conflict. If at least one recipient already has a pending invitation or is already an active member, no invitations are created for any recipient.
+                    description: Conflict. If at least one recipient already has a pending invitation, or if a recipient email matches multiple existing users, the request is rejected.
                     content:
                         application/json:
                             schema:
@@ -7329,17 +7332,18 @@ components:
             properties:
                 recipients:
                     description: >
-                        Invitees to create as pending invitations. The batch is processed all-or-nothing:
-                        all recipients are invited or none are, and the API does not return per-recipient results.
+                        Recipients to process. Recipients matching existing users are added directly as application
+                        members; the remaining recipients are created as pending invitations. The API does not
+                        return per-recipient results.
                     type: array
                     minItems: 1
                     items:
                         $ref: "#/components/schemas/InvitationRecipientInput"
                 role:
-                    description: Role assigned to all created invitations.
+                    description: Role assigned to created invitations and directly added application members.
                     type: string
                 notify:
-                    description: Whether invitation notifications should be sent when invitations are created.
+                    description: Whether invitation notifications should be sent when pending invitations are created.
                     type: boolean
                     default: true
                 confirmation_page_url:

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/invitation/domain_service/CreateApplicationInvitationsDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/invitation/domain_service/CreateApplicationInvitationsDomainService.java
@@ -15,6 +15,8 @@
  */
 package io.gravitee.apim.core.invitation.domain_service;
 
+import static io.gravitee.apim.core.member.model.SystemRole.PRIMARY_OWNER;
+
 import io.gravitee.apim.core.DomainService;
 import io.gravitee.apim.core.exception.ConflictDomainException;
 import io.gravitee.apim.core.exception.ValidationDomainException;
@@ -22,10 +24,17 @@ import io.gravitee.apim.core.invitation.crud_service.InvitationCrudService;
 import io.gravitee.apim.core.invitation.model.ApplicationInvitation;
 import io.gravitee.apim.core.invitation.model.InvitationReference;
 import io.gravitee.apim.core.invitation.query_service.InvitationQueryService;
+import io.gravitee.apim.core.member.model.MembershipReferenceType;
+import io.gravitee.apim.core.membership.domain_service.MembershipDomainService;
+import io.gravitee.apim.core.user.crud_service.UserCrudService;
+import io.gravitee.rest.api.model.permissions.RoleScope;
+import io.gravitee.rest.api.service.common.ExecutionContext;
+import io.gravitee.rest.api.service.exceptions.SinglePrimaryOwnerException;
 import jakarta.annotation.Nonnull;
 import jakarta.mail.internet.AddressException;
 import jakarta.mail.internet.InternetAddress;
 import java.net.URI;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
@@ -38,6 +47,8 @@ public class CreateApplicationInvitationsDomainService {
     private final InvitationCrudService invitationCrudService;
     private final ValidateApplicationInvitationRoleDomainService validateApplicationInvitationRoleDomainService;
     private final ApplicationInvitationNotificationDomainService applicationInvitationNotificationDomainService;
+    private final UserCrudService userCrudService;
+    private final MembershipDomainService membershipDomainService;
 
     public List<ApplicationInvitation> create(
         @Nonnull String organizationId,
@@ -52,13 +63,18 @@ public class CreateApplicationInvitationsDomainService {
         var emails = validateRecipients(recipientEmails);
 
         validateNoPendingInvitation(applicationId, emails);
-        var createdInvitations = emails
+        var resolvedRecipients = resolveRecipients(organizationId, emails);
+        validateDirectMemberAdditionRole(roleName, resolvedRecipients);
+        addExistingUsersAsApplicationMembers(organizationId, environmentId, applicationId, roleName, resolvedRecipients);
+
+        var createdInvitations = resolvedRecipients
+            .invitationRecipients()
             .stream()
             .map(email -> ApplicationInvitation.create(applicationId, email, roleName))
             .map(invitationCrudService::create)
             .toList();
 
-        if (notifyUsers) {
+        if (notifyUsers && !createdInvitations.isEmpty()) {
             applicationInvitationNotificationDomainService.dispatchAsync(
                 organizationId,
                 environmentId,
@@ -88,6 +104,53 @@ public class CreateApplicationInvitationsDomainService {
         return recipients;
     }
 
+    private ResolvedRecipients resolveRecipients(String organizationId, Set<String> emails) {
+        var existingUserRecipients = new ArrayList<ExistingUserRecipient>();
+        var invitationRecipients = new ArrayList<String>();
+
+        emails.forEach(email -> {
+            var users = userCrudService.findBaseUsersByEmail(organizationId, email);
+            if (users.size() > 1) {
+                throw new ConflictDomainException("Application invitation email [" + email + "] matches multiple users.", email);
+            }
+            if (users.size() == 1) {
+                existingUserRecipients.add(new ExistingUserRecipient(users.getFirst().getId()));
+            } else {
+                invitationRecipients.add(email);
+            }
+        });
+
+        return new ResolvedRecipients(existingUserRecipients, invitationRecipients);
+    }
+
+    private void validateDirectMemberAdditionRole(String roleName, ResolvedRecipients resolvedRecipients) {
+        if (!resolvedRecipients.existingUserRecipients().isEmpty() && PRIMARY_OWNER.name().equals(roleName)) {
+            throw new SinglePrimaryOwnerException(RoleScope.APPLICATION);
+        }
+    }
+
+    private void addExistingUsersAsApplicationMembers(
+        String organizationId,
+        String environmentId,
+        String applicationId,
+        String roleName,
+        ResolvedRecipients resolvedRecipients
+    ) {
+        var executionContext = new ExecutionContext(organizationId, environmentId);
+        resolvedRecipients
+            .existingUserRecipients()
+            .forEach(recipient ->
+                membershipDomainService.createNewMembership(
+                    executionContext,
+                    MembershipReferenceType.APPLICATION,
+                    applicationId,
+                    recipient.userId(),
+                    null,
+                    roleName
+                )
+            );
+    }
+
     private boolean isValidEmail(String email) {
         try {
             var internetAddress = new InternetAddress(email);
@@ -109,4 +172,8 @@ public class CreateApplicationInvitationsDomainService {
                 throw new ConflictDomainException("A pending application invitation already exists for email [" + email + "].", email);
             });
     }
+
+    private record ExistingUserRecipient(String userId) {}
+
+    private record ResolvedRecipients(List<ExistingUserRecipient> existingUserRecipients, List<String> invitationRecipients) {}
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/invitation/domain_service/CreateApplicationInvitationsDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/invitation/domain_service/CreateApplicationInvitationsDomainService.java
@@ -26,6 +26,8 @@ import io.gravitee.apim.core.invitation.model.InvitationReference;
 import io.gravitee.apim.core.invitation.query_service.InvitationQueryService;
 import io.gravitee.apim.core.member.model.MembershipReferenceType;
 import io.gravitee.apim.core.membership.domain_service.MembershipDomainService;
+import io.gravitee.apim.core.membership.model.Membership;
+import io.gravitee.apim.core.membership.query_service.MembershipQueryService;
 import io.gravitee.apim.core.user.crud_service.UserCrudService;
 import io.gravitee.rest.api.model.permissions.RoleScope;
 import io.gravitee.rest.api.service.common.ExecutionContext;
@@ -36,7 +38,9 @@ import jakarta.mail.internet.InternetAddress;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 
 @DomainService
@@ -48,6 +52,7 @@ public class CreateApplicationInvitationsDomainService {
     private final ValidateApplicationInvitationRoleDomainService validateApplicationInvitationRoleDomainService;
     private final ApplicationInvitationNotificationDomainService applicationInvitationNotificationDomainService;
     private final UserCrudService userCrudService;
+    private final MembershipQueryService membershipQueryService;
     private final MembershipDomainService membershipDomainService;
 
     public List<ApplicationInvitation> create(
@@ -109,7 +114,7 @@ public class CreateApplicationInvitationsDomainService {
         var invitationRecipients = new ArrayList<String>();
 
         emails.forEach(email -> {
-            var users = userCrudService.findBaseUsersByEmail(organizationId, email);
+            var users = userCrudService.findBaseUsersByEmail(organizationId, email.toLowerCase(Locale.ROOT));
             if (users.size() > 1) {
                 throw new ConflictDomainException("Application invitation email [" + email + "] matches multiple users.", email);
             }
@@ -137,18 +142,35 @@ public class CreateApplicationInvitationsDomainService {
         ResolvedRecipients resolvedRecipients
     ) {
         var executionContext = new ExecutionContext(organizationId, environmentId);
-        resolvedRecipients
-            .existingUserRecipients()
-            .forEach(recipient ->
-                membershipDomainService.createNewMembership(
-                    executionContext,
-                    MembershipReferenceType.APPLICATION,
-                    applicationId,
-                    recipient.userId(),
-                    null,
-                    roleName
-                )
-            );
+        filterAlreadyApplicationMembers(applicationId, resolvedRecipients.existingUserRecipients()).forEach(recipient ->
+            membershipDomainService.createNewMembership(
+                executionContext,
+                MembershipReferenceType.APPLICATION,
+                applicationId,
+                recipient.userId(),
+                null,
+                roleName
+            )
+        );
+    }
+
+    private List<ExistingUserRecipient> filterAlreadyApplicationMembers(String applicationId, List<ExistingUserRecipient> recipients) {
+        if (recipients.isEmpty()) {
+            return recipients;
+        }
+
+        var userIds = recipients.stream().map(ExistingUserRecipient::userId).collect(Collectors.toSet());
+        var existingApplicationMemberIds = membershipQueryService
+            .findByMemberIdsAndMemberTypeAndReferenceType(userIds, Membership.Type.USER, Membership.ReferenceType.APPLICATION)
+            .stream()
+            .filter(membership -> applicationId.equals(membership.getReferenceId()))
+            .map(Membership::getMemberId)
+            .collect(Collectors.toSet());
+
+        return recipients
+            .stream()
+            .filter(recipient -> !existingApplicationMemberIds.contains(recipient.userId()))
+            .toList();
     }
 
     private boolean isValidEmail(String email) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/user/crud_service/UserCrudService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/user/crud_service/UserCrudService.java
@@ -24,6 +24,7 @@ import java.util.Set;
 public interface UserCrudService {
     Optional<BaseUserEntity> findBaseUserById(String id);
     Set<BaseUserEntity> findBaseUsersByIds(List<String> userIds);
+    List<BaseUserEntity> findBaseUsersByEmail(String organizationId, String email);
     BaseUserEntity getBaseUser(String id);
 
     default BaseUserEntity create(BaseUserEntity user) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/crud_service/user/UserCrudServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/crud_service/user/UserCrudServiceImpl.java
@@ -69,6 +69,17 @@ public class UserCrudServiceImpl implements UserCrudService {
     }
 
     @Override
+    public List<BaseUserEntity> findBaseUsersByEmail(String organizationId, String email) {
+        try {
+            log.debug("Find users [organizationId={}, email={}]", organizationId, email);
+            return userRepository.findByEmail(email, organizationId).stream().map(UserAdapter.INSTANCE::fromUser).toList();
+        } catch (TechnicalException ex) {
+            log.error("An error occurs while trying to find users using [organizationId={}, email={}]", organizationId, email, ex);
+            throw new TechnicalManagementException(ex);
+        }
+    }
+
+    @Override
     public BaseUserEntity getBaseUser(String id) {
         try {
             log.debug("Find user [userId={}]", id);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/UserCrudServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/UserCrudServiceInMemory.java
@@ -54,7 +54,7 @@ public class UserCrudServiceInMemory implements UserCrudService, InMemoryAlterna
         return storage
             .stream()
             .filter(user -> organizationId.equals(user.getOrganizationId()))
-            .filter(user -> email.equals(user.getEmail()))
+            .filter(user -> user.getEmail() != null && user.getEmail().equalsIgnoreCase(email))
             .toList();
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/UserCrudServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/UserCrudServiceInMemory.java
@@ -50,6 +50,15 @@ public class UserCrudServiceInMemory implements UserCrudService, InMemoryAlterna
     }
 
     @Override
+    public List<BaseUserEntity> findBaseUsersByEmail(String organizationId, String email) {
+        return storage
+            .stream()
+            .filter(user -> organizationId.equals(user.getOrganizationId()))
+            .filter(user -> email.equals(user.getEmail()))
+            .toList();
+    }
+
+    @Override
     public BaseUserEntity getBaseUser(String userId) {
         return storage
             .stream()

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/UserRepositoryInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/UserRepositoryInMemory.java
@@ -97,7 +97,13 @@ public class UserRepositoryInMemory implements UserRepository {
 
     @Override
     public List<User> findByEmail(String email, String organizationId) throws TechnicalException {
-        throw new UnsupportedOperationException();
+        maybeThrow();
+        return storage
+            .values()
+            .stream()
+            .filter(u -> Objects.equals(u.getEmail(), email))
+            .filter(u -> Objects.equals(u.getOrganizationId(), organizationId))
+            .toList();
     }
 
     @Override

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/UserRepositoryInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/UserRepositoryInMemory.java
@@ -101,7 +101,7 @@ public class UserRepositoryInMemory implements UserRepository {
         return storage
             .values()
             .stream()
-            .filter(u -> Objects.equals(u.getEmail(), email))
+            .filter(u -> u.getEmail() != null && u.getEmail().equalsIgnoreCase(email))
             .filter(u -> Objects.equals(u.getOrganizationId(), organizationId))
             .toList();
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/invitation/domain_service/CreateApplicationInvitationsDomainServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/invitation/domain_service/CreateApplicationInvitationsDomainServiceTest.java
@@ -16,11 +16,13 @@
 package io.gravitee.apim.core.invitation.domain_service;
 
 import static fixtures.core.model.ApplicationInvitationFixtures.anApplicationInvitation;
+import static fixtures.core.model.BaseUserEntityFixtures.aBaseUserEntity;
 import static fixtures.core.model.RoleFixtures.anApplicationRole;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -33,9 +35,16 @@ import io.gravitee.apim.core.invitation.crud_service.InvitationCrudService;
 import io.gravitee.apim.core.invitation.model.ApplicationInvitation;
 import io.gravitee.apim.core.invitation.model.InvitationReference;
 import io.gravitee.apim.core.invitation.query_service.InvitationQueryService;
+import io.gravitee.apim.core.member.model.MembershipReferenceType;
+import io.gravitee.apim.core.membership.domain_service.MembershipDomainService;
 import io.gravitee.apim.core.membership.exception.RoleNotFoundException;
 import io.gravitee.apim.core.membership.query_service.RoleQueryService;
+import io.gravitee.apim.core.user.crud_service.UserCrudService;
+import io.gravitee.rest.api.model.MembershipMemberType;
+import io.gravitee.rest.api.service.common.ExecutionContext;
 import io.gravitee.rest.api.service.common.ReferenceContext;
+import io.gravitee.rest.api.service.exceptions.MembershipAlreadyExistsException;
+import io.gravitee.rest.api.service.exceptions.SinglePrimaryOwnerException;
 import java.net.URI;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -72,6 +81,12 @@ class CreateApplicationInvitationsDomainServiceTest {
     @Mock
     private ApplicationInvitationNotificationDomainService applicationInvitationNotificationDomainService;
 
+    @Mock
+    private UserCrudService userCrudService;
+
+    @Mock
+    private MembershipDomainService membershipDomainService;
+
     private CreateApplicationInvitationsDomainService cut;
 
     @BeforeEach
@@ -80,7 +95,9 @@ class CreateApplicationInvitationsDomainServiceTest {
             invitationQueryService,
             invitationCrudService,
             new ValidateApplicationInvitationRoleDomainService(roleQueryService),
-            applicationInvitationNotificationDomainService
+            applicationInvitationNotificationDomainService,
+            userCrudService,
+            membershipDomainService
         );
     }
 
@@ -88,6 +105,7 @@ class CreateApplicationInvitationsDomainServiceTest {
     void should_create_invitations_with_normalized_input_when_notify_is_false() {
         givenExistingRole();
         when(invitationQueryService.findByReference(InvitationReference.application(APPLICATION_ID))).thenReturn(List.of());
+        givenNoExistingUsers("alice@example.com", "bob@example.com");
         when(invitationCrudService.create(any(ApplicationInvitation.class))).thenReturn(
             anApplicationInvitation(INVITATION_ID_1, "alice@example.com"),
             anApplicationInvitation(INVITATION_ID_2, "bob@example.com")
@@ -132,6 +150,7 @@ class CreateApplicationInvitationsDomainServiceTest {
     void should_create_invitations_and_dispatch_notification_when_notify_is_true() {
         givenExistingRole();
         when(invitationQueryService.findByReference(InvitationReference.application(APPLICATION_ID))).thenReturn(List.of());
+        givenNoExistingUsers("alice@example.com");
         when(invitationCrudService.create(any(ApplicationInvitation.class))).thenReturn(
             anApplicationInvitation(INVITATION_ID_1, "alice@example.com")
         );
@@ -157,6 +176,171 @@ class CreateApplicationInvitationsDomainServiceTest {
     }
 
     @Test
+    void should_add_existing_user_as_application_member_without_creating_invitation() {
+        givenExistingRole();
+        when(invitationQueryService.findByReference(InvitationReference.application(APPLICATION_ID))).thenReturn(List.of());
+        when(userCrudService.findBaseUsersByEmail(ORGANIZATION_ID, "alice@example.com")).thenReturn(
+            List.of(aBaseUserEntity("user-id", ORGANIZATION_ID, "alice@example.com"))
+        );
+
+        var result = cut.create(
+            ORGANIZATION_ID,
+            ENVIRONMENT_ID,
+            APPLICATION_ID,
+            Set.of("alice@example.com"),
+            ROLE_NAME,
+            true,
+            CONFIRMATION_PAGE_URL
+        );
+
+        assertThat(result).isEmpty();
+        verify(membershipDomainService).createNewMembership(
+            new ExecutionContext(ORGANIZATION_ID, ENVIRONMENT_ID),
+            MembershipReferenceType.APPLICATION,
+            APPLICATION_ID,
+            "user-id",
+            null,
+            ROLE_NAME
+        );
+        verifyNoInteractions(invitationCrudService, applicationInvitationNotificationDomainService);
+    }
+
+    @Test
+    void should_create_invitation_for_unknown_email_and_add_member_for_existing_user_in_same_request() {
+        givenExistingRole();
+        when(invitationQueryService.findByReference(InvitationReference.application(APPLICATION_ID))).thenReturn(List.of());
+        when(userCrudService.findBaseUsersByEmail(ORGANIZATION_ID, "alice@example.com")).thenReturn(
+            List.of(aBaseUserEntity("user-id", ORGANIZATION_ID, "alice@example.com"))
+        );
+        givenNoExistingUsers("bob@example.com");
+        when(invitationCrudService.create(any(ApplicationInvitation.class))).thenReturn(
+            anApplicationInvitation(INVITATION_ID_1, "bob@example.com")
+        );
+
+        var result = cut.create(
+            ORGANIZATION_ID,
+            ENVIRONMENT_ID,
+            APPLICATION_ID,
+            recipients("alice@example.com", "bob@example.com"),
+            ROLE_NAME,
+            true,
+            CONFIRMATION_PAGE_URL
+        );
+
+        assertThat(result).extracting(ApplicationInvitation::email).containsExactly("bob@example.com");
+        var inOrder = inOrder(membershipDomainService, invitationCrudService);
+        inOrder
+            .verify(membershipDomainService)
+            .createNewMembership(
+                new ExecutionContext(ORGANIZATION_ID, ENVIRONMENT_ID),
+                MembershipReferenceType.APPLICATION,
+                APPLICATION_ID,
+                "user-id",
+                null,
+                ROLE_NAME
+            );
+        inOrder.verify(invitationCrudService).create(any(ApplicationInvitation.class));
+        verify(applicationInvitationNotificationDomainService).dispatchAsync(
+            ORGANIZATION_ID,
+            ENVIRONMENT_ID,
+            APPLICATION_ID,
+            result,
+            CONFIRMATION_PAGE_URL
+        );
+    }
+
+    @Test
+    void should_reject_primary_owner_role_when_existing_user_would_be_added_as_member() {
+        givenExistingRole("PRIMARY_OWNER");
+        when(invitationQueryService.findByReference(InvitationReference.application(APPLICATION_ID))).thenReturn(List.of());
+        when(userCrudService.findBaseUsersByEmail(ORGANIZATION_ID, "alice@example.com")).thenReturn(
+            List.of(aBaseUserEntity("user-id", ORGANIZATION_ID, "alice@example.com"))
+        );
+
+        var throwable = catchThrowable(() ->
+            cut.create(ORGANIZATION_ID, ENVIRONMENT_ID, APPLICATION_ID, Set.of("alice@example.com"), "PRIMARY_OWNER", false, null)
+        );
+
+        assertThat(throwable).isInstanceOf(SinglePrimaryOwnerException.class);
+        verifyNoInteractions(membershipDomainService, invitationCrudService, applicationInvitationNotificationDomainService);
+    }
+
+    @Test
+    void should_keep_current_primary_owner_pending_invitation_behavior_when_all_recipients_are_unknown() {
+        givenExistingRole("PRIMARY_OWNER");
+        when(invitationQueryService.findByReference(InvitationReference.application(APPLICATION_ID))).thenReturn(List.of());
+        givenNoExistingUsers("alice@example.com");
+        when(invitationCrudService.create(any(ApplicationInvitation.class))).thenReturn(
+            anApplicationInvitation(INVITATION_ID_1, "alice@example.com")
+        );
+
+        var result = cut.create(ORGANIZATION_ID, ENVIRONMENT_ID, APPLICATION_ID, Set.of("alice@example.com"), "PRIMARY_OWNER", false, null);
+
+        assertThat(result).extracting(ApplicationInvitation::email).containsExactly("alice@example.com");
+        verifyNoInteractions(membershipDomainService, applicationInvitationNotificationDomainService);
+    }
+
+    @Test
+    void should_propagate_membership_already_exists_when_existing_user_is_already_application_member() {
+        givenExistingRole();
+        when(invitationQueryService.findByReference(InvitationReference.application(APPLICATION_ID))).thenReturn(List.of());
+        when(userCrudService.findBaseUsersByEmail(ORGANIZATION_ID, "alice@example.com")).thenReturn(
+            List.of(aBaseUserEntity("user-id", ORGANIZATION_ID, "alice@example.com"))
+        );
+        givenNoExistingUsers("bob@example.com");
+        var membershipAlreadyExists = new MembershipAlreadyExistsException(
+            "user-id",
+            MembershipMemberType.USER,
+            APPLICATION_ID,
+            io.gravitee.rest.api.model.MembershipReferenceType.APPLICATION
+        );
+        when(
+            membershipDomainService.createNewMembership(
+                new ExecutionContext(ORGANIZATION_ID, ENVIRONMENT_ID),
+                MembershipReferenceType.APPLICATION,
+                APPLICATION_ID,
+                "user-id",
+                null,
+                ROLE_NAME
+            )
+        ).thenThrow(membershipAlreadyExists);
+
+        var throwable = catchThrowable(() ->
+            cut.create(
+                ORGANIZATION_ID,
+                ENVIRONMENT_ID,
+                APPLICATION_ID,
+                recipients("alice@example.com", "bob@example.com"),
+                ROLE_NAME,
+                true,
+                CONFIRMATION_PAGE_URL
+            )
+        );
+
+        assertThat(throwable).isSameAs(membershipAlreadyExists);
+        verifyNoInteractions(invitationCrudService, applicationInvitationNotificationDomainService);
+    }
+
+    @Test
+    void should_reject_existing_user_email_when_email_matches_multiple_users_before_any_write() {
+        givenExistingRole();
+        when(invitationQueryService.findByReference(InvitationReference.application(APPLICATION_ID))).thenReturn(List.of());
+        when(userCrudService.findBaseUsersByEmail(ORGANIZATION_ID, "alice@example.com")).thenReturn(
+            List.of(
+                aBaseUserEntity("user-id-1", ORGANIZATION_ID, "alice@example.com"),
+                aBaseUserEntity("user-id-2", ORGANIZATION_ID, "alice@example.com")
+            )
+        );
+
+        var throwable = catchThrowable(() ->
+            cut.create(ORGANIZATION_ID, ENVIRONMENT_ID, APPLICATION_ID, Set.of("alice@example.com"), ROLE_NAME, false, null)
+        );
+
+        assertThat(throwable).isInstanceOf(ConflictDomainException.class).hasMessageContaining("matches multiple users");
+        verifyNoInteractions(membershipDomainService, invitationCrudService, applicationInvitationNotificationDomainService);
+    }
+
+    @Test
     void should_reject_pending_invitation_conflict_before_creating_any_invitation() {
         givenExistingRole();
         when(invitationQueryService.findByReference(InvitationReference.application(APPLICATION_ID))).thenReturn(
@@ -169,6 +353,7 @@ class CreateApplicationInvitationsDomainServiceTest {
 
         assertThat(throwable).isInstanceOf(ConflictDomainException.class).hasMessageContaining("pending application invitation");
         verifyNoInteractions(invitationCrudService);
+        verifyNoInteractions(userCrudService, membershipDomainService);
     }
 
     @Test
@@ -184,9 +369,19 @@ class CreateApplicationInvitationsDomainServiceTest {
     }
 
     private void givenExistingRole() {
-        when(roleQueryService.findApplicationRole(eq(ROLE_NAME), any(ReferenceContext.class))).thenReturn(
-            Optional.of(anApplicationRole("role-id", ROLE_NAME))
+        givenExistingRole(ROLE_NAME);
+    }
+
+    private void givenExistingRole(String roleName) {
+        when(roleQueryService.findApplicationRole(eq(roleName), any(ReferenceContext.class))).thenReturn(
+            Optional.of(anApplicationRole("role-id", roleName))
         );
+    }
+
+    private void givenNoExistingUsers(String... emails) {
+        for (var email : emails) {
+            when(userCrudService.findBaseUsersByEmail(ORGANIZATION_ID, email)).thenReturn(List.of());
+        }
     }
 
     private Set<String> recipients(String... emails) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/invitation/domain_service/CreateApplicationInvitationsDomainServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/invitation/domain_service/CreateApplicationInvitationsDomainServiceTest.java
@@ -38,12 +38,12 @@ import io.gravitee.apim.core.invitation.query_service.InvitationQueryService;
 import io.gravitee.apim.core.member.model.MembershipReferenceType;
 import io.gravitee.apim.core.membership.domain_service.MembershipDomainService;
 import io.gravitee.apim.core.membership.exception.RoleNotFoundException;
+import io.gravitee.apim.core.membership.model.Membership;
+import io.gravitee.apim.core.membership.query_service.MembershipQueryService;
 import io.gravitee.apim.core.membership.query_service.RoleQueryService;
 import io.gravitee.apim.core.user.crud_service.UserCrudService;
-import io.gravitee.rest.api.model.MembershipMemberType;
 import io.gravitee.rest.api.service.common.ExecutionContext;
 import io.gravitee.rest.api.service.common.ReferenceContext;
-import io.gravitee.rest.api.service.exceptions.MembershipAlreadyExistsException;
 import io.gravitee.rest.api.service.exceptions.SinglePrimaryOwnerException;
 import java.net.URI;
 import java.util.LinkedHashSet;
@@ -85,6 +85,9 @@ class CreateApplicationInvitationsDomainServiceTest {
     private UserCrudService userCrudService;
 
     @Mock
+    private MembershipQueryService membershipQueryService;
+
+    @Mock
     private MembershipDomainService membershipDomainService;
 
     private CreateApplicationInvitationsDomainService cut;
@@ -97,6 +100,7 @@ class CreateApplicationInvitationsDomainServiceTest {
             new ValidateApplicationInvitationRoleDomainService(roleQueryService),
             applicationInvitationNotificationDomainService,
             userCrudService,
+            membershipQueryService,
             membershipDomainService
         );
     }
@@ -182,12 +186,13 @@ class CreateApplicationInvitationsDomainServiceTest {
         when(userCrudService.findBaseUsersByEmail(ORGANIZATION_ID, "alice@example.com")).thenReturn(
             List.of(aBaseUserEntity("user-id", ORGANIZATION_ID, "alice@example.com"))
         );
+        givenNoExistingApplicationMembers("user-id");
 
         var result = cut.create(
             ORGANIZATION_ID,
             ENVIRONMENT_ID,
             APPLICATION_ID,
-            Set.of("alice@example.com"),
+            Set.of("Alice@Example.com"),
             ROLE_NAME,
             true,
             CONFIRMATION_PAGE_URL
@@ -212,6 +217,7 @@ class CreateApplicationInvitationsDomainServiceTest {
         when(userCrudService.findBaseUsersByEmail(ORGANIZATION_ID, "alice@example.com")).thenReturn(
             List.of(aBaseUserEntity("user-id", ORGANIZATION_ID, "alice@example.com"))
         );
+        givenNoExistingApplicationMembers("user-id");
         givenNoExistingUsers("bob@example.com");
         when(invitationCrudService.create(any(ApplicationInvitation.class))).thenReturn(
             anApplicationInvitation(INVITATION_ID_1, "bob@example.com")
@@ -281,44 +287,44 @@ class CreateApplicationInvitationsDomainServiceTest {
     }
 
     @Test
-    void should_propagate_membership_already_exists_when_existing_user_is_already_application_member() {
+    void should_skip_existing_application_member_and_create_invitation_for_unknown_email() {
         givenExistingRole();
         when(invitationQueryService.findByReference(InvitationReference.application(APPLICATION_ID))).thenReturn(List.of());
         when(userCrudService.findBaseUsersByEmail(ORGANIZATION_ID, "alice@example.com")).thenReturn(
             List.of(aBaseUserEntity("user-id", ORGANIZATION_ID, "alice@example.com"))
         );
         givenNoExistingUsers("bob@example.com");
-        var membershipAlreadyExists = new MembershipAlreadyExistsException(
-            "user-id",
-            MembershipMemberType.USER,
+        givenExistingApplicationMembers(
+            Membership.builder()
+                .memberId("user-id")
+                .memberType(Membership.Type.USER)
+                .referenceType(Membership.ReferenceType.APPLICATION)
+                .referenceId(APPLICATION_ID)
+                .build()
+        );
+        when(invitationCrudService.create(any(ApplicationInvitation.class))).thenReturn(
+            anApplicationInvitation(INVITATION_ID_1, "bob@example.com")
+        );
+
+        var result = cut.create(
+            ORGANIZATION_ID,
+            ENVIRONMENT_ID,
             APPLICATION_ID,
-            io.gravitee.rest.api.model.MembershipReferenceType.APPLICATION
-        );
-        when(
-            membershipDomainService.createNewMembership(
-                new ExecutionContext(ORGANIZATION_ID, ENVIRONMENT_ID),
-                MembershipReferenceType.APPLICATION,
-                APPLICATION_ID,
-                "user-id",
-                null,
-                ROLE_NAME
-            )
-        ).thenThrow(membershipAlreadyExists);
-
-        var throwable = catchThrowable(() ->
-            cut.create(
-                ORGANIZATION_ID,
-                ENVIRONMENT_ID,
-                APPLICATION_ID,
-                recipients("alice@example.com", "bob@example.com"),
-                ROLE_NAME,
-                true,
-                CONFIRMATION_PAGE_URL
-            )
+            recipients("alice@example.com", "bob@example.com"),
+            ROLE_NAME,
+            true,
+            CONFIRMATION_PAGE_URL
         );
 
-        assertThat(throwable).isSameAs(membershipAlreadyExists);
-        verifyNoInteractions(invitationCrudService, applicationInvitationNotificationDomainService);
+        assertThat(result).extracting(ApplicationInvitation::email).containsExactly("bob@example.com");
+        verify(membershipDomainService, never()).createNewMembership(any(), any(), any(), any(), any(), any());
+        verify(applicationInvitationNotificationDomainService).dispatchAsync(
+            ORGANIZATION_ID,
+            ENVIRONMENT_ID,
+            APPLICATION_ID,
+            result,
+            CONFIRMATION_PAGE_URL
+        );
     }
 
     @Test
@@ -382,6 +388,30 @@ class CreateApplicationInvitationsDomainServiceTest {
         for (var email : emails) {
             when(userCrudService.findBaseUsersByEmail(ORGANIZATION_ID, email)).thenReturn(List.of());
         }
+    }
+
+    private void givenNoExistingApplicationMembers(String... userIds) {
+        when(
+            membershipQueryService.findByMemberIdsAndMemberTypeAndReferenceType(
+                Set.of(userIds),
+                Membership.Type.USER,
+                Membership.ReferenceType.APPLICATION
+            )
+        ).thenReturn(List.of());
+    }
+
+    private void givenExistingApplicationMembers(Membership... memberships) {
+        var userIds = new LinkedHashSet<String>();
+        for (var membership : memberships) {
+            userIds.add(membership.getMemberId());
+        }
+        when(
+            membershipQueryService.findByMemberIdsAndMemberTypeAndReferenceType(
+                userIds,
+                Membership.Type.USER,
+                Membership.ReferenceType.APPLICATION
+            )
+        ).thenReturn(List.of(memberships));
     }
 
     private Set<String> recipients(String... emails) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/crud_service/user/UserCrudServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/crud_service/user/UserCrudServiceImplTest.java
@@ -155,7 +155,7 @@ public class UserCrudServiceImplTest {
                 )
             );
 
-            var users = service.findBaseUsersByEmail("organization-id", "same@gravitee.io");
+            var users = service.findBaseUsersByEmail("organization-id", "SAME@gravitee.io");
 
             assertThat(users).extracting(BaseUserEntity::getId).containsExactly("1", "2");
         }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/crud_service/user/UserCrudServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/crud_service/user/UserCrudServiceImplTest.java
@@ -143,6 +143,43 @@ public class UserCrudServiceImplTest {
     }
 
     @Nested
+    class FindBaseUsersByEmail {
+
+        @Test
+        void should_find_users_by_email_in_organization_and_adapt_them() {
+            userRepository.initWith(
+                List.of(
+                    aRepositoryUser("1", "source-1", "source-id-1", "same@gravitee.io", "Jane 1", "Doe 1"),
+                    aRepositoryUser("2", "source-2", "source-id-2", "same@gravitee.io", "Jane 2", "Doe 2"),
+                    User.builder().id("3").organizationId("other-organization").email("same@gravitee.io").build()
+                )
+            );
+
+            var users = service.findBaseUsersByEmail("organization-id", "same@gravitee.io");
+
+            assertThat(users).extracting(BaseUserEntity::getId).containsExactly("1", "2");
+        }
+
+        @Test
+        void should_return_empty_when_no_matching_email() {
+            userRepository.initWith(List.of(aRepositoryUser()));
+
+            var result = service.findBaseUsersByEmail("organization-id", "unknown@gravitee.io");
+
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        void should_throw_when_technical_exception_occurs() {
+            userRepository.failsWith(new TechnicalException("technical exception"));
+
+            var throwable = catchThrowable(() -> service.findBaseUsersByEmail("organization-id", "same@gravitee.io"));
+
+            assertThat(throwable).isInstanceOf(TechnicalManagementException.class).hasMessageContaining("technical exception");
+        }
+    }
+
+    @Nested
     class Create {
 
         @Test


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-14407

## Description

- Map application invitation recipients with existing user emails to active application members.
- Keep pending invitation creation unchanged for unknown emails.
- Keep API response and OpenAPI contract unchanged: response contains only created invitations.




https://github.com/user-attachments/assets/5454f0be-8800-4d58-b852-365686c3add7


