### PR TITLE
fix(rest-api): preserve persisted flow IDs on JSON-Patch sub-path edits

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/use_case/PatchApiUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/use_case/PatchApiUseCase.java
@@ -171,6 +171,12 @@ public class PatchApiUseCase {
             throw new ApiInvalidTypeException(input.apiId(), ApiType.PROXY);
         }
 
+        var dbFlows = flowCrudService.getApiV4Flows(input.apiId());
+        var existingHttpV4 = existingApi.getApiDefinitionHttpV4();
+        if (!dbFlows.isEmpty() && existingHttpV4 != null) {
+            existingApi = existingApi.toBuilder().apiDefinitionValue(existingHttpV4.toBuilder().flows(dbFlows).build()).build();
+        }
+
         var currentNode = apiV4Deserializer.toCurrentStateNode(existingApi);
         var patchNode = parseBody(input.patchBody());
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/PatchApiUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api/use_case/PatchApiUseCaseTest.java
@@ -1551,6 +1551,29 @@ class PatchApiUseCaseTest {
     class FlowsResolution {
 
         @Test
+        void json_patch_on_one_flow_subpath_preserves_persisted_id_of_untouched_sibling() {
+            var definitionFlows = List.of(
+                aFlow("flow-0", List.of(aStep("s0", "policy-a"))),
+                aFlow("flow-1", List.of(aStep("s1", "policy-b")))
+            );
+            givenExistingApi(apiWithFlows(definitionFlows));
+            flowCrudService.saveApiFlows(
+                API_ID,
+                List.of(
+                    aFlow("flow-0", List.of(aStep("s0", "policy-a"))).toBuilder().id("flow-0-id").build(),
+                    aFlow("flow-1", List.of(aStep("s1", "policy-b"))).toBuilder().id("flow-1-id").build()
+                )
+            );
+
+            execute(PatchApiUseCase.PatchType.JSON_PATCH, patch("replace", "/flows/1/name", "flow-1-renamed"), false);
+
+            var persistedFlows = flowCrudService.getApiV4Flows(API_ID);
+            assertThat(persistedFlows).hasSize(2);
+            assertThat(persistedFlows.getFirst().getId()).isEqualTo("flow-0-id");
+            assertThat(persistedFlows.get(1).getId()).isEqualTo("flow-1-id");
+        }
+
+        @Test
         void merge_patch_with_flows_null_clears_flows_on_rebuilt_definition() {
             givenExistingApi(apiWithFlows(List.of(aFlow("f1", List.of(aStep("s1", "policy-a"))))));
 


### PR DESCRIPTION
## Why

When a JSON-Patch operation targets a sub-path of `/flows` (e.g. `/flows/1/name`), `PatchApiUseCase` was building the patch base from the in-memory API definition, which holds flows without their database-assigned IDs. After the patch was applied and flows were re-saved, the untouched sibling flows lost their persisted IDs, breaking any downstream reference to those IDs.

## What changed

- `PatchApiUseCase` now fetches the persisted flows from the database before constructing the JSON-Patch base node and merges them into the existing API definition, so all flows carry their stored IDs when the patch is applied.
- Added a regression test in `PatchApiUseCaseTest` that patches one flow's name and asserts the sibling flow's persisted ID is retained.

## User-facing impact

Flows patched via the JSON-Patch API endpoint will no longer lose their persisted IDs when only a sub-path (e.g. the name) of a sibling flow is modified.
