### PR TITLE
feat(observability): add POST /observability/logs/search endpoint in Gamma

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-container/src/main/java/io/gravitee/rest/api/standalone/spring/StandaloneConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-container/src/main/java/io/gravitee/rest/api/standalone/spring/StandaloneConfiguration.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.rest.api.standalone.spring;
 
+import io.gravitee.gamma.rest.infra.config.GammaLogsConfiguration;
 import io.gravitee.gamma.rest.infra.config.GammaObservabilityFilterConfiguration;
 import io.gravitee.gamma.rest.infra.config.GammaTracingConfiguration;
 import io.gravitee.integration.controller.spring.IntegrationControllerConfiguration;
@@ -47,6 +48,7 @@ import org.springframework.context.annotation.Import;
         RestPortalConfiguration.class,
         GammaTracingConfiguration.class,
         GammaObservabilityFilterConfiguration.class,
+        GammaLogsConfiguration.class,
     }
 )
 public class StandaloneConfiguration {

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/GammaModuleApplication.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/GammaModuleApplication.java
@@ -20,6 +20,7 @@ import io.gravitee.gamma.rest.resources.GammaRootResource;
 import io.gravitee.gamma.rest.resources.GammaUIResource;
 import io.gravitee.gamma.rest.resources.OpenAPIResource;
 import io.gravitee.gamma.rest.resources.observability.filters.ObservabilityFiltersResource;
+import io.gravitee.gamma.rest.resources.observability.logs.LogsResource;
 import io.gravitee.gamma.rest.resources.tracing.TracingResource;
 import io.gravitee.rest.api.management.rest.mapper.ObjectMapperResolver;
 import io.gravitee.rest.api.management.rest.provider.BadRequestExceptionMapper;
@@ -58,6 +59,7 @@ public class GammaModuleApplication extends ResourceConfig {
         register(OpenAPIResource.class);
         register(TracingResource.class);
         register(ObservabilityFiltersResource.class);
+        register(LogsResource.class);
 
         register(MultiPartFeature.class);
         register(PayloadInputBodyReader.class);

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/filter/exception/UnsupportedObservabilityFilterException.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/filter/exception/UnsupportedObservabilityFilterException.java
@@ -16,6 +16,7 @@
 package io.gravitee.gamma.rest.core.observability.filter.exception;
 
 import io.gravitee.apim.core.exception.ValidationDomainException;
+import io.gravitee.gamma.rest.core.observability.filter.model.Signal;
 
 /**
  * Raised when an observability query receives a {@code FilterCondition} that references an unknown
@@ -40,10 +41,24 @@ public class UnsupportedObservabilityFilterException extends ValidationDomainExc
         );
     }
 
+    public static UnsupportedObservabilityFilterException signalMismatch(String filterName, Signal requiredSignal) {
+        return new UnsupportedObservabilityFilterException(
+            "Filter '" + filterName + "' does not apply to signal " + requiredSignal,
+            "observability.filter.signal_mismatch"
+        );
+    }
+
     public static UnsupportedObservabilityFilterException valueListingNotSupported(String filterName, String type) {
         return new UnsupportedObservabilityFilterException(
             "Filter '" + filterName + "' of type " + type + " does not support value listing",
             "observability.filter.value_listing_not_supported"
+        );
+    }
+
+    public static UnsupportedObservabilityFilterException searchTranslationNotSupported(String filterName) {
+        return new UnsupportedObservabilityFilterException(
+            "Filter '" + filterName + "' is not yet supported for log search",
+            "observability.filter.search_translation_not_supported"
         );
     }
 

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/logs/domain_service/AccessibleApiScopeDomainService.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/logs/domain_service/AccessibleApiScopeDomainService.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gamma.rest.core.observability.logs.domain_service;
+
+import io.gravitee.apim.core.DomainService;
+import io.gravitee.gamma.rest.core.observability.filter.model.ApiType;
+import io.gravitee.gamma.rest.core.observability.logs.port.service_provider.ObservabilityLogsDataPort.AccessibleApi;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Computes the effective API scope for an observability query by intersecting the caller's
+ * RBAC-accessible APIs with the signal's supported API kinds and any user-supplied API filter.
+ *
+ * <p>This encapsulation avoids duplicating the scoping logic across logs, analytics, and future
+ * observability consumers. The service is stateless — all inputs are passed explicitly so it can
+ * be unit-tested without infrastructure.
+ *
+ * @author GraviteeSource Team
+ */
+@DomainService
+public class AccessibleApiScopeDomainService {
+
+    public record ScopedApis(Set<String> apiIds, Map<String, String> apiNamesById) {}
+
+    /**
+     * @param accessibleApis   All APIs the caller can read (from the data port).
+     * @param wantedApiTypes   API kinds relevant for the current signal (e.g. PROXY, LLM_PROXY,
+     *                         MCP_PROXY for LOGS). Extensible: adding MESSAGE or NATIVE later only
+     *                         requires widening this set.
+     * @param userApiFilter    API IDs explicitly requested by the caller (from an {@code API}
+     *                         filter condition). {@code null} or empty means "all accessible".
+     * @return The intersection of the three constraints. An empty {@code apiIds} means the caller
+     *         has no data to see (→ empty result, not 403).
+     */
+    public ScopedApis computeScope(List<AccessibleApi> accessibleApis, Set<ApiType> wantedApiTypes, Set<String> userApiFilter) {
+        var filtered = accessibleApis.stream().filter(api -> api.type() != null && wantedApiTypes.contains(api.type()));
+
+        if (userApiFilter != null && !userApiFilter.isEmpty()) {
+            filtered = filtered.filter(api -> userApiFilter.contains(api.id()));
+        }
+
+        var apiList = filtered.toList();
+        var ids = apiList.stream().map(AccessibleApi::id).collect(Collectors.toSet());
+        var names = apiList.stream().collect(Collectors.toMap(AccessibleApi::id, AccessibleApi::name, (a, b) -> a));
+
+        return new ScopedApis(ids, names);
+    }
+}

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/logs/model/LogEntry.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/logs/model/LogEntry.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gamma.rest.core.observability.logs.model;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import lombok.Builder;
+
+/**
+ * Light log row from the {@code v4-metrics} index — carries per-request metadata but no HTTP
+ * bodies/headers (those live in the heavy detail endpoint, GMA-424). Fields are enriched with
+ * display names (api, plan, application, gateway, apiProduct) so the table can render without
+ * additional round-trips.
+ *
+ * @author GraviteeSource Team
+ */
+@Builder(toBuilder = true)
+public record LogEntry(
+    String apiId,
+    String apiName,
+    String apiType,
+    Instant timestamp,
+    String requestId,
+    String method,
+    String clientIdentifier,
+    String planId,
+    String planName,
+    String applicationId,
+    String applicationName,
+    String transactionId,
+    Integer status,
+    Boolean requestEnded,
+    Integer gatewayResponseTime,
+    String gateway,
+    String gatewayHostname,
+    String uri,
+    String endpoint,
+    String message,
+    String errorKey,
+    String errorComponentName,
+    String errorComponentType,
+    List<LogEntryWarning> warnings,
+    Map<String, Object> additionalMetrics,
+    String mcpMethod,
+    String apiProductId,
+    String apiProductName
+) {}

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/logs/model/LogEntryWarning.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/logs/model/LogEntryWarning.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gamma.rest.core.observability.logs.model;
+
+/**
+ * A diagnostic warning attached to a log entry (e.g. policy failure that did not interrupt the
+ * request flow).
+ *
+ * @author GraviteeSource Team
+ */
+public record LogEntryWarning(String componentType, String componentName, String key, String message) {}

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/logs/model/LogsPage.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/logs/model/LogsPage.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gamma.rest.core.observability.logs.model;
+
+import java.util.List;
+
+/**
+ * Paginated search result for log entries.
+ *
+ * @author GraviteeSource Team
+ */
+public record LogsPage(List<LogEntry> data, long totalCount) {
+    public static final LogsPage EMPTY = new LogsPage(List.of(), 0);
+}

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/logs/model/LogsSearchQuery.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/logs/model/LogsSearchQuery.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gamma.rest.core.observability.logs.model;
+
+import io.gravitee.gamma.rest.core.observability.filter.model.FilterCondition;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import lombok.Builder;
+
+/**
+ * Fully resolved search query passed from the use case to the data port. The {@code apiIds} are
+ * already intersected with the caller's accessible scope; the {@code conditions} are pre-validated
+ * against the filter registry for the {@code LOGS} signal; the {@code apiNamesById} map provides
+ * enrichment context so the adapter can attach display names without re-loading the API entities.
+ *
+ * @author GraviteeSource Team
+ */
+@Builder
+public record LogsSearchQuery(
+    Set<String> apiIds,
+    Map<String, String> apiNamesById,
+    List<FilterCondition> conditions,
+    Long from,
+    Long to,
+    int page,
+    int perPage
+) {}

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/logs/port/service_provider/ObservabilityLogsDataPort.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/logs/port/service_provider/ObservabilityLogsDataPort.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gamma.rest.core.observability.logs.port.service_provider;
+
+import io.gravitee.gamma.rest.core.observability.filter.model.ApiType;
+import io.gravitee.gamma.rest.core.observability.logs.model.LogsPage;
+import io.gravitee.gamma.rest.core.observability.logs.model.LogsSearchQuery;
+import java.util.List;
+
+/**
+ * Core-side port onto the logs data store and the RBAC-scoped API inventory. The infra adapter
+ * delegates to the platform's {@code ConnectionLogsCrudService}, {@code UserContextLoader}, and
+ * the various name-enrichment services so the core stays unaware of those mechanics.
+ *
+ * <p>Tenancy / actor scoping for {@link #loadAccessibleApis} is resolved by the adapter from the
+ * ambient request context (same source the rest of the rest-api uses).
+ *
+ * @author GraviteeSource Team
+ */
+public interface ObservabilityLogsDataPort {
+    /**
+     * An API the current caller is allowed to read, carrying the definition-level type so the use
+     * case can filter by signal-relevant API kinds without leaking repository details.
+     */
+    record AccessibleApi(String id, String name, ApiType type) {}
+
+    /** Loads all APIs the current caller can read in the given environment. */
+    List<AccessibleApi> loadAccessibleApis(String organizationId, String environmentId);
+
+    /**
+     * Searches the {@code v4-metrics} index with the pre-scoped query and returns enriched log
+     * entries (plan/application/gateway/apiProduct names resolved). Only V4 definition versions are
+     * queried.
+     */
+    LogsPage searchLogs(String organizationId, String environmentId, LogsSearchQuery query);
+}

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/logs/use_case/SearchObservabilityLogsUseCase.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/logs/use_case/SearchObservabilityLogsUseCase.java
@@ -1,0 +1,185 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gamma.rest.core.observability.logs.use_case;
+
+import io.gravitee.apim.core.UseCase;
+import io.gravitee.apim.core.exception.ValidationDomainException;
+import io.gravitee.gamma.rest.core.observability.filter.exception.UnsupportedObservabilityFilterException;
+import io.gravitee.gamma.rest.core.observability.filter.model.ApiType;
+import io.gravitee.gamma.rest.core.observability.filter.model.FilterCondition;
+import io.gravitee.gamma.rest.core.observability.filter.model.FilterSpec;
+import io.gravitee.gamma.rest.core.observability.filter.model.Signal;
+import io.gravitee.gamma.rest.core.observability.filter.port.service_provider.FilterRegistry;
+import io.gravitee.gamma.rest.core.observability.logs.domain_service.AccessibleApiScopeDomainService;
+import io.gravitee.gamma.rest.core.observability.logs.model.LogsPage;
+import io.gravitee.gamma.rest.core.observability.logs.model.LogsSearchQuery;
+import io.gravitee.gamma.rest.core.observability.logs.port.service_provider.ObservabilityLogsDataPort;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import lombok.AllArgsConstructor;
+
+/**
+ * Environment-wide log search returning light rows from the {@code v4-metrics} index. Validates
+ * every incoming {@link FilterCondition} against the unified filter registry for the
+ * {@link Signal#LOGS} signal, computes the RBAC-scoped API set via
+ * {@link AccessibleApiScopeDomainService}, applies default entrypoint scoping so table totals match
+ * the dashboard, and delegates the actual search to the data port.
+ *
+ * @author GraviteeSource Team
+ */
+@UseCase
+@AllArgsConstructor
+public class SearchObservabilityLogsUseCase {
+
+    private static final int DEFAULT_PAGE = 1;
+    private static final int DEFAULT_PER_PAGE = 20;
+    private static final int MAX_PER_PAGE = 100;
+
+    /**
+     * API types the LOGS signal serves today. Extensible: adding MESSAGE or NATIVE later only
+     * requires widening this set — the rest of the pipeline (AccessibleApiScope, query building)
+     * adjusts automatically.
+     */
+    static final Set<ApiType> LOGS_SUPPORTED_API_TYPES = Set.of(ApiType.HTTP_PROXY, ApiType.LLM, ApiType.MCP);
+
+    /**
+     * Canonical HTTP entrypoints applied when no explicit entrypoint filter is set, so the logs
+     * table total matches the analytics dashboard for the same time range. Mirrors
+     * {@code FilterAdapter.httpFilter()} from the analytics ES adapter. The ES query builder
+     * adds a field-missing fallback alongside these terms.
+     */
+    static final Set<String> DEFAULT_ENTRYPOINT_IDS = Set.of("http-get", "http-post", "http-proxy", "llm-proxy", "mcp-proxy");
+
+    private final ObservabilityLogsDataPort logsDataPort;
+    private final FilterRegistry filterRegistry;
+    private final AccessibleApiScopeDomainService accessibleApiScope;
+
+    public record Input(
+        String organizationId,
+        String environmentId,
+        List<FilterCondition> filters,
+        Instant from,
+        Instant to,
+        Integer page,
+        Integer perPage
+    ) {}
+
+    public record Output(LogsPage data, int page, int perPage) {}
+
+    public Output execute(Input input) {
+        int page = resolvePage(input);
+        int perPage = resolvePerPage(input);
+
+        var conditions = input.filters != null ? input.filters : List.<FilterCondition>of();
+        var filtersByName = buildFilterSpecMap();
+
+        validateConditions(conditions, filtersByName);
+        validateTimeRange(input.from, input.to);
+
+        var accessibleApis = logsDataPort.loadAccessibleApis(input.organizationId, input.environmentId);
+
+        var userApiFilter = extractApiFilter(conditions);
+        var scope = accessibleApiScope.computeScope(accessibleApis, LOGS_SUPPORTED_API_TYPES, userApiFilter);
+
+        if (scope.apiIds().isEmpty()) {
+            return new Output(LogsPage.EMPTY, page, perPage);
+        }
+
+        var effectiveConditions = applyDefaultEntrypointScoping(removeApiConditions(conditions));
+
+        var query = LogsSearchQuery.builder()
+            .apiIds(scope.apiIds())
+            .apiNamesById(scope.apiNamesById())
+            .conditions(effectiveConditions)
+            .from(input.from != null ? input.from.toEpochMilli() : null)
+            .to(input.to != null ? input.to.toEpochMilli() : null)
+            .page(page)
+            .perPage(perPage)
+            .build();
+
+        var result = logsDataPort.searchLogs(input.organizationId, input.environmentId, query);
+        return new Output(result, page, perPage);
+    }
+
+    private static int resolvePage(Input input) {
+        return (input.page() != null && input.page() > 0) ? input.page() : DEFAULT_PAGE;
+    }
+
+    private static int resolvePerPage(Input input) {
+        return (input.perPage() != null && input.perPage() > 0) ? Math.min(input.perPage(), MAX_PER_PAGE) : DEFAULT_PER_PAGE;
+    }
+
+    private Map<String, FilterSpec> buildFilterSpecMap() {
+        return filterRegistry.getFilters(Set.of(), Set.of()).stream().collect(Collectors.toMap(FilterSpec::name, f -> f, (a, b) -> b));
+    }
+
+    private static void validateConditions(List<FilterCondition> conditions, Map<String, FilterSpec> specsByName) {
+        for (var condition : conditions) {
+            var spec = specsByName.get(condition.name());
+            if (spec == null) {
+                throw UnsupportedObservabilityFilterException.unknownName(condition.name());
+            }
+            if (!spec.signals().contains(Signal.LOGS)) {
+                throw UnsupportedObservabilityFilterException.signalMismatch(condition.name(), Signal.LOGS);
+            }
+        }
+    }
+
+    private static void validateTimeRange(Instant from, Instant to) {
+        if (from != null && to != null && from.isAfter(to)) {
+            throw new ValidationDomainException("Invalid time range: 'from' must be before 'to'.");
+        }
+    }
+
+    private static Set<String> extractApiFilter(List<FilterCondition> conditions) {
+        return conditions
+            .stream()
+            .filter(c -> "API".equals(c.name()))
+            .flatMap(c -> c.values().stream())
+            .collect(Collectors.toSet());
+    }
+
+    private static List<FilterCondition> removeApiConditions(List<FilterCondition> conditions) {
+        return conditions
+            .stream()
+            .filter(c -> !"API".equals(c.name()))
+            .toList();
+    }
+
+    /**
+     * If the caller didn't supply an explicit entrypoint filter, inject the canonical HTTP
+     * entrypoint set so the logs table matches the dashboard totals.
+     */
+    private static List<FilterCondition> applyDefaultEntrypointScoping(List<FilterCondition> conditions) {
+        boolean hasEntrypoint = conditions.stream().anyMatch(c -> "ENTRYPOINT".equals(c.name()));
+        if (hasEntrypoint) {
+            return conditions;
+        }
+        var result = new ArrayList<>(conditions);
+        result.add(
+            new FilterCondition(
+                "ENTRYPOINT",
+                io.gravitee.gamma.rest.core.observability.filter.model.FilterOperator.IN,
+                List.copyOf(DEFAULT_ENTRYPOINT_IDS)
+            )
+        );
+        return List.copyOf(result);
+    }
+}

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/infra/adapter/ObservabilityLogsDataPortAdapter.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/infra/adapter/ObservabilityLogsDataPortAdapter.java
@@ -1,0 +1,324 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gamma.rest.infra.adapter;
+
+import io.gravitee.apim.core.api_product.model.ApiProduct;
+import io.gravitee.apim.core.api_product.query_service.ApiProductQueryService;
+import io.gravitee.apim.core.application.crud_service.ApplicationCrudService;
+import io.gravitee.apim.core.gateway.model.BaseInstance;
+import io.gravitee.apim.core.gateway.query_service.InstanceQueryService;
+import io.gravitee.apim.core.log.crud_service.ConnectionLogsCrudService;
+import io.gravitee.apim.core.plan.crud_service.PlanCrudService;
+import io.gravitee.apim.core.plan.model.Plan;
+import io.gravitee.apim.core.user.domain_service.UserContextLoader;
+import io.gravitee.apim.core.user.model.UserContext;
+import io.gravitee.common.http.HttpMethod;
+import io.gravitee.definition.model.DefinitionVersion;
+import io.gravitee.gamma.rest.core.observability.filter.exception.UnsupportedObservabilityFilterException;
+import io.gravitee.gamma.rest.core.observability.filter.model.FilterCondition;
+import io.gravitee.gamma.rest.core.observability.filter.model.FilterOperator;
+import io.gravitee.gamma.rest.core.observability.logs.model.LogEntry;
+import io.gravitee.gamma.rest.core.observability.logs.model.LogEntryWarning;
+import io.gravitee.gamma.rest.core.observability.logs.model.LogsPage;
+import io.gravitee.gamma.rest.core.observability.logs.model.LogsSearchQuery;
+import io.gravitee.gamma.rest.core.observability.logs.port.service_provider.ObservabilityLogsDataPort;
+import io.gravitee.rest.api.model.BaseApplicationEntity;
+import io.gravitee.rest.api.model.analytics.Range;
+import io.gravitee.rest.api.model.analytics.SearchLogsFilters;
+import io.gravitee.rest.api.model.common.PageableImpl;
+import io.gravitee.rest.api.model.v4.log.connection.BaseConnectionLog;
+import io.gravitee.rest.api.model.v4.log.connection.ConnectionDiagnosticModel;
+import io.gravitee.rest.api.service.common.ExecutionContext;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.format.DateTimeParseException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+/**
+ * Adapter that delegates to the APIM platform's connection-log search infrastructure
+ * ({@link ConnectionLogsCrudService}, {@link UserContextLoader}) and enriches the raw results
+ * with display names (plans, applications, gateways, API products).
+ *
+ * @author GraviteeSource Team
+ */
+@RequiredArgsConstructor
+public class ObservabilityLogsDataPortAdapter implements ObservabilityLogsDataPort {
+
+    private final ConnectionLogsCrudService connectionLogsCrudService;
+    private final UserContextLoader userContextLoader;
+    private final PlanCrudService planCrudService;
+    private final ApplicationCrudService applicationCrudService;
+    private final InstanceQueryService instanceQueryService;
+    private final ApiProductQueryService apiProductQueryService;
+
+    @Override
+    public List<AccessibleApi> loadAccessibleApis(String organizationId, String environmentId) {
+        var auditInfo = currentAuditInfo(organizationId, environmentId);
+        var userContext = userContextLoader.loadApis(new UserContext(auditInfo));
+
+        return userContext
+            .apis()
+            .orElseGet(Collections::emptyList)
+            .stream()
+            .map(api -> new AccessibleApi(api.getId(), api.getName(), toGammaApiType(api.getType())))
+            .toList();
+    }
+
+    @Override
+    public LogsPage searchLogs(String organizationId, String environmentId, LogsSearchQuery query) {
+        var executionContext = new ExecutionContext(organizationId, environmentId);
+        var pageable = new PageableImpl(query.page(), query.perPage());
+
+        var searchFilters = buildSearchFilters(query);
+        var result = connectionLogsCrudService.searchApiConnectionLogs(
+            executionContext,
+            searchFilters,
+            pageable,
+            List.of(DefinitionVersion.V4)
+        );
+
+        var rawEntries = result.logs() == null ? List.<BaseConnectionLog>of() : result.logs();
+
+        var entries = rawEntries
+            .stream()
+            .map(log -> mapToLogEntry(log, query.apiNamesById()))
+            .toList();
+        var enriched = enrichWithNames(executionContext, entries);
+
+        return new LogsPage(enriched, result.total());
+    }
+
+    private SearchLogsFilters buildSearchFilters(LogsSearchQuery query) {
+        var builder = SearchLogsFilters.builder();
+        builder.apiIds(query.apiIds());
+        builder.from(query.from());
+        builder.to(query.to());
+
+        Set<String> applicationIds = new HashSet<>();
+        Set<String> planIds = new HashSet<>();
+        Set<HttpMethod> methods = new HashSet<>();
+        Set<String> mcpMethods = new HashSet<>();
+        Set<Integer> statuses = new HashSet<>();
+        Set<String> entrypointIds = new HashSet<>();
+        Set<String> requestIds = new HashSet<>();
+        Set<String> transactionIds = new HashSet<>();
+        Set<String> errorKeys = new HashSet<>();
+        Set<String> apiProductIds = new HashSet<>();
+        String uri = null;
+        List<Range> responseTimeRanges = new ArrayList<>();
+        Long responseTimeFrom = null;
+        Long responseTimeTo = null;
+
+        for (FilterCondition condition : query.conditions()) {
+            var values = condition.values() != null ? condition.values() : List.<String>of();
+            switch (condition.name()) {
+                case "APPLICATION" -> applicationIds.addAll(values);
+                case "PLAN" -> planIds.addAll(values);
+                case "HTTP_METHOD" -> methods.addAll(values.stream().map(this::toHttpMethod).toList());
+                case "HTTP_STATUS" -> statuses.addAll(values.stream().map(Integer::valueOf).toList());
+                case "URI" -> {
+                    if (!values.isEmpty()) uri = values.getFirst();
+                }
+                case "HTTP_GATEWAY_RESPONSE_TIME" -> {
+                    if (!values.isEmpty()) {
+                        long val = Long.parseLong(values.getFirst());
+                        if (condition.operator() == FilterOperator.GTE) responseTimeFrom = val;
+                        else if (condition.operator() == FilterOperator.LTE) responseTimeTo = val;
+                    }
+                }
+                case "ENTRYPOINT" -> entrypointIds.addAll(values);
+                case "MCP_PROXY_METHOD" -> mcpMethods.addAll(values);
+                case "REQUEST_ID" -> requestIds.addAll(values);
+                case "TRANSACTION_ID" -> transactionIds.addAll(values);
+                case "ERROR_KEY" -> errorKeys.addAll(values);
+                case "API_PRODUCT" -> apiProductIds.addAll(values);
+                default -> throw UnsupportedObservabilityFilterException.searchTranslationNotSupported(condition.name());
+            }
+        }
+
+        if (responseTimeFrom != null || responseTimeTo != null) {
+            responseTimeRanges.add(new Range(responseTimeFrom, responseTimeTo));
+        }
+
+        builder.applicationIds(applicationIds);
+        builder.planIds(planIds);
+        builder.methods(methods);
+        builder.mcpMethods(mcpMethods);
+        builder.statuses(statuses);
+        builder.entrypointIds(entrypointIds);
+        builder.requestIds(requestIds);
+        builder.transactionIds(transactionIds);
+        builder.errorKeys(errorKeys);
+        builder.apiProductIds(apiProductIds);
+        builder.uri(uri);
+        builder.responseTimeRanges(responseTimeRanges);
+
+        return builder.build();
+    }
+
+    private LogEntry mapToLogEntry(BaseConnectionLog log, Map<String, String> apiNamesById) {
+        return LogEntry.builder()
+            .apiId(log.getApiId())
+            .apiName(apiNamesById.getOrDefault(log.getApiId(), null))
+            .timestamp(parseTimestamp(log.getTimestamp()))
+            .requestId(log.getRequestId())
+            .method(log.getMethod() != null ? log.getMethod().name() : null)
+            .clientIdentifier(log.getClientIdentifier())
+            .planId(log.getPlanId())
+            .applicationId(log.getApplicationId())
+            .transactionId(log.getTransactionId())
+            .status(log.getStatus())
+            .requestEnded(log.isRequestEnded())
+            .gatewayResponseTime(safeToInteger(log.getGatewayResponseTime()))
+            .gateway(log.getGateway())
+            .uri(log.getUri())
+            .endpoint(log.getEndpoint())
+            .message(log.getMessage())
+            .errorKey(log.getErrorKey())
+            .errorComponentName(log.getErrorComponentName())
+            .errorComponentType(log.getErrorComponentType())
+            .warnings(mapWarnings(log.getWarnings()))
+            .additionalMetrics(log.getAdditionalMetrics() != null ? log.getAdditionalMetrics() : Map.of())
+            .mcpMethod(log.getMcpMethod())
+            .apiProductId(log.getApiProductId())
+            .build();
+    }
+
+    private List<LogEntry> enrichWithNames(ExecutionContext executionContext, List<LogEntry> entries) {
+        var planIds = entries.stream().map(LogEntry::planId).filter(Objects::nonNull).distinct().toList();
+        var planNameById = planIds.isEmpty()
+            ? Map.<String, String>of()
+            : planCrudService
+                .findByIds(planIds)
+                .stream()
+                .filter(p -> p.getName() != null)
+                .collect(Collectors.toMap(Plan::getId, Plan::getName, (a, b) -> a));
+
+        var appIds = entries.stream().map(LogEntry::applicationId).filter(Objects::nonNull).distinct().toList();
+        var appNameById = appIds.isEmpty()
+            ? Map.<String, String>of()
+            : applicationCrudService
+                .findByIds(appIds, executionContext.getEnvironmentId())
+                .stream()
+                .filter(a -> a.getName() != null)
+                .collect(Collectors.toMap(BaseApplicationEntity::getId, BaseApplicationEntity::getName, (a, b) -> a));
+
+        var gatewayIds = entries.stream().map(LogEntry::gateway).filter(Objects::nonNull).distinct().toList();
+        var gatewayHostnameById = gatewayIds.isEmpty()
+            ? Map.<String, String>of()
+            : instanceQueryService
+                .findByIds(executionContext, gatewayIds)
+                .stream()
+                .filter(i -> i.getHostname() != null)
+                .collect(Collectors.toMap(BaseInstance::getId, BaseInstance::getHostname, (a, b) -> a));
+
+        var apiProductIds = entries.stream().map(LogEntry::apiProductId).filter(Objects::nonNull).collect(Collectors.toSet());
+        var apiProductNameById = apiProductIds.isEmpty()
+            ? Map.<String, String>of()
+            : apiProductQueryService
+                .findByEnvironmentIdAndIdIn(executionContext.getEnvironmentId(), apiProductIds)
+                .stream()
+                .filter(p -> p.getName() != null)
+                .collect(Collectors.toMap(ApiProduct::getId, ApiProduct::getName, (a, b) -> a));
+
+        return entries
+            .stream()
+            .map(entry ->
+                entry
+                    .toBuilder()
+                    .planName(planNameById.get(entry.planId()))
+                    .applicationName(appNameById.get(entry.applicationId()))
+                    .gatewayHostname(gatewayHostnameById.get(entry.gateway()))
+                    .apiProductName(entry.apiProductId() == null ? "Standalone API" : apiProductNameById.get(entry.apiProductId()))
+                    .build()
+            )
+            .toList();
+    }
+
+    private static Instant parseTimestamp(String timestamp) {
+        if (timestamp == null) {
+            return null;
+        }
+        try {
+            return OffsetDateTime.parse(timestamp).toInstant();
+        } catch (DateTimeParseException e) {
+            return null;
+        }
+    }
+
+    private static Integer safeToInteger(long value) {
+        return (int) Math.min(Integer.MAX_VALUE, value);
+    }
+
+    private HttpMethod toHttpMethod(String method) {
+        try {
+            return HttpMethod.valueOf(method);
+        } catch (IllegalArgumentException e) {
+            return HttpMethod.OTHER;
+        }
+    }
+
+    private static List<LogEntryWarning> mapWarnings(List<ConnectionDiagnosticModel> warnings) {
+        if (warnings == null) {
+            return List.of();
+        }
+        return warnings
+            .stream()
+            .map(w -> new LogEntryWarning(w.getComponentType(), w.getComponentName(), w.getKey(), w.getMessage()))
+            .toList();
+    }
+
+    private static io.gravitee.apim.core.audit.model.AuditInfo currentAuditInfo(String organizationId, String environmentId) {
+        var authentication = SecurityContextHolder.getContext().getAuthentication();
+        io.gravitee.apim.core.audit.model.AuditActor actor;
+        if (authentication != null && authentication.getName() != null) {
+            actor = io.gravitee.apim.core.audit.model.AuditActor.builder().userId(authentication.getName()).build();
+        } else {
+            actor = io.gravitee.apim.core.audit.model.AuditActor.builder().userId("unknown").build();
+        }
+        return io.gravitee.apim.core.audit.model.AuditInfo.builder()
+            .organizationId(organizationId)
+            .environmentId(environmentId)
+            .actor(actor)
+            .build();
+    }
+
+    private static io.gravitee.gamma.rest.core.observability.filter.model.ApiType toGammaApiType(
+        io.gravitee.definition.model.v4.ApiType definitionType
+    ) {
+        if (definitionType == null) {
+            return null;
+        }
+        return switch (definitionType) {
+            case PROXY -> io.gravitee.gamma.rest.core.observability.filter.model.ApiType.HTTP_PROXY;
+            case MESSAGE -> io.gravitee.gamma.rest.core.observability.filter.model.ApiType.MESSAGE;
+            case LLM_PROXY -> io.gravitee.gamma.rest.core.observability.filter.model.ApiType.LLM;
+            case MCP_PROXY -> io.gravitee.gamma.rest.core.observability.filter.model.ApiType.MCP;
+            case NATIVE -> io.gravitee.gamma.rest.core.observability.filter.model.ApiType.NATIVE;
+            case EDGE -> io.gravitee.gamma.rest.core.observability.filter.model.ApiType.EDGE;
+            case A2A_PROXY -> null; // No Gamma equivalent yet — APIs with this type are excluded from scope
+        };
+    }
+}

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/infra/config/GammaLogsConfiguration.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/infra/config/GammaLogsConfiguration.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gamma.rest.infra.config;
+
+import io.gravitee.apim.core.DomainService;
+import io.gravitee.apim.core.UseCase;
+import io.gravitee.apim.core.api_product.query_service.ApiProductQueryService;
+import io.gravitee.apim.core.application.crud_service.ApplicationCrudService;
+import io.gravitee.apim.core.gateway.query_service.InstanceQueryService;
+import io.gravitee.apim.core.log.crud_service.ConnectionLogsCrudService;
+import io.gravitee.apim.core.plan.crud_service.PlanCrudService;
+import io.gravitee.apim.core.user.domain_service.UserContextLoader;
+import io.gravitee.gamma.rest.core.observability.logs.port.service_provider.ObservabilityLogsDataPort;
+import io.gravitee.gamma.rest.infra.adapter.ObservabilityLogsDataPortAdapter;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.FilterType;
+
+/**
+ * Spring wiring for the observability logs search domain. Picks up the use case via
+ * {@link ComponentScan} and declares the data port adapter as a bean.
+ *
+ * @author GraviteeSource Team
+ */
+@Configuration
+@ComponentScan(
+    basePackages = "io.gravitee.gamma.rest.core.observability.logs",
+    includeFilters = {
+        @ComponentScan.Filter(type = FilterType.ANNOTATION, value = UseCase.class),
+        @ComponentScan.Filter(type = FilterType.ANNOTATION, value = DomainService.class),
+    }
+)
+public class GammaLogsConfiguration {
+
+    @Bean
+    public ObservabilityLogsDataPort observabilityLogsDataPort(
+        ConnectionLogsCrudService connectionLogsCrudService,
+        UserContextLoader userContextLoader,
+        PlanCrudService planCrudService,
+        ApplicationCrudService applicationCrudService,
+        InstanceQueryService instanceQueryService,
+        ApiProductQueryService apiProductQueryService
+    ) {
+        return new ObservabilityLogsDataPortAdapter(
+            connectionLogsCrudService,
+            userContextLoader,
+            planCrudService,
+            applicationCrudService,
+            instanceQueryService,
+            apiProductQueryService
+        );
+    }
+}

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/resources/GammaRootResource.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/resources/GammaRootResource.java
@@ -16,6 +16,7 @@
 package io.gravitee.gamma.rest.resources;
 
 import io.gravitee.gamma.rest.resources.observability.filters.ObservabilityFiltersResource;
+import io.gravitee.gamma.rest.resources.observability.logs.LogsResource;
 import io.gravitee.gamma.rest.resources.tracing.TracingResource;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.container.ResourceContext;
@@ -58,5 +59,14 @@ public class GammaRootResource {
     @Path("/organizations/{orgId}/environments/{envId}/observability/filters")
     public ObservabilityFiltersResource getObservabilityFiltersResource() {
         return resourceContext.getResource(ObservabilityFiltersResource.class);
+    }
+
+    /**
+     * Environment-wide logs search (light rows, v4-only). Server-side RBAC scoping — no mandatory
+     * {@code apiId}. See {@link LogsResource} for the contract.
+     */
+    @Path("/organizations/{orgId}/environments/{envId}/observability/logs")
+    public LogsResource getLogsResource() {
+        return resourceContext.getResource(LogsResource.class);
     }
 }

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/resources/observability/logs/LogsResource.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/resources/observability/logs/LogsResource.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gamma.rest.resources.observability.logs;
+
+import io.gravitee.common.http.MediaType;
+import io.gravitee.gamma.rest.core.observability.filter.model.FilterCondition;
+import io.gravitee.gamma.rest.core.observability.logs.use_case.SearchObservabilityLogsUseCase;
+import io.gravitee.gamma.rest.resources.observability.logs.dto.FilterConditionDto;
+import io.gravitee.gamma.rest.resources.observability.logs.dto.LogEntryDto;
+import io.gravitee.gamma.rest.resources.observability.logs.dto.SearchLogsRequestDto;
+import io.gravitee.gamma.rest.resources.tracing.dto.PaginatedResponseDto;
+import io.gravitee.rest.api.model.permissions.RolePermission;
+import io.gravitee.rest.api.model.permissions.RolePermissionAction;
+import io.gravitee.rest.api.service.PermissionService;
+import io.gravitee.rest.api.service.common.ExecutionContext;
+import io.gravitee.rest.api.service.common.GraviteeContext;
+import io.gravitee.rest.api.service.exceptions.ForbiddenAccessException;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import java.util.List;
+
+/**
+ * Environment-wide logs search endpoint, mounted under
+ * {@code /gamma/organizations/{orgId}/environments/{envId}/observability/logs} by
+ * {@code GammaRootResource}.
+ *
+ * <h2>Endpoints</h2>
+ * <ul>
+ *   <li>{@code POST /search?page=&perPage=} — paginated logs listing. Body carries an optional
+ *       {@code timeRange} and optional filter conditions. Pagination is 1-based in the query
+ *       string. Response uses the shared paginated envelope
+ *       {@code { data, pagination: { totalCount, page, pageCount } }}.</li>
+ * </ul>
+ *
+ * <h2>Authorization</h2>
+ * Same coarse env-level guard as the filter catalog: the caller must be able to read dashboards
+ * or APIs in the current environment, otherwise {@code 403}. Row-level scoping (which APIs the
+ * caller sees) is handled server-side by the use case via {@code AccessibleApiScopeDomainService}.
+ *
+ * @author GraviteeSource Team
+ */
+public class LogsResource {
+
+    @Inject
+    private SearchObservabilityLogsUseCase searchLogsUseCase;
+
+    @Inject
+    private PermissionService permissionService;
+
+    @POST
+    @Path("/search")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public PaginatedResponseDto<LogEntryDto> searchLogs(
+        @QueryParam("page") Integer page,
+        @QueryParam("perPage") Integer perPage,
+        SearchLogsRequestDto request
+    ) {
+        checkReadObservabilityPermission();
+
+        List<FilterCondition> filters = List.of();
+        if (request != null && request.filters() != null) {
+            filters = request.filters().stream().map(FilterConditionDto::toCore).toList();
+        }
+
+        var ctx = GraviteeContext.getExecutionContext();
+        var output = searchLogsUseCase.execute(
+            new SearchObservabilityLogsUseCase.Input(
+                ctx.getOrganizationId(),
+                ctx.getEnvironmentId(),
+                filters,
+                request != null && request.timeRange() != null ? request.timeRange().from() : null,
+                request != null && request.timeRange() != null ? request.timeRange().to() : null,
+                page,
+                perPage
+            )
+        );
+
+        List<LogEntryDto> data = output.data().data().stream().map(LogEntryDto::from).toList();
+        return PaginatedResponseDto.of(data, output.data().totalCount(), output.page(), output.perPage());
+    }
+
+    private void checkReadObservabilityPermission() {
+        ExecutionContext executionContext = GraviteeContext.getExecutionContext();
+        String environmentId = executionContext.getEnvironmentId();
+        boolean allowed =
+            permissionService.hasPermission(
+                executionContext,
+                RolePermission.ENVIRONMENT_DASHBOARD,
+                environmentId,
+                RolePermissionAction.READ
+            ) ||
+            permissionService.hasPermission(executionContext, RolePermission.ENVIRONMENT_API, environmentId, RolePermissionAction.READ);
+        if (!allowed) {
+            throw new ForbiddenAccessException();
+        }
+    }
+}

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/resources/observability/logs/dto/FilterConditionDto.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/resources/observability/logs/dto/FilterConditionDto.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gamma.rest.resources.observability.logs.dto;
+
+import io.gravitee.gamma.rest.core.observability.filter.exception.UnsupportedObservabilityFilterException;
+import io.gravitee.gamma.rest.core.observability.filter.model.FilterCondition;
+import io.gravitee.gamma.rest.core.observability.filter.model.FilterOperator;
+import java.util.List;
+
+/**
+ * Wire shape for one filter condition on the POST search body. Same polymorphic {@code value}
+ * contract as the tracing endpoint's {@code FilterConditionDto}: scalar for
+ * {@code EQ}/{@code GTE}/{@code LTE}, array for {@code IN}. Operator is UPPERCASE on the wire.
+ */
+public record FilterConditionDto(String name, String operator, Object value) {
+    public FilterCondition toCore() {
+        if (name == null || name.isBlank()) {
+            throw UnsupportedObservabilityFilterException.unknownName(name);
+        }
+        if (operator == null || operator.isBlank()) {
+            throw UnsupportedObservabilityFilterException.unsupportedOperator(name, "(missing)");
+        }
+        FilterOperator op;
+        try {
+            op = FilterOperator.valueOf(operator.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            throw UnsupportedObservabilityFilterException.unsupportedOperator(name, operator);
+        }
+        return new FilterCondition(name, op, normalizeValues(op, value));
+    }
+
+    private static List<String> normalizeValues(FilterOperator op, Object value) {
+        if (value == null) {
+            return List.of();
+        }
+        if (op == FilterOperator.IN || op == FilterOperator.NOT_IN) {
+            if (value instanceof List<?> list) {
+                return list.stream().map(FilterConditionDto::asString).toList();
+            }
+            return List.of(asString(value));
+        }
+        if (value instanceof List<?> list) {
+            return list.stream().map(FilterConditionDto::asString).toList();
+        }
+        return List.of(asString(value));
+    }
+
+    private static String asString(Object v) {
+        return v == null ? "" : v.toString();
+    }
+}

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/resources/observability/logs/dto/LogEntryDto.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/resources/observability/logs/dto/LogEntryDto.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gamma.rest.resources.observability.logs.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.gravitee.gamma.rest.core.observability.logs.model.LogEntry;
+import io.gravitee.gamma.rest.core.observability.logs.model.LogEntryWarning;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Wire shape for one light log row returned by {@code POST /observability/logs/search}. Null
+ * fields are omitted from the JSON to keep the payload lean.
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record LogEntryDto(
+    String apiId,
+    String apiName,
+    String apiType,
+    Instant timestamp,
+    String requestId,
+    String method,
+    String clientIdentifier,
+    String planId,
+    String planName,
+    String applicationId,
+    String applicationName,
+    String transactionId,
+    Integer status,
+    Boolean requestEnded,
+    Integer gatewayResponseTime,
+    String gateway,
+    String gatewayHostname,
+    String uri,
+    String endpoint,
+    String message,
+    String errorKey,
+    String errorComponentName,
+    String errorComponentType,
+    List<WarningDto> warnings,
+    Map<String, Object> additionalMetrics,
+    String mcpMethod,
+    String apiProductId,
+    String apiProductName
+) {
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public record WarningDto(String componentType, String componentName, String key, String message) {
+        public static WarningDto from(LogEntryWarning w) {
+            return new WarningDto(w.componentType(), w.componentName(), w.key(), w.message());
+        }
+    }
+
+    public static LogEntryDto from(LogEntry entry) {
+        return new LogEntryDto(
+            entry.apiId(),
+            entry.apiName(),
+            entry.apiType(),
+            entry.timestamp(),
+            entry.requestId(),
+            entry.method(),
+            entry.clientIdentifier(),
+            entry.planId(),
+            entry.planName(),
+            entry.applicationId(),
+            entry.applicationName(),
+            entry.transactionId(),
+            entry.status(),
+            entry.requestEnded(),
+            entry.gatewayResponseTime(),
+            entry.gateway(),
+            entry.gatewayHostname(),
+            entry.uri(),
+            entry.endpoint(),
+            entry.message(),
+            entry.errorKey(),
+            entry.errorComponentName(),
+            entry.errorComponentType(),
+            entry.warnings() != null ? entry.warnings().stream().map(WarningDto::from).toList() : null,
+            entry.additionalMetrics(),
+            entry.mcpMethod(),
+            entry.apiProductId(),
+            entry.apiProductName()
+        );
+    }
+}

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/resources/observability/logs/dto/SearchLogsRequestDto.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/resources/observability/logs/dto/SearchLogsRequestDto.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gamma.rest.resources.observability.logs.dto;
+
+import java.time.Instant;
+import java.util.List;
+
+/**
+ * POST body for {@code /observability/logs/search}. Carries an ISO-8601 time window and a
+ * (possibly empty) list of filter conditions. Pagination travels in the URL query string
+ * ({@code ?page=&perPage=}) — same convention as the tracing and management v2 logs endpoints.
+ *
+ * <p>Unlike the tracing endpoint, there is no mandatory {@code apiId}: the logs search is
+ * environment-wide with server-side RBAC scoping.
+ */
+public record SearchLogsRequestDto(TimeRangeDto timeRange, List<FilterConditionDto> filters) {
+    /**
+     * ISO-8601 time window. {@code null} on either bound defers to the use case's default
+     * handling.
+     */
+    public record TimeRangeDto(Instant from, Instant to) {}
+}

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/resources/openapi/observability/openapi-observability.yaml
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/resources/openapi/observability/openapi-observability.yaml
@@ -35,6 +35,14 @@ tags:
           return distinct values from the data store, NUMBER and STRING filters have no enumerable
           values (400). Id-based KEYWORD filters (API, APPLICATION, PLAN, API_PRODUCT) return
           entity ids as values; use the `resolve` endpoint to hydrate them into display labels.
+    - name: Logs
+      description: |
+          Environment-wide log search returning light rows from the `v4-metrics` index. Results
+          are RBAC-scoped: the caller only sees logs for APIs they have read access to.
+
+          Filter conditions reference the shared filter catalog narrowed to the `LOGS` signal.
+          When no explicit entrypoint filter is supplied, the server injects the canonical HTTP
+          entrypoints so table totals match the analytics dashboard.
 
 paths:
     /organizations/{orgId}/environments/{envId}/observability/filters/definition:
@@ -345,6 +353,235 @@ paths:
                                 httpStatus: 403
                                 message: "Insufficient permissions to access observability metadata."
 
+    /organizations/{orgId}/environments/{envId}/observability/logs/search:
+        parameters:
+            - $ref: "#/components/parameters/orgIdParam"
+            - $ref: "#/components/parameters/envIdParam"
+        post:
+            tags:
+                - Logs
+            summary: Search environment-wide logs
+            description: |
+                Paginated log search across all APIs the caller has access to in the given
+                environment. Returns light rows from the `v4-metrics` Elasticsearch index — no
+                HTTP bodies or headers (those live in the detail endpoint, planned in GMA-424).
+
+                **RBAC scoping**: the response only contains logs for APIs the caller has `READ`
+                access to. When the caller requests specific APIs via an `API` filter, the server
+                intersects that set with the caller's accessible APIs. If the intersection is
+                empty, the response is an empty page (not 403).
+
+                **Filter validation**: every `FilterCondition` in the request body is validated
+                against the shared filter catalog (see the *Filters* tag) narrowed to the `LOGS`
+                signal. Unknown filter names or filters that do not apply to the `LOGS` signal
+                are rejected with 400. Use `GET /observability/filters/definition?signal=LOGS` to
+                discover valid filters.
+
+                **Default entrypoint scoping**: when no explicit `ENTRYPOINT` filter is supplied,
+                the server injects the canonical HTTP entrypoints (`http-get`, `http-post`,
+                `http-proxy`, `llm-proxy`, `mcp-proxy`) so log table totals match the analytics
+                dashboard for the same time range.
+
+                **Enrichment**: each log entry is enriched server-side with display names for API,
+                plan, application, gateway hostname, and API product. Use the `resolve` endpoint
+                from the *Filters* tag for batch id-to-label resolution on saved filter values.
+
+                **Pagination**: 1-based. `perPage` defaults to 20 and is clamped server-side at
+                100. The response `pagination` object reflects the effective (clamped) values.
+
+                **Supported API types**: only logs from `HTTP_PROXY`, `LLM`, and `MCP` APIs are
+                returned. `MESSAGE` and `NATIVE` APIs are excluded from the logs signal.
+            operationId: searchObservabilityLogs
+            parameters:
+                - name: page
+                  in: query
+                  required: false
+                  description: 1-based page number.
+                  schema:
+                      type: integer
+                      default: 1
+                      minimum: 1
+                - name: perPage
+                  in: query
+                  required: false
+                  description: Page size (capped server-side at 100).
+                  schema:
+                      type: integer
+                      default: 20
+                      minimum: 1
+                      maximum: 100
+            requestBody:
+                required: false
+                content:
+                    application/json:
+                        schema:
+                            $ref: "#/components/schemas/SearchLogsRequest"
+                        examples:
+                            with-time-range-and-filters:
+                                summary: Search with time range and status filter
+                                value:
+                                    timeRange:
+                                        from: "2026-06-10T00:00:00Z"
+                                        to: "2026-06-11T00:00:00Z"
+                                    filters:
+                                        - name: "HTTP_STATUS"
+                                          operator: "EQ"
+                                          value: "200"
+                            with-api-filter:
+                                summary: Search scoped to specific APIs
+                                value:
+                                    filters:
+                                        - name: "API"
+                                          operator: "IN"
+                                          value:
+                                              - "67e246cb-ab02-4da4-8f47-f9fa3e061d6b"
+                                              - "a1b2c3d4-0000-1111-2222-333344445555"
+                            with-response-time-range:
+                                summary: Search with response time bounds
+                                value:
+                                    timeRange:
+                                        from: "2026-06-10T00:00:00Z"
+                                        to: "2026-06-11T00:00:00Z"
+                                    filters:
+                                        - name: "HTTP_GATEWAY_RESPONSE_TIME"
+                                          operator: "GTE"
+                                          value: "500"
+                                        - name: "HTTP_GATEWAY_RESPONSE_TIME"
+                                          operator: "LTE"
+                                          value: "5000"
+                            with-multiple-filters:
+                                summary: Combine status, method, and application filters
+                                value:
+                                    timeRange:
+                                        from: "2026-06-10T00:00:00Z"
+                                        to: "2026-06-11T00:00:00Z"
+                                    filters:
+                                        - name: "HTTP_STATUS"
+                                          operator: "GTE"
+                                          value: "500"
+                                        - name: "HTTP_METHOD"
+                                          operator: "IN"
+                                          value: ["GET", "POST"]
+                                        - name: "APPLICATION"
+                                          operator: "EQ"
+                                          value: "b5c6d7e8-9999-aaaa-bbbb-ccccddddeeee"
+                            empty-body:
+                                summary: Search with defaults (all accessible APIs, no filter)
+                                value: {}
+            responses:
+                "200":
+                    description: A page of log entries enriched with display names.
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/LogsSearchResponse"
+                            examples:
+                                single-entry:
+                                    summary: Single HTTP proxy log entry
+                                    value:
+                                        data:
+                                            - apiId: "67e246cb-ab02-4da4-8f47-f9fa3e061d6b"
+                                              apiName: "Petstore API"
+                                              apiType: "HTTP_PROXY"
+                                              timestamp: "2026-06-10T14:32:01Z"
+                                              requestId: "req-abc-123"
+                                              transactionId: "txn-xyz-789"
+                                              method: "GET"
+                                              uri: "/pets/42"
+                                              status: 200
+                                              requestEnded: true
+                                              gatewayResponseTime: 12
+                                              planId: "plan-001"
+                                              planName: "Gold"
+                                              applicationId: "app-001"
+                                              applicationName: "Mobile App"
+                                              gateway: "gw-eu-1"
+                                              gatewayHostname: "gateway-eu-west-1.example.com"
+                                              apiProductName: "Standalone API"
+                                        pagination:
+                                            totalCount: 1
+                                            page: 1
+                                            perPage: 20
+                                            pageCount: 1
+                                            pageItemsCount: 1
+                                with-warnings:
+                                    summary: Log entry with policy warnings
+                                    value:
+                                        data:
+                                            - apiId: "67e246cb-ab02-4da4-8f47-f9fa3e061d6b"
+                                              apiName: "Petstore API"
+                                              timestamp: "2026-06-10T14:33:00Z"
+                                              requestId: "req-def-456"
+                                              method: "POST"
+                                              uri: "/pets"
+                                              status: 200
+                                              gatewayResponseTime: 85
+                                              warnings:
+                                                  - componentType: "policy"
+                                                    componentName: "rate-limit"
+                                                    key: "RATE_LIMIT_NOT_APPLIED"
+                                                    message: "Request bypassed rate limit policy due to internal error"
+                                        pagination:
+                                            totalCount: 1
+                                            page: 1
+                                            perPage: 20
+                                            pageCount: 1
+                                            pageItemsCount: 1
+                                empty-result:
+                                    summary: No logs match (empty page)
+                                    value:
+                                        data: []
+                                        pagination:
+                                            totalCount: 0
+                                            page: 1
+                                            perPage: 20
+                                            pageCount: 0
+                                            pageItemsCount: 0
+                "400":
+                    description: |
+                        A filter condition is invalid. Possible causes:
+                        - Unknown filter name (`observability.filter.unknown_name`)
+                        - Filter does not apply to the LOGS signal (`observability.filter.signal_mismatch`)
+                        - Filter is valid for LOGS but not yet supported by log search (`observability.filter.search_translation_not_supported`)
+                        - `from` is after `to` in the time range
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/Error"
+                            examples:
+                                unknown-filter:
+                                    summary: Unknown filter name
+                                    value:
+                                        httpStatus: 400
+                                        message: "Filter 'UNKNOWN_FILTER' is not supported by this backend"
+                                        technicalCode: "observability.filter.unknown_name"
+                                signal-mismatch:
+                                    summary: Filter not applicable to LOGS signal
+                                    value:
+                                        httpStatus: 400
+                                        message: "Filter 'GATEWAY' does not apply to signal LOGS"
+                                        technicalCode: "observability.filter.signal_mismatch"
+                                search-translation-not-supported:
+                                    summary: Filter valid for LOGS but not yet translated by log search
+                                    value:
+                                        httpStatus: 400
+                                        message: "Filter 'HTTP_STATUS_CODE_GROUP' is not yet supported for log search"
+                                        technicalCode: "observability.filter.search_translation_not_supported"
+                                invalid-time-range:
+                                    summary: Invalid time range (from > to)
+                                    value:
+                                        httpStatus: 400
+                                        message: "Invalid time range: 'from' must be before 'to'."
+                "403":
+                    description: The caller cannot read observability data in this environment (missing `ENVIRONMENT_DASHBOARD:READ` or `ENVIRONMENT_API:READ` permission).
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/Error"
+                            example:
+                                httpStatus: 403
+                                message: "Insufficient permissions to access observability data."
+
 components:
     securitySchemes:
         CookieAuth:
@@ -387,7 +624,7 @@ components:
         FilterOperator:
             type: string
             description: Comparison operator supported by a filter.
-            enum: [EQ, IN, GTE, LTE]
+            enum: [EQ, IN, NOT_IN, GTE, LTE]
 
         EnumValue:
             type: object
@@ -567,6 +804,207 @@ components:
                     type: array
                     items:
                         $ref: "#/components/schemas/ResolveFilterLabelsResponseEntry"
+
+        SearchLogsRequest:
+            type: object
+            description: Request body for the logs search endpoint.
+            properties:
+                timeRange:
+                    $ref: "#/components/schemas/TimeRange"
+                filters:
+                    type: array
+                    description: Filter conditions to apply. Validated against the LOGS signal catalog.
+                    items:
+                        $ref: "#/components/schemas/FilterCondition"
+
+        TimeRange:
+            type: object
+            description: |
+                ISO-8601 time window. Both bounds are optional; omitting either defers to server
+                defaults (no constraint on that side). When both are provided, `from` must be
+                before `to` — otherwise the server returns 400.
+            properties:
+                from:
+                    type: string
+                    format: date-time
+                    description: Start of the time window (inclusive).
+                    example: "2026-06-10T00:00:00Z"
+                to:
+                    type: string
+                    format: date-time
+                    description: End of the time window (inclusive).
+                    example: "2026-06-11T00:00:00Z"
+
+        FilterCondition:
+            type: object
+            description: |
+                A single filter condition. `operator` is uppercase (`EQ`, `IN`, `GTE`, `LTE`).
+                `value` is a scalar string for `EQ`/`GTE`/`LTE`, or an array of strings for `IN`.
+            required: [name, operator, value]
+            properties:
+                name:
+                    type: string
+                    description: Canonical filter name from the catalog.
+                    example: HTTP_STATUS
+                operator:
+                    $ref: "#/components/schemas/FilterOperator"
+                value:
+                    description: Scalar for EQ/GTE/LTE, array of strings for IN/NOT_IN.
+                    oneOf:
+                        - type: string
+                        - type: array
+                          items:
+                              type: string
+                    example: "200"
+
+        LogEntry:
+            type: object
+            description: |
+                Light log row from the `v4-metrics` Elasticsearch index. Fields are enriched
+                server-side with display names so the UI can render without additional round-trips.
+                Null fields are omitted from the JSON response (`@JsonInclude(NON_NULL)`).
+            properties:
+                apiId:
+                    type: string
+                    description: Unique identifier of the API that handled the request.
+                    example: "67e246cb-ab02-4da4-8f47-f9fa3e061d6b"
+                apiName:
+                    type: string
+                    description: Display name of the API (enriched server-side).
+                    example: "Petstore API"
+                apiType:
+                    type: string
+                    description: API kind as stored in the definition (e.g. `HTTP_PROXY`, `LLM`, `MCP`).
+                    example: "HTTP_PROXY"
+                timestamp:
+                    type: string
+                    format: date-time
+                    description: ISO-8601 instant the request was received by the gateway.
+                    example: "2026-06-10T14:32:01Z"
+                requestId:
+                    type: string
+                    description: Unique identifier of the gateway request.
+                    example: "req-abc-123"
+                method:
+                    type: string
+                    description: HTTP method of the client request.
+                    example: "GET"
+                clientIdentifier:
+                    type: string
+                    description: Client identifier extracted by the gateway (e.g. subscription id, IP, header value).
+                planId:
+                    type: string
+                    description: Identifier of the plan the request was matched to.
+                    example: "plan-001"
+                planName:
+                    type: string
+                    description: Display name of the plan (enriched server-side).
+                    example: "Gold"
+                applicationId:
+                    type: string
+                    description: Identifier of the consuming application.
+                    example: "app-001"
+                applicationName:
+                    type: string
+                    description: Display name of the application (enriched server-side).
+                    example: "Mobile App"
+                transactionId:
+                    type: string
+                    description: Correlation id shared across chained requests in the same transaction.
+                    example: "txn-xyz-789"
+                status:
+                    type: integer
+                    description: HTTP status code returned to the client.
+                    example: 200
+                requestEnded:
+                    type: boolean
+                    description: Whether the full request/response cycle completed.
+                gatewayResponseTime:
+                    type: integer
+                    description: Total response time measured by the gateway, in milliseconds.
+                    example: 42
+                gateway:
+                    type: string
+                    description: Identifier of the gateway instance that processed the request.
+                    example: "gw-eu-1"
+                gatewayHostname:
+                    type: string
+                    description: Hostname of the gateway instance (enriched server-side).
+                    example: "gateway-eu-west-1.example.com"
+                uri:
+                    type: string
+                    description: Request URI path.
+                    example: "/pets/42"
+                endpoint:
+                    type: string
+                    description: Backend endpoint the request was proxied to.
+                message:
+                    type: string
+                    description: Error or diagnostic message attached to the log entry.
+                errorKey:
+                    type: string
+                    description: Machine-readable error key (e.g. `CORS_PREFLIGHT_FAILED`, `RATE_LIMIT_TOO_MANY_REQUESTS`).
+                errorComponentName:
+                    type: string
+                    description: Name of the component (policy, connector) that produced the error.
+                errorComponentType:
+                    type: string
+                    description: Type of the component that produced the error (e.g. `policy`, `connector`).
+                warnings:
+                    type: array
+                    description: Diagnostic warnings from policies that did not interrupt the request flow.
+                    items:
+                        $ref: "#/components/schemas/LogEntryWarning"
+                additionalMetrics:
+                    type: object
+                    description: Extra metrics attached by plugins or custom policies.
+                    additionalProperties: true
+                mcpMethod:
+                    type: string
+                    description: MCP method name (present only for `MCP` API type requests).
+                    example: "tools/list"
+                apiProductId:
+                    type: string
+                    description: Identifier of the API product the API belongs to (`null` for standalone APIs).
+                apiProductName:
+                    type: string
+                    description: Display name of the API product (enriched server-side). Returns `"Standalone API"` when the API has no product.
+                    example: "Standalone API"
+
+        LogEntryWarning:
+            type: object
+            description: |
+                A diagnostic warning attached to a log entry. Warnings are produced by policies
+                or connectors that encountered an issue but did not interrupt the request flow
+                (e.g. rate-limit bypass due to internal error).
+            properties:
+                componentType:
+                    type: string
+                    description: Type of the component that raised the warning (e.g. `policy`, `connector`).
+                    example: "policy"
+                componentName:
+                    type: string
+                    description: Name of the component.
+                    example: "rate-limit"
+                key:
+                    type: string
+                    description: Machine-readable warning key.
+                    example: "RATE_LIMIT_NOT_APPLIED"
+                message:
+                    type: string
+                    description: Human-readable description of what happened.
+                    example: "Request bypassed rate limit policy due to internal error"
+
+        LogsSearchResponse:
+            type: object
+            required: [data, pagination]
+            properties:
+                data:
+                    type: array
+                    items:
+                        $ref: "#/components/schemas/LogEntry"
+                pagination:
+                    $ref: "#/components/schemas/Pagination"
 
         Error:
             type: object

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/test/java/io/gravitee/gamma/rest/core/observability/logs/use_case/SearchObservabilityLogsUseCaseTest.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/test/java/io/gravitee/gamma/rest/core/observability/logs/use_case/SearchObservabilityLogsUseCaseTest.java
@@ -1,0 +1,332 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gamma.rest.core.observability.logs.use_case;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.apim.core.exception.ValidationDomainException;
+import io.gravitee.gamma.rest.core.observability.filter.exception.UnsupportedObservabilityFilterException;
+import io.gravitee.gamma.rest.core.observability.filter.model.ApiType;
+import io.gravitee.gamma.rest.core.observability.filter.model.FilterCondition;
+import io.gravitee.gamma.rest.core.observability.filter.model.FilterOperator;
+import io.gravitee.gamma.rest.core.observability.filter.model.FilterSpec;
+import io.gravitee.gamma.rest.core.observability.filter.model.FilterType;
+import io.gravitee.gamma.rest.core.observability.filter.model.Signal;
+import io.gravitee.gamma.rest.core.observability.filter.port.service_provider.FilterRegistry;
+import io.gravitee.gamma.rest.core.observability.logs.domain_service.AccessibleApiScopeDomainService;
+import io.gravitee.gamma.rest.core.observability.logs.model.LogEntry;
+import io.gravitee.gamma.rest.core.observability.logs.model.LogsPage;
+import io.gravitee.gamma.rest.core.observability.logs.model.LogsSearchQuery;
+import io.gravitee.gamma.rest.core.observability.logs.port.service_provider.ObservabilityLogsDataPort;
+import io.gravitee.gamma.rest.core.observability.logs.port.service_provider.ObservabilityLogsDataPort.AccessibleApi;
+import java.time.Instant;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class SearchObservabilityLogsUseCaseTest {
+
+    private static final String ORG_ID = "org-1";
+    private static final String ENV_ID = "env-1";
+
+    @Mock
+    private ObservabilityLogsDataPort logsDataPort;
+
+    @Mock
+    private FilterRegistry filterRegistry;
+
+    private AccessibleApiScopeDomainService accessibleApiScope;
+
+    private SearchObservabilityLogsUseCase useCase;
+
+    @BeforeEach
+    void setUp() {
+        accessibleApiScope = new AccessibleApiScopeDomainService();
+        useCase = new SearchObservabilityLogsUseCase(logsDataPort, filterRegistry, accessibleApiScope);
+
+        when(filterRegistry.getFilters(any(), any())).thenReturn(
+            List.of(
+                new FilterSpec(
+                    "API",
+                    "API",
+                    FilterType.KEYWORD,
+                    List.of(FilterOperator.EQ, FilterOperator.IN),
+                    null,
+                    null,
+                    Set.of(Signal.LOGS, Signal.ANALYTICS),
+                    io.gravitee.gamma.rest.core.observability.filter.model.ApiType.ALL
+                ),
+                new FilterSpec(
+                    "HTTP_STATUS",
+                    "Status Code",
+                    FilterType.NUMBER,
+                    List.of(FilterOperator.EQ, FilterOperator.GTE, FilterOperator.LTE),
+                    null,
+                    new FilterSpec.Range(100, 599),
+                    Set.of(Signal.LOGS, Signal.ANALYTICS),
+                    Set.of(io.gravitee.gamma.rest.core.observability.filter.model.ApiType.HTTP_PROXY)
+                ),
+                new FilterSpec(
+                    "APPLICATION",
+                    "Application",
+                    FilterType.KEYWORD,
+                    List.of(FilterOperator.EQ, FilterOperator.IN),
+                    null,
+                    null,
+                    Set.of(Signal.LOGS, Signal.ANALYTICS),
+                    io.gravitee.gamma.rest.core.observability.filter.model.ApiType.ALL
+                ),
+                new FilterSpec(
+                    "GATEWAY",
+                    "Gateway",
+                    FilterType.KEYWORD,
+                    List.of(FilterOperator.EQ, FilterOperator.IN),
+                    null,
+                    null,
+                    Set.of(Signal.ANALYTICS),
+                    io.gravitee.gamma.rest.core.observability.filter.model.ApiType.ALL
+                )
+            )
+        );
+    }
+
+    @Nested
+    class Scoping {
+
+        @Test
+        void should_return_empty_page_when_no_accessible_apis() {
+            when(logsDataPort.loadAccessibleApis(ORG_ID, ENV_ID)).thenReturn(List.of());
+
+            var output = useCase.execute(new SearchObservabilityLogsUseCase.Input(ORG_ID, ENV_ID, List.of(), null, null, 1, 20));
+
+            assertThat(output.data()).isEqualTo(LogsPage.EMPTY);
+            assertThat(output.page()).isEqualTo(1);
+            assertThat(output.perPage()).isEqualTo(20);
+            verify(logsDataPort).loadAccessibleApis(ORG_ID, ENV_ID);
+        }
+
+        @Test
+        void should_filter_accessible_apis_by_supported_api_types() {
+            when(logsDataPort.loadAccessibleApis(ORG_ID, ENV_ID)).thenReturn(
+                List.of(
+                    new AccessibleApi("api-proxy", "Proxy API", ApiType.HTTP_PROXY),
+                    new AccessibleApi("api-message", "Message API", ApiType.MESSAGE),
+                    new AccessibleApi("api-llm", "LLM API", ApiType.LLM)
+                )
+            );
+            when(logsDataPort.searchLogs(eq(ORG_ID), eq(ENV_ID), any())).thenReturn(LogsPage.EMPTY);
+
+            useCase.execute(new SearchObservabilityLogsUseCase.Input(ORG_ID, ENV_ID, List.of(), null, null, 1, 20));
+
+            var captor = ArgumentCaptor.forClass(LogsSearchQuery.class);
+            verify(logsDataPort).searchLogs(eq(ORG_ID), eq(ENV_ID), captor.capture());
+            assertThat(captor.getValue().apiIds()).containsExactlyInAnyOrder("api-proxy", "api-llm");
+        }
+
+        @Test
+        void should_intersect_user_api_filter_with_accessible_apis() {
+            when(logsDataPort.loadAccessibleApis(ORG_ID, ENV_ID)).thenReturn(
+                List.of(new AccessibleApi("api-1", "API 1", ApiType.HTTP_PROXY), new AccessibleApi("api-2", "API 2", ApiType.HTTP_PROXY))
+            );
+            when(logsDataPort.searchLogs(eq(ORG_ID), eq(ENV_ID), any())).thenReturn(LogsPage.EMPTY);
+
+            var filters = List.of(new FilterCondition("API", FilterOperator.EQ, List.of("api-1")));
+            useCase.execute(new SearchObservabilityLogsUseCase.Input(ORG_ID, ENV_ID, filters, null, null, 1, 20));
+
+            var captor = ArgumentCaptor.forClass(LogsSearchQuery.class);
+            verify(logsDataPort).searchLogs(eq(ORG_ID), eq(ENV_ID), captor.capture());
+            assertThat(captor.getValue().apiIds()).containsExactly("api-1");
+        }
+
+        @Test
+        void should_return_empty_page_when_user_api_filter_excludes_all_accessible_apis() {
+            when(logsDataPort.loadAccessibleApis(ORG_ID, ENV_ID)).thenReturn(
+                List.of(new AccessibleApi("api-1", "API 1", ApiType.HTTP_PROXY))
+            );
+
+            var filters = List.of(new FilterCondition("API", FilterOperator.EQ, List.of("api-unknown")));
+            var output = useCase.execute(new SearchObservabilityLogsUseCase.Input(ORG_ID, ENV_ID, filters, null, null, 1, 20));
+
+            assertThat(output.data()).isEqualTo(LogsPage.EMPTY);
+        }
+    }
+
+    @Nested
+    class FilterValidation {
+
+        @Test
+        void should_reject_unknown_filter_name() {
+            var filters = List.of(new FilterCondition("UNKNOWN_FILTER", FilterOperator.EQ, List.of("val")));
+
+            assertThatThrownBy(() ->
+                useCase.execute(new SearchObservabilityLogsUseCase.Input(ORG_ID, ENV_ID, filters, null, null, 1, 20))
+            ).isInstanceOf(UnsupportedObservabilityFilterException.class);
+            verifyNoInteractions(logsDataPort);
+        }
+
+        @Test
+        void should_reject_filter_whose_signals_exclude_logs() {
+            var filters = List.of(new FilterCondition("GATEWAY", FilterOperator.EQ, List.of("gw-1")));
+
+            assertThatThrownBy(() ->
+                useCase.execute(new SearchObservabilityLogsUseCase.Input(ORG_ID, ENV_ID, filters, null, null, 1, 20))
+            ).isInstanceOf(UnsupportedObservabilityFilterException.class);
+            verifyNoInteractions(logsDataPort);
+        }
+
+        @Test
+        void should_accept_valid_logs_filter() {
+            when(logsDataPort.loadAccessibleApis(ORG_ID, ENV_ID)).thenReturn(
+                List.of(new AccessibleApi("api-1", "API 1", ApiType.HTTP_PROXY))
+            );
+            when(logsDataPort.searchLogs(eq(ORG_ID), eq(ENV_ID), any())).thenReturn(LogsPage.EMPTY);
+
+            var filters = List.of(new FilterCondition("HTTP_STATUS", FilterOperator.EQ, List.of("200")));
+            var output = useCase.execute(new SearchObservabilityLogsUseCase.Input(ORG_ID, ENV_ID, filters, null, null, 1, 20));
+
+            assertThat(output.data()).isNotNull();
+        }
+    }
+
+    @Nested
+    class TimeRange {
+
+        @Test
+        void should_reject_invalid_time_range() {
+            var from = Instant.parse("2026-06-11T12:00:00Z");
+            var to = Instant.parse("2026-06-10T12:00:00Z");
+
+            assertThatThrownBy(() ->
+                useCase.execute(new SearchObservabilityLogsUseCase.Input(ORG_ID, ENV_ID, List.of(), from, to, 1, 20))
+            ).isInstanceOf(ValidationDomainException.class);
+
+            verifyNoInteractions(logsDataPort);
+        }
+
+        @Test
+        void should_pass_time_range_to_port() {
+            when(logsDataPort.loadAccessibleApis(ORG_ID, ENV_ID)).thenReturn(
+                List.of(new AccessibleApi("api-1", "API 1", ApiType.HTTP_PROXY))
+            );
+            when(logsDataPort.searchLogs(eq(ORG_ID), eq(ENV_ID), any())).thenReturn(LogsPage.EMPTY);
+
+            var from = Instant.parse("2026-06-10T00:00:00Z");
+            var to = Instant.parse("2026-06-11T00:00:00Z");
+            useCase.execute(new SearchObservabilityLogsUseCase.Input(ORG_ID, ENV_ID, List.of(), from, to, 1, 20));
+
+            var captor = ArgumentCaptor.forClass(LogsSearchQuery.class);
+            verify(logsDataPort).searchLogs(eq(ORG_ID), eq(ENV_ID), captor.capture());
+            assertThat(captor.getValue().from()).isEqualTo(from.toEpochMilli());
+            assertThat(captor.getValue().to()).isEqualTo(to.toEpochMilli());
+        }
+    }
+
+    @Nested
+    class DefaultEntrypointScoping {
+
+        @Test
+        void should_inject_default_entrypoint_filter_when_none_provided() {
+            when(logsDataPort.loadAccessibleApis(ORG_ID, ENV_ID)).thenReturn(
+                List.of(new AccessibleApi("api-1", "API 1", ApiType.HTTP_PROXY))
+            );
+            when(logsDataPort.searchLogs(eq(ORG_ID), eq(ENV_ID), any())).thenReturn(LogsPage.EMPTY);
+
+            useCase.execute(new SearchObservabilityLogsUseCase.Input(ORG_ID, ENV_ID, List.of(), null, null, 1, 20));
+
+            var captor = ArgumentCaptor.forClass(LogsSearchQuery.class);
+            verify(logsDataPort).searchLogs(eq(ORG_ID), eq(ENV_ID), captor.capture());
+            var entrypointCondition = captor
+                .getValue()
+                .conditions()
+                .stream()
+                .filter(c -> "ENTRYPOINT".equals(c.name()))
+                .findFirst();
+            assertThat(entrypointCondition).isPresent();
+            assertThat(entrypointCondition.get().values()).containsExactlyInAnyOrder(
+                "http-get",
+                "http-post",
+                "http-proxy",
+                "llm-proxy",
+                "mcp-proxy"
+            );
+        }
+    }
+
+    @Nested
+    class PaginationDefaults {
+
+        @Test
+        void should_use_default_page_and_perPage_when_zero_or_negative() {
+            when(logsDataPort.loadAccessibleApis(ORG_ID, ENV_ID)).thenReturn(
+                List.of(new AccessibleApi("api-1", "API 1", ApiType.HTTP_PROXY))
+            );
+            when(logsDataPort.searchLogs(eq(ORG_ID), eq(ENV_ID), any())).thenReturn(LogsPage.EMPTY);
+
+            var output = useCase.execute(new SearchObservabilityLogsUseCase.Input(ORG_ID, ENV_ID, List.of(), null, null, 0, -1));
+
+            var captor = ArgumentCaptor.forClass(LogsSearchQuery.class);
+            verify(logsDataPort).searchLogs(eq(ORG_ID), eq(ENV_ID), captor.capture());
+            assertThat(captor.getValue().page()).isEqualTo(1);
+            assertThat(captor.getValue().perPage()).isEqualTo(20);
+            assertThat(output.page()).isEqualTo(1);
+            assertThat(output.perPage()).isEqualTo(20);
+        }
+
+        @Test
+        void should_use_default_page_and_perPage_when_null() {
+            when(logsDataPort.loadAccessibleApis(ORG_ID, ENV_ID)).thenReturn(
+                List.of(new AccessibleApi("api-1", "API 1", ApiType.HTTP_PROXY))
+            );
+            when(logsDataPort.searchLogs(eq(ORG_ID), eq(ENV_ID), any())).thenReturn(LogsPage.EMPTY);
+
+            var output = useCase.execute(new SearchObservabilityLogsUseCase.Input(ORG_ID, ENV_ID, List.of(), null, null, null, null));
+
+            assertThat(output.page()).isEqualTo(1);
+            assertThat(output.perPage()).isEqualTo(20);
+        }
+
+        @Test
+        void should_clamp_perPage_to_max() {
+            when(logsDataPort.loadAccessibleApis(ORG_ID, ENV_ID)).thenReturn(
+                List.of(new AccessibleApi("api-1", "API 1", ApiType.HTTP_PROXY))
+            );
+            when(logsDataPort.searchLogs(eq(ORG_ID), eq(ENV_ID), any())).thenReturn(LogsPage.EMPTY);
+
+            var output = useCase.execute(new SearchObservabilityLogsUseCase.Input(ORG_ID, ENV_ID, List.of(), null, null, 1, 500));
+
+            var captor = ArgumentCaptor.forClass(LogsSearchQuery.class);
+            verify(logsDataPort).searchLogs(eq(ORG_ID), eq(ENV_ID), captor.capture());
+            assertThat(captor.getValue().perPage()).isEqualTo(100);
+            assertThat(output.perPage()).isEqualTo(100);
+        }
+    }
+}

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/test/java/io/gravitee/gamma/rest/infra/adapter/ObservabilityLogsDataPortAdapterTest.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/test/java/io/gravitee/gamma/rest/infra/adapter/ObservabilityLogsDataPortAdapterTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gamma.rest.infra.adapter;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import io.gravitee.apim.core.api_product.query_service.ApiProductQueryService;
+import io.gravitee.apim.core.application.crud_service.ApplicationCrudService;
+import io.gravitee.apim.core.gateway.query_service.InstanceQueryService;
+import io.gravitee.apim.core.log.crud_service.ConnectionLogsCrudService;
+import io.gravitee.apim.core.plan.crud_service.PlanCrudService;
+import io.gravitee.apim.core.user.domain_service.UserContextLoader;
+import io.gravitee.gamma.rest.core.observability.filter.exception.UnsupportedObservabilityFilterException;
+import io.gravitee.gamma.rest.core.observability.filter.model.FilterCondition;
+import io.gravitee.gamma.rest.core.observability.filter.model.FilterOperator;
+import io.gravitee.gamma.rest.core.observability.logs.model.LogsSearchQuery;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class ObservabilityLogsDataPortAdapterTest {
+
+    @Mock
+    private ConnectionLogsCrudService connectionLogsCrudService;
+
+    @Mock
+    private UserContextLoader userContextLoader;
+
+    @Mock
+    private PlanCrudService planCrudService;
+
+    @Mock
+    private ApplicationCrudService applicationCrudService;
+
+    @Mock
+    private InstanceQueryService instanceQueryService;
+
+    @Mock
+    private ApiProductQueryService apiProductQueryService;
+
+    private ObservabilityLogsDataPortAdapter adapter;
+
+    @BeforeEach
+    void setUp() {
+        adapter = new ObservabilityLogsDataPortAdapter(
+            connectionLogsCrudService,
+            userContextLoader,
+            planCrudService,
+            applicationCrudService,
+            instanceQueryService,
+            apiProductQueryService
+        );
+    }
+
+    @Test
+    void should_reject_filter_not_translatable_to_log_search() {
+        var query = LogsSearchQuery.builder()
+            .apiIds(Set.of("api-1"))
+            .apiNamesById(Map.of("api-1", "API 1"))
+            .conditions(List.of(new FilterCondition("HTTP_STATUS_CODE_GROUP", FilterOperator.IN, List.of("2XX"))))
+            .page(1)
+            .perPage(20)
+            .build();
+
+        assertThatThrownBy(() -> adapter.searchLogs("org-1", "env-1", query))
+            .isInstanceOf(UnsupportedObservabilityFilterException.class)
+            .hasMessageContaining("HTTP_STATUS_CODE_GROUP");
+
+        verifyNoInteractions(connectionLogsCrudService);
+    }
+}

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/test/java/io/gravitee/gamma/rest/resource/observability/logs/LogsResourceTest.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/test/java/io/gravitee/gamma/rest/resource/observability/logs/LogsResourceTest.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gamma.rest.resource.observability.logs;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.gravitee.common.http.HttpStatusCode;
+import io.gravitee.gamma.rest.core.observability.logs.model.LogEntry;
+import io.gravitee.gamma.rest.core.observability.logs.model.LogsPage;
+import io.gravitee.gamma.rest.core.observability.logs.use_case.SearchObservabilityLogsUseCase;
+import io.gravitee.gamma.rest.resource.AbstractResourceTest;
+import io.gravitee.gamma.rest.resource.observability.logs.LogsResourceTest.LogsTestConfiguration;
+import io.gravitee.gamma.rest.spring.ResourceContextConfiguration;
+import io.gravitee.rest.api.model.EnvironmentEntity;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.client.Entity;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.ContextConfiguration;
+
+@ContextConfiguration(classes = { ResourceContextConfiguration.class, LogsTestConfiguration.class })
+class LogsResourceTest extends AbstractResourceTest {
+
+    private static final String ENVIRONMENT = "fake-env";
+
+    @Inject
+    private SearchObservabilityLogsUseCase searchLogsUseCase;
+
+    @Override
+    protected String contextPath() {
+        return "/organizations/" + ORGANIZATION + "/environments/" + ENVIRONMENT + "/observability/logs";
+    }
+
+    @BeforeEach
+    void prepareEnvironment() {
+        EnvironmentEntity env = new EnvironmentEntity();
+        env.setId(ENVIRONMENT);
+        env.setOrganizationId(ORGANIZATION);
+        when(environmentService.findByOrgAndIdOrHrid(ORGANIZATION, ENVIRONMENT)).thenReturn(env);
+    }
+
+    @AfterEach
+    void resetUseCases() {
+        reset(searchLogsUseCase);
+    }
+
+    @Nested
+    class SearchLogs {
+
+        @Test
+        void should_return_200_with_paginated_envelope() {
+            var entry = LogEntry.builder()
+                .apiId("api-1")
+                .apiName("Petstore")
+                .requestId("req-1")
+                .timestamp(Instant.parse("2026-06-10T10:00:00Z"))
+                .status(200)
+                .method("GET")
+                .uri("/pets")
+                .gatewayResponseTime(42)
+                .build();
+            when(searchLogsUseCase.execute(any())).thenReturn(
+                new SearchObservabilityLogsUseCase.Output(new LogsPage(List.of(entry), 1), 1, 20)
+            );
+
+            Response response = rootTarget("search").request().post(Entity.entity(Map.of(), MediaType.APPLICATION_JSON_TYPE));
+
+            assertThat(response.getStatus()).isEqualTo(HttpStatusCode.OK_200);
+            JsonNode body = response.readEntity(JsonNode.class);
+            assertThat(body.get("data")).hasSize(1);
+            assertThat(body.get("data").get(0).get("apiId").asText()).isEqualTo("api-1");
+            assertThat(body.get("data").get(0).get("apiName").asText()).isEqualTo("Petstore");
+            assertThat(body.get("data").get(0).get("status").asInt()).isEqualTo(200);
+            assertThat(body.get("pagination").get("totalCount").asLong()).isEqualTo(1L);
+            assertThat(body.get("pagination").get("page").asInt()).isEqualTo(1);
+        }
+
+        @Test
+        void should_forward_page_and_perPage_to_use_case() {
+            when(searchLogsUseCase.execute(any())).thenReturn(new SearchObservabilityLogsUseCase.Output(LogsPage.EMPTY, 2, 5));
+
+            rootTarget("search")
+                .queryParam("page", 2)
+                .queryParam("perPage", 5)
+                .request()
+                .post(Entity.entity(Map.of(), MediaType.APPLICATION_JSON_TYPE));
+
+            var captor = ArgumentCaptor.forClass(SearchObservabilityLogsUseCase.Input.class);
+            Mockito.verify(searchLogsUseCase).execute(captor.capture());
+            assertThat(captor.getValue().page()).isEqualTo(2);
+            assertThat(captor.getValue().perPage()).isEqualTo(5);
+        }
+
+        @Test
+        void should_forward_filters_and_time_range_to_use_case() {
+            when(searchLogsUseCase.execute(any())).thenReturn(new SearchObservabilityLogsUseCase.Output(LogsPage.EMPTY, 1, 20));
+
+            var body = Map.of(
+                "timeRange",
+                Map.of("from", "2026-06-10T00:00:00Z", "to", "2026-06-11T00:00:00Z"),
+                "filters",
+                List.of(Map.of("name", "HTTP_STATUS", "operator", "EQ", "value", "200"))
+            );
+
+            rootTarget("search").request().post(Entity.entity(body, MediaType.APPLICATION_JSON_TYPE));
+
+            var captor = ArgumentCaptor.forClass(SearchObservabilityLogsUseCase.Input.class);
+            verify(searchLogsUseCase).execute(captor.capture());
+            assertThat(captor.getValue().from()).isNotNull();
+            assertThat(captor.getValue().to()).isNotNull();
+            assertThat(captor.getValue().filters()).hasSize(1);
+            assertThat(captor.getValue().filters().getFirst().name()).isEqualTo("HTTP_STATUS");
+        }
+
+        @Test
+        void should_return_200_with_empty_body() {
+            when(searchLogsUseCase.execute(any())).thenReturn(new SearchObservabilityLogsUseCase.Output(LogsPage.EMPTY, 1, 20));
+
+            Response response = rootTarget("search").request().post(Entity.entity("", MediaType.APPLICATION_JSON_TYPE));
+
+            assertThat(response.getStatus()).isEqualTo(HttpStatusCode.OK_200);
+        }
+
+        @Test
+        void should_return_403_when_caller_cannot_read_observability() {
+            when(permissionService.hasPermission(any(), any(), any(), any())).thenReturn(false);
+
+            Response response = rootTarget("search").request().post(Entity.entity(Map.of(), MediaType.APPLICATION_JSON_TYPE));
+
+            assertThat(response.getStatus()).isEqualTo(HttpStatusCode.FORBIDDEN_403);
+            verifyNoInteractions(searchLogsUseCase);
+        }
+    }
+
+    @Configuration
+    static class LogsTestConfiguration {
+
+        @Bean
+        SearchObservabilityLogsUseCase searchObservabilityLogsUseCase() {
+            return mock(SearchObservabilityLogsUseCase.class);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Add an environment-wide logs search endpoint (`POST /gamma/.../observability/logs/search`) to the Gamma REST API, implementing [GMA-423](https://gravitee.atlassian.net/browse/GMA-423). This brings paginated, RBAC-scoped, filter-aware log search backed by the `v4-metrics` index, with display-name enrichment for APIs, plans, applications, gateways, and API products.

<img width="1514" height="954" alt="Screenshot 2026-06-15 at 14 12 17" src="https://github.com/user-attachments/assets/db2242ef-c6d7-42ad-97cd-6abef2d65a10" />
<img width="961" height="534" alt="Screenshot 2026-06-15 at 14 12 34" src="https://github.com/user-attachments/assets/ceba0558-78be-4083-9af3-55dec2f1fe2f" />
<img width="736" height="806" alt="Screenshot 2026-06-15 at 15 33 14" src="https://github.com/user-attachments/assets/27fb9b93-ea8b-4f60-a37d-765faba7ccd1" />


## Changes

### Core layer (`core/observability/logs/`)
- **Domain models**: `LogEntry`, `LogEntryWarning`, `LogsPage`, `LogsSearchQuery` — light log row records matching the v4-metrics index fields
- **Port**: `ObservabilityLogsDataPort` — abstracts RBAC-scoped API loading and log search
- **Domain service**: `AccessibleApiScopeDomainService` — computes the effective API scope by intersecting RBAC-accessible APIs, signal-relevant API types, and optional user-supplied API filter. Reusable for analytics/traces
- **Use case**: `SearchObservabilityLogsUseCase` — validates filters against the unified filter registry (LOGS signal), validates time range, applies default entrypoint scoping, delegates search to the data port. Pagination resolved/clamped (`MAX_PER_PAGE=100`), exposed in `Output(data, page, perPage)` following the pattern established in `GetObservabilityFilterValuesUseCase`
- **Exception**: `UnsupportedObservabilityFilterException` — added `signalMismatch()` and `searchTranslationNotSupported()` static factory methods for explicit rejection of untranslatable filters

### Infrastructure layer
- **Adapter**: `ObservabilityLogsDataPortAdapter` — delegates to `ConnectionLogsCrudService`, `UserContextLoader`, enriches results with plan/app/gateway/apiProduct names in batch. Maps `io.gravitee.definition.model.v4.ApiType` → Gamma `ApiType` with exhaustive switch. **Explicitly rejects** untranslatable filter conditions (e.g. `HTTP_STATUS_CODE_GROUP`) with a descriptive 400 error instead of silently dropping them
- **Config**: `GammaLogsConfiguration` — Spring wiring with `@ComponentScan` for `@UseCase` + `@DomainService`, `@Bean` for the adapter. Imported from `StandaloneConfiguration`

### REST layer (`resources/observability/logs/`)
- **Resource**: `LogsResource` — `POST /search?page=&perPage=` with coarse env-level permission guard, delegates to use case
- **DTOs**: `SearchLogsRequestDto`, `FilterConditionDto`, `LogEntryDto` — wire shapes with `@JsonInclude(NON_NULL)`, polymorphic filter value normalization
- **Mounting**: `GammaRootResource` sub-resource at `/observability/logs`, registered in `GammaModuleApplication`

### OpenAPI documentation
- **Spec**: Added `Logs` tag and `POST /logs/search` path to `openapi-observability.yaml` with full request/response schemas (`SearchLogsRequest`, `LogEntry`, `LogEntryWarning`, `LogsSearchResponse`), enriched field descriptions, and error examples (400 for signal mismatch, search translation not supported; 403 for insufficient permissions)
- **Filter operator**: Added `NOT_IN` to `FilterOperator` enum in the spec

### Tests
- **Unit**: `SearchObservabilityLogsUseCaseTest` — 15 tests covering scoping, filter validation, time range, default entrypoint injection, pagination defaults/clamping/null handling
- **REST**: `LogsResourceTest` — 5 tests covering 200 envelope, param forwarding, filter/time forwarding, empty body, 403
- **Adapter**: `ObservabilityLogsDataPortAdapterTest` — verifies explicit rejection of untranslatable filter conditions

## Test plan

- [ ] `mvn -pl gravitee-gamma/gravitee-gamma-rest-api clean test` — 124 tests pass, 0 failures
- [ ] ArchUnit `CoreRulesTest` passes — no forbidden core→infra dependencies
- [ ] Verify `POST /gamma/.../observability/logs/search` returns paginated logs with filter conditions
- [ ] Verify RBAC scoping: non-admin user only sees logs from APIs they have access to
- [ ] Verify `perPage > 100` is clamped to 100
- [ ] Verify default entrypoint scoping matches analytics dashboard totals
- [ ] Verify untranslatable filters (e.g. `HTTP_STATUS_CODE_GROUP`) return 400 with descriptive error

Refs GMA-423

[GMA-423]: https://gravitee.atlassian.net/browse/GMA-423?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ