### PR TITLE
feat(helm): support multiple Kafka custom domains and metrics principalName

### DIFF
--- a/helm/CHANGELOG.md
+++ b/helm/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 This file documents all notable changes to [Gravitee.io API Management 3.x](https://github.com/gravitee-io/helm-charts/tree/master/apim/3.x) Helm Chart. The release numbering uses [semantic versioning](http://semver.org).
 
+### 4.13.0
+- Support multiple custom domains for native Kafka APIs with `gateway.kafka.routingHostMode.domains` (list). `defaultDomain` is deprecated and ignored when `domains` is set.
+- Document `gateway.services.metrics.kafka.durations.principalName` to add the `principal_name` tag to Kafka duration metrics (disabled by default).
+
 ### 4.12.0
 - Add support for Kubernetes Gateway API HTTPRoute for all components (API, Gateway, User Interface, Portal).
     - HTTPRoute is compatible alongside Nginx Ingress.

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -33,8 +33,6 @@ annotations:
     - kind: added
       description: "Support multiple custom domains for native Kafka APIs with `gateway.kafka.routingHostMode.domains` (list)"
       links:
-        - name: Jira
-          url: https://gravitee.atlassian.net/browse/APIM-14274
         - name: Github PR
           url: https://github.com/gravitee-io/gravitee-api-management/pull/17691
     - kind: deprecated

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -29,4 +29,15 @@ annotations:
   ###########
   # "changes" must be the last section in this file, because a CI job clean it after each release
   ###########
-  artifacthub.io/changes:
+  artifacthub.io/changes: |
+    - kind: added
+      description: "Support multiple custom domains for native Kafka APIs with `gateway.kafka.routingHostMode.domains` (list)"
+      links:
+        - name: Jira
+          url: https://gravitee.atlassian.net/browse/APIM-14274
+        - name: Github PR
+          url: https://github.com/gravitee-io/gravitee-api-management/pull/17691
+    - kind: deprecated
+      description: "`gateway.kafka.routingHostMode.defaultDomain` is deprecated in favor of `domains` and ignored when `domains` is set"
+    - kind: added
+      description: "Document `gateway.services.metrics.kafka.durations.principalName` to add the principal_name tag to Kafka duration metrics (disabled by default)"

--- a/helm/templates/gateway/gateway-configmap.yaml
+++ b/helm/templates/gateway/gateway-configmap.yaml
@@ -277,6 +277,12 @@ data:
         {{- if hasKey .Values.gateway.kafka.routingHostMode "domainSeparator" }}
         domainSeparator: {{ .Values.gateway.kafka.routingHostMode.domainSeparator | quote }}
         {{- end}}
+        {{- if hasKey .Values.gateway.kafka.routingHostMode "domains" }}
+        domains:
+          {{- range .Values.gateway.kafka.routingHostMode.domains }}
+          - {{ . | quote }}
+          {{- end }}
+        {{- end}}
         {{- if hasKey .Values.gateway.kafka.routingHostMode "defaultDomain" }}
         defaultDomain: {{ .Values.gateway.kafka.routingHostMode.defaultDomain | quote }}
         {{- end}}

--- a/helm/tests/gateway/configmap_kafka_test.yaml
+++ b/helm/tests/gateway/configmap_kafka_test.yaml
@@ -98,6 +98,30 @@ tests:
               tcpKeepAlive: 42
               instances: 42
               requestTimeout: 42
+  - it: Enable Kafka and set multiple custom domains
+    template: gateway/gateway-configmap.yaml
+    set:
+      gateway:
+        kafka:
+          enabled: true
+          routingMode: host
+          routingHostMode:
+            domains:
+              - kafka.gravitee.io
+              - kafka.mycompany.org
+            defaultPort: 9092
+    asserts:
+      - matchRegex:
+          path: data["gravitee.yml"]
+          pattern: |
+            kafka:
+              enabled: true
+              routingMode: host
+              routingHostMode:
+                domains:
+                  - "kafka.gravitee.io"
+                  - "kafka.mycompany.org"
+                defaultPort: 9092
   - it: Enable Kafka and set ssl values
     template: gateway/gateway-configmap.yaml
     set:

--- a/helm/tests/gateway/configmap_metrics_test.yaml
+++ b/helm/tests/gateway/configmap_metrics_test.yaml
@@ -39,6 +39,32 @@ tests:
             \s     concurrencyLimit: 3
             \s     enabled: true
 
+  - it: Enable metrics service and set kafka durations `principalName`
+    template: gateway/gateway-configmap.yaml
+    set:
+      gateway:
+        services:
+          metrics:
+            enabled: true
+            kafka:
+              durations:
+                principalName: true
+            prometheus:
+              enabled: true
+              concurrencyLimit: 3
+    asserts:
+      - matchRegex:
+          path: data["gravitee.yml"]
+          pattern: |
+            \s metrics:
+            \s   enabled: true
+            \s   kafka:
+            \s     durations:
+            \s       principalName: true
+            \s   prometheus:
+            \s     concurrencyLimit: 3
+            \s     enabled: true
+
   - it: Enable metrics service and don't set any `labels`
     template: gateway/gateway-configmap.yaml
     set:

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -1422,7 +1422,14 @@ gateway:
 #      brokerPrefix: broker-          # default is broker-
 #      domainSeparator: -             # Used to separate broker's name from api & defaultDomain. Default is '-'
 #
+#      # The domains where the Kafka APIs are exposed. ex: `myapi` will be exposed as `myapi.mycompany.org` and `myapi.mycompany.com`
+#      # Each domain should be set according to a public wildcard DNS/Certificate.
+#      domains:
+#        - mycompany.org
+#        - mycompany.com
+#
 #      # The default domain where the Kafka APIs are exposed. ex: `myapi` will be exposed as `myapi.mycompany.org`
+#      # Deprecated: use `domains` instead. Ignored when `domains` is set.
 #      defaultDomain: mycompany.org   # Should set according to the public wildcard DNS/Certificate. Default is empty
 #      defaultPort:   9092            # Default public port for Kafka APIs. Default is 9092
 #
@@ -1996,6 +2003,11 @@ gateway:
       prometheus:
         enabled: true
         concurrencyLimit: 3
+#     # Native Kafka APIs metrics
+#     kafka:
+#       durations:
+#         # Add the `principal_name` tag to Kafka duration metrics. Disabled by default as it can lead to high cardinality.
+#         principalName: false
 #   opentelemetry:
 #      enabled: false
 #      verbose: false


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-14274

## Description

Update the Helm chart to support two new `gravitee.yml` properties for the native Kafka gateway:

- `gateway.kafka.routingHostMode.domains` (list): multiple custom domains for native Kafka APIs. Rendered as a YAML list in the gateway configmap. `defaultDomain` is now documented as deprecated and is ignored when `domains` is set.
- `gateway.services.metrics.kafka.durations.principalName` (boolean, default `false`): adds the `principal_name` tag to Kafka duration metrics. No template change needed (`services.metrics` is a full passthrough); documented in `values.yaml` and covered by a unit test.

### Changes

- `helm/templates/gateway/gateway-configmap.yaml`: render `routingHostMode.domains` as a quoted list
- `helm/values.yaml`: document `domains` (with `defaultDomain` deprecation note) and `metrics.kafka.durations.principalName`
- `helm/tests/gateway/configmap_kafka_test.yaml`: new test for the `domains` list rendering
- `helm/tests/gateway/configmap_metrics_test.yaml`: new test for the `principalName` passthrough
- `helm/CHANGELOG.md`: changelog entry

## Additional context

Backend support comes from `gravitee-reactor-native-kafka` (multi custom domains: APIM-14274; configurable principal name on duration metrics). Full helm unittest suite passes.
