### PR TITLE
fix(deps): bump gravitee-policy-oas-validation to 1.2.3 (APIM-13243)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -215,7 +215,7 @@
         <gravitee-policy-mock.version>1.15.0</gravitee-policy-mock.version>
         <gravitee-policy-mtls.version>3.0.0</gravitee-policy-mtls.version>
         <gravitee-policy-oauth2.version>5.3.0</gravitee-policy-oauth2.version>
-        <gravitee-policy-oas-validation.version>1.2.2</gravitee-policy-oas-validation.version>
+        <gravitee-policy-oas-validation.version>1.2.3</gravitee-policy-oas-validation.version>
         <gravitee-policy-openid-connect-userinfo.version>1.7.0</gravitee-policy-openid-connect-userinfo.version>
         <gravitee-policy-override-http-method.version>2.2.1</gravitee-policy-override-http-method.version>
         <!--    Version of policy-ratelimit is also used for policy-quota, policy-spikearrest and gateway-services-ratelimit    -->


### PR DESCRIPTION
## Issue
https://gravitee.atlassian.net/browse/APIM-13243

## Description
Bumps gravitee-policy-oas-validation from 1.2.2 to 1.2.3.

v1.2.3 excludes jackson-core from the plugin ZIP (PR #46 in gravitee-policy-oas-validation).
This resolves GHSA-72hv-8253-57qq reported by grype on gravitee-policy-oas-validation-1.2.2.zip.

No other changes.

Made with [Cursor](https://cursor.com)