### PR TITLE
fix: remove gravitee-tracer-jaeger (not supported anymore since apim 4.6)

### DIFF
--- a/gravitee-apim-distribution/pom.xml
+++ b/gravitee-apim-distribution/pom.xml
@@ -1287,21 +1287,6 @@
                 </exclusion>
             </exclusions>
         </dependency>
-
-        <!-- Tracers -->
-        <dependency>
-            <groupId>io.gravitee.tracer</groupId>
-            <artifactId>gravitee-tracer-jaeger</artifactId>
-            <version>${gravitee-tracer-jaeger.version}</version>
-            <type>zip</type>
-            <scope>runtime</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>*</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
     </dependencies>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -267,7 +267,6 @@
         <gravitee-reporter-otel.version>1.2.0</gravitee-reporter-otel.version>
         <!--    Version of policy-ratelimit is also used for policy-quota, policy-spikearrest and gateway-services-ratelimit    -->
         <!--    <gravitee-gateway-services-ratelimit.version>3.0.0</gravitee-gateway-services-ratelimit.version>    -->
-        <gravitee-tracer-jaeger.version>3.0.1</gravitee-tracer-jaeger.version>
 
         <!-- Versions of the plugins for the full distribution on dev environment-->
         <!-- Management API & Gateway -->


### PR DESCRIPTION
https://documentation.gravitee.io/apim/release-information/breaking-changes-and-deprecations#id-4.6.0

https://gravitee.atlassian.net/browse/APIM-14118