### PR TITLE
chore(distribution): ship Kafka-compatible policies in the default bundle

### DIFF
--- a/gravitee-apim-distribution/pom.xml
+++ b/gravitee-apim-distribution/pom.xml
@@ -1817,6 +1817,32 @@
                         </exclusion>
                     </exclusions>
                 </dependency>
+                <dependency>
+                    <groupId>com.graviteesource.resource</groupId>
+                    <artifactId>gravitee-resource-schema-registry-confluent</artifactId>
+                    <version>${gravitee-resource-schema-registry-confluent.version}</version>
+                    <type>zip</type>
+                    <scope>runtime</scope>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>*</groupId>
+                            <artifactId>*</artifactId>
+                        </exclusion>
+                    </exclusions>
+                </dependency>
+                <dependency>
+                    <groupId>com.graviteesource.resource</groupId>
+                    <artifactId>gravitee-resource-schema-registry-embedded</artifactId>
+                    <version>${gravitee-resource-schema-registry-embedded.version}</version>
+                    <type>zip</type>
+                    <scope>runtime</scope>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>*</groupId>
+                            <artifactId>*</artifactId>
+                        </exclusion>
+                    </exclusions>
+                </dependency>
 
                 <!-- Policies -->
                 <dependency>
@@ -2031,6 +2057,32 @@
                     <groupId>com.graviteesource.policy</groupId>
                     <artifactId>gravitee-policy-kafka-message-encryption-decryption</artifactId>
                     <version>${gravitee-policy-kafka-message-encryption-decryption.version}</version>
+                    <type>zip</type>
+                    <scope>runtime</scope>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>*</groupId>
+                            <artifactId>*</artifactId>
+                        </exclusion>
+                    </exclusions>
+                </dependency>
+                <dependency>
+                    <groupId>com.graviteesource.policy</groupId>
+                    <artifactId>gravitee-policy-transform-avro-json</artifactId>
+                    <version>${gravitee-policy-transform-avro-json.version}</version>
+                    <type>zip</type>
+                    <scope>runtime</scope>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>*</groupId>
+                            <artifactId>*</artifactId>
+                        </exclusion>
+                    </exclusions>
+                </dependency>
+                <dependency>
+                    <groupId>com.graviteesource.policy</groupId>
+                    <artifactId>gravitee-policy-transform-protobuf-json</artifactId>
+                    <version>${gravitee-policy-transform-protobuf-json.version}</version>
                     <type>zip</type>
                     <scope>runtime</scope>
                     <exclusions>
@@ -2325,32 +2377,6 @@
                 <!-- Policies -->
                 <dependency>
                     <groupId>com.graviteesource.policy</groupId>
-                    <artifactId>gravitee-policy-transform-avro-json</artifactId>
-                    <version>${gravitee-policy-transform-avro-json.version}</version>
-                    <type>zip</type>
-                    <scope>runtime</scope>
-                    <exclusions>
-                        <exclusion>
-                            <groupId>*</groupId>
-                            <artifactId>*</artifactId>
-                        </exclusion>
-                    </exclusions>
-                </dependency>
-                <dependency>
-                    <groupId>com.graviteesource.policy</groupId>
-                    <artifactId>gravitee-policy-transform-protobuf-json</artifactId>
-                    <version>${gravitee-policy-transform-protobuf-json.version}</version>
-                    <type>zip</type>
-                    <scope>runtime</scope>
-                    <exclusions>
-                        <exclusion>
-                            <groupId>*</groupId>
-                            <artifactId>*</artifactId>
-                        </exclusion>
-                    </exclusions>
-                </dependency>
-                <dependency>
-                    <groupId>com.graviteesource.policy</groupId>
                     <artifactId>gravitee-policy-transform-avro-protobuf</artifactId>
                     <version>${gravitee-policy-transform-avro-protobuf.version}</version>
                     <type>zip</type>
@@ -2591,32 +2617,6 @@
                     <groupId>io.gravitee.resource</groupId>
                     <artifactId>gravitee-resource-oauth2-provider-keycloak</artifactId>
                     <version>${gravitee-resource-oauth2-provider-keycloak.version}</version>
-                    <type>zip</type>
-                    <scope>runtime</scope>
-                    <exclusions>
-                        <exclusion>
-                            <groupId>*</groupId>
-                            <artifactId>*</artifactId>
-                        </exclusion>
-                    </exclusions>
-                </dependency>
-                <dependency>
-                    <groupId>com.graviteesource.resource</groupId>
-                    <artifactId>gravitee-resource-schema-registry-confluent</artifactId>
-                    <version>${gravitee-resource-schema-registry-confluent.version}</version>
-                    <type>zip</type>
-                    <scope>runtime</scope>
-                    <exclusions>
-                        <exclusion>
-                            <groupId>*</groupId>
-                            <artifactId>*</artifactId>
-                        </exclusion>
-                    </exclusions>
-                </dependency>
-                <dependency>
-                    <groupId>com.graviteesource.resource</groupId>
-                    <artifactId>gravitee-resource-schema-registry-embedded</artifactId>
-                    <version>${gravitee-resource-schema-registry-embedded.version}</version>
                     <type>zip</type>
                     <scope>runtime</scope>
                     <exclusions>


### PR DESCRIPTION
## Why

Several policies that are compatible with the **native Kafka API** were only shipped in the **dev** bundle (`-Dbundle=dev`), so they were not available in the default/prod distribution. This moves them into the default bundle so a standard install gets native-Kafka governance and Avro/Protobuf transformation out of the box.

## What

### Moved `bundle-dev` → `bundle-default`
| Artifact | Native Kafka phases |
| --- | --- |
| `gravitee-policy-transform-avro-json` | `PUBLISH,SUBSCRIBE` |
| `gravitee-policy-transform-protobuf-json` | `PUBLISH,SUBSCRIBE` |
| `gravitee-resource-schema-registry-confluent` | (registry-mode dependency) |
| `gravitee-resource-schema-registry-embedded` | (registry-mode dependency) |

The two schema-registry **resources** move alongside the policies because the Avro/Protobuf policies' Schema-Registry validation mode depends on them — shipping the policies without the resources would only support inline-schema mode in the default bundle.

## Deliberately left out

- **`gravitee-policy-transform-avro-protobuf`** — stays in the dev bundle: it is HTTP-only (`proxy`/`message` phases, **no** `native_kafka`), so it is not Kafka-compatible.
- **`gravitee-policy-native-ipfiltering`** (`ENTRYPOINT_CONNECT`) — already shipped in `bundle-default` on master; no change needed.

## Notes

The already-named `kafka-*` policies (`kafka-acl`, `kafka-quota`, `kafka-topic-mapping`, `kafka-transform-key`, `kafka-message-filtering`, `kafka-message-encryption-decryption`, etc.) were already in the default bundle and are unchanged.

Both `pom.xml` files validated as well-formed; the change is purely dependency-section moves.