### PR TITLE
feat(portal): integrate Portal Next toggles for membership, invitatio…

### DIFF
--- a/gravitee-apim-console-webui/src/entities/portal/portalSettings.fixture.ts
+++ b/gravitee-apim-console-webui/src/entities/portal/portalSettings.fixture.ts
@@ -230,7 +230,7 @@ export function fakePortalConfiguration(attributes?: Partial<PortalConfiguration
       },
       applications: {
         membership: {
-          enabled: { enabled: false },
+          enabled: false,
           transferOwnership: { enabled: false },
           invitations: { enabled: false },
         },

--- a/gravitee-apim-console-webui/src/entities/portal/portalSettings.ts
+++ b/gravitee-apim-console-webui/src/entities/portal/portalSettings.ts
@@ -260,7 +260,7 @@ export interface PortalSettingsPortalNext {
   };
   applications?: {
     membership?: {
-      enabled?: { enabled?: boolean };
+      enabled?: boolean;
       transferOwnership?: { enabled?: boolean };
       invitations?: { enabled?: boolean };
     };

--- a/gravitee-apim-console-webui/src/management/settings/portal-settings/portal-settings.component.html
+++ b/gravitee-apim-console-webui/src/management/settings/portal-settings/portal-settings.component.html
@@ -491,7 +491,7 @@
             </gio-form-slide-toggle>
             <div formGroupName="applications">
               <div formGroupName="membership">
-                <gio-form-slide-toggle formGroupName="enabled" class="portal__form__card__form-field">
+                <gio-form-slide-toggle class="portal__form__card__form-field">
                   <gio-form-label>Enable Application Membership Settings</gio-form-label>
                   <mat-slide-toggle
                     id="enable-portal-next-member-mapping"

--- a/gravitee-apim-console-webui/src/management/settings/portal-settings/portal-settings.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/settings/portal-settings/portal-settings.component.spec.ts
@@ -206,7 +206,7 @@ describe('PortalSettingsComponent', () => {
           },
           applications: {
             membership: {
-              enabled: { enabled: false },
+              enabled: false,
               transferOwnership: { enabled: false },
               invitations: { enabled: false },
             },
@@ -251,7 +251,7 @@ describe('PortalSettingsComponent', () => {
 
       const req = httpTestingController.expectOne(`${CONSTANTS_TESTING.env.baseURL}/settings`);
       expect(req.request.method).toEqual('POST');
-      expect(req.request.body.portalNext.applications.membership.enabled.enabled).toEqual(true);
+      expect(req.request.body.portalNext.applications.membership.enabled).toEqual(true);
     });
 
     it('display settings form and edit Portal Next transfer of ownership toggle', async () => {

--- a/gravitee-apim-console-webui/src/management/settings/portal-settings/portal-settings.component.ts
+++ b/gravitee-apim-console-webui/src/management/settings/portal-settings/portal-settings.component.ts
@@ -445,19 +445,19 @@ export class PortalSettingsComponent implements OnInit {
             enabled: new FormGroup({
               enabled: new FormControl({
                 value: !!this.settings.portalNext?.applications?.membership?.enabled?.enabled,
-                disabled: this.isReadonly('portal.next.memberMapping.enabled'),
+                disabled: this.isReadonly('portal.next.applications.membership.enabled'),
               }),
             }),
             transferOwnership: new FormGroup({
               enabled: new FormControl({
                 value: !!this.settings.portalNext?.applications?.membership?.transferOwnership?.enabled,
-                disabled: this.isReadonly('portal.next.transferOwnership.enabled'),
+                disabled: this.isReadonly('portal.next.applications.membership.transferOwnership.enabled'),
               }),
             }),
             invitations: new FormGroup({
               enabled: new FormControl({
                 value: !!this.settings.portalNext?.applications?.membership?.invitations?.enabled,
-                disabled: this.isReadonly('portal.next.invitations.enabled'),
+                disabled: this.isReadonly('portal.next.applications.membership.invitations.enabled'),
               }),
             }),
           }),

--- a/gravitee-apim-console-webui/src/management/settings/portal-settings/portal-settings.component.ts
+++ b/gravitee-apim-console-webui/src/management/settings/portal-settings/portal-settings.component.ts
@@ -117,7 +117,7 @@ interface PortalForm {
     analytics: FormGroup<{ enabled: FormControl<boolean> }>;
     applications: FormGroup<{
       membership: FormGroup<{
-        enabled: FormGroup<{ enabled: FormControl<boolean> }>;
+        enabled: FormControl<boolean>;
         transferOwnership: FormGroup<{ enabled: FormControl<boolean> }>;
         invitations: FormGroup<{ enabled: FormControl<boolean> }>;
       }>;
@@ -442,11 +442,9 @@ export class PortalSettingsComponent implements OnInit {
         }),
         applications: new FormGroup({
           membership: new FormGroup({
-            enabled: new FormGroup({
-              enabled: new FormControl({
-                value: !!this.settings.portalNext?.applications?.membership?.enabled?.enabled,
-                disabled: this.isReadonly('portal.next.applications.membership.enabled'),
-              }),
+            enabled: new FormControl({
+              value: !!this.settings.portalNext?.applications?.membership?.enabled,
+              disabled: this.isReadonly('portal.next.applications.membership.enabled'),
             }),
             transferOwnership: new FormGroup({
               enabled: new FormControl({

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-members/application-tab-members.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-members/application-tab-members.component.spec.ts
@@ -60,7 +60,21 @@ describe('ApplicationTabMembersComponent', () => {
         provideNoopAnimations(),
         provideRouter([]),
         { provide: ApplicationService, useValue: { getApplicationRoles: () => of(APPLICATION_ROLES) } },
-        { provide: ConfigService, useValue: { baseURL: TESTING_BASE_URL } },
+        {
+          provide: ConfigService,
+          useValue: {
+            baseURL: TESTING_BASE_URL,
+            configuration: {
+              portalNext: {
+                applications: {
+                  membership: {
+                    transferOwnership: { enabled: true },
+                  },
+                },
+              },
+            },
+          },
+        },
         { provide: CurrentUserService, useValue: { user: () => ({ id: CURRENT_USER_ID }) } },
       ],
     })
@@ -545,6 +559,49 @@ describe('ApplicationTabMembersComponent', () => {
     it('should not show transfer ownership button when current user is not the application owner', async () => {
       fixture.componentRef.setInput('application', fakeApplication('other-owner-id'));
       fixture.componentRef.setInput('userApplicationPermissions', fakeUserApplicationPermissions({ MEMBER: ['R', 'U'] }));
+      const harness = await flush(fakeMembersResponse([fakeMember()]));
+
+      expect(await harness.getTransferOwnershipButton()).toBeNull();
+    });
+
+    it('should not show transfer ownership button when transfer ownership toggle is disabled', async () => {
+      TestBed.resetTestingModule();
+      await TestBed.configureTestingModule({
+        imports: [ApplicationTabMembersComponent, ConfirmDialogComponent, MatDialogModule],
+        providers: [
+          provideHttpClient(),
+          provideHttpClientTesting(),
+          provideNoopAnimations(),
+          provideRouter([]),
+          { provide: ApplicationService, useValue: { getApplicationRoles: () => of(APPLICATION_ROLES) } },
+          {
+            provide: ConfigService,
+            useValue: {
+              baseURL: TESTING_BASE_URL,
+              configuration: {
+                portalNext: {
+                  applications: {
+                    membership: {
+                      transferOwnership: { enabled: false },
+                    },
+                  },
+                },
+              },
+            },
+          },
+          { provide: CurrentUserService, useValue: { user: () => ({ id: CURRENT_USER_ID }) } },
+        ],
+      })
+        .overrideProvider(InteractivityChecker, { useValue: { isFocusable: () => true, isTabbable: () => true } })
+        .compileComponents();
+
+      fixture = TestBed.createComponent(ApplicationTabMembersComponent);
+      httpTestingController = TestBed.inject(HttpTestingController);
+      rootLoader = TestbedHarnessEnvironment.documentRootLoader(fixture);
+      fixture.componentRef.setInput('applicationId', applicationId);
+      fixture.componentRef.setInput('application', fakeApplication(CURRENT_USER_ID));
+      fixture.componentRef.setInput('userApplicationPermissions', fakeUserApplicationPermissions({ MEMBER: ['R', 'U'] }));
+
       const harness = await flush(fakeMembersResponse([fakeMember()]));
 
       expect(await harness.getTransferOwnershipButton()).toBeNull();

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-members/application-tab-members.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application-tab-members/application-tab-members.component.ts
@@ -29,6 +29,7 @@ import { UserCellComponent, UserCellVM } from '../../../../components/user-cell/
 import { APPLICATION_PRIMARY_OWNER_ROLE_NAME, Application } from '../../../../entities/application/application';
 import { Member, MemberSearchFilters, MembersResponse } from '../../../../entities/member/member';
 import { UserApplicationPermissions } from '../../../../entities/permission/permission';
+import { ConfigService } from '../../../../services/config.service';
 import { CurrentUserService } from '../../../../services/current-user.service';
 import { MembershipService } from '../../../../services/membership.service';
 import { PermissionsService } from '../../../../services/permissions.service';
@@ -79,6 +80,7 @@ interface MembersRequestParams {
 })
 export class ApplicationTabMembersComponent {
   private readonly membershipService = inject(MembershipService);
+  private readonly configService = inject(ConfigService);
   private readonly currentUserService = inject(CurrentUserService);
   private readonly matDialog = inject(MatDialog);
   private readonly destroyRef = inject(DestroyRef);
@@ -104,9 +106,11 @@ export class ApplicationTabMembersComponent {
   readonly canUpdate = computed(() => this.effectiveUserApplicationPermissions().MEMBER?.includes('U') ?? false);
   readonly canDelete = computed(() => this.effectiveUserApplicationPermissions().MEMBER?.includes('D') ?? false);
   readonly canTransferOwnership = computed(() => {
+    const transferOwnershipEnabled =
+      this.configService.configuration.portalNext?.applications?.membership?.transferOwnership?.enabled === true;
     const currentUserId = this.currentUserService.user()?.id;
     const ownerId = this.application()?.owner?.id;
-    return this.canUpdate() && !!currentUserId && currentUserId === ownerId;
+    return transferOwnershipEnabled && this.canUpdate() && !!currentUserId && currentUserId === ownerId;
   });
 
   readonly actions = computed<TableAction<MemberTableRow>[]>(() => {

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application.component.spec.ts
@@ -27,18 +27,24 @@ import { BreadcrumbService } from '../../../services/breadcrumb.service';
 import { ConfigService } from '../../../services/config.service';
 import { applicationListBreadcrumb } from '../applications/application-breadcrumbs';
 
-function createConfigService(portalNext?: ConfigurationPortalNext) {
+type MembershipConfig = NonNullable<NonNullable<ConfigurationPortalNext['applications']>['membership']>;
+
+const defaultMembership: MembershipConfig = {
+  enabled: true,
+  transferOwnership: { enabled: true },
+  invitations: { enabled: true },
+};
+
+function createConfigService(membershipOverride?: Partial<MembershipConfig>) {
   return {
     configuration: {
       portalNext: {
         applications: {
           membership: {
-            enabled: { enabled: true },
-            transferOwnership: { enabled: true },
-            invitations: { enabled: true },
+            ...defaultMembership,
+            ...membershipOverride,
           },
         },
-        ...portalNext,
       },
     },
   };
@@ -52,23 +58,28 @@ class TestIdHarness extends ComponentHarness {
   }
 }
 
+async function setupApplicationComponent(configService = createConfigService()) {
+  await TestBed.configureTestingModule({
+    imports: [ApplicationComponent],
+    providers: [provideRouter([]), provideNoopAnimations(), { provide: ConfigService, useValue: configService }],
+  }).compileComponents();
+
+  const fixture = TestBed.createComponent(ApplicationComponent);
+  const breadcrumbService = TestBed.inject(BreadcrumbService);
+  breadcrumbService.clear();
+  const loader = TestbedHarnessEnvironment.loader(fixture);
+  fixture.componentRef.setInput('application', fakeApplication({ id: 'app-1', name: 'My App' }));
+  fixture.componentRef.setInput('userApplicationPermissions', fakeUserApplicationPermissions({ MEMBER: ['R'] }));
+  return { fixture, breadcrumbService, loader };
+}
+
 describe('ApplicationComponent', () => {
   let fixture: ComponentFixture<ApplicationComponent>;
   let breadcrumbService: BreadcrumbService;
   let loader: HarnessLoader;
 
   beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      imports: [ApplicationComponent],
-      providers: [provideRouter([]), provideNoopAnimations(), { provide: ConfigService, useValue: createConfigService() }],
-    }).compileComponents();
-
-    fixture = TestBed.createComponent(ApplicationComponent);
-    breadcrumbService = TestBed.inject(BreadcrumbService);
-    breadcrumbService.clear();
-    loader = TestbedHarnessEnvironment.loader(fixture);
-    fixture.componentRef.setInput('application', fakeApplication({ id: 'app-1', name: 'My App' }));
-    fixture.componentRef.setInput('userApplicationPermissions', fakeUserApplicationPermissions({ MEMBER: ['R'] }));
+    ({ fixture, breadcrumbService, loader } = await setupApplicationComponent());
   });
 
   afterEach(() => {
@@ -113,52 +124,32 @@ describe('ApplicationComponent', () => {
     fixture.detectChanges();
     expect(await loader.getHarnessOrNull(TestIdHarness.for('application-invitations-tab'))).toBeNull();
   });
+});
+
+describe('ApplicationComponent with disabled membership toggles', () => {
+  let fixture: ComponentFixture<ApplicationComponent>;
+  let loader: HarnessLoader;
+
+  afterEach(() => {
+    fixture.destroy();
+  });
 
   it('should not render Members tab when member mapping toggle is disabled', async () => {
-    TestBed.resetTestingModule();
-    await TestBed.configureTestingModule({
-      imports: [ApplicationComponent],
-      providers: [
-        provideRouter([]),
-        provideNoopAnimations(),
-        {
-          provide: ConfigService,
-          useValue: createConfigService({
-            applications: { membership: { enabled: { enabled: false }, invitations: { enabled: true } } },
-          }),
-        },
-      ],
-    }).compileComponents();
-
-    fixture = TestBed.createComponent(ApplicationComponent);
-    loader = TestbedHarnessEnvironment.loader(fixture);
-    fixture.componentRef.setInput('application', fakeApplication({ id: 'app-1', name: 'My App' }));
-    fixture.componentRef.setInput('userApplicationPermissions', fakeUserApplicationPermissions({ MEMBER: ['R'] }));
+    ({ fixture, loader } = await setupApplicationComponent(createConfigService({ enabled: false })));
     fixture.detectChanges();
 
     expect(await loader.getHarnessOrNull(TestIdHarness.for('application-members-tab'))).toBeNull();
   });
 
   it('should not render Invitations tab when invitations toggle is disabled', async () => {
-    TestBed.resetTestingModule();
-    await TestBed.configureTestingModule({
-      imports: [ApplicationComponent],
-      providers: [
-        provideRouter([]),
-        provideNoopAnimations(),
-        {
-          provide: ConfigService,
-          useValue: createConfigService({
-            applications: { membership: { enabled: { enabled: true }, invitations: { enabled: false } } },
-          }),
-        },
-      ],
-    }).compileComponents();
+    ({ fixture, loader } = await setupApplicationComponent(createConfigService({ invitations: { enabled: false } })));
+    fixture.detectChanges();
 
-    fixture = TestBed.createComponent(ApplicationComponent);
-    loader = TestbedHarnessEnvironment.loader(fixture);
-    fixture.componentRef.setInput('application', fakeApplication({ id: 'app-1', name: 'My App' }));
-    fixture.componentRef.setInput('userApplicationPermissions', fakeUserApplicationPermissions({ MEMBER: ['R'] }));
+    expect(await loader.getHarnessOrNull(TestIdHarness.for('application-invitations-tab'))).toBeNull();
+  });
+
+  it('should not render Invitations tab when parent membership toggle is disabled', async () => {
+    ({ fixture, loader } = await setupApplicationComponent(createConfigService({ enabled: false, invitations: { enabled: true } })));
     fixture.detectChanges();
 
     expect(await loader.getHarnessOrNull(TestIdHarness.for('application-invitations-tab'))).toBeNull();

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application.component.spec.ts
@@ -21,9 +21,28 @@ import { provideRouter } from '@angular/router';
 
 import ApplicationComponent from './application.component';
 import { fakeApplication } from '../../../entities/application/application.fixture';
+import { ConfigurationPortalNext } from '../../../entities/configuration/configuration-portal-next';
 import { fakeUserApplicationPermissions } from '../../../entities/permission/permission.fixtures';
 import { BreadcrumbService } from '../../../services/breadcrumb.service';
+import { ConfigService } from '../../../services/config.service';
 import { applicationListBreadcrumb } from '../applications/application-breadcrumbs';
+
+function createConfigService(portalNext?: ConfigurationPortalNext) {
+  return {
+    configuration: {
+      portalNext: {
+        applications: {
+          membership: {
+            enabled: { enabled: true },
+            transferOwnership: { enabled: true },
+            invitations: { enabled: true },
+          },
+        },
+        ...portalNext,
+      },
+    },
+  };
+}
 
 class TestIdHarness extends ComponentHarness {
   static hostSelector = '[data-testid]';
@@ -41,7 +60,7 @@ describe('ApplicationComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [ApplicationComponent],
-      providers: [provideRouter([]), provideNoopAnimations()],
+      providers: [provideRouter([]), provideNoopAnimations(), { provide: ConfigService, useValue: createConfigService() }],
     }).compileComponents();
 
     fixture = TestBed.createComponent(ApplicationComponent);
@@ -92,6 +111,56 @@ describe('ApplicationComponent', () => {
   it('should not render Invitations tab when MEMBER has no R flag', async () => {
     fixture.componentRef.setInput('userApplicationPermissions', fakeUserApplicationPermissions({ MEMBER: ['U'] }));
     fixture.detectChanges();
+    expect(await loader.getHarnessOrNull(TestIdHarness.for('application-invitations-tab'))).toBeNull();
+  });
+
+  it('should not render Members tab when member mapping toggle is disabled', async () => {
+    TestBed.resetTestingModule();
+    await TestBed.configureTestingModule({
+      imports: [ApplicationComponent],
+      providers: [
+        provideRouter([]),
+        provideNoopAnimations(),
+        {
+          provide: ConfigService,
+          useValue: createConfigService({
+            applications: { membership: { enabled: { enabled: false }, invitations: { enabled: true } } },
+          }),
+        },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ApplicationComponent);
+    loader = TestbedHarnessEnvironment.loader(fixture);
+    fixture.componentRef.setInput('application', fakeApplication({ id: 'app-1', name: 'My App' }));
+    fixture.componentRef.setInput('userApplicationPermissions', fakeUserApplicationPermissions({ MEMBER: ['R'] }));
+    fixture.detectChanges();
+
+    expect(await loader.getHarnessOrNull(TestIdHarness.for('application-members-tab'))).toBeNull();
+  });
+
+  it('should not render Invitations tab when invitations toggle is disabled', async () => {
+    TestBed.resetTestingModule();
+    await TestBed.configureTestingModule({
+      imports: [ApplicationComponent],
+      providers: [
+        provideRouter([]),
+        provideNoopAnimations(),
+        {
+          provide: ConfigService,
+          useValue: createConfigService({
+            applications: { membership: { enabled: { enabled: true }, invitations: { enabled: false } } },
+          }),
+        },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ApplicationComponent);
+    loader = TestbedHarnessEnvironment.loader(fixture);
+    fixture.componentRef.setInput('application', fakeApplication({ id: 'app-1', name: 'My App' }));
+    fixture.componentRef.setInput('userApplicationPermissions', fakeUserApplicationPermissions({ MEMBER: ['R'] }));
+    fixture.detectChanges();
+
     expect(await loader.getHarnessOrNull(TestIdHarness.for('application-invitations-tab'))).toBeNull();
   });
 });

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application.component.ts
@@ -37,11 +37,12 @@ export default class ApplicationComponent {
   readonly userApplicationPermissions = input.required<UserApplicationPermissions>();
 
   readonly canViewMembersTab = computed(() => {
-    const memberMappingEnabled = this.configService.configuration.portalNext?.applications?.membership?.enabled?.enabled === true;
+    const memberMappingEnabled = this.configService.configuration.portalNext?.applications?.membership?.enabled === true;
     return memberMappingEnabled && (this.userApplicationPermissions().MEMBER?.includes('R') ?? false);
   });
   readonly canViewInvitationsTab = computed(() => {
-    const invitationsEnabled = this.configService.configuration.portalNext?.applications?.membership?.invitations?.enabled === true;
+    const membership = this.configService.configuration.portalNext?.applications?.membership;
+    const invitationsEnabled = membership?.enabled === true && membership?.invitations?.enabled === true;
     return invitationsEnabled && (this.userApplicationPermissions().MEMBER?.includes('R') ?? false);
   });
 

--- a/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/dashboard/application-details/application.component.ts
@@ -20,6 +20,7 @@ import { RouterLink, RouterLinkActive, RouterOutlet } from '@angular/router';
 import { Application } from '../../../entities/application/application';
 import { UserApplicationPermissions } from '../../../entities/permission/permission';
 import { BreadcrumbService } from '../../../services/breadcrumb.service';
+import { ConfigService } from '../../../services/config.service';
 import { applicationListBreadcrumb } from '../applications/application-breadcrumbs';
 
 @Component({
@@ -30,12 +31,19 @@ import { applicationListBreadcrumb } from '../applications/application-breadcrum
 })
 export default class ApplicationComponent {
   private readonly breadcrumbService = inject(BreadcrumbService);
+  private readonly configService = inject(ConfigService);
 
   readonly application = input.required<Application>();
   readonly userApplicationPermissions = input.required<UserApplicationPermissions>();
 
-  readonly canViewMembersTab = computed(() => this.userApplicationPermissions().MEMBER?.includes('R') ?? false);
-  readonly canViewInvitationsTab = computed(() => this.userApplicationPermissions().MEMBER?.includes('R') ?? false);
+  readonly canViewMembersTab = computed(() => {
+    const memberMappingEnabled = this.configService.configuration.portalNext?.applications?.membership?.enabled?.enabled === true;
+    return memberMappingEnabled && (this.userApplicationPermissions().MEMBER?.includes('R') ?? false);
+  });
+  readonly canViewInvitationsTab = computed(() => {
+    const invitationsEnabled = this.configService.configuration.portalNext?.applications?.membership?.invitations?.enabled === true;
+    return invitationsEnabled && (this.userApplicationPermissions().MEMBER?.includes('R') ?? false);
+  });
 
   constructor() {
     effect(() => {

--- a/gravitee-apim-portal-webui-next/src/entities/configuration/configuration-portal-next.ts
+++ b/gravitee-apim-portal-webui-next/src/entities/configuration/configuration-portal-next.ts
@@ -36,7 +36,7 @@ export class ConfigurationPortalNext {
   };
   applications?: {
     membership?: {
-      enabled?: { enabled?: boolean };
+      enabled?: boolean;
       transferOwnership?: { enabled?: boolean };
       invitations?: { enabled?: boolean };
     };

--- a/gravitee-apim-portal-webui-next/src/guards/application-membership-enabled.guard.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/guards/application-membership-enabled.guard.spec.ts
@@ -33,7 +33,7 @@ describe('applicationMembershipEnabledGuard', () => {
         {
           provide: ConfigService,
           useValue: {
-            configuration: { portalNext: { applications: { membership: { enabled: { enabled: true } } } } },
+            configuration: { portalNext: { applications: { membership: { enabled: true } } } },
           },
         },
         { provide: Router, useValue: { parseUrl: jest.fn() } },
@@ -52,7 +52,7 @@ describe('applicationMembershipEnabledGuard', () => {
         {
           provide: ConfigService,
           useValue: {
-            configuration: { portalNext: { applications: { membership: { enabled: { enabled: false } } } } },
+            configuration: { portalNext: { applications: { membership: { enabled: false } } } },
           },
         },
         { provide: Router, useValue: { parseUrl } },
@@ -135,13 +135,15 @@ describe('applicationTransferOwnershipEnabledGuard', () => {
 });
 
 describe('applicationInvitationsEnabledGuard', () => {
-  it('should allow navigation when invitations are enabled', () => {
+  it('should allow navigation when membership and invitations are both enabled', () => {
     TestBed.configureTestingModule({
       providers: [
         {
           provide: ConfigService,
           useValue: {
-            configuration: { portalNext: { applications: { membership: { invitations: { enabled: true } } } } },
+            configuration: {
+              portalNext: { applications: { membership: { enabled: true, invitations: { enabled: true } } } },
+            },
           },
         },
         { provide: Router, useValue: { parseUrl: jest.fn() } },
@@ -153,14 +155,38 @@ describe('applicationInvitationsEnabledGuard', () => {
     expect(result).toBe(true);
   });
 
-  it('should redirect to home when invitations are disabled', () => {
+  it('should redirect to home when invitations toggle is disabled', () => {
     const parseUrl = jest.fn().mockReturnValue('PARSED');
     TestBed.configureTestingModule({
       providers: [
         {
           provide: ConfigService,
           useValue: {
-            configuration: { portalNext: { applications: { membership: { invitations: { enabled: false } } } } },
+            configuration: {
+              portalNext: { applications: { membership: { enabled: true, invitations: { enabled: false } } } },
+            },
+          },
+        },
+        { provide: Router, useValue: { parseUrl } },
+      ],
+    });
+
+    const result = TestBed.runInInjectionContext(() => applicationInvitationsEnabledGuard(dummyRoute, dummyState));
+
+    expect(parseUrl).toHaveBeenCalledWith('/');
+    expect(result).toBe('PARSED');
+  });
+
+  it('should redirect to home when parent membership toggle is disabled', () => {
+    const parseUrl = jest.fn().mockReturnValue('PARSED');
+    TestBed.configureTestingModule({
+      providers: [
+        {
+          provide: ConfigService,
+          useValue: {
+            configuration: {
+              portalNext: { applications: { membership: { enabled: false, invitations: { enabled: true } } } },
+            },
           },
         },
         { provide: Router, useValue: { parseUrl } },

--- a/gravitee-apim-portal-webui-next/src/guards/application-membership-enabled.guard.ts
+++ b/gravitee-apim-portal-webui-next/src/guards/application-membership-enabled.guard.ts
@@ -19,7 +19,7 @@ import { CanActivateFn, Router } from '@angular/router';
 import { ConfigService } from '../services/config.service';
 
 export const applicationMembershipEnabledGuard: CanActivateFn = () => {
-  const enabled = inject(ConfigService).configuration.portalNext?.applications?.membership?.enabled?.enabled === true;
+  const enabled = inject(ConfigService).configuration.portalNext?.applications?.membership?.enabled === true;
   if (enabled) {
     return true;
   }
@@ -35,7 +35,8 @@ export const applicationTransferOwnershipEnabledGuard: CanActivateFn = () => {
 };
 
 export const applicationInvitationsEnabledGuard: CanActivateFn = () => {
-  const enabled = inject(ConfigService).configuration.portalNext?.applications?.membership?.invitations?.enabled === true;
+  const membership = inject(ConfigService).configuration.portalNext?.applications?.membership;
+  const enabled = membership?.enabled === true && membership?.invitations?.enabled === true;
   if (enabled) {
     return true;
   }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/parameters/Key.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/parameters/Key.java
@@ -145,17 +145,21 @@ public enum Key {
     PORTAL_NEXT_CATALOG_VIEW_MODE("portal.next.catalog.viewMode", new HashSet<>(singletonList(ENVIRONMENT))),
     PORTAL_NEXT_MTLS_ENABLED("portal.next.mtls.enabled", new HashSet<>(singletonList(ENVIRONMENT))),
     PORTAL_NEXT_ANALYTICS_ENABLED("portal.next.analytics.enabled", Boolean.FALSE.toString(), new HashSet<>(singletonList(ENVIRONMENT))),
-    PORTAL_NEXT_MEMBER_MAPPING_ENABLED(
-        "portal.next.memberMapping.enabled",
+    PORTAL_NEXT_APPLICATIONS_MEMBERSHIP_ENABLED(
+        "portal.next.applications.membership.enabled",
         Boolean.FALSE.toString(),
         new HashSet<>(singletonList(ENVIRONMENT))
     ),
-    PORTAL_NEXT_TRANSFER_OWNERSHIP_ENABLED(
-        "portal.next.transferOwnership.enabled",
+    PORTAL_NEXT_APPLICATIONS_MEMBERSHIP_TRANSFER_OWNERSHIP_ENABLED(
+        "portal.next.applications.membership.transferOwnership.enabled",
         Boolean.FALSE.toString(),
         new HashSet<>(singletonList(ENVIRONMENT))
     ),
-    PORTAL_NEXT_INVITATIONS_ENABLED("portal.next.invitations.enabled", Boolean.FALSE.toString(), new HashSet<>(singletonList(ENVIRONMENT))),
+    PORTAL_NEXT_APPLICATIONS_MEMBERSHIP_INVITATIONS_ENABLED(
+        "portal.next.applications.membership.invitations.enabled",
+        Boolean.FALSE.toString(),
+        new HashSet<>(singletonList(ENVIRONMENT))
+    ),
 
     MANAGEMENT_TITLE("management.title", "Gravitee.io Management", new HashSet<>(Arrays.asList(ORGANIZATION, SYSTEM))),
     MANAGEMENT_URL("management.url", new HashSet<>(Arrays.asList(ORGANIZATION, SYSTEM))),

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/settings/PortalNext.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/settings/PortalNext.java
@@ -69,13 +69,13 @@ public class PortalNext {
         @JsonIgnoreProperties(ignoreUnknown = true)
         public static class Membership {
 
-            @ParameterKey(Key.PORTAL_NEXT_MEMBER_MAPPING_ENABLED)
+            @ParameterKey(Key.PORTAL_NEXT_APPLICATIONS_MEMBERSHIP_ENABLED)
             private Enabled enabled;
 
-            @ParameterKey(Key.PORTAL_NEXT_TRANSFER_OWNERSHIP_ENABLED)
+            @ParameterKey(Key.PORTAL_NEXT_APPLICATIONS_MEMBERSHIP_TRANSFER_OWNERSHIP_ENABLED)
             private Enabled transferOwnership;
 
-            @ParameterKey(Key.PORTAL_NEXT_INVITATIONS_ENABLED)
+            @ParameterKey(Key.PORTAL_NEXT_APPLICATIONS_MEMBERSHIP_INVITATIONS_ENABLED)
             private Enabled invitations;
         }
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/settings/PortalNext.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/settings/PortalNext.java
@@ -70,7 +70,7 @@ public class PortalNext {
         public static class Membership {
 
             @ParameterKey(Key.PORTAL_NEXT_APPLICATIONS_MEMBERSHIP_ENABLED)
-            private Enabled enabled;
+            private Boolean enabled;
 
             @ParameterKey(Key.PORTAL_NEXT_APPLICATIONS_MEMBERSHIP_TRANSFER_OWNERSHIP_ENABLED)
             private Enabled transferOwnership;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/mapper/ConfigurationMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/mapper/ConfigurationMapper.java
@@ -86,7 +86,7 @@ public class ConfigurationMapper {
         }
         ConfigurationPortalNextApplicationsMembership config = new ConfigurationPortalNextApplicationsMembership();
         if (membership.getEnabled() != null) {
-            config.setEnabled(convert(membership.getEnabled()));
+            config.setEnabled(membership.getEnabled());
         }
         if (membership.getTransferOwnership() != null) {
             config.setTransferOwnership(convert(membership.getTransferOwnership()));

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/resources/portal-openapi.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/main/resources/portal-openapi.yaml
@@ -6946,7 +6946,8 @@ components:
             description: Configuration of membership-related features for Portal Next applications
             properties:
                 enabled:
-                    $ref: "#/components/schemas/Enabled"
+                    description: Whether application membership settings are enabled
+                    type: boolean
                 transferOwnership:
                     $ref: "#/components/schemas/Enabled"
                 invitations:

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/mapper/ConfigurationMapperTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/mapper/ConfigurationMapperTest.java
@@ -236,15 +236,15 @@ public class ConfigurationMapperTest {
         PortalNext portalNext = new PortalNext();
         portalNext.setAccess(new Enabled(false));
 
-        portalNext.getApplications().getMembership().setEnabled(new Enabled(true));
+        portalNext.getApplications().getMembership().setEnabled(true);
         ConfigurationPortalNext result = configurationMapper.convert(portalNext);
         Assertions.assertNotNull(result.getApplications().getMembership().getEnabled());
-        Assertions.assertEquals(Boolean.TRUE, result.getApplications().getMembership().getEnabled().getEnabled());
+        Assertions.assertEquals(Boolean.TRUE, result.getApplications().getMembership().getEnabled());
 
-        portalNext.getApplications().getMembership().setEnabled(new Enabled(false));
+        portalNext.getApplications().getMembership().setEnabled(false);
         result = configurationMapper.convert(portalNext);
         Assertions.assertNotNull(result.getApplications().getMembership().getEnabled());
-        Assertions.assertEquals(Boolean.FALSE, result.getApplications().getMembership().getEnabled().getEnabled());
+        Assertions.assertEquals(Boolean.FALSE, result.getApplications().getMembership().getEnabled());
 
         portalNext.getApplications().getMembership().setEnabled(null);
         result = configurationMapper.convert(portalNext);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ConfigServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ConfigServiceTest.java
@@ -299,7 +299,7 @@ class ConfigServiceTest {
 
         PortalSettingsEntity portalSettings = configService.getPortalSettings(GraviteeContext.getExecutionContext());
 
-        assertThat(portalSettings.getPortalNext().getApplications().getMembership().getEnabled().isEnabled())
+        assertThat(portalSettings.getPortalNext().getApplications().getMembership().getEnabled())
             .as("portalNext applications.membership.enabled enabled")
             .isTrue();
         assertThat(portalSettings.getPortalNext().getApplications().getMembership().getTransferOwnership().isEnabled())
@@ -326,7 +326,7 @@ class ConfigServiceTest {
 
         PortalSettingsEntity portalSettings = configService.getPortalSettings(GraviteeContext.getExecutionContext());
 
-        assertThat(portalSettings.getPortalNext().getApplications().getMembership().getEnabled().isEnabled())
+        assertThat(portalSettings.getPortalNext().getApplications().getMembership().getEnabled())
             .as("portalNext applications.membership.enabled disabled by default")
             .isFalse();
         assertThat(portalSettings.getPortalNext().getApplications().getMembership().getTransferOwnership().isEnabled())
@@ -340,7 +340,7 @@ class ConfigServiceTest {
     @Test
     void shouldSavePortalNextToggles() {
         PortalSettingsEntity portalSettingsEntity = new PortalSettingsEntity();
-        portalSettingsEntity.getPortalNext().getApplications().getMembership().setEnabled(new Enabled(true));
+        portalSettingsEntity.getPortalNext().getApplications().getMembership().setEnabled(true);
         portalSettingsEntity.getPortalNext().getApplications().getMembership().setTransferOwnership(new Enabled(false));
         portalSettingsEntity.getPortalNext().getApplications().getMembership().setInvitations(new Enabled(true));
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ConfigServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ConfigServiceTest.java
@@ -45,9 +45,9 @@ import static io.gravitee.rest.api.model.parameters.Key.LOGGING_USER_DISPLAYED;
 import static io.gravitee.rest.api.model.parameters.Key.OPEN_API_DOC_TYPE_SWAGGER_ENABLED;
 import static io.gravitee.rest.api.model.parameters.Key.PORTAL_ANALYTICS_ENABLED;
 import static io.gravitee.rest.api.model.parameters.Key.PORTAL_AUTHENTICATION_FORCELOGIN_ENABLED;
-import static io.gravitee.rest.api.model.parameters.Key.PORTAL_NEXT_INVITATIONS_ENABLED;
-import static io.gravitee.rest.api.model.parameters.Key.PORTAL_NEXT_MEMBER_MAPPING_ENABLED;
-import static io.gravitee.rest.api.model.parameters.Key.PORTAL_NEXT_TRANSFER_OWNERSHIP_ENABLED;
+import static io.gravitee.rest.api.model.parameters.Key.PORTAL_NEXT_APPLICATIONS_MEMBERSHIP_ENABLED;
+import static io.gravitee.rest.api.model.parameters.Key.PORTAL_NEXT_APPLICATIONS_MEMBERSHIP_INVITATIONS_ENABLED;
+import static io.gravitee.rest.api.model.parameters.Key.PORTAL_NEXT_APPLICATIONS_MEMBERSHIP_TRANSFER_OWNERSHIP_ENABLED;
 import static io.gravitee.rest.api.model.parameters.Key.PORTAL_SCHEDULER_NOTIFICATIONS;
 import static io.gravitee.rest.api.model.parameters.Key.PORTAL_URL;
 import static io.gravitee.rest.api.model.parameters.Key.USER_GROUP_REQUIRED_ENABLED;
@@ -281,9 +281,9 @@ class ConfigServiceTest {
     @Test
     void shouldGetPortalSettingsWithPortalNextTogglesEnabled() {
         Map<String, List<String>> params = new HashMap<>();
-        params.put(PORTAL_NEXT_MEMBER_MAPPING_ENABLED.key(), singletonList("true"));
-        params.put(PORTAL_NEXT_TRANSFER_OWNERSHIP_ENABLED.key(), singletonList("true"));
-        params.put(PORTAL_NEXT_INVITATIONS_ENABLED.key(), singletonList("true"));
+        params.put(PORTAL_NEXT_APPLICATIONS_MEMBERSHIP_ENABLED.key(), singletonList("true"));
+        params.put(PORTAL_NEXT_APPLICATIONS_MEMBERSHIP_TRANSFER_OWNERSHIP_ENABLED.key(), singletonList("true"));
+        params.put(PORTAL_NEXT_APPLICATIONS_MEMBERSHIP_INVITATIONS_ENABLED.key(), singletonList("true"));
 
         when(
             mockParameterService.findAll(
@@ -348,21 +348,21 @@ class ConfigServiceTest {
 
         verify(mockParameterService, times(1)).save(
             GraviteeContext.getExecutionContext(),
-            PORTAL_NEXT_MEMBER_MAPPING_ENABLED,
+            PORTAL_NEXT_APPLICATIONS_MEMBERSHIP_ENABLED,
             "true",
             "DEFAULT",
             ParameterReferenceType.ENVIRONMENT
         );
         verify(mockParameterService, times(1)).save(
             GraviteeContext.getExecutionContext(),
-            PORTAL_NEXT_TRANSFER_OWNERSHIP_ENABLED,
+            PORTAL_NEXT_APPLICATIONS_MEMBERSHIP_TRANSFER_OWNERSHIP_ENABLED,
             "false",
             "DEFAULT",
             ParameterReferenceType.ENVIRONMENT
         );
         verify(mockParameterService, times(1)).save(
             GraviteeContext.getExecutionContext(),
-            PORTAL_NEXT_INVITATIONS_ENABLED,
+            PORTAL_NEXT_APPLICATIONS_MEMBERSHIP_INVITATIONS_ENABLED,
             "true",
             "DEFAULT",
             ParameterReferenceType.ENVIRONMENT

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ParameterServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/ParameterServiceTest.java
@@ -891,19 +891,19 @@ public class ParameterServiceTest {
     @Test
     public void shouldAuditPortalNextToggleOnFirstCreate() throws TechnicalException {
         final Parameter savedParameter = new Parameter();
-        savedParameter.setKey(PORTAL_NEXT_MEMBER_MAPPING_ENABLED.key());
+        savedParameter.setKey(PORTAL_NEXT_APPLICATIONS_MEMBERSHIP_ENABLED.key());
         savedParameter.setReferenceId("DEFAULT");
         savedParameter.setReferenceType(ParameterReferenceType.ENVIRONMENT);
         savedParameter.setValue("true");
 
         when(
-            parameterRepository.findById(PORTAL_NEXT_MEMBER_MAPPING_ENABLED.key(), "DEFAULT", ParameterReferenceType.ENVIRONMENT)
+            parameterRepository.findById(PORTAL_NEXT_APPLICATIONS_MEMBERSHIP_ENABLED.key(), "DEFAULT", ParameterReferenceType.ENVIRONMENT)
         ).thenReturn(empty());
         when(parameterRepository.create(savedParameter)).thenReturn(savedParameter);
 
         parameterService.save(
             GraviteeContext.getExecutionContext(),
-            PORTAL_NEXT_MEMBER_MAPPING_ENABLED,
+            PORTAL_NEXT_APPLICATIONS_MEMBERSHIP_ENABLED,
             "true",
             io.gravitee.rest.api.model.parameters.ParameterReferenceType.ENVIRONMENT
         );
@@ -912,7 +912,7 @@ public class ParameterServiceTest {
             eq(GraviteeContext.getExecutionContext()),
             argThat(
                 auditLogData ->
-                    auditLogData.getProperties().equals(singletonMap(PARAMETER, PORTAL_NEXT_MEMBER_MAPPING_ENABLED.key())) &&
+                    auditLogData.getProperties().equals(singletonMap(PARAMETER, PORTAL_NEXT_APPLICATIONS_MEMBERSHIP_ENABLED.key())) &&
                     auditLogData.getEvent().equals(PARAMETER_CREATED) &&
                     auditLogData.getOldValue() == null &&
                     auditLogData.getNewValue().equals(savedParameter)
@@ -923,25 +923,29 @@ public class ParameterServiceTest {
     @Test
     public void shouldAuditPortalNextToggleOnUpdate() throws TechnicalException {
         final Parameter oldParameter = new Parameter();
-        oldParameter.setKey(PORTAL_NEXT_INVITATIONS_ENABLED.key());
+        oldParameter.setKey(PORTAL_NEXT_APPLICATIONS_MEMBERSHIP_INVITATIONS_ENABLED.key());
         oldParameter.setReferenceId("DEFAULT");
         oldParameter.setReferenceType(ParameterReferenceType.ENVIRONMENT);
         oldParameter.setValue("false");
 
         final Parameter updatedParameter = new Parameter();
-        updatedParameter.setKey(PORTAL_NEXT_INVITATIONS_ENABLED.key());
+        updatedParameter.setKey(PORTAL_NEXT_APPLICATIONS_MEMBERSHIP_INVITATIONS_ENABLED.key());
         updatedParameter.setReferenceId("DEFAULT");
         updatedParameter.setReferenceType(ParameterReferenceType.ENVIRONMENT);
         updatedParameter.setValue("true");
 
-        when(parameterRepository.findById(PORTAL_NEXT_INVITATIONS_ENABLED.key(), "DEFAULT", ParameterReferenceType.ENVIRONMENT)).thenReturn(
-            of(oldParameter)
-        );
+        when(
+            parameterRepository.findById(
+                PORTAL_NEXT_APPLICATIONS_MEMBERSHIP_INVITATIONS_ENABLED.key(),
+                "DEFAULT",
+                ParameterReferenceType.ENVIRONMENT
+            )
+        ).thenReturn(of(oldParameter));
         when(parameterRepository.update(updatedParameter)).thenReturn(updatedParameter);
 
         parameterService.save(
             GraviteeContext.getExecutionContext(),
-            PORTAL_NEXT_INVITATIONS_ENABLED,
+            PORTAL_NEXT_APPLICATIONS_MEMBERSHIP_INVITATIONS_ENABLED,
             "true",
             io.gravitee.rest.api.model.parameters.ParameterReferenceType.ENVIRONMENT
         );
@@ -950,7 +954,9 @@ public class ParameterServiceTest {
             eq(GraviteeContext.getExecutionContext()),
             argThat(
                 auditLogData ->
-                    auditLogData.getProperties().equals(singletonMap(PARAMETER, PORTAL_NEXT_INVITATIONS_ENABLED.key())) &&
+                    auditLogData
+                        .getProperties()
+                        .equals(singletonMap(PARAMETER, PORTAL_NEXT_APPLICATIONS_MEMBERSHIP_INVITATIONS_ENABLED.key())) &&
                     auditLogData.getEvent().equals(PARAMETER_UPDATED) &&
                     auditLogData.getOldValue().equals(oldParameter) &&
                     auditLogData.getNewValue().equals(updatedParameter)
@@ -961,18 +967,22 @@ public class ParameterServiceTest {
     @Test
     public void shouldNotAuditPortalNextToggleWhenValueUnchanged() throws TechnicalException {
         final Parameter existingParameter = new Parameter();
-        existingParameter.setKey(PORTAL_NEXT_TRANSFER_OWNERSHIP_ENABLED.key());
+        existingParameter.setKey(PORTAL_NEXT_APPLICATIONS_MEMBERSHIP_TRANSFER_OWNERSHIP_ENABLED.key());
         existingParameter.setReferenceId("DEFAULT");
         existingParameter.setReferenceType(ParameterReferenceType.ENVIRONMENT);
         existingParameter.setValue("false");
 
         when(
-            parameterRepository.findById(PORTAL_NEXT_TRANSFER_OWNERSHIP_ENABLED.key(), "DEFAULT", ParameterReferenceType.ENVIRONMENT)
+            parameterRepository.findById(
+                PORTAL_NEXT_APPLICATIONS_MEMBERSHIP_TRANSFER_OWNERSHIP_ENABLED.key(),
+                "DEFAULT",
+                ParameterReferenceType.ENVIRONMENT
+            )
         ).thenReturn(of(existingParameter));
 
         parameterService.save(
             GraviteeContext.getExecutionContext(),
-            PORTAL_NEXT_TRANSFER_OWNERSHIP_ENABLED,
+            PORTAL_NEXT_APPLICATIONS_MEMBERSHIP_TRANSFER_OWNERSHIP_ENABLED,
             "false",
             io.gravitee.rest.api.model.parameters.ParameterReferenceType.ENVIRONMENT
         );


### PR DESCRIPTION
…ns, and ownership controls

Implement conditional rendering of application tab contents (Members, Invitations) and actions (Transfer Ownership) based on Portal Next membership configuration. Update tests to reflect new toggle behaviors.

## Issue

https://gravitee.atlassian.net/browse/APIM-14398
https://gravitee.atlassian.net/browse/APIM-14399
https://gravitee.atlassian.net/browse/APIM-14400


## Summary

Completes UI-level gating for the three Portal Next application membership features introduced in the admin console. When a toggle is **disabled**, the corresponding tab or button is **hidden** on the Next Gen Portal — in addition to the route guards already added in #17685.

Gating remains **UI-only**: portal REST endpoints are unchanged and still governed by existing RBAC.

---

## What's included

###  Hide Members tab
**`application.component.ts`**
- `canViewMembersTab` now requires `portalNext.applications.membership.enabled.enabled === true` **and** `MEMBER[R]`

**`application.component.spec.ts`**
- Tab hidden when member mapping toggle is off, even with `MEMBER[R]`

Route guard (`applicationMembershipEnabledGuard` on `/members`) was delivered in #17685.

---

### Hide Transfer Ownership button
**`application-tab-members.component.ts`**
- `canTransferOwnership` now also checks `portalNext.applications.membership.transferOwnership.enabled === true`
- Existing checks unchanged: primary owner + `MEMBER[U]`

**`application-tab-members.component.spec.ts`**
- Button hidden when transfer ownership toggle is off, even for the application owner with `MEMBER[U]`

No route guard — transfer ownership is a dialog on the Members tab, not a separate route.

---

### Hide Invitations tab
**`application.component.ts`**
- `canViewInvitationsTab` now requires `portalNext.applications.membership.invitations.enabled === true` **and** `MEMBER[R]`

**`application.component.spec.ts`**
- Tab hidden when invitations toggle is off, even with `MEMBER[R]`

Route guard (`applicationInvitationsEnabledGuard` on `/invitations`) was delivered in #17685.

---

## Acceptance criteria mapping

| Criterion | Status |
|-----------|--------|
| Members tab hidden when toggle OFF | Done |
| Invitations tab hidden when toggle OFF | Done |
| Transfer Ownership button hidden when toggle OFF | Done |
| Direct URL navigation blocked when OFF | Done (route guards from #17685) |
| Enabled → existing RBAC behavior unchanged | Done |
| Default OFF → features hidden | Done |

---

## Test plan

- [x] `npx jest application.component.spec.ts` — Members/Invitations tab visibility with toggles on/off
- [x] `npx jest application-tab-members.component.spec.ts` — Transfer Ownership button with toggle on/off
- [x] With all three toggles **OFF** in Console → Portal Settings: Members tab, Invitations tab, and Transfer Ownership button are not visible
- [x] With toggles **ON** and correct RBAC: tabs and button behave as before
- [x] Direct navigation to `/dashboard/applications/{id}/members` or `/invitations` with toggles OFF redirects to home (regression from #17685)
- [x] Enable toggles, reload portal: features become visible without backend restart

## Additional context


https://github.com/user-attachments/assets/33fd9b2f-64fb-4b11-8742-d739ce82fbd7


<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

