### PR TITLE
ci(helm): validate artifacthub.io/changes annotation with ah lint

### DIFF
--- a/.circleci/ci/src/config.ts
+++ b/.circleci/ci/src/config.ts
@@ -91,6 +91,8 @@ const executor = {
 const helm = {
   defaultVersion: 'v3.12.3',
   helmUnitVersion: '0.5.1',
+  // Artifact Hub CLI, used to validate the artifacthub.io/* annotations (e.g. changes) before publishing
+  artifactHubVersion: '1.22.0',
 };
 
 const jobContext = ['cicd-orchestrator'];

--- a/.circleci/ci/src/jobs/helm/job-test-apim-charts.ts
+++ b/.circleci/ci/src/jobs/helm/job-test-apim-charts.ts
@@ -47,6 +47,19 @@ export class TestApimChartsJob {
         command: `helm lint helm/`,
       }),
       new commands.Run({
+        name: 'Install Artifact Hub CLI (ah)',
+        command: `curl -fsSL "https://github.com/artifacthub/hub/releases/download/v${config.helm.artifactHubVersion}/ah_${config.helm.artifactHubVersion}_linux_amd64.tar.gz" | tar -xz -C /tmp ah
+sudo mv /tmp/ah /usr/local/bin/ah
+ah version`,
+      }),
+      new commands.Run({
+        // 'helm lint' treats the artifacthub.io/changes annotation as an opaque string and never validates its
+        // content. Artifact Hub re-parses it at publish time, so malformed entries (invalid kind, broken YAML)
+        // are only caught after the chart is published. 'ah lint' applies the exact same checks locally/in CI.
+        name: 'Validate Artifact Hub annotations (artifacthub.io/changes) in helm/',
+        command: `ah lint -k helm -p helm`,
+      }),
+      new commands.Run({
         name: 'Execute the units tests in helm/',
         command: "helm unittest -f 'tests/**/*.yaml' helm/ -t JUnit -o apim-result.xml",
       }),

--- a/.circleci/ci/src/pipelines/tests/resources/helm-tests/helm-tests.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/helm-tests/helm-tests.yml
@@ -57,6 +57,15 @@ jobs:
           name: Lint the helm charts available in helm/
           command: helm lint helm/
       - run:
+          name: Install Artifact Hub CLI (ah)
+          command: |-
+            curl -fsSL "https://github.com/artifacthub/hub/releases/download/v1.22.0/ah_1.22.0_linux_amd64.tar.gz" | tar -xz -C /tmp ah
+            sudo mv /tmp/ah /usr/local/bin/ah
+            ah version
+      - run:
+          name: Validate Artifact Hub annotations (artifacthub.io/changes) in helm/
+          command: ah lint -k helm -p helm
+      - run:
           name: Execute the units tests in helm/
           command: helm unittest -f 'tests/**/*.yaml' helm/ -t JUnit -o apim-result.xml
       - store_test_results:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-4-1-x.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-4-1-x.yml
@@ -170,6 +170,15 @@ jobs:
           name: Lint the helm charts available in helm/
           command: helm lint helm/
       - run:
+          name: Install Artifact Hub CLI (ah)
+          command: |-
+            curl -fsSL "https://github.com/artifacthub/hub/releases/download/v1.22.0/ah_1.22.0_linux_amd64.tar.gz" | tar -xz -C /tmp ah
+            sudo mv /tmp/ah /usr/local/bin/ah
+            ah version
+      - run:
+          name: Validate Artifact Hub annotations (artifacthub.io/changes) in helm/
+          command: ah lint -k helm -p helm
+      - run:
           name: Execute the units tests in helm/
           command: helm unittest -f 'tests/**/*.yaml' helm/ -t JUnit -o apim-result.xml
       - store_test_results:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-helm-only.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch-helm-only.yml
@@ -77,6 +77,15 @@ jobs:
           name: Lint the helm charts available in helm/
           command: helm lint helm/
       - run:
+          name: Install Artifact Hub CLI (ah)
+          command: |-
+            curl -fsSL "https://github.com/artifacthub/hub/releases/download/v1.22.0/ah_1.22.0_linux_amd64.tar.gz" | tar -xz -C /tmp ah
+            sudo mv /tmp/ah /usr/local/bin/ah
+            ah version
+      - run:
+          name: Validate Artifact Hub annotations (artifacthub.io/changes) in helm/
+          command: ah lint -k helm -p helm
+      - run:
           name: Execute the units tests in helm/
           command: helm unittest -f 'tests/**/*.yaml' helm/ -t JUnit -o apim-result.xml
       - store_test_results:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-custom-branch.yml
@@ -146,6 +146,15 @@ jobs:
           name: Lint the helm charts available in helm/
           command: helm lint helm/
       - run:
+          name: Install Artifact Hub CLI (ah)
+          command: |-
+            curl -fsSL "https://github.com/artifacthub/hub/releases/download/v1.22.0/ah_1.22.0_linux_amd64.tar.gz" | tar -xz -C /tmp ah
+            sudo mv /tmp/ah /usr/local/bin/ah
+            ah version
+      - run:
+          name: Validate Artifact Hub annotations (artifacthub.io/changes) in helm/
+          command: ah lint -k helm -p helm
+      - run:
           name: Execute the units tests in helm/
           command: helm unittest -f 'tests/**/*.yaml' helm/ -t JUnit -o apim-result.xml
       - store_test_results:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-master.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-master.yml
@@ -170,6 +170,15 @@ jobs:
           name: Lint the helm charts available in helm/
           command: helm lint helm/
       - run:
+          name: Install Artifact Hub CLI (ah)
+          command: |-
+            curl -fsSL "https://github.com/artifacthub/hub/releases/download/v1.22.0/ah_1.22.0_linux_amd64.tar.gz" | tar -xz -C /tmp ah
+            sudo mv /tmp/ah /usr/local/bin/ah
+            ah version
+      - run:
+          name: Validate Artifact Hub annotations (artifacthub.io/changes) in helm/
+          command: ah lint -k helm -p helm
+      - run:
           name: Execute the units tests in helm/
           command: helm unittest -f 'tests/**/*.yaml' helm/ -t JUnit -o apim-result.xml
       - store_test_results:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-mergify.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-mergify.yml
@@ -146,6 +146,15 @@ jobs:
           name: Lint the helm charts available in helm/
           command: helm lint helm/
       - run:
+          name: Install Artifact Hub CLI (ah)
+          command: |-
+            curl -fsSL "https://github.com/artifacthub/hub/releases/download/v1.22.0/ah_1.22.0_linux_amd64.tar.gz" | tar -xz -C /tmp ah
+            sudo mv /tmp/ah /usr/local/bin/ah
+            ah version
+      - run:
+          name: Validate Artifact Hub annotations (artifacthub.io/changes) in helm/
+          command: ah lint -k helm -p helm
+      - run:
           name: Execute the units tests in helm/
           command: helm unittest -f 'tests/**/*.yaml' helm/ -t JUnit -o apim-result.xml
       - store_test_results:

--- a/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-run-e2e.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/pull-requests/pull-requests-run-e2e.yml
@@ -171,6 +171,15 @@ jobs:
           name: Lint the helm charts available in helm/
           command: helm lint helm/
       - run:
+          name: Install Artifact Hub CLI (ah)
+          command: |-
+            curl -fsSL "https://github.com/artifacthub/hub/releases/download/v1.22.0/ah_1.22.0_linux_amd64.tar.gz" | tar -xz -C /tmp ah
+            sudo mv /tmp/ah /usr/local/bin/ah
+            ah version
+      - run:
+          name: Validate Artifact Hub annotations (artifacthub.io/changes) in helm/
+          command: ah lint -k helm -p helm
+      - run:
           name: Execute the units tests in helm/
           command: helm unittest -f 'tests/**/*.yaml' helm/ -t JUnit -o apim-result.xml
       - store_test_results:

--- a/.circleci/ci/src/pipelines/tests/resources/release-helm/release-helm-dry-run.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/release-helm/release-helm-dry-run.yml
@@ -64,6 +64,15 @@ jobs:
           name: Lint the helm charts available in helm/
           command: helm lint helm/
       - run:
+          name: Install Artifact Hub CLI (ah)
+          command: |-
+            curl -fsSL "https://github.com/artifacthub/hub/releases/download/v1.22.0/ah_1.22.0_linux_amd64.tar.gz" | tar -xz -C /tmp ah
+            sudo mv /tmp/ah /usr/local/bin/ah
+            ah version
+      - run:
+          name: Validate Artifact Hub annotations (artifacthub.io/changes) in helm/
+          command: ah lint -k helm -p helm
+      - run:
           name: Execute the units tests in helm/
           command: helm unittest -f 'tests/**/*.yaml' helm/ -t JUnit -o apim-result.xml
       - store_test_results:

--- a/.circleci/ci/src/pipelines/tests/resources/release-helm/release-helm.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/release-helm/release-helm.yml
@@ -64,6 +64,15 @@ jobs:
           name: Lint the helm charts available in helm/
           command: helm lint helm/
       - run:
+          name: Install Artifact Hub CLI (ah)
+          command: |-
+            curl -fsSL "https://github.com/artifacthub/hub/releases/download/v1.22.0/ah_1.22.0_linux_amd64.tar.gz" | tar -xz -C /tmp ah
+            sudo mv /tmp/ah /usr/local/bin/ah
+            ah version
+      - run:
+          name: Validate Artifact Hub annotations (artifacthub.io/changes) in helm/
+          command: ah lint -k helm -p helm
+      - run:
           name: Execute the units tests in helm/
           command: helm unittest -f 'tests/**/*.yaml' helm/ -t JUnit -o apim-result.xml
       - store_test_results:


### PR DESCRIPTION
## Problem

`helm lint` (run in `job-test-apim-charts`) treats the `artifacthub.io/changes` annotation as an **opaque string** and never validates its content. Artifact Hub re-parses that string at **publish time**, so malformed entries (invalid `kind`, broken YAML indentation, unquoted special characters) are only discovered **after** the Helm chart is published — too late.

## Change

Add the Artifact Hub CLI (`ah`) to `job-test-apim-charts` and run `ah lint -k helm -p helm` on every PR. It applies the **exact same checks** as the Artifact Hub backend, so a malformed `changes` annotation now fails the build early, with a precise message.

- New step **Install Artifact Hub CLI (ah)** — pinned version `1.22.0` (`config.helm.artifactHubVersion`)
- New step **Validate Artifact Hub annotations (artifacthub.io/changes) in helm/**
- Regenerated the affected CircleCI golden config fixtures

It is a **no-op when the `changes` section is empty** (the normal state during development), so it does not disturb regular PRs.

## Validation

| Case | Result | Exit |
|------|--------|------|
| Current chart (empty `changes`) | ✅ SUCCEEDED (warning only) | 0 |
| `origin/4.12.x` (11 real entries + links) | ✅ SUCCEEDED | 0 |
| Invalid `kind` (`changed` → `changd`) | ❌ `invalid change: invalid kind: changd` | 1 |
| Broken YAML (links indentation) | ❌ `invalid changes annotation. Please use quotes...` | 1 |

Local checks: `npm run build` ✅ · `jest` 100/100 ✅ · `npm run lint` ✅