### PR TITLE
fix: use duplicated API id when copying V2 plans

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiDuplicatorServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiDuplicatorServiceImpl.java
@@ -307,7 +307,7 @@ public class ApiDuplicatorServiceImpl extends AbstractService implements ApiDupl
                 .findByApi(executionContext, apiId)
                 .forEach(plan -> {
                     plan.setId(plansIdsMap.get(plan.getId()));
-                    plan.setReferenceId(duplicatedApi.getReferenceId());
+                    plan.setReferenceId(duplicatedApi.getId());
                     if (plan.getGeneralConditions() != null) {
                         plan.setGeneralConditions(pagesIdsMap.get(plan.getGeneralConditions()));
                     }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-14403


## Additional context
### Before fix
https://github.com/user-attachments/assets/7632598c-ca58-47db-8ded-eb8ac70afed2

### After Fix
https://github.com/user-attachments/assets/2df98aeb-9396-4b5f-abd4-7a9ba8355328


