### PR TITLE
feat: add portal navigation propagation query params

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/environment/PortalNavigationItemResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/environment/PortalNavigationItemResource.java
@@ -33,9 +33,11 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.DefaultValue;
 import jakarta.ws.rs.PUT;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.Response;
 import lombok.CustomLog;
 
@@ -59,13 +61,15 @@ public class PortalNavigationItemResource extends AbstractResource {
     @Permissions({ @Permission(value = RolePermission.ENVIRONMENT_DOCUMENTATION, acls = RolePermissionAction.UPDATE) })
     public Response updatePortalNavigationItem(
         @PathParam("navId") String navigationItemId,
+        @QueryParam("propagatePublishToChildren") @DefaultValue("false") boolean propagatePublishToChildren,
         @Valid @NotNull final BaseUpdatePortalNavigationItem updatePortalNavigationItem
     ) {
         var input = new UpdatePortalNavigationItemUseCase.Input(
             GraviteeContext.getCurrentOrganization(),
             GraviteeContext.getCurrentEnvironment(),
             navigationItemId,
-            mapper.map(updatePortalNavigationItem)
+            mapper.map(updatePortalNavigationItem),
+            propagatePublishToChildren
         );
 
         var output = updatePortalNavigationItemUseCase.execute(input);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-environments.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-environments.yaml
@@ -1039,6 +1039,18 @@ paths:
           required: true
           schema:
             type: string
+        - name: propagatePublishToChildren
+          in: query
+          description: >
+            Controls whether a publication change on a container navigation item is propagated to descendants.
+            If omitted or false, publishing affects only the selected item.
+            If true, publishing also affects descendants.
+            For unpublishing a FOLDER or API, this parameter is ignored and descendants are always unpublished
+            according to the business rule.
+          required: false
+          schema:
+            type: boolean
+            default: false
       requestBody:
         required: true
         content:
@@ -1067,6 +1079,16 @@ paths:
           required: true
           schema:
             type: string
+        - name: propagateDeleteToChildren
+          in: query
+          description: >
+            Controls whether deleting a container navigation item also deletes its descendants.
+            If omitted or false, only the selected item is deleted.
+            If true, descendants are also deleted.
+          required: false
+          schema:
+            type: boolean
+            default: false
       responses:
         "204":
           description: Portal navigation item deleted

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-environments.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-environments.yaml
@@ -1031,6 +1031,11 @@ paths:
         ParentId is the unique identifier of the parent item.
         * Optional parent ID. If provided, the item is set to that parent.
         * If omitted, the item is moved to the root level.
+
+        Publication propagation applies only when the `published` value changes on a container navigation item (`FOLDER` or `API`).
+        When publishing a container, descendants are published only if `propagatePublishToChildren=true`.
+        If `propagatePublishToChildren` is omitted or false, only the selected item is published.
+        When unpublishing a container, descendants are always unpublished according to the business rule; `propagatePublishToChildren` is ignored and may be omitted.
       operationId: updatePortalNavigationItem
       parameters:
         - name: navId
@@ -1042,11 +1047,11 @@ paths:
         - name: propagatePublishToChildren
           in: query
           description: >
-            Controls whether a publication change on a container navigation item is propagated to descendants.
+            Controls whether publishing a container navigation item (`FOLDER` or `API`) is propagated to descendants.
+            Only evaluated when `published` changes to true on a container item.
             If omitted or false, publishing affects only the selected item.
             If true, publishing also affects descendants.
-            For unpublishing a FOLDER or API, this parameter is ignored and descendants are always unpublished
-            according to the business rule.
+            Ignored for unpublish; container descendants are always unpublished according to the business rule.
           required: false
           schema:
             type: boolean

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-environments.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-environments.yaml
@@ -1079,16 +1079,6 @@ paths:
           required: true
           schema:
             type: string
-        - name: propagateDeleteToChildren
-          in: query
-          description: >
-            Controls whether deleting a container navigation item also deletes its descendants.
-            If omitted or false, only the selected item is deleted.
-            If true, descendants are also deleted.
-          required: false
-          schema:
-            type: boolean
-            default: false
       responses:
         "204":
           description: Portal navigation item deleted

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/environment/PortalNavigationItemsResource_PutTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/environment/PortalNavigationItemsResource_PutTest.java
@@ -49,6 +49,7 @@ import io.gravitee.rest.api.service.common.GraviteeContext;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.client.WebTarget;
 import jakarta.ws.rs.core.Response;
+import java.util.List;
 import java.util.UUID;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -354,6 +355,92 @@ class PortalNavigationItemResource_PutTest extends AbstractResourceTest {
     }
 
     @Test
+    void should_publish_only_selected_folder_when_propagation_query_param_is_omitted() {
+        var parentFolder = PortalNavigationItemFixtures.aFolder("20000000-0000-4000-8000-000000000019", "Parent")
+            .toBuilder()
+            .published(false)
+            .build();
+        var childFolder = PortalNavigationItemFixtures.aFolder("20000000-0000-4000-8000-000000000020", "Child", parentFolder.getId())
+            .toBuilder()
+            .published(false)
+            .build();
+        var grandChildPage = PortalNavigationItemFixtures.aPage("20000000-0000-4000-8000-000000000021", "Grand Child", childFolder.getId())
+            .toBuilder()
+            .published(false)
+            .build();
+        initStorageWith(List.of(parentFolder, childFolder, grandChildPage));
+
+        Response response = target.path(parentFolder.getId().toString()).request().put(json(updateFolderPublished(parentFolder, true)));
+
+        assertThat(response).hasStatus(OK_200);
+        PortalNavigationFolder body = response.readEntity(PortalNavigationFolder.class);
+        assertThat(body.getPublished()).isTrue();
+        assertThat(portalNavigationItemsQueryService.findByIdAndEnvironmentId(ENVIRONMENT, parentFolder.getId()).getPublished()).isTrue();
+        assertThat(portalNavigationItemsQueryService.findByIdAndEnvironmentId(ENVIRONMENT, childFolder.getId()).getPublished()).isFalse();
+        assertThat(
+            portalNavigationItemsQueryService.findByIdAndEnvironmentId(ENVIRONMENT, grandChildPage.getId()).getPublished()
+        ).isFalse();
+    }
+
+    @Test
+    void should_publish_folder_descendants_when_propagation_query_param_is_true() {
+        var parentFolder = PortalNavigationItemFixtures.aFolder("20000000-0000-4000-8000-000000000022", "Parent")
+            .toBuilder()
+            .published(false)
+            .build();
+        var childFolder = PortalNavigationItemFixtures.aFolder("20000000-0000-4000-8000-000000000023", "Child", parentFolder.getId())
+            .toBuilder()
+            .published(false)
+            .build();
+        var grandChildPage = PortalNavigationItemFixtures.aPage("20000000-0000-4000-8000-000000000024", "Grand Child", childFolder.getId())
+            .toBuilder()
+            .published(false)
+            .build();
+        initStorageWith(List.of(parentFolder, childFolder, grandChildPage));
+
+        Response response = target
+            .path(parentFolder.getId().toString())
+            .queryParam("propagatePublishToChildren", true)
+            .request()
+            .put(json(updateFolderPublished(parentFolder, true)));
+
+        assertThat(response).hasStatus(OK_200);
+        PortalNavigationFolder body = response.readEntity(PortalNavigationFolder.class);
+        assertThat(body.getPublished()).isTrue();
+        assertThat(portalNavigationItemsQueryService.findByIdAndEnvironmentId(ENVIRONMENT, parentFolder.getId()).getPublished()).isTrue();
+        assertThat(portalNavigationItemsQueryService.findByIdAndEnvironmentId(ENVIRONMENT, childFolder.getId()).getPublished()).isTrue();
+        assertThat(portalNavigationItemsQueryService.findByIdAndEnvironmentId(ENVIRONMENT, grandChildPage.getId()).getPublished()).isTrue();
+    }
+
+    @Test
+    void should_unpublish_folder_descendants_when_propagation_query_param_is_omitted() {
+        var parentFolder = PortalNavigationItemFixtures.aFolder("20000000-0000-4000-8000-000000000025", "Parent")
+            .toBuilder()
+            .published(true)
+            .build();
+        var childFolder = PortalNavigationItemFixtures.aFolder("20000000-0000-4000-8000-000000000026", "Child", parentFolder.getId())
+            .toBuilder()
+            .published(true)
+            .build();
+        var grandChildPage = PortalNavigationItemFixtures.aPage("20000000-0000-4000-8000-000000000027", "Grand Child", childFolder.getId())
+            .toBuilder()
+            .published(true)
+            .build();
+        initStorageWith(List.of(parentFolder, childFolder, grandChildPage));
+
+        Response response = target.path(parentFolder.getId().toString()).request().put(json(updateFolderPublished(parentFolder, false)));
+
+        assertThat(response).hasStatus(OK_200);
+        PortalNavigationFolder body = response.readEntity(PortalNavigationFolder.class);
+        assertThat(body.getPublished()).isFalse();
+        assertThat(portalNavigationItemsQueryService.findByIdAndEnvironmentId(ENVIRONMENT, parentFolder.getId()).getPublished()).isFalse();
+        assertThat(portalNavigationItemsQueryService.findByIdAndEnvironmentId(ENVIRONMENT, childFolder.getId()).getPublished()).isFalse();
+        assertThat(
+            portalNavigationItemsQueryService.findByIdAndEnvironmentId(ENVIRONMENT, grandChildPage.getId()).getPublished()
+        ).isFalse();
+    }
+
+    @Test
     void should_change_a_page_visibility_to_private() {
         // Given an existing PAGE item
         String navId = PAGE11_ID;
@@ -406,5 +493,26 @@ class PortalNavigationItemResource_PutTest extends AbstractResourceTest {
         // And storage reflects the change
         var updated = portalNavigationItemsQueryService.findByIdAndEnvironmentId(ENVIRONMENT, PortalNavigationItemId.of(navId));
         assertThat(updated.getOrder()).isEqualTo(1);
+    }
+
+    private void initStorageWith(List<io.gravitee.apim.core.portal_page.model.PortalNavigationItem> items) {
+        items.forEach(i -> {
+            i.setEnvironmentId(ENVIRONMENT);
+            i.setOrganizationId(ORGANIZATION);
+        });
+        ((PortalNavigationItemsQueryServiceInMemory) portalNavigationItemsQueryService).initWith(items);
+        ((PortalNavigationItemsCrudServiceInMemory) portalNavigationItemCrudService).initWith(items);
+    }
+
+    private BaseUpdatePortalNavigationItem updateFolderPublished(
+        io.gravitee.apim.core.portal_page.model.PortalNavigationFolder folder,
+        boolean published
+    ) {
+        return new UpdatePortalNavigationFolder()
+            .title(folder.getTitle())
+            .type(PortalNavigationItemType.FOLDER)
+            .order(folder.getOrder())
+            .published(published)
+            .visibility(PortalVisibility.valueOf(folder.getVisibility().name()));
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/PortalNavigationItemDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/PortalNavigationItemDomainService.java
@@ -199,12 +199,21 @@ public class PortalNavigationItemDomainService {
     }
 
     public PortalNavigationItem update(UpdatePortalNavigationItem toUpdate, PortalNavigationItem originalItem) {
+        return update(toUpdate, originalItem, false);
+    }
+
+    public PortalNavigationItem update(
+        UpdatePortalNavigationItem toUpdate,
+        PortalNavigationItem originalItem,
+        boolean propagatePublishToChildren
+    ) {
         final Integer originalOrder = originalItem.getOrder();
         final PortalNavigationItemId originalParentId = originalItem.getParentId();
         final var changedVisibility = !Objects.equals(originalItem.getVisibility(), toUpdate.getVisibility())
             ? toUpdate.getVisibility()
             : null;
         final var changedPublished = !Objects.equals(originalItem.getPublished(), toUpdate.getPublished()) ? toUpdate.getPublished() : null;
+        final var publishedToPropagate = resolvePublishedToPropagate(changedPublished, propagatePublishToChildren);
 
         boolean isMoveToNewParent = !Objects.equals(originalParentId, toUpdate.getParentId());
 
@@ -247,8 +256,13 @@ public class PortalNavigationItemDomainService {
         var updatedItem = crudService.update(originalItem);
 
         final var visibilityToPropagate = PortalVisibility.PRIVATE.equals(changedVisibility) ? PortalVisibility.PRIVATE : null;
-        if (visibilityToPropagate != null || changedPublished != null) {
-            propagateAttributesToDescendants(updatedItem.getId(), updatedItem.getEnvironmentId(), visibilityToPropagate, changedPublished);
+        if (visibilityToPropagate != null || publishedToPropagate != null) {
+            propagateAttributesToDescendants(
+                updatedItem.getId(),
+                updatedItem.getEnvironmentId(),
+                visibilityToPropagate,
+                publishedToPropagate
+            );
         }
         if (isMoveToNewParent) {
             propagateRootIdToDescendants(updatedItem.getId(), updatedItem.getEnvironmentId());
@@ -264,6 +278,16 @@ public class PortalNavigationItemDomainService {
         siblingsToUpdate.forEach(crudService::update);
 
         return updatedItem;
+    }
+
+    private Boolean resolvePublishedToPropagate(Boolean changedPublished, boolean propagatePublishToChildren) {
+        if (changedPublished == null) {
+            return null;
+        }
+        if (Boolean.FALSE.equals(changedPublished)) {
+            return false;
+        }
+        return propagatePublishToChildren ? Boolean.TRUE : null;
     }
 
     private PortalNavigationItemContainer resolveParentContainer(PortalNavigationItemId parentId, String environmentId) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/use_case/UpdatePortalNavigationItemUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/use_case/UpdatePortalNavigationItemUseCase.java
@@ -45,7 +45,7 @@ public class UpdatePortalNavigationItemUseCase {
             throw new PortalNavigationItemNotFoundException(input.navigationItemId);
         }
         validatorService.validateToUpdate(toUpdate, existing);
-        return new Output(domainService.update(toUpdate, existing));
+        return new Output(domainService.update(toUpdate, existing, input.propagatePublishToChildren()));
     }
 
     @Builder
@@ -53,7 +53,8 @@ public class UpdatePortalNavigationItemUseCase {
         String organizationId,
         String environmentId,
         String navigationItemId,
-        UpdatePortalNavigationItem updatePortalNavigationItem
+        UpdatePortalNavigationItem updatePortalNavigationItem,
+        boolean propagatePublishToChildren
     ) {}
 
     public record Output(PortalNavigationItem updatedItem) {}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/domain_service/PortalNavigationItemDomainServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/domain_service/PortalNavigationItemDomainServiceTest.java
@@ -1045,7 +1045,7 @@ public class PortalNavigationItemDomainServiceTest {
         }
 
         @Test
-        void should_update_subtree_when_folder_published_changes_from_false_to_true() {
+        void should_update_subtree_when_folder_published_changes_from_false_to_true_and_propagation_enabled() {
             PortalNavigationFolder parentFolder = PortalNavigationItemFixtures.aFolder("20000000-0000-4000-8000-000000000001", "Parent")
                 .toBuilder()
                 .published(false)
@@ -1078,7 +1078,7 @@ public class PortalNavigationItemDomainServiceTest {
                 .published(true)
                 .build();
 
-            var result = domainService.update(toUpdate, parentFolder);
+            var result = domainService.update(toUpdate, parentFolder, true);
 
             assertThat(result.getPublished()).isTrue();
             assertThat(
@@ -1095,6 +1095,112 @@ public class PortalNavigationItemDomainServiceTest {
                 .containsEntry(parentFolder.getId(), true)
                 .containsEntry(childFolder.getId(), true)
                 .containsEntry(grandChildPage.getId(), true);
+        }
+
+        @Test
+        void should_not_update_subtree_when_folder_published_changes_from_false_to_true_and_propagation_disabled() {
+            PortalNavigationFolder parentFolder = PortalNavigationItemFixtures.aFolder("20000000-0000-4000-8000-000000000004", "Parent")
+                .toBuilder()
+                .published(false)
+                .build();
+            PortalNavigationFolder childFolder = PortalNavigationItemFixtures.aFolder(
+                "20000000-0000-4000-8000-000000000005",
+                "Child",
+                parentFolder.getId()
+            )
+                .toBuilder()
+                .published(false)
+                .build();
+            PortalNavigationPage grandChildPage = PortalNavigationItemFixtures.aPage(
+                "20000000-0000-4000-8000-000000000006",
+                "Grand Child",
+                childFolder.getId()
+            )
+                .toBuilder()
+                .published(false)
+                .build();
+            portalNavigationItemsCrudService.initWith(List.of(parentFolder, childFolder, grandChildPage));
+            portalNavigationItemsQueryService.initWith(List.copyOf(portalNavigationItemsCrudService.storage()));
+
+            var toUpdate = UpdatePortalNavigationItem.builder()
+                .order(parentFolder.getOrder())
+                .title(parentFolder.getTitle())
+                .visibility(parentFolder.getVisibility())
+                .type(parentFolder.getType())
+                .parentId(parentFolder.getParentId())
+                .published(true)
+                .build();
+
+            var result = domainService.update(toUpdate, parentFolder, false);
+
+            assertThat(result.getPublished()).isTrue();
+            assertThat(
+                portalNavigationItemsCrudService
+                    .storage()
+                    .stream()
+                    .collect(
+                        Collectors.toMap(
+                            io.gravitee.apim.core.portal_page.model.PortalNavigationItem::getId,
+                            io.gravitee.apim.core.portal_page.model.PortalNavigationItem::getPublished
+                        )
+                    )
+            )
+                .containsEntry(parentFolder.getId(), true)
+                .containsEntry(childFolder.getId(), false)
+                .containsEntry(grandChildPage.getId(), false);
+        }
+
+        @Test
+        void should_update_subtree_when_folder_published_changes_from_true_to_false_and_propagation_disabled() {
+            PortalNavigationFolder parentFolder = PortalNavigationItemFixtures.aFolder("20000000-0000-4000-8000-000000000007", "Parent")
+                .toBuilder()
+                .published(true)
+                .build();
+            PortalNavigationFolder childFolder = PortalNavigationItemFixtures.aFolder(
+                "20000000-0000-4000-8000-000000000008",
+                "Child",
+                parentFolder.getId()
+            )
+                .toBuilder()
+                .published(true)
+                .build();
+            PortalNavigationPage grandChildPage = PortalNavigationItemFixtures.aPage(
+                "20000000-0000-4000-8000-000000000009",
+                "Grand Child",
+                childFolder.getId()
+            )
+                .toBuilder()
+                .published(true)
+                .build();
+            portalNavigationItemsCrudService.initWith(List.of(parentFolder, childFolder, grandChildPage));
+            portalNavigationItemsQueryService.initWith(List.copyOf(portalNavigationItemsCrudService.storage()));
+
+            var toUpdate = UpdatePortalNavigationItem.builder()
+                .order(parentFolder.getOrder())
+                .title(parentFolder.getTitle())
+                .visibility(parentFolder.getVisibility())
+                .type(parentFolder.getType())
+                .parentId(parentFolder.getParentId())
+                .published(false)
+                .build();
+
+            var result = domainService.update(toUpdate, parentFolder, false);
+
+            assertThat(result.getPublished()).isFalse();
+            assertThat(
+                portalNavigationItemsCrudService
+                    .storage()
+                    .stream()
+                    .collect(
+                        Collectors.toMap(
+                            io.gravitee.apim.core.portal_page.model.PortalNavigationItem::getId,
+                            io.gravitee.apim.core.portal_page.model.PortalNavigationItem::getPublished
+                        )
+                    )
+            )
+                .containsEntry(parentFolder.getId(), false)
+                .containsEntry(childFolder.getId(), false)
+                .containsEntry(grandChildPage.getId(), false);
         }
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/UpdatePortalNavigationItemUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/UpdatePortalNavigationItemUseCaseTest.java
@@ -46,6 +46,7 @@ import io.gravitee.apim.core.portal_page.model.PortalNavigationItemType;
 import io.gravitee.apim.core.portal_page.model.PortalVisibility;
 import io.gravitee.apim.core.portal_page.model.UpdatePortalNavigationItem;
 import java.util.ArrayList;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
@@ -229,6 +230,103 @@ class UpdatePortalNavigationItemUseCaseTest {
         assertThat(output.updatedItem().getTitle()).isEqualTo("New Title");
         assertThat(output.updatedItem().getPublished()).isTrue();
         assertThat(output.updatedItem().getVisibility()).isEqualTo(existing.getVisibility());
+    }
+
+    @Test
+    void should_publish_only_selected_folder_when_propagation_is_omitted() {
+        var parentFolder = PortalNavigationItemFixtures.aFolder("20000000-0000-4000-8000-000000000010", "Parent")
+            .toBuilder()
+            .published(false)
+            .build();
+        var childFolder = PortalNavigationItemFixtures.aFolder("20000000-0000-4000-8000-000000000011", "Child", parentFolder.getId())
+            .toBuilder()
+            .published(false)
+            .build();
+        var grandChildPage = PortalNavigationItemFixtures.aPage("20000000-0000-4000-8000-000000000012", "Grand Child", childFolder.getId())
+            .toBuilder()
+            .published(false)
+            .build();
+        crudService.initWith(List.of(parentFolder, childFolder, grandChildPage));
+        queryService.initWith(List.copyOf(crudService.storage()));
+
+        var input = UpdatePortalNavigationItemUseCase.Input.builder()
+            .organizationId(ORG_ID)
+            .environmentId(ENV_ID)
+            .navigationItemId(parentFolder.getId().toString())
+            .updatePortalNavigationItem(updateFolderPublished(parentFolder, true))
+            .build();
+
+        var output = useCase.execute(input);
+
+        assertThat(output.updatedItem().getPublished()).isTrue();
+        assertThat(queryService.findByIdAndEnvironmentId(ENV_ID, parentFolder.getId()).getPublished()).isTrue();
+        assertThat(queryService.findByIdAndEnvironmentId(ENV_ID, childFolder.getId()).getPublished()).isFalse();
+        assertThat(queryService.findByIdAndEnvironmentId(ENV_ID, grandChildPage.getId()).getPublished()).isFalse();
+    }
+
+    @Test
+    void should_publish_folder_descendants_when_propagation_is_enabled() {
+        var parentFolder = PortalNavigationItemFixtures.aFolder("20000000-0000-4000-8000-000000000013", "Parent")
+            .toBuilder()
+            .published(false)
+            .build();
+        var childFolder = PortalNavigationItemFixtures.aFolder("20000000-0000-4000-8000-000000000014", "Child", parentFolder.getId())
+            .toBuilder()
+            .published(false)
+            .build();
+        var grandChildPage = PortalNavigationItemFixtures.aPage("20000000-0000-4000-8000-000000000015", "Grand Child", childFolder.getId())
+            .toBuilder()
+            .published(false)
+            .build();
+        crudService.initWith(List.of(parentFolder, childFolder, grandChildPage));
+        queryService.initWith(List.copyOf(crudService.storage()));
+
+        var input = UpdatePortalNavigationItemUseCase.Input.builder()
+            .organizationId(ORG_ID)
+            .environmentId(ENV_ID)
+            .navigationItemId(parentFolder.getId().toString())
+            .updatePortalNavigationItem(updateFolderPublished(parentFolder, true))
+            .propagatePublishToChildren(true)
+            .build();
+
+        var output = useCase.execute(input);
+
+        assertThat(output.updatedItem().getPublished()).isTrue();
+        assertThat(queryService.findByIdAndEnvironmentId(ENV_ID, parentFolder.getId()).getPublished()).isTrue();
+        assertThat(queryService.findByIdAndEnvironmentId(ENV_ID, childFolder.getId()).getPublished()).isTrue();
+        assertThat(queryService.findByIdAndEnvironmentId(ENV_ID, grandChildPage.getId()).getPublished()).isTrue();
+    }
+
+    @Test
+    void should_unpublish_folder_descendants_when_propagation_is_omitted() {
+        var parentFolder = PortalNavigationItemFixtures.aFolder("20000000-0000-4000-8000-000000000016", "Parent")
+            .toBuilder()
+            .published(true)
+            .build();
+        var childFolder = PortalNavigationItemFixtures.aFolder("20000000-0000-4000-8000-000000000017", "Child", parentFolder.getId())
+            .toBuilder()
+            .published(true)
+            .build();
+        var grandChildPage = PortalNavigationItemFixtures.aPage("20000000-0000-4000-8000-000000000018", "Grand Child", childFolder.getId())
+            .toBuilder()
+            .published(true)
+            .build();
+        crudService.initWith(List.of(parentFolder, childFolder, grandChildPage));
+        queryService.initWith(List.copyOf(crudService.storage()));
+
+        var input = UpdatePortalNavigationItemUseCase.Input.builder()
+            .organizationId(ORG_ID)
+            .environmentId(ENV_ID)
+            .navigationItemId(parentFolder.getId().toString())
+            .updatePortalNavigationItem(updateFolderPublished(parentFolder, false))
+            .build();
+
+        var output = useCase.execute(input);
+
+        assertThat(output.updatedItem().getPublished()).isFalse();
+        assertThat(queryService.findByIdAndEnvironmentId(ENV_ID, parentFolder.getId()).getPublished()).isFalse();
+        assertThat(queryService.findByIdAndEnvironmentId(ENV_ID, childFolder.getId()).getPublished()).isFalse();
+        assertThat(queryService.findByIdAndEnvironmentId(ENV_ID, grandChildPage.getId()).getPublished()).isFalse();
     }
 
     @Test
@@ -556,5 +654,16 @@ class UpdatePortalNavigationItemUseCaseTest {
 
         var exception = assertThrows(InvalidPortalNavigationItemDataException.class, () -> useCase.execute(input));
         assertThat(exception.getMessage()).isEqualTo("Parent hierarchy cannot include API items.");
+    }
+
+    private UpdatePortalNavigationItem updateFolderPublished(PortalNavigationFolder folder, boolean published) {
+        return UpdatePortalNavigationItem.builder()
+            .type(folder.getType())
+            .title(folder.getTitle())
+            .order(folder.getOrder())
+            .parentId(folder.getParentId())
+            .published(published)
+            .visibility(folder.getVisibility())
+            .build();
     }
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/EXT-145

## Summary

Adds backend/API support for choosing whether publishing a Developer Portal navigation container should affect only the selected item or also its descendants.

The propagation choice is available only for publish actions. Unpublish and delete remain mandatory recursive actions for container navigation items.

## Changes

- Added `propagatePublishToChildren` query parameter to `PUT /portal-navigation-items/{navId}`.
- Defaults publish propagation to `false` when the query parameter is omitted.
- Publishes descendants only when `propagatePublishToChildren=true`.
- Keeps unpublish recursive for folders/APIs regardless of the query parameter value.
- Keeps delete contract unchanged: no delete propagation flag, deleting a container always deletes descendants.
- Updated OpenAPI documentation and backend/resource tests accordingly.

❗ It will be a a follow-up PR soon for the frontend updates 