### PR TITLE
fix(reporter): respect lifecycle property-name overrides in ES templates

### DIFF
--- a/gravitee-apim-reporter/gravitee-apim-reporter-elasticsearch/src/main/java/io/gravitee/apim/reporter/elasticsearch/config/ReporterConfiguration.java
+++ b/gravitee-apim-reporter/gravitee-apim-reporter-elasticsearch/src/main/java/io/gravitee/apim/reporter/elasticsearch/config/ReporterConfiguration.java
@@ -462,7 +462,7 @@ public class ReporterConfiguration {
     }
 
     public String getIndexLifecyclePolicyPropertyName() {
-        return indexLifecyclePolicyPropertyName;
+        return blankToDefault(indexLifecyclePolicyPropertyName, DEFAULT_INDEX_LIFECYCLE_POLICY_PROPERTY_NAME);
     }
 
     public void setIndexLifecyclePolicyPropertyName(String indexLifecyclePolicyPropertyName) {
@@ -581,10 +581,29 @@ public class ReporterConfiguration {
     }
 
     public String getIndexLifecycleRolloverAliasPropertyName() {
-        return indexLifecycleRolloverAliasPropertyName;
+        return blankToDefault(indexLifecycleRolloverAliasPropertyName, DEFAULT_INDEX_LIFECYCLE_ROLLOVER_ALIAS_PROPERTY_NAME);
     }
 
     public void setIndexLifecycleRolloverAliasPropertyName(String indexLifecycleRolloverAliasPropertyName) {
         this.indexLifecycleRolloverAliasPropertyName = indexLifecycleRolloverAliasPropertyName;
+    }
+
+    /**
+     * Spring's {@code ${property:default}} only falls back when the property is absent: a property that is
+     * present but empty — {@code rollover_alias_property_name:} in YAML, an empty environment variable, or a
+     * blank Helm value — resolves to an empty string and skips the default. An empty settings key makes the
+     * cluster reject the whole index template, taking the shard, replica and refresh settings down with it,
+     * so treat blank as unset. Surrounding whitespace is stripped for the same reason: a quoted YAML value,
+     * a Helm value or an environment variable can carry it, and a padded key is rejected just like an empty
+     * one. Only the property <em>names</em> are normalised — a blank policy already means "no lifecycle for
+     * this type", and a whitespace-only policy is an ordinary typo the cluster reports through its own
+     * lifecycle explain API.
+     */
+    private static String blankToDefault(String value, String defaultValue) {
+        if (value == null) {
+            return defaultValue;
+        }
+        final String stripped = value.strip();
+        return stripped.isEmpty() ? defaultValue : stripped;
     }
 }

--- a/gravitee-apim-reporter/gravitee-apim-reporter-elasticsearch/src/main/resources/freemarker/es7x/mapping/index-template-event-metrics.ftl
+++ b/gravitee-apim-reporter/gravitee-apim-reporter-elasticsearch/src/main/resources/freemarker/es7x/mapping/index-template-event-metrics.ftl
@@ -4,8 +4,8 @@
     "data_stream": {},
     "template": {
         "settings": {
-            <#if indexLifecyclePolicyEventMetrics??>"index.lifecycle.name": "${indexLifecyclePolicyEventMetrics}",</#if>
-            <#if indexLifecyclePolicyEventMetrics??>"index.lifecycle.rollover_alias": "${indexName}",</#if>
+            <#if indexLifecyclePolicyEventMetrics?has_content>"${indexLifecyclePolicyPropertyName?json_string}": "${indexLifecyclePolicyEventMetrics?json_string}",</#if>
+            <#if indexLifecyclePolicyEventMetrics?has_content>"${indexLifecycleRolloverAliasPropertyName?json_string}": "${indexName}",</#if>
             "index.number_of_shards":${numberOfShards},
             "index.number_of_replicas":${numberOfReplicas},
             "index.refresh_interval": "${refreshInterval}"

--- a/gravitee-apim-reporter/gravitee-apim-reporter-elasticsearch/src/main/resources/freemarker/es7x/mapping/index-template-health.ftl
+++ b/gravitee-apim-reporter/gravitee-apim-reporter-elasticsearch/src/main/resources/freemarker/es7x/mapping/index-template-health.ftl
@@ -2,8 +2,8 @@
 {
     "index_patterns": ["${indexName}*"],
     "settings": {
-        <#if indexLifecyclePolicyHealth??>"${indexLifecyclePolicyPropertyName}": "${indexLifecyclePolicyHealth}",</#if>
-        <#if indexLifecyclePolicyHealth??>"${indexLifecycleRolloverAliasPropertyName}": "${indexName}",</#if>
+        <#if indexLifecyclePolicyHealth?has_content>"${indexLifecyclePolicyPropertyName?json_string}": "${indexLifecyclePolicyHealth?json_string}",</#if>
+        <#if indexLifecyclePolicyHealth?has_content>"${indexLifecycleRolloverAliasPropertyName?json_string}": "${indexName}",</#if>
         "index.number_of_shards":${numberOfShards},
         "index.number_of_replicas":${numberOfReplicas},
         "index.refresh_interval": "${refreshInterval}"

--- a/gravitee-apim-reporter/gravitee-apim-reporter-elasticsearch/src/main/resources/freemarker/es7x/mapping/index-template-log.ftl
+++ b/gravitee-apim-reporter/gravitee-apim-reporter-elasticsearch/src/main/resources/freemarker/es7x/mapping/index-template-log.ftl
@@ -2,8 +2,8 @@
 {
     "index_patterns": ["${indexName}*"],
     "settings": {
-        <#if indexLifecyclePolicyLog??>"${indexLifecyclePolicyPropertyName}": "${indexLifecyclePolicyLog}",</#if>
-        <#if indexLifecyclePolicyLog??>"${indexLifecycleRolloverAliasPropertyName}": "${indexName}",</#if>
+        <#if indexLifecyclePolicyLog?has_content>"${indexLifecyclePolicyPropertyName?json_string}": "${indexLifecyclePolicyLog?json_string}",</#if>
+        <#if indexLifecyclePolicyLog?has_content>"${indexLifecycleRolloverAliasPropertyName?json_string}": "${indexName}",</#if>
         "index.number_of_shards":${numberOfShards},
         "index.number_of_replicas":${numberOfReplicas},
         "index.refresh_interval": "${refreshInterval}"

--- a/gravitee-apim-reporter/gravitee-apim-reporter-elasticsearch/src/main/resources/freemarker/es7x/mapping/index-template-monitor.ftl
+++ b/gravitee-apim-reporter/gravitee-apim-reporter-elasticsearch/src/main/resources/freemarker/es7x/mapping/index-template-monitor.ftl
@@ -2,8 +2,8 @@
 {
     "index_patterns": ["${indexName}*"],
     "settings": {
-        <#if indexLifecyclePolicyMonitor??>"${indexLifecyclePolicyPropertyName}": "${indexLifecyclePolicyMonitor}",</#if>
-        <#if indexLifecyclePolicyMonitor??>"${indexLifecycleRolloverAliasPropertyName}": "${indexName}",</#if>
+        <#if indexLifecyclePolicyMonitor?has_content>"${indexLifecyclePolicyPropertyName?json_string}": "${indexLifecyclePolicyMonitor?json_string}",</#if>
+        <#if indexLifecyclePolicyMonitor?has_content>"${indexLifecycleRolloverAliasPropertyName?json_string}": "${indexName}",</#if>
         "index.number_of_shards":${numberOfShards},
         "index.number_of_replicas":${numberOfReplicas},
         "index.refresh_interval": "${refreshInterval}"

--- a/gravitee-apim-reporter/gravitee-apim-reporter-elasticsearch/src/main/resources/freemarker/es7x/mapping/index-template-request.ftl
+++ b/gravitee-apim-reporter/gravitee-apim-reporter-elasticsearch/src/main/resources/freemarker/es7x/mapping/index-template-request.ftl
@@ -2,8 +2,8 @@
 {
     "index_patterns": ["${indexName}*"],
     "settings": {
-        <#if indexLifecyclePolicyRequest??>"${indexLifecyclePolicyPropertyName}": "${indexLifecyclePolicyRequest}",</#if>
-        <#if indexLifecyclePolicyRequest??>"${indexLifecycleRolloverAliasPropertyName}": "${indexName}",</#if>
+        <#if indexLifecyclePolicyRequest?has_content>"${indexLifecyclePolicyPropertyName?json_string}": "${indexLifecyclePolicyRequest?json_string}",</#if>
+        <#if indexLifecyclePolicyRequest?has_content>"${indexLifecycleRolloverAliasPropertyName?json_string}": "${indexName}",</#if>
         "index.number_of_shards":${numberOfShards},
         "index.number_of_replicas":${numberOfReplicas},
         "index.refresh_interval": "${refreshInterval}"

--- a/gravitee-apim-reporter/gravitee-apim-reporter-elasticsearch/src/main/resources/freemarker/es7x/mapping/index-template-v4-log.ftl
+++ b/gravitee-apim-reporter/gravitee-apim-reporter-elasticsearch/src/main/resources/freemarker/es7x/mapping/index-template-v4-log.ftl
@@ -2,8 +2,8 @@
 {
     "index_patterns": ["${indexName}*"],
     "settings": {
-        <#if indexLifecyclePolicyLog??>"${indexLifecyclePolicyPropertyName}": "${indexLifecyclePolicyLog}",</#if>
-        <#if indexLifecyclePolicyLog??>"${indexLifecycleRolloverAliasPropertyName}": "${indexName}",</#if>
+        <#if indexLifecyclePolicyLog?has_content>"${indexLifecyclePolicyPropertyName?json_string}": "${indexLifecyclePolicyLog?json_string}",</#if>
+        <#if indexLifecyclePolicyLog?has_content>"${indexLifecycleRolloverAliasPropertyName?json_string}": "${indexName}",</#if>
         "index.number_of_shards":${numberOfShards},
         "index.number_of_replicas":${numberOfReplicas},
         "index.refresh_interval": "${refreshInterval}"

--- a/gravitee-apim-reporter/gravitee-apim-reporter-elasticsearch/src/main/resources/freemarker/es7x/mapping/index-template-v4-message-log.ftl
+++ b/gravitee-apim-reporter/gravitee-apim-reporter-elasticsearch/src/main/resources/freemarker/es7x/mapping/index-template-v4-message-log.ftl
@@ -2,8 +2,8 @@
 {
     "index_patterns": ["${indexName}*"],
     "settings": {
-        <#if indexLifecyclePolicyLog??>"${indexLifecyclePolicyPropertyName}": "${indexLifecyclePolicyLog}",</#if>
-        <#if indexLifecyclePolicyLog??>"${indexLifecycleRolloverAliasPropertyName}": "${indexName}",</#if>
+        <#if indexLifecyclePolicyLog?has_content>"${indexLifecyclePolicyPropertyName?json_string}": "${indexLifecyclePolicyLog?json_string}",</#if>
+        <#if indexLifecyclePolicyLog?has_content>"${indexLifecycleRolloverAliasPropertyName?json_string}": "${indexName}",</#if>
         "index.number_of_shards":${numberOfShards},
         "index.number_of_replicas":${numberOfReplicas},
         "index.refresh_interval": "${refreshInterval}"

--- a/gravitee-apim-reporter/gravitee-apim-reporter-elasticsearch/src/main/resources/freemarker/es7x/mapping/index-template-v4-message-metrics.ftl
+++ b/gravitee-apim-reporter/gravitee-apim-reporter-elasticsearch/src/main/resources/freemarker/es7x/mapping/index-template-v4-message-metrics.ftl
@@ -2,8 +2,8 @@
 {
     "index_patterns": ["${indexName}*"],
     "settings": {
-        <#if indexLifecyclePolicyRequest??>"${indexLifecyclePolicyPropertyName}": "${indexLifecyclePolicyRequest}",</#if>
-        <#if indexLifecyclePolicyRequest??>"${indexLifecycleRolloverAliasPropertyName}": "${indexName}",</#if>
+        <#if indexLifecyclePolicyRequest?has_content>"${indexLifecyclePolicyPropertyName?json_string}": "${indexLifecyclePolicyRequest?json_string}",</#if>
+        <#if indexLifecyclePolicyRequest?has_content>"${indexLifecycleRolloverAliasPropertyName?json_string}": "${indexName}",</#if>
         "index.number_of_shards":${numberOfShards},
         "index.number_of_replicas":${numberOfReplicas},
         "index.refresh_interval": "${refreshInterval}"

--- a/gravitee-apim-reporter/gravitee-apim-reporter-elasticsearch/src/main/resources/freemarker/es7x/mapping/index-template-v4-metrics.ftl
+++ b/gravitee-apim-reporter/gravitee-apim-reporter-elasticsearch/src/main/resources/freemarker/es7x/mapping/index-template-v4-metrics.ftl
@@ -2,8 +2,8 @@
 {
     "index_patterns": ["${indexName}*"],
     "settings": {
-        <#if indexLifecyclePolicyRequest??>"${indexLifecyclePolicyPropertyName}": "${indexLifecyclePolicyRequest}",</#if>
-        <#if indexLifecyclePolicyRequest??>"${indexLifecycleRolloverAliasPropertyName}": "${indexName}",</#if>
+        <#if indexLifecyclePolicyRequest?has_content>"${indexLifecyclePolicyPropertyName?json_string}": "${indexLifecyclePolicyRequest?json_string}",</#if>
+        <#if indexLifecyclePolicyRequest?has_content>"${indexLifecycleRolloverAliasPropertyName?json_string}": "${indexName}",</#if>
         "index.number_of_shards":${numberOfShards},
         "index.number_of_replicas":${numberOfReplicas},
         "index.refresh_interval": "${refreshInterval}"

--- a/gravitee-apim-reporter/gravitee-apim-reporter-elasticsearch/src/main/resources/freemarker/es8x/mapping/index-template-event-metrics.ftl
+++ b/gravitee-apim-reporter/gravitee-apim-reporter-elasticsearch/src/main/resources/freemarker/es8x/mapping/index-template-event-metrics.ftl
@@ -4,8 +4,8 @@
     "data_stream": {},
     "template": {
         "settings": {
-            <#if indexLifecyclePolicyEventMetrics??>"index.lifecycle.name": "${indexLifecyclePolicyEventMetrics}",</#if>
-            <#if indexLifecyclePolicyEventMetrics??>"index.lifecycle.rollover_alias": "${indexName}",</#if>
+            <#if indexLifecyclePolicyEventMetrics?has_content>"${indexLifecyclePolicyPropertyName?json_string}": "${indexLifecyclePolicyEventMetrics?json_string}",</#if>
+            <#if indexLifecyclePolicyEventMetrics?has_content>"${indexLifecycleRolloverAliasPropertyName?json_string}": "${indexName}",</#if>
             "index.number_of_shards":${numberOfShards},
             "index.number_of_replicas":${numberOfReplicas},
             "index.refresh_interval": "${refreshInterval}"

--- a/gravitee-apim-reporter/gravitee-apim-reporter-elasticsearch/src/main/resources/freemarker/es8x/mapping/index-template-health.ftl
+++ b/gravitee-apim-reporter/gravitee-apim-reporter-elasticsearch/src/main/resources/freemarker/es8x/mapping/index-template-health.ftl
@@ -3,8 +3,8 @@
     "index_patterns": ["${indexName}*"],
     "template": {
         "settings": {
-            <#if indexLifecyclePolicyHealth??>"${indexLifecyclePolicyPropertyName}": "${indexLifecyclePolicyHealth}",</#if>
-            <#if indexLifecyclePolicyHealth??>"index.lifecycle.rollover_alias": "${indexName}",</#if>
+            <#if indexLifecyclePolicyHealth?has_content>"${indexLifecyclePolicyPropertyName?json_string}": "${indexLifecyclePolicyHealth?json_string}",</#if>
+            <#if indexLifecyclePolicyHealth?has_content>"${indexLifecycleRolloverAliasPropertyName?json_string}": "${indexName}",</#if>
             "index.number_of_shards":${numberOfShards},
             "index.number_of_replicas":${numberOfReplicas},
             "index.refresh_interval": "${refreshInterval}"

--- a/gravitee-apim-reporter/gravitee-apim-reporter-elasticsearch/src/main/resources/freemarker/es8x/mapping/index-template-log.ftl
+++ b/gravitee-apim-reporter/gravitee-apim-reporter-elasticsearch/src/main/resources/freemarker/es8x/mapping/index-template-log.ftl
@@ -3,8 +3,8 @@
     "index_patterns": ["${indexName}*"],
     "template": {
         "settings": {
-            <#if indexLifecyclePolicyLog??>"${indexLifecyclePolicyPropertyName}": "${indexLifecyclePolicyLog}",</#if>
-            <#if indexLifecyclePolicyLog??>"index.lifecycle.rollover_alias": "${indexName}",</#if>
+            <#if indexLifecyclePolicyLog?has_content>"${indexLifecyclePolicyPropertyName?json_string}": "${indexLifecyclePolicyLog?json_string}",</#if>
+            <#if indexLifecyclePolicyLog?has_content>"${indexLifecycleRolloverAliasPropertyName?json_string}": "${indexName}",</#if>
             "index.number_of_shards":${numberOfShards},
             "index.number_of_replicas":${numberOfReplicas},
             "index.refresh_interval": "${refreshInterval}"

--- a/gravitee-apim-reporter/gravitee-apim-reporter-elasticsearch/src/main/resources/freemarker/es8x/mapping/index-template-monitor.ftl
+++ b/gravitee-apim-reporter/gravitee-apim-reporter-elasticsearch/src/main/resources/freemarker/es8x/mapping/index-template-monitor.ftl
@@ -3,8 +3,8 @@
     "index_patterns": ["${indexName}*"],
     "template": {
         "settings": {
-            <#if indexLifecyclePolicyMonitor??>"${indexLifecyclePolicyPropertyName}": "${indexLifecyclePolicyMonitor}",</#if>
-            <#if indexLifecyclePolicyMonitor??>"index.lifecycle.rollover_alias": "${indexName}",</#if>
+            <#if indexLifecyclePolicyMonitor?has_content>"${indexLifecyclePolicyPropertyName?json_string}": "${indexLifecyclePolicyMonitor?json_string}",</#if>
+            <#if indexLifecyclePolicyMonitor?has_content>"${indexLifecycleRolloverAliasPropertyName?json_string}": "${indexName}",</#if>
             "index.number_of_shards":${numberOfShards},
             "index.number_of_replicas":${numberOfReplicas},
             "index.refresh_interval": "${refreshInterval}"

--- a/gravitee-apim-reporter/gravitee-apim-reporter-elasticsearch/src/main/resources/freemarker/es8x/mapping/index-template-request.ftl
+++ b/gravitee-apim-reporter/gravitee-apim-reporter-elasticsearch/src/main/resources/freemarker/es8x/mapping/index-template-request.ftl
@@ -3,8 +3,8 @@
     "index_patterns": ["${indexName}*"],
     "template": {
         "settings": {
-            <#if indexLifecyclePolicyRequest??>"${indexLifecyclePolicyPropertyName}": "${indexLifecyclePolicyRequest}",</#if>
-            <#if indexLifecyclePolicyRequest??>"index.lifecycle.rollover_alias": "${indexName}",</#if>
+            <#if indexLifecyclePolicyRequest?has_content>"${indexLifecyclePolicyPropertyName?json_string}": "${indexLifecyclePolicyRequest?json_string}",</#if>
+            <#if indexLifecyclePolicyRequest?has_content>"${indexLifecycleRolloverAliasPropertyName?json_string}": "${indexName}",</#if>
             "index.number_of_shards":${numberOfShards},
             "index.number_of_replicas":${numberOfReplicas},
             "index.refresh_interval": "${refreshInterval}"

--- a/gravitee-apim-reporter/gravitee-apim-reporter-elasticsearch/src/main/resources/freemarker/es8x/mapping/index-template-v4-log.ftl
+++ b/gravitee-apim-reporter/gravitee-apim-reporter-elasticsearch/src/main/resources/freemarker/es8x/mapping/index-template-v4-log.ftl
@@ -3,8 +3,8 @@
     "index_patterns": ["${indexName}*"],
     "template": {
         "settings": {
-            <#if indexLifecyclePolicyLog??>"${indexLifecyclePolicyPropertyName}": "${indexLifecyclePolicyLog}",</#if>
-            <#if indexLifecyclePolicyLog??>"index.lifecycle.rollover_alias": "${indexName}",</#if>
+            <#if indexLifecyclePolicyLog?has_content>"${indexLifecyclePolicyPropertyName?json_string}": "${indexLifecyclePolicyLog?json_string}",</#if>
+            <#if indexLifecyclePolicyLog?has_content>"${indexLifecycleRolloverAliasPropertyName?json_string}": "${indexName}",</#if>
             "index.number_of_shards":${numberOfShards},
             "index.number_of_replicas":${numberOfReplicas},
             "index.refresh_interval": "${refreshInterval}"

--- a/gravitee-apim-reporter/gravitee-apim-reporter-elasticsearch/src/main/resources/freemarker/es8x/mapping/index-template-v4-message-log.ftl
+++ b/gravitee-apim-reporter/gravitee-apim-reporter-elasticsearch/src/main/resources/freemarker/es8x/mapping/index-template-v4-message-log.ftl
@@ -3,8 +3,8 @@
     "index_patterns": ["${indexName}*"],
     "template": {
         "settings": {
-            <#if indexLifecyclePolicyLog??>"${indexLifecyclePolicyPropertyName}": "${indexLifecyclePolicyLog}",</#if>
-            <#if indexLifecyclePolicyLog??>"index.lifecycle.rollover_alias": "${indexName}",</#if>
+            <#if indexLifecyclePolicyLog?has_content>"${indexLifecyclePolicyPropertyName?json_string}": "${indexLifecyclePolicyLog?json_string}",</#if>
+            <#if indexLifecyclePolicyLog?has_content>"${indexLifecycleRolloverAliasPropertyName?json_string}": "${indexName}",</#if>
             "index.number_of_shards":${numberOfShards},
             "index.number_of_replicas":${numberOfReplicas},
             "index.refresh_interval": "${refreshInterval}"

--- a/gravitee-apim-reporter/gravitee-apim-reporter-elasticsearch/src/main/resources/freemarker/es8x/mapping/index-template-v4-message-metrics.ftl
+++ b/gravitee-apim-reporter/gravitee-apim-reporter-elasticsearch/src/main/resources/freemarker/es8x/mapping/index-template-v4-message-metrics.ftl
@@ -3,8 +3,8 @@
     "index_patterns": ["${indexName}*"],
     "template": {
         "settings": {
-            <#if indexLifecyclePolicyRequest??>"${indexLifecyclePolicyPropertyName}": "${indexLifecyclePolicyRequest}",</#if>
-            <#if indexLifecyclePolicyRequest??>"index.lifecycle.rollover_alias": "${indexName}",</#if>
+            <#if indexLifecyclePolicyRequest?has_content>"${indexLifecyclePolicyPropertyName?json_string}": "${indexLifecyclePolicyRequest?json_string}",</#if>
+            <#if indexLifecyclePolicyRequest?has_content>"${indexLifecycleRolloverAliasPropertyName?json_string}": "${indexName}",</#if>
             "index.number_of_shards":${numberOfShards},
             "index.number_of_replicas":${numberOfReplicas},
             "index.refresh_interval": "${refreshInterval}"

--- a/gravitee-apim-reporter/gravitee-apim-reporter-elasticsearch/src/main/resources/freemarker/es8x/mapping/index-template-v4-metrics.ftl
+++ b/gravitee-apim-reporter/gravitee-apim-reporter-elasticsearch/src/main/resources/freemarker/es8x/mapping/index-template-v4-metrics.ftl
@@ -3,8 +3,8 @@
     "index_patterns": ["${indexName}*"],
     "template": {
         "settings": {
-            <#if indexLifecyclePolicyRequest??>"${indexLifecyclePolicyPropertyName}": "${indexLifecyclePolicyRequest}",</#if>
-            <#if indexLifecyclePolicyRequest??>"index.lifecycle.rollover_alias": "${indexName}",</#if>
+            <#if indexLifecyclePolicyRequest?has_content>"${indexLifecyclePolicyPropertyName?json_string}": "${indexLifecyclePolicyRequest?json_string}",</#if>
+            <#if indexLifecyclePolicyRequest?has_content>"${indexLifecycleRolloverAliasPropertyName?json_string}": "${indexName}",</#if>
             "index.number_of_shards":${numberOfShards},
             "index.number_of_replicas":${numberOfReplicas},
             "index.refresh_interval": "${refreshInterval}"

--- a/gravitee-apim-reporter/gravitee-apim-reporter-elasticsearch/src/main/resources/freemarker/es9x/mapping/index-template-event-metrics.ftl
+++ b/gravitee-apim-reporter/gravitee-apim-reporter-elasticsearch/src/main/resources/freemarker/es9x/mapping/index-template-event-metrics.ftl
@@ -4,8 +4,8 @@
     "data_stream": {},
     "template": {
         "settings": {
-            <#if indexLifecyclePolicyEventMetrics??>"index.lifecycle.name": "${indexLifecyclePolicyEventMetrics}",</#if>
-            <#if indexLifecyclePolicyEventMetrics??>"index.lifecycle.rollover_alias": "${indexName}",</#if>
+            <#if indexLifecyclePolicyEventMetrics?has_content>"${indexLifecyclePolicyPropertyName?json_string}": "${indexLifecyclePolicyEventMetrics?json_string}",</#if>
+            <#if indexLifecyclePolicyEventMetrics?has_content>"${indexLifecycleRolloverAliasPropertyName?json_string}": "${indexName}",</#if>
             "index.number_of_shards":${numberOfShards},
             "index.number_of_replicas":${numberOfReplicas},
             "index.refresh_interval": "${refreshInterval}"

--- a/gravitee-apim-reporter/gravitee-apim-reporter-elasticsearch/src/main/resources/freemarker/es9x/mapping/index-template-health.ftl
+++ b/gravitee-apim-reporter/gravitee-apim-reporter-elasticsearch/src/main/resources/freemarker/es9x/mapping/index-template-health.ftl
@@ -3,8 +3,8 @@
     "index_patterns": ["${indexName}*"],
     "template": {
         "settings": {
-            <#if indexLifecyclePolicyHealth??>"${indexLifecyclePolicyPropertyName}": "${indexLifecyclePolicyHealth}",</#if>
-            <#if indexLifecyclePolicyHealth??>"index.lifecycle.rollover_alias": "${indexName}",</#if>
+            <#if indexLifecyclePolicyHealth?has_content>"${indexLifecyclePolicyPropertyName?json_string}": "${indexLifecyclePolicyHealth?json_string}",</#if>
+            <#if indexLifecyclePolicyHealth?has_content>"${indexLifecycleRolloverAliasPropertyName?json_string}": "${indexName}",</#if>
             "index.number_of_shards":${numberOfShards},
             "index.number_of_replicas":${numberOfReplicas},
             "index.refresh_interval": "${refreshInterval}"

--- a/gravitee-apim-reporter/gravitee-apim-reporter-elasticsearch/src/main/resources/freemarker/es9x/mapping/index-template-log.ftl
+++ b/gravitee-apim-reporter/gravitee-apim-reporter-elasticsearch/src/main/resources/freemarker/es9x/mapping/index-template-log.ftl
@@ -3,8 +3,8 @@
     "index_patterns": ["${indexName}*"],
     "template": {
         "settings": {
-            <#if indexLifecyclePolicyLog??>"${indexLifecyclePolicyPropertyName}": "${indexLifecyclePolicyLog}",</#if>
-            <#if indexLifecyclePolicyLog??>"index.lifecycle.rollover_alias": "${indexName}",</#if>
+            <#if indexLifecyclePolicyLog?has_content>"${indexLifecyclePolicyPropertyName?json_string}": "${indexLifecyclePolicyLog?json_string}",</#if>
+            <#if indexLifecyclePolicyLog?has_content>"${indexLifecycleRolloverAliasPropertyName?json_string}": "${indexName}",</#if>
             "index.number_of_shards":${numberOfShards},
             "index.number_of_replicas":${numberOfReplicas},
             "index.refresh_interval": "${refreshInterval}"

--- a/gravitee-apim-reporter/gravitee-apim-reporter-elasticsearch/src/main/resources/freemarker/es9x/mapping/index-template-monitor.ftl
+++ b/gravitee-apim-reporter/gravitee-apim-reporter-elasticsearch/src/main/resources/freemarker/es9x/mapping/index-template-monitor.ftl
@@ -3,8 +3,8 @@
     "index_patterns": ["${indexName}*"],
     "template": {
         "settings": {
-            <#if indexLifecyclePolicyMonitor??>"${indexLifecyclePolicyPropertyName}": "${indexLifecyclePolicyMonitor}",</#if>
-            <#if indexLifecyclePolicyMonitor??>"index.lifecycle.rollover_alias": "${indexName}",</#if>
+            <#if indexLifecyclePolicyMonitor?has_content>"${indexLifecyclePolicyPropertyName?json_string}": "${indexLifecyclePolicyMonitor?json_string}",</#if>
+            <#if indexLifecyclePolicyMonitor?has_content>"${indexLifecycleRolloverAliasPropertyName?json_string}": "${indexName}",</#if>
             "index.number_of_shards":${numberOfShards},
             "index.number_of_replicas":${numberOfReplicas},
             "index.refresh_interval": "${refreshInterval}"

--- a/gravitee-apim-reporter/gravitee-apim-reporter-elasticsearch/src/main/resources/freemarker/es9x/mapping/index-template-request.ftl
+++ b/gravitee-apim-reporter/gravitee-apim-reporter-elasticsearch/src/main/resources/freemarker/es9x/mapping/index-template-request.ftl
@@ -3,8 +3,8 @@
     "index_patterns": ["${indexName}*"],
     "template": {
         "settings": {
-            <#if indexLifecyclePolicyRequest??>"${indexLifecyclePolicyPropertyName}": "${indexLifecyclePolicyRequest}",</#if>
-            <#if indexLifecyclePolicyRequest??>"index.lifecycle.rollover_alias": "${indexName}",</#if>
+            <#if indexLifecyclePolicyRequest?has_content>"${indexLifecyclePolicyPropertyName?json_string}": "${indexLifecyclePolicyRequest?json_string}",</#if>
+            <#if indexLifecyclePolicyRequest?has_content>"${indexLifecycleRolloverAliasPropertyName?json_string}": "${indexName}",</#if>
             "index.number_of_shards":${numberOfShards},
             "index.number_of_replicas":${numberOfReplicas},
             "index.refresh_interval": "${refreshInterval}"

--- a/gravitee-apim-reporter/gravitee-apim-reporter-elasticsearch/src/main/resources/freemarker/es9x/mapping/index-template-v4-log.ftl
+++ b/gravitee-apim-reporter/gravitee-apim-reporter-elasticsearch/src/main/resources/freemarker/es9x/mapping/index-template-v4-log.ftl
@@ -3,8 +3,8 @@
     "index_patterns": ["${indexName}*"],
     "template": {
         "settings": {
-            <#if indexLifecyclePolicyLog??>"${indexLifecyclePolicyPropertyName}": "${indexLifecyclePolicyLog}",</#if>
-            <#if indexLifecyclePolicyLog??>"index.lifecycle.rollover_alias": "${indexName}",</#if>
+            <#if indexLifecyclePolicyLog?has_content>"${indexLifecyclePolicyPropertyName?json_string}": "${indexLifecyclePolicyLog?json_string}",</#if>
+            <#if indexLifecyclePolicyLog?has_content>"${indexLifecycleRolloverAliasPropertyName?json_string}": "${indexName}",</#if>
             "index.number_of_shards":${numberOfShards},
             "index.number_of_replicas":${numberOfReplicas},
             "index.refresh_interval": "${refreshInterval}"

--- a/gravitee-apim-reporter/gravitee-apim-reporter-elasticsearch/src/main/resources/freemarker/es9x/mapping/index-template-v4-message-log.ftl
+++ b/gravitee-apim-reporter/gravitee-apim-reporter-elasticsearch/src/main/resources/freemarker/es9x/mapping/index-template-v4-message-log.ftl
@@ -3,8 +3,8 @@
     "index_patterns": ["${indexName}*"],
     "template": {
         "settings": {
-            <#if indexLifecyclePolicyLog??>"${indexLifecyclePolicyPropertyName}": "${indexLifecyclePolicyLog}",</#if>
-            <#if indexLifecyclePolicyLog??>"index.lifecycle.rollover_alias": "${indexName}",</#if>
+            <#if indexLifecyclePolicyLog?has_content>"${indexLifecyclePolicyPropertyName?json_string}": "${indexLifecyclePolicyLog?json_string}",</#if>
+            <#if indexLifecyclePolicyLog?has_content>"${indexLifecycleRolloverAliasPropertyName?json_string}": "${indexName}",</#if>
             "index.number_of_shards":${numberOfShards},
             "index.number_of_replicas":${numberOfReplicas},
             "index.refresh_interval": "${refreshInterval}"

--- a/gravitee-apim-reporter/gravitee-apim-reporter-elasticsearch/src/main/resources/freemarker/es9x/mapping/index-template-v4-message-metrics.ftl
+++ b/gravitee-apim-reporter/gravitee-apim-reporter-elasticsearch/src/main/resources/freemarker/es9x/mapping/index-template-v4-message-metrics.ftl
@@ -3,8 +3,8 @@
     "index_patterns": ["${indexName}*"],
     "template": {
         "settings": {
-            <#if indexLifecyclePolicyRequest??>"${indexLifecyclePolicyPropertyName}": "${indexLifecyclePolicyRequest}",</#if>
-            <#if indexLifecyclePolicyRequest??>"index.lifecycle.rollover_alias": "${indexName}",</#if>
+            <#if indexLifecyclePolicyRequest?has_content>"${indexLifecyclePolicyPropertyName?json_string}": "${indexLifecyclePolicyRequest?json_string}",</#if>
+            <#if indexLifecyclePolicyRequest?has_content>"${indexLifecycleRolloverAliasPropertyName?json_string}": "${indexName}",</#if>
             "index.number_of_shards":${numberOfShards},
             "index.number_of_replicas":${numberOfReplicas},
             "index.refresh_interval": "${refreshInterval}"

--- a/gravitee-apim-reporter/gravitee-apim-reporter-elasticsearch/src/main/resources/freemarker/es9x/mapping/index-template-v4-metrics.ftl
+++ b/gravitee-apim-reporter/gravitee-apim-reporter-elasticsearch/src/main/resources/freemarker/es9x/mapping/index-template-v4-metrics.ftl
@@ -3,8 +3,8 @@
     "index_patterns": ["${indexName}*"],
     "template": {
         "settings": {
-            <#if indexLifecyclePolicyRequest??>"${indexLifecyclePolicyPropertyName}": "${indexLifecyclePolicyRequest}",</#if>
-            <#if indexLifecyclePolicyRequest??>"index.lifecycle.rollover_alias": "${indexName}",</#if>
+            <#if indexLifecyclePolicyRequest?has_content>"${indexLifecyclePolicyPropertyName?json_string}": "${indexLifecyclePolicyRequest?json_string}",</#if>
+            <#if indexLifecyclePolicyRequest?has_content>"${indexLifecycleRolloverAliasPropertyName?json_string}": "${indexName}",</#if>
             "index.number_of_shards":${numberOfShards},
             "index.number_of_replicas":${numberOfReplicas},
             "index.refresh_interval": "${refreshInterval}"

--- a/gravitee-apim-reporter/gravitee-apim-reporter-elasticsearch/src/main/resources/freemarker/opensearch/mapping/index-template-event-metrics.ftl
+++ b/gravitee-apim-reporter/gravitee-apim-reporter-elasticsearch/src/main/resources/freemarker/opensearch/mapping/index-template-event-metrics.ftl
@@ -4,8 +4,8 @@
     "data_stream": {},
     "template": {
         "settings": {
-            <#if indexLifecyclePolicyEventMetrics??>"index.plugins.index_state_management.policy_id": "${indexLifecyclePolicyEventMetrics}",</#if>
-            <#if indexLifecyclePolicyEventMetrics??>"index.plugins.index_state_management.rollover_alias": "${indexName}",</#if>
+            <#if indexLifecyclePolicyEventMetrics?has_content>"index.plugins.index_state_management.policy_id": "${indexLifecyclePolicyEventMetrics}",</#if>
+            <#if indexLifecyclePolicyEventMetrics?has_content>"index.plugins.index_state_management.rollover_alias": "${indexName}",</#if>
             "index.number_of_shards":${numberOfShards},
             "index.number_of_replicas":${numberOfReplicas},
             "index.refresh_interval": "${refreshInterval}"

--- a/gravitee-apim-reporter/gravitee-apim-reporter-elasticsearch/src/main/resources/freemarker/opensearch/mapping/index-template-health.ftl
+++ b/gravitee-apim-reporter/gravitee-apim-reporter-elasticsearch/src/main/resources/freemarker/opensearch/mapping/index-template-health.ftl
@@ -3,8 +3,8 @@
     "index_patterns": ["${indexName}*"],
     "template": {
         "settings": {
-            <#if indexLifecyclePolicyHealth??>"index.plugins.index_state_management.policy_id": "${indexLifecyclePolicyHealth}",</#if>
-            <#if indexLifecyclePolicyHealth??>"index.plugins.index_state_management.rollover_alias": "${indexName}",</#if>
+            <#if indexLifecyclePolicyHealth?has_content>"index.plugins.index_state_management.policy_id": "${indexLifecyclePolicyHealth}",</#if>
+            <#if indexLifecyclePolicyHealth?has_content>"index.plugins.index_state_management.rollover_alias": "${indexName}",</#if>
             "index.number_of_shards":${numberOfShards},
             "index.number_of_replicas":${numberOfReplicas},
             "index.refresh_interval": "${refreshInterval}"

--- a/gravitee-apim-reporter/gravitee-apim-reporter-elasticsearch/src/main/resources/freemarker/opensearch/mapping/index-template-log.ftl
+++ b/gravitee-apim-reporter/gravitee-apim-reporter-elasticsearch/src/main/resources/freemarker/opensearch/mapping/index-template-log.ftl
@@ -3,8 +3,8 @@
     "index_patterns": ["${indexName}*"],
     "template": {
         "settings": {
-            <#if indexLifecyclePolicyLog??>"index.plugins.index_state_management.policy_id": "${indexLifecyclePolicyLog}",</#if>
-            <#if indexLifecyclePolicyLog??>"index.plugins.index_state_management.rollover_alias": "${indexName}",</#if>
+            <#if indexLifecyclePolicyLog?has_content>"index.plugins.index_state_management.policy_id": "${indexLifecyclePolicyLog}",</#if>
+            <#if indexLifecyclePolicyLog?has_content>"index.plugins.index_state_management.rollover_alias": "${indexName}",</#if>
             "index.number_of_shards":${numberOfShards},
             "index.number_of_replicas":${numberOfReplicas},
             "index.refresh_interval": "${refreshInterval}"

--- a/gravitee-apim-reporter/gravitee-apim-reporter-elasticsearch/src/main/resources/freemarker/opensearch/mapping/index-template-monitor.ftl
+++ b/gravitee-apim-reporter/gravitee-apim-reporter-elasticsearch/src/main/resources/freemarker/opensearch/mapping/index-template-monitor.ftl
@@ -3,8 +3,8 @@
     "index_patterns": ["${indexName}*"],
     "template": {
         "settings": {
-            <#if indexLifecyclePolicyMonitor??>"index.plugins.index_state_management.policy_id": "${indexLifecyclePolicyMonitor}",</#if>
-            <#if indexLifecyclePolicyMonitor??>"index.plugins.index_state_management.rollover_alias": "${indexName}",</#if>
+            <#if indexLifecyclePolicyMonitor?has_content>"index.plugins.index_state_management.policy_id": "${indexLifecyclePolicyMonitor}",</#if>
+            <#if indexLifecyclePolicyMonitor?has_content>"index.plugins.index_state_management.rollover_alias": "${indexName}",</#if>
             "index.number_of_shards":${numberOfShards},
             "index.number_of_replicas":${numberOfReplicas},
             "index.refresh_interval": "${refreshInterval}"

--- a/gravitee-apim-reporter/gravitee-apim-reporter-elasticsearch/src/main/resources/freemarker/opensearch/mapping/index-template-request.ftl
+++ b/gravitee-apim-reporter/gravitee-apim-reporter-elasticsearch/src/main/resources/freemarker/opensearch/mapping/index-template-request.ftl
@@ -3,8 +3,8 @@
     "index_patterns": ["${indexName}*"],
     "template": {
         "settings": {
-            <#if indexLifecyclePolicyRequest??>"index.plugins.index_state_management.policy_id": "${indexLifecyclePolicyRequest}",</#if>
-            <#if indexLifecyclePolicyRequest??>"index.plugins.index_state_management.rollover_alias": "${indexName}",</#if>
+            <#if indexLifecyclePolicyRequest?has_content>"index.plugins.index_state_management.policy_id": "${indexLifecyclePolicyRequest}",</#if>
+            <#if indexLifecyclePolicyRequest?has_content>"index.plugins.index_state_management.rollover_alias": "${indexName}",</#if>
             "index.number_of_shards":${numberOfShards},
             "index.number_of_replicas":${numberOfReplicas},
             "index.refresh_interval": "${refreshInterval}"

--- a/gravitee-apim-reporter/gravitee-apim-reporter-elasticsearch/src/main/resources/freemarker/opensearch/mapping/index-template-v4-log.ftl
+++ b/gravitee-apim-reporter/gravitee-apim-reporter-elasticsearch/src/main/resources/freemarker/opensearch/mapping/index-template-v4-log.ftl
@@ -3,8 +3,8 @@
     "index_patterns": ["${indexName}*"],
     "template": {
         "settings": {
-            <#if indexLifecyclePolicyLog??>"index.plugins.index_state_management.policy_id": "${indexLifecyclePolicyLog}",</#if>
-            <#if indexLifecyclePolicyLog??>"index.plugins.index_state_management.rollover_alias": "${indexName}",</#if>
+            <#if indexLifecyclePolicyLog?has_content>"index.plugins.index_state_management.policy_id": "${indexLifecyclePolicyLog}",</#if>
+            <#if indexLifecyclePolicyLog?has_content>"index.plugins.index_state_management.rollover_alias": "${indexName}",</#if>
             "index.number_of_shards":${numberOfShards},
             "index.number_of_replicas":${numberOfReplicas},
             "index.refresh_interval": "${refreshInterval}"

--- a/gravitee-apim-reporter/gravitee-apim-reporter-elasticsearch/src/main/resources/freemarker/opensearch/mapping/index-template-v4-message-log.ftl
+++ b/gravitee-apim-reporter/gravitee-apim-reporter-elasticsearch/src/main/resources/freemarker/opensearch/mapping/index-template-v4-message-log.ftl
@@ -3,8 +3,8 @@
     "index_patterns": ["${indexName}*"],
     "template": {
         "settings": {
-            <#if indexLifecyclePolicyLog??>"index.plugins.index_state_management.policy_id": "${indexLifecyclePolicyLog}",</#if>
-            <#if indexLifecyclePolicyLog??>"index.plugins.index_state_management.rollover_alias": "${indexName}",</#if>
+            <#if indexLifecyclePolicyLog?has_content>"index.plugins.index_state_management.policy_id": "${indexLifecyclePolicyLog}",</#if>
+            <#if indexLifecyclePolicyLog?has_content>"index.plugins.index_state_management.rollover_alias": "${indexName}",</#if>
             "index.number_of_shards":${numberOfShards},
             "index.number_of_replicas":${numberOfReplicas},
             "index.refresh_interval": "${refreshInterval}"

--- a/gravitee-apim-reporter/gravitee-apim-reporter-elasticsearch/src/main/resources/freemarker/opensearch/mapping/index-template-v4-message-metrics.ftl
+++ b/gravitee-apim-reporter/gravitee-apim-reporter-elasticsearch/src/main/resources/freemarker/opensearch/mapping/index-template-v4-message-metrics.ftl
@@ -3,8 +3,8 @@
     "index_patterns": ["${indexName}*"],
     "template": {
         "settings": {
-            <#if indexLifecyclePolicyRequest??>"index.plugins.index_state_management.policy_id": "${indexLifecyclePolicyRequest}",</#if>
-            <#if indexLifecyclePolicyRequest??>"index.plugins.index_state_management.rollover_alias": "${indexName}",</#if>
+            <#if indexLifecyclePolicyRequest?has_content>"index.plugins.index_state_management.policy_id": "${indexLifecyclePolicyRequest}",</#if>
+            <#if indexLifecyclePolicyRequest?has_content>"index.plugins.index_state_management.rollover_alias": "${indexName}",</#if>
             "index.number_of_shards":${numberOfShards},
             "index.number_of_replicas":${numberOfReplicas},
             "index.refresh_interval": "${refreshInterval}"

--- a/gravitee-apim-reporter/gravitee-apim-reporter-elasticsearch/src/main/resources/freemarker/opensearch/mapping/index-template-v4-metrics.ftl
+++ b/gravitee-apim-reporter/gravitee-apim-reporter-elasticsearch/src/main/resources/freemarker/opensearch/mapping/index-template-v4-metrics.ftl
@@ -3,8 +3,8 @@
     "index_patterns": ["${indexName}*"],
     "template": {
         "settings": {
-            <#if indexLifecyclePolicyRequest??>"index.plugins.index_state_management.policy_id": "${indexLifecyclePolicyRequest}",</#if>
-            <#if indexLifecyclePolicyRequest??>"index.plugins.index_state_management.rollover_alias": "${indexName}",</#if>
+            <#if indexLifecyclePolicyRequest?has_content>"index.plugins.index_state_management.policy_id": "${indexLifecyclePolicyRequest}",</#if>
+            <#if indexLifecyclePolicyRequest?has_content>"index.plugins.index_state_management.rollover_alias": "${indexName}",</#if>
             "index.number_of_shards":${numberOfShards},
             "index.number_of_replicas":${numberOfReplicas},
             "index.refresh_interval": "${refreshInterval}"

--- a/gravitee-apim-reporter/gravitee-apim-reporter-elasticsearch/src/test/java/io/gravitee/apim/reporter/elasticsearch/mapping/IndexPreparerIntegrationTest.java
+++ b/gravitee-apim-reporter/gravitee-apim-reporter-elasticsearch/src/test/java/io/gravitee/apim/reporter/elasticsearch/mapping/IndexPreparerIntegrationTest.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.reporter.elasticsearch.mapping;
+
+import io.gravitee.apim.reporter.elasticsearch.UnitTestConfiguration;
+import io.gravitee.apim.reporter.elasticsearch.config.PipelineConfiguration;
+import io.gravitee.apim.reporter.elasticsearch.config.ReporterConfiguration;
+import io.gravitee.apim.reporter.elasticsearch.mapping.es7.ES7IndexPreparer;
+import io.gravitee.apim.reporter.elasticsearch.mapping.es8.ES8IndexPreparer;
+import io.gravitee.apim.reporter.elasticsearch.mapping.es9.ES9IndexPreparer;
+import io.gravitee.common.templating.FreeMarkerComponent;
+import io.gravitee.elasticsearch.client.Client;
+import io.gravitee.elasticsearch.config.Endpoint;
+import io.reactivex.rxjava3.observers.TestObserver;
+import java.util.Collections;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.utility.DockerImageName;
+
+/**
+ * Drives {@link AbstractIndexPreparer#prepare()} against a real OpenSearch container through each
+ * es{@code 7,8,9}x preparer. The ES preparers are instantiated directly so the put-template HTTP path
+ * actually exercises the freemarker templates this change fixes —
+ * {@link io.gravitee.apim.reporter.elasticsearch.factory.BeanFactoryBuilder} would auto-pick
+ * {@code OpenSearchIndexPreparer} for an OpenSearch cluster and use the unchanged {@code opensearch/}
+ * templates instead, masking the regression.
+ *
+ * <p>This reproduces the AWS-OpenSearch-compat-mode scenario where the reporter picks the es{@code Nx}
+ * template tree and the ISM property-name overrides must flow into the rendered body for OpenSearch to
+ * accept the PUT.
+ *
+ * <p>Scope: this proves OpenSearch accepts the rendered templates. What the rendered body actually
+ * contains is asserted by {@link IndexTemplateTest}, which needs no container.
+ */
+@SpringJUnitConfig(IndexPreparerIntegrationTest.OpenSearchTestConfig.class)
+@TestPropertySource(
+    properties = {
+        "reporters.elasticsearch.index=gravitee-ism-override",
+        "reporters.elasticsearch.lifecycle.policy_property_name=index.plugins.index_state_management.policy_id",
+        "reporters.elasticsearch.lifecycle.rollover_alias_property_name=index.plugins.index_state_management.rollover_alias",
+        "reporters.elasticsearch.lifecycle.policies.health=policy-health",
+        "reporters.elasticsearch.lifecycle.policies.monitor=policy-monitor",
+        "reporters.elasticsearch.lifecycle.policies.request=policy-request",
+        "reporters.elasticsearch.lifecycle.policies.log=policy-log",
+    }
+)
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class IndexPreparerIntegrationTest {
+
+    @Autowired
+    private Client client;
+
+    @Autowired
+    private ReporterConfiguration configuration;
+
+    @Autowired
+    private FreeMarkerComponent freeMarkerComponent;
+
+    @Autowired
+    private PipelineConfiguration pipelineConfiguration;
+
+    static Stream<Arguments> es_preparers() {
+        return Stream.of(Arguments.of("es7x"), Arguments.of("es8x"), Arguments.of("es9x"));
+    }
+
+    @ParameterizedTest(name = "{0} preparer against OpenSearch")
+    @MethodSource("es_preparers")
+    void should_put_templates_against_opensearch_when_ism_property_names_set(String esDir) {
+        AbstractIndexPreparer preparer = preparerFor(esDir);
+
+        TestObserver<Void> observer = preparer.prepare().test();
+        observer.awaitDone(60, TimeUnit.SECONDS);
+        observer.assertComplete();
+        observer.assertNoErrors();
+    }
+
+    private AbstractIndexPreparer preparerFor(String esDir) {
+        return switch (esDir) {
+            case "es7x" -> new ES7IndexPreparer(configuration, pipelineConfiguration, freeMarkerComponent, client);
+            case "es8x" -> new ES8IndexPreparer(configuration, pipelineConfiguration, freeMarkerComponent, client);
+            case "es9x" -> new ES9IndexPreparer(configuration, pipelineConfiguration, freeMarkerComponent, client);
+            default -> throw new IllegalArgumentException("Unknown es dir: " + esDir);
+        };
+    }
+
+    @Configuration
+    @Import(UnitTestConfiguration.class)
+    static class OpenSearchTestConfig {
+
+        public static final String OPENSEARCH_DEFAULT_VERSION = "2.13.0";
+
+        @Value("${opensearch.version:" + OPENSEARCH_DEFAULT_VERSION + "}")
+        private String opensearchVersion;
+
+        @Bean
+        public ReporterConfiguration configuration(GenericContainer<?> openSearchContainer) {
+            ReporterConfiguration configuration = new ReporterConfiguration();
+            configuration.setEndpoints(
+                Collections.singletonList(
+                    new Endpoint("http://" + openSearchContainer.getHost() + ":" + openSearchContainer.getMappedPort(9200))
+                )
+            );
+            return configuration;
+        }
+
+        @Bean(destroyMethod = "stop")
+        public GenericContainer<?> openSearchContainer() {
+            final GenericContainer<?> container = new GenericContainer<>(
+                DockerImageName.parse("opensearchproject/opensearch:" + opensearchVersion)
+            )
+                .withExposedPorts(9200)
+                .withEnv("discovery.type", "single-node")
+                .withEnv("DISABLE_SECURITY_PLUGIN", "true")
+                .withEnv("DISABLE_INSTALL_DEMO_CONFIG", "true")
+                .waitingFor(Wait.forHttp("/").forStatusCode(200));
+            container.start();
+            return container;
+        }
+    }
+}

--- a/gravitee-apim-reporter/gravitee-apim-reporter-elasticsearch/src/test/java/io/gravitee/apim/reporter/elasticsearch/mapping/IndexTemplateTest.java
+++ b/gravitee-apim-reporter/gravitee-apim-reporter-elasticsearch/src/test/java/io/gravitee/apim/reporter/elasticsearch/mapping/IndexTemplateTest.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.reporter.elasticsearch.mapping;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.apim.reporter.elasticsearch.config.PipelineConfiguration;
+import io.gravitee.apim.reporter.elasticsearch.config.ReporterConfiguration;
+import io.gravitee.apim.reporter.elasticsearch.mapping.es7.ES7IndexPreparer;
+import io.gravitee.apim.reporter.elasticsearch.mapping.es8.ES8IndexPreparer;
+import io.gravitee.apim.reporter.elasticsearch.mapping.es9.ES9IndexPreparer;
+import io.gravitee.common.templating.FreeMarkerComponent;
+import io.gravitee.elasticsearch.utils.Type;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/**
+ * Asserts what the es{@code 7,8,9}x index templates actually render: the configured lifecycle property names
+ * when they are overridden, the Elasticsearch defaults when they are blank, and JSON-safe output when a name
+ * is malformed. Runs without the OpenSearch container {@link IndexPreparerIntegrationTest} needs, which
+ * proves the complementary half — that a cluster accepts the rendered body.
+ */
+class IndexTemplateTest {
+
+    /**
+     * Every type whose template can render lifecycle settings. EVENT_METRICS is excluded because
+     * {@link AbstractIndexPreparer#getTemplateData()} never puts its policy into the model, so its
+     * lifecycle block cannot render whatever the configuration says. es7x is kept alongside es8x/es9x
+     * because it is the odd one out structurally — its settings sit at the root rather than under
+     * {@code template} — and it is pushed through the legacy template API.
+     */
+    static Stream<Arguments> es_trees_and_lifecycle_types() {
+        return Stream.of("es7x", "es8x", "es9x").flatMap(esDir ->
+            Stream.of(
+                Type.REQUEST,
+                Type.HEALTH_CHECK,
+                Type.LOG,
+                Type.MONITOR,
+                Type.V4_LOG,
+                Type.V4_METRICS,
+                Type.V4_MESSAGE_LOG,
+                Type.V4_MESSAGE_METRICS
+            ).map(type -> Arguments.of(esDir, type))
+        );
+    }
+
+    @ParameterizedTest(name = "{0} {1} template uses the configured ISM property names")
+    @MethodSource("es_trees_and_lifecycle_types")
+    void should_render_configured_ism_property_names_instead_of_hardcoded_ilm_keys(String esDir, Type type) {
+        var configuration = configurationWithPolicies();
+        configuration.setIndexLifecyclePolicyPropertyName("index.plugins.index_state_management.policy_id");
+        configuration.setIndexLifecycleRolloverAliasPropertyName("index.plugins.index_state_management.rollover_alias");
+
+        assertThat(preparerFor(esDir, configuration).generateIndexTemplate(type))
+            .contains("\"index.plugins.index_state_management.policy_id\"")
+            .contains("\"index.plugins.index_state_management.rollover_alias\"")
+            .doesNotContain("\"index.lifecycle.");
+    }
+
+    @ParameterizedTest(name = "{0} {1} template falls back to the default keys when property names are blank")
+    @MethodSource("es_trees_and_lifecycle_types")
+    void should_fall_back_to_default_property_names_when_configured_blank(String esDir, Type type) {
+        var configuration = configurationWithPolicies();
+        configuration.setIndexLifecyclePolicyPropertyName("");
+        configuration.setIndexLifecycleRolloverAliasPropertyName("  index.lifecycle.rollover_alias  ");
+
+        // An empty or padded key would make the cluster reject the whole template, taking the shard, replica
+        // and refresh settings down with it — blank has to mean "unset", not "render nothing at all".
+        assertThat(preparerFor(esDir, configuration).generateIndexTemplate(type))
+            .contains("\"index.lifecycle.name\"")
+            .contains("\"index.lifecycle.rollover_alias\"")
+            .doesNotContain("\"\":")
+            .doesNotContain("\"  index.lifecycle.rollover_alias  \"");
+    }
+
+    @Test
+    void should_render_default_ilm_keys_for_an_untouched_elasticsearch_configuration() {
+        assertThat(preparerFor("es8x", configurationWithPolicies()).generateIndexTemplate(Type.LOG))
+            .contains("\"index.lifecycle.name\": \"policy-log\"")
+            .contains("\"index.lifecycle.rollover_alias\"");
+    }
+
+    @Test
+    void should_escape_property_names_and_policies_so_a_malformed_one_cannot_break_the_json_body() {
+        var configuration = configurationWithPolicies();
+        configuration.setIndexLifecyclePolicyPropertyName("bad\"name");
+        configuration.setIndexLifecycleRolloverAliasPropertyName("bad\"alias");
+        configuration.setIndexLifecyclePolicyLog("bad\"policy");
+
+        assertThat(preparerFor("es8x", configuration).generateIndexTemplate(Type.LOG))
+            .contains("\"bad\\\"name\"")
+            .contains("\"bad\\\"alias\"")
+            .contains("\"bad\\\"policy\"");
+    }
+
+    private static ReporterConfiguration configurationWithPolicies() {
+        var configuration = new ReporterConfiguration();
+        configuration.setIndexLifecyclePolicyHealth("policy-health");
+        configuration.setIndexLifecyclePolicyMonitor("policy-monitor");
+        configuration.setIndexLifecyclePolicyRequest("policy-request");
+        configuration.setIndexLifecyclePolicyLog("policy-log");
+        return configuration;
+    }
+
+    private static AbstractIndexPreparer preparerFor(String esDir, ReporterConfiguration configuration) {
+        var freeMarkerComponent = FreeMarkerComponent.builder()
+            .classLoader(IndexTemplateTest.class.getClassLoader())
+            .classLoaderTemplateBase("freemarker")
+            .build();
+        var pipelineConfiguration = new PipelineConfiguration(freeMarkerComponent);
+
+        // No client: generateIndexTemplate only renders, it never talks to the cluster.
+        return switch (esDir) {
+            case "es7x" -> new ES7IndexPreparer(configuration, pipelineConfiguration, freeMarkerComponent, null);
+            case "es8x" -> new ES8IndexPreparer(configuration, pipelineConfiguration, freeMarkerComponent, null);
+            case "es9x" -> new ES9IndexPreparer(configuration, pipelineConfiguration, freeMarkerComponent, null);
+            default -> throw new IllegalArgumentException("Unknown es dir: " + esDir);
+        };
+    }
+}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-11655

## Description

The `es8x`/`es9x` index templates hard-coded the Elasticsearch ILM rollover-alias key `index.lifecycle.rollover_alias` instead of using the configured `reporters.elasticsearch.lifecycle.rollover_alias_property_name`. OpenSearch rejects an unknown index setting outright rather than ignoring it, so an operator pointing the lifecycle keys at ISM — AWS OpenSearch in Elasticsearch-compatibility mode, where the reporter selects the `es{N}x` tree — got `unknown setting [index.lifecycle.rollover_alias]` and index preparation failed at startup. The policy-name key already honoured its override; only the rollover-alias key was broken.

- Render the configured property names in every `es7x`/`es8x`/`es9x` template.
- Guard the lifecycle block with `?has_content` instead of `??`, so a policy configured as an empty string emits no lifecycle settings rather than an empty policy id. The Helm chart emits all four policy keys unconditionally once `es.lifecycle.enabled` is true, so blanking the ones you don't want is the normal way to enable a policy on a single type.
- Treat a blank or padded property *name* as unset and fall back to the default. Spring's `${property:default}` only falls back when the property is absent, so `rollover_alias_property_name:` in YAML resolves to an empty string — which rendered an empty settings key. The cluster refuses that along with the shard, replica and refresh settings in the same template, and a failed template PUT aborts index preparation, leaving the ingest pipeline unbuilt and every subsequent report dropped.
- Escape the interpolated names and policies with `?json_string`. The JSON output format does not escape interpolations, so a value containing a quote produced a malformed request body and an opaque parse error instead of a diagnosable unknown-setting response.

## Additional context

- Targets master. The same code lives on `4.11.x` and `4.12.x` and carries the same bug; the `apply-on-4-11-x` / `apply-on-4-12-x` labels propagate this commit to both. `4.9.x` and `4.10.x` have no reporter module in the monorepo — they pin the external `gravitee-reporter-elasticsearch` plugin (6.3.7 and 7.4.6), which is affected too and is tracked separately under the same Jira.
- **event-metrics behaviour is unchanged.** Its lifecycle variable is never placed in the FreeMarker data map (`AbstractIndexPreparer.getTemplateData()`), so the block is inert whatever the configuration says. Its templates were parameterised for consistency with their siblings rather than left as the only hard-coded ILM keys, but nothing renders differently. Making that policy configurable is **APIM-14441** — rollover-alias is invalid on a data stream's backing indices, so it is a distinct change.
- The `opensearch/` tree still hard-codes its ISM keys and ignores the property-name overrides. Pre-existing, untouched here.
- Tests: `IndexTemplateTest` asserts the rendered body across all three template trees for every lifecycle-capable type — configured names when overridden, default ILM keys when blank or padded, escaped output when a name or policy is malformed — and needs no container. `IndexPreparerIntegrationTest` drives `prepare()` through the es7x/es8x/es9x preparers against a real OpenSearch container with the ISM overrides set, asserting the PUTs are accepted. Module suite is 93/93 green under `TZ=UTC`.
