### PR TITLE
fix(api-search): fix UnsupportedOperationException in searchIds when excluding EDGE APIs

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcApiRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcApiRepository.java
@@ -616,7 +616,7 @@ public class JdbcApiRepository extends JdbcAbstractPageableRepository<Api> imple
             clauses.add("a.type in (" + getOrm().buildInClause(apiCriteria.getApiTypes()) + ")");
         }
         if (!isEmpty(apiCriteria.getNotApiTypes())) {
-            clauses.add("a.type not in (" + getOrm().buildInClause(apiCriteria.getNotApiTypes()) + ")");
+            clauses.add("(a.type is null or a.type not in (" + getOrm().buildInClause(apiCriteria.getNotApiTypes()) + "))");
         }
         if (apiCriteria.getUpdatedAtFrom() != null) {
             clauses.add("a.updated_at >= ?");

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/ApiSearchServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/v4/impl/ApiSearchServiceImpl.java
@@ -524,8 +524,9 @@ public class ApiSearchServiceImpl extends AbstractService implements ApiSearchSe
             .setSort(sortable)
             .setFilters(filters);
         if (isNotEmpty(excludeDefinitionVersions)) {
-            searchEngineQueryBuilder.setExcludedFilters(
-                Map.of(FIELD_DEFINITION_VERSION, stream(excludeDefinitionVersions).map(DefinitionVersion::getLabel).toList())
+            searchEngineQueryBuilder.addExcludedFilter(
+                FIELD_DEFINITION_VERSION,
+                stream(excludeDefinitionVersions).map(DefinitionVersion::getLabel).toList()
             );
         }
         searchEngineQueryBuilder.addExcludedFilter(FIELD_API_TYPE, List.of(DefinitionVersion.V4.name() + "_" + ApiType.EDGE.name()));


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/GMA-499

## Description

`ApiSearchServiceImpl.searchIds()` called `setExcludedFilters(Map.of(...))` which replaced the internal mutable `HashMap` with an immutable `Map.of()`. The immediately following `addExcludedFilter()` call then threw `UnsupportedOperationException` when trying to `.put()` on that immutable map.

This caused the `POST /apis/_search` (management v1) endpoint to return a 500, breaking the e2e tests for API Search. The management v2 list endpoint was not affected as it uses a different code path.

Fix: replace `setExcludedFilters(Map.of(...))` with `addExcludedFilter(...)` to keep operating on the default mutable `HashMap`.