### PR TITLE
feat(console): warning banner on native api traffic page

### DIFF
--- a/gravitee-apim-console-webui/src/management/api/api-navigation/api-v4-menu.service.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-navigation/api-v4-menu.service.spec.ts
@@ -173,6 +173,24 @@ describe('ApiV4MenuService', () => {
     });
   });
 
+  describe('API Traffic menu header', () => {
+    beforeEach(() => {
+      TestBed.overrideProvider(GioTestingPermissionProvider, { useValue: ['api-analytics-r'] });
+      service = TestBed.inject(ApiV4MenuService);
+    });
+
+    it.each([
+      ['NATIVE', undefined],
+      ['PROXY', undefined],
+      ['MCP_PROXY', undefined],
+      ['LLM_PROXY', undefined],
+      ['MESSAGE', { title: 'API Traffic' }],
+    ] as const)('apiType %s -> header %p', (type, expected) => {
+      const apiTraffic = service.getMenu(fakeApiV4({ type })).subMenuItems.find(item => item.displayName === 'API Traffic');
+      expect(apiTraffic?.header).toEqual(expected);
+    });
+  });
+
   describe('Logs menu for NATIVE API', () => {
     it('should include Logs menu pointing to v4/runtime-logs-native when user has api-native_log-r permission', () => {
       TestBed.overrideProvider(GioTestingPermissionProvider, { useValue: ['api-native_log-r'] });

--- a/gravitee-apim-console-webui/src/management/api/api-navigation/api-v4-menu.service.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-navigation/api-v4-menu.service.ts
@@ -380,7 +380,7 @@ export class ApiV4MenuService implements ApiMenuService {
         icon: 'bar-chart-2',
         routerLink: hasTcpListeners ? 'DISABLED' : 'v4/analytics',
       };
-      if (apiType === 'PROXY' || apiType === 'MCP_PROXY' || apiType === 'LLM_PROXY') {
+      if (apiType === 'PROXY' || apiType === 'MCP_PROXY' || apiType === 'LLM_PROXY' || apiType === 'NATIVE') {
         return baseMenuItem;
       } else {
         return {

--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/analytics/api-analytics-native/api-analytics-native.component.harness.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/analytics/api-analytics-native/api-analytics-native.component.harness.ts
@@ -21,10 +21,20 @@ export class ApiAnalyticsNativeHarness extends ComponentHarness {
   static hostSelector = 'api-analytics-native';
 
   protected emptyPanelHarness = this.locatorForOptional('gio-card-empty-state');
+  protected reportingDisabledBanner = this.locatorForOptional('[data-testid="native_analytics_reporting_disabled_banner"]');
+  protected configureReportingLink = this.locatorForOptional('[data-testid="native_analytics_configure_reporting"]');
 
   getFiltersBarHarness = this.locatorForOptional(ApiAnalyticsNativeFilterBarHarness);
 
   async isEmptyPanelDisplayed(): Promise<boolean> {
     return (await this.emptyPanelHarness()) !== null;
+  }
+
+  async isReportingDisabledBannerDisplayed(): Promise<boolean> {
+    return (await this.reportingDisabledBanner()) !== null;
+  }
+
+  async isConfigureReportingButtonDisplayed(): Promise<boolean> {
+    return (await this.configureReportingLink()) !== null;
   }
 }

--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/analytics/api-analytics-native/api-analytics-native.component.html
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/analytics/api-analytics-native/api-analytics-native.component.html
@@ -15,6 +15,18 @@
     limitations under the License.
 
 -->
+<api-navigation-header [menuItemHeader]="{ title: 'API Traffic' }">
+  <div actionButtons>
+    <a mat-raised-button [routerLink]="['../../reporter-settings']" data-testid="native_analytics_configure_reporting"
+      >Configure Reporting</a
+    >
+  </div>
+</api-navigation-header>
+
+@if (isAnalyticsDisabled()) {
+  <reporting-disabled-banner data-testid="native_analytics_reporting_disabled_banner"></reporting-disabled-banner>
+}
+
 <api-analytics-native-filter-bar
   [activeFilters]="activeFilters()"
   [plans]="apiPlans$ | async"

--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/analytics/api-analytics-native/api-analytics-native.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/analytics/api-analytics-native/api-analytics-native.component.spec.ts
@@ -27,7 +27,7 @@ import { ApiAnalyticsNativeHarness } from './api-analytics-native.component.harn
 import { ApiAnalyticsNativeComponent } from './api-analytics-native.component';
 
 import { CONSTANTS_TESTING, GioTestingModule } from '../../../../../shared/testing';
-import { fakePagedResult, fakePlanV4, PlanV4 } from '../../../../../entities/management-api-v2';
+import { ApiV4, fakeNativeKafkaApiV4, fakePagedResult, fakePlanV4, PlanV4 } from '../../../../../entities/management-api-v2';
 import { fakeAnalyticsHistogram } from '../../../../../entities/management-api-v2/analytics/analyticsHistogram.fixture';
 import { fakeGroupByResponse } from '../../../../../entities/management-api-v2/analytics/analyticsGroupBy.fixture';
 import { fakeAnalyticsStatsResponse } from '../../../../../entities/management-api-v2/analytics/analyticsStats.fixture';
@@ -39,7 +39,10 @@ describe('ApiAnalyticsNativeComponent', () => {
   let componentHarness: ApiAnalyticsNativeHarness;
   let httpTestingController: HttpTestingController;
 
-  const initComponent = async (queryParams = {}) => {
+  const initComponent = async (
+    queryParams = {},
+    api: ApiV4 = fakeNativeKafkaApiV4({ analytics: { enabled: true, reporterMetricsEnabled: true } }),
+  ) => {
     TestBed.configureTestingModule({
       imports: [ApiAnalyticsNativeComponent, OwlNativeDateTimeModule, NoopAnimationsModule, MatIconTestingModule, GioTestingModule],
       providers: [
@@ -63,6 +66,7 @@ describe('ApiAnalyticsNativeComponent', () => {
     httpTestingController = TestBed.inject(HttpTestingController);
     componentHarness = await TestbedHarnessEnvironment.harnessForFixture(fixture, ApiAnalyticsNativeHarness);
     fixture.detectChanges();
+    expectApiGet(api);
   };
 
   afterEach(() => {
@@ -80,9 +84,33 @@ describe('ApiAnalyticsNativeComponent', () => {
       expect(await componentHarness.isEmptyPanelDisplayed()).toBeFalsy();
     });
 
+    it('should not display the reporting-disabled banner', async () => {
+      expect(await componentHarness.isReportingDisabledBannerDisplayed()).toBe(false);
+    });
+
+    it('should always display the Configure Reporting button', async () => {
+      expect(await componentHarness.isConfigureReportingButtonDisplayed()).toBe(true);
+    });
+
     it('should refresh when filters are applied', async () => {
       const filtersBar = await componentHarness.getFiltersBarHarness();
       await filtersBar.clickRefresh();
+    });
+  });
+
+  describe('GIVEN an API with analytics.enabled=false', () => {
+    beforeEach(async () => {
+      await initComponent({}, fakeNativeKafkaApiV4({ analytics: { enabled: false, reporterMetricsEnabled: true } }));
+      expectPlanList();
+      flushAllRequests();
+    });
+
+    it('should display the reporting-disabled banner', async () => {
+      expect(await componentHarness.isReportingDisabledBannerDisplayed()).toBe(true);
+    });
+
+    it('should display the Configure Reporting button', async () => {
+      expect(await componentHarness.isConfigureReportingButtonDisplayed()).toBe(true);
     });
   });
 
@@ -249,6 +277,11 @@ describe('ApiAnalyticsNativeComponent', () => {
         request.flush(fakeAnalyticsStatsResponse());
       }
     });
+  }
+
+  function expectApiGet(api: ApiV4) {
+    httpTestingController.expectOne({ url: `${CONSTANTS_TESTING.env.v2BaseURL}/apis/${API_ID}`, method: 'GET' }).flush(api);
+    fixture.detectChanges();
   }
 
   function expectPlanList(plans: PlanV4[] = []) {

--- a/gravitee-apim-console-webui/src/management/api/api-traffic-v4/analytics/api-analytics-native/api-analytics-native.component.ts
+++ b/gravitee-apim-console-webui/src/management/api/api-traffic-v4/analytics/api-analytics-native/api-analytics-native.component.ts
@@ -16,8 +16,9 @@
 
 import { Component, computed, effect, inject, OnDestroy, OnInit, Signal } from '@angular/core';
 import { GioCardEmptyStateModule, GioLoaderModule } from '@gravitee/ui-particles-angular';
+import { MatButtonModule } from '@angular/material/button';
 import { MatCardModule } from '@angular/material/card';
-import { ActivatedRoute, Router } from '@angular/router';
+import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { CommonModule } from '@angular/common';
 import { Observable, of } from 'rxjs';
 import { toSignal } from '@angular/core/rxjs-interop';
@@ -35,8 +36,11 @@ import { ApiAnalyticsDashboardWidgetConfig } from '../api-analytics-proxy/api-an
 import { GioChartPieModule } from '../../../../../shared/components/gio-chart-pie/gio-chart-pie.module';
 import { ApiPlanV2Service } from '../../../../../services-ngx/api-plan-v2.service';
 import { AggregationFields, AggregationTypes } from '../../../../../entities/management-api-v2/analytics/analyticsHistogram';
-import { BaseApplication } from '../../../../../entities/management-api-v2';
+import { ApiV4, BaseApplication } from '../../../../../entities/management-api-v2';
 import { ApiV2Service } from '../../../../../services-ngx/api-v2.service';
+import { ActionButtonsDirective } from '../../../api-navigation/api-navigation-header/action-buttons.directive';
+import { ApiNavigationModule } from '../../../api-navigation/api-navigation.module';
+import { ReportingDisabledBannerComponent } from '../../components/reporting-disabled-banner/reporting-disabled-banner.component';
 
 interface QueryParamsBase {
   from?: string;
@@ -50,9 +54,14 @@ interface QueryParamsBase {
   selector: 'api-analytics-native',
   imports: [
     CommonModule,
+    MatButtonModule,
     MatCardModule,
+    RouterLink,
     GioLoaderModule,
     GioCardEmptyStateModule,
+    ActionButtonsDirective,
+    ApiNavigationModule,
+    ReportingDisabledBannerComponent,
     ApiAnalyticsNativeFilterBarComponent,
     ApiAnalyticsWidgetComponent,
     GioChartPieModule,
@@ -65,6 +74,11 @@ export class ApiAnalyticsNativeComponent implements OnInit, OnDestroy {
   private activatedRouteQueryParams = toSignal(this.activatedRoute.queryParams);
   private planService = inject(ApiPlanV2Service);
   private apiService = inject(ApiV2Service);
+
+  public readonly isAnalyticsDisabled = toSignal(
+    this.apiService.getLastApiFetch(this.apiId).pipe(map((api: ApiV4) => api.analytics?.enabled === false)),
+    { initialValue: false },
+  );
 
   public topRowTransformed$: Observable<ApiAnalyticsWidgetConfig>[];
   public leftColumnTransformed$: Observable<ApiAnalyticsWidgetConfig>[];


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-11897

## Description

Display a warning banner on the Kafka API → API Traffic page when analytics is disabled (`api.analytics.enabled === false`), mirroring the existing Runtime Logs banner pattern. Adds a `Configure Reporting` action button linking to the Reporter Settings page.

## Additional context

- Banner gate: `analytics.enabled` (event-metrics). The complementary `reporterMetricsEnabled` flag already has banner coverage on the Connection Logs page (`api-runtime-logs-native`).
- Header restructure: `api-v4-menu.service` no longer auto-renders the parent "API Traffic" header for NATIVE — the native child page now owns the header (same pattern already used for PROXY / MCP_PROXY / LLM_PROXY). Avoids duplicate headers.
- Reuses `gio-banner-info` and copy verbatim from the proxy v4 runtime-logs banner.
- API fetch reuses `apiService.getLastApiFetch(apiId)` so the parent dispatcher's cache is shared (no redundant HTTP).

### Reproduction

1. Create or open a Kafka (V4 NATIVE) API.
2. Deployment → Reporter Settings → toggle **Enable event-metrics reporting** OFF, Save.
3. Navigate to API Traffic. Banner appears above filters; `Configure Reporting` button in the page header routes to Reporter Settings.
4. Toggle ON → banner disappears.

### Test
<img width="1464" height="699" alt="Screenshot 2026-06-14 at 2 18 53 PM" src="https://github.com/user-attachments/assets/103e0a07-a545-45c1-a083-9ec92b44bcee" />
