### PR TITLE
Fix/ratelimit redis per event loop

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-redis/src/main/java/io/gravitee/repository/exception/RedisNotConnectedException.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-redis/src/main/java/io/gravitee/repository/exception/RedisNotConnectedException.java
@@ -25,4 +25,9 @@ public class RedisNotConnectedException extends Exception {
     public RedisNotConnectedException() {
         super("Connection to Redis not available");
     }
+
+    @Override
+    public synchronized Throwable fillInStackTrace() {
+        return this;
+    }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-redis/src/main/java/io/gravitee/repository/exception/RedisOperationTimeoutException.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-redis/src/main/java/io/gravitee/repository/exception/RedisOperationTimeoutException.java
@@ -25,4 +25,9 @@ public class RedisOperationTimeoutException extends Exception {
     public RedisOperationTimeoutException(int delayMs) {
         super("Operation on Redis took more than " + delayMs + "ms");
     }
+
+    @Override
+    public synchronized Throwable fillInStackTrace() {
+        return this;
+    }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-redis/src/main/java/io/gravitee/repository/redis/vertx/RedisClient.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-redis/src/main/java/io/gravitee/repository/redis/vertx/RedisClient.java
@@ -18,6 +18,7 @@ package io.gravitee.repository.redis.vertx;
 import io.gravitee.node.vertx.client.redis.VertxRedisClientFactory;
 import io.gravitee.plugin.configurations.redis.RedisClientOptions;
 import io.gravitee.repository.redis.ratelimit.RedisRateLimitRepository;
+import io.vertx.core.Context;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 import io.vertx.redis.client.Redis;
@@ -26,6 +27,7 @@ import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -41,17 +43,17 @@ public class RedisClient {
 
     private static final String SCRIPT_LOAD_COMMAND = "LOAD";
 
+    /**
+     * Shared by callers without a Vert.x context (health checks, tests, blocking threads).
+     */
+    private static final int FALLBACK_LOOP_KEY = 0;
+
     private final Vertx vertx;
     private final VertxRedisClientFactory factory;
     private final RedisClientOptions clientOptions;
     private final Map<String, String> scripts;
-    private final Map<String, String> scriptsSha = new ConcurrentHashMap<>();
     private final Map<String, String> scriptsSource = new ConcurrentHashMap<>();
-    private Future<RedisAPI> redisAPIFuture;
-
-    private final AtomicBoolean connected = new AtomicBoolean(false);
-    private final AtomicBoolean connecting = new AtomicBoolean(false);
-    private Redis redis;
+    private final ConcurrentHashMap<Integer, LoopRedis> loops = new ConcurrentHashMap<>();
 
     public RedisClient(
         final Vertx vertx,
@@ -63,98 +65,164 @@ public class RedisClient {
         this.factory = factory;
         this.clientOptions = clientOptions;
         this.scripts = scripts;
-        this.connect(0);
+        preloadScriptSources();
+        vertx.runOnContext(v -> redisApi());
     }
 
     public boolean isConnected() {
-        return connected.get();
-    }
-
-    private void connect(final int retry) {
-        if (redis != null) {
-            redis.close();
-            redis = null;
-            connected.set(false);
+        LoopRedis loop = loops.get(currentLoopKey());
+        if (loop != null && loop.connected.get()) {
+            return true;
         }
-
-        if (connecting.compareAndSet(false, true)) {
-            redis = factory.createClient(clientOptions);
-            this.redisAPIFuture = redis
-                .connect()
-                .onSuccess(conn -> {
-                    log.debug("Connected to Redis");
-                    conn.exceptionHandler(e -> attemptReconnect(0));
-                    conn.endHandler(v -> attemptReconnect(0));
-                })
-                .flatMap(redisConnection -> {
-                    RedisAPI redisAPI = RedisAPI.api(redisConnection);
-                    return loadScripts(redisAPI);
-                })
-                .onSuccess(redisAPI -> {
-                    log.info("Redis is now ready to be used.");
-                    connecting.set(false);
-                    connected.set(true);
-                })
-                .timeout(clientOptions.getConnectTimeout(), TimeUnit.MILLISECONDS)
-                .onFailure(t -> {
-                    log.error("Unable to connect to Redis", t);
-                    connected.set(false);
-                    attemptReconnect(retry);
-                });
-        }
-    }
-
-    private void attemptReconnect(int retry) {
-        connecting.set(false);
-        long backoff = (long) (Math.pow(2, Math.min(retry, 10)) * 10);
-        vertx.setTimer(backoff, timer -> connect(retry + 1));
-    }
-
-    private Future<RedisAPI> loadScripts(final RedisAPI redisAPI) {
-        if (scripts != null) {
-            return Future.all(
-                scripts
-                    .entrySet()
-                    .stream()
-                    .map(entry -> {
-                        String key = entry.getKey();
-                        String script = entry.getValue();
-                        try (InputStream stream = RedisRateLimitRepository.class.getClassLoader().getResourceAsStream(script)) {
-                            if (stream == null) {
-                                return Future.failedFuture(new IllegalStateException("Lua script not found on classpath: " + script));
-                            }
-                            String source = new String(stream.readAllBytes(), StandardCharsets.UTF_8);
-                            // Keep the source so consumers can fall back to EVAL when a clustered
-                            // node returns NOSCRIPT (SCRIPT LOAD only reaches the contacted node).
-                            scriptsSource.put(key, source);
-                            return redisAPI
-                                .script(Arrays.asList(SCRIPT_LOAD_COMMAND, source))
-                                .onSuccess(response -> {
-                                    log.debug("Lua script '{}' registered to Redis", script);
-                                    scriptsSha.put(key, response.toString());
-                                })
-                                .mapEmpty();
-                        } catch (Exception ex) {
-                            return Future.failedFuture(
-                                new IllegalStateException("Unexpected error while loading lua script '" + script + "'", ex)
-                            );
-                        }
-                    })
-                    .collect(Collectors.toList())
-            ).map(v -> redisAPI);
-        }
-        return Future.succeededFuture(redisAPI);
+        return loops
+            .values()
+            .stream()
+            .anyMatch(l -> l.connected.get());
     }
 
     public Future<RedisAPI> redisApi() {
-        return redisAPIFuture;
+        LoopRedis loop = resolveLoop();
+        synchronized (loop) {
+            if (loop.redisAPIFuture == null) {
+                startConnectLoop(loop, 0);
+            }
+            if (loop.redisAPIFuture == null) {
+                return Future.failedFuture("Redis connection is not available");
+            }
+            return loop.redisAPIFuture;
+        }
     }
 
     public String scriptSha1(final String key) {
-        return scriptsSha.get(key);
+        LoopRedis loop = loops.get(currentLoopKey());
+        if (loop != null) {
+            String sha = loop.scriptsSha.get(key);
+            if (sha != null) {
+                return sha;
+            }
+        }
+        return loops
+            .values()
+            .stream()
+            .map(l -> l.scriptsSha.get(key))
+            .filter(Objects::nonNull)
+            .findFirst()
+            .orElse(null);
     }
 
     public String scriptSource(final String key) {
         return scriptsSource.get(key);
+    }
+
+    private LoopRedis resolveLoop() {
+        return loops.computeIfAbsent(currentLoopKey(), k -> new LoopRedis());
+    }
+
+    private static int currentLoopKey() {
+        Context context = Vertx.currentContext();
+        if (context == null) {
+            return FALLBACK_LOOP_KEY;
+        }
+        return System.identityHashCode(context.owner());
+    }
+
+    private void startConnectLoop(final LoopRedis loop, final int retry) {
+        if (loop.redis != null) {
+            loop.redis.close();
+            loop.redis = null;
+            loop.connected.set(false);
+            loop.redisAPIFuture = null;
+        }
+
+        if (!loop.connecting.compareAndSet(false, true)) {
+            return;
+        }
+
+        loop.redis = factory.createClient(clientOptions);
+        loop.redisAPIFuture = loop.redis
+            .connect()
+            .onSuccess(conn -> {
+                log.debug("Connected to Redis on event loop {}", currentLoopKey());
+                conn.exceptionHandler(e -> attemptReconnect(loop, 0));
+                conn.endHandler(v -> attemptReconnect(loop, 0));
+            })
+            .flatMap(redisConnection -> loadScripts(RedisAPI.api(redisConnection), loop))
+            .onSuccess(redisAPI -> {
+                log.info("Redis is now ready to be used on event loop {}.", currentLoopKey());
+                loop.connecting.set(false);
+                loop.connected.set(true);
+            })
+            .timeout(clientOptions.getConnectTimeout(), TimeUnit.MILLISECONDS)
+            .onFailure(t -> {
+                log.error("Unable to connect to Redis on event loop {}", currentLoopKey(), t);
+                loop.connected.set(false);
+                loop.connecting.set(false);
+                loop.redisAPIFuture = null;
+                attemptReconnect(loop, retry);
+            });
+    }
+
+    private void attemptReconnect(final LoopRedis loop, int retry) {
+        loop.connecting.set(false);
+        long backoff = (long) (Math.pow(2, Math.min(retry, 10)) * 10);
+        vertx.setTimer(backoff, timer -> {
+            synchronized (loop) {
+                if (loop.connected.get()) {
+                    return;
+                }
+                startConnectLoop(loop, retry + 1);
+            }
+        });
+    }
+
+    private void preloadScriptSources() {
+        if (scripts == null) {
+            return;
+        }
+        scripts.forEach((key, scriptPath) -> {
+            try (InputStream stream = RedisRateLimitRepository.class.getClassLoader().getResourceAsStream(scriptPath)) {
+                if (stream == null) {
+                    throw new IllegalStateException("Lua script not found on classpath: " + scriptPath);
+                }
+                scriptsSource.put(key, new String(stream.readAllBytes(), StandardCharsets.UTF_8));
+            } catch (Exception ex) {
+                throw new IllegalStateException("Unexpected error while reading lua script '" + scriptPath + "'", ex);
+            }
+        });
+    }
+
+    private Future<RedisAPI> loadScripts(final RedisAPI redisAPI, final LoopRedis loop) {
+        if (scripts == null || scripts.isEmpty()) {
+            return Future.succeededFuture(redisAPI);
+        }
+        return Future.all(
+            scripts
+                .entrySet()
+                .stream()
+                .map(entry -> {
+                    String key = entry.getKey();
+                    String source = scriptsSource.get(key);
+                    if (source == null) {
+                        return Future.failedFuture(new IllegalStateException("Lua script source not loaded for key: " + key));
+                    }
+                    return redisAPI
+                        .script(Arrays.asList(SCRIPT_LOAD_COMMAND, source))
+                        .onSuccess(response -> {
+                            log.debug("Lua script '{}' registered to Redis", entry.getValue());
+                            loop.scriptsSha.put(key, response.toString());
+                        })
+                        .mapEmpty();
+                })
+                .collect(Collectors.toList())
+        ).map(v -> redisAPI);
+    }
+
+    private static final class LoopRedis {
+
+        private final AtomicBoolean connected = new AtomicBoolean(false);
+        private final AtomicBoolean connecting = new AtomicBoolean(false);
+        private final Map<String, String> scriptsSha = new ConcurrentHashMap<>();
+        private volatile Redis redis;
+        private volatile Future<RedisAPI> redisAPIFuture;
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-redis/src/test/java/io/gravitee/repository/exception/RedisExceptionTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-redis/src/test/java/io/gravitee/repository/exception/RedisExceptionTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.exception;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class RedisExceptionTest {
+
+    @Test
+    void redis_operation_timeout_exception_does_not_capture_stack_trace() {
+        var ex = new RedisOperationTimeoutException(10);
+
+        assertThat(ex.getMessage()).isEqualTo("Operation on Redis took more than 10ms");
+        assertThat(ex.getStackTrace()).isEmpty();
+    }
+
+    @Test
+    void redis_not_connected_exception_does_not_capture_stack_trace() {
+        var ex = new RedisNotConnectedException();
+
+        assertThat(ex.getMessage()).isEqualTo("Connection to Redis not available");
+        assertThat(ex.getStackTrace()).isEmpty();
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-redis/src/test/java/io/gravitee/repository/redis/vertx/RedisClientConcurrencyTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-redis/src/test/java/io/gravitee/repository/redis/vertx/RedisClientConcurrencyTest.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.redis.vertx;
+
+import static io.gravitee.repository.redis.ratelimit.RateLimitRepositoryConfiguration.SCRIPTS_RATELIMIT_LUA;
+import static io.gravitee.repository.redis.ratelimit.RateLimitRepositoryConfiguration.SCRIPT_RATELIMIT_KEY;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+import io.gravitee.platform.repository.api.Scope;
+import io.gravitee.repository.ratelimit.model.RateLimit;
+import io.gravitee.repository.redis.common.RedisConnectionFactory;
+import io.gravitee.repository.redis.ratelimit.RedisRateLimitRepository;
+import io.vertx.core.Vertx;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.springframework.mock.env.MockEnvironment;
+import org.testcontainers.DockerClientFactory;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.utility.DockerImageName;
+
+/**
+ * Stress-tests {@link RedisClient} and {@link RedisRateLimitRepository} under concurrent load.
+ * Complements unit tests; per-event-loop connection scaling is validated via k6 benchmarks.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class RedisClientConcurrencyTest {
+
+    private final Vertx vertx = Vertx.vertx();
+
+    private GenericContainer<?> redis;
+    private RedisRateLimitRepository repository;
+
+    @BeforeAll
+    void start_redis() throws Exception {
+        assumeTrue(DockerClientFactory.instance().isDockerAvailable(), "Docker not available");
+
+        redis = new GenericContainer<>(DockerImageName.parse("redis:7.4-alpine")).withExposedPorts(6379);
+        redis.start();
+
+        String propertyPrefix = Scope.RATE_LIMIT.getName() + ".redis.";
+        MockEnvironment environment = new MockEnvironment();
+        environment.setProperty(propertyPrefix + "host", redis.getHost());
+        environment.setProperty(propertyPrefix + "port", redis.getFirstMappedPort().toString());
+
+        RedisClient client = new RedisConnectionFactory(
+            environment,
+            vertx,
+            Scope.RATE_LIMIT.getName(),
+            Map.of(SCRIPT_RATELIMIT_KEY, SCRIPTS_RATELIMIT_LUA)
+        ).createRedisClient();
+
+        await_connected(client);
+        repository = new RedisRateLimitRepository(client, 2000);
+    }
+
+    @AfterAll
+    void stop_redis() {
+        if (redis != null) {
+            redis.stop();
+        }
+        vertx.close();
+    }
+
+    @Test
+    void should_increment_rate_limit_concurrently_without_errors() throws Exception {
+        int threads = 50;
+        ExecutorService pool = Executors.newFixedThreadPool(threads);
+        CountDownLatch done = new CountDownLatch(threads);
+        AtomicReference<Throwable> error = new AtomicReference<>();
+        AtomicInteger successes = new AtomicInteger();
+
+        for (int i = 0; i < threads; i++) {
+            pool.submit(() -> {
+                try {
+                    RateLimit rateLimit = repository
+                        .incrementAndGet("concurrent-key", 1, () -> {
+                            RateLimit rate = new RateLimit("concurrent-key");
+                            rate.setLimit(100_000);
+                            rate.setResetTime(System.currentTimeMillis() + 60_000);
+                            rate.setSubscription("sub");
+                            return rate;
+                        })
+                        .blockingGet();
+                    assertThat(rateLimit.getCounter()).isPositive();
+                    successes.incrementAndGet();
+                } catch (Throwable t) {
+                    error.compareAndSet(null, t);
+                } finally {
+                    done.countDown();
+                }
+            });
+        }
+
+        assertThat(done.await(30, TimeUnit.SECONDS)).isTrue();
+        pool.shutdown();
+
+        assertThat(error.get()).isNull();
+        assertThat(successes.get()).isEqualTo(threads);
+    }
+
+    private void await_connected(RedisClient client) throws Exception {
+        long deadline = System.currentTimeMillis() + 30_000;
+        while (!client.isConnected() && System.currentTimeMillis() < deadline) {
+            TimeUnit.MILLISECONDS.sleep(200);
+        }
+        assertThat(client.isConnected()).isTrue();
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-redis/src/test/java/io/gravitee/repository/redis/vertx/RedisClientTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-redis/src/test/java/io/gravitee/repository/redis/vertx/RedisClientTest.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.redis.vertx;
+
+import static io.gravitee.repository.redis.ratelimit.RateLimitRepositoryConfiguration.SCRIPTS_RATELIMIT_LUA;
+import static io.gravitee.repository.redis.ratelimit.RateLimitRepositoryConfiguration.SCRIPT_RATELIMIT_KEY;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+import io.gravitee.node.vertx.client.redis.VertxRedisClientFactory;
+import io.gravitee.plugin.configurations.redis.RedisClientOptions;
+import io.gravitee.repository.redis.common.RedisConnectionFactory;
+import io.vertx.core.Vertx;
+import io.vertx.redis.client.RedisAPI;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.springframework.mock.env.MockEnvironment;
+import org.testcontainers.DockerClientFactory;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.utility.DockerImageName;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class RedisClientTest {
+
+    private final Vertx vertx = Vertx.vertx();
+
+    private GenericContainer<?> redis;
+    private RedisClient client;
+
+    @BeforeAll
+    void start_redis() throws Exception {
+        assumeTrue(DockerClientFactory.instance().isDockerAvailable(), "Docker not available");
+
+        redis = new GenericContainer<>(DockerImageName.parse("redis:7.4-alpine")).withExposedPorts(6379);
+        redis.start();
+
+        client = createClient(Map.of(SCRIPT_RATELIMIT_KEY, SCRIPTS_RATELIMIT_LUA));
+        await_connected(client);
+    }
+
+    @AfterAll
+    void stop_redis() {
+        if (redis != null) {
+            redis.stop();
+        }
+        vertx.close();
+    }
+
+    @Test
+    void script_sha1_is_available_from_non_vertx_thread() throws Exception {
+        String sha = CompletableFuture.supplyAsync(() -> client.scriptSha1(SCRIPT_RATELIMIT_KEY)).get(10, TimeUnit.SECONDS);
+
+        assertThat(sha).isNotBlank();
+    }
+
+    @Test
+    void script_sha1_returns_null_for_unknown_key() {
+        assertThat(client.scriptSha1("unknown-key")).isNull();
+    }
+
+    @Test
+    void script_source_returns_preloaded_lua() {
+        assertThat(client.scriptSource(SCRIPT_RATELIMIT_KEY)).isNotBlank();
+    }
+
+    @Test
+    void is_connected_true_from_non_vertx_thread_when_event_loop_is_connected() {
+        assertThat(CompletableFuture.supplyAsync(client::isConnected).join()).isTrue();
+    }
+
+    @Test
+    void redis_api_is_available_from_non_vertx_thread() throws Exception {
+        RedisAPI api = client.redisApi().toCompletionStage().toCompletableFuture().get(10, TimeUnit.SECONDS);
+
+        assertThat(api).isNotNull();
+    }
+
+    @Test
+    void should_connect_without_scripts() throws Exception {
+        RedisClient clientWithoutScripts = createClient(null);
+        await_connected(clientWithoutScripts);
+
+        assertThat(clientWithoutScripts.isConnected()).isTrue();
+        assertThat(clientWithoutScripts.scriptSha1(SCRIPT_RATELIMIT_KEY)).isNull();
+        assertThat(clientWithoutScripts.scriptSource(SCRIPT_RATELIMIT_KEY)).isNull();
+    }
+
+    @Test
+    void is_connected_false_when_redis_unreachable() throws Exception {
+        RedisClientOptions options = RedisClientOptions.builder().host("127.0.0.1").port(1).connectTimeout(500).build();
+        RedisClient unreachable = new RedisClient(vertx, new VertxRedisClientFactory(vertx), options, null);
+
+        TimeUnit.MILLISECONDS.sleep(1_500);
+
+        assertThat(unreachable.isConnected()).isFalse();
+    }
+
+    private RedisClient createClient(Map<String, String> scripts) {
+        MockEnvironment environment = new MockEnvironment();
+        environment.setProperty("ratelimit.redis.host", redis.getHost());
+        environment.setProperty("ratelimit.redis.port", redis.getFirstMappedPort().toString());
+
+        return new RedisConnectionFactory(environment, vertx, "ratelimit", scripts).createRedisClient();
+    }
+
+    private void await_connected(RedisClient redisClient) throws Exception {
+        long deadline = System.currentTimeMillis() + 30_000;
+        while (!redisClient.isConnected() && System.currentTimeMillis() < deadline) {
+            TimeUnit.MILLISECONDS.sleep(200);
+        }
+        assertThat(redisClient.isConnected()).isTrue();
+    }
+}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-14010

## Description

Fixes gateway throughput degradation when the Rate Limit policy runs in **sync mode** (`async: false`) with a Redis backend under high concurrency on a single pod.

### Root cause:
All sync rate-limit requests shared **one Redis connection** on a single Vert.x event loop, serializing Redis `evalsha` calls across concurrent requests. Flame graphs also showed significant CPU in `RedisOperationTimeoutException.fillInStackTrace()`.

### Based on:

Profile 1 - Higher throughput. - Backend is responding quick within microseconds: https://graviteeperf.grafana.net/a/grafana-pyroscope-app/explore?searchText=&panelType=time-series&layout=grid&hideNoData=off&explorationType=flame-graph&var-serviceName=java%2Fgravitee-apim%2Fgravitee-apim-gateway&var-profileMetricId=process_cpu%3Acpu%3Ananoseconds%3Acpu%3Ananoseconds&var-groupBy=all&var-profileIdSelector=&var-spanSelector=&var-dataSource=grafanacloud-profiles&var-filters=&var-filtersBaseline=&var-filtersComparison=&diffFrom=&diffTo=&diffFrom-2=&diffTo-2=&comparisonFrom=&comparisonTo=&from=1779099136323&to=1779099606379&timezone=browser&maxNodes=16384

Profile 2 - Daily regression - Backend response times are high like 20ms: https://graviteeperf.grafana.net/a/grafana-pyroscope-app/explore?searchText=&panelType=time-series&layout=grid&hideNoData=off&explorationType=flame-graph&var-serviceName=java%2Fgravitee-apim%2Fgravitee-apim-gateway&var-profileMetricId=process_cpu%3Acpu%3Ananoseconds%3Acpu%3Ananoseconds&var-groupBy=all&var-profileIdSelector=&var-spanSelector=&var-dataSource=grafanacloud-profiles&var-filters=&var-filtersBaseline=&var-filtersComparison=&diffFrom=&diffTo=&diffFrom-2=&diffTo-2=&comparisonFrom=&comparisonTo=&from=1779100509656&to=1779100908353&timezone=browser&maxNodes=16384

### This PR:
- Opens a **dedicated Redis connection per event loop** (lazy connect, per-loop script SHA, reconnect handling, fallback for non-Vert.x threads)
- Overrides **`fillInStackTrace()`** on Redis timeout/not-connected exceptions to avoid stack capture on the hot path

## Problem

Marketing/perf benchmarks (sync rate-limit, Redis, single gateway replica) showed rising latency and capped TPS as concurrency increased, while adding gateway replicas improved throughput — indicating an in-pod bottleneck rather than Redis or the backend.

Profiling highlighted:
- Netty event loop saturation
- Per-request Redis `evalsha` on a single shared connection
- `RedisOperationTimeoutException.fillInStackTrace()` CPU cost (~7% in flame graphs)

## Solution

### Per-event-loop `RedisClient` (commit 2)
- `ConcurrentHashMap` keyed by event-loop identity
- Lazy connection per loop via `redisApi()`
- Script sources preloaded at startup; SHA cached per loop
- Synchronized reconnect to avoid races between timer and first request
- `isConnected()` returns true if the current loop or any loop is connected

### Lighter Redis exceptions (commit 1)
- `RedisOperationTimeoutException` and `RedisNotConnectedException` return `this` from `fillInStackTrace()`
  
  
## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

