### PR TITLE
fix(gateway): strip Transfer-Encoding when Content-Length set on proxied request

### DIFF
--- a/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-http-proxy/src/main/java/io/gravitee/plugin/endpoint/http/proxy/connector/HttpConnector.java
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-http-proxy/src/main/java/io/gravitee/plugin/endpoint/http/proxy/connector/HttpConnector.java
@@ -30,6 +30,7 @@ import static io.gravitee.plugin.endpoint.http.proxy.client.UriHelper.URI_QUERY_
 import static io.gravitee.plugin.endpoint.http.proxy.client.UriHelper.URI_QUERY_DELIMITER_CHAR_SEQUENCE;
 
 import io.gravitee.common.http.HttpHeader;
+import io.gravitee.common.http.HttpHeadersValues;
 import io.gravitee.common.util.LinkedMultiValueMap;
 import io.gravitee.common.util.MultiValueMap;
 import io.gravitee.common.util.URIUtils;
@@ -177,6 +178,20 @@ public class HttpConnector implements ProxyConnector {
     }
 
     private Single<HttpClientResponse> sendEndpointRequestChunks(HttpClientRequest httpClientRequest, HttpRequest request) {
+        if (hasContentLength(request) && isChunked(request)) {
+            // A request-phase policy (e.g. Assign Content) can rewrite the body, set Content-Length, and
+            // leave the client's Transfer-Encoding: chunked in place. Forwarding both violates RFC 9112
+            // §6.1 and strict backends (NGINX, Jetty) return 400. The body is already de-chunked, so send
+            // it fixed-length: drop Transfer-Encoding and set Content-Length to its actual length. Only
+            // chunked is dropped — a content-coding like gzip must stay, or the backend can't decode the body.
+            httpClientRequest.headers().remove(HttpHeaders.TRANSFER_ENCODING);
+            return request
+                .bodyOrEmpty()
+                .flatMap(body -> {
+                    httpClientRequest.headers().set(HttpHeaders.CONTENT_LENGTH, Integer.toString(body.length()));
+                    return httpClientRequest.rxSend(BufferInternal.buffer(body.getNativeBuffer()));
+                });
+        }
         if (hasBodyHeaders(request) || request.version() == io.gravitee.common.http.HttpVersion.HTTP_2) {
             // For HTTP1.1, the presence of a message body in a request is signaled by a
             // Content-Length or Transfer-Encoding header
@@ -342,9 +357,19 @@ public class HttpConnector implements ProxyConnector {
     }
 
     private static boolean hasBodyHeaders(HttpRequest request) {
-        return (
-            request.headers().get(HttpHeaderNames.TRANSFER_ENCODING) != null ||
-            request.headers().get(HttpHeaderNames.CONTENT_LENGTH) != null
-        );
+        return hasTransferEncoding(request) || hasContentLength(request);
+    }
+
+    private static boolean hasContentLength(HttpRequest request) {
+        return request.headers().get(HttpHeaderNames.CONTENT_LENGTH) != null;
+    }
+
+    private static boolean hasTransferEncoding(HttpRequest request) {
+        return request.headers().get(HttpHeaderNames.TRANSFER_ENCODING) != null;
+    }
+
+    private static boolean isChunked(HttpRequest request) {
+        final String transferEncoding = request.headers().get(HttpHeaderNames.TRANSFER_ENCODING);
+        return transferEncoding != null && HttpHeadersValues.TRANSFER_ENCODING_CHUNKED.equalsIgnoreCase(transferEncoding.trim());
     }
 }

--- a/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-http-proxy/src/test/java/io/gravitee/plugin/endpoint/http/proxy/connector/HttpConnectorTest.java
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-endpoint/gravitee-apim-plugin-endpoint-http-proxy/src/test/java/io/gravitee/plugin/endpoint/http/proxy/connector/HttpConnectorTest.java
@@ -24,6 +24,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.serverError;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static io.gravitee.gateway.api.http.HttpHeaderNames.CONTENT_LENGTH;
 import static io.gravitee.gateway.api.http.HttpHeaderNames.HOST;
 import static io.gravitee.gateway.api.http.HttpHeaderNames.TRANSFER_ENCODING;
 import static io.gravitee.gateway.reactive.api.context.ContextAttributes.ATTR_REQUEST_ENDPOINT;
@@ -64,6 +65,7 @@ import io.gravitee.plugin.endpoint.http.proxy.configuration.HttpProxyEndpointCon
 import io.gravitee.plugin.endpoint.http.proxy.configuration.HttpProxyEndpointConnectorSharedConfiguration;
 import io.gravitee.reporter.api.v4.metric.Metrics;
 import io.reactivex.rxjava3.core.Flowable;
+import io.reactivex.rxjava3.core.Single;
 import io.reactivex.rxjava3.observers.TestObserver;
 import io.vertx.core.http.impl.headers.HeadersMultiMap;
 import io.vertx.rxjava3.core.Vertx;
@@ -371,6 +373,31 @@ class HttpConnectorTest {
             postRequestedFor(urlPathEqualTo("/team"))
                 .withHeader(TRANSFER_ENCODING, new EqualToPattern("chunked"))
                 .withRequestBody(new EqualToPattern(REQUEST_BODY.trim()))
+        );
+    }
+
+    @Test
+    void should_drop_transfer_encoding_when_content_length_also_present() throws InterruptedException {
+        // A policy set a fresh Content-Length on a chunked request. The backend must receive
+        // Content-Length only, never both (RFC 9112 §6.1).
+        when(request.method()).thenReturn(HttpMethod.POST);
+        when(request.headers()).thenReturn(
+            HttpHeaders.create().add(TRANSFER_ENCODING, "chunked").add(CONTENT_LENGTH, Integer.toString(REQUEST_BODY_LENGTH))
+        );
+        when(request.bodyOrEmpty()).thenReturn(Single.just(Buffer.buffer(REQUEST_BODY)));
+
+        wiremock.stubFor(post("/team").withRequestBody(new EqualToPattern(REQUEST_BODY)).willReturn(ok(BACKEND_RESPONSE_BODY)));
+
+        final TestObserver<Void> obs = cut.connect(ctx).test();
+        assertNoTimeout(obs);
+        obs.assertComplete();
+
+        wiremock.verify(
+            1,
+            postRequestedFor(urlPathEqualTo("/team"))
+                .withoutHeader(TRANSFER_ENCODING)
+                .withHeader(CONTENT_LENGTH, new EqualToPattern(Integer.toString(REQUEST_BODY_LENGTH)))
+                .withRequestBody(new EqualToPattern(REQUEST_BODY))
         );
     }
 


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-14235

## Description

When a request-phase policy (e.g. Assign Content) rewrites the body and sets a fresh `Content-Length` without stripping the client's `Transfer-Encoding: chunked`, the HTTP proxy endpoint connector forwarded **both** framing headers to the backend. That violates RFC 9112 §6.1 (ex-RFC 7230 §3.3.1/§3.3.3), and strict HTTP/1.1 backends (NGINX, Jetty) reject it with `400 Bad Request`.

The connector now reconciles the two: when both `Content-Length` and `Transfer-Encoding` are present, it materializes the rewritten body, drops `Transfer-Encoding`, and sends a fixed-length request whose `Content-Length` is re-derived from the actual bytes. The other paths (Content-Length-only streaming, Transfer-Encoding-only chunked passthrough) are unchanged.

## Additional context

**Root cause:** `HttpConnector.sendEndpointRequestChunks` always used `rxSend(Flowable)` whenever a body header was present, re-introducing chunked framing on top of the policy-set `Content-Length`. No Content-Length/Transfer-Encoding reconciliation existed, so both ended up on the wire.

**Reproduction (4.11.5):**
1. API with an Assign Content policy on the request phase that rewrites the body, endpoint behind a strict HTTP/1.1 backend (NGINX ≥ 1.21.1).
2. Client sends the request with `Transfer-Encoding: chunked`.
3. Backend returns `400 Bad Request` (both `Content-Length` and `Transfer-Encoding` present); a response-phase policy consuming `#response.content` then surfaces a `500`.

**Affected:** all maintained 4.x lines — the connector send path is identical on 4.8.x–4.12.x. Re-derived `Content-Length` keeps the declared length equal to the body bytes (RFC 9112 §6.3). Supersedes the config-only workaround tracked in APIM-13363.
