### PR TITLE
feat(portal-documentation): materialize into navigation tree

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal/use_case/CreateOrUpdatePortalUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal/use_case/CreateOrUpdatePortalUseCase.java
@@ -24,6 +24,9 @@ import io.gravitee.apim.core.portal.domain_service.PortalNavigationSyncDomainSer
 import io.gravitee.apim.core.portal.domain_service.ValidatePortalDomainService;
 import io.gravitee.apim.core.portal.model.NavigationPath;
 import io.gravitee.apim.core.portal.model.Portal;
+import io.gravitee.apim.core.portal_page.domain_service.PortalDocumentationSyncDomainService;
+import io.gravitee.apim.core.portal_page.model.AutomationMetadata;
+import io.gravitee.apim.core.portal_page.query_service.PortalPageContentQueryService;
 import io.gravitee.apim.core.validation.Validator;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -37,6 +40,8 @@ public class CreateOrUpdatePortalUseCase {
     private final PortalCrudService portalCrudService;
     private final PortalNavigationSyncDomainService portalNavigationSyncDomainService;
     private final PortalNavigationListingDomainService portalNavigationListingDomainService;
+    private final PortalPageContentQueryService portalPageContentQueryService;
+    private final PortalDocumentationSyncDomainService portalDocumentationSyncDomainService;
 
     public record Input(AuditInfo auditInfo, Portal portal, List<NavigationPath> navigation) {
         public Input(AuditInfo auditInfo, Portal portal) {
@@ -64,6 +69,9 @@ public class CreateOrUpdatePortalUseCase {
         var existing = portalCrudService.findByIdAndEnvironmentId(portal.getId(), input.auditInfo().environmentId());
         var saved = existing.isPresent() ? portalCrudService.update(portal) : portalCrudService.create(portal);
         portalNavigationSyncDomainService.sync(input.auditInfo(), portal.getId(), sanitized.navigation());
+        portalPageContentQueryService
+            .findByReference(input.auditInfo().environmentId(), AutomationMetadata.ReferenceType.PORTAL, portal.getId().toString())
+            .forEach(pc -> portalDocumentationSyncDomainService.materialize(input.auditInfo(), pc));
         var navigation = portalNavigationListingDomainService.listAsNavigationPaths(input.auditInfo().environmentId());
         return new Output(saved, navigation, warnings);
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_documentation/domain_service/navigation/DocumentationNavigationIds.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_documentation/domain_service/navigation/DocumentationNavigationIds.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal_documentation.domain_service.navigation;
+
+import io.gravitee.apim.core.audit.model.AuditInfo;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
+import io.gravitee.apim.core.portal_page.model.PortalPageContentId;
+import io.gravitee.rest.api.service.common.HRIDToUUID;
+
+public final class DocumentationNavigationIds {
+
+    private DocumentationNavigationIds() {}
+
+    public static PortalNavigationItemId navigationItemId(AuditInfo auditInfo, String portalId, PortalPageContentId pageContentId) {
+        return PortalNavigationItemId.of(
+            HRIDToUUID.navigation().context(auditInfo).portal(portalId).documentation(pageContentId.toString()).id()
+        );
+    }
+
+    public static PortalNavigationItemId folderId(AuditInfo auditInfo, String portalId, String location) {
+        if (location == null || location.isBlank() || "/".equals(location)) {
+            return null;
+        }
+        return PortalNavigationItemId.of(HRIDToUUID.navigation().context(auditInfo).portal(portalId).folder(location).id());
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_documentation/domain_service/navigation/DocumentationNavigationPageMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_documentation/domain_service/navigation/DocumentationNavigationPageMapper.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal_documentation.domain_service.navigation;
+
+import io.gravitee.apim.core.portal_page.model.AutomationMetadata;
+import io.gravitee.apim.core.portal_page.model.CreatePortalNavigationItem;
+import io.gravitee.apim.core.portal_page.model.PortalArea;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItem;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItemContainer;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItemType;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationPage;
+import io.gravitee.apim.core.portal_page.model.PortalPageContentId;
+import io.gravitee.apim.core.portal_page.model.PortalVisibility;
+import io.gravitee.apim.core.portal_page.model.Slug;
+import jakarta.annotation.Nullable;
+
+public final class DocumentationNavigationPageMapper {
+
+    private static final PortalArea AREA = PortalArea.TOP_NAVBAR;
+    private static final int DEFAULT_ORDER = 0;
+
+    private DocumentationNavigationPageMapper() {}
+
+    public static PortalNavigationItem build(
+        PortalNavigationItemId navigationItemId,
+        PortalPageContentId contentId,
+        @Nullable PortalNavigationItemContainer parent,
+        String organizationId,
+        String environmentId,
+        AutomationMetadata meta,
+        Slug segment
+    ) {
+        var create = CreatePortalNavigationItem.builder()
+            .id(navigationItemId)
+            .title(meta.name())
+            .segment(segment.value())
+            .area(AREA)
+            .type(PortalNavigationItemType.PAGE)
+            .order(meta.order().orElse(DEFAULT_ORDER))
+            .portalPageContentId(contentId)
+            .visibility(PortalVisibility.PUBLIC)
+            .published(true)
+            .build();
+        return PortalNavigationItem.from(create, organizationId, environmentId, parent);
+    }
+
+    public static void apply(
+        PortalNavigationPage page,
+        PortalPageContentId contentId,
+        @Nullable PortalNavigationItemContainer parent,
+        AutomationMetadata meta,
+        Slug segment
+    ) {
+        page.setTitle(meta.name());
+        page.setSegment(segment.value());
+        page.setArea(AREA);
+        page.setOrder(meta.order().orElse(DEFAULT_ORDER));
+        page.setPortalPageContentId(contentId);
+        page.setVisibility(PortalVisibility.PUBLIC);
+        page.setPublished(true);
+        if (parent == null) {
+            page.markAsRoot();
+        } else {
+            page.updateParent(parent);
+        }
+    }
+
+    public static PortalNavigationItemContainer phantomParent(@Nullable PortalNavigationItemId folderId) {
+        if (folderId == null) return null;
+        return new PortalNavigationItemContainer() {
+            @Override
+            public PortalNavigationItemId getId() {
+                return folderId;
+            }
+
+            @Override
+            public PortalNavigationItemId getRootId() {
+                return folderId;
+            }
+        };
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/PortalDocumentationSyncDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/domain_service/PortalDocumentationSyncDomainService.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal_page.domain_service;
+
+import io.gravitee.apim.core.DomainService;
+import io.gravitee.apim.core.audit.model.AuditInfo;
+import io.gravitee.apim.core.portal_documentation.domain_service.navigation.DocumentationNavigationIds;
+import io.gravitee.apim.core.portal_documentation.domain_service.navigation.DocumentationNavigationPageMapper;
+import io.gravitee.apim.core.portal_page.crud_service.PortalNavigationItemCrudService;
+import io.gravitee.apim.core.portal_page.model.AutomationMetadata;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItem;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItemContainer;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationPage;
+import io.gravitee.apim.core.portal_page.model.PortalPageContent;
+import io.gravitee.apim.core.portal_page.model.PortalPageContentId;
+import io.gravitee.apim.core.portal_page.model.Slug;
+import io.gravitee.apim.core.portal_page.query_service.PortalNavigationItemsQueryService;
+import java.util.Set;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+
+@DomainService
+@RequiredArgsConstructor
+public class PortalDocumentationSyncDomainService {
+
+    private final PortalNavigationItemCrudService navigationItemCrudService;
+    private final PortalNavigationItemsQueryService navigationItemsQueryService;
+
+    public void materialize(AuditInfo auditInfo, PortalPageContent<?> pageContent) {
+        final var meta = pageContent.getAutomationMetadata();
+        final var portalId = meta.referenceId();
+        final var contentId = pageContent.getId();
+        final var navigationItemId = DocumentationNavigationIds.navigationItemId(auditInfo, portalId, contentId);
+        final var parent = resolveParent(auditInfo, meta.location().orElse(null), portalId);
+        upsertNavigationPage(auditInfo, navigationItemId, contentId, parent, meta);
+    }
+
+    public void dematerialize(AuditInfo auditInfo, String portalId, PortalPageContentId pageContentId) {
+        final var navigationItemId = DocumentationNavigationIds.navigationItemId(auditInfo, portalId, pageContentId);
+        final var existing = navigationItemsQueryService.findByIdAndEnvironmentId(auditInfo.environmentId(), navigationItemId);
+        if (existing != null) {
+            navigationItemCrudService.delete(navigationItemId);
+        }
+    }
+
+    private void upsertNavigationPage(
+        AuditInfo auditInfo,
+        PortalNavigationItemId navigationItemId,
+        PortalPageContentId contentId,
+        PortalNavigationItemContainer parent,
+        AutomationMetadata meta
+    ) {
+        final var existing = navigationItemsQueryService.findByIdAndEnvironmentId(auditInfo.environmentId(), navigationItemId);
+        final var parentId = parent == null ? null : parent.getId();
+
+        if (existing instanceof PortalNavigationPage page) {
+            final var segment = Slug.from(meta.name(), siblingsSlugs(auditInfo.environmentId(), parentId, navigationItemId));
+            DocumentationNavigationPageMapper.apply(page, contentId, parent, meta, segment);
+            navigationItemCrudService.update(page);
+            return;
+        }
+        if (existing != null) {
+            navigationItemCrudService.delete(navigationItemId);
+        }
+        final var segment = Slug.from(meta.name(), siblingsSlugs(auditInfo.environmentId(), parentId, null));
+        navigationItemCrudService.create(
+            DocumentationNavigationPageMapper.build(
+                navigationItemId,
+                contentId,
+                parent,
+                auditInfo.organizationId(),
+                auditInfo.environmentId(),
+                meta,
+                segment
+            )
+        );
+    }
+
+    private Set<Slug> siblingsSlugs(String environmentId, PortalNavigationItemId parentId, PortalNavigationItemId excludeId) {
+        return navigationItemsQueryService
+            .findByParentIdAndEnvironmentId(environmentId, parentId)
+            .stream()
+            .filter(item -> !item.getId().equals(excludeId))
+            .map(PortalNavigationItem::getSegment)
+            .map(Slug::new)
+            .collect(Collectors.toSet());
+    }
+
+    private PortalNavigationItemContainer resolveParent(AuditInfo auditInfo, String location, String portalId) {
+        var folderId = DocumentationNavigationIds.folderId(auditInfo, portalId, location);
+        if (folderId == null) return null;
+        var existing = navigationItemsQueryService.findByIdAndEnvironmentId(auditInfo.environmentId(), folderId);
+        if (existing instanceof PortalNavigationItemContainer container) {
+            return container;
+        }
+        return DocumentationNavigationPageMapper.phantomParent(folderId);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/use_case/CreateOrUpdatePortalDocumentationUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/use_case/CreateOrUpdatePortalDocumentationUseCase.java
@@ -24,6 +24,7 @@ import io.gravitee.apim.core.open_api.OpenApi;
 import io.gravitee.apim.core.portal.model.PortalId;
 import io.gravitee.apim.core.portal_documentation.domain_service.ValidatePortalDocumentationDomainService;
 import io.gravitee.apim.core.portal_page.crud_service.PortalPageContentCrudService;
+import io.gravitee.apim.core.portal_page.domain_service.PortalDocumentationSyncDomainService;
 import io.gravitee.apim.core.portal_page.model.AsyncApiPageContent;
 import io.gravitee.apim.core.portal_page.model.AutomationMetadata;
 import io.gravitee.apim.core.portal_page.model.GraviteeMarkdownPageContent;
@@ -47,6 +48,7 @@ public class CreateOrUpdatePortalDocumentationUseCase {
     private final ValidatePortalDocumentationDomainService validator;
     private final PortalPageContentCrudService portalPageContentCrudService;
     private final PortalPageContentQueryService portalPageContentQueryService;
+    private final PortalDocumentationSyncDomainService syncDomainService;
 
     public record Input(
         AuditInfo auditInfo,
@@ -106,6 +108,8 @@ public class CreateOrUpdatePortalDocumentationUseCase {
         } else {
             saved = portalPageContentCrudService.create(buildNew(sanitized, meta));
         }
+
+        syncDomainService.materialize(input.auditInfo(), saved);
 
         return new Output(saved.getId(), warnings);
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/use_case/DeletePortalDocumentationUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal_page/use_case/DeletePortalDocumentationUseCase.java
@@ -19,6 +19,7 @@ import io.gravitee.apim.core.UseCase;
 import io.gravitee.apim.core.audit.model.AuditInfo;
 import io.gravitee.apim.core.portal_documentation.exception.PortalDocumentationNotFoundException;
 import io.gravitee.apim.core.portal_page.crud_service.PortalPageContentCrudService;
+import io.gravitee.apim.core.portal_page.domain_service.PortalDocumentationSyncDomainService;
 import io.gravitee.apim.core.portal_page.model.PortalPageContentId;
 import io.gravitee.apim.core.portal_page.query_service.PortalPageContentQueryService;
 import lombok.RequiredArgsConstructor;
@@ -29,14 +30,17 @@ public class DeletePortalDocumentationUseCase {
 
     private final PortalPageContentCrudService portalPageContentCrudService;
     private final PortalPageContentQueryService portalPageContentQueryService;
+    private final PortalDocumentationSyncDomainService syncDomainService;
 
     public record Input(AuditInfo auditInfo, PortalPageContentId portalPageContentId) {}
 
     public void execute(Input input) {
-        portalPageContentQueryService
+        var pageContent = portalPageContentQueryService
             .findById(input.portalPageContentId())
             .filter(pc -> pc.getAutomationMetadata() != null)
             .orElseThrow(() -> new PortalDocumentationNotFoundException(input.portalPageContentId().toString()));
+        var referenceId = pageContent.getAutomationMetadata().referenceId();
+        syncDomainService.dematerialize(input.auditInfo(), referenceId, input.portalPageContentId());
         portalPageContentCrudService.delete(input.portalPageContentId());
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/common/HRIDToUUID.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/common/HRIDToUUID.java
@@ -171,9 +171,10 @@ public final class HRIDToUUID {
         public NavigationItemResult folder(String path) {
             return new NavigationItemResult(organizationId, environmentId, portalId, "folder", path);
         }
-        // Future:
-        // public NavigationItemResult documentation(String docHrid) { … }
-        // public NavigationItemResult listingApi(String apiHrid)    { … }
+
+        public NavigationItemResult documentation(String contentId) {
+            return new NavigationItemResult(organizationId, environmentId, portalId, "documentation", contentId);
+        }
     }
 
     public record NavigationItemResult(String organizationId, String environmentId, String portalId, String kind, String identifier) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal/use_case/CreateOrUpdatePortalUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal/use_case/CreateOrUpdatePortalUseCaseTest.java
@@ -23,6 +23,7 @@ import inmemory.PortalCrudServiceInMemory;
 import inmemory.PortalNavigationItemsCrudServiceInMemory;
 import inmemory.PortalNavigationItemsQueryServiceInMemory;
 import inmemory.PortalPageContentCrudServiceInMemory;
+import inmemory.PortalPageContentQueryServiceInMemory;
 import io.gravitee.apim.core.audit.model.AuditActor;
 import io.gravitee.apim.core.audit.model.AuditInfo;
 import io.gravitee.apim.core.exception.ValidationDomainException;
@@ -31,6 +32,7 @@ import io.gravitee.apim.core.portal.domain_service.PortalNavigationSyncDomainSer
 import io.gravitee.apim.core.portal.domain_service.ValidatePortalDomainService;
 import io.gravitee.apim.core.portal.model.NavigationPath;
 import io.gravitee.apim.core.portal.model.Portal;
+import io.gravitee.apim.core.portal_page.domain_service.PortalDocumentationSyncDomainService;
 import io.gravitee.apim.core.portal_page.model.PortalArea;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemType;
 import java.util.List;
@@ -57,6 +59,7 @@ class CreateOrUpdatePortalUseCaseTest {
         navCrudService.storage()
     );
     private final PortalPageContentCrudServiceInMemory pageContentCrudService = new PortalPageContentCrudServiceInMemory();
+    private final PortalPageContentQueryServiceInMemory pageContentQueryService = new PortalPageContentQueryServiceInMemory();
     private CreateOrUpdatePortalUseCase useCase;
 
     @BeforeEach
@@ -65,7 +68,9 @@ class CreateOrUpdatePortalUseCaseTest {
             validator,
             portalCrudService,
             new PortalNavigationSyncDomainService(navCrudService, navQueryService, pageContentCrudService),
-            new PortalNavigationListingDomainService(navQueryService)
+            new PortalNavigationListingDomainService(navQueryService),
+            pageContentQueryService,
+            new PortalDocumentationSyncDomainService(navCrudService, navQueryService)
         );
     }
 
@@ -74,6 +79,7 @@ class CreateOrUpdatePortalUseCaseTest {
         portalCrudService.reset();
         navCrudService.reset();
         pageContentCrudService.reset();
+        pageContentQueryService.reset();
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/domain_service/PortalDocumentationSyncDomainServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/domain_service/PortalDocumentationSyncDomainServiceTest.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.portal_page.domain_service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import inmemory.PortalNavigationItemsCrudServiceInMemory;
+import inmemory.PortalNavigationItemsQueryServiceInMemory;
+import io.gravitee.apim.core.audit.model.AuditActor;
+import io.gravitee.apim.core.audit.model.AuditInfo;
+import io.gravitee.apim.core.gravitee_markdown.GraviteeMarkdown;
+import io.gravitee.apim.core.portal.model.PortalId;
+import io.gravitee.apim.core.portal_page.model.AutomationMetadata;
+import io.gravitee.apim.core.portal_page.model.GraviteeMarkdownPageContent;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationItemId;
+import io.gravitee.apim.core.portal_page.model.PortalNavigationPage;
+import io.gravitee.apim.core.portal_page.model.PortalPageContent;
+import io.gravitee.apim.core.portal_page.model.PortalPageContentId;
+import io.gravitee.rest.api.service.common.HRIDToUUID;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class PortalDocumentationSyncDomainServiceTest {
+
+    private static final AuditInfo AUDIT_INFO = AuditInfo.builder()
+        .organizationId("organization-id")
+        .environmentId("environment-id")
+        .actor(AuditActor.builder().userId("user-id").build())
+        .build();
+    private static final PortalId PORTAL_ID = PortalId.of("11111111-1111-1111-1111-111111111111");
+    private static final PortalPageContentId DOC_ID = PortalPageContentId.of("22222222-2222-2222-2222-222222222222");
+
+    private final PortalNavigationItemsCrudServiceInMemory navItemCrud = new PortalNavigationItemsCrudServiceInMemory();
+    private final PortalNavigationItemsQueryServiceInMemory navItemQuery = new PortalNavigationItemsQueryServiceInMemory(
+        navItemCrud.storage()
+    );
+
+    private PortalDocumentationSyncDomainService syncService;
+
+    @BeforeEach
+    void setUp() {
+        navItemCrud.reset();
+        syncService = new PortalDocumentationSyncDomainService(navItemCrud, navItemQuery);
+    }
+
+    @Test
+    void materialize_creates_nav_page_with_deterministic_id() {
+        syncService.materialize(AUDIT_INFO, markdownDoc("Getting Started", "/projects/alpha", 1));
+
+        assertThat(navItemCrud.storage()).hasSize(1);
+
+        var page = (PortalNavigationPage) navItemCrud.storage().get(0);
+        assertThat(page.getId()).isEqualTo(expectedNavItemId());
+        assertThat(page.getTitle()).isEqualTo("Getting Started");
+        assertThat(page.getSegment()).isEqualTo("getting-started");
+        assertThat(page.getOrder()).isEqualTo(1);
+        assertThat(page.getPortalPageContentId()).isEqualTo(DOC_ID);
+        assertThat(page.getParentId()).isEqualTo(expectedFolderId("/projects/alpha"));
+    }
+
+    @Test
+    void materialize_is_idempotent() {
+        var doc = markdownDoc("Getting Started", "/projects/alpha", 1);
+
+        syncService.materialize(AUDIT_INFO, doc);
+        syncService.materialize(AUDIT_INFO, doc);
+
+        assertThat(navItemCrud.storage()).hasSize(1);
+    }
+
+    @Test
+    void materialize_updates_nav_page_when_doc_changes() {
+        syncService.materialize(AUDIT_INFO, markdownDoc("Getting Started", "/projects/alpha", 1));
+
+        syncService.materialize(AUDIT_INFO, markdownDoc("Renamed", "/projects/beta", 2));
+
+        var page = (PortalNavigationPage) navItemCrud.storage().get(0);
+        assertThat(page.getTitle()).isEqualTo("Renamed");
+        assertThat(page.getSegment()).isEqualTo("renamed");
+        assertThat(page.getOrder()).isEqualTo(2);
+        assertThat(page.getParentId()).isEqualTo(expectedFolderId("/projects/beta"));
+    }
+
+    @Test
+    void dematerialize_removes_nav_page() {
+        syncService.materialize(AUDIT_INFO, markdownDoc("Getting Started", "/projects/alpha", 1));
+
+        syncService.dematerialize(AUDIT_INFO, PORTAL_ID.toString(), DOC_ID);
+
+        assertThat(navItemCrud.storage()).isEmpty();
+    }
+
+    @Test
+    void dematerialize_is_idempotent_when_nothing_materialized() {
+        syncService.dematerialize(AUDIT_INFO, PORTAL_ID.toString(), DOC_ID);
+
+        assertThat(navItemCrud.storage()).isEmpty();
+    }
+
+    @Test
+    void materialize_with_null_location_marks_page_as_root() {
+        syncService.materialize(AUDIT_INFO, markdownDoc("Getting Started", null, 1));
+
+        var page = (PortalNavigationPage) navItemCrud.storage().get(0);
+        assertThat(page.getParentId()).isNull();
+        assertThat(page.getRootId()).isEqualTo(page.getId());
+    }
+
+    @Test
+    void materialize_points_at_deterministic_folder_id_even_when_folder_missing() {
+        syncService.materialize(AUDIT_INFO, markdownDoc("Getting Started", "/unknown", 1));
+
+        var page = (PortalNavigationPage) navItemCrud.storage().get(0);
+        assertThat(page.getParentId()).isEqualTo(expectedFolderId("/unknown"));
+    }
+
+    @Test
+    void materialize_uses_zero_when_order_is_null() {
+        syncService.materialize(AUDIT_INFO, markdownDoc("Getting Started", "/projects/alpha", null));
+
+        var page = (PortalNavigationPage) navItemCrud.storage().get(0);
+        assertThat(page.getOrder()).isZero();
+    }
+
+    private static PortalPageContent<?> markdownDoc(String name, String location, Integer order) {
+        return new GraviteeMarkdownPageContent(
+            DOC_ID,
+            AUDIT_INFO.organizationId(),
+            AUDIT_INFO.environmentId(),
+            GraviteeMarkdown.of("# Hello"),
+            new AutomationMetadata(
+                AutomationMetadata.ReferenceType.PORTAL,
+                PORTAL_ID.toString(),
+                name,
+                Optional.ofNullable(location),
+                Optional.ofNullable(order)
+            )
+        );
+    }
+
+    private static PortalNavigationItemId expectedNavItemId() {
+        return PortalNavigationItemId.of(
+            HRIDToUUID.navigation().context(AUDIT_INFO).portal(PORTAL_ID.toString()).documentation(DOC_ID.toString()).id()
+        );
+    }
+
+    private static PortalNavigationItemId expectedFolderId(String path) {
+        return PortalNavigationItemId.of(HRIDToUUID.navigation().context(AUDIT_INFO).portal(PORTAL_ID.toString()).folder(path).id());
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/CreateOrUpdatePortalDocumentationUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/CreateOrUpdatePortalDocumentationUseCaseTest.java
@@ -18,6 +18,8 @@ package io.gravitee.apim.core.portal_page.use_case;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
 
+import inmemory.PortalNavigationItemsCrudServiceInMemory;
+import inmemory.PortalNavigationItemsQueryServiceInMemory;
 import inmemory.PortalPageContentCrudServiceInMemory;
 import inmemory.PortalPageContentQueryServiceInMemory;
 import io.gravitee.apim.core.audit.model.AuditActor;
@@ -25,6 +27,7 @@ import io.gravitee.apim.core.audit.model.AuditInfo;
 import io.gravitee.apim.core.exception.ValidationDomainException;
 import io.gravitee.apim.core.portal.model.PortalId;
 import io.gravitee.apim.core.portal_documentation.domain_service.ValidatePortalDocumentationDomainService;
+import io.gravitee.apim.core.portal_page.domain_service.PortalDocumentationSyncDomainService;
 import io.gravitee.apim.core.portal_page.model.AutomationMetadata;
 import io.gravitee.apim.core.portal_page.model.PortalPageContentId;
 import io.gravitee.apim.core.portal_page.model.PortalPageContentType;
@@ -53,18 +56,28 @@ class CreateOrUpdatePortalDocumentationUseCaseTest {
 
     private final PortalPageContentCrudServiceInMemory crudService = new PortalPageContentCrudServiceInMemory();
     private final PortalPageContentQueryServiceInMemory queryService = new PortalPageContentQueryServiceInMemory();
+    private final PortalNavigationItemsCrudServiceInMemory navCrudService = new PortalNavigationItemsCrudServiceInMemory();
+    private final PortalNavigationItemsQueryServiceInMemory navQueryService = new PortalNavigationItemsQueryServiceInMemory(
+        navCrudService.storage()
+    );
     private final ValidatePortalDocumentationDomainService validator = new ValidatePortalDocumentationDomainService();
     private CreateOrUpdatePortalDocumentationUseCase useCase;
 
     @BeforeEach
     void setUp() {
-        useCase = new CreateOrUpdatePortalDocumentationUseCase(validator, crudService, queryService);
+        useCase = new CreateOrUpdatePortalDocumentationUseCase(
+            validator,
+            crudService,
+            queryService,
+            new PortalDocumentationSyncDomainService(navCrudService, navQueryService)
+        );
     }
 
     @AfterEach
     void tearDown() {
         crudService.reset();
         queryService.reset();
+        navCrudService.reset();
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/DeletePortalDocumentationUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal_page/use_case/DeletePortalDocumentationUseCaseTest.java
@@ -18,12 +18,15 @@ package io.gravitee.apim.core.portal_page.use_case;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
 
+import inmemory.PortalNavigationItemsCrudServiceInMemory;
+import inmemory.PortalNavigationItemsQueryServiceInMemory;
 import inmemory.PortalPageContentCrudServiceInMemory;
 import inmemory.PortalPageContentQueryServiceInMemory;
 import io.gravitee.apim.core.audit.model.AuditActor;
 import io.gravitee.apim.core.audit.model.AuditInfo;
 import io.gravitee.apim.core.gravitee_markdown.GraviteeMarkdown;
 import io.gravitee.apim.core.portal_documentation.exception.PortalDocumentationNotFoundException;
+import io.gravitee.apim.core.portal_page.domain_service.PortalDocumentationSyncDomainService;
 import io.gravitee.apim.core.portal_page.model.AutomationMetadata;
 import io.gravitee.apim.core.portal_page.model.GraviteeMarkdownPageContent;
 import io.gravitee.apim.core.portal_page.model.PortalPageContentId;
@@ -47,17 +50,26 @@ class DeletePortalDocumentationUseCaseTest {
 
     private final PortalPageContentCrudServiceInMemory crudService = new PortalPageContentCrudServiceInMemory();
     private final PortalPageContentQueryServiceInMemory queryService = new PortalPageContentQueryServiceInMemory();
+    private final PortalNavigationItemsCrudServiceInMemory navCrudService = new PortalNavigationItemsCrudServiceInMemory();
+    private final PortalNavigationItemsQueryServiceInMemory navQueryService = new PortalNavigationItemsQueryServiceInMemory(
+        navCrudService.storage()
+    );
     private DeletePortalDocumentationUseCase useCase;
 
     @BeforeEach
     void setUp() {
-        useCase = new DeletePortalDocumentationUseCase(crudService, queryService);
+        useCase = new DeletePortalDocumentationUseCase(
+            crudService,
+            queryService,
+            new PortalDocumentationSyncDomainService(navCrudService, navQueryService)
+        );
     }
 
     @AfterEach
     void tearDown() {
         crudService.reset();
         queryService.reset();
+        navCrudService.reset();
     }
 
     @Test


### PR DESCRIPTION
## Issue
https://gravitee.atlassian.net/browse/EXT-141

## Description

Wires Portal Documentation rows into the navigation tree so docs created via the Automation API actually appear in the portal editor. Builds on #17804.

### Key design choices

- Docs remain the source of truth; the nav-tree representation is derived from them and rebuilt idempotently.
- Doc PUT/DELETE keeps the derived nav item and page content in sync.
- Portal PUT re-materializes all docs attached to that portal after folder sync, so docs reappear automatically when their parent folder is recreated.
- A type change on an existing doc always recreates the content row from scratch; the doc ID stays stable.

### What's in

- New domain service handling the doc → nav-tree projection.
- Doc PUT/DELETE and portal PUT trigger materialization/dematerialization automatically.
- Tests covering create, update, type swap, delete and apply-order edge cases.

### Demo


https://github.com/user-attachments/assets/c2c2a355-4ad3-4e67-ad8b-f9c7aa0c53ff

