### PR TITLE
test(rest-api): pin real PATCH v4 listener-type validation and remove misleading test

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource_PatchApiListenersTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiResource_PatchApiListenersTest.java
@@ -173,28 +173,6 @@ public class ApiResource_PatchApiListenersTest extends ApiResourceTest {
         return assertThat(response).hasStatus(OK_200).asEntity(ApiV4.class).actual();
     }
 
-    @ParameterizedTest
-    @ValueSource(strings = { "HTTP", "TCP", "SUBSCRIPTION" })
-    void patch_listener_type_uppercase_returns_200_and_persists(String uppercaseType) {
-        givenApiWithListeners(List.of(defaultHttpListener("/existing")));
-
-        var listeners = List.of(uppercaseListenerMap(uppercaseType, "/patched"));
-        var body = "{\"listeners\":" + toJson(listeners) + "}";
-
-        var response = rootTarget(API).request().method("PATCH", Entity.entity(body, MERGE_PATCH_TYPE));
-
-        assertThat(response).hasStatus(OK_200);
-
-        if ("HTTP".equals(uppercaseType)) {
-            var persistedListeners = capturePersistedListeners();
-            Assertions.assertThat(persistedListeners).hasSize(1);
-            Assertions.assertThat(persistedListeners.getFirst().getType()).isEqualTo(ListenerType.HTTP);
-            Assertions.assertThat(((HttpListener) persistedListeners.getFirst()).getPaths())
-                .extracting(Path::getPath)
-                .containsExactly("/patched");
-        }
-    }
-
     @Test
     void patch_listeners_round_trip_from_get_response_returns_200() {
         givenApiWithListeners(List.of(defaultHttpListener("/http")));

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/PatchApiUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/PatchApiUseCaseTest.java
@@ -30,6 +30,8 @@ import fixtures.core.model.AuditInfoFixtures;
 import inmemory.ApiCrudServiceInMemory;
 import inmemory.FlowCrudServiceInMemory;
 import inmemory.WorkflowQueryServiceInMemory;
+import io.gravitee.apim.core.api.domain_service.ApiHostValidatorDomainService;
+import io.gravitee.apim.core.api.domain_service.ApiPathIndex;
 import io.gravitee.apim.core.api.domain_service.UpdateApiDomainService;
 import io.gravitee.apim.core.api.domain_service.VerifyApiHostsDomainService;
 import io.gravitee.apim.core.api.domain_service.VerifyApiPathDomainService;
@@ -38,8 +40,10 @@ import io.gravitee.apim.core.api.exception.ApiInvalidDefinitionVersionException;
 import io.gravitee.apim.core.api.exception.ApiInvalidTypeException;
 import io.gravitee.apim.core.api.exception.ApiPatchNotAllowedException;
 import io.gravitee.apim.core.api.model.Api;
+import io.gravitee.apim.core.api.query_service.ApiQueryService;
 import io.gravitee.apim.core.audit.model.AuditInfo;
 import io.gravitee.apim.core.exception.ValidationDomainException;
+import io.gravitee.apim.core.installation.query_service.InstallationAccessQueryService;
 import io.gravitee.apim.core.json_patch.domain_service.JsonPatchDomainService;
 import io.gravitee.apim.core.membership.domain_service.ApiPrimaryOwnerDomainService;
 import io.gravitee.apim.core.membership.model.PrimaryOwnerEntity;
@@ -52,6 +56,7 @@ import io.gravitee.common.util.DataEncryptor;
 import io.gravitee.definition.jackson.datatype.GraviteeMapper;
 import io.gravitee.definition.model.ResponseTemplate;
 import io.gravitee.definition.model.flow.Operator;
+import io.gravitee.definition.model.v4.ApiType;
 import io.gravitee.definition.model.v4.analytics.Analytics;
 import io.gravitee.definition.model.v4.analytics.sampling.SamplingType;
 import io.gravitee.definition.model.v4.endpointgroup.Endpoint;
@@ -66,6 +71,7 @@ import io.gravitee.definition.model.v4.flow.selector.ConditionSelector;
 import io.gravitee.definition.model.v4.flow.selector.HttpSelector;
 import io.gravitee.definition.model.v4.flow.step.Step;
 import io.gravitee.definition.model.v4.listener.Listener;
+import io.gravitee.definition.model.v4.listener.ListenerType;
 import io.gravitee.definition.model.v4.listener.entrypoint.Entrypoint;
 import io.gravitee.definition.model.v4.listener.http.HttpListener;
 import io.gravitee.definition.model.v4.listener.http.Path;
@@ -73,8 +79,11 @@ import io.gravitee.definition.model.v4.property.Property;
 import io.gravitee.definition.model.v4.resource.Resource;
 import io.gravitee.definition.model.v4.service.ApiServices;
 import io.gravitee.definition.model.v4.service.Service;
+import io.gravitee.rest.api.model.v4.connector.ConnectorPluginEntity;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.v4.EndpointConnectorPluginService;
 import io.gravitee.rest.api.service.v4.EntrypointConnectorPluginService;
+import io.gravitee.rest.api.service.v4.exception.ListenerEntrypointUnsupportedListenerTypeException;
 import io.gravitee.rest.api.service.v4.exception.ListenerMissingException;
 import io.gravitee.rest.api.service.v4.impl.validation.ListenerValidationServiceImpl;
 import io.gravitee.rest.api.service.v4.validation.CorsValidationService;
@@ -3190,6 +3199,121 @@ class PatchApiUseCaseTest {
                     assertThat(ex.getParameters()).containsKey("location");
                     assertThat(ex.getParameters().get("location")).startsWith("/endpointGroups/0");
                 });
+        }
+    }
+
+    @Nested
+    class ListenerTypeRealValidation {
+
+        @BeforeEach
+        void wireRealListenerValidation() {
+            var entrypointService = mock(EntrypointConnectorPluginService.class);
+            when(entrypointService.findById("http-proxy")).thenReturn(
+                ConnectorPluginEntity.builder()
+                    .id("http-proxy")
+                    .supportedListenerType(ListenerType.HTTP)
+                    .supportedApiType(ApiType.PROXY)
+                    .build()
+            );
+            when(entrypointService.findById("tcp-proxy")).thenReturn(
+                ConnectorPluginEntity.builder()
+                    .id("tcp-proxy")
+                    .supportedListenerType(ListenerType.TCP)
+                    .supportedApiType(ApiType.PROXY)
+                    .build()
+            );
+            when(entrypointService.validateConnectorConfiguration(anyString(), any())).thenAnswer(inv -> inv.getArgument(1));
+
+            var apiQueryService = mock(ApiQueryService.class);
+            var installationAccessQueryService = mock(InstallationAccessQueryService.class);
+            when(installationAccessQueryService.getGatewayRestrictedDomains(any())).thenReturn(List.of());
+
+            var listenerValidator = new ListenerValidationServiceImpl(
+                new VerifyApiPathDomainService(
+                    apiQueryService,
+                    installationAccessQueryService,
+                    mock(ApiHostValidatorDomainService.class),
+                    new ApiPathIndex()
+                ),
+                entrypointService,
+                mock(EndpointConnectorPluginService.class),
+                mock(CorsValidationService.class),
+                mock(VerifyApiHostsDomainService.class)
+            );
+
+            when(updateApiDomainService.validateV4(any(), any())).thenAnswer(inv -> {
+                var api = (Api) inv.getArgument(0);
+                var entity = ApiAdapter.INSTANCE.toUpdateApiEntity(api, api.getApiDefinitionHttpV4());
+                listenerValidator.validateAndSanitizeHttpV4(
+                    GraviteeContext.getExecutionContext(),
+                    api.getId(),
+                    entity.getListeners(),
+                    entity.getEndpointGroups()
+                );
+                return api;
+            });
+        }
+
+        static Map<String, Object> httpListenerMap(String path) {
+            return Map.of(
+                "type",
+                "http",
+                "paths",
+                List.of(Map.of("path", path)),
+                "entrypoints",
+                List.of(Map.of("type", "http-proxy", "configuration", "{}"))
+            );
+        }
+
+        static Map<String, Object> tcpListenerMap(String host) {
+            return Map.of(
+                "type",
+                "tcp",
+                "hosts",
+                List.of(host),
+                "entrypoints",
+                List.of(Map.of("type", "tcp-proxy", "configuration", "{}"))
+            );
+        }
+
+        static Map<String, Object> subscriptionListenerMap() {
+            return Map.of("type", "subscription", "entrypoints", List.of(Map.of("type", "http-proxy", "configuration", "{}")));
+        }
+
+        @Test
+        void http_listener_is_accepted() {
+            givenExistingApi(apiWithListeners(List.of(anHttpListener("/existing"))));
+
+            assertThatNoException().isThrownBy(() ->
+                execute(PatchApiUseCase.PatchType.MERGE_PATCH, mergePatch("listeners", List.of(httpListenerMap("/patched"))), true)
+            );
+        }
+
+        @Test
+        void tcp_listener_is_accepted() {
+            givenExistingApi(apiWithListeners(List.of(anHttpListener("/existing"))));
+
+            assertThatNoException().isThrownBy(() ->
+                execute(PatchApiUseCase.PatchType.MERGE_PATCH, mergePatch("listeners", List.of(tcpListenerMap("tcp.example.com"))), true)
+            );
+        }
+
+        @Test
+        void subscription_listener_is_rejected_by_entrypoint_listener_type_check() {
+            givenExistingApi(apiWithListeners(List.of(anHttpListener("/existing"))));
+
+            assertThatThrownBy(() ->
+                execute(PatchApiUseCase.PatchType.MERGE_PATCH, mergePatch("listeners", List.of(subscriptionListenerMap())), true)
+            ).isInstanceOf(ListenerEntrypointUnsupportedListenerTypeException.class);
+        }
+
+        @Test
+        void native_kafka_api_is_rejected_by_v4_proxy_gate() {
+            givenExistingApi(ApiFixtures.aNativeApi());
+
+            assertThatThrownBy(() ->
+                execute(PatchApiUseCase.PatchType.MERGE_PATCH, mergePatch("listeners", List.of(httpListenerMap("/patched"))), true)
+            ).isInstanceOf(ApiInvalidTypeException.class);
         }
     }
 }


### PR DESCRIPTION
## Why

`ApiResource_PatchApiListenersTest` contained a parameterised test (`patch_listener_type_uppercase_returns_200_and_persists`) that asserted HTTP 200 for `HTTP`, `TCP`, and `SUBSCRIPTION` listener types on a v4 PROXY API — while stubbing `validateV4` as an identity function. Because validation was bypassed, the 200 responses for `TCP` and `SUBSCRIPTION` only proved the JSON deserialiser accepts the uppercase token; they said nothing about whether those listener types are actually valid on a PROXY API. The test even gated its persisted-listener assertions behind an `HTTP`-only check, making the TCP/SUBSCRIPTION cases entirely vacuous.

No test exercised the real validator against the type matrix, so the boundary was untested and the misleading test risked giving false confidence.

## What changed

- **`PatchApiUseCaseTest`** — added a new `@Nested` class `ListenerTypeRealValidation` that wires a real `ListenerValidationServiceImpl` (with connector plugin metadata stubbed to actual values: `http-proxy → HTTP/PROXY`, `tcp-proxy → TCP/PROXY`) and overrides the `validateV4` stub to invoke it. Four tests pin the true matrix:
  - HTTP listener accepted
  - TCP listener accepted
  - SUBSCRIPTION listener rejected (`ListenerEntrypointUnsupportedListenerTypeException`) — the entrypoint/listener-type compatibility check fires because no http-proxy entrypoint supports a SUBSCRIPTION listener type
  - Native/Kafka API rejected (`ApiInvalidTypeException`) — the v4-PROXY gate in `PatchApiUseCase` fires before any listener validation

- **`ApiResource_PatchApiListenersTest`** — deleted `patch_listener_type_uppercase_returns_200_and_persists`. The only real assertion it made (uppercase `HTTP` is deserialized and persisted) is already covered by the existing `patch_listeners_round_trip_from_get_response_returns_200` test.

## User-facing impact

No production code changed. Test-only.

## Gotchas / Follow-up

**Surprise: SUBSCRIPTION is not rejected by the API-type gate.** The task spec described the API-type gate in `PatchApiUseCase` as the expected rejection point for SUBSCRIPTION. In practice, a PROXY API clears that gate; SUBSCRIPTION is rejected one layer deeper, inside `ListenerValidationServiceImpl`'s entrypoint/listener-type compatibility check. This is correct behaviour — the test asserts the actual exception type (`ListenerEntrypointUnsupportedListenerTypeException`) to make the enforcement point explicit.