### PR TITLE
feat(helm): add native ingress support for gateway edge reactor

### DIFF
--- a/helm/templates/gateway/gateway-edge-ingress.yaml
+++ b/helm/templates/gateway/gateway-edge-ingress.yaml
@@ -1,0 +1,64 @@
+{{- if .Values.gateway.enabled -}}
+{{- if hasKey .Values.gateway "edge" -}}
+{{- if and .Values.gateway.edge.enabled .Values.gateway.services.edge.enabled -}}
+{{- if .Values.gateway.services.edge.ingress.enabled -}}
+{{- $serviceGWName := include "gravitee.gateway.fullname" . -}}
+{{- $serviceGWPort := .Values.gateway.services.edge.service.externalPort -}}
+{{- $ingressPath   := .Values.gateway.services.edge.ingress.path -}}
+{{- $ingressPathType   := .Values.gateway.services.edge.ingress.pathType -}}
+{{- $apiVersion := include "common.capabilities.ingress.apiVersion" . -}}
+apiVersion: {{ $apiVersion }}
+kind: Ingress
+metadata:
+  name: {{ template "gravitee.gateway.fullname" . }}-edge
+  labels:
+    app.kubernetes.io/name: {{ template "gravitee.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/version: {{ .Values.gateway.image.tag | default .Chart.AppVersion | quote }}
+    app.kubernetes.io/component: "{{ .Values.gateway.name }}"
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    {{- if and .Values.common .Values.common.labels }}
+    {{- range $key, $value := .Values.common.labels }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+    {{- end }}
+  annotations:
+    {{- if .Values.gateway.services.edge.ingress.annotations }}
+      {{- include "common.ingress.annotations.render" (dict "annotations" .Values.gateway.services.edge.ingress.annotations "ingressClassName" .Values.gateway.services.edge.ingress.ingressClassName "openshift" .Values.openshift "context" $) | nindent 4 }}
+    {{- end }}
+    {{- if and .Values.common .Values.common.annotations }}
+    {{- range $key, $value := .Values.common.annotations }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+    {{- end }}
+spec:
+  {{- if and (eq (include "common.ingress.supportsIngressClassname" .) "true") (.Values.gateway.services.edge.ingress.ingressClassName) (ne .Values.gateway.services.edge.ingress.ingressClassName "none") }}
+  ingressClassName: {{ .Values.gateway.services.edge.ingress.ingressClassName | quote }}
+  {{- end }}
+  rules:
+  {{- range $host := .Values.gateway.services.edge.ingress.hosts }}
+  - host: {{ $host }}
+    http:
+      paths:
+      - pathType: {{ $ingressPathType }}
+        path: {{ $ingressPath }}
+        backend:
+          {{- if (eq $apiVersion "networking.k8s.io/v1") }}
+          service:
+            name: {{ $serviceGWName }}
+            port:
+              number: {{ $serviceGWPort }}
+          {{ else }}
+          serviceName: {{ $serviceGWName }}
+          servicePort: {{ $serviceGWPort }}
+          {{- end -}}
+  {{- end -}}
+  {{- if .Values.gateway.services.edge.ingress.tls }}
+  tls:
+{{ toYaml .Values.gateway.services.edge.ingress.tls | indent 4 }}
+  {{- end -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}

--- a/helm/templates/gateway/gateway-edge-ingress.yaml
+++ b/helm/templates/gateway/gateway-edge-ingress.yaml
@@ -24,7 +24,7 @@ metadata:
     {{- end }}
     {{- end }}
   annotations:
-    {{- if .Values.gateway.services.edge.ingress.annotations }}
+    {{- if or .Values.gateway.services.edge.ingress.annotations .Values.gateway.services.edge.ingress.ingressClassName }}
       {{- include "common.ingress.annotations.render" (dict "annotations" .Values.gateway.services.edge.ingress.annotations "ingressClassName" .Values.gateway.services.edge.ingress.ingressClassName "openshift" .Values.openshift "context" $) | nindent 4 }}
     {{- end }}
     {{- if and .Values.common .Values.common.annotations }}
@@ -56,7 +56,7 @@ spec:
   {{- end -}}
   {{- if .Values.gateway.services.edge.ingress.tls }}
   tls:
-{{ toYaml .Values.gateway.services.edge.ingress.tls | indent 4 }}
+    {{- toYaml .Values.gateway.services.edge.ingress.tls | nindent 4 }}
   {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/helm/tests/gateway/ingress_edge_test.yaml
+++ b/helm/tests/gateway/ingress_edge_test.yaml
@@ -1,0 +1,196 @@
+suite: Test API Gateway Ingress with Edge Reactor enabled
+templates:
+  - "gateway/gateway-edge-ingress.yaml"
+tests:
+  - it: Check edge ingress disabled by default
+    set:
+      gateway:
+        edge:
+          enabled: true
+        services:
+          edge:
+            ingress:
+              enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: Check edge ingress not rendered when gateway.edge.enabled is false
+    set:
+      gateway:
+        edge:
+          enabled: false
+        services:
+          edge:
+            ingress:
+              enabled: true
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: Check edge ingress enabled with networking.k8s.io/v1
+    set:
+      gateway:
+        edge:
+          enabled: true
+        services:
+          edge:
+            service:
+              externalPort: 18093
+              internalPort: 18093
+            ingress:
+              enabled: true
+              path: /
+              hosts:
+                - apim-edge.example.com
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Ingress
+      - isAPIVersion:
+          of: networking.k8s.io/v1
+      - equal:
+          path: spec.rules[0].host
+          value: apim-edge.example.com
+      - equal:
+          path: spec.rules[0].http.paths[0].path
+          value: /
+      - equal:
+          path: spec.rules[0].http.paths[0].backend.service.port.number
+          value: 18093
+
+  - it: Check edge ingress with extensions/v1beta1
+    set:
+      global:
+        kubeVersion: 1.13.0
+      gateway:
+        edge:
+          enabled: true
+        services:
+          edge:
+            ingress:
+              enabled: true
+              hosts:
+                - apim-edge.example.com
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Ingress
+      - isAPIVersion:
+          of: extensions/v1beta1
+      - notExists:
+          path: spec.ingressClassName
+
+  - it: Check edge ingress with networking.k8s.io/v1beta1
+    set:
+      global:
+        kubeVersion: 1.15.0
+      gateway:
+        edge:
+          enabled: true
+        services:
+          edge:
+            ingress:
+              enabled: true
+              hosts:
+                - apim-edge.example.com
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Ingress
+      - isAPIVersion:
+          of: networking.k8s.io/v1beta1
+      - notExists:
+          path: spec.ingressClassName
+
+  - it: Check edge ingress without ingressClassName
+    set:
+      gateway:
+        edge:
+          enabled: true
+        services:
+          edge:
+            ingress:
+              enabled: true
+              hosts:
+                - apim-edge.example.com
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Ingress
+      - isAPIVersion:
+          of: networking.k8s.io/v1
+      - notExists:
+          path: spec.ingressClassName
+
+  - it: Check edge ingress with ingressClassName and kube >= 1.18-0
+    set:
+      global:
+        kubeVersion: 1.18.0
+      gateway:
+        edge:
+          enabled: true
+        services:
+          edge:
+            ingress:
+              enabled: true
+              ingressClassName: "nginx"
+              hosts:
+                - apim-edge.example.com
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Ingress
+      - isAPIVersion:
+          of: networking.k8s.io/v1beta1
+      - equal:
+          path: spec.ingressClassName
+          value: nginx
+
+  - it: Check edge ingress with ingressClassName "none" and kube >= 1.18-0
+    set:
+      global:
+        kubeVersion: 1.18.0
+      gateway:
+        edge:
+          enabled: true
+        services:
+          edge:
+            ingress:
+              enabled: true
+              ingressClassName: "none"
+              hosts:
+                - apim-edge.example.com
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Ingress
+      - isAPIVersion:
+          of: networking.k8s.io/v1beta1
+      - notExists:
+          path: spec.ingressClassName
+
+  - it: Check edge ingress pathType and path
+    set:
+      gateway:
+        edge:
+          enabled: true
+        services:
+          edge:
+            ingress:
+              enabled: true
+              pathType: Exact
+              path: /edge
+    asserts:
+      - equal:
+          path: spec.rules[0].http.paths[0].pathType
+          value: Exact
+      - equal:
+          path: spec.rules[0].http.paths[0].path
+          value: /edge

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -1914,6 +1914,21 @@ gateway:
       service:
         externalPort: 18093
         internalPort: 18093
+      ingress:
+        enabled: false
+        ingressClassName: ""
+        pathType: Prefix
+        path: /
+      #   # Used to create an Ingress record.
+        hosts:
+          - apim.example.com
+        annotations: {}
+      #     kubernetes.io/ingress.class: nginx
+      #     nginx.ingress.kubernetes.io/ssl-redirect: "false"
+        tls: []
+      #   - secretName: apim-gateway-edge-tls
+      #     hosts:
+      #       - apim.example.com
     bridge:
       enabled: false
       # host: localhost

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -1919,16 +1919,16 @@ gateway:
         ingressClassName: ""
         pathType: Prefix
         path: /
-      #   # Used to create an Ingress record.
+        # Used to create an Ingress record.
         hosts:
           - apim.example.com
         annotations: {}
-      #     kubernetes.io/ingress.class: nginx
-      #     nginx.ingress.kubernetes.io/ssl-redirect: "false"
+        # kubernetes.io/ingress.class: nginx
+        # nginx.ingress.kubernetes.io/ssl-redirect: "false"
         tls: []
-      #   - secretName: apim-gateway-edge-tls
-      #     hosts:
-      #       - apim.example.com
+        # - secretName: apim-gateway-edge-tls
+        #   hosts:
+        #     - apim.example.com
     bridge:
       enabled: false
       # host: localhost


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/GMA-522

**Description**

Add a native Helm ingress template for the gateway edge reactor, following the same pattern as the existing bridge ingress.

- New template `gateway/gateway-edge-ingress.yaml` rendering an `Ingress` resource for the edge reactor (port 18093)
- New `ingress` section under `gateway.services.edge` in `values.yaml` (disabled by default)
- 9 unit tests covering: disabled state, API versions (extensions/v1beta1, networking.k8s.io/v1beta1, v1), ingressClassName handling, pathType/path

Previously, exposing the edge reactor externally required a workaround via `extraObjects`. Users can now configure it natively via `gateway.services.edge.ingress.enabled: true`.