### PR TITLE
test(tracing): test server span kind for entry span

### DIFF
--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/tracing/OpenTelemetryTracingV4IntegrationTest.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/tracing/OpenTelemetryTracingV4IntegrationTest.java
@@ -146,13 +146,13 @@ class OpenTelemetryTracingV4IntegrationTest extends AbstractGatewayTest {
             .assertNoErrors();
 
         Set<String> expectedOperationNames = Set.of(
-            "POST",
+            "POST /test",
             "Request phase",
             "REQUEST flow (api-flow-1)",
             "REQUEST policy-latency",
             "REQUEST Security (keyless)",
             "endpoint-invoker",
-            "POST /endpoint",
+            "POST",
             "Response phase",
             "RESPONSE flow (api-flow-1)",
             "RESPONSE policy-latency"
@@ -174,7 +174,9 @@ class OpenTelemetryTracingV4IntegrationTest extends AbstractGatewayTest {
                     .get();
 
                 assertThat(response.statusCode()).isEqualTo(200);
-                assertData(response.bodyAsJsonObject(), expectedOperationNames);
+                JsonObject body = response.bodyAsJsonObject();
+                assertData(body, expectedOperationNames);
+                assertExactlyOneSpanWithKind(body, "POST /test", "server");
             });
     }
 
@@ -231,7 +233,9 @@ class OpenTelemetryTracingV4IntegrationTest extends AbstractGatewayTest {
                     .get();
 
                 assertThat(response.statusCode()).isEqualTo(200);
-                assertData(response.bodyAsJsonObject(), expectedOperationNames);
+                JsonObject body = response.bodyAsJsonObject();
+                assertData(body, expectedOperationNames);
+                assertExactlyOneSpanWithKind(body, "GET /test", "server");
             });
     }
 
@@ -262,5 +266,27 @@ class OpenTelemetryTracingV4IntegrationTest extends AbstractGatewayTest {
             .map(span -> span.getString("operationName"))
             .toArray(String[]::new);
         assertThat(expectedOperationName).containsOnly(operationNames);
+    }
+
+    private static void assertExactlyOneSpanWithKind(JsonObject json, String expectedOperationName, String expectedKind) {
+        var spans = json.getJsonArray("data").getJsonObject(0).getJsonArray("spans");
+        var matchingSpans = spans
+            .stream()
+            .map(JsonObject.class::cast)
+            .filter(span -> hasSpanKind(span, expectedKind))
+            .toList();
+        assertThat(matchingSpans).as("spans with kind=%s", expectedKind).hasSize(1);
+        assertThat(matchingSpans.get(0).getString("operationName")).as("entry span operation name").isEqualTo(expectedOperationName);
+    }
+
+    private static boolean hasSpanKind(JsonObject span, String expectedKind) {
+        var tags = span.getJsonArray("tags");
+        if (tags == null) {
+            return false;
+        }
+        return tags
+            .stream()
+            .map(JsonObject.class::cast)
+            .anyMatch(tag -> "span.kind".equals(tag.getString("key")) && expectedKind.equals(tag.getString("value")));
     }
 }


### PR DESCRIPTION
> **Do not merge** until gravitee-node [#573](https://github.com/gravitee-io/gravitee-node/pull/573) is released and the master bump PR [#17812](https://github.com/gravitee-io/gravitee-api-management/pull/17812) is updated to the released version and merged.

## Issue

https://gravitee.atlassian.net/browse/APIM-12354

## Description

Add regression coverage in `OpenTelemetryTracingV4IntegrationTest` for correct gateway entry span naming and kind:

- Entry span: `{METHOD} {path}` with `SpanKind.SERVER` (e.g. `POST /test`)
- Backend span: `{METHOD}` only (e.g. `POST`)

Adds an `assertRootSpanKind` helper and applies the new assertions to both HTTP and message API tests.

## Additional context

- gravitee-node fix: https://github.com/gravitee-io/gravitee-node/pull/573
- APIM master bump: https://github.com/gravitee-io/gravitee-api-management/pull/17812
- CI will fail on this PR until both above are merged on master.
