### PR TITLE
feat(EXT-130): User guidance for Next-Gen portal

### DIFF
--- a/gravitee-apim-console-webui/src/components/gio-side-nav/gio-side-nav.component.harness.ts
+++ b/gravitee-apim-console-webui/src/components/gio-side-nav/gio-side-nav.component.harness.ts
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ComponentHarness, TestElement } from '@angular/cdk/testing';
+
+export class GioSideNavHarness extends ComponentHarness {
+  public static readonly hostSelector = 'gio-side-nav';
+
+  private readonly getAllAnchors = this.locatorForAll('a');
+
+  async getAnchorsWithTarget(target: string): Promise<TestElement[]> {
+    const result: TestElement[] = [];
+    for (const anchor of await this.getAllAnchors()) {
+      if ((await anchor.getAttribute('target')) === target) {
+        result.push(anchor);
+      }
+    }
+    return result;
+  }
+
+  async countAnchorsWithAnyTarget(): Promise<number> {
+    let count = 0;
+    for (const anchor of await this.getAllAnchors()) {
+      if ((await anchor.getAttribute('target')) !== null) {
+        count++;
+      }
+    }
+    return count;
+  }
+
+  async countAnchorsWithAnyRel(): Promise<number> {
+    let count = 0;
+    for (const anchor of await this.getAllAnchors()) {
+      if ((await anchor.getAttribute('rel')) !== null) {
+        count++;
+      }
+    }
+    return count;
+  }
+}

--- a/gravitee-apim-console-webui/src/components/gio-side-nav/gio-side-nav.component.html
+++ b/gravitee-apim-console-webui/src/components/gio-side-nav/gio-side-nav.component.html
@@ -32,7 +32,7 @@
     <gio-menu-list>
       <ng-container *ngFor="let item of mainMenuItems">
         <ng-container *ngIf="!item.items; else menuItemsGroup">
-          <a [routerLink]="item.routerLink">
+          <a [routerLink]="item.routerLink" [target]="item.target" [attr.rel]="item.target === '_blank' ? 'noopener noreferrer' : null">
             <gio-menu-item
               tabIndex="1"
               routerLinkActive
@@ -42,8 +42,13 @@
               [active]="rla.isActive"
               [gioLicense]="item?.licenseOptions"
               [iconRight]="item?.iconRight$ | async"
-              >{{ item.displayName }}</gio-menu-item
             >
+              @if (item.externalLink) {
+                <span class="gio-side-nav__external-label">{{ item.displayName }}<mat-icon svgIcon="gio:external-link"></mat-icon></span>
+              } @else {
+                {{ item.displayName }}
+              }
+            </gio-menu-item>
           </a>
         </ng-container>
 
@@ -57,7 +62,12 @@
             iconRightTooltip="{{ item.iconRightTooltip }}"
           >
             <ng-container *ngFor="let child of item.items">
-              <a [routerLink]="child.routerLink" [tabindex]="1">
+              <a
+                [routerLink]="child.routerLink"
+                [tabindex]="1"
+                [target]="child.target"
+                [attr.rel]="child.target === '_blank' ? 'noopener noreferrer' : null"
+              >
                 <gio-menu-item routerLinkActive>{{ child.displayName }}</gio-menu-item>
               </a>
             </ng-container>
@@ -74,7 +84,7 @@
     </gio-menu-license-expiration-notification>
     <gio-menu-footer *ngIf="footerMenuItems.length > 0">
       <ng-container *ngFor="let item of footerMenuItems">
-        <a [routerLink]="item.routerLink">
+        <a [routerLink]="item.routerLink" [target]="item.target" [attr.rel]="item.target === '_blank' ? 'noopener noreferrer' : null">
           <gio-menu-item
             tabIndex="1"
             routerLinkActive

--- a/gravitee-apim-console-webui/src/components/gio-side-nav/gio-side-nav.component.spec.ts
+++ b/gravitee-apim-console-webui/src/components/gio-side-nav/gio-side-nav.component.spec.ts
@@ -28,7 +28,8 @@ import {
 import { ActivatedRoute } from '@angular/router';
 import { of, Subject } from 'rxjs';
 
-import { GioSideNavComponent, SIDE_NAV_GROUP_ID } from './gio-side-nav.component';
+import { GioSideNavComponent, PORTAL_SETTINGS_PERMISSIONS, SIDE_NAV_GROUP_ID } from './gio-side-nav.component';
+import { GioSideNavHarness } from './gio-side-nav.component.harness';
 import { GioSideNavModule } from './gio-side-nav.module';
 
 import { License } from '../../entities/license/License';
@@ -36,6 +37,8 @@ import { GioPermissionService } from '../../shared/components/gio-permission/gio
 import { CONSTANTS_TESTING, GioTestingModule } from '../../shared/testing';
 import { Constants } from '../../entities/Constants';
 import { EnvironmentSettingsService } from '../../services-ngx/environment-settings.service';
+
+const PORTAL_SETTINGS_PERMISSIONS_SET = new Set(PORTAL_SETTINGS_PERMISSIONS);
 
 describe('GioSideNavComponent', () => {
   let fixture: ComponentFixture<GioSideNavComponent>;
@@ -51,6 +54,8 @@ describe('GioSideNavComponent', () => {
     hasLicenseMgmtPermission = true,
     scoringEnabled = true,
     hasApiProductPermission = true,
+    hasPortalSettingsPermission = true,
+    portalNextEnabled = true,
   ) => {
     await TestBed.configureTestingModule({
       declarations: [GioSideNavComponent],
@@ -67,6 +72,12 @@ describe('GioSideNavComponent', () => {
               }
               const isMatchingApiProductPermission = permissions.length === 1 && permissions[0] === 'environment-api_product-r';
               if (isMatchingApiProductPermission && !hasApiProductPermission) {
+                return false;
+              }
+              const isMatchingPortalSettingsPermissions =
+                permissions.length === PORTAL_SETTINGS_PERMISSIONS_SET.size &&
+                permissions.every(p => PORTAL_SETTINGS_PERMISSIONS_SET.has(p));
+              if (isMatchingPortalSettingsPermissions && !hasPortalSettingsPermission) {
                 return false;
               }
               // Return default true for all the rest of 'hasMatching' permission checks
@@ -98,7 +109,7 @@ describe('GioSideNavComponent', () => {
           provide: EnvironmentSettingsService,
           useValue: {
             get: () => {
-              return of({ apiScore: { enabled: scoringEnabled } });
+              return of({ apiScore: { enabled: scoringEnabled }, portalNext: { access: { enabled: portalNextEnabled } } });
             },
           },
         },
@@ -187,18 +198,17 @@ describe('GioSideNavComponent', () => {
       expect(removeSearchItemByGroupIds).toHaveBeenCalledTimes(1);
       expect(removeSearchItemByGroupIds).toHaveBeenCalledWith([SIDE_NAV_GROUP_ID]);
       expect(addSearchItemByGroupIds).toHaveBeenCalledTimes(1);
-      expect(addSearchItemByGroupIds).toHaveBeenCalledWith(
-        expect.arrayContaining([
-          expect.objectContaining({ name: 'Dashboard', routerLink: expect.not.stringContaining('./') }),
-          expect.objectContaining({ name: 'APIs', routerLink: expect.not.stringContaining('./') }),
-          expect.objectContaining({ name: 'API Products', routerLink: expect.not.stringContaining('./') }),
-          expect.objectContaining({ name: 'Applications', routerLink: expect.not.stringContaining('./') }),
-          expect.objectContaining({ name: 'Gateways', routerLink: expect.not.stringContaining('./') }),
-          expect.objectContaining({ name: 'Audit', routerLink: expect.not.stringContaining('./') }),
-          expect.objectContaining({ name: 'Analytics', routerLink: expect.not.stringContaining('./') }),
-          expect.objectContaining({ name: 'Settings', routerLink: expect.not.stringContaining('./') }),
-        ]),
+      const searchItems: { name: string }[] = addSearchItemByGroupIds.mock.calls[0][0];
+      const searchItemNames = searchItems.map(i => i.name);
+
+      // flat items with real routerLinks must appear
+      expect(searchItemNames).toEqual(
+        expect.arrayContaining(['Dashboard', 'APIs', 'API Products', 'Applications', 'Gateways', 'Audit', 'Settings']),
       );
+      // group-only items (no routerLink of their own) must NOT appear in search
+      expect(searchItemNames).not.toContain('Kafka');
+      expect(searchItemNames).not.toContain('Observability');
+      expect(searchItemNames).not.toContain('Analytics');
     });
   });
 
@@ -251,6 +261,33 @@ describe('GioSideNavComponent', () => {
 
       const apiProductsItem = fixture.componentInstance.mainMenuItems.find(item => item.displayName === 'API Products');
       expect(apiProductsItem).toBeDefined();
+    });
+
+    it('should show Portal Settings menu item when user has required portal permissions', async () => {
+      await init(true, true, false, true, true);
+      expectLicense({ tier: '', features: [], packs: [], expiresAt: new Date() });
+
+      const portalSettingsItem = fixture.componentInstance.mainMenuItems.find(item => item.displayName === 'Portal Settings');
+      expect(portalSettingsItem).toBeDefined();
+      expect(portalSettingsItem?.routerLink).toBe('./_portal');
+      expect(portalSettingsItem?.icon).toBe('gio:monitor');
+      expect(portalSettingsItem?.externalLink).toBe(true);
+    });
+
+    it('should hide Portal Settings menu item when user lacks all portal permissions', async () => {
+      await init(true, true, false, true, false);
+      expectLicense({ tier: '', features: [], packs: [], expiresAt: new Date() });
+
+      const portalSettingsItem = fixture.componentInstance.mainMenuItems.find(item => item.displayName === 'Portal Settings');
+      expect(portalSettingsItem).toBeUndefined();
+    });
+
+    it('should hide Portal Settings menu item when portal next is disabled', async () => {
+      await init(true, true, true, true, true, false);
+      expectLicense({ tier: '', features: [], packs: [], expiresAt: new Date() });
+
+      const portalSettingsItem = fixture.componentInstance.mainMenuItems.find(item => item.displayName === 'Portal Settings');
+      expect(portalSettingsItem).toBeUndefined();
     });
   });
 
@@ -318,6 +355,85 @@ describe('GioSideNavComponent', () => {
       expect(kafka?.routerBasePath).toBe(`/${envHrid}/clusters`);
 
       ctrl.verify();
+    });
+  });
+
+  describe('target attribute on menu item anchors', () => {
+    let sideNavHarness: GioSideNavHarness;
+
+    beforeEach(async () => {
+      await init();
+      // Use a non-expiring license to prevent GioLicenseExpirationNotificationComponent from
+      // rendering its own <a target="_blank"> "Contact Gravitee" link (shown when daysRemaining <= 30).
+      expectLicense({ tier: '', features: [], packs: [], expiresAt: expirationDateInOneYear });
+      sideNavHarness = await TestbedHarnessEnvironment.harnessForFixture(fixture, GioSideNavHarness);
+      fixture.detectChanges();
+    });
+
+    it('should not add target or rel attribute to anchor elements when menu items have no target', async () => {
+      fixture.componentInstance.mainMenuItems = [{ icon: 'gio:home', routerLink: './test', displayName: 'Test', category: 'test' }];
+      fixture.componentInstance.footerMenuItems = [];
+      fixture.detectChanges();
+
+      expect(await sideNavHarness.countAnchorsWithAnyTarget()).toBe(0);
+      expect(await sideNavHarness.countAnchorsWithAnyRel()).toBe(0);
+    });
+
+    it('should set target="_blank" and rel="noopener noreferrer" on anchor when main menu item has target set', async () => {
+      fixture.componentInstance.mainMenuItems = [
+        { icon: 'gio:home', routerLink: './test', displayName: 'Test', category: 'test', target: '_blank' },
+      ];
+      fixture.detectChanges();
+
+      const anchors = await sideNavHarness.getAnchorsWithTarget('_blank');
+      expect(anchors.length).toBe(1);
+      expect(await anchors[0].getAttribute('rel')).toBe('noopener noreferrer');
+    });
+
+    it('should not set target or rel on anchor when main menu item target is absent', async () => {
+      fixture.componentInstance.mainMenuItems = [{ icon: 'gio:home', routerLink: './test', displayName: 'Test', category: 'test' }];
+      fixture.detectChanges();
+
+      expect(await sideNavHarness.countAnchorsWithAnyTarget()).toBe(0);
+      expect(await sideNavHarness.countAnchorsWithAnyRel()).toBe(0);
+    });
+
+    it('should set target="_blank" and rel="noopener noreferrer" on anchor when submenu child item has target set', async () => {
+      fixture.componentInstance.mainMenuItems = [
+        {
+          displayName: 'Group',
+          category: 'test',
+          routerBasePath: '/test/group',
+          items: [{ displayName: 'Child', routerLink: './child', category: 'test', target: '_blank' }],
+        },
+      ];
+      fixture.detectChanges();
+
+      const anchors = await sideNavHarness.getAnchorsWithTarget('_blank');
+      expect(anchors.length).toBe(1);
+      expect(await anchors[0].getAttribute('rel')).toBe('noopener noreferrer');
+    });
+
+    it('should set target="_blank" and rel="noopener noreferrer" on anchor when footer menu item has target set', async () => {
+      fixture.componentInstance.mainMenuItems = [];
+      fixture.componentInstance.footerMenuItems = [
+        { icon: 'gio:building', routerLink: './test-footer', displayName: 'Test Footer', category: 'test', target: '_blank' },
+      ];
+      fixture.detectChanges();
+
+      const anchors = await sideNavHarness.getAnchorsWithTarget('_blank');
+      expect(anchors.length).toBe(1);
+      expect(await anchors[0].getAttribute('rel')).toBe('noopener noreferrer');
+    });
+
+    it('should not set rel on footer anchor when target is absent', async () => {
+      fixture.componentInstance.mainMenuItems = [];
+      fixture.componentInstance.footerMenuItems = [
+        { icon: 'gio:building', routerLink: './test-footer', displayName: 'Test Footer', category: 'test' },
+      ];
+      fixture.detectChanges();
+
+      expect(await sideNavHarness.countAnchorsWithAnyRel()).toBe(0);
     });
   });
 

--- a/gravitee-apim-console-webui/src/components/gio-side-nav/gio-side-nav.component.ts
+++ b/gravitee-apim-console-webui/src/components/gio-side-nav/gio-side-nav.component.ts
@@ -29,6 +29,7 @@ import { EnvironmentSettingsService } from '../../services-ngx/environment-setti
 interface MenuItem {
   icon?: string;
   routerLink?: string;
+  target?: string;
   displayName: string;
   permissions?: string[];
   licenseOptions?: LicenseOptions;
@@ -38,9 +39,24 @@ interface MenuItem {
   category: string;
   items?: MenuItem[];
   routerBasePath?: string;
+  externalLink?: boolean;
 }
 
 export const SIDE_NAV_GROUP_ID = 'side-nav-items';
+
+// prettier-ignore
+export const PORTAL_SETTINGS_PERMISSIONS = [
+  'environment-settings-r',
+  'environment-settings-u',
+  'environment-theme-r',
+  'environment-theme-u',
+  'environment-category-r',
+  'environment-category-u',
+  'environment-documentation-r',
+  'environment-documentation-u',
+  'environment-metadata-r',
+  'environment-metadata-u',
+];
 
 @Component({
   selector: 'gio-side-nav',
@@ -274,6 +290,18 @@ export class GioSideNavComponent implements OnInit, OnDestroy {
       });
     }
 
+    if (envSettings?.portalNext?.access?.enabled) {
+      mainMenuItems.push({
+        icon: 'gio:monitor',
+        routerLink: './_portal',
+        displayName: 'Portal Settings',
+        category: 'Portal Settings',
+        permissions: PORTAL_SETTINGS_PERMISSIONS,
+        target: '_blank',
+        externalLink: true,
+      });
+    }
+
     mainMenuItems.push({
       icon: 'gio:settings',
       routerLink: './settings',
@@ -350,6 +378,7 @@ export class GioSideNavComponent implements OnInit, OnDestroy {
 
   private getSideNaveMenuSearchItems(): MenuSearchItem[] {
     return this.mainMenuItems
+      .filter(item => !!item.routerLink)
       .map(item => {
         return {
           name: item.displayName,
@@ -359,12 +388,14 @@ export class GioSideNavComponent implements OnInit, OnDestroy {
         };
       })
       .concat(
-        this.footerMenuItems.map(item => ({
-          name: item.displayName,
-          routerLink: `/${cleanRouterLink(item.routerLink)}`,
-          category: item.category,
-          groupIds: [SIDE_NAV_GROUP_ID],
-        })),
+        this.footerMenuItems
+          .filter(item => !!item.routerLink)
+          .map(item => ({
+            name: item.displayName,
+            routerLink: `/${cleanRouterLink(item.routerLink)}`,
+            category: item.category,
+            groupIds: [SIDE_NAV_GROUP_ID],
+          })),
       );
   }
 }

--- a/gravitee-apim-console-webui/src/components/gio-side-nav/gio-side-nav.module.ts
+++ b/gravitee-apim-console-webui/src/components/gio-side-nav/gio-side-nav.module.ts
@@ -15,10 +15,17 @@
  */
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
-import { GioLicenseExpirationNotificationModule, GioLicenseModule, GioMenuModule, GioSubmenuModule } from '@gravitee/ui-particles-angular';
+import {
+  GioIconsModule,
+  GioLicenseExpirationNotificationModule,
+  GioLicenseModule,
+  GioMenuModule,
+  GioSubmenuModule,
+} from '@gravitee/ui-particles-angular';
 import { MatSelectModule } from '@angular/material/select';
 import { RouterModule } from '@angular/router';
 import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
 
 import { GioSideNavComponent } from './gio-side-nav.component';
 
@@ -35,6 +42,8 @@ import { GioPermissionModule } from '../../shared/components/gio-permission/gio-
     GioLicenseExpirationNotificationModule,
     GioPermissionModule,
     MatButtonModule,
+    MatIconModule,
+    GioIconsModule,
   ],
   declarations: [GioSideNavComponent],
   exports: [GioSideNavComponent],

--- a/gravitee-apim-console-webui/src/management/api/documentation-v4/api-documentation-v4.module.ts
+++ b/gravitee-apim-console-webui/src/management/api/documentation-v4/api-documentation-v4.module.ts
@@ -61,6 +61,7 @@ import { ApiDocumentationV4NewtAiDialogComponent } from './dialog/documentation-
 
 import { GioPermissionModule } from '../../../shared/components/gio-permission/gio-permission.module';
 import { GioTooltipOnEllipsisModule } from '../../../shared/components/gio-tooltip-on-ellipsis/gio-tooltip-on-ellipsis.module';
+import { ClassicPortalOnlyBannerComponent } from '../../../shared/components/classic-portal-only-banner/classic-portal-only-banner.component';
 import { GioSwaggerUiModule } from '../../../components/documentation/gio-swagger-ui/gio-swagger-ui.module';
 import { GioAsyncApiModule } from '../../../components/documentation/gio-async-api/gio-async-api-module';
 import { GioMetadataModule } from '../../../components/gio-metadata/gio-metadata.module';
@@ -124,6 +125,7 @@ import { GioApiMetadataListModule } from '../component/gio-api-metadata-list/gio
     ApiDocumentationV4BreadcrumbComponent,
     ApiDocumentationV4FileUploadComponent,
     GioBannerModule,
+    ClassicPortalOnlyBannerComponent,
   ],
 })
 export class ApiDocumentationV4Module {}

--- a/gravitee-apim-console-webui/src/management/api/documentation-v4/documentation-pages-tab/api-documentation-v4-documentation-pages-tab.component.html
+++ b/gravitee-apim-console-webui/src/management/api/documentation-v4/documentation-pages-tab/api-documentation-v4-documentation-pages-tab.component.html
@@ -16,6 +16,11 @@
 
 -->
 <mat-card>
+  <mat-card-content>
+    <classic-portal-only-banner
+      body="This documentation is used by the Classic Developer Portal. Manage Next Gen Portal API content in Next Gen Portal settings."
+    />
+  </mat-card-content>
   @if (data$ | async; as data) {
     <api-documentation-list-navigation-header
       [breadcrumbs]="data.breadcrumbs"

--- a/gravitee-apim-console-webui/src/management/api/documentation-v4/documentation-pages-tab/api-documentation-v4-documentation-pages-tab.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/documentation-v4/documentation-pages-tab/api-documentation-v4-documentation-pages-tab.component.spec.ts
@@ -39,6 +39,11 @@ import { GioTestingPermissionProvider } from '../../../../shared/components/gio-
 import { PageType } from '../../../../entities/page';
 import { Constants } from '../../../../entities/Constants';
 import { ApiSpecGenRequestState, ApiSpecGenState } from '../../../../services-ngx/api-spec-gen.service';
+import { EnvironmentSettingsService } from '../../../../services-ngx/environment-settings.service';
+import { PortalNavigationItemService } from '../../../../services-ngx/portal-navigation-item.service';
+import { ClassicPortalOnlyBannerHarness } from '../../../../shared/components/classic-portal-only-banner/classic-portal-only-banner.component.harness';
+
+const ENV_HRID = 'my-env';
 
 describe('ApiDocumentationV4DocumentationPagesTab', () => {
   let fixture: ComponentFixture<ApiDocumentationV4DocumentationPagesTabComponent>;
@@ -54,6 +59,8 @@ describe('ApiDocumentationV4DocumentationPagesTab', () => {
     portalUrl = 'portal.url',
     apiLifecycleStatus: ApiLifecycleState = 'PUBLISHED',
     apiSpecGenState: ApiSpecGenState = ApiSpecGenState.UNAVAILABLE,
+    portalNextEnabled = false,
+    permissions: string[] = ['api-documentation-u', 'api-documentation-c', 'api-documentation-r', 'api-documentation-d'],
   ) => {
     await TestBed.configureTestingModule({
       declarations: [ApiDocumentationV4DocumentationPagesTabComponent],
@@ -64,11 +71,12 @@ describe('ApiDocumentationV4DocumentationPagesTab', () => {
           useValue: {
             params: of({ apiId: API_ID }),
             queryParams: new BehaviorSubject({ parentId }),
+            snapshot: { params: { apiId: API_ID, envHrid: ENV_HRID } },
           },
         },
         {
           provide: GioTestingPermissionProvider,
-          useValue: ['api-documentation-u', 'api-documentation-c', 'api-documentation-r', 'api-documentation-d'],
+          useValue: permissions,
         },
         {
           provide: Constants,
@@ -81,6 +89,14 @@ describe('ApiDocumentationV4DocumentationPagesTab', () => {
             });
             return constants;
           },
+        },
+        {
+          provide: EnvironmentSettingsService,
+          useValue: { isPortalNextEnabled: () => of(portalNextEnabled) },
+        },
+        {
+          provide: PortalNavigationItemService,
+          useValue: { getNavigationItems: () => of({ items: [] }) },
         },
       ],
     })
@@ -108,6 +124,53 @@ describe('ApiDocumentationV4DocumentationPagesTab', () => {
   afterEach(() => {
     httpTestingController.verify();
     jest.resetAllMocks();
+  });
+
+  describe('Classic Portal Only banner', () => {
+    it('should show the banner when portalNext is enabled', async () => {
+      await init([], [], 'ROOT', 'portal.url', 'PUBLISHED', ApiSpecGenState.UNAVAILABLE, true);
+      const banner = await harnessLoader.getHarness(ClassicPortalOnlyBannerHarness);
+      expect(await banner.isBannerContentVisible()).toBe(true);
+    });
+
+    it('should hide the banner when portalNext is disabled', async () => {
+      await init([], [], 'ROOT', 'portal.url', 'PUBLISHED', ApiSpecGenState.UNAVAILABLE, false);
+      const banner = await harnessLoader.getHarness(ClassicPortalOnlyBannerHarness);
+      expect(await banner.isBannerContentVisible()).toBe(false);
+    });
+
+    it('should show the settings action when portalNext is enabled and user has environment-settings permission', async () => {
+      await init([], [], 'ROOT', 'portal.url', 'PUBLISHED', ApiSpecGenState.UNAVAILABLE, true, [
+        'api-documentation-u',
+        'api-documentation-c',
+        'api-documentation-r',
+        'api-documentation-d',
+        'environment-settings-r',
+      ]);
+      const banner = await harnessLoader.getHarness(ClassicPortalOnlyBannerHarness);
+      expect(await banner.isSettingsActionVisible()).toBe(true);
+    });
+
+    it('should hide the settings action when user lacks environment-settings permission', async () => {
+      await init([], [], 'ROOT', 'portal.url', 'PUBLISHED', ApiSpecGenState.UNAVAILABLE, true, [
+        'api-documentation-u',
+        'api-documentation-c',
+        'api-documentation-r',
+        'api-documentation-d',
+      ]);
+      const banner = await harnessLoader.getHarness(ClassicPortalOnlyBannerHarness);
+      expect(await banner.isSettingsActionVisible()).toBe(false);
+    });
+
+    it('should show the settings action with a link when envHrid is in route and user has environment-settings permission', async () => {
+      await init([], [], 'ROOT', 'portal.url', 'PUBLISHED', ApiSpecGenState.UNAVAILABLE, true, [
+        'api-documentation-u',
+        'environment-settings-r',
+      ]);
+      fixture.detectChanges();
+      const banner = await harnessLoader.getHarness(ClassicPortalOnlyBannerHarness);
+      expect(await banner.isSettingsActionVisible()).toBe(true);
+    });
   });
 
   describe('Custom section', () => {

--- a/gravitee-apim-console-webui/src/management/api/documentation-v4/main-pages-tab/api-documentation-v4-main-pages-tab.component.html
+++ b/gravitee-apim-console-webui/src/management/api/documentation-v4/main-pages-tab/api-documentation-v4-main-pages-tab.component.html
@@ -16,6 +16,11 @@
 
 -->
 <mat-card>
+  <mat-card-content>
+    <classic-portal-only-banner
+      body="This documentation is used by the Classic Developer Portal. Manage Next Gen Portal API content in Next Gen Portal settings."
+    />
+  </mat-card-content>
   @if (data$ | async; as data) {
     <div class="homepage__header">
       <h3 class="homepage__header__title">Homepage</h3>

--- a/gravitee-apim-console-webui/src/management/api/documentation-v4/main-pages-tab/api-documentation-v4-main-pages-tab.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/documentation-v4/main-pages-tab/api-documentation-v4-main-pages-tab.component.spec.ts
@@ -37,6 +37,11 @@ import { PageType } from '../../../../entities/page';
 import { CONSTANTS_TESTING, GioTestingModule } from '../../../../shared/testing';
 import { ApiDocumentationV4Module } from '../api-documentation-v4.module';
 import { ApiLifecycleState, Breadcrumb, fakeApiV4, fakeMarkdown, Page } from '../../../../entities/management-api-v2';
+import { EnvironmentSettingsService } from '../../../../services-ngx/environment-settings.service';
+import { PortalNavigationItemService } from '../../../../services-ngx/portal-navigation-item.service';
+import { ClassicPortalOnlyBannerHarness } from '../../../../shared/components/classic-portal-only-banner/classic-portal-only-banner.component.harness';
+
+const ENV_HRID = 'my-env';
 
 describe('ApiDocumentationV4MainPagesTab', () => {
   let fixture: ComponentFixture<ApiDocumentationV4MainPagesTabComponent>;
@@ -51,6 +56,8 @@ describe('ApiDocumentationV4MainPagesTab', () => {
     parentId = 'ROOT',
     portalUrl = 'portal.url',
     apiLifecycleStatus: ApiLifecycleState = 'PUBLISHED',
+    portalNextEnabled = false,
+    permissions: string[] = ['api-documentation-u', 'api-documentation-c', 'api-documentation-r', 'api-documentation-d'],
   ) => {
     await TestBed.configureTestingModule({
       declarations: [ApiDocumentationV4MainPagesTabComponent],
@@ -61,11 +68,12 @@ describe('ApiDocumentationV4MainPagesTab', () => {
           useValue: {
             params: of({ apiId: API_ID }),
             queryParams: new BehaviorSubject({ parentId }),
+            snapshot: { params: { apiId: API_ID, envHrid: ENV_HRID } },
           },
         },
         {
           provide: GioTestingPermissionProvider,
-          useValue: ['api-documentation-u', 'api-documentation-c', 'api-documentation-r', 'api-documentation-d'],
+          useValue: permissions,
         },
         {
           provide: Constants,
@@ -78,6 +86,14 @@ describe('ApiDocumentationV4MainPagesTab', () => {
             });
             return constants;
           },
+        },
+        {
+          provide: EnvironmentSettingsService,
+          useValue: { isPortalNextEnabled: () => of(portalNextEnabled) },
+        },
+        {
+          provide: PortalNavigationItemService,
+          useValue: { getNavigationItems: () => of({ items: [] }) },
         },
       ],
     })
@@ -110,6 +126,50 @@ describe('ApiDocumentationV4MainPagesTab', () => {
   afterEach(() => {
     httpTestingController.verify();
     jest.resetAllMocks();
+  });
+
+  describe('Classic Portal Only banner', () => {
+    it('should show the banner when portalNext is enabled', async () => {
+      await init([], [], 'ROOT', 'portal.url', 'PUBLISHED', true);
+      const banner = await harnessLoader.getHarness(ClassicPortalOnlyBannerHarness);
+      expect(await banner.isBannerContentVisible()).toBe(true);
+    });
+
+    it('should hide the banner when portalNext is disabled', async () => {
+      await init([], [], 'ROOT', 'portal.url', 'PUBLISHED', false);
+      const banner = await harnessLoader.getHarness(ClassicPortalOnlyBannerHarness);
+      expect(await banner.isBannerContentVisible()).toBe(false);
+    });
+
+    it('should show the settings action when portalNext is enabled and user has environment-settings permission', async () => {
+      await init([], [], 'ROOT', 'portal.url', 'PUBLISHED', true, [
+        'api-documentation-u',
+        'api-documentation-c',
+        'api-documentation-r',
+        'api-documentation-d',
+        'environment-settings-r',
+      ]);
+      const banner = await harnessLoader.getHarness(ClassicPortalOnlyBannerHarness);
+      expect(await banner.isSettingsActionVisible()).toBe(true);
+    });
+
+    it('should hide the settings action when user lacks environment-settings permission', async () => {
+      await init([], [], 'ROOT', 'portal.url', 'PUBLISHED', true, [
+        'api-documentation-u',
+        'api-documentation-c',
+        'api-documentation-r',
+        'api-documentation-d',
+      ]);
+      const banner = await harnessLoader.getHarness(ClassicPortalOnlyBannerHarness);
+      expect(await banner.isSettingsActionVisible()).toBe(false);
+    });
+
+    it('should show the settings action with a link when envHrid is in route and user has environment-settings permission', async () => {
+      await init([], [], 'ROOT', 'portal.url', 'PUBLISHED', true, ['api-documentation-u', 'api-documentation-c', 'environment-settings-r']);
+      fixture.detectChanges();
+      const banner = await harnessLoader.getHarness(ClassicPortalOnlyBannerHarness);
+      expect(await banner.isSettingsActionVisible()).toBe(true);
+    });
   });
 
   describe('API does not have pages', () => {

--- a/gravitee-apim-console-webui/src/management/api/general-info/api-general-info-danger-zone/api-general-info-danger-zone.component.html
+++ b/gravitee-apim-console-webui/src/management/api/general-info/api-general-info-danger-zone/api-general-info-danger-zone.component.html
@@ -56,6 +56,14 @@
           </gio-license-banner>
         </div>
 
+        @if (
+          dangerActions.canChangeApiLifecycle || dangerActions.canChangeVisibilityToPublic || dangerActions.canChangeVisibilityToPrivate
+        ) {
+          <classic-portal-only-banner
+            body="These actions only affect Classic Developer Portal visibility and publication. Manage Next Gen Portal API visibility in Next Gen Portal settings."
+          />
+        }
+
         <div *ngIf="dangerActions.canChangeApiLifecycle" class="danger-card__actions__action">
           <ng-container *ngIf="dangerActions.canPublish">
             <span> Publish the {{ subject }}. It will be available on portal (depending on visibility/rights). </span>

--- a/gravitee-apim-console-webui/src/management/api/general-info/api-general-info-danger-zone/api-general-info-danger-zone.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/general-info/api-general-info-danger-zone/api-general-info-danger-zone.component.spec.ts
@@ -24,10 +24,13 @@ import { MatDialogHarness } from '@angular/material/dialog/testing';
 import { GioConfirmAndValidateDialogHarness, LICENSE_CONFIGURATION_TESTING } from '@gravitee/ui-particles-angular';
 import { HarnessLoader } from '@angular/cdk/testing';
 import { SimpleChange } from '@angular/core';
-import { Router } from '@angular/router';
+import { ActivatedRoute, Router } from '@angular/router';
+import { of } from 'rxjs';
 
 import { ApiGeneralInfoDangerZoneComponent } from './api-general-info-danger-zone.component';
 
+import { EnvironmentSettingsService } from '../../../../services-ngx/environment-settings.service';
+import { ClassicPortalOnlyBannerHarness } from '../../../../shared/components/classic-portal-only-banner/classic-portal-only-banner.component.harness';
 import { ApiGeneralInfoModule } from '../api-general-info.module';
 import { CONSTANTS_TESTING, GioTestingModule } from '../../../../shared/testing';
 import { Api, fakeApiV2, fakeApiV4 } from '../../../../entities/management-api-v2';
@@ -43,6 +46,7 @@ describe('ApiGeneralInfoDangerZoneComponent', () => {
   let httpTestingController: HttpTestingController;
   let routerNavigateSpy: jest.SpyInstance;
   let component: ApiGeneralInfoDangerZoneComponent;
+  let portalNextEnabled = false;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
@@ -76,6 +80,14 @@ describe('ApiGeneralInfoDangerZoneComponent', () => {
               },
             },
           },
+        },
+        {
+          provide: EnvironmentSettingsService,
+          useValue: { isPortalNextEnabled: () => of(portalNextEnabled) },
+        },
+        {
+          provide: ActivatedRoute,
+          useValue: { snapshot: { params: { envHrid: 'test-env' } } },
         },
       ],
     }).overrideProvider(InteractivityChecker, {
@@ -328,6 +340,71 @@ describe('ApiGeneralInfoDangerZoneComponent', () => {
     const detachButtons = await loader.getAllHarnesses(MatButtonHarness.with({ text: 'Detach the API' }));
 
     expect(detachButtons.length).toBe(0);
+  });
+
+  describe('Classic Developer Portal Only banner', () => {
+    it('should show banner when portalNext is enabled and publish action is present', async () => {
+      portalNextEnabled = true;
+      const api = fakeApiV2({ id: API_ID, lifecycleState: 'CREATED' });
+      createComponent(api);
+
+      const banner = await loader.getHarness(ClassicPortalOnlyBannerHarness);
+      expect(await banner.isBannerContentVisible()).toBe(true);
+    });
+
+    it('should show banner when portalNext is enabled and visibility action is present', async () => {
+      portalNextEnabled = true;
+      const api = fakeApiV2({ id: API_ID, visibility: 'PRIVATE', lifecycleState: 'PUBLISHED' });
+      createComponent(api);
+
+      const banner = await loader.getHarness(ClassicPortalOnlyBannerHarness);
+      expect(await banner.isBannerContentVisible()).toBe(true);
+    });
+
+    it('should hide banner when portalNext is disabled', async () => {
+      portalNextEnabled = false;
+      const api = fakeApiV2({ id: API_ID, lifecycleState: 'CREATED' });
+      createComponent(api);
+
+      const banner = await loader.getHarness(ClassicPortalOnlyBannerHarness);
+      expect(await banner.isBannerContentVisible()).toBe(false);
+    });
+
+    it('should hide banner when no portal-affecting actions are visible', async () => {
+      portalNextEnabled = true;
+      // DEPRECATED api with DRAFT workflowState: canChangeApiLifecycle=false, canChangeVisibilityToPublic=false, canChangeVisibilityToPrivate=false
+      const api = fakeApiV2({ id: API_ID, lifecycleState: 'DEPRECATED', workflowState: 'DRAFT' });
+      createComponent(api);
+
+      const banners = await loader.getAllHarnesses(ClassicPortalOnlyBannerHarness);
+      for (const banner of banners) {
+        expect(await banner.isBannerContentVisible()).toBe(false);
+      }
+    });
+
+    it('should hide settings action when environment-settings permission is missing', async () => {
+      portalNextEnabled = true;
+      // GioTestingPermissionProvider only provides api-definition-u and api-definition-d, no environment-settings
+      const api = fakeApiV2({ id: API_ID, lifecycleState: 'CREATED' });
+      createComponent(api);
+
+      const banner = await loader.getHarness(ClassicPortalOnlyBannerHarness);
+      expect(await banner.isBannerContentVisible()).toBe(true);
+      expect(await banner.isSettingsActionVisible()).toBe(false);
+    });
+
+    it('should show settings action when user has environment-settings-r permission', async () => {
+      TestBed.overrideProvider(GioTestingPermissionProvider, {
+        useValue: ['api-definition-u', 'api-definition-d', 'environment-settings-r'],
+      });
+      portalNextEnabled = true;
+      const api = fakeApiV2({ id: API_ID, lifecycleState: 'CREATED' });
+      createComponent(api);
+
+      const banner = await loader.getHarness(ClassicPortalOnlyBannerHarness);
+      expect(await banner.isBannerContentVisible()).toBe(true);
+      expect(await banner.isSettingsActionVisible()).toBe(true);
+    });
   });
 
   function expectApiGetRequest(api: Api) {

--- a/gravitee-apim-console-webui/src/management/api/general-info/api-general-info-danger-zone/api-general-info-danger-zone.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/general-info/api-general-info-danger-zone/api-general-info-danger-zone.component.ts
@@ -42,6 +42,17 @@ import { ApimFeature, UTMTags } from '../../../../shared/components/gio-license/
   standalone: false,
 })
 export class ApiGeneralInfoDangerZoneComponent implements OnChanges, OnDestroy, OnInit {
+  constructor(
+    private readonly router: Router,
+    private readonly activatedRoute: ActivatedRoute,
+    private readonly apiReviewV2Service: ApiReviewV2Service,
+    private readonly apiService: ApiV2Service,
+    private readonly matDialog: MatDialog,
+    private readonly snackBarService: SnackBarService,
+    @Inject(Constants) private readonly constants: Constants,
+    private readonly licenseService: GioLicenseService,
+  ) {}
+
   private unsubscribe$: Subject<boolean> = new Subject<boolean>();
 
   private licenseOptions = {
@@ -79,17 +90,6 @@ export class ApiGeneralInfoDangerZoneComponent implements OnChanges, OnDestroy, 
   public isOEM$: Observable<boolean>;
   public shouldUpgrade: boolean;
   public subject = 'API';
-
-  constructor(
-    private readonly router: Router,
-    private readonly activatedRoute: ActivatedRoute,
-    private readonly apiReviewV2Service: ApiReviewV2Service,
-    private readonly apiService: ApiV2Service,
-    private readonly matDialog: MatDialog,
-    private readonly snackBarService: SnackBarService,
-    @Inject(Constants) private readonly constants: Constants,
-    private readonly licenseService: GioLicenseService,
-  ) {}
 
   ngOnInit(): void {
     this.updateOriginContextState();

--- a/gravitee-apim-console-webui/src/management/api/general-info/api-general-info.module.ts
+++ b/gravitee-apim-console-webui/src/management/api/general-info/api-general-info.module.ts
@@ -57,6 +57,7 @@ import { GioPermissionModule } from '../../../shared/components/gio-permission/g
 import { GioCircularPercentageModule } from '../../../shared/components/gio-circular-percentage/gio-circular-percentage.module';
 import { GioApiImportDialogModule } from '../component/gio-api-import-dialog/gio-api-import-dialog.module';
 import { GioLicenseBannerModule } from '../../../shared/components/gio-license-banner/gio-license-banner.module';
+import { ClassicPortalOnlyBannerComponent } from '../../../shared/components/classic-portal-only-banner/classic-portal-only-banner.component';
 
 @NgModule({
   declarations: [
@@ -103,6 +104,7 @@ import { GioLicenseBannerModule } from '../../../shared/components/gio-license-b
     GioLicenseBannerModule,
     ApiGeneralInfoAgentCardComponent,
     ApiImportV4FormDialogComponent,
+    ClassicPortalOnlyBannerComponent,
   ],
 })
 export class ApiGeneralInfoModule {}

--- a/gravitee-apim-console-webui/src/services-ngx/environment-settings.service.spec.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/environment-settings.service.spec.ts
@@ -75,6 +75,42 @@ describe('EnvironmentSettingsService', () => {
     expect(expectedGetSettingsSecondValue).toEqual([envSettingsMock]);
   });
 
+  describe('isPortalNextEnabled', () => {
+    it('should emit true when portalNext.access.enabled is true', () => {
+      const emitted: boolean[] = [];
+      environmentSettingsService.isPortalNextEnabled().subscribe(value => emitted.push(value));
+
+      environmentSettingsService.load().subscribe();
+      expectGetEnvironmentSettingsRequest({
+        portalNext: { access: { enabled: true }, banner: { enabled: false, title: '', subtitle: '' } },
+      });
+
+      expect(emitted).toEqual([true]);
+    });
+
+    it('should emit false when portalNext.access.enabled is false', () => {
+      const emitted: boolean[] = [];
+      environmentSettingsService.isPortalNextEnabled().subscribe(value => emitted.push(value));
+
+      environmentSettingsService.load().subscribe();
+      expectGetEnvironmentSettingsRequest({
+        portalNext: { access: { enabled: false }, banner: { enabled: false, title: '', subtitle: '' } },
+      });
+
+      expect(emitted).toEqual([false]);
+    });
+
+    it('should emit false when portalNext is missing from settings', () => {
+      const emitted: boolean[] = [];
+      environmentSettingsService.isPortalNextEnabled().subscribe(value => emitted.push(value));
+
+      environmentSettingsService.load().subscribe();
+      expectGetEnvironmentSettingsRequest({ analytics: { clientTimeout: 300 } } as Partial<EnvSettings>);
+
+      expect(emitted).toEqual([false]);
+    });
+  });
+
   function expectGetEnvironmentSettingsRequest(envSettings: Partial<EnvSettings>) {
     httpTestingController
       .expectOne({

--- a/gravitee-apim-console-webui/src/services-ngx/environment-settings.service.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/environment-settings.service.ts
@@ -53,4 +53,8 @@ export class EnvironmentSettingsService {
   getSnapshot(): EnvSettings {
     return this.currentSettings.getValue();
   }
+
+  isPortalNextEnabled(): Observable<boolean> {
+    return this.get().pipe(map(settings => settings?.portalNext?.access?.enabled === true));
+  }
 }

--- a/gravitee-apim-console-webui/src/shared/components/classic-portal-only-banner/classic-portal-only-banner.component.harness.ts
+++ b/gravitee-apim-console-webui/src/shared/components/classic-portal-only-banner/classic-portal-only-banner.component.harness.ts
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ComponentHarness } from '@angular/cdk/testing';
+
+export class ClassicPortalOnlyBannerHarness extends ComponentHarness {
+  public static readonly hostSelector = 'classic-portal-only-banner';
+
+  private readonly getBannerInfoElement = this.locatorForOptional('gio-banner-info');
+  private readonly getTitleElement = this.locatorFor('[data-testid="banner-title"]');
+  private readonly getBodyElement = this.locatorForOptional('[data-testid="banner-body"]');
+  private readonly getSettingsActionElement = this.locatorForOptional('[data-testid="settings-action"]');
+
+  public async isBannerContentVisible(): Promise<boolean> {
+    return (await this.getBannerInfoElement()) !== null;
+  }
+
+  public async getTitleText(): Promise<string> {
+    return (await this.getTitleElement()).text();
+  }
+
+  public async getBodyText(): Promise<string | null> {
+    const element = await this.getBodyElement();
+    return element ? element.text() : null;
+  }
+
+  public async getSettingsActionText(): Promise<string | null> {
+    const element = await this.getSettingsActionElement();
+    return element ? element.text() : null;
+  }
+
+  public async isSettingsActionVisible(): Promise<boolean> {
+    return (await this.getSettingsActionElement()) !== null;
+  }
+
+  public async getSettingsActionRelAttribute(): Promise<string | null> {
+    const element = await this.getSettingsActionElement();
+    return element ? element.getAttribute('rel') : null;
+  }
+
+  public async getSettingsActionHref(): Promise<string | null> {
+    const element = await this.getSettingsActionElement();
+    return element ? element.getAttribute('href') : null;
+  }
+}

--- a/gravitee-apim-console-webui/src/shared/components/classic-portal-only-banner/classic-portal-only-banner.component.html
+++ b/gravitee-apim-console-webui/src/shared/components/classic-portal-only-banner/classic-portal-only-banner.component.html
@@ -1,0 +1,38 @@
+<!--
+
+    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+@if (isPortalNextEnabled()) {
+  <gio-banner-info>
+    <span data-testid="banner-title">{{ title() }}</span>
+    @if (body()) {
+      <span gioBannerBody data-testid="banner-body">{{ body() }}</span>
+    }
+    @if (canShowSettingsAction && settingsRouterLink) {
+      <div gioBannerAction>
+        <a
+          mat-stroked-button
+          target="_blank"
+          rel="noopener noreferrer"
+          [routerLink]="settingsRouterLink"
+          [queryParams]="settingsRouterLinkQueryParams()"
+          data-testid="settings-action"
+          >{{ actionLabel() }}</a
+        >
+      </div>
+    }
+  </gio-banner-info>
+}

--- a/gravitee-apim-console-webui/src/shared/components/classic-portal-only-banner/classic-portal-only-banner.component.scss
+++ b/gravitee-apim-console-webui/src/shared/components/classic-portal-only-banner/classic-portal-only-banner.component.scss
@@ -13,37 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-@use 'sass:map';
-
-.gio-side-nav {
-  height: 100%;
-  display: flex;
-  flex-direction: column;
-  z-index: 1;
-
-  &__menu {
-    flex: 1 1 auto;
-
-    &__selector {
-      margin-bottom: 24px;
-    }
-  }
-
-  a {
-    text-decoration: none;
-  }
-
-  &__external-label {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-
-    mat-icon {
-      width: 12px;
-      height: 12px;
-      font-size: 12px;
-      line-height: 1;
-      overflow: visible;
-    }
-  }
+:host {
+  display: block;
 }

--- a/gravitee-apim-console-webui/src/shared/components/classic-portal-only-banner/classic-portal-only-banner.component.spec.ts
+++ b/gravitee-apim-console-webui/src/shared/components/classic-portal-only-banner/classic-portal-only-banner.component.spec.ts
@@ -1,0 +1,241 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Component } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { HarnessLoader } from '@angular/cdk/testing';
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { ActivatedRoute, provideRouter } from '@angular/router';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { MatIconTestingModule } from '@angular/material/icon/testing';
+import { BehaviorSubject, of } from 'rxjs';
+
+import { ClassicPortalOnlyBannerComponent } from './classic-portal-only-banner.component';
+import { ClassicPortalOnlyBannerHarness } from './classic-portal-only-banner.component.harness';
+
+import { EnvironmentSettingsService } from '../../../services-ngx/environment-settings.service';
+import { GioPermissionService } from '../gio-permission/gio-permission.service';
+import { PortalNavigationItemService } from '../../../services-ngx/portal-navigation-item.service';
+import { PortalNavigationItem } from '../../../entities/management-api-v2';
+import { fakePortalNavigationApi } from '../../../entities/management-api-v2/portalNavigationItem/portalNavigationItem.fixture';
+
+@Component({
+  template: ` <classic-portal-only-banner [title]="title" [body]="body" [actionLabel]="actionLabel" /> `,
+  standalone: true,
+  imports: [ClassicPortalOnlyBannerComponent],
+})
+class TestHostComponent {
+  title = 'Classic Developer Portal Only';
+  body = '';
+  actionLabel = 'Next Gen Portal Settings';
+}
+
+function buildTestBed(
+  portalNextEnabled$: BehaviorSubject<boolean>,
+  hasSettingsPermission = true,
+  envHrid: string | null = 'test-env',
+  apiId: string | null = null,
+  navigationItems: PortalNavigationItem[] = [],
+) {
+  return TestBed.configureTestingModule({
+    imports: [TestHostComponent, MatIconTestingModule],
+    providers: [
+      provideRouter([]),
+      provideNoopAnimations(),
+      {
+        provide: EnvironmentSettingsService,
+        useValue: { isPortalNextEnabled: () => portalNextEnabled$.asObservable() },
+      },
+      {
+        provide: GioPermissionService,
+        useValue: { hasAnyMatching: () => hasSettingsPermission },
+      },
+      {
+        provide: ActivatedRoute,
+        useValue: { snapshot: { params: { ...(envHrid != null ? { envHrid } : {}), ...(apiId != null ? { apiId } : {}) } } },
+      },
+      {
+        provide: PortalNavigationItemService,
+        useValue: { getNavigationItems: () => of({ items: navigationItems }) },
+      },
+    ],
+  }).compileComponents();
+}
+
+describe('ClassicPortalOnlyBannerComponent — portal-next gating', () => {
+  let fixture: ComponentFixture<TestHostComponent>;
+  let loader: HarnessLoader;
+  let harness: ClassicPortalOnlyBannerHarness;
+  let portalNextEnabled$: BehaviorSubject<boolean>;
+
+  beforeEach(async () => {
+    portalNextEnabled$ = new BehaviorSubject<boolean>(false);
+    await buildTestBed(portalNextEnabled$);
+
+    fixture = TestBed.createComponent(TestHostComponent);
+    loader = TestbedHarnessEnvironment.loader(fixture);
+    harness = await loader.getHarness(ClassicPortalOnlyBannerHarness);
+    fixture.detectChanges();
+  });
+
+  it('should show the banner when portalNext.access.enabled is true', async () => {
+    portalNextEnabled$.next(true);
+    fixture.detectChanges();
+    expect(await harness.isBannerContentVisible()).toBe(true);
+  });
+
+  it('should hide the banner when portalNext.access.enabled is false', async () => {
+    portalNextEnabled$.next(false);
+    fixture.detectChanges();
+    expect(await harness.isBannerContentVisible()).toBe(false);
+  });
+
+  it('should hide the banner before the settings have been loaded (initial false value)', async () => {
+    expect(await harness.isBannerContentVisible()).toBe(false);
+  });
+
+  it('should update visibility reactively when the setting changes', async () => {
+    portalNextEnabled$.next(true);
+    fixture.detectChanges();
+    expect(await harness.isBannerContentVisible()).toBe(true);
+
+    portalNextEnabled$.next(false);
+    fixture.detectChanges();
+    expect(await harness.isBannerContentVisible()).toBe(false);
+  });
+});
+
+describe('ClassicPortalOnlyBannerComponent — inputs', () => {
+  let fixture: ComponentFixture<TestHostComponent>;
+  let host: TestHostComponent;
+  let loader: HarnessLoader;
+  let harness: ClassicPortalOnlyBannerHarness;
+
+  beforeEach(async () => {
+    const portalNextEnabled$ = new BehaviorSubject<boolean>(true);
+    await buildTestBed(portalNextEnabled$);
+
+    fixture = TestBed.createComponent(TestHostComponent);
+    host = fixture.componentInstance;
+    loader = TestbedHarnessEnvironment.loader(fixture);
+    harness = await loader.getHarness(ClassicPortalOnlyBannerHarness);
+    fixture.detectChanges();
+  });
+
+  it('should render the default title', async () => {
+    expect(await harness.getTitleText()).toBe('Classic Developer Portal Only');
+  });
+
+  it('should render a custom title', async () => {
+    host.title = 'Custom Title';
+    fixture.detectChanges();
+    expect(await harness.getTitleText()).toBe('Custom Title');
+  });
+
+  it('should not render the body when body input is empty', async () => {
+    expect(await harness.getBodyText()).toBeNull();
+  });
+
+  it('should render the body when body input is provided', async () => {
+    host.body = 'This documentation is used by the Classic Developer Portal.';
+    fixture.detectChanges();
+    expect(await harness.getBodyText()).toBe('This documentation is used by the Classic Developer Portal.');
+  });
+
+  it('should show the settings action with default label', async () => {
+    expect(await harness.isSettingsActionVisible()).toBe(true);
+    expect(await harness.getSettingsActionText()).toBe('Next Gen Portal Settings');
+  });
+
+  it('should show the settings action with a custom label', async () => {
+    host.actionLabel = 'Go to Portal Settings';
+    fixture.detectChanges();
+    expect(await harness.getSettingsActionText()).toBe('Go to Portal Settings');
+  });
+
+  it('should set rel="noopener noreferrer" on the settings action link', async () => {
+    expect(await harness.getSettingsActionRelAttribute()).toBe('noopener noreferrer');
+  });
+});
+
+describe('ClassicPortalOnlyBannerComponent — settings action permission and route gating', () => {
+  const portalNextEnabled$ = new BehaviorSubject<boolean>(true);
+
+  it('should show the settings action when user has environment-settings-r and envHrid is in route', async () => {
+    await buildTestBed(portalNextEnabled$, true, 'my-env');
+    const fixture = TestBed.createComponent(TestHostComponent);
+    const loader = TestbedHarnessEnvironment.loader(fixture);
+    fixture.detectChanges();
+    const harness = await loader.getHarness(ClassicPortalOnlyBannerHarness);
+    expect(await harness.isSettingsActionVisible()).toBe(true);
+  });
+
+  it('should hide the settings action when user lacks environment-settings permissions', async () => {
+    await buildTestBed(portalNextEnabled$, false, 'my-env');
+    const fixture = TestBed.createComponent(TestHostComponent);
+    const loader = TestbedHarnessEnvironment.loader(fixture);
+    fixture.detectChanges();
+    const harness = await loader.getHarness(ClassicPortalOnlyBannerHarness);
+    expect(await harness.isSettingsActionVisible()).toBe(false);
+  });
+
+  it('should hide the settings action when route has no envHrid', async () => {
+    await buildTestBed(portalNextEnabled$, true, null);
+    const fixture = TestBed.createComponent(TestHostComponent);
+    const loader = TestbedHarnessEnvironment.loader(fixture);
+    fixture.detectChanges();
+    const harness = await loader.getHarness(ClassicPortalOnlyBannerHarness);
+    expect(await harness.isSettingsActionVisible()).toBe(false);
+  });
+});
+
+describe('ClassicPortalOnlyBannerComponent — navId query param resolution', () => {
+  const portalNextEnabled$ = new BehaviorSubject<boolean>(true);
+
+  it('should include navId query param in the settings link when apiId matches a navigation item', async () => {
+    const navItem = fakePortalNavigationApi({ id: 'nav-id-1', apiId: 'my-api-id' });
+    await buildTestBed(portalNextEnabled$, true, 'test-env', 'my-api-id', [navItem]);
+    const fixture = TestBed.createComponent(TestHostComponent);
+    const harness = await TestbedHarnessEnvironment.loader(fixture).getHarness(ClassicPortalOnlyBannerHarness);
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    expect(await harness.getSettingsActionHref()).toContain('navId=nav-id-1');
+  });
+
+  it('should not include navId query param when no navigation item matches the apiId', async () => {
+    const navItem = fakePortalNavigationApi({ id: 'nav-id-1', apiId: 'other-api-id' });
+    await buildTestBed(portalNextEnabled$, true, 'test-env', 'my-api-id', [navItem]);
+    const fixture = TestBed.createComponent(TestHostComponent);
+    const harness = await TestbedHarnessEnvironment.loader(fixture).getHarness(ClassicPortalOnlyBannerHarness);
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    expect(await harness.getSettingsActionHref()).not.toContain('navId=');
+  });
+
+  it('should not include navId query param when no apiId is in the route', async () => {
+    await buildTestBed(portalNextEnabled$, true, 'test-env', null, []);
+    const fixture = TestBed.createComponent(TestHostComponent);
+    const harness = await TestbedHarnessEnvironment.loader(fixture).getHarness(ClassicPortalOnlyBannerHarness);
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    expect(await harness.getSettingsActionHref()).not.toContain('navId=');
+  });
+});

--- a/gravitee-apim-console-webui/src/shared/components/classic-portal-only-banner/classic-portal-only-banner.component.ts
+++ b/gravitee-apim-console-webui/src/shared/components/classic-portal-only-banner/classic-portal-only-banner.component.ts
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Component, computed, inject, input } from '@angular/core';
+import { rxResource, toSignal } from '@angular/core/rxjs-interop';
+import { ActivatedRoute, RouterLink } from '@angular/router';
+import { MatButtonModule } from '@angular/material/button';
+import { GioBannerModule } from '@gravitee/ui-particles-angular';
+import { map, of } from 'rxjs';
+
+import { EnvironmentSettingsService } from '../../../services-ngx/environment-settings.service';
+import { GioPermissionService } from '../gio-permission/gio-permission.service';
+import { PortalNavigationItemService } from '../../../services-ngx/portal-navigation-item.service';
+import { PortalNavigationApi } from '../../../entities/management-api-v2';
+
+@Component({
+  selector: 'classic-portal-only-banner',
+  standalone: true,
+  imports: [GioBannerModule, RouterLink, MatButtonModule],
+  templateUrl: './classic-portal-only-banner.component.html',
+  styleUrl: './classic-portal-only-banner.component.scss',
+})
+export class ClassicPortalOnlyBannerComponent {
+  private readonly environmentSettingsService = inject(EnvironmentSettingsService);
+  private readonly permissionService = inject(GioPermissionService);
+  private readonly activatedRoute = inject(ActivatedRoute);
+  private readonly portalNavigationItemService = inject(PortalNavigationItemService);
+
+  title = input('Classic Developer Portal Only');
+  body = input('');
+  actionLabel = input('Next Gen Portal Settings');
+
+  protected readonly canShowSettingsAction: boolean = this.permissionService.hasAnyMatching([
+    'environment-settings-r',
+    'environment-settings-u',
+  ]);
+  protected readonly settingsRouterLink: string[] | null = (() => {
+    const envHrid = this.activatedRoute.snapshot.params['envHrid'];
+    return envHrid ? ['/', envHrid, '_portal', 'navigation'] : null;
+  })();
+  private readonly apiId: string | null = this.activatedRoute.snapshot.params['apiId'] ?? null;
+
+  protected readonly isPortalNextEnabled = toSignal(this.environmentSettingsService.isPortalNextEnabled(), { initialValue: false });
+
+  protected readonly navItemResource = rxResource({
+    params: () => (this.isPortalNextEnabled() && this.apiId ? this.apiId : null),
+    stream: ({ params: apiId }) =>
+      apiId
+        ? this.portalNavigationItemService.getNavigationItems('TOP_NAVBAR').pipe(
+            map(({ items }) => {
+              const matchingItem = items.find((i): i is PortalNavigationApi => i.type === 'API' && i.apiId === apiId);
+              return matchingItem?.id ?? null;
+            }),
+          )
+        : of(null),
+  });
+
+  protected readonly settingsRouterLinkQueryParams = computed(() => {
+    const navId = this.navItemResource.value();
+    return navId ? { navId } : null;
+  });
+}

--- a/gravitee-apim-console-webui/src/shared/components/classic-portal-only-banner/classic-portal-only-banner.stories.ts
+++ b/gravitee-apim-console-webui/src/shared/components/classic-portal-only-banner/classic-portal-only-banner.stories.ts
@@ -1,0 +1,94 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { applicationConfig, Meta, StoryObj } from '@storybook/angular';
+import { ActivatedRoute, provideRouter } from '@angular/router';
+import { of } from 'rxjs';
+
+import { ClassicPortalOnlyBannerComponent } from './classic-portal-only-banner.component';
+
+import { EnvironmentSettingsService } from '../../../services-ngx/environment-settings.service';
+import { GioPermissionService } from '../gio-permission/gio-permission.service';
+
+const withPortalNextDisabled = applicationConfig({
+  providers: [
+    provideRouter([]),
+    { provide: EnvironmentSettingsService, useValue: { isPortalNextEnabled: () => of(false) } },
+    { provide: GioPermissionService, useValue: { hasAnyMatching: () => false } },
+    { provide: ActivatedRoute, useValue: { snapshot: { params: {} } } },
+  ],
+});
+
+const withPortalNextEnabledNoAction = applicationConfig({
+  providers: [
+    provideRouter([]),
+    { provide: EnvironmentSettingsService, useValue: { isPortalNextEnabled: () => of(true) } },
+    { provide: GioPermissionService, useValue: { hasAnyMatching: () => false } },
+    { provide: ActivatedRoute, useValue: { snapshot: { params: {} } } },
+  ],
+});
+
+const withPortalNextEnabledAndAction = applicationConfig({
+  providers: [
+    provideRouter([]),
+    { provide: EnvironmentSettingsService, useValue: { isPortalNextEnabled: () => of(true) } },
+    { provide: GioPermissionService, useValue: { hasAnyMatching: () => true } },
+    { provide: ActivatedRoute, useValue: { snapshot: { params: { envHrid: 'my-env' } } } },
+  ],
+});
+
+export default {
+  title: 'Shared / Classic Portal Only Banner',
+  component: ClassicPortalOnlyBannerComponent,
+  render: ({ title, body, actionLabel }) => ({
+    props: { title, body, actionLabel },
+  }),
+} as Meta;
+
+export const Default: StoryObj = {
+  decorators: [withPortalNextDisabled],
+  args: {
+    title: 'Classic Developer Portal Only',
+    body: '',
+    actionLabel: 'Next Gen Portal Settings',
+  },
+};
+
+export const WithBody: StoryObj = {
+  decorators: [withPortalNextEnabledNoAction],
+  args: {
+    title: 'Classic Developer Portal Only',
+    body: 'This documentation is used by the Classic Developer Portal. Manage Next Gen Portal API content in Next Gen Portal settings.',
+    actionLabel: 'Next Gen Portal Settings',
+  },
+};
+
+export const WithAction: StoryObj = {
+  decorators: [withPortalNextEnabledAndAction],
+  args: {
+    title: 'Classic Developer Portal Only',
+    body: 'This documentation is used by the Classic Developer Portal. Manage Next Gen Portal API content in Next Gen Portal settings.',
+    actionLabel: 'Next Gen Portal Settings',
+  },
+};
+
+export const ApiConfiguration: StoryObj = {
+  decorators: [withPortalNextEnabledAndAction],
+  args: {
+    title: 'Classic Developer Portal Only',
+    body: 'These actions only affect Classic Developer Portal visibility and publication. Manage Next Gen Portal API visibility in Next Gen Portal settings.',
+    actionLabel: 'Next Gen Portal Settings',
+  },
+};


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/EXT-130

## Description

Added a banner in the Danger Zone that informs user that the changes there affect only old portal and provides a button to navigate to the Next gen portal settings. Also added the navigation on the side bar. 

## Additional context

Updated the sidebar navigation menu item to have an option to open the link in a new tab. The Next-gen portal settings seem to have no navigation back to the APIM console so opening in the same tab seemed troublesome.

<img width="1436" height="710" alt="Zrzut ekranu 2026-06-17 o 23 15 52" src="https://github.com/user-attachments/assets/bfff7351-0325-4f66-967f-51aaabe56a02" />
<img width="1449" height="707" alt="Zrzut ekranu 2026-06-17 o 23 16 08" src="https://github.com/user-attachments/assets/c64dd770-8558-4d8f-8799-1a6b03724d2f" />
<img width="1451" height="718" alt="Zrzut ekranu 2026-06-17 o 23 16 24" src="https://github.com/user-attachments/assets/7736d3bf-eca1-4b39-8575-367f8b712cd2" />
<img width="211" height="179" alt="Zrzut ekranu 2026-06-17 o 23 16 32" src="https://github.com/user-attachments/assets/4a4ba591-a26d-4e91-a2d1-fe13db1bb38a" />


