### PR TITLE
feat(release): allow triggering a release from any branch (4.10.x)

### DIFF
--- a/.circleci/ci/src/pipelines/pipeline-full-release.ts
+++ b/.circleci/ci/src/pipelines/pipeline-full-release.ts
@@ -15,15 +15,10 @@
  */
 import { Config } from '@circleci/circleci-config-sdk';
 import { CircleCIEnvironment } from './circleci-environment';
-import { isSupportBranch } from '../utils';
 import { FullReleaseWorkflow } from '../workflows';
 import { initDynamicConfig } from './config-factory';
 
 export function generateFullReleaseConfig(environment: CircleCIEnvironment): Config {
-  if (!isSupportBranch(environment.branch)) {
-    throw new Error('Full release is only supported on support branches');
-  }
-
   const dynamicConfig = initDynamicConfig();
   const workflow = FullReleaseWorkflow.create(dynamicConfig, environment);
   dynamicConfig.addWorkflow(workflow);

--- a/.circleci/ci/src/pipelines/tests/pipeline-full-release.spec.ts
+++ b/.circleci/ci/src/pipelines/tests/pipeline-full-release.spec.ts
@@ -45,24 +45,23 @@ describe('Full release tests', () => {
     },
   );
 
-  it('should throw error when branch is not a support branch', () => {
-    expect.assertions(1);
+  it('should build full release config from any branch (not only support branches)', () => {
+    const result = generateFullReleaseConfig({
+      action: 'full_release',
+      sha1: '784ff35ca',
+      changedFiles: [],
+      buildNum: '1234',
+      buildId: '1234',
+      graviteeioVersion: '4.1.0',
+      branch: 'apim-1234-dev',
+      baseBranch: 'master',
+      isDryRun: false,
+      apimVersionPath: './src/pipelines/tests/resources/common/pom-snapshot.xml',
+    });
 
-    try {
-      generateFullReleaseConfig({
-        action: 'release',
-        sha1: '784ff35ca',
-        changedFiles: [],
-        buildNum: '1234',
-        buildId: '1234',
-        graviteeioVersion: '4.1.0',
-        branch: 'apim-1234-dev',
-        baseBranch: 'master',
-        isDryRun: false,
-        apimVersionPath: './src/pipelines/tests/resources/common/pom.xml',
-      });
-    } catch (e) {
-      expect(e).toStrictEqual(new Error('Full release is only supported on support branches'));
-    }
+    const stringified = result.stringify();
+    expect(stringified).toContain('full_release');
+    // The version bump commit is pushed to the very branch that triggered the release.
+    expect(stringified).toContain('apim-1234-dev');
   });
 });

--- a/release/README.adoc
+++ b/release/README.adoc
@@ -60,6 +60,7 @@ Optional flag:
 
 * `--dry-run`: allow to run the pipeline in dry run mode (except for `nexus_sync` which does not have this mode)
 * `--latest`: to tag the docker image as the `latest`
+* `--branch=<name>`: target branch on which the pipeline is triggered. When omitted, the branch is derived from the version (e.g. `4.5.x` for `4.5.11`). Use it to release from any branch (the version bump commit and tag are pushed to that branch). You will be asked to confirm when it differs from the derived branch.
 
 Here is the command to fully release APIM (Releasing 3.15.11, in the following example):
 

--- a/release/helpers/option-helper.mjs
+++ b/release/helpers/option-helper.mjs
@@ -1,3 +1,12 @@
 export function isDryRun() {
   return !!argv['dry-run'];
 }
+
+/**
+ * Target branch of the pipeline: --branch if provided, otherwise the branch derived from the version.
+ * @param {{branch: string}} versions result of computeVersion()
+ * @returns {string}
+ */
+export function getTargetBranch(versions) {
+  return argv.branch ?? versions.branch;
+}

--- a/release/steps/1-release.mjs
+++ b/release/steps/1-release.mjs
@@ -2,7 +2,7 @@
 
 import { checkToken } from '../helpers/circleci-helper.mjs';
 import { computeVersion, extractVersion } from '../helpers/version-helper.mjs';
-import { isDryRun } from '../helpers/option-helper.mjs';
+import { isDryRun, getTargetBranch } from '../helpers/option-helper.mjs';
 
 await checkToken();
 
@@ -12,7 +12,7 @@ const versions = computeVersion(releasingVersion);
 console.log(chalk.blue(`Triggering Release Pipeline`));
 
 const body = {
-  branch: versions.branch,
+  branch: getTargetBranch(versions),
   parameters: {
     gio_action: 'release',
     dry_run: isDryRun(),

--- a/release/steps/2-package_zip.mjs
+++ b/release/steps/2-package_zip.mjs
@@ -2,7 +2,7 @@
 
 import { checkToken } from '../helpers/circleci-helper.mjs';
 import { computeVersion, extractVersion } from '../helpers/version-helper.mjs';
-import { isDryRun } from '../helpers/option-helper.mjs';
+import { isDryRun, getTargetBranch } from '../helpers/option-helper.mjs';
 
 await checkToken();
 
@@ -13,7 +13,7 @@ console.log(chalk.blue(`Triggering Package Zip Pipeline`));
 
 // Use the preconfigured payload from config folder with the good parameters
 const body = {
-  branch: versions.branch,
+  branch: getTargetBranch(versions),
   parameters: {
     gio_action: 'package_bundle',
     dry_run: isDryRun(),

--- a/release/steps/3-docker.mjs
+++ b/release/steps/3-docker.mjs
@@ -2,7 +2,7 @@
 
 import { checkToken } from '../helpers/circleci-helper.mjs';
 import { computeVersion, extractVersion } from '../helpers/version-helper.mjs';
-import { isDryRun } from '../helpers/option-helper.mjs';
+import { isDryRun, getTargetBranch } from '../helpers/option-helper.mjs';
 
 await checkToken();
 
@@ -23,7 +23,7 @@ console.log(chalk.blue(`Triggering Docker Pipeline`));
 
 // Use the preconfigured payload from config folder with the good parameters
 const body = {
-  branch: versions.branch,
+  branch: getTargetBranch(versions),
   parameters: {
     gio_action: 'build_docker_images',
     docker_tag_as_latest: isLatest,

--- a/release/steps/4-rpms.mjs
+++ b/release/steps/4-rpms.mjs
@@ -2,7 +2,7 @@
 
 import { checkToken } from '../helpers/circleci-helper.mjs';
 import { computeVersion, extractVersion } from '../helpers/version-helper.mjs';
-import { isDryRun } from '../helpers/option-helper.mjs';
+import { isDryRun, getTargetBranch } from '../helpers/option-helper.mjs';
 
 await checkToken();
 
@@ -13,7 +13,7 @@ console.log(chalk.blue(`Triggering RPMs Pipeline`));
 
 // Use the preconfigured payload from config folder with the good parameters
 const body = {
-  branch: versions.branch,
+  branch: getTargetBranch(versions),
   parameters: {
     gio_action: 'build_rpm',
     dry_run: isDryRun(),

--- a/release/steps/5-helm-chart.mjs
+++ b/release/steps/5-helm-chart.mjs
@@ -2,7 +2,7 @@
 
 import { checkToken } from '../helpers/circleci-helper.mjs';
 import { computeVersion, extractVersion } from '../helpers/version-helper.mjs';
-import { isDryRun } from '../helpers/option-helper.mjs';
+import { isDryRun, getTargetBranch } from '../helpers/option-helper.mjs';
 
 await checkToken();
 
@@ -12,7 +12,7 @@ const versions = computeVersion(releasingVersion);
 console.log(chalk.blue(`Triggering Helm Chart generation Pipeline`));
 
 const body = {
-  branch: versions.branch,
+  branch: getTargetBranch(versions),
   parameters: {
     gio_action: 'release_helm',
     dry_run: isDryRun(),

--- a/release/steps/6-generate_release_notes.mjs
+++ b/release/steps/6-generate_release_notes.mjs
@@ -2,7 +2,7 @@
 
 import { checkToken } from '../helpers/circleci-helper.mjs';
 import { computeVersion, extractVersion } from '../helpers/version-helper.mjs';
-import { isDryRun } from '../helpers/option-helper.mjs';
+import { isDryRun, getTargetBranch } from '../helpers/option-helper.mjs';
 
 await checkToken();
 
@@ -14,7 +14,7 @@ console.log(chalk.blue(`Triggering Release Notes generation Pipeline`));
 // Use the preconfigured payload from config folder with the good parameters
 // For release-notes generation, always work on master
 const body = {
-  branch: versions.branch,
+  branch: getTargetBranch(versions),
   parameters: {
     gio_action: 'release_notes_apim',
     dry_run: isDryRun(),

--- a/release/steps/7-nexus_sync.mjs
+++ b/release/steps/7-nexus_sync.mjs
@@ -2,7 +2,7 @@
 
 import { checkToken } from '../helpers/circleci-helper.mjs';
 import { computeVersion, extractVersion } from '../helpers/version-helper.mjs';
-import { isDryRun } from '../helpers/option-helper.mjs';
+import { isDryRun, getTargetBranch } from '../helpers/option-helper.mjs';
 
 await checkToken();
 
@@ -13,7 +13,7 @@ console.log(chalk.blue(`Triggering Nexus Sync Pipeline`));
 
 // Use the preconfigured payload from config folder with the good parameters
 const body = {
-  branch: versions.branch,
+  branch: getTargetBranch(versions),
   parameters: {
     gio_action: 'nexus_staging',
     dry_run: isDryRun(),

--- a/release/steps/full_release.mjs
+++ b/release/steps/full_release.mjs
@@ -2,7 +2,7 @@
 
 import { checkToken } from '../helpers/circleci-helper.mjs';
 import { computeVersion, extractVersion } from '../helpers/version-helper.mjs';
-import { isDryRun } from '../helpers/option-helper.mjs';
+import { isDryRun, getTargetBranch } from '../helpers/option-helper.mjs';
 
 await checkToken();
 
@@ -43,8 +43,24 @@ if (argv.latest) {
   }
 }
 
+const targetBranch = getTargetBranch(versions);
+if (argv.branch && argv.branch !== versions.branch) {
+  const confirmBranch = await question(
+    chalk.yellow(
+      `⚠️ Releasing ${releasingVersion} from non-default branch '${targetBranch}'. The version bump commit and tag will be pushed there. Should we continue? (y/n)\n`,
+    ),
+  );
+  if (confirmBranch === 'n') {
+    console.log(chalk.yellow(`🚦 Release process interrupted. Re-run with the right '--branch' (or none) and try again!`));
+    process.exit(1);
+  }
+}
+
+console.log(chalk.blue(`Version: ${releasingVersion}`));
+console.log(chalk.blue(`Branch: ${targetBranch}\n`));
+
 const body = {
-  branch: versions.branch,
+  branch: targetBranch,
   parameters: {
     gio_action: 'full_release',
     docker_tag_as_latest: isLatest,


### PR DESCRIPTION
## Issue

No JIRA ticket for this change.

## Description

Allow triggering a full release from **any branch**, not only support branches (`X.Y.x`).

- Add an optional `--branch` flag to the release scripts (`release/steps`), falling back to the version-derived branch when omitted. `full_release` asks for confirmation when the branch differs from the default (the version bump commit and tag are pushed there).
- Remove the `isSupportBranch` guard in the CI full-release pipeline (`pipeline-full-release.ts`) so any branch is accepted; downstream jobs already rely on the actual branch and version.
- Update tests and README accordingly.

## Additional context

Coordinated change applied to `master` and the active support branches (`4.8.x` → `4.12.x`): the CI-side guard removal must live on every branch a release can be triggered from, since CircleCI generates its config from the released branch.

Note: `release/steps/maven_release.mjs` does not exist on this branch (added on `master` later), so the `maven_release` part of the change is intentionally omitted here.

Commits carry `[skip ci]` since this only touches the release process and CI config.
