### PR TITLE
fix(deps): bump gravitee-node to 9.0.0-alpha.18

### DIFF
--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/tracing/OpenTelemetryTracingV4IntegrationTest.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/tracing/OpenTelemetryTracingV4IntegrationTest.java
@@ -146,13 +146,13 @@ class OpenTelemetryTracingV4IntegrationTest extends AbstractGatewayTest {
             .assertNoErrors();
 
         Set<String> expectedOperationNames = Set.of(
-            "POST",
+            "POST /test",
             "Request phase",
             "REQUEST flow (api-flow-1)",
             "REQUEST policy-latency",
             "REQUEST Security (keyless)",
             "endpoint-invoker",
-            "POST /endpoint",
+            "POST",
             "Response phase",
             "RESPONSE flow (api-flow-1)",
             "RESPONSE policy-latency"
@@ -174,7 +174,9 @@ class OpenTelemetryTracingV4IntegrationTest extends AbstractGatewayTest {
                     .get();
 
                 assertThat(response.statusCode()).isEqualTo(200);
-                assertData(response.bodyAsJsonObject(), expectedOperationNames);
+                JsonObject body = response.bodyAsJsonObject();
+                assertData(body, expectedOperationNames);
+                assertExactlyOneSpanWithKind(body, "POST /test", "server");
             });
     }
 
@@ -231,7 +233,9 @@ class OpenTelemetryTracingV4IntegrationTest extends AbstractGatewayTest {
                     .get();
 
                 assertThat(response.statusCode()).isEqualTo(200);
-                assertData(response.bodyAsJsonObject(), expectedOperationNames);
+                JsonObject body = response.bodyAsJsonObject();
+                assertData(body, expectedOperationNames);
+                assertExactlyOneSpanWithKind(body, "GET /test", "server");
             });
     }
 
@@ -262,5 +266,27 @@ class OpenTelemetryTracingV4IntegrationTest extends AbstractGatewayTest {
             .map(span -> span.getString("operationName"))
             .toArray(String[]::new);
         assertThat(expectedOperationName).containsOnly(operationNames);
+    }
+
+    private static void assertExactlyOneSpanWithKind(JsonObject json, String expectedOperationName, String expectedKind) {
+        var spans = json.getJsonArray("data").getJsonObject(0).getJsonArray("spans");
+        var matchingSpans = spans
+            .stream()
+            .map(JsonObject.class::cast)
+            .filter(span -> hasSpanKind(span, expectedKind))
+            .toList();
+        assertThat(matchingSpans).as("spans with kind=%s", expectedKind).hasSize(1);
+        assertThat(matchingSpans.get(0).getString("operationName")).as("entry span operation name").isEqualTo(expectedOperationName);
+    }
+
+    private static boolean hasSpanKind(JsonObject span, String expectedKind) {
+        var tags = span.getJsonArray("tags");
+        if (tags == null) {
+            return false;
+        }
+        return tags
+            .stream()
+            .map(JsonObject.class::cast)
+            .anyMatch(tag -> "span.kind".equals(tag.getString("key")) && expectedKind.equals(tag.getString("value")));
     }
 }

--- a/helm/tests/api/deployment_federation_test.yaml
+++ b/helm/tests/api/deployment_federation_test.yaml
@@ -37,7 +37,7 @@ tests:
             - command:
                 - sh
                 - -c
-                - mkdir -p /tmp/plugins && cd /tmp/plugins && ( rm  gravitee-node-cache-plugin-hazelcast-9.0.0-alpha.2.zip  2>/dev/null || true ) && wget https://download.gravitee.io/pre-releases/plugins/node-cache/gravitee-node-cache-plugin-hazelcast/gravitee-node-cache-plugin-hazelcast-9.0.0-alpha.2.zip && ( rm  gravitee-node-cluster-plugin-hazelcast-9.0.0-alpha.2.zip  2>/dev/null || true ) && wget https://download.gravitee.io/pre-releases/plugins/node-cluster/gravitee-node-cluster-plugin-hazelcast/gravitee-node-cluster-plugin-hazelcast-9.0.0-alpha.2.zip
+                - mkdir -p /tmp/plugins && cd /tmp/plugins && ( rm  gravitee-node-cache-plugin-hazelcast-9.0.0-apim-12354-alpha-SNAPSHOT.zip  2>/dev/null || true ) && wget https://download.gravitee.io/pre-releases/plugins/node-cache/gravitee-node-cache-plugin-hazelcast/gravitee-node-cache-plugin-hazelcast-9.0.0-apim-12354-alpha-SNAPSHOT.zip && ( rm  gravitee-node-cluster-plugin-hazelcast-9.0.0-apim-12354-alpha-SNAPSHOT.zip  2>/dev/null || true ) && wget https://download.gravitee.io/pre-releases/plugins/node-cluster/gravitee-node-cluster-plugin-hazelcast/gravitee-node-cluster-plugin-hazelcast-9.0.0-apim-12354-alpha-SNAPSHOT.zip
               env: [ ]
               image: alpine:latest
               imagePullPolicy: Always

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -510,8 +510,8 @@ cloud:
 
 cluster:
   plugins:
-    - https://download.gravitee.io/pre-releases/plugins/node-cache/gravitee-node-cache-plugin-hazelcast/gravitee-node-cache-plugin-hazelcast-9.0.0-alpha.2.zip
-    - https://download.gravitee.io/pre-releases/plugins/node-cluster/gravitee-node-cluster-plugin-hazelcast/gravitee-node-cluster-plugin-hazelcast-9.0.0-alpha.2.zip
+    - https://download.gravitee.io/pre-releases/plugins/node-cache/gravitee-node-cache-plugin-hazelcast/gravitee-node-cache-plugin-hazelcast-9.0.0-apim-12354-alpha-SNAPSHOT.zip
+    - https://download.gravitee.io/pre-releases/plugins/node-cluster/gravitee-node-cluster-plugin-hazelcast/gravitee-node-cluster-plugin-hazelcast-9.0.0-apim-12354-alpha-SNAPSHOT.zip
 
 api:
   enabled: true

--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
         <gravitee-integration-api.version>5.1.0</gravitee-integration-api.version>
         <gravitee-json-validation.version>2.2.0</gravitee-json-validation.version>
         <gravitee-kubernetes.version>4.0.0-alpha.1</gravitee-kubernetes.version>
-        <gravitee-node.version>9.0.0-alpha.17</gravitee-node.version>
+        <gravitee-node.version>9.0.0-apim-12354-alpha-SNAPSHOT</gravitee-node.version>
         <gravitee-notifier-api.version>2.0.0</gravitee-notifier-api.version>
         <gravitee-platform-repository-api.version>2.0.0</gravitee-platform-repository-api.version>
         <gravitee-plugin.version>5.1.2</gravitee-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
         <gravitee-integration-api.version>5.1.0</gravitee-integration-api.version>
         <gravitee-json-validation.version>2.2.0</gravitee-json-validation.version>
         <gravitee-kubernetes.version>4.0.0-alpha.1</gravitee-kubernetes.version>
-        <gravitee-node.version>9.0.0-apim-12354-alpha-SNAPSHOT</gravitee-node.version>
+        <gravitee-node.version>9.0.0-alpha.18</gravitee-node.version>
         <gravitee-notifier-api.version>2.0.0</gravitee-notifier-api.version>
         <gravitee-platform-repository-api.version>2.0.0</gravitee-platform-repository-api.version>
         <gravitee-plugin.version>5.1.2</gravitee-plugin.version>


### PR DESCRIPTION
> **Do not merge** until gravitee-node [#573](https://github.com/gravitee-io/gravitee-node/pull/573) is released; update the SNAPSHOT version in code to the released version before merge.

## Issue

https://gravitee.atlassian.net/browse/APIM-12354

## Description

Bump `gravitee-node.version` to `9.0.0-alpha.18` to pick up the OpenTelemetry entry-span SERVER kind and naming fix.

## Additional context

- gravitee-node fix: https://github.com/gravitee-io/gravitee-node/pull/573
- APIM integration test: https://github.com/gravitee-io/gravitee-api-management/pull/17811
