### PR TITLE
fix(hazelcast): upgrade hazelcast to 5.7.0 to fix GHSA-72hv-8253-57qq (APIM-13243)

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-hazelcast/pom.xml
+++ b/gravitee-apim-repository/gravitee-apim-repository-hazelcast/pom.xml
@@ -48,10 +48,12 @@
             <scope>provided</scope>
         </dependency>
 
-        <!-- Hazelcast: bundled in the plugin zip so this plugin is fully self-contained. -->
+        <!-- Hazelcast: bundled in the plugin zip so this plugin is fully self-contained.
+             5.7.0+ bundles jackson-core >= 2.21.1 which fixes GHSA-72hv-8253-57qq. -->
         <dependency>
             <groupId>com.hazelcast</groupId>
             <artifactId>hazelcast</artifactId>
+            <version>5.7.0</version>
         </dependency>
 
         <!-- Spring -->


### PR DESCRIPTION
## Issue
https://gravitee.atlassian.net/browse/APIM-13243

## Description
Fixes GHSA-72hv-8253-57qq: jackson-core was bundled inside \`hazelcast-5.6.0.jar\` as a shaded dependency (not a standalone transitive jar).

**Root cause:** hazelcast 5.6.0 shades jackson-core 2.19.2 inside its own uber-jar (\`lib/hazelcast-5.6.0.jar\`). Standard exclusions + \`scope=provided\` cannot remove it — only a hazelcast version upgrade resolves this.

**Fix:** Upgrade \`com.hazelcast:hazelcast\` from 5.6.0 → 5.7.0. Hazelcast 5.7.0 ships with jackson-core >= 2.21.1 (the fixed version). Grype confirms 0 matches for GHSA-72hv-8253-57qq.

Changes (pom.xml only, no breaking changes):
- Pin \`com.hazelcast:hazelcast\` to 5.7.0 in \`gravitee-apim-repository-hazelcast/pom.xml\`

## Grype verification
```
grype gravitee-apim-repository-hazelcast-4.12.0-milestone.3-SNAPSHOT.zip -o json \
  | jq '[.matches[] | select(.vulnerability.id=="GHSA-72hv-8253-57qq")] | length'
# Result: 0
```

Made with [Cursor](https://cursor.com)