### PR TITLE
feat(portal-documentation) core

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/java/io/gravitee/apim/rest/api/automation/mapper/PortalDocumentationMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/java/io/gravitee/apim/rest/api/automation/mapper/PortalDocumentationMapper.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.rest.api.automation.mapper;
+
+import io.gravitee.apim.core.audit.model.AuditInfo;
+import io.gravitee.apim.core.portal_page.model.AsyncApiPageContent;
+import io.gravitee.apim.core.portal_page.model.GraviteeMarkdownPageContent;
+import io.gravitee.apim.core.portal_page.model.OpenApiPageContent;
+import io.gravitee.apim.core.portal_page.model.PortalPageContent;
+import io.gravitee.apim.core.portal_page.model.PortalPageContentType;
+import io.gravitee.apim.core.validation.Validator;
+import io.gravitee.apim.rest.api.automation.model.DocumentationSpec;
+import io.gravitee.apim.rest.api.automation.model.DocumentationState;
+import io.gravitee.apim.rest.api.automation.model.Errors;
+import java.util.List;
+import org.mapstruct.Mapper;
+import org.mapstruct.factory.Mappers;
+
+/**
+ * @author GraviteeSource Team
+ */
+@Mapper
+public interface PortalDocumentationMapper {
+    PortalDocumentationMapper INSTANCE = Mappers.getMapper(PortalDocumentationMapper.class);
+
+    default DocumentationState toDocumentationState(
+        DocumentationSpec spec,
+        String id,
+        List<Validator.Error> errors,
+        AuditInfo audit,
+        String portalHrid
+    ) {
+        var state = new DocumentationState(id, audit.environmentId(), audit.organizationId(), toErrors(errors), portalHrid, null);
+        state.setHrid(spec.getHrid());
+        state.setName(spec.getName());
+        state.setType(spec.getType());
+        state.setContent(spec.getContent());
+        state.setLocation(spec.getLocation());
+        state.setOrder(spec.getOrder());
+        return state;
+    }
+
+    default DocumentationState toDocumentationState(PortalPageContent<?> pageContent, String hrid, String portalHrid) {
+        var meta = pageContent.getAutomationMetadata();
+        String rawContent = switch (pageContent) {
+            case GraviteeMarkdownPageContent gmd -> gmd.getContent().value();
+            case OpenApiPageContent oapi -> oapi.getContent().value();
+            case AsyncApiPageContent aapi -> aapi.getContent().value();
+        };
+        var state = new DocumentationState(
+            pageContent.getId() != null ? pageContent.getId().toString() : null,
+            pageContent.getEnvironmentId(),
+            pageContent.getOrganizationId(),
+            null,
+            portalHrid,
+            null
+        );
+        state.setHrid(hrid);
+        state.setName(meta.name());
+        state.setType(toWireType(pageContent.getType()));
+        state.setContent(rawContent);
+        state.setLocation(meta.location().orElse(null));
+        state.setOrder(meta.order().orElse(null));
+        return state;
+    }
+
+    default Errors toErrors(List<Validator.Error> validationErrors) {
+        if (validationErrors == null || validationErrors.isEmpty()) {
+            return null;
+        }
+        var wire = new Errors();
+        wire.setSevere(validationErrors.stream().filter(Validator.Error::isSevere).map(Validator.Error::getMessage).toList());
+        wire.setWarning(validationErrors.stream().filter(Validator.Error::isWarning).map(Validator.Error::getMessage).toList());
+        return wire;
+    }
+
+    default PortalPageContentType toDomainType(io.gravitee.apim.rest.api.automation.model.DocumentationType wire) {
+        return wire == null ? null : PortalPageContentType.valueOf(wire.getValue());
+    }
+
+    default io.gravitee.apim.rest.api.automation.model.DocumentationType toWireType(PortalPageContentType domain) {
+        return domain == null ? null : io.gravitee.apim.rest.api.automation.model.DocumentationType.fromValue(domain.name());
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/java/io/gravitee/apim/rest/api/automation/resource/PortalDocumentationResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/java/io/gravitee/apim/rest/api/automation/resource/PortalDocumentationResource.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.rest.api.automation.resource;
+
+import io.gravitee.apim.core.portal_documentation.exception.PortalDocumentationNotFoundException;
+import io.gravitee.apim.core.portal_page.model.PortalPageContentId;
+import io.gravitee.apim.core.portal_page.use_case.DeletePortalDocumentationUseCase;
+import io.gravitee.apim.core.portal_page.use_case.GetPortalDocumentationUseCase;
+import io.gravitee.apim.rest.api.automation.exception.HRIDNotFoundException;
+import io.gravitee.apim.rest.api.automation.mapper.PortalDocumentationMapper;
+import io.gravitee.common.http.MediaType;
+import io.gravitee.rest.api.model.permissions.RolePermission;
+import io.gravitee.rest.api.model.permissions.RolePermissionAction;
+import io.gravitee.rest.api.rest.annotation.Permission;
+import io.gravitee.rest.api.rest.annotation.Permissions;
+import io.gravitee.rest.api.service.common.HRIDToUUID;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.Response;
+
+/**
+ * @author GraviteeSource Team
+ */
+public class PortalDocumentationResource extends AbstractResource {
+
+    @Inject
+    private GetPortalDocumentationUseCase getPortalDocumentationUseCase;
+
+    @Inject
+    private DeletePortalDocumentationUseCase deletePortalDocumentationUseCase;
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    @Permissions({ @Permission(value = RolePermission.ENVIRONMENT_PORTAL, acls = RolePermissionAction.READ) })
+    public Response getPortalDocumentationByHRID(@PathParam("hrid") String portalHrid, @PathParam("docHrid") String docHrid) {
+        var auditInfo = getAuditInfo();
+        var documentationId = PortalPageContentId.of(
+            HRIDToUUID.portalDocumentation().context(auditInfo).portal(portalHrid).hrid(docHrid).id()
+        );
+        try {
+            var output = getPortalDocumentationUseCase.execute(new GetPortalDocumentationUseCase.Input(auditInfo, documentationId));
+            return Response.ok(PortalDocumentationMapper.INSTANCE.toDocumentationState(output.pageContent(), docHrid, portalHrid)).build();
+        } catch (PortalDocumentationNotFoundException e) {
+            throw new HRIDNotFoundException(docHrid);
+        }
+    }
+
+    @DELETE
+    @Permissions({ @Permission(value = RolePermission.ENVIRONMENT_PORTAL, acls = RolePermissionAction.DELETE) })
+    public Response deletePortalDocumentationByHrid(@PathParam("hrid") String portalHrid, @PathParam("docHrid") String docHrid) {
+        var auditInfo = getAuditInfo();
+        var documentationId = PortalPageContentId.of(
+            HRIDToUUID.portalDocumentation().context(auditInfo).portal(portalHrid).hrid(docHrid).id()
+        );
+        try {
+            deletePortalDocumentationUseCase.execute(new DeletePortalDocumentationUseCase.Input(auditInfo, documentationId));
+        } catch (PortalDocumentationNotFoundException e) {
+            throw new HRIDNotFoundException(docHrid);
+        }
+        return Response.noContent().build();
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/java/io/gravitee/apim/rest/api/automation/resource/PortalDocumentationsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/java/io/gravitee/apim/rest/api/automation/resource/PortalDocumentationsResource.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.rest.api.automation.resource;
+
+import static io.gravitee.rest.api.model.permissions.RolePermissionAction.CREATE;
+import static io.gravitee.rest.api.model.permissions.RolePermissionAction.UPDATE;
+
+import io.gravitee.apim.core.portal.model.PortalId;
+import io.gravitee.apim.core.portal_page.model.PortalPageContentId;
+import io.gravitee.apim.core.portal_page.use_case.CreateOrUpdatePortalDocumentationUseCase;
+import io.gravitee.apim.core.portal_page.use_case.ValidatePortalDocumentationUseCase;
+import io.gravitee.apim.rest.api.automation.mapper.PortalDocumentationMapper;
+import io.gravitee.apim.rest.api.automation.model.DocumentationSpec;
+import io.gravitee.common.http.MediaType;
+import io.gravitee.rest.api.model.permissions.RolePermission;
+import io.gravitee.rest.api.rest.annotation.Permission;
+import io.gravitee.rest.api.rest.annotation.Permissions;
+import io.gravitee.rest.api.service.common.HRIDToUUID;
+import jakarta.inject.Inject;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.PUT;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.container.ResourceContext;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.Response;
+
+/**
+ * @author GraviteeSource Team
+ */
+public class PortalDocumentationsResource extends AbstractResource {
+
+    @Context
+    private ResourceContext resourceContext;
+
+    @Inject
+    private CreateOrUpdatePortalDocumentationUseCase createOrUpdatePortalDocumentationUseCase;
+
+    @Inject
+    private ValidatePortalDocumentationUseCase validatePortalDocumentationUseCase;
+
+    @Path("/{docHrid}")
+    public PortalDocumentationResource getPortalDocumentationResource() {
+        return resourceContext.getResource(PortalDocumentationResource.class);
+    }
+
+    @PUT
+    @Produces(MediaType.APPLICATION_JSON)
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Permissions({ @Permission(value = RolePermission.ENVIRONMENT_PORTAL, acls = { CREATE, UPDATE }) })
+    public Response createOrUpdate(
+        @PathParam("hrid") String portalHrid,
+        @Valid @NotNull DocumentationSpec spec,
+        @QueryParam("dryRun") boolean dryRun
+    ) {
+        var auditInfo = getAuditInfo();
+        var portalId = PortalId.of(HRIDToUUID.portal().context(auditInfo).hrid(portalHrid).id());
+        var documentationId = PortalPageContentId.of(
+            HRIDToUUID.portalDocumentation().context(auditInfo).portal(portalHrid).hrid(spec.getHrid()).id()
+        );
+
+        var input = new CreateOrUpdatePortalDocumentationUseCase.Input(
+            auditInfo,
+            documentationId,
+            portalId,
+            spec.getName(),
+            PortalDocumentationMapper.INSTANCE.toDomainType(spec.getType()),
+            spec.getContent(),
+            spec.getLocation(),
+            spec.getOrder()
+        );
+        var output = dryRun ? validatePortalDocumentationUseCase.execute(input) : createOrUpdatePortalDocumentationUseCase.execute(input);
+
+        return Response.ok(
+            PortalDocumentationMapper.INSTANCE.toDocumentationState(
+                spec,
+                output.id() != null ? output.id().toString() : null,
+                output.errors(),
+                auditInfo,
+                portalHrid
+            )
+        ).build();
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/java/io/gravitee/apim/rest/api/automation/resource/PortalResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/java/io/gravitee/apim/rest/api/automation/resource/PortalResource.java
@@ -56,6 +56,11 @@ public class PortalResource extends AbstractResource {
         return resourceContext.getResource(PortalListingsResource.class);
     }
 
+    @Path("/documentations")
+    public PortalDocumentationsResource getPortalDocumentationsResource() {
+        return resourceContext.getResource(PortalDocumentationsResource.class);
+    }
+
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     @Permissions({ @Permission(value = RolePermission.ENVIRONMENT_PORTAL, acls = RolePermissionAction.READ) })

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/mapper/PortalDocumentationMapperTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/mapper/PortalDocumentationMapperTest.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.rest.api.automation.mapper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.apim.core.audit.model.AuditInfo;
+import io.gravitee.apim.core.open_api.OpenApi;
+import io.gravitee.apim.core.portal_page.model.AutomationMetadata;
+import io.gravitee.apim.core.portal_page.model.OpenApiPageContent;
+import io.gravitee.apim.core.portal_page.model.PortalPageContentId;
+import io.gravitee.apim.core.portal_page.model.PortalPageContentType;
+import io.gravitee.apim.core.portal_page.model.RedocConfiguration;
+import io.gravitee.apim.core.validation.Validator;
+import io.gravitee.apim.rest.api.automation.model.DocumentationSpec;
+import java.util.List;
+import java.util.Optional;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class PortalDocumentationMapperTest {
+
+    private static final PortalPageContentId DOC_ID = PortalPageContentId.of("00000000-0000-0000-0000-0000000000c1");
+    private static final AuditInfo AUDIT = AuditInfo.builder().organizationId("organization-id").environmentId("environment-id").build();
+
+    @Test
+    void put_state_includes_severe_and_warning_errors() {
+        var spec = aSpec();
+        var errors = List.of(Validator.Error.severe("boom"), Validator.Error.warning("careful"));
+
+        var state = PortalDocumentationMapper.INSTANCE.toDocumentationState(spec, DOC_ID.toString(), errors, AUDIT, "default-portal");
+
+        SoftAssertions.assertSoftly(soft -> {
+            soft.assertThat(state.getErrors()).isNotNull();
+            soft.assertThat(state.getErrors().getSevere()).containsExactly("boom");
+            soft.assertThat(state.getErrors().getWarning()).containsExactly("careful");
+        });
+    }
+
+    @Test
+    void put_state_returns_null_errors_when_list_is_empty() {
+        var state = PortalDocumentationMapper.INSTANCE.toDocumentationState(aSpec(), DOC_ID.toString(), List.of(), AUDIT, "default-portal");
+
+        assertThat(state.getErrors()).isNull();
+    }
+
+    @Test
+    void put_state_returns_null_errors_when_list_is_null() {
+        var state = PortalDocumentationMapper.INSTANCE.toDocumentationState(aSpec(), DOC_ID.toString(), null, AUDIT, "default-portal");
+
+        assertThat(state.getErrors()).isNull();
+    }
+
+    @Test
+    void put_state_emits_null_id_when_use_case_did_not_produce_one() {
+        var state = PortalDocumentationMapper.INSTANCE.toDocumentationState(aSpec(), null, List.of(), AUDIT, "default-portal");
+
+        assertThat(state.getId()).isNull();
+    }
+
+    @Test
+    void get_state_copies_persisted_entity_fields() {
+        var pageContent = new OpenApiPageContent(
+            DOC_ID,
+            "organization-id",
+            "environment-id",
+            OpenApi.of("openapi: 3.0.0"),
+            new RedocConfiguration(),
+            new AutomationMetadata(
+                AutomationMetadata.ReferenceType.PORTAL,
+                "portal-id",
+                "Getting Started",
+                Optional.of("/projects/alpha"),
+                Optional.of(7)
+            )
+        );
+
+        var state = PortalDocumentationMapper.INSTANCE.toDocumentationState(pageContent, "getting-started", "default-portal");
+
+        SoftAssertions.assertSoftly(soft -> {
+            soft.assertThat(state.getId()).isEqualTo(DOC_ID.toString());
+            soft.assertThat(state.getHrid()).isEqualTo("getting-started");
+            soft.assertThat(state.getName()).isEqualTo("Getting Started");
+            soft.assertThat(state.getType().getValue()).isEqualTo("OPENAPI");
+            soft.assertThat(state.getContent()).isEqualTo("openapi: 3.0.0");
+            soft.assertThat(state.getLocation()).isEqualTo("/projects/alpha");
+            soft.assertThat(state.getOrder()).isEqualTo(7);
+            soft.assertThat(state.getPortalHrid()).isEqualTo("default-portal");
+            soft.assertThat(state.getApiHrid()).isNull();
+            soft.assertThat(state.getErrors()).isNull();
+        });
+    }
+
+    @Test
+    void domain_and_wire_type_round_trip_through_each_value() {
+        for (PortalPageContentType domain : PortalPageContentType.values()) {
+            var wire = PortalDocumentationMapper.INSTANCE.toWireType(domain);
+            assertThat(PortalDocumentationMapper.INSTANCE.toDomainType(wire)).isEqualTo(domain);
+        }
+    }
+
+    @Test
+    void enum_conversions_pass_null_through() {
+        assertThat(PortalDocumentationMapper.INSTANCE.toDomainType(null)).isNull();
+        assertThat(PortalDocumentationMapper.INSTANCE.toWireType(null)).isNull();
+    }
+
+    private static DocumentationSpec aSpec() {
+        var spec = new DocumentationSpec();
+        spec.setHrid("getting-started");
+        spec.setName("Getting Started");
+        spec.setType(io.gravitee.apim.rest.api.automation.model.DocumentationType.GRAVITEE_MARKDOWN);
+        spec.setContent("# Hello");
+        spec.setLocation("/projects/alpha");
+        spec.setOrder(1);
+        return spec;
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/resource/PortalDocumentationResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/resource/PortalDocumentationResourceTest.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.rest.api.automation.resource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.apim.core.gravitee_markdown.GraviteeMarkdown;
+import io.gravitee.apim.core.portal_documentation.exception.PortalDocumentationNotFoundException;
+import io.gravitee.apim.core.portal_page.model.AutomationMetadata;
+import io.gravitee.apim.core.portal_page.model.GraviteeMarkdownPageContent;
+import io.gravitee.apim.core.portal_page.model.PortalPageContentId;
+import io.gravitee.apim.core.portal_page.use_case.DeletePortalDocumentationUseCase;
+import io.gravitee.apim.core.portal_page.use_case.GetPortalDocumentationUseCase;
+import io.gravitee.apim.rest.api.automation.model.DocumentationState;
+import io.gravitee.apim.rest.api.automation.resource.base.AbstractResourceTest;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.core.MediaType;
+import java.util.Optional;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class PortalDocumentationResourceTest extends AbstractResourceTest {
+
+    private static final String PORTAL_HRID = "default-portal";
+    private static final String DOC_HRID = "getting-started";
+
+    @Inject
+    private GetPortalDocumentationUseCase getPortalDocumentationUseCase;
+
+    @Inject
+    private DeletePortalDocumentationUseCase deletePortalDocumentationUseCase;
+
+    @AfterEach
+    void tearDown() {
+        reset(getPortalDocumentationUseCase, deletePortalDocumentationUseCase);
+    }
+
+    @Override
+    protected String contextPath() {
+        return "/organizations/" + ORGANIZATION + "/environments/" + ENVIRONMENT + "/portals/" + PORTAL_HRID + "/documentations";
+    }
+
+    @Nested
+    class Get {
+
+        @Test
+        void should_return_portal_documentation() {
+            when(getPortalDocumentationUseCase.execute(any())).thenReturn(new GetPortalDocumentationUseCase.Output(aPageContent()));
+
+            try (var response = rootTarget(DOC_HRID).request().accept(MediaType.APPLICATION_JSON_TYPE).get()) {
+                assertThat(response.getStatus()).isEqualTo(200);
+                verify(getPortalDocumentationUseCase).execute(any(GetPortalDocumentationUseCase.Input.class));
+
+                var state = response.readEntity(DocumentationState.class);
+                SoftAssertions.assertSoftly(soft -> {
+                    soft.assertThat(state.getHrid()).isEqualTo(DOC_HRID);
+                    soft.assertThat(state.getName()).isEqualTo("Getting Started");
+                    soft.assertThat(state.getType().getValue()).isEqualTo("GRAVITEE_MARKDOWN");
+                    soft.assertThat(state.getContent()).contains("Hello");
+                    soft.assertThat(state.getLocation()).isEqualTo("/projects/alpha");
+                    soft.assertThat(state.getOrder()).isEqualTo(1);
+                    soft.assertThat(state.getPortalHrid()).isEqualTo(PORTAL_HRID);
+                    soft.assertThat(state.getApiHrid()).isNull();
+                });
+            }
+        }
+
+        @Test
+        void should_return_404_when_documentation_is_missing() {
+            when(getPortalDocumentationUseCase.execute(any())).thenThrow(new PortalDocumentationNotFoundException(DOC_HRID));
+
+            try (var response = rootTarget(DOC_HRID).request().accept(MediaType.APPLICATION_JSON_TYPE).get()) {
+                assertThat(response.getStatus()).isEqualTo(404);
+            }
+        }
+    }
+
+    @Nested
+    class Delete {
+
+        @Test
+        void should_delete_portal_documentation() {
+            try (var response = rootTarget(DOC_HRID).request().delete()) {
+                assertThat(response.getStatus()).isEqualTo(204);
+                verify(deletePortalDocumentationUseCase).execute(any(DeletePortalDocumentationUseCase.Input.class));
+            }
+        }
+
+        @Test
+        void should_return_404_when_documentation_is_missing() {
+            org.mockito.Mockito.doThrow(new PortalDocumentationNotFoundException(DOC_HRID))
+                .when(deletePortalDocumentationUseCase)
+                .execute(any());
+
+            try (var response = rootTarget(DOC_HRID).request().delete()) {
+                assertThat(response.getStatus()).isEqualTo(404);
+            }
+        }
+    }
+
+    private static GraviteeMarkdownPageContent aPageContent() {
+        return new GraviteeMarkdownPageContent(
+            PortalPageContentId.of("00000000-0000-0000-0000-0000000000c1"),
+            ORGANIZATION,
+            ENVIRONMENT,
+            GraviteeMarkdown.of("# Hello\n\nMarkdown"),
+            new AutomationMetadata(
+                AutomationMetadata.ReferenceType.PORTAL,
+                "00000000-0000-0000-0000-0000000000a1",
+                "Getting Started",
+                Optional.of("/projects/alpha"),
+                Optional.of(1)
+            )
+        );
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/resource/PortalDocumentationsResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/resource/PortalDocumentationsResourceTest.java
@@ -1,0 +1,194 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.rest.api.automation.resource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.apim.core.exception.ValidationDomainException;
+import io.gravitee.apim.core.portal_page.model.PortalPageContentId;
+import io.gravitee.apim.core.portal_page.use_case.CreateOrUpdatePortalDocumentationUseCase;
+import io.gravitee.apim.core.portal_page.use_case.ValidatePortalDocumentationUseCase;
+import io.gravitee.apim.core.validation.Validator;
+import io.gravitee.apim.rest.api.automation.model.DocumentationState;
+import io.gravitee.apim.rest.api.automation.resource.base.AbstractResourceTest;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.client.Entity;
+import jakarta.ws.rs.core.MediaType;
+import java.util.List;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class PortalDocumentationsResourceTest extends AbstractResourceTest {
+
+    private static final String PORTAL_HRID = "default-portal";
+
+    @Inject
+    private CreateOrUpdatePortalDocumentationUseCase createOrUpdatePortalDocumentationUseCase;
+
+    @Inject
+    private ValidatePortalDocumentationUseCase validatePortalDocumentationUseCase;
+
+    @AfterEach
+    void tearDown() {
+        reset(createOrUpdatePortalDocumentationUseCase, validatePortalDocumentationUseCase);
+    }
+
+    @Override
+    protected String contextPath() {
+        return "/organizations/" + ORGANIZATION + "/environments/" + ENVIRONMENT + "/portals/" + PORTAL_HRID + "/documentations";
+    }
+
+    @Nested
+    class DryRun {
+
+        @Test
+        void should_return_populated_state_when_validation_passes() {
+            when(validatePortalDocumentationUseCase.execute(any())).thenReturn(
+                new CreateOrUpdatePortalDocumentationUseCase.Output(
+                    PortalPageContentId.of("00000000-0000-0000-0000-0000000000c1"),
+                    List.of()
+                )
+            );
+
+            try (
+                var response = rootTarget()
+                    .queryParam("dryRun", true)
+                    .request()
+                    .accept(MediaType.APPLICATION_JSON_TYPE)
+                    .put(Entity.json(readJSON("portal-documentation.json")))
+            ) {
+                assertThat(response.getStatus()).isEqualTo(200);
+                verify(validatePortalDocumentationUseCase).execute(any(CreateOrUpdatePortalDocumentationUseCase.Input.class));
+                verifyNoInteractions(createOrUpdatePortalDocumentationUseCase);
+
+                var state = response.readEntity(DocumentationState.class);
+                SoftAssertions.assertSoftly(soft -> {
+                    soft.assertThat(state.getHrid()).isEqualTo("getting-started");
+                    soft.assertThat(state.getName()).isEqualTo("Getting Started");
+                    soft.assertThat(state.getType().getValue()).isEqualTo("GRAVITEE_MARKDOWN");
+                    soft.assertThat(state.getContent()).contains("Hello");
+                    soft.assertThat(state.getLocation()).isEqualTo("/projects/alpha");
+                    soft.assertThat(state.getOrder()).isEqualTo(1);
+                    soft.assertThat(state.getPortalHrid()).isEqualTo(PORTAL_HRID);
+                    soft.assertThat(state.getApiHrid()).isNull();
+                    soft.assertThat(state.getEnvironmentId()).isEqualTo(ENVIRONMENT);
+                    soft.assertThat(state.getOrganizationId()).isEqualTo(ORGANIZATION);
+                    soft.assertThat(state.getId()).isEqualTo("00000000-0000-0000-0000-0000000000c1");
+                    soft.assertThat(state.getErrors()).isNull();
+                });
+            }
+        }
+
+        @Test
+        void should_return_state_with_errors_when_validation_fails() {
+            when(validatePortalDocumentationUseCase.execute(any())).thenReturn(
+                new CreateOrUpdatePortalDocumentationUseCase.Output(
+                    PortalPageContentId.of("00000000-0000-0000-0000-0000000000c1"),
+                    List.of(Validator.Error.severe("location must start with '/'"))
+                )
+            );
+
+            try (
+                var response = rootTarget()
+                    .queryParam("dryRun", true)
+                    .request()
+                    .accept(MediaType.APPLICATION_JSON_TYPE)
+                    .put(Entity.json(readJSON("portal-documentation.json")))
+            ) {
+                assertThat(response.getStatus()).isEqualTo(200);
+                verifyNoInteractions(createOrUpdatePortalDocumentationUseCase);
+
+                var state = response.readEntity(DocumentationState.class);
+                assertThat(state.getErrors()).isNotNull();
+                assertThat(state.getErrors().getSevere()).hasSize(1);
+                assertThat(state.getErrors().getSevere().get(0)).contains("location");
+            }
+        }
+
+        @Test
+        void should_return_400_when_hrid_is_missing() {
+            try (
+                var response = rootTarget()
+                    .queryParam("dryRun", true)
+                    .request()
+                    .accept(MediaType.APPLICATION_JSON_TYPE)
+                    .put(Entity.json(readJSON("invalid-portal-documentation.json")))
+            ) {
+                assertThat(response.getStatus()).isEqualTo(400);
+                verifyNoInteractions(validatePortalDocumentationUseCase);
+                verifyNoInteractions(createOrUpdatePortalDocumentationUseCase);
+            }
+        }
+    }
+
+    @Nested
+    class Run {
+
+        @Test
+        void should_create_or_update_portal_documentation() {
+            when(createOrUpdatePortalDocumentationUseCase.execute(any())).thenReturn(
+                new CreateOrUpdatePortalDocumentationUseCase.Output(
+                    PortalPageContentId.of("00000000-0000-0000-0000-0000000000c1"),
+                    List.of()
+                )
+            );
+
+            try (
+                var response = rootTarget()
+                    .request()
+                    .accept(MediaType.APPLICATION_JSON_TYPE)
+                    .put(Entity.json(readJSON("portal-documentation.json")))
+            ) {
+                assertThat(response.getStatus()).isEqualTo(200);
+                verify(createOrUpdatePortalDocumentationUseCase).execute(any(CreateOrUpdatePortalDocumentationUseCase.Input.class));
+
+                var state = response.readEntity(DocumentationState.class);
+                SoftAssertions.assertSoftly(soft -> {
+                    soft.assertThat(state.getId()).isEqualTo("00000000-0000-0000-0000-0000000000c1");
+                    soft.assertThat(state.getHrid()).isEqualTo("getting-started");
+                    soft.assertThat(state.getPortalHrid()).isEqualTo(PORTAL_HRID);
+                    soft.assertThat(state.getApiHrid()).isNull();
+                });
+            }
+        }
+
+        @Test
+        void should_return_400_when_validation_severe_error_raised() {
+            when(createOrUpdatePortalDocumentationUseCase.execute(any())).thenThrow(
+                new ValidationDomainException("location must start with '/'")
+            );
+
+            try (
+                var response = rootTarget()
+                    .request()
+                    .accept(MediaType.APPLICATION_JSON_TYPE)
+                    .put(Entity.json(readJSON("portal-documentation.json")))
+            ) {
+                assertThat(response.getStatus()).isEqualTo(400);
+            }
+        }
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/spring/ResourceContextConfiguration.java
@@ -154,10 +154,14 @@ import io.gravitee.apim.core.portal_page.query_service.PortalNavigationItemsQuer
 import io.gravitee.apim.core.portal_page.query_service.PortalPageContentQueryService;
 import io.gravitee.apim.core.portal_page.service_provider.PortalNavigationTemplatingService;
 import io.gravitee.apim.core.portal_page.use_case.CreateDefaultPortalNavigationItemsUseCase;
+import io.gravitee.apim.core.portal_page.use_case.CreateOrUpdatePortalDocumentationUseCase;
 import io.gravitee.apim.core.portal_page.use_case.CreatePortalNavigationItemUseCase;
+import io.gravitee.apim.core.portal_page.use_case.DeletePortalDocumentationUseCase;
+import io.gravitee.apim.core.portal_page.use_case.GetPortalDocumentationUseCase;
 import io.gravitee.apim.core.portal_page.use_case.GetPortalPageContentUseCase;
 import io.gravitee.apim.core.portal_page.use_case.ListPortalNavigationItemsUseCase;
 import io.gravitee.apim.core.portal_page.use_case.UpdatePortalNavigationItemUseCase;
+import io.gravitee.apim.core.portal_page.use_case.ValidatePortalDocumentationUseCase;
 import io.gravitee.apim.core.promotion.service_provider.CockpitPromotionServiceProvider;
 import io.gravitee.apim.core.promotion.use_case.CreatePromotionUseCase;
 import io.gravitee.apim.core.promotion.use_case.ProcessPromotionUseCase;
@@ -1336,5 +1340,25 @@ public class ResourceContextConfiguration {
     @Bean
     public ValidatePortalListingUseCase validatePortalListingUseCase() {
         return mock(ValidatePortalListingUseCase.class);
+    }
+
+    @Bean
+    public CreateOrUpdatePortalDocumentationUseCase createOrUpdatePortalDocumentationUseCase() {
+        return mock(CreateOrUpdatePortalDocumentationUseCase.class);
+    }
+
+    @Bean
+    public GetPortalDocumentationUseCase getPortalDocumentationUseCase() {
+        return mock(GetPortalDocumentationUseCase.class);
+    }
+
+    @Bean
+    public DeletePortalDocumentationUseCase deletePortalDocumentationUseCase() {
+        return mock(DeletePortalDocumentationUseCase.class);
+    }
+
+    @Bean
+    public ValidatePortalDocumentationUseCase validatePortalDocumentationUseCase() {
+        return mock(ValidatePortalDocumentationUseCase.class);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/resources/io/gravitee/apim/rest/api/automation/resource/invalid-portal-documentation.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/resources/io/gravitee/apim/rest/api/automation/resource/invalid-portal-documentation.json
@@ -1,0 +1,5 @@
+{
+  "name": "Missing HRID",
+  "type": "GRAVITEE_MARKDOWN",
+  "content": "# Hello"
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/resources/io/gravitee/apim/rest/api/automation/resource/portal-documentation.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/resources/io/gravitee/apim/rest/api/automation/resource/portal-documentation.json
@@ -1,0 +1,8 @@
+{
+  "hrid": "getting-started",
+  "name": "Getting Started",
+  "type": "GRAVITEE_MARKDOWN",
+  "content": "# Hello\n\nThis is markdown.",
+  "location": "/projects/alpha",
+  "order": 1
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal/use_case/CreateOrUpdatePortalUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal/use_case/CreateOrUpdatePortalUseCase.java
@@ -59,9 +59,7 @@ public class CreateOrUpdatePortalUseCase {
 
         var warnings = validation.warning().orElseGet(List::of);
 
-        var sanitized = validation
-            .value()
-            .orElse(new ValidatePortalDomainService.Input(input.auditInfo(), input.portal(), input.navigation()));
+        var sanitized = validation.value().orElseThrow(() -> new ValidationDomainException("Unable to sanitize portal"));
         var portal = sanitized.portal();
         var existing = portalCrudService.findByIdAndEnvironmentId(portal.getId(), input.auditInfo().environmentId());
         var saved = existing.isPresent() ? portalCrudService.update(portal) : portalCrudService.create(portal);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_documentation/domain_service/ValidatePortalDocumentationDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_documentation/domain_service/ValidatePortalDocumentationDomainService.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal_documentation.domain_service;
+
+import io.gravitee.apim.core.DomainService;
+import io.gravitee.apim.core.audit.model.AuditInfo;
+import io.gravitee.apim.core.portal.model.PortalId;
+import io.gravitee.apim.core.portal.validation.NavigationPathValidator;
+import io.gravitee.apim.core.portal_page.model.PortalPageContentId;
+import io.gravitee.apim.core.portal_page.model.PortalPageContentType;
+import io.gravitee.apim.core.validation.Validator;
+import java.util.ArrayList;
+
+/**
+ * Validates Portal Documentation input. Format checks only — no reference-existence checks
+ * (parent portal). Missing parent is tolerated as orphan per the orphan-tolerance design;
+ * the doc materializes once the missing CRD applies.
+ *
+ * @author GraviteeSource Team
+ */
+@DomainService
+public class ValidatePortalDocumentationDomainService implements Validator<ValidatePortalDocumentationDomainService.Input> {
+
+    public record Input(
+        AuditInfo auditInfo,
+        PortalPageContentId portalPageContentId,
+        PortalId portalId,
+        String name,
+        PortalPageContentType type,
+        String content,
+        String location,
+        Integer order
+    ) implements Validator.Input {}
+
+    @Override
+    public Result<Input> validateAndSanitize(Input input) {
+        var errors = new ArrayList<Error>();
+
+        if (input.name() == null || input.name().isBlank()) {
+            errors.add(Error.severe("name must not be blank"));
+        }
+        if (input.type() == null) {
+            errors.add(Error.severe("type must not be null"));
+        }
+        if (input.content() == null) {
+            errors.add(Error.severe("content must not be null"));
+        }
+        if (input.location() != null) {
+            errors.addAll(NavigationPathValidator.validate(input.location(), "location"));
+        }
+
+        return Result.ofBoth(input, errors);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_documentation/exception/PortalDocumentationNotFoundException.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_documentation/exception/PortalDocumentationNotFoundException.java
@@ -13,16 +13,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.apim.core.portal_page.query_service;
+package io.gravitee.apim.core.portal_documentation.exception;
 
-import io.gravitee.apim.core.portal_page.model.AutomationMetadata;
-import io.gravitee.apim.core.portal_page.model.PortalPageContent;
-import io.gravitee.apim.core.portal_page.model.PortalPageContentId;
-import java.util.List;
-import java.util.Optional;
+import io.gravitee.apim.core.exception.NotFoundDomainException;
 
-public interface PortalPageContentQueryService {
-    Optional<PortalPageContent<?>> findById(PortalPageContentId id);
+/**
+ * @author GraviteeSource Team
+ */
+public class PortalDocumentationNotFoundException extends NotFoundDomainException {
 
-    List<PortalPageContent<?>> findByReference(String environmentId, AutomationMetadata.ReferenceType referenceType, String referenceId);
+    public PortalDocumentationNotFoundException(String documentationId) {
+        super("Portal Documentation [ " + documentationId + " ] not found", documentationId);
+    }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_listing/use_case/CreateOrUpdatePortalListingUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_listing/use_case/CreateOrUpdatePortalListingUseCase.java
@@ -53,15 +53,17 @@ public class CreateOrUpdatePortalListingUseCase {
 
         var warnings = validation.warning().orElseGet(List::of);
 
+        var sanitized = validation.value().orElseThrow(() -> new ValidationDomainException("Unable to sanitize portal listing"));
+
         var listing = PortalListing.of(
-            input.listingId(),
+            sanitized.listingId(),
             input.auditInfo().environmentId(),
             input.auditInfo().organizationId(),
-            input.portalId(),
-            input.apis() == null ? List.of() : input.apis()
+            sanitized.portalId(),
+            sanitized.apis() == null ? List.of() : sanitized.apis()
         );
 
-        var existing = portalListingCrudService.findByIdAndEnvironmentId(input.listingId(), input.auditInfo().environmentId());
+        var existing = portalListingCrudService.findByIdAndEnvironmentId(sanitized.listingId(), input.auditInfo().environmentId());
         var saved = existing.isPresent() ? portalListingCrudService.update(listing) : portalListingCrudService.create(listing);
 
         return new Output(saved.getId(), warnings);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/model/AsyncApiPageContent.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/model/AsyncApiPageContent.java
@@ -17,6 +17,7 @@ package io.gravitee.apim.core.portal_page.model;
 
 import io.gravitee.apim.core.async_api.AsyncApi;
 import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -35,7 +36,17 @@ public final class AsyncApiPageContent extends PortalPageContent<AsyncApi> {
         @Nonnull String environmentId,
         @Nonnull AsyncApi content
     ) {
-        super(id, organizationId, environmentId);
+        this(id, organizationId, environmentId, content, null);
+    }
+
+    public AsyncApiPageContent(
+        @Nonnull PortalPageContentId id,
+        @Nonnull String organizationId,
+        @Nonnull String environmentId,
+        @Nonnull AsyncApi content,
+        @Nullable AutomationMetadata automationMetadata
+    ) {
+        super(id, organizationId, environmentId, automationMetadata);
         this.content = content;
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/model/AutomationMetadata.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/model/AutomationMetadata.java
@@ -13,16 +13,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.apim.core.portal_page.query_service;
+package io.gravitee.apim.core.portal_page.model;
 
-import io.gravitee.apim.core.portal_page.model.AutomationMetadata;
-import io.gravitee.apim.core.portal_page.model.PortalPageContent;
-import io.gravitee.apim.core.portal_page.model.PortalPageContentId;
-import java.util.List;
 import java.util.Optional;
 
-public interface PortalPageContentQueryService {
-    Optional<PortalPageContent<?>> findById(PortalPageContentId id);
-
-    List<PortalPageContent<?>> findByReference(String environmentId, AutomationMetadata.ReferenceType referenceType, String referenceId);
+public record AutomationMetadata(
+    ReferenceType referenceType,
+    String referenceId,
+    String name,
+    Optional<String> location,
+    Optional<Integer> order
+) {
+    public enum ReferenceType {
+        PORTAL,
+        API,
+    }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/model/GraviteeMarkdownPageContent.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/model/GraviteeMarkdownPageContent.java
@@ -17,6 +17,7 @@ package io.gravitee.apim.core.portal_page.model;
 
 import io.gravitee.apim.core.gravitee_markdown.GraviteeMarkdown;
 import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -35,7 +36,17 @@ public final class GraviteeMarkdownPageContent extends PortalPageContent<Gravite
         @Nonnull String environmentId,
         @Nonnull GraviteeMarkdown content
     ) {
-        super(id, organizationId, environmentId);
+        this(id, organizationId, environmentId, content, null);
+    }
+
+    public GraviteeMarkdownPageContent(
+        @Nonnull PortalPageContentId id,
+        @Nonnull String organizationId,
+        @Nonnull String environmentId,
+        @Nonnull GraviteeMarkdown content,
+        @Nullable AutomationMetadata automationMetadata
+    ) {
+        super(id, organizationId, environmentId, automationMetadata);
         this.content = content;
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/model/OpenApiPageContent.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/model/OpenApiPageContent.java
@@ -17,6 +17,7 @@ package io.gravitee.apim.core.portal_page.model;
 
 import io.gravitee.apim.core.open_api.OpenApi;
 import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -39,7 +40,7 @@ public final class OpenApiPageContent extends PortalPageContent<OpenApi> {
         @Nonnull String environmentId,
         @Nonnull OpenApi content
     ) {
-        this(id, organizationId, environmentId, content, new RedocConfiguration());
+        this(id, organizationId, environmentId, content, new RedocConfiguration(), null);
     }
 
     public OpenApiPageContent(
@@ -49,7 +50,18 @@ public final class OpenApiPageContent extends PortalPageContent<OpenApi> {
         @Nonnull OpenApi content,
         @Nonnull OpenApiConfiguration viewerSettings
     ) {
-        super(id, organizationId, environmentId);
+        this(id, organizationId, environmentId, content, viewerSettings, null);
+    }
+
+    public OpenApiPageContent(
+        @Nonnull PortalPageContentId id,
+        @Nonnull String organizationId,
+        @Nonnull String environmentId,
+        @Nonnull OpenApi content,
+        @Nonnull OpenApiConfiguration viewerSettings,
+        @Nullable AutomationMetadata automationMetadata
+    ) {
+        super(id, organizationId, environmentId, automationMetadata);
         this.content = content;
         this.viewerSettings = viewerSettings;
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/model/PortalPageContent.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/model/PortalPageContent.java
@@ -16,6 +16,7 @@
 package io.gravitee.apim.core.portal_page.model;
 
 import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
 import lombok.Getter;
 
 @Getter
@@ -30,13 +31,27 @@ public abstract sealed class PortalPageContent<T> permits GraviteeMarkdownPageCo
     @Nonnull
     private final String environmentId;
 
-    protected PortalPageContent(@Nonnull PortalPageContentId id, @Nonnull String organizationId, @Nonnull String environmentId) {
+    @Nullable
+    private AutomationMetadata automationMetadata;
+
+    protected PortalPageContent(
+        @Nonnull PortalPageContentId id,
+        @Nonnull String organizationId,
+        @Nonnull String environmentId,
+        @Nullable AutomationMetadata automationMetadata
+    ) {
         this.id = id;
         this.organizationId = organizationId;
         this.environmentId = environmentId;
+        this.automationMetadata = automationMetadata;
     }
 
     public abstract void update(@Nonnull UpdatePortalPageContent updatePortalPageContent);
+
+    public final void update(@Nonnull UpdatePortalPageContent updatePortalPageContent, @Nullable AutomationMetadata automationMetadata) {
+        this.automationMetadata = automationMetadata;
+        update(updatePortalPageContent);
+    }
 
     public abstract PortalPageContentType getType();
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/use_case/CreateOrUpdatePortalDocumentationUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/use_case/CreateOrUpdatePortalDocumentationUseCase.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal_page.use_case;
+
+import io.gravitee.apim.core.UseCase;
+import io.gravitee.apim.core.async_api.AsyncApi;
+import io.gravitee.apim.core.audit.model.AuditInfo;
+import io.gravitee.apim.core.exception.ValidationDomainException;
+import io.gravitee.apim.core.gravitee_markdown.GraviteeMarkdown;
+import io.gravitee.apim.core.open_api.OpenApi;
+import io.gravitee.apim.core.portal.model.PortalId;
+import io.gravitee.apim.core.portal_documentation.domain_service.ValidatePortalDocumentationDomainService;
+import io.gravitee.apim.core.portal_page.crud_service.PortalPageContentCrudService;
+import io.gravitee.apim.core.portal_page.model.AsyncApiPageContent;
+import io.gravitee.apim.core.portal_page.model.AutomationMetadata;
+import io.gravitee.apim.core.portal_page.model.GraviteeMarkdownPageContent;
+import io.gravitee.apim.core.portal_page.model.OpenApiPageContent;
+import io.gravitee.apim.core.portal_page.model.PortalPageContent;
+import io.gravitee.apim.core.portal_page.model.PortalPageContentId;
+import io.gravitee.apim.core.portal_page.model.PortalPageContentType;
+import io.gravitee.apim.core.portal_page.model.RedocConfiguration;
+import io.gravitee.apim.core.portal_page.model.UpdatePortalPageContent;
+import io.gravitee.apim.core.portal_page.query_service.PortalPageContentQueryService;
+import io.gravitee.apim.core.validation.Validator;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+
+@UseCase
+@RequiredArgsConstructor
+public class CreateOrUpdatePortalDocumentationUseCase {
+
+    private final ValidatePortalDocumentationDomainService validator;
+    private final PortalPageContentCrudService portalPageContentCrudService;
+    private final PortalPageContentQueryService portalPageContentQueryService;
+
+    public record Input(
+        AuditInfo auditInfo,
+        PortalPageContentId portalPageContentId,
+        PortalId portalId,
+        String name,
+        PortalPageContentType type,
+        String content,
+        String location,
+        Integer order
+    ) {}
+
+    public record Output(PortalPageContentId id, List<Validator.Error> errors) {}
+
+    public Output execute(Input input) {
+        var validation = validator.validateAndSanitize(
+            new ValidatePortalDocumentationDomainService.Input(
+                input.auditInfo(),
+                input.portalPageContentId(),
+                input.portalId(),
+                input.name(),
+                input.type(),
+                input.content(),
+                input.location(),
+                input.order()
+            )
+        );
+
+        validation
+            .severe()
+            .ifPresent(errors -> {
+                throw new ValidationDomainException(errors.stream().map(Validator.Error::getMessage).collect(Collectors.joining(", ")));
+            });
+
+        var warnings = validation.warning().orElseGet(List::of);
+        var sanitized = validation.value().orElseThrow(() -> new ValidationDomainException("Unable to sanitize portal documentation"));
+
+        var meta = new AutomationMetadata(
+            AutomationMetadata.ReferenceType.PORTAL,
+            sanitized.portalId().toString(),
+            sanitized.name(),
+            Optional.ofNullable(sanitized.location()),
+            Optional.ofNullable(sanitized.order())
+        );
+
+        var existing = portalPageContentQueryService.findById(sanitized.portalPageContentId());
+        PortalPageContent<?> saved;
+        if (existing.isPresent()) {
+            var current = existing.get();
+            if (current.getType() != sanitized.type()) {
+                portalPageContentCrudService.delete(current.getId());
+                saved = portalPageContentCrudService.create(buildNew(sanitized, meta));
+            } else {
+                current.update(new UpdatePortalPageContent(sanitized.content(), null), meta);
+                saved = portalPageContentCrudService.update(current);
+            }
+        } else {
+            saved = portalPageContentCrudService.create(buildNew(sanitized, meta));
+        }
+
+        return new Output(saved.getId(), warnings);
+    }
+
+    private PortalPageContent<?> buildNew(ValidatePortalDocumentationDomainService.Input sanitized, AutomationMetadata meta) {
+        var id = sanitized.portalPageContentId();
+        var orgId = sanitized.auditInfo().organizationId();
+        var envId = sanitized.auditInfo().environmentId();
+        return switch (sanitized.type()) {
+            case GRAVITEE_MARKDOWN -> new GraviteeMarkdownPageContent(id, orgId, envId, GraviteeMarkdown.of(sanitized.content()), meta);
+            case OPENAPI -> new OpenApiPageContent(id, orgId, envId, OpenApi.of(sanitized.content()), new RedocConfiguration(), meta);
+            case ASYNCAPI -> new AsyncApiPageContent(id, orgId, envId, AsyncApi.of(sanitized.content()), meta);
+        };
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/use_case/DeletePortalDocumentationUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/use_case/DeletePortalDocumentationUseCase.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal_page.use_case;
+
+import io.gravitee.apim.core.UseCase;
+import io.gravitee.apim.core.audit.model.AuditInfo;
+import io.gravitee.apim.core.portal_documentation.exception.PortalDocumentationNotFoundException;
+import io.gravitee.apim.core.portal_page.crud_service.PortalPageContentCrudService;
+import io.gravitee.apim.core.portal_page.model.PortalPageContentId;
+import io.gravitee.apim.core.portal_page.query_service.PortalPageContentQueryService;
+import lombok.RequiredArgsConstructor;
+
+@UseCase
+@RequiredArgsConstructor
+public class DeletePortalDocumentationUseCase {
+
+    private final PortalPageContentCrudService portalPageContentCrudService;
+    private final PortalPageContentQueryService portalPageContentQueryService;
+
+    public record Input(AuditInfo auditInfo, PortalPageContentId portalPageContentId) {}
+
+    public void execute(Input input) {
+        portalPageContentQueryService
+            .findById(input.portalPageContentId())
+            .filter(pc -> pc.getAutomationMetadata() != null)
+            .orElseThrow(() -> new PortalDocumentationNotFoundException(input.portalPageContentId().toString()));
+        portalPageContentCrudService.delete(input.portalPageContentId());
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/use_case/GetPortalDocumentationUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/use_case/GetPortalDocumentationUseCase.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal_page.use_case;
+
+import io.gravitee.apim.core.UseCase;
+import io.gravitee.apim.core.audit.model.AuditInfo;
+import io.gravitee.apim.core.portal_documentation.exception.PortalDocumentationNotFoundException;
+import io.gravitee.apim.core.portal_page.model.PortalPageContent;
+import io.gravitee.apim.core.portal_page.model.PortalPageContentId;
+import io.gravitee.apim.core.portal_page.query_service.PortalPageContentQueryService;
+import lombok.RequiredArgsConstructor;
+
+@UseCase
+@RequiredArgsConstructor
+public class GetPortalDocumentationUseCase {
+
+    private final PortalPageContentQueryService portalPageContentQueryService;
+
+    public record Input(AuditInfo auditInfo, PortalPageContentId portalPageContentId) {}
+
+    public record Output(PortalPageContent<?> pageContent) {}
+
+    public Output execute(Input input) {
+        var pageContent = portalPageContentQueryService
+            .findById(input.portalPageContentId())
+            .filter(pc -> pc.getAutomationMetadata() != null)
+            .orElseThrow(() -> new PortalDocumentationNotFoundException(input.portalPageContentId().toString()));
+        return new Output(pageContent);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/use_case/ValidatePortalDocumentationUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/use_case/ValidatePortalDocumentationUseCase.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal_page.use_case;
+
+import io.gravitee.apim.core.UseCase;
+import io.gravitee.apim.core.portal_documentation.domain_service.ValidatePortalDocumentationDomainService;
+import io.gravitee.apim.core.validation.Validator;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+
+@UseCase
+@RequiredArgsConstructor
+public class ValidatePortalDocumentationUseCase {
+
+    private final ValidatePortalDocumentationDomainService validator;
+
+    public CreateOrUpdatePortalDocumentationUseCase.Output execute(CreateOrUpdatePortalDocumentationUseCase.Input input) {
+        var result = validator.validateAndSanitize(
+            new ValidatePortalDocumentationDomainService.Input(
+                input.auditInfo(),
+                input.portalPageContentId(),
+                input.portalId(),
+                input.name(),
+                input.type(),
+                input.content(),
+                input.location(),
+                input.order()
+            )
+        );
+        List<Validator.Error> errors = result.errors().orElseGet(List::of);
+        return new CreateOrUpdatePortalDocumentationUseCase.Output(input.portalPageContentId(), errors);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/PortalPageContentAdapter.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/PortalPageContentAdapter.java
@@ -20,6 +20,7 @@ import io.gravitee.apim.core.async_api.AsyncApi;
 import io.gravitee.apim.core.gravitee_markdown.GraviteeMarkdown;
 import io.gravitee.apim.core.open_api.OpenApi;
 import io.gravitee.apim.core.portal_page.model.AsyncApiPageContent;
+import io.gravitee.apim.core.portal_page.model.AutomationMetadata;
 import io.gravitee.apim.core.portal_page.model.GraviteeMarkdownPageContent;
 import io.gravitee.apim.core.portal_page.model.OpenApiConfiguration;
 import io.gravitee.apim.core.portal_page.model.OpenApiPageContent;
@@ -27,6 +28,8 @@ import io.gravitee.apim.core.portal_page.model.PortalPageContent;
 import io.gravitee.apim.core.portal_page.model.PortalPageContentId;
 import io.gravitee.apim.core.portal_page.model.RedocConfiguration;
 import io.gravitee.apim.core.portal_page.model.SwaggerUiConfiguration;
+import io.gravitee.repository.management.model.AutomationTargetReferenceType;
+import jakarta.annotation.Nullable;
 import java.util.LinkedHashMap;
 import java.util.Optional;
 import org.mapstruct.Mapper;
@@ -38,26 +41,39 @@ public interface PortalPageContentAdapter {
     ObjectMapper JSON = new ObjectMapper();
 
     default PortalPageContent<?> toEntity(io.gravitee.repository.management.model.PortalPageContent portalPageContent) {
+        var repoMeta = portalPageContent.getAutomationMetadata();
+        var meta = repoMeta == null
+            ? null
+            : new AutomationMetadata(
+                AutomationMetadata.ReferenceType.valueOf(repoMeta.getReferenceType().name()),
+                repoMeta.getReferenceId(),
+                repoMeta.getName(),
+                Optional.ofNullable(repoMeta.getLocation()),
+                Optional.ofNullable(repoMeta.getOrder())
+            );
         return switch (portalPageContent.getType()) {
-            case GRAVITEE_MARKDOWN -> graviteeMarkdownPageContentFromRepository(portalPageContent);
-            case OPENAPI -> openApiPageContentFromRepository(portalPageContent);
-            case ASYNCAPI -> asyncApiPageContentFromRepository(portalPageContent);
+            case GRAVITEE_MARKDOWN -> graviteeMarkdownPageContentFromRepository(portalPageContent, meta);
+            case OPENAPI -> openApiPageContentFromRepository(portalPageContent, meta);
+            case ASYNCAPI -> asyncApiPageContentFromRepository(portalPageContent, meta);
         };
     }
 
     default GraviteeMarkdownPageContent graviteeMarkdownPageContentFromRepository(
-        io.gravitee.repository.management.model.PortalPageContent portalPageContent
+        io.gravitee.repository.management.model.PortalPageContent portalPageContent,
+        @Nullable AutomationMetadata automationMetadata
     ) {
         return new GraviteeMarkdownPageContent(
             PortalPageContentId.of(portalPageContent.getId()),
             portalPageContent.getOrganizationId(),
             portalPageContent.getEnvironmentId(),
-            GraviteeMarkdown.of(portalPageContent.getContent())
+            GraviteeMarkdown.of(portalPageContent.getContent()),
+            automationMetadata
         );
     }
 
     default OpenApiPageContent openApiPageContentFromRepository(
-        io.gravitee.repository.management.model.PortalPageContent portalPageContent
+        io.gravitee.repository.management.model.PortalPageContent portalPageContent,
+        @Nullable AutomationMetadata automationMetadata
     ) {
         OpenApiConfiguration configuration = null;
         if (portalPageContent.getConfiguration() != null && !portalPageContent.getConfiguration().isBlank()) {
@@ -79,18 +95,21 @@ public interface PortalPageContentAdapter {
             portalPageContent.getOrganizationId(),
             portalPageContent.getEnvironmentId(),
             OpenApi.of(portalPageContent.getContent()),
-            Optional.ofNullable(configuration).orElseGet(RedocConfiguration::new)
+            Optional.ofNullable(configuration).orElseGet(RedocConfiguration::new),
+            automationMetadata
         );
     }
 
     default AsyncApiPageContent asyncApiPageContentFromRepository(
-        io.gravitee.repository.management.model.PortalPageContent portalPageContent
+        io.gravitee.repository.management.model.PortalPageContent portalPageContent,
+        @Nullable AutomationMetadata automationMetadata
     ) {
         return new AsyncApiPageContent(
             PortalPageContentId.of(portalPageContent.getId()),
             portalPageContent.getOrganizationId(),
             portalPageContent.getEnvironmentId(),
-            AsyncApi.of(portalPageContent.getContent())
+            AsyncApi.of(portalPageContent.getContent()),
+            automationMetadata
         );
     }
 
@@ -115,6 +134,7 @@ public interface PortalPageContentAdapter {
                 );
             }
         }
+        var meta = portalPageContent.getAutomationMetadata();
         return io.gravitee.repository.management.model.PortalPageContent.builder()
             .id(portalPageContent.getId().toString())
             .organizationId(portalPageContent.getOrganizationId())
@@ -122,6 +142,17 @@ public interface PortalPageContentAdapter {
             .type(toRepositoryType(portalPageContent.getType()))
             .content(rawContent)
             .configuration(rawConfiguration)
+            .automationMetadata(
+                meta == null
+                    ? null
+                    : io.gravitee.repository.management.model.PortalPageContent.AutomationMetadata.builder()
+                        .referenceType(AutomationTargetReferenceType.valueOf(meta.referenceType().name()))
+                        .referenceId(meta.referenceId())
+                        .name(meta.name())
+                        .location(meta.location().orElse(null))
+                        .order(meta.order().orElse(null))
+                        .build()
+            )
             .build();
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/query_service/portal_page/PortalPageContentQueryServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/query_service/portal_page/PortalPageContentQueryServiceImpl.java
@@ -16,12 +16,15 @@
 package io.gravitee.apim.infra.query_service.portal_page;
 
 import io.gravitee.apim.core.exception.TechnicalDomainException;
+import io.gravitee.apim.core.portal_page.model.AutomationMetadata;
 import io.gravitee.apim.core.portal_page.model.PortalPageContent;
 import io.gravitee.apim.core.portal_page.model.PortalPageContentId;
 import io.gravitee.apim.core.portal_page.query_service.PortalPageContentQueryService;
 import io.gravitee.apim.infra.adapter.PortalPageContentAdapter;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.PortalPageContentRepository;
+import io.gravitee.repository.management.model.AutomationTargetReferenceType;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Service;
@@ -42,6 +45,29 @@ public class PortalPageContentQueryServiceImpl implements PortalPageContentQuery
             return portalPageContentRepository.findById(id.json()).map(portalPageContentAdapter::toEntity);
         } catch (TechnicalException e) {
             String errorMessage = String.format("An error occurred while finding portal page content by id %s", id.json());
+            throw new TechnicalDomainException(errorMessage, e);
+        }
+    }
+
+    @Override
+    public List<PortalPageContent<?>> findByReference(
+        String environmentId,
+        AutomationMetadata.ReferenceType referenceType,
+        String referenceId
+    ) {
+        try {
+            return portalPageContentRepository
+                .findByAutomationReference(environmentId, AutomationTargetReferenceType.valueOf(referenceType.name()), referenceId)
+                .stream()
+                .map(portalPageContentAdapter::toEntity)
+                .toList();
+        } catch (TechnicalException e) {
+            String errorMessage = String.format(
+                "An error occurred while finding portal page contents by reference %s/%s in env %s",
+                referenceType,
+                referenceId,
+                environmentId
+            );
             throw new TechnicalDomainException(errorMessage, e);
         }
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/common/HRIDToUUID.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/common/HRIDToUUID.java
@@ -82,6 +82,10 @@ public final class HRIDToUUID {
         return new PortalSubResourceBuilder();
     }
 
+    public static PortalSubResourceBuilder portalDocumentation() {
+        return new PortalSubResourceBuilder();
+    }
+
     public static class TopLevelBuilder {
 
         public TopLevelWithContext context(AuditInfo audit) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/PortalPageContentQueryServiceInMemory.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/inmemory/PortalPageContentQueryServiceInMemory.java
@@ -15,6 +15,7 @@
  */
 package inmemory;
 
+import io.gravitee.apim.core.portal_page.model.AutomationMetadata;
 import io.gravitee.apim.core.portal_page.model.PortalPageContent;
 import io.gravitee.apim.core.portal_page.model.PortalPageContentId;
 import io.gravitee.apim.core.portal_page.query_service.PortalPageContentQueryService;
@@ -40,6 +41,26 @@ public class PortalPageContentQueryServiceInMemory implements InMemoryAlternativ
             .stream()
             .filter(content -> content.getId().equals(id))
             .findFirst();
+    }
+
+    @Override
+    public List<PortalPageContent<?>> findByReference(
+        String environmentId,
+        AutomationMetadata.ReferenceType referenceType,
+        String referenceId
+    ) {
+        return storage
+            .stream()
+            .filter(content -> {
+                var meta = content.getAutomationMetadata();
+                return (
+                    meta != null &&
+                    meta.referenceType() == referenceType &&
+                    meta.referenceId().equals(referenceId) &&
+                    content.getEnvironmentId().equals(environmentId)
+                );
+            })
+            .toList();
     }
 
     @Override

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/CreateOrUpdatePortalDocumentationUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/CreateOrUpdatePortalDocumentationUseCaseTest.java
@@ -1,0 +1,193 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal_page.use_case;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+
+import inmemory.PortalPageContentCrudServiceInMemory;
+import inmemory.PortalPageContentQueryServiceInMemory;
+import io.gravitee.apim.core.audit.model.AuditActor;
+import io.gravitee.apim.core.audit.model.AuditInfo;
+import io.gravitee.apim.core.exception.ValidationDomainException;
+import io.gravitee.apim.core.portal.model.PortalId;
+import io.gravitee.apim.core.portal_documentation.domain_service.ValidatePortalDocumentationDomainService;
+import io.gravitee.apim.core.portal_page.model.AutomationMetadata;
+import io.gravitee.apim.core.portal_page.model.PortalPageContentId;
+import io.gravitee.apim.core.portal_page.model.PortalPageContentType;
+import io.gravitee.rest.api.service.common.HRIDToUUID;
+import java.util.Optional;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class CreateOrUpdatePortalDocumentationUseCaseTest {
+
+    private static final AuditInfo AUDIT_INFO = AuditInfo.builder()
+        .organizationId("organization-id")
+        .environmentId("environment-id")
+        .actor(AuditActor.builder().userId("user-id").build())
+        .build();
+    private static final String PORTAL_HRID = "default-portal";
+    private static final String DOC_HRID = "getting-started";
+    private static final PortalId PORTAL_ID = PortalId.of(HRIDToUUID.portal().context(AUDIT_INFO).hrid(PORTAL_HRID).id());
+    private static final PortalPageContentId DOC_ID = PortalPageContentId.of(
+        HRIDToUUID.portalDocumentation().context(AUDIT_INFO).portal(PORTAL_HRID).hrid(DOC_HRID).id()
+    );
+
+    private final PortalPageContentCrudServiceInMemory crudService = new PortalPageContentCrudServiceInMemory();
+    private final PortalPageContentQueryServiceInMemory queryService = new PortalPageContentQueryServiceInMemory();
+    private final ValidatePortalDocumentationDomainService validator = new ValidatePortalDocumentationDomainService();
+    private CreateOrUpdatePortalDocumentationUseCase useCase;
+
+    @BeforeEach
+    void setUp() {
+        useCase = new CreateOrUpdatePortalDocumentationUseCase(validator, crudService, queryService);
+    }
+
+    @AfterEach
+    void tearDown() {
+        crudService.reset();
+        queryService.reset();
+    }
+
+    @Test
+    void should_create_when_not_existing() {
+        var output = useCase.execute(input("Getting Started", PortalPageContentType.GRAVITEE_MARKDOWN, "# Hello", "/projects/alpha", 1));
+
+        assertThat(output.id()).isEqualTo(DOC_ID);
+        assertThat(output.errors()).isEmpty();
+        assertThat(crudService.storage()).hasSize(1);
+        var stored = crudService.storage().get(0);
+        var meta = stored.getAutomationMetadata();
+        assertThat(meta.name()).isEqualTo("Getting Started");
+        assertThat(meta.referenceType()).isEqualTo(AutomationMetadata.ReferenceType.PORTAL);
+        assertThat(meta.referenceId()).isEqualTo(PORTAL_ID.toString());
+    }
+
+    @Test
+    void should_update_when_existing() {
+        useCase.execute(input("Getting Started", PortalPageContentType.GRAVITEE_MARKDOWN, "# Hello", "/projects/alpha", 1));
+        queryService.initWith(crudService.storage());
+
+        var output = useCase.execute(input("Renamed", PortalPageContentType.OPENAPI, "openapi: 3.0.0", "/projects/alpha/v2", 5));
+
+        assertThat(output.id()).isEqualTo(DOC_ID);
+        assertThat(crudService.storage()).hasSize(1);
+        var stored = crudService.storage().get(0);
+        var meta = stored.getAutomationMetadata();
+        assertThat(meta.name()).isEqualTo("Renamed");
+        assertThat(stored.getType()).isEqualTo(PortalPageContentType.OPENAPI);
+        assertThat(meta.location()).contains("/projects/alpha/v2");
+        assertThat(meta.order()).contains(5);
+    }
+
+    @Test
+    void should_be_idempotent_when_put_twice() {
+        var input = input("Getting Started", PortalPageContentType.GRAVITEE_MARKDOWN, "# Hello", "/projects/alpha", 1);
+
+        var first = useCase.execute(input);
+        queryService.initWith(crudService.storage());
+        var second = useCase.execute(input);
+
+        assertThat(first.id()).isEqualTo(second.id());
+        assertThat(crudService.storage()).hasSize(1);
+    }
+
+    @Test
+    void should_persist_even_when_parent_portal_does_not_exist() {
+        var output = useCase.execute(input("Getting Started", PortalPageContentType.GRAVITEE_MARKDOWN, "# Hello", "/projects/alpha", 1));
+
+        assertThat(output.errors()).isEmpty();
+        assertThat(crudService.storage()).hasSize(1);
+    }
+
+    @Test
+    void should_persist_with_null_location_and_order() {
+        var output = useCase.execute(input("Getting Started", PortalPageContentType.GRAVITEE_MARKDOWN, "# Hello", null, null));
+
+        assertThat(output.errors()).isEmpty();
+        var stored = crudService.storage().get(0);
+        assertThat(stored.getAutomationMetadata().location()).isEmpty();
+        assertThat(stored.getAutomationMetadata().order()).isEmpty();
+    }
+
+    @Test
+    void should_throw_validation_error_when_location_is_malformed() {
+        var throwable = catchThrowable(() ->
+            useCase.execute(input("Getting Started", PortalPageContentType.GRAVITEE_MARKDOWN, "# Hello", "projects/alpha", 1))
+        );
+
+        assertThat(throwable).isInstanceOf(ValidationDomainException.class);
+        assertThat(throwable.getMessage()).contains("location");
+        assertThat(crudService.storage()).isEmpty();
+    }
+
+    @Test
+    void should_throw_validation_error_when_name_is_null() {
+        var throwable = catchThrowable(() ->
+            useCase.execute(input(null, PortalPageContentType.GRAVITEE_MARKDOWN, "# Hello", "/projects/alpha", 1))
+        );
+
+        assertThat(throwable).isInstanceOf(ValidationDomainException.class);
+        assertThat(throwable.getMessage()).contains("name");
+        assertThat(crudService.storage()).isEmpty();
+    }
+
+    @Test
+    void should_throw_validation_error_when_type_is_null() {
+        var throwable = catchThrowable(() -> useCase.execute(input("Getting Started", null, "# Hello", "/projects/alpha", 1)));
+
+        assertThat(throwable).isInstanceOf(ValidationDomainException.class);
+        assertThat(throwable.getMessage()).contains("type");
+        assertThat(crudService.storage()).isEmpty();
+    }
+
+    @Test
+    void should_throw_validation_error_when_name_is_blank() {
+        var throwable = catchThrowable(() ->
+            useCase.execute(input("  ", PortalPageContentType.GRAVITEE_MARKDOWN, "# Hello", "/projects/alpha", 1))
+        );
+
+        assertThat(throwable).isInstanceOf(ValidationDomainException.class);
+        assertThat(throwable.getMessage()).contains("name");
+        assertThat(crudService.storage()).isEmpty();
+    }
+
+    @Test
+    void should_throw_validation_error_when_content_is_null() {
+        var throwable = catchThrowable(() ->
+            useCase.execute(input("Getting Started", PortalPageContentType.GRAVITEE_MARKDOWN, null, "/projects/alpha", 1))
+        );
+
+        assertThat(throwable).isInstanceOf(ValidationDomainException.class);
+        assertThat(throwable.getMessage()).contains("content");
+        assertThat(crudService.storage()).isEmpty();
+    }
+
+    private static CreateOrUpdatePortalDocumentationUseCase.Input input(
+        String name,
+        PortalPageContentType type,
+        String content,
+        String location,
+        Integer order
+    ) {
+        return new CreateOrUpdatePortalDocumentationUseCase.Input(AUDIT_INFO, DOC_ID, PORTAL_ID, name, type, content, location, order);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/DeletePortalDocumentationUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/DeletePortalDocumentationUseCaseTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal_page.use_case;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+
+import inmemory.PortalPageContentCrudServiceInMemory;
+import inmemory.PortalPageContentQueryServiceInMemory;
+import io.gravitee.apim.core.audit.model.AuditActor;
+import io.gravitee.apim.core.audit.model.AuditInfo;
+import io.gravitee.apim.core.gravitee_markdown.GraviteeMarkdown;
+import io.gravitee.apim.core.portal_documentation.exception.PortalDocumentationNotFoundException;
+import io.gravitee.apim.core.portal_page.model.AutomationMetadata;
+import io.gravitee.apim.core.portal_page.model.GraviteeMarkdownPageContent;
+import io.gravitee.apim.core.portal_page.model.PortalPageContentId;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class DeletePortalDocumentationUseCaseTest {
+
+    private static final AuditInfo AUDIT_INFO = AuditInfo.builder()
+        .organizationId("organization-id")
+        .environmentId("environment-id")
+        .actor(AuditActor.builder().userId("user-id").build())
+        .build();
+    private static final PortalPageContentId DOC_ID = PortalPageContentId.of("00000000-0000-0000-0000-0000000000c1");
+
+    private final PortalPageContentCrudServiceInMemory crudService = new PortalPageContentCrudServiceInMemory();
+    private final PortalPageContentQueryServiceInMemory queryService = new PortalPageContentQueryServiceInMemory();
+    private DeletePortalDocumentationUseCase useCase;
+
+    @BeforeEach
+    void setUp() {
+        useCase = new DeletePortalDocumentationUseCase(crudService, queryService);
+    }
+
+    @AfterEach
+    void tearDown() {
+        crudService.reset();
+        queryService.reset();
+    }
+
+    @Test
+    void should_delete_documentation() {
+        var pageContent = aPageContent();
+        crudService.initWith(List.of(pageContent));
+        queryService.initWith(List.of(pageContent));
+
+        useCase.execute(new DeletePortalDocumentationUseCase.Input(AUDIT_INFO, DOC_ID));
+
+        assertThat(crudService.storage()).isEmpty();
+    }
+
+    @Test
+    void should_throw_when_missing() {
+        var throwable = catchThrowable(() -> useCase.execute(new DeletePortalDocumentationUseCase.Input(AUDIT_INFO, DOC_ID)));
+
+        assertThat(throwable).isInstanceOf(PortalDocumentationNotFoundException.class);
+    }
+
+    @Test
+    void should_throw_when_page_content_has_no_automation_metadata() {
+        var pageContent = new GraviteeMarkdownPageContent(
+            DOC_ID,
+            AUDIT_INFO.organizationId(),
+            AUDIT_INFO.environmentId(),
+            GraviteeMarkdown.of("# Hello")
+        );
+        crudService.initWith(List.of(pageContent));
+        queryService.initWith(List.of(pageContent));
+
+        var throwable = catchThrowable(() -> useCase.execute(new DeletePortalDocumentationUseCase.Input(AUDIT_INFO, DOC_ID)));
+
+        assertThat(throwable).isInstanceOf(PortalDocumentationNotFoundException.class);
+    }
+
+    private static GraviteeMarkdownPageContent aPageContent() {
+        return new GraviteeMarkdownPageContent(
+            DOC_ID,
+            AUDIT_INFO.organizationId(),
+            AUDIT_INFO.environmentId(),
+            GraviteeMarkdown.of("# Hello"),
+            new AutomationMetadata(
+                AutomationMetadata.ReferenceType.PORTAL,
+                "00000000-0000-0000-0000-0000000000a1",
+                "Getting Started",
+                Optional.of("/projects/alpha"),
+                Optional.of(1)
+            )
+        );
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/GetPortalDocumentationUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/GetPortalDocumentationUseCaseTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal_page.use_case;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+
+import inmemory.PortalPageContentQueryServiceInMemory;
+import io.gravitee.apim.core.audit.model.AuditActor;
+import io.gravitee.apim.core.audit.model.AuditInfo;
+import io.gravitee.apim.core.gravitee_markdown.GraviteeMarkdown;
+import io.gravitee.apim.core.portal_documentation.exception.PortalDocumentationNotFoundException;
+import io.gravitee.apim.core.portal_page.model.AutomationMetadata;
+import io.gravitee.apim.core.portal_page.model.GraviteeMarkdownPageContent;
+import io.gravitee.apim.core.portal_page.model.PortalPageContentId;
+import io.gravitee.apim.core.portal_page.model.PortalPageContentType;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class GetPortalDocumentationUseCaseTest {
+
+    private static final AuditInfo AUDIT_INFO = AuditInfo.builder()
+        .organizationId("organization-id")
+        .environmentId("environment-id")
+        .actor(AuditActor.builder().userId("user-id").build())
+        .build();
+    private static final PortalPageContentId DOC_ID = PortalPageContentId.of("00000000-0000-0000-0000-0000000000c1");
+
+    private final PortalPageContentQueryServiceInMemory queryService = new PortalPageContentQueryServiceInMemory();
+    private GetPortalDocumentationUseCase useCase;
+
+    @BeforeEach
+    void setUp() {
+        useCase = new GetPortalDocumentationUseCase(queryService);
+    }
+
+    @AfterEach
+    void tearDown() {
+        queryService.reset();
+    }
+
+    @Test
+    void should_return_documentation() {
+        queryService.initWith(List.of(aPageContent()));
+
+        var output = useCase.execute(new GetPortalDocumentationUseCase.Input(AUDIT_INFO, DOC_ID));
+
+        assertThat(output.pageContent().getId()).isEqualTo(DOC_ID);
+        assertThat(output.pageContent().getAutomationMetadata().name()).isEqualTo("Getting Started");
+        assertThat(output.pageContent().getType()).isEqualTo(PortalPageContentType.GRAVITEE_MARKDOWN);
+        assertThat(output.pageContent().getAutomationMetadata().location()).contains("/projects/alpha");
+        assertThat(output.pageContent().getAutomationMetadata().order()).contains(1);
+    }
+
+    @Test
+    void should_throw_when_missing() {
+        var throwable = catchThrowable(() -> useCase.execute(new GetPortalDocumentationUseCase.Input(AUDIT_INFO, DOC_ID)));
+
+        assertThat(throwable).isInstanceOf(PortalDocumentationNotFoundException.class);
+    }
+
+    @Test
+    void should_throw_when_page_content_has_no_automation_metadata() {
+        var pageContent = new GraviteeMarkdownPageContent(
+            DOC_ID,
+            AUDIT_INFO.organizationId(),
+            AUDIT_INFO.environmentId(),
+            GraviteeMarkdown.of("# Hello")
+        );
+        queryService.initWith(List.of(pageContent));
+
+        var throwable = catchThrowable(() -> useCase.execute(new GetPortalDocumentationUseCase.Input(AUDIT_INFO, DOC_ID)));
+
+        assertThat(throwable).isInstanceOf(PortalDocumentationNotFoundException.class);
+    }
+
+    private static GraviteeMarkdownPageContent aPageContent() {
+        return new GraviteeMarkdownPageContent(
+            DOC_ID,
+            AUDIT_INFO.organizationId(),
+            AUDIT_INFO.environmentId(),
+            GraviteeMarkdown.of("# Hello"),
+            new AutomationMetadata(
+                AutomationMetadata.ReferenceType.PORTAL,
+                "00000000-0000-0000-0000-0000000000a1",
+                "Getting Started",
+                Optional.of("/projects/alpha"),
+                Optional.of(1)
+            )
+        );
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/ValidatePortalDocumentationUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/ValidatePortalDocumentationUseCaseTest.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal_page.use_case;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.apim.core.audit.model.AuditActor;
+import io.gravitee.apim.core.audit.model.AuditInfo;
+import io.gravitee.apim.core.portal.model.PortalId;
+import io.gravitee.apim.core.portal_documentation.domain_service.ValidatePortalDocumentationDomainService;
+import io.gravitee.apim.core.portal_page.model.PortalPageContentId;
+import io.gravitee.apim.core.portal_page.model.PortalPageContentType;
+import io.gravitee.apim.core.validation.Validator;
+import io.gravitee.rest.api.service.common.HRIDToUUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class ValidatePortalDocumentationUseCaseTest {
+
+    private static final AuditInfo AUDIT_INFO = AuditInfo.builder()
+        .organizationId("organization-id")
+        .environmentId("environment-id")
+        .actor(AuditActor.builder().userId("user-id").build())
+        .build();
+    private static final String PORTAL_HRID = "default-portal";
+    private static final String DOC_HRID = "getting-started";
+    private static final PortalId PORTAL_ID = PortalId.of(HRIDToUUID.portal().context(AUDIT_INFO).hrid(PORTAL_HRID).id());
+    private static final PortalPageContentId DOC_ID = PortalPageContentId.of(
+        HRIDToUUID.portalDocumentation().context(AUDIT_INFO).portal(PORTAL_HRID).hrid(DOC_HRID).id()
+    );
+
+    private ValidatePortalDocumentationUseCase useCase;
+
+    @BeforeEach
+    void setUp() {
+        useCase = new ValidatePortalDocumentationUseCase(new ValidatePortalDocumentationDomainService());
+    }
+
+    @Test
+    void should_return_documentation_id_and_no_errors_for_well_formed_input() {
+        var output = useCase.execute(input("Getting Started", PortalPageContentType.GRAVITEE_MARKDOWN, "# Hello", "/projects/alpha", 1));
+
+        assertThat(output.id()).isEqualTo(DOC_ID);
+        assertThat(output.errors()).isEmpty();
+    }
+
+    @Test
+    void should_not_block_when_referenced_portal_does_not_exist() {
+        var output = useCase.execute(input("Getting Started", PortalPageContentType.GRAVITEE_MARKDOWN, "# Hello", "/projects/alpha", 1));
+
+        assertThat(output.errors()).isEmpty();
+    }
+
+    @Test
+    void should_surface_location_format_error() {
+        var output = useCase.execute(input("Getting Started", PortalPageContentType.GRAVITEE_MARKDOWN, "# Hello", "projects/alpha", 1));
+
+        assertThat(output.errors()).isNotEmpty();
+        assertThat(output.errors())
+            .extracting(Validator.Error::getMessage)
+            .anyMatch(m -> m.contains("location"));
+    }
+
+    @Test
+    void should_surface_blank_name_error() {
+        var output = useCase.execute(input("  ", PortalPageContentType.GRAVITEE_MARKDOWN, "# Hello", "/projects/alpha", 1));
+
+        assertThat(output.errors())
+            .extracting(Validator.Error::getMessage)
+            .anyMatch(m -> m.contains("name"));
+    }
+
+    @Test
+    void should_surface_null_type_error() {
+        var output = useCase.execute(input("Getting Started", null, "# Hello", "/projects/alpha", 1));
+
+        assertThat(output.errors())
+            .extracting(Validator.Error::getMessage)
+            .anyMatch(m -> m.contains("type"));
+    }
+
+    @Test
+    void should_surface_null_content_error() {
+        var output = useCase.execute(input("Getting Started", PortalPageContentType.GRAVITEE_MARKDOWN, null, "/projects/alpha", 1));
+
+        assertThat(output.errors())
+            .extracting(Validator.Error::getMessage)
+            .anyMatch(m -> m.contains("content"));
+    }
+
+    private static CreateOrUpdatePortalDocumentationUseCase.Input input(
+        String name,
+        PortalPageContentType type,
+        String content,
+        String location,
+        Integer order
+    ) {
+        return new CreateOrUpdatePortalDocumentationUseCase.Input(AUDIT_INFO, DOC_ID, PORTAL_ID, name, type, content, location, order);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/common/HRIDToUUIDTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/common/HRIDToUUIDTest.java
@@ -196,6 +196,56 @@ class HRIDToUUIDTest {
     }
 
     @Nested
+    class PortalDocumentation {
+
+        @Test
+        void should_generate_same_id_for_same_inputs() {
+            assertThat(HRIDToUUID.portalDocumentation().context(AUDIT).portal("my-portal").hrid("my-doc").id()).isEqualTo(
+                HRIDToUUID.portalDocumentation().context(AUDIT).portal("my-portal").hrid("my-doc").id()
+            );
+        }
+
+        @Test
+        void should_generate_different_id_for_different_doc_hrid() {
+            assertThat(HRIDToUUID.portalDocumentation().context(AUDIT).portal("my-portal").hrid("doc-a").id()).isNotEqualTo(
+                HRIDToUUID.portalDocumentation().context(AUDIT).portal("my-portal").hrid("doc-b").id()
+            );
+        }
+
+        @Test
+        void should_generate_different_id_for_different_portal_hrid() {
+            assertThat(HRIDToUUID.portalDocumentation().context(AUDIT).portal("portal-a").hrid("doc").id()).isNotEqualTo(
+                HRIDToUUID.portalDocumentation().context(AUDIT).portal("portal-b").hrid("doc").id()
+            );
+        }
+
+        @Test
+        void should_produce_same_result_from_audit_info_and_execution_context() {
+            assertThat(HRIDToUUID.portalDocumentation().context(AUDIT).portal("portal").hrid("doc").id()).isEqualTo(
+                HRIDToUUID.portalDocumentation().context(EXEC_CTX).portal("portal").hrid("doc").id()
+            );
+        }
+
+        @Test
+        void should_not_collide_with_portal_top_level_id() {
+            String portalId = HRIDToUUID.portal().context(AUDIT).hrid("my-portal").id();
+            String docId = HRIDToUUID.portalDocumentation().context(AUDIT).portal("my-portal").hrid("my-portal").id();
+            assertThat(portalId).isNotEqualTo(docId);
+        }
+
+        @Test
+        void portal_documentation_and_portal_listing_share_formula_by_design() {
+            // portalDocumentation() and portalListing() return the same PortalSubResourceBuilder —
+            // same UUID for the same HRID inputs. This is intentional: they live in separate tables
+            // (documentations vs portal_listings), so the PK scope is different. If this test ever
+            // fails it means the builders have been split — verify UUID uniqueness across tables.
+            String docId = HRIDToUUID.portalDocumentation().context(AUDIT).portal("portal").hrid("x").id();
+            String listingId = HRIDToUUID.portalListing().context(AUDIT).portal("portal").hrid("x").id();
+            assertThat(docId).isEqualTo(listingId);
+        }
+    }
+
+    @Nested
     class CrossResourceConsistency {
 
         @Test


### PR DESCRIPTION
## Issue
https://gravitee.atlassian.net/browse/EXT-141

## Description

Core domain and Automation REST for Portal Documentation. Builds on #17792; together they make `PUT/GET/DELETE /portals/{portalHrid}/documentations` a working round-trip.

Navigation-tree sync is in the next PR.

### What's in

- `Documentation` value object for the REST/domain-service boundary — flat record holding name, location, order, type, content, and reference info.
- `PortalPageContentQueryService.findByReference()` backed by the mirrored index columns from #17792.
- Automation REST wiring: `PUT/GET/DELETE /portals/{hrid}/documentations/{docHrid}` + `?dryRun=true` support.
- Use-case and REST tests with JSON fixtures.
- Drive-by fix: PortalListing use cases now read sanitized validator output instead of raw input.

### What's *not* in (follow-up PR)

- Materialization sync into the nav tree. Docs persist and are accessible via the API, but don't yet appear as pages in the portal editor.