### PR TITLE
fix(gateway): route Log to reporters based on ReportTarget

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/reactive/core/v4/analytics/LoggingContext.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/reactive/core/v4/analytics/LoggingContext.java
@@ -18,9 +18,13 @@ package io.gravitee.gateway.reactive.core.v4.analytics;
 import io.gravitee.common.utils.SizeUtils;
 import io.gravitee.definition.model.ConditionSupplier;
 import io.gravitee.definition.model.v4.analytics.logging.Logging;
+import io.gravitee.definition.model.v4.analytics.logging.LoggingMode;
 import io.gravitee.gateway.core.logging.LoggableContentType;
 import io.gravitee.gateway.reactive.api.context.base.BaseExecutionContext;
 import io.gravitee.gateway.report.guard.LogGuardService;
+import io.gravitee.reporter.api.ReportTarget;
+import java.util.EnumSet;
+import java.util.Set;
 import lombok.CustomLog;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -157,5 +161,36 @@ public class LoggingContext implements ConditionSupplier {
      */
     public boolean isBodyLoggable() {
         return logGuardService == null || !logGuardService.isLogGuardActive();
+    }
+
+    private static final Set<ReportTarget> TRACING_ONLY = EnumSet.of(ReportTarget.TRACING);
+    private static final Set<ReportTarget> ANALYTICS_ONLY = EnumSet.of(ReportTarget.ANALYTICS);
+
+    /**
+     * Computes the set of {@link ReportTarget}s for a log based on the current configuration.
+     * This determines which reporters will receive the log object.
+     */
+    public Set<ReportTarget> computeReportTargets() {
+        boolean analyticsLogging = isAnalyticsLoggingEnabled();
+        if (otelLogsEnabled && analyticsLogging) {
+            return ReportTarget.ALL;
+        }
+        if (otelLogsEnabled) {
+            return TRACING_ONLY;
+        }
+        if (analyticsLogging) {
+            return ANALYTICS_ONLY;
+        }
+        // Unreachable in practice: LogInitProcessor only calls this when logging is enabled
+        // (either otelLogs or analytics). Default to ANALYTICS for backward compatibility.
+        return ANALYTICS_ONLY;
+    }
+
+    private boolean isAnalyticsLoggingEnabled() {
+        if (logging == null) {
+            return false;
+        }
+        LoggingMode mode = logging.getMode();
+        return mode != null && mode.isEnabled();
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-core/src/test/java/io/gravitee/gateway/reactive/core/v4/analytics/LoggingContextOtelTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-core/src/test/java/io/gravitee/gateway/reactive/core/v4/analytics/LoggingContextOtelTest.java
@@ -17,8 +17,13 @@ package io.gravitee.gateway.reactive.core.v4.analytics;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.gravitee.definition.model.v4.analytics.logging.Logging;
+import io.gravitee.definition.model.v4.analytics.logging.LoggingMode;
+import io.gravitee.reporter.api.ReportTarget;
+import java.util.EnumSet;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -109,5 +114,47 @@ class LoggingContextOtelTest {
         assertThat(ctx.endpointRequestHeaders()).isFalse();
         assertThat(ctx.entrypointResponseHeaders()).isFalse();
         assertThat(ctx.endpointResponseHeaders()).isFalse();
+    }
+
+    @Nested
+    class ComputeReportTargets {
+
+        @Test
+        void should_return_tracing_only_when_otel_logs_on_and_es_logging_off() {
+            LoggingContext ctx = new LoggingContext(null);
+            ctx.setOtelLogsEnabled(true);
+            assertThat(ctx.computeReportTargets()).isEqualTo(EnumSet.of(ReportTarget.TRACING));
+        }
+
+        @Test
+        void should_return_analytics_only_when_otel_logs_off_and_es_logging_on() {
+            Logging logging = new Logging();
+            LoggingMode mode = new LoggingMode();
+            mode.setEntrypoint(true);
+            logging.setMode(mode);
+
+            LoggingContext ctx = new LoggingContext(logging);
+            ctx.setOtelLogsEnabled(false);
+            assertThat(ctx.computeReportTargets()).isEqualTo(EnumSet.of(ReportTarget.ANALYTICS));
+        }
+
+        @Test
+        void should_return_both_when_otel_logs_on_and_es_logging_on() {
+            Logging logging = new Logging();
+            LoggingMode mode = new LoggingMode();
+            mode.setEntrypoint(true);
+            logging.setMode(mode);
+
+            LoggingContext ctx = new LoggingContext(logging);
+            ctx.setOtelLogsEnabled(true);
+            assertThat(ctx.computeReportTargets()).isEqualTo(ReportTarget.ALL);
+        }
+
+        @Test
+        void should_return_analytics_when_neither_otel_logs_nor_es_logging() {
+            LoggingContext ctx = new LoggingContext(null);
+            ctx.setOtelLogsEnabled(false);
+            assertThat(ctx.computeReportTargets()).containsExactly(ReportTarget.ANALYTICS);
+        }
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/processor/logging/LogInitProcessor.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/reactive/handlers/api/v4/processor/logging/LogInitProcessor.java
@@ -82,6 +82,7 @@ public class LogInitProcessor implements Processor {
             .apiName(ctx.getAttribute(ContextAttributes.ATTR_API_NAME))
             .organizationId(ctx.metrics().getOrganizationId())
             .environmentId(ctx.metrics().getEnvironmentId())
+            .targets(loggingContext.computeReportTargets())
             .build();
         ctx.metrics().setLog(log);
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/v4/processor/logging/LogInitProcessorTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/reactive/handlers/api/v4/processor/logging/LogInitProcessorTest.java
@@ -62,6 +62,7 @@ class LogInitProcessorTest extends AbstractV4ProcessorTest {
         lenient().when(analyticsContext.isEnabled()).thenReturn(true);
         lenient().when(analyticsContext.getLoggingContext()).thenReturn(loggingContext);
         lenient().when(analyticsContext.isLoggingEnabled()).thenReturn(true);
+        lenient().when(loggingContext.computeReportTargets()).thenReturn(io.gravitee.reporter.api.ReportTarget.DEFAULT);
         ctx.setInternalAttribute(InternalContextAttributes.ATTR_INTERNAL_ANALYTICS_CONTEXT, analyticsContext);
     }
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/test/java/io/gravitee/gateway/standalone/reporter/FakeReporter.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-container/src/test/java/io/gravitee/gateway/standalone/reporter/FakeReporter.java
@@ -15,11 +15,12 @@
  */
 package io.gravitee.gateway.standalone.reporter;
 
-import io.gravitee.common.component.Lifecycle;
 import io.gravitee.common.service.AbstractService;
 import io.gravitee.gateway.api.handler.Handler;
+import io.gravitee.reporter.api.ReportTarget;
 import io.gravitee.reporter.api.Reportable;
 import io.gravitee.reporter.api.Reporter;
+import java.util.Set;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -38,6 +39,11 @@ public class FakeReporter extends AbstractService<Reporter> implements Reporter 
     @Override
     public void report(Reportable reportable) {
         reportHandler.handle(reportable);
+    }
+
+    @Override
+    public Set<ReportTarget> supportedTargets() {
+        return ReportTarget.ALL;
     }
 
     public void reset() {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/src/main/java/io/gravitee/apim/gateway/tests/sdk/reporter/FakeReporter.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-tests-sdk/src/main/java/io/gravitee/apim/gateway/tests/sdk/reporter/FakeReporter.java
@@ -17,8 +17,10 @@ package io.gravitee.apim.gateway.tests.sdk.reporter;
 
 import io.gravitee.common.service.AbstractService;
 import io.gravitee.gateway.api.handler.Handler;
+import io.gravitee.reporter.api.ReportTarget;
 import io.gravitee.reporter.api.Reportable;
 import io.gravitee.reporter.api.Reporter;
+import java.util.Set;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -37,6 +39,11 @@ public class FakeReporter extends AbstractService<Reporter> implements Reporter 
     @Override
     public void report(Reportable reportable) {
         reportHandler.handle(reportable);
+    }
+
+    @Override
+    public Set<ReportTarget> supportedTargets() {
+        return ReportTarget.ALL;
     }
 
     public void reset() {

--- a/pom.xml
+++ b/pom.xml
@@ -65,13 +65,13 @@
         <gravitee-integration-api.version>5.1.0</gravitee-integration-api.version>
         <gravitee-json-validation.version>2.2.0</gravitee-json-validation.version>
         <gravitee-kubernetes.version>4.0.0-alpha.1</gravitee-kubernetes.version>
-        <gravitee-node.version>9.0.0-alpha.18</gravitee-node.version>
+        <gravitee-node.version>9.0.0-alpha.19</gravitee-node.version>
         <gravitee-notifier-api.version>2.0.0</gravitee-notifier-api.version>
         <gravitee-platform-repository-api.version>2.0.0</gravitee-platform-repository-api.version>
         <gravitee-plugin.version>5.1.2</gravitee-plugin.version>
         <gravitee-plugin-common-configurations.version>1.4.0</gravitee-plugin-common-configurations.version>
         <gravitee-policy-api.version>1.11.0</gravitee-policy-api.version>
-        <gravitee-reporter-api.version>2.4.0</gravitee-reporter-api.version>
+        <gravitee-reporter-api.version>2.5.0</gravitee-reporter-api.version>
         <gravitee-resource-api.version>1.1.0</gravitee-resource-api.version>
         <gravitee-resource-auth-provider-api.version>1.3.0</gravitee-resource-auth-provider-api.version>
         <gravitee-resource-cache-provider-api.version>2.2.0</gravitee-resource-cache-provider-api.version>
@@ -264,7 +264,7 @@
         <!-- Gateway Only -->
         <gravitee-reporter-tcp.version>5.0.0-alpha.1</gravitee-reporter-tcp.version>
         <gravitee-reporter-cloud.version>4.0.0-alpha.2</gravitee-reporter-cloud.version>
-        <gravitee-reporter-otel.version>1.2.0</gravitee-reporter-otel.version>
+        <gravitee-reporter-otel.version>1.3.0</gravitee-reporter-otel.version>
         <!--    Version of policy-ratelimit is also used for policy-quota, policy-spikearrest and gateway-services-ratelimit    -->
         <!--    <gravitee-gateway-services-ratelimit.version>3.0.0</gravitee-gateway-services-ratelimit.version>    -->
 


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-14388

## Description

- `LoggingContext.computeReportTargets()` returns `{**_TRACING_**}`, `{**_ANALYTICS_**}`, or **_ALL_** based on otelLogs + ES logging config
- `LogInitProcessor` sets targets on Log at creation time
- `ElasticsearchReporter` declares `supportedTargets = {ANALYTICS}`
- `FileReporter` declares `supportedTargets = {ANALYTICS}`
- Both use cached static constants to avoid per-call allocation

## Additional context

Fixes OTel Logs dual reporting: when OTel Logs is ON but ES logging is OFF, Log objects were dispatched to all reporters including Elasticsearch and causing unnecessary double writes and GC pressure.

After this fix, the gateway stamps each Log with its intended targets. The node dispatch layer (gravitee-node) filters based on target intersection. ES/File reporters declare ANALYTICS, so they skip TRACING-only logs.

**Depends on**: **_gravitee-reporter-api_** + **_gravitee-node_** releases.

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

