### PR TITLE
feat(portal): add dry-run validation for Portal automation resource

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/java/io/gravitee/apim/rest/api/automation/mapper/PortalMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/java/io/gravitee/apim/rest/api/automation/mapper/PortalMapper.java
@@ -16,6 +16,8 @@
 package io.gravitee.apim.rest.api.automation.mapper;
 
 import io.gravitee.apim.core.portal.model.Portal;
+import io.gravitee.apim.core.validation.Validator;
+import io.gravitee.apim.rest.api.automation.model.Errors;
 import io.gravitee.apim.rest.api.automation.model.NavigationPath;
 import io.gravitee.apim.rest.api.automation.model.PortalState;
 import java.util.List;
@@ -33,17 +35,32 @@ import org.mapstruct.factory.Mappers;
 public interface PortalMapper {
     PortalMapper INSTANCE = Mappers.getMapper(PortalMapper.class);
 
-    default PortalState toPortalState(Portal portal, String hrid, List<io.gravitee.apim.core.portal.model.NavigationPath> navigation) {
+    default PortalState toPortalState(
+        Portal portal,
+        String hrid,
+        List<io.gravitee.apim.core.portal.model.NavigationPath> navigation,
+        List<Validator.Error> errors
+    ) {
         var state = new PortalState(
             portal.getId() != null ? portal.getId().toString() : null,
             portal.getEnvironmentId(),
             portal.getOrganizationId(),
-            null
+            toErrors(errors)
         );
         state.setHrid(hrid);
         mapPortalToState(portal, state);
         state.setNavigation(toApiNavigation(navigation));
         return state;
+    }
+
+    default Errors toErrors(List<Validator.Error> validationErrors) {
+        if (validationErrors == null || validationErrors.isEmpty()) {
+            return null;
+        }
+        var wire = new Errors();
+        wire.setSevere(validationErrors.stream().filter(Validator.Error::isSevere).map(Validator.Error::getMessage).toList());
+        wire.setWarning(validationErrors.stream().filter(Validator.Error::isWarning).map(Validator.Error::getMessage).toList());
+        return wire;
     }
 
     @Mapping(target = "id", ignore = true)

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/java/io/gravitee/apim/rest/api/automation/resource/PortalResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/java/io/gravitee/apim/rest/api/automation/resource/PortalResource.java
@@ -64,7 +64,7 @@ public class PortalResource extends AbstractResource {
         PortalId id = PortalId.of(HRIDToUUID.portal().context(auditInfo).hrid(hrid).id());
         try {
             var output = getPortalUseCase.execute(new GetPortalUseCase.Input(auditInfo, id));
-            return Response.ok(PortalMapper.INSTANCE.toPortalState(output.portal(), hrid, output.navigation())).build();
+            return Response.ok(PortalMapper.INSTANCE.toPortalState(output.portal(), hrid, output.navigation(), null)).build();
         } catch (PortalNotFoundException e) {
             throw new HRIDNotFoundException(hrid);
         }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/java/io/gravitee/apim/rest/api/automation/resource/PortalsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/java/io/gravitee/apim/rest/api/automation/resource/PortalsResource.java
@@ -21,6 +21,7 @@ import static io.gravitee.rest.api.model.permissions.RolePermissionAction.UPDATE
 import io.gravitee.apim.core.portal.model.Portal;
 import io.gravitee.apim.core.portal.model.PortalId;
 import io.gravitee.apim.core.portal.use_case.CreateOrUpdatePortalUseCase;
+import io.gravitee.apim.core.portal.use_case.ValidatePortalUseCase;
 import io.gravitee.apim.rest.api.automation.mapper.PortalMapper;
 import io.gravitee.apim.rest.api.automation.model.PortalSpec;
 import io.gravitee.common.http.MediaType;
@@ -51,6 +52,9 @@ public class PortalsResource extends AbstractResource {
     @Inject
     private CreateOrUpdatePortalUseCase createOrUpdatePortalUseCase;
 
+    @Inject
+    private ValidatePortalUseCase validatePortalUseCase;
+
     @Path("/{hrid}")
     public PortalResource getPortalResource() {
         return resourceContext.getResource(PortalResource.class);
@@ -70,12 +74,11 @@ public class PortalsResource extends AbstractResource {
         );
         var navigation = PortalMapper.INSTANCE.toCoreNavigation(spec.getNavigation());
 
-        if (dryRun) {
-            return Response.ok(PortalMapper.INSTANCE.toPortalState(portal, spec.getHrid(), navigation)).build();
-        }
+        var input = new CreateOrUpdatePortalUseCase.Input(auditInfo, portal, navigation);
+        var output = dryRun ? validatePortalUseCase.execute(input) : createOrUpdatePortalUseCase.execute(input);
 
-        var output = createOrUpdatePortalUseCase.execute(new CreateOrUpdatePortalUseCase.Input(auditInfo, portal, navigation));
-
-        return Response.ok(PortalMapper.INSTANCE.toPortalState(output.portal(), spec.getHrid(), output.navigation())).build();
+        return Response.ok(
+            PortalMapper.INSTANCE.toPortalState(output.portal(), spec.getHrid(), output.navigation(), output.errors())
+        ).build();
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/resource/PortalsResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/resource/PortalsResourceTest.java
@@ -26,6 +26,7 @@ import io.gravitee.apim.core.portal.model.NavigationPath;
 import io.gravitee.apim.core.portal.model.Portal;
 import io.gravitee.apim.core.portal.model.PortalId;
 import io.gravitee.apim.core.portal.use_case.CreateOrUpdatePortalUseCase;
+import io.gravitee.apim.core.portal.use_case.ValidatePortalUseCase;
 import io.gravitee.apim.rest.api.automation.model.PortalState;
 import io.gravitee.apim.rest.api.automation.resource.base.AbstractResourceTest;
 import jakarta.inject.Inject;
@@ -44,9 +45,12 @@ class PortalsResourceTest extends AbstractResourceTest {
     @Inject
     private CreateOrUpdatePortalUseCase createOrUpdatePortalUseCase;
 
+    @Inject
+    private ValidatePortalUseCase validatePortalUseCase;
+
     @AfterEach
     void tearDown() {
-        reset(createOrUpdatePortalUseCase);
+        reset(createOrUpdatePortalUseCase, validatePortalUseCase);
     }
 
     @Override
@@ -59,6 +63,11 @@ class PortalsResourceTest extends AbstractResourceTest {
 
         @Test
         void should_return_populated_state_without_calling_use_case() {
+            when(validatePortalUseCase.execute(any())).thenAnswer(inv -> {
+                var input = (CreateOrUpdatePortalUseCase.Input) inv.getArgument(0);
+                return new CreateOrUpdatePortalUseCase.Output(input.portal(), input.navigation(), List.of());
+            });
+
             try (
                 var response = rootTarget()
                     .queryParam("dryRun", true)
@@ -82,6 +91,11 @@ class PortalsResourceTest extends AbstractResourceTest {
 
         @Test
         void should_echo_navigation_in_dry_run() {
+            when(validatePortalUseCase.execute(any())).thenAnswer(inv -> {
+                var input = (CreateOrUpdatePortalUseCase.Input) inv.getArgument(0);
+                return new CreateOrUpdatePortalUseCase.Output(input.portal(), input.navigation(), List.of());
+            });
+
             try (
                 var response = rootTarget()
                     .queryParam("dryRun", true)
@@ -111,6 +125,7 @@ class PortalsResourceTest extends AbstractResourceTest {
             ) {
                 assertThat(response.getStatus()).isEqualTo(400);
                 verifyNoInteractions(createOrUpdatePortalUseCase);
+                verifyNoInteractions(validatePortalUseCase);
             }
         }
     }
@@ -121,7 +136,9 @@ class PortalsResourceTest extends AbstractResourceTest {
         @Test
         void should_create_or_update_portal() {
             var persisted = Portal.of(PortalId.of("00000000-0000-0000-0000-0000000000a1"), ENVIRONMENT, ORGANIZATION, "Default Portal");
-            when(createOrUpdatePortalUseCase.execute(any())).thenReturn(new CreateOrUpdatePortalUseCase.Output(persisted, List.of()));
+            when(createOrUpdatePortalUseCase.execute(any())).thenReturn(
+                new CreateOrUpdatePortalUseCase.Output(persisted, List.of(), List.of())
+            );
 
             try (var response = rootTarget().request().accept(MediaType.APPLICATION_JSON_TYPE).put(Entity.json(readJSON("portal.json")))) {
                 assertThat(response.getStatus()).isEqualTo(200);
@@ -147,7 +164,9 @@ class PortalsResourceTest extends AbstractResourceTest {
                 new NavigationPath("/projects/alpha", Optional.of("Alpha")),
                 new NavigationPath("/projects/alpha/docs", Optional.empty())
             );
-            when(createOrUpdatePortalUseCase.execute(any())).thenReturn(new CreateOrUpdatePortalUseCase.Output(persisted, echoed));
+            when(createOrUpdatePortalUseCase.execute(any())).thenReturn(
+                new CreateOrUpdatePortalUseCase.Output(persisted, echoed, List.of())
+            );
 
             try (
                 var response = rootTarget()

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/spring/ResourceContextConfiguration.java
@@ -1304,6 +1304,11 @@ public class ResourceContextConfiguration {
     }
 
     @Bean
+    public io.gravitee.apim.core.portal.use_case.ValidatePortalUseCase validatePortalUseCase() {
+        return mock(io.gravitee.apim.core.portal.use_case.ValidatePortalUseCase.class);
+    }
+
+    @Bean
     public GetPortalUseCase getPortalUseCase() {
         return mock(GetPortalUseCase.class);
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal/domain_service/ValidatePortalDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal/domain_service/ValidatePortalDomainService.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal.domain_service;
+
+import io.gravitee.apim.core.audit.model.AuditInfo;
+import io.gravitee.apim.core.portal.model.NavigationPath;
+import io.gravitee.apim.core.portal.model.Portal;
+import io.gravitee.apim.core.validation.Validator;
+import java.util.List;
+
+/**
+ * @author GraviteeSource Team
+ */
+public interface ValidatePortalDomainService extends Validator<ValidatePortalDomainService.Input> {
+    record Input(AuditInfo auditInfo, Portal portal, List<NavigationPath> navigation) implements Validator.Input {}
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal/use_case/CreateOrUpdatePortalUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal/use_case/CreateOrUpdatePortalUseCase.java
@@ -17,18 +17,23 @@ package io.gravitee.apim.core.portal.use_case;
 
 import io.gravitee.apim.core.UseCase;
 import io.gravitee.apim.core.audit.model.AuditInfo;
+import io.gravitee.apim.core.exception.ValidationDomainException;
 import io.gravitee.apim.core.portal.crud_service.PortalCrudService;
 import io.gravitee.apim.core.portal.domain_service.PortalNavigationListingDomainService;
 import io.gravitee.apim.core.portal.domain_service.PortalNavigationSyncDomainService;
+import io.gravitee.apim.core.portal.domain_service.ValidatePortalDomainService;
 import io.gravitee.apim.core.portal.model.NavigationPath;
 import io.gravitee.apim.core.portal.model.Portal;
+import io.gravitee.apim.core.validation.Validator;
 import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 
 @UseCase
 @RequiredArgsConstructor
 public class CreateOrUpdatePortalUseCase {
 
+    private final ValidatePortalDomainService validator;
     private final PortalCrudService portalCrudService;
     private final PortalNavigationSyncDomainService portalNavigationSyncDomainService;
     private final PortalNavigationListingDomainService portalNavigationListingDomainService;
@@ -39,14 +44,26 @@ public class CreateOrUpdatePortalUseCase {
         }
     }
 
-    public record Output(Portal portal, List<NavigationPath> navigation) {}
+    public record Output(Portal portal, List<NavigationPath> navigation, List<Validator.Error> errors) {}
 
     public Output execute(Input input) {
+        var validation = validator.validateAndSanitize(
+            new ValidatePortalDomainService.Input(input.auditInfo(), input.portal(), input.navigation())
+        );
+
+        validation
+            .severe()
+            .ifPresent(errors -> {
+                throw new ValidationDomainException(errors.stream().map(Validator.Error::getMessage).collect(Collectors.joining(", ")));
+            });
+
+        var warnings = validation.warning().orElseGet(List::of);
+
         var portal = input.portal();
         var existing = portalCrudService.findByIdAndEnvironmentId(portal.getId(), input.auditInfo().environmentId());
         var saved = existing.isPresent() ? portalCrudService.update(portal) : portalCrudService.create(portal);
         portalNavigationSyncDomainService.sync(input.auditInfo(), portal.getId(), input.navigation());
         var navigation = portalNavigationListingDomainService.listAsNavigationPaths(input.auditInfo().environmentId());
-        return new Output(saved, navigation);
+        return new Output(saved, navigation, warnings);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal/use_case/ValidatePortalUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal/use_case/ValidatePortalUseCase.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal.use_case;
+
+import io.gravitee.apim.core.UseCase;
+import io.gravitee.apim.core.portal.domain_service.ValidatePortalDomainService;
+import io.gravitee.apim.core.validation.Validator;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+
+@UseCase
+@RequiredArgsConstructor
+public class ValidatePortalUseCase {
+
+    private final ValidatePortalDomainService validator;
+
+    public CreateOrUpdatePortalUseCase.Output execute(CreateOrUpdatePortalUseCase.Input input) {
+        var result = validator.validateAndSanitize(
+            new ValidatePortalDomainService.Input(input.auditInfo(), input.portal(), input.navigation())
+        );
+        List<Validator.Error> errors = result.errors().orElseGet(List::of);
+        return new CreateOrUpdatePortalUseCase.Output(input.portal(), input.navigation(), errors);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/portal/ValidatePortalDomainServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/portal/ValidatePortalDomainServiceImpl.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.infra.domain_service.portal;
+
+import io.gravitee.apim.core.portal.domain_service.ValidatePortalDomainService;
+import io.gravitee.apim.core.portal.model.NavigationPath;
+import io.gravitee.apim.core.portal.validation.NavigationPathValidator;
+import java.util.ArrayList;
+import java.util.List;
+import org.springframework.stereotype.Component;
+
+/**
+ * Validates Portal input. Format checks only — no reference-existence checks.
+ *
+ * @author GraviteeSource Team
+ */
+@Component
+public class ValidatePortalDomainServiceImpl implements ValidatePortalDomainService {
+
+    @Override
+    public Result<Input> validateAndSanitize(Input input) {
+        var errors = new ArrayList<Error>();
+        List<NavigationPath> navigation = input.navigation() == null ? List.of() : input.navigation();
+        for (int i = 0; i < navigation.size(); i++) {
+            errors.addAll(NavigationPathValidator.validate(navigation.get(i).path(), "navigation[" + i + "].path"));
+        }
+        return Result.ofBoth(input, errors);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/ValidatePortalDomainServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/ValidatePortalDomainServiceInMemory.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package inmemory;
+
+import io.gravitee.apim.core.portal.domain_service.ValidatePortalDomainService;
+import io.gravitee.apim.core.portal.model.NavigationPath;
+import io.gravitee.apim.core.portal.validation.NavigationPathValidator;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Mirrors {@code ValidatePortalDomainServiceImpl}. Uses the same shared
+ * {@link NavigationPathValidator} so the test path stays aligned with production.
+ */
+public class ValidatePortalDomainServiceInMemory implements ValidatePortalDomainService {
+
+    @Override
+    public Result<Input> validateAndSanitize(Input input) {
+        var errors = new ArrayList<Error>();
+        List<NavigationPath> navigation = input.navigation() == null ? List.of() : input.navigation();
+        for (int i = 0; i < navigation.size(); i++) {
+            errors.addAll(NavigationPathValidator.validate(navigation.get(i).path(), "navigation[" + i + "].path"));
+        }
+        return Result.ofBoth(input, errors);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal/use_case/CreateOrUpdatePortalUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal/use_case/CreateOrUpdatePortalUseCaseTest.java
@@ -16,14 +16,17 @@
 package io.gravitee.apim.core.portal.use_case;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import fixtures.core.model.PortalFixtures;
 import inmemory.PortalCrudServiceInMemory;
 import inmemory.PortalNavigationItemsCrudServiceInMemory;
 import inmemory.PortalNavigationItemsQueryServiceInMemory;
 import inmemory.PortalPageContentCrudServiceInMemory;
+import inmemory.ValidatePortalDomainServiceInMemory;
 import io.gravitee.apim.core.audit.model.AuditActor;
 import io.gravitee.apim.core.audit.model.AuditInfo;
+import io.gravitee.apim.core.exception.ValidationDomainException;
 import io.gravitee.apim.core.portal.domain_service.PortalNavigationListingDomainService;
 import io.gravitee.apim.core.portal.domain_service.PortalNavigationSyncDomainService;
 import io.gravitee.apim.core.portal.model.NavigationPath;
@@ -47,6 +50,7 @@ class CreateOrUpdatePortalUseCaseTest {
         .actor(AuditActor.builder().userId("user-id").build())
         .build();
 
+    private final ValidatePortalDomainServiceInMemory validator = new ValidatePortalDomainServiceInMemory();
     private final PortalCrudServiceInMemory portalCrudService = new PortalCrudServiceInMemory();
     private final PortalNavigationItemsCrudServiceInMemory navCrudService = new PortalNavigationItemsCrudServiceInMemory();
     private final PortalNavigationItemsQueryServiceInMemory navQueryService = new PortalNavigationItemsQueryServiceInMemory(
@@ -58,6 +62,7 @@ class CreateOrUpdatePortalUseCaseTest {
     @BeforeEach
     void setUp() {
         useCase = new CreateOrUpdatePortalUseCase(
+            validator,
             portalCrudService,
             new PortalNavigationSyncDomainService(navCrudService, navQueryService, pageContentCrudService),
             new PortalNavigationListingDomainService(navQueryService)
@@ -148,5 +153,33 @@ class CreateOrUpdatePortalUseCaseTest {
                 .map(it -> it.getTitle())
                 .toList()
         ).containsExactlyInAnyOrder("projects", "Alpha", "beta");
+    }
+
+    @Test
+    void should_throw_when_navigation_path_is_invalid() {
+        var portal = PortalFixtures.aPortal();
+
+        assertThatThrownBy(() ->
+            useCase.execute(
+                new CreateOrUpdatePortalUseCase.Input(
+                    AUDIT_INFO,
+                    portal,
+                    List.of(new NavigationPath("/valid", Optional.empty()), new NavigationPath("bad-path", Optional.empty()))
+                )
+            )
+        )
+            .isInstanceOf(ValidationDomainException.class)
+            .hasMessageContaining("navigation[1].path");
+    }
+
+    @Test
+    void should_return_empty_errors_when_navigation_is_valid() {
+        var portal = PortalFixtures.aPortal();
+
+        var output = useCase.execute(
+            new CreateOrUpdatePortalUseCase.Input(AUDIT_INFO, portal, List.of(new NavigationPath("/docs", Optional.empty())))
+        );
+
+        assertThat(output.errors()).isEmpty();
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal/use_case/ValidatePortalUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal/use_case/ValidatePortalUseCaseTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal.use_case;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import inmemory.ValidatePortalDomainServiceInMemory;
+import io.gravitee.apim.core.audit.model.AuditActor;
+import io.gravitee.apim.core.audit.model.AuditInfo;
+import io.gravitee.apim.core.portal.model.NavigationPath;
+import io.gravitee.apim.core.portal.model.Portal;
+import io.gravitee.apim.core.portal.model.PortalId;
+import io.gravitee.rest.api.service.common.HRIDToUUID;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class ValidatePortalUseCaseTest {
+
+    private static final AuditInfo AUDIT_INFO = AuditInfo.builder()
+        .organizationId("organization-id")
+        .environmentId("environment-id")
+        .actor(AuditActor.builder().userId("user-id").build())
+        .build();
+    private static final String PORTAL_HRID = "default-portal";
+    private static final Portal PORTAL = Portal.of(
+        PortalId.of(HRIDToUUID.portal().context(AUDIT_INFO).hrid(PORTAL_HRID).id()),
+        AUDIT_INFO.environmentId(),
+        AUDIT_INFO.organizationId(),
+        "Default Portal"
+    );
+
+    private final ValidatePortalDomainServiceInMemory validator = new ValidatePortalDomainServiceInMemory();
+    private ValidatePortalUseCase useCase;
+
+    @BeforeEach
+    void setUp() {
+        useCase = new ValidatePortalUseCase(validator);
+    }
+
+    @Test
+    void should_return_portal_and_no_errors_for_well_formed_input() {
+        var output = useCase.execute(
+            new CreateOrUpdatePortalUseCase.Input(
+                AUDIT_INFO,
+                PORTAL,
+                List.of(new NavigationPath("/docs", Optional.empty()), new NavigationPath("/docs/getting-started", Optional.empty()))
+            )
+        );
+
+        assertThat(output.portal()).isEqualTo(PORTAL);
+        assertThat(output.errors()).isEmpty();
+    }
+
+    @Test
+    void should_surface_path_format_errors_with_indexed_field_name() {
+        var output = useCase.execute(
+            new CreateOrUpdatePortalUseCase.Input(
+                AUDIT_INFO,
+                PORTAL,
+                List.of(new NavigationPath("/valid", Optional.empty()), new NavigationPath("bad-path", Optional.empty()))
+            )
+        );
+
+        assertThat(output.errors()).anyMatch(e -> e.getMessage().contains("navigation[1].path"));
+    }
+
+    @Test
+    void should_echo_navigation_in_output() {
+        var nav = List.of(new NavigationPath("/docs", Optional.empty()));
+        var output = useCase.execute(new CreateOrUpdatePortalUseCase.Input(AUDIT_INFO, PORTAL, nav));
+
+        assertThat(output.navigation()).containsExactlyElementsOf(nav);
+        assertThat(output.errors()).isEmpty();
+    }
+}


### PR DESCRIPTION
## Summary

- `?dryRun=true` on the Portal `PUT` endpoint previously echoed the spec back with no validation — GKO could not detect invalid navigation paths without actually applying the CRD
- Adds `ValidatePortalDomainService` + `ValidatePortalUseCase` following the same pattern as `PortalListing`; navigation paths are validated with the existing `NavigationPathValidator`
- `CreateOrUpdatePortalUseCase` now also validates on the non-dry-run path and throws `ValidationDomainException` on severe errors
