### PR TITLE
feat(portal-documentation): add persistence layer

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/PortalPageContentRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/api/PortalPageContentRepository.java
@@ -16,9 +16,13 @@
 package io.gravitee.repository.management.api;
 
 import io.gravitee.repository.exceptions.TechnicalException;
+import io.gravitee.repository.management.model.AutomationTargetReferenceType;
 import io.gravitee.repository.management.model.PortalPageContent;
 import java.util.List;
 
 public interface PortalPageContentRepository extends CrudRepository<PortalPageContent, String> {
     List<PortalPageContent> findAllByType(PortalPageContent.Type type) throws TechnicalException;
+
+    List<PortalPageContent> findByAutomationReference(String environmentId, AutomationTargetReferenceType referenceType, String referenceId)
+        throws TechnicalException;
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/AutomationTargetReferenceType.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/AutomationTargetReferenceType.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.management.model;
+
+/**
+ * @author GraviteeSource Team
+ */
+public enum AutomationTargetReferenceType {
+    PORTAL,
+    API,
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/PortalPageContent.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/PortalPageContent.java
@@ -17,6 +17,7 @@ package io.gravitee.repository.management.model;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -50,4 +51,20 @@ public class PortalPageContent {
     private String configuration;
 
     private String content;
+
+    /** Populated only for pages managed by the Automation API; null for non-automation pages. */
+    private AutomationMetadata automationMetadata;
+
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class AutomationMetadata {
+
+        private AutomationTargetReferenceType referenceType;
+        private String referenceId;
+        private String name;
+        private String location;
+        private Integer order;
+    }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcPortalPageContentRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcPortalPageContentRepository.java
@@ -15,10 +15,13 @@
  */
 package io.gravitee.repository.jdbc.management;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.jdbc.orm.JdbcObjectMapper;
 import io.gravitee.repository.management.api.PortalPageContentRepository;
+import io.gravitee.repository.management.model.AutomationTargetReferenceType;
 import io.gravitee.repository.management.model.PortalPageContent;
+import io.gravitee.repository.management.model.PortalPageContent.AutomationMetadata;
 import java.sql.Types;
 import java.util.List;
 import lombok.CustomLog;
@@ -30,6 +33,8 @@ import org.springframework.stereotype.Repository;
 public class JdbcPortalPageContentRepository
     extends JdbcAbstractCrudRepository<PortalPageContent, String>
     implements PortalPageContentRepository {
+
+    private static final ObjectMapper JSON = new ObjectMapper();
 
     JdbcPortalPageContentRepository(@Value("${management.jdbc.prefix:}") String tablePrefix) {
         super(tablePrefix, "portal_page_contents");
@@ -44,6 +49,20 @@ public class JdbcPortalPageContentRepository
             .addColumn("content", Types.NVARCHAR, String.class)
             .addColumn("organization_id", Types.NVARCHAR, String.class)
             .addColumn("environment_id", Types.NVARCHAR, String.class)
+            .addColumn(
+                "automation_metadata",
+                Types.NCLOB,
+                AutomationMetadata.class,
+                JdbcPortalPageContentRepository::serialize,
+                JdbcPortalPageContentRepository::deserialize
+            )
+            .addMirroredColumn("automation_reference_type", Types.NVARCHAR, item -> {
+                var meta = item.getAutomationMetadata();
+                return meta != null && meta.getReferenceType() != null ? meta.getReferenceType().name() : null;
+            })
+            .addMirroredColumn("automation_reference_id", Types.NVARCHAR, item ->
+                item.getAutomationMetadata() != null ? item.getAutomationMetadata().getReferenceId() : null
+            )
             .build();
     }
 
@@ -51,8 +70,7 @@ public class JdbcPortalPageContentRepository
     public List<PortalPageContent> findAllByType(PortalPageContent.Type type) throws TechnicalException {
         log.debug("JdbcPortalPageContentRepository.findAllByType({})", type);
         try {
-            final String sql = getOrm().getSelectAllSql() + " where type = ?";
-            return jdbcTemplate.query(sql, getOrm().getRowMapper(), type.name());
+            return jdbcTemplate.query(getOrm().getSelectAllSql() + " WHERE type = ?", getOrm().getRowMapper(), type.name());
         } catch (Exception ex) {
             log.error("Failed to find portal page contents by type", ex);
             throw new TechnicalException("Failed to find portal page contents by type", ex);
@@ -62,5 +80,42 @@ public class JdbcPortalPageContentRepository
     @Override
     protected String getId(PortalPageContent item) {
         return item.getId();
+    }
+
+    @Override
+    public List<PortalPageContent> findByAutomationReference(
+        String environmentId,
+        AutomationTargetReferenceType referenceType,
+        String referenceId
+    ) throws TechnicalException {
+        log.debug("JdbcPortalPageContentRepository.findByAutomationReference({}, {}, {})", environmentId, referenceType, referenceId);
+        try {
+            return jdbcTemplate.query(
+                getOrm().getSelectAllSql() + " WHERE environment_id = ? AND automation_reference_type = ? AND automation_reference_id = ?",
+                getOrm().getRowMapper(),
+                environmentId,
+                referenceType.name(),
+                referenceId
+            );
+        } catch (Exception ex) {
+            log.error("Failed to find portal page contents by automation reference", ex);
+            throw new TechnicalException("Failed to find portal page contents by automation reference", ex);
+        }
+    }
+
+    private static String serialize(AutomationMetadata meta) {
+        try {
+            return JSON.writeValueAsString(meta);
+        } catch (Exception e) {
+            throw new IllegalArgumentException("Failed to serialize automation metadata", e);
+        }
+    }
+
+    private static AutomationMetadata deserialize(String json) {
+        try {
+            return JSON.readValue(json, AutomationMetadata.class);
+        } catch (Exception e) {
+            throw new IllegalArgumentException("Failed to deserialize automation metadata", e);
+        }
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/orm/JdbcColumn.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/orm/JdbcColumn.java
@@ -18,6 +18,7 @@ package io.gravitee.repository.jdbc.orm;
 import static org.springframework.util.StringUtils.capitalize;
 
 import java.lang.reflect.Method;
+import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import lombok.CustomLog;
@@ -34,11 +35,26 @@ public class JdbcColumn {
     public final Class javaType;
     public final Method getter;
     public final Method setter;
+    public final Function<?, String> serializer;
+    public final Function<String, ?> deserializer;
 
     JdbcColumn(String name, int jdbcType, Class owningClass, Class fieldType) {
+        this(name, jdbcType, owningClass, fieldType, null, null);
+    }
+
+    JdbcColumn(
+        String name,
+        int jdbcType,
+        Class owningClass,
+        Class fieldType,
+        Function<?, String> serializer,
+        Function<String, ?> deserializer
+    ) {
         this.name = getAccessorName(name);
         this.jdbcType = jdbcType;
         this.javaType = fieldType;
+        this.serializer = serializer;
+        this.deserializer = deserializer;
         String getterName = "get";
         if (fieldType == boolean.class) {
             getterName = "is";

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/orm/JdbcObjectMapper.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/orm/JdbcObjectMapper.java
@@ -39,6 +39,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Date;
 import java.util.List;
+import java.util.function.Function;
 import lombok.CustomLog;
 import lombok.Getter;
 import org.springframework.jdbc.core.BatchPreparedStatementSetter;
@@ -52,10 +53,14 @@ import org.springframework.jdbc.core.RowMapper;
 @CustomLog
 public class JdbcObjectMapper<T> {
 
+    private record MirroredColumnDef<T>(String name, int jdbcType, Function<T, String> serializer) {}
+
     private final Constructor<T> constructor;
 
     @Getter
     private final List<JdbcColumn> columns;
+
+    private final List<MirroredColumnDef<T>> mirroredColumns;
 
     private final String idColumn;
     private final String insertSql;
@@ -124,6 +129,15 @@ public class JdbcObjectMapper<T> {
             PreparedStatement stmt = cnctn.prepareStatement(sql);
             int idx = setStatementValues(stmt, item, 1);
 
+            for (MirroredColumnDef<T> mirrored : mirroredColumns) {
+                String value = mirrored.serializer().apply(item);
+                if (value == null) {
+                    stmt.setNull(idx++, nullType(mirrored.jdbcType()));
+                } else {
+                    stmt.setString(idx++, value);
+                }
+            }
+
             for (Object id : ids) {
                 stmt.setObject(idx++, id);
             }
@@ -153,6 +167,7 @@ public class JdbcObjectMapper<T> {
         private String tableName;
         private String updateSql;
         private List<JdbcColumn> columns = new ArrayList<>();
+        private List<MirroredColumnDef<T>> mirroredColumns = new ArrayList<>();
 
         private Builder(final Class<T> value, final String tableName, String idColumn) {
             this.clazz = value;
@@ -170,8 +185,24 @@ public class JdbcObjectMapper<T> {
             return this;
         }
 
+        public <V> Builder<T> addColumn(
+            String name,
+            int jdbcType,
+            Class<V> fieldType,
+            Function<V, String> serializer,
+            Function<String, V> deserializer
+        ) {
+            this.columns.add(new JdbcColumn(name, jdbcType, clazz, fieldType, v -> serializer.apply((V) v), deserializer::apply));
+            return this;
+        }
+
+        public Builder<T> addMirroredColumn(String name, int jdbcType, Function<T, String> serializer) {
+            this.mirroredColumns.add(new MirroredColumnDef<>(name, jdbcType, serializer));
+            return this;
+        }
+
         public JdbcObjectMapper<T> build() {
-            return new JdbcObjectMapper<>(clazz, idColumn, columns, updateSql, tableName);
+            return new JdbcObjectMapper<>(clazz, idColumn, columns, mirroredColumns, updateSql, tableName);
         }
     }
 
@@ -187,6 +218,7 @@ public class JdbcObjectMapper<T> {
         final Class<T> clazz,
         final String idColumn,
         final List<JdbcColumn> columns,
+        final List<MirroredColumnDef<T>> mirroredColumns,
         final String updateSql,
         final String tableName
     ) {
@@ -198,6 +230,7 @@ public class JdbcObjectMapper<T> {
         }
         this.tableName = tableName;
         this.columns = columns;
+        this.mirroredColumns = mirroredColumns;
         this.idColumn = idColumn;
         this.insertSql = buildInsertStatement();
         this.updateSql = updateSql == null ? buildUpdateStatement() : updateSql;
@@ -277,7 +310,11 @@ public class JdbcObjectMapper<T> {
                         }
                         value = rslt.toString();
                     }
-                    value = checkTypeAndConvert(item, column, value);
+                    if (column.deserializer != null) {
+                        value = ((Function<String, Object>) column.deserializer).apply((String) value);
+                    } else {
+                        value = checkTypeAndConvert(item, column, value);
+                    }
                     column.setter.invoke(item, value);
                 }
             } catch (SQLException ex) {
@@ -335,9 +372,13 @@ public class JdbcObjectMapper<T> {
             first = false;
             builder.append(escapeReservedWord(getDBName(column.name)));
         }
+        for (MirroredColumnDef<T> mirrored : mirroredColumns) {
+            builder.append(", ").append(escapeReservedWord(mirrored.name()));
+        }
         builder.append(" ) values ( ");
         first = true;
-        for (int i = 0; i < columns.size(); i++) {
+        int totalColumns = columns.size() + mirroredColumns.size();
+        for (int i = 0; i < totalColumns; i++) {
             if (!first) {
                 builder.append(", ");
             }
@@ -354,11 +395,10 @@ public class JdbcObjectMapper<T> {
                 final Object value = column.getter.invoke(item);
                 if (value == null) {
                     log.debug("Setting {}/{} to null for the type {}", idx, getDBName(column.name), column.jdbcType);
-                    if (column.jdbcType == Types.NVARCHAR) {
-                        stmt.setNull(idx, Types.VARCHAR);
-                    } else {
-                        stmt.setNull(idx, column.jdbcType);
-                    }
+                    stmt.setNull(idx, nullType(column.jdbcType));
+                } else if (column.serializer != null) {
+                    stmt.setString(idx, ((Function<Object, String>) column.serializer).apply(value));
+                    log.debug("Setting {}/{} via custom serializer for the type {}", idx, getDBName(column.name), column.jdbcType);
                 } else if (column.javaType.isEnum() && (column.jdbcType == Types.NVARCHAR)) {
                     stmt.setString(idx, value.toString());
                 } else if (value instanceof Date) {
@@ -402,6 +442,9 @@ public class JdbcObjectMapper<T> {
             builder.append(escapeReservedWord(getDBName(column.name)));
             builder.append(" = ?");
         }
+        for (MirroredColumnDef<T> mirrored : mirroredColumns) {
+            builder.append(", ").append(escapeReservedWord(mirrored.name())).append(" = ?");
+        }
         builder.append(" where ");
         builder.append(escapeReservedWord(idColumn));
         builder.append(" = ?");
@@ -420,5 +463,13 @@ public class JdbcObjectMapper<T> {
         } else {
             return emptyList();
         }
+    }
+
+    private static int nullType(int jdbcType) {
+        return switch (jdbcType) {
+            case Types.NVARCHAR -> Types.VARCHAR;
+            case Types.NCLOB -> Types.CLOB;
+            default -> jdbcType;
+        };
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_12_0/16_add_automation_metadata_to_portal_page_contents.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_12_0/16_add_automation_metadata_to_portal_page_contents.yml
@@ -1,0 +1,25 @@
+databaseChangeLog:
+  - changeSet:
+      id: 4.12.0_add_automation_metadata_to_portal_page_contents
+      author: GraviteeSource Team
+      changes:
+        - addColumn:
+            tableName: ${gravitee_prefix}portal_page_contents
+            columns:
+              - column: {name: automation_metadata, type: nclob, constraints: { nullable: true } }
+              - column: {name: automation_reference_type, type: nvarchar(32), constraints: { nullable: true } }
+              - column: {name: automation_reference_id, type: nvarchar(64), constraints: { nullable: true } }
+
+        - createIndex:
+            indexName: idx_${gravitee_prefix}portal_page_contents_automation_reference
+            columns:
+              - column:
+                  name: environment_id
+                  type: nvarchar(64)
+              - column:
+                  name: automation_reference_type
+                  type: nvarchar(32)
+              - column:
+                  name: automation_reference_id
+                  type: nvarchar(64)
+            tableName: ${gravitee_prefix}portal_page_contents

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/master.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/master.yml
@@ -375,3 +375,5 @@ databaseChangeLog:
         - file: liquibase/changelogs/v4_12_0/14_add_portal_listings_table.yml
     - include:
         - file: liquibase/changelogs/v4_12_0/15_add_environment_id_to_am_connections.yml
+    - include:
+        - file: liquibase/changelogs/v4_12_0/16_add_automation_metadata_to_portal_page_contents.yml

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/test/java/io/gravitee/repository/jdbc/orm/JdbcObjectMapperTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/test/java/io/gravitee/repository/jdbc/orm/JdbcObjectMapperTest.java
@@ -1,0 +1,255 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.jdbc.orm;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.Types;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+class JdbcObjectMapperTest {
+
+    // ─── Minimal test entity ──────────────────────────────────────────────────
+
+    public static class Item {
+
+        private String id;
+        private String name;
+        private Nested nested;
+
+        public String getId() {
+            return id;
+        }
+
+        public void setId(String id) {
+            this.id = id;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        public Nested getNested() {
+            return nested;
+        }
+
+        public void setNested(Nested nested) {
+            this.nested = nested;
+        }
+    }
+
+    public static class Nested {
+
+        private String value;
+
+        public Nested() {}
+
+        public Nested(String value) {
+            this.value = value;
+        }
+
+        public String getValue() {
+            return value;
+        }
+    }
+
+    // ─── Mapper setup ─────────────────────────────────────────────────────────
+
+    private JdbcObjectMapper<Item> mapper;
+
+    @BeforeEach
+    void setUp() {
+        mapper = JdbcObjectMapper.builder(Item.class, "items", "id")
+            .addColumn("id", Types.NVARCHAR, String.class)
+            .addColumn("name", Types.NVARCHAR, String.class)
+            // "nested" maps to getNested()/setNested(Nested); ser/deser handle JSON encoding
+            .addColumn(
+                "nested",
+                Types.NCLOB,
+                Nested.class,
+                n -> "json:" + n.getValue(),
+                json -> new Nested(json.substring("json:".length()))
+            )
+            .addMirroredColumn("nested_value", Types.NVARCHAR, item -> item.getNested() != null ? item.getNested().getValue() : null)
+            .build();
+    }
+
+    // ─── SQL generation ───────────────────────────────────────────────────────
+
+    @Test
+    void insert_sql_contains_all_column_names() throws Exception {
+        String sql = captureInsertSql();
+
+        assertTrue(sql.contains("nested"), "INSERT SQL should include custom-serialized column");
+        assertTrue(sql.contains("nested_value"), "INSERT SQL should include mirrored column");
+    }
+
+    @Test
+    void update_sql_contains_all_column_names() throws Exception {
+        String sql = captureUpdateSql();
+
+        assertTrue(sql.contains("nested"), "UPDATE SQL should include custom-serialized column");
+        assertTrue(sql.contains("nested_value"), "UPDATE SQL should include mirrored column");
+    }
+
+    @Test
+    void insert_sql_has_correct_placeholder_count() throws Exception {
+        String sql = captureInsertSql();
+        // id, name, nested, nested_value = 4 placeholders
+        long count = sql
+            .chars()
+            .filter(c -> c == '?')
+            .count();
+        assertEquals(4, count);
+    }
+
+    // ─── Write behaviour ──────────────────────────────────────────────────────
+
+    @Test
+    void custom_column_serializer_is_called_on_insert() throws Exception {
+        var item = itemWithNested("hello");
+        var ps = mockInsert(item);
+
+        // position 3 = nested (after id=1, name=2)
+        verify(ps).setString(3, "json:hello");
+    }
+
+    @Test
+    void mirrored_column_is_written_on_insert() throws Exception {
+        var item = itemWithNested("hello");
+        var ps = mockInsert(item);
+
+        // position 4 = nested_value (after id=1, name=2, nested=3)
+        verify(ps).setString(4, "hello");
+    }
+
+    @Test
+    void custom_column_null_sets_null_on_insert() throws Exception {
+        var item = new Item();
+        item.setId("id1");
+        var ps = mockInsert(item);
+
+        verify(ps).setNull(3, Types.CLOB);
+    }
+
+    @Test
+    void mirrored_column_null_sets_null_on_insert() throws Exception {
+        var item = new Item();
+        item.setId("id1");
+        var ps = mockInsert(item);
+
+        verify(ps).setNull(4, Types.VARCHAR);
+    }
+
+    // ─── Read behaviour ───────────────────────────────────────────────────────
+
+    @Test
+    void custom_column_deserializer_is_called_on_row_mapping() throws Exception {
+        var rs = mockResultSet("id1", "myName", "json:world");
+
+        Item item = mapper.getRowMapper().mapRow(rs, 0);
+
+        assertNotNull(item.getNested());
+        assertEquals("world", item.getNested().getValue());
+    }
+
+    @Test
+    void base_columns_are_populated_on_row_mapping() throws Exception {
+        var rs = mockResultSet("id1", "myName", "json:world");
+
+        Item item = mapper.getRowMapper().mapRow(rs, 0);
+
+        assertEquals("id1", item.getId());
+        assertEquals("myName", item.getName());
+    }
+
+    @Test
+    void null_custom_column_leaves_nested_null() throws Exception {
+        var rs = mockResultSet("id1", "myName", null);
+
+        Item item = mapper.getRowMapper().mapRow(rs, 0);
+
+        assertNull(item.getNested());
+    }
+
+    @Test
+    void mirrored_column_does_not_affect_entity_on_row_mapping() throws Exception {
+        var rs = mockResultSet("id1", "myName", "json:world");
+        when(rs.getString("nested_value")).thenReturn("ignored");
+
+        Item item = mapper.getRowMapper().mapRow(rs, 0);
+
+        // nested comes from the "nested" column, not nested_value
+        assertEquals("world", item.getNested().getValue());
+        verify(rs, never()).getObject("nested_value");
+        verify(rs, never()).getString("nested_value");
+    }
+
+    // ─── Helpers ──────────────────────────────────────────────────────────────
+
+    private Item itemWithNested(String value) {
+        var item = new Item();
+        item.setId("id1");
+        item.setName("test");
+        item.setNested(new Nested(value));
+        return item;
+    }
+
+    private PreparedStatement mockInsert(Item item) throws Exception {
+        var con = mock(Connection.class);
+        var ps = mock(PreparedStatement.class);
+        when(con.prepareStatement(anyString())).thenReturn(ps);
+        mapper.buildInsertPreparedStatementCreator(item).createPreparedStatement(con);
+        return ps;
+    }
+
+    private String captureInsertSql() throws Exception {
+        var con = mock(Connection.class);
+        var ps = mock(PreparedStatement.class);
+        var captor = ArgumentCaptor.forClass(String.class);
+        when(con.prepareStatement(captor.capture())).thenReturn(ps);
+        mapper.buildInsertPreparedStatementCreator(new Item()).createPreparedStatement(con);
+        return captor.getValue();
+    }
+
+    private String captureUpdateSql() throws Exception {
+        var con = mock(Connection.class);
+        var ps = mock(PreparedStatement.class);
+        var captor = ArgumentCaptor.forClass(String.class);
+        when(con.prepareStatement(captor.capture())).thenReturn(ps);
+        mapper.buildUpdatePreparedStatementCreator(new Item(), "id1").createPreparedStatement(con);
+        return captor.getValue();
+    }
+
+    private ResultSet mockResultSet(String id, String name, String nestedJson) throws Exception {
+        var rs = mock(ResultSet.class);
+        when(rs.getObject("id")).thenReturn(id);
+        when(rs.getObject("name")).thenReturn(name);
+        when(rs.getObject("nested")).thenReturn(nestedJson);
+        when(rs.wasNull()).thenReturn(false);
+        return rs;
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoPortalPageContentRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/MongoPortalPageContentRepository.java
@@ -18,6 +18,7 @@ package io.gravitee.repository.mongodb.management;
 
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.PortalPageContentRepository;
+import io.gravitee.repository.management.model.AutomationTargetReferenceType;
 import io.gravitee.repository.management.model.PortalPageContent;
 import io.gravitee.repository.mongodb.management.internal.model.PortalPageContentMongo;
 import io.gravitee.repository.mongodb.management.internal.portalpagecontent.PortalPageContentMongoRepository;
@@ -100,6 +101,37 @@ public class MongoPortalPageContentRepository implements PortalPageContentReposi
         } catch (Exception ex) {
             log.error("Failed to find all portal page contents", ex);
             throw new TechnicalException("Failed to find all portal page contents", ex);
+        }
+    }
+
+    @Override
+    public List<PortalPageContent> findByAutomationReference(
+        String environmentId,
+        AutomationTargetReferenceType referenceType,
+        String referenceId
+    ) throws TechnicalException {
+        log.debug("Find portal page contents by automation reference [env={}, type={}, id={}]", environmentId, referenceType, referenceId);
+        try {
+            return internalRepo
+                .findByEnvironmentIdAndAutomationMetadata_ReferenceTypeAndAutomationMetadata_ReferenceId(
+                    environmentId,
+                    referenceType,
+                    referenceId
+                )
+                .stream()
+                .map(mapper::map)
+                .toList();
+        } catch (Exception e) {
+            throw new TechnicalException(
+                "An error occurred when finding portal page contents by automation reference [" +
+                    environmentId +
+                    ", " +
+                    referenceType +
+                    ", " +
+                    referenceId +
+                    "]",
+                e
+            );
         }
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/model/PortalPageContentMongo.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/model/PortalPageContentMongo.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.repository.mongodb.management.internal.model;
 
+import io.gravitee.repository.management.model.AutomationTargetReferenceType;
 import io.gravitee.repository.management.model.PortalPageContent;
 import lombok.Data;
 import org.springframework.data.mongodb.core.mapping.Document;
@@ -29,4 +30,17 @@ public class PortalPageContentMongo {
     private PortalPageContent.Type type;
     private String configuration;
     private String content;
+
+    /** Populated only for pages managed by the Automation API; null for non-automation pages. */
+    private AutomationMetadata automationMetadata;
+
+    @Data
+    public static class AutomationMetadata {
+
+        private AutomationTargetReferenceType referenceType;
+        private String referenceId;
+        private String name;
+        private String location;
+        private Integer order;
+    }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/portalpagecontent/PortalPageContentMongoRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/portalpagecontent/PortalPageContentMongoRepository.java
@@ -15,8 +15,10 @@
  */
 package io.gravitee.repository.mongodb.management.internal.portalpagecontent;
 
+import io.gravitee.repository.management.model.AutomationTargetReferenceType;
 import io.gravitee.repository.management.model.PortalPageContent;
 import io.gravitee.repository.mongodb.management.internal.model.PortalPageContentMongo;
+import java.util.List;
 import java.util.Set;
 import org.springframework.data.mongodb.repository.MongoRepository;
 import org.springframework.stereotype.Repository;
@@ -24,4 +26,10 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface PortalPageContentMongoRepository extends MongoRepository<PortalPageContentMongo, String> {
     Set<PortalPageContentMongo> findAllByType(PortalPageContent.Type type);
+
+    List<PortalPageContentMongo> findByEnvironmentIdAndAutomationMetadata_ReferenceTypeAndAutomationMetadata_ReferenceId(
+        String environmentId,
+        AutomationTargetReferenceType referenceType,
+        String referenceId
+    );
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/index/portalpagecontents/AutomationReferenceIndexUpgrader.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/upgrade/upgrader/index/portalpagecontents/AutomationReferenceIndexUpgrader.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.mongodb.management.upgrade.upgrader.index.portalpagecontents;
+
+import io.gravitee.repository.mongodb.management.upgrade.upgrader.index.Index;
+import io.gravitee.repository.mongodb.management.upgrade.upgrader.index.IndexUpgrader;
+import org.springframework.stereotype.Component;
+
+/**
+ * Compound index on portal_page_contents to support {@code findByAutomationReference} queries.
+ * Mirrors the JDBC {@code idx_portal_page_contents_automation_reference} index.
+ */
+@Component
+public class AutomationReferenceIndexUpgrader extends IndexUpgrader {
+
+    @Override
+    protected Index buildIndex() {
+        return Index.builder()
+            .collection("portal_page_contents")
+            .name("automation_reference_1")
+            .key("environmentId", ascending())
+            .key("automationMetadata.referenceType", ascending())
+            .key("automationMetadata.referenceId", ascending())
+            .build();
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/cockpit/command/handler/DeleteEnvironmentCommandHandler.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/cockpit/command/handler/DeleteEnvironmentCommandHandler.java
@@ -483,11 +483,11 @@ public class DeleteEnvironmentCommandHandler implements CommandHandler<DeleteEnv
         }
         try {
             var node = OBJECT_MAPPER.readTree(configuration);
-            if (node.has("pageId")) {
-                return node.get("pageId").asText();
+            if (node.has("portalPageContentId")) {
+                return node.get("portalPageContentId").asText();
             }
         } catch (Exception e) {
-            log.error("Failed to extract pageId from configuration: {}", configuration, e);
+            log.error("Failed to extract portalPageContentId from configuration: {}", configuration, e);
         }
         return null;
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/cockpit/command/handler/DeleteOrganizationCommandHandler.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/cockpit/command/handler/DeleteOrganizationCommandHandler.java
@@ -78,6 +78,7 @@ public class DeleteOrganizationCommandHandler implements CommandHandler<DeleteOr
     private final UserRepository userRepository;
     private final ClusterRepository clusterRepository;
     private final DashboardRepository dashboardRepository;
+    private final PortalListingRepository portalListingRepository;
     private final DeleteEnvironmentCommandHandler deleteEnvironmentCommandHandler;
 
     public DeleteOrganizationCommandHandler(
@@ -104,6 +105,7 @@ public class DeleteOrganizationCommandHandler implements CommandHandler<DeleteOr
         @Lazy UserRepository userRepository,
         @Lazy ClusterRepository clusterRepository,
         @Lazy DashboardRepository dashboardRepository,
+        @Lazy PortalListingRepository portalListingRepository,
         AccessPointCrudService accessPointService,
         EnvironmentService environmentService,
         IdentityProviderActivationService identityProviderActivationService,
@@ -139,6 +141,7 @@ public class DeleteOrganizationCommandHandler implements CommandHandler<DeleteOr
         this.userRepository = userRepository;
         this.clusterRepository = clusterRepository;
         this.dashboardRepository = dashboardRepository;
+        this.portalListingRepository = portalListingRepository;
         this.deleteEnvironmentCommandHandler = deleteEnvironmentCommandHandler;
     }
 
@@ -236,6 +239,7 @@ public class DeleteOrganizationCommandHandler implements CommandHandler<DeleteOr
         );
         entrypointRepository.deleteByReferenceIdAndReferenceType(organization.getId(), EntrypointReferenceType.ORGANIZATION);
         clusterRepository.deleteByOrganizationId(organization.getId());
+        portalListingRepository.deleteByOrganizationId(organization.getId());
         log.debug("Deleting am connection for organization [{}]", organization.getId());
         amConnectionRepository.delete(organization.getId());
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/cockpit/command/handler/DeleteEnvironmentCommandHandlerTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/cockpit/command/handler/DeleteEnvironmentCommandHandlerTest.java
@@ -433,7 +433,7 @@ public class DeleteEnvironmentCommandHandlerTest {
                     null,
                     "root-id",
                     13,
-                    "{\"pageId\":\"" + PAGE_CONTENT_ID + "\"}",
+                    "{\"portalPageContentId\":\"" + PAGE_CONTENT_ID + "\"}",
                     true,
                     PortalNavigationItem.Visibility.PUBLIC,
                     null
@@ -594,6 +594,7 @@ public class DeleteEnvironmentCommandHandlerTest {
 
         verify(portalPageContentRepository).delete(PAGE_CONTENT_ID);
         verify(portalNavigationItemRepository).deleteByEnvironmentId(ENV_ID);
+        verify(portalListingRepository).deleteByEnvironmentId(ENV_ID);
 
         verify(metadataRepository).deleteByReferenceIdAndReferenceType(ENV_ID, MetadataReferenceType.ENVIRONMENT);
         verify(scoringRulesetRepository).deleteByReferenceId(ENV_ID, "ENVIRONMENT");
@@ -645,8 +646,8 @@ public class DeleteEnvironmentCommandHandlerTest {
     }
 
     @Test
-    public void should_skip_portal_page_content_delete_when_pageId_cannot_be_extracted() throws Exception {
-        // override navigation items to provide an item without pageId in configuration
+    public void should_skip_portal_page_content_delete_when_portalPageContentId_cannot_be_extracted() throws Exception {
+        // override navigation items to provide an item without portalPageContentId in configuration
         when(portalNavigationItemRepository.findAllByOrganizationIdAndEnvironmentId(ORG_ID, ENV_ID)).thenReturn(
             List.of(
                 new PortalNavigationItem(
@@ -674,7 +675,7 @@ public class DeleteEnvironmentCommandHandlerTest {
 
         assertEquals(CommandStatus.SUCCEEDED, reply.getCommandStatus());
 
-        // page delete should not be invoked because no pageId could be extracted
+        // page delete should not be invoked because no portalPageContentId could be extracted
         org.mockito.Mockito.verify(portalPageContentRepository, org.mockito.Mockito.never()).delete(org.mockito.Mockito.anyString());
         // navigation items should still be deleted
         verify(portalNavigationItemRepository).deleteByEnvironmentId(ENV_ID);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/cockpit/command/handler/DeleteOrganizationCommandHandlerTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/cockpit/command/handler/DeleteOrganizationCommandHandlerTest.java
@@ -47,6 +47,7 @@ import io.gravitee.repository.management.api.MembershipRepository;
 import io.gravitee.repository.management.api.MetadataRepository;
 import io.gravitee.repository.management.api.NotificationTemplateRepository;
 import io.gravitee.repository.management.api.ParameterRepository;
+import io.gravitee.repository.management.api.PortalListingRepository;
 import io.gravitee.repository.management.api.PortalNotificationRepository;
 import io.gravitee.repository.management.api.RoleRepository;
 import io.gravitee.repository.management.api.TagRepository;
@@ -181,6 +182,9 @@ public class DeleteOrganizationCommandHandlerTest {
     private DashboardRepository dashboardRepository;
 
     @Mock
+    private PortalListingRepository portalListingRepository;
+
+    @Mock
     private DeleteEnvironmentCommandHandler deleteEnvironmentCommandHandler;
 
     private DeleteOrganizationCommandHandler cut;
@@ -223,6 +227,7 @@ public class DeleteOrganizationCommandHandlerTest {
             userRepository,
             clusterRepository,
             dashboardRepository,
+            portalListingRepository,
             accessPointService,
             environmentService,
             identityProviderActivationService,
@@ -365,6 +370,7 @@ public class DeleteOrganizationCommandHandlerTest {
             EntrypointReferenceType.ORGANIZATION
         );
         verify(clusterRepository).deleteByOrganizationId(executionContext.getOrganizationId());
+        verify(portalListingRepository).deleteByOrganizationId(executionContext.getOrganizationId());
         verify(amConnectionRepository).delete(executionContext.getOrganizationId());
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/OpenApiPortalPageContentConfigurationUpgraderTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/OpenApiPortalPageContentConfigurationUpgraderTest.java
@@ -22,6 +22,7 @@ import static org.assertj.core.groups.Tuple.tuple;
 import io.gravitee.node.api.upgrader.UpgraderException;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.PortalPageContentRepository;
+import io.gravitee.repository.management.model.AutomationTargetReferenceType;
 import io.gravitee.repository.management.model.PortalPageContent;
 import java.util.Collections;
 import java.util.LinkedHashSet;
@@ -169,6 +170,15 @@ class OpenApiPortalPageContentConfigurationUpgraderTest {
         @Override
         public void delete(String id) {
             contents.removeIf(content -> content.getId().equals(id));
+        }
+
+        @Override
+        public List<PortalPageContent> findByAutomationReference(
+            String environmentId,
+            AutomationTargetReferenceType referenceType,
+            String referenceId
+        ) {
+            return List.of();
         }
     }
 }


### PR DESCRIPTION
## Issue
https://gravitee.atlassian.net/browse/EXT-134

## Description

Persistence layer for Portal Documentation. Core domain and REST will follow in separate PRs.

### Key design choices

- Automation metadata stored directly on `portal_page_contents` — no separate table, no extra join.
- `automation_metadata` is a JSON blob (NCLOB). Two flat mirror columns (`automation_reference_type`, `automation_reference_id`) back a composite index for filtered lookups.

### What's in

- Liquibase migration: `automation_metadata`, `automation_reference_type`, `automation_reference_id` columns + composite index on `portal_page_contents`.
- `JdbcPortalPageContentRepository`: JSON ser/deser via ORM + `findByAutomationReference()`.
- MongoDB: `automationMetadata` as embedded document + index upgrader.
- `JdbcObjectMapperTest`: SQL generation, write, and read behaviour for custom-serialized and mirrored columns.

### What's *not* in (follow-up PRs)

- Core domain model and use cases.
- Automation REST resources.
- Materialization sync into the navigation tree.