### PR TITLE
Ext 145 frontend potral nav items action propagation

### DIFF
--- a/gravitee-apim-console-webui/src/management/api-products/configuration/api-product-configuration.component.spec.ts
+++ b/gravitee-apim-console-webui/src/management/api-products/configuration/api-product-configuration.component.spec.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, fakeAsync, flush, TestBed, tick } from '@angular/core/testing';
 import { HarnessLoader } from '@angular/cdk/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { MatButtonHarness } from '@angular/material/button/testing';
@@ -22,7 +22,6 @@ import { MatIconTestingModule } from '@angular/material/icon/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { HttpTestingController } from '@angular/common/http/testing';
 import { ActivatedRoute, Router } from '@angular/router';
-import { fakeAsync, flush, tick } from '@angular/core/testing';
 import { of } from 'rxjs';
 import { GioConfirmAndValidateDialogHarness, GioConfirmDialogHarness } from '@gravitee/ui-particles-angular';
 

--- a/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.spec.ts
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.spec.ts
@@ -34,6 +34,7 @@ import { PortalNavigationItemsHarness } from './portal-navigation-items.harness'
 import { SectionEditorDialogHarness } from './section-editor-dialog/section-editor-dialog.harness';
 import { ApiSectionEditorDialogHarness } from './api-section-editor-dialog/api-section-editor-dialog.harness';
 import { OpenApiConfigDialogHarness } from './openapi-config-dialog/openapi-config-dialog.harness';
+import { PublishNavigationItemDialogHarness } from './publish-navigation-item-dialog/publish-navigation-item-dialog.harness';
 
 import { CONSTANTS_TESTING, GioTestingModule } from '../../shared/testing';
 import { GioTestingPermissionProvider } from '../../shared/components/gio-permission/gio-permission.service';
@@ -1332,8 +1333,8 @@ describe('PortalNavigationItemsComponent', () => {
       it('should unpublish the item when "Unpublish" button is clicked', async () => {
         await harness.clickUnpublishButton();
 
-        const confirmDialog = await rootLoader.getHarness(GioConfirmDialogHarness);
-        await confirmDialog.confirm();
+        const dialog = await rootLoader.getHarness(PublishNavigationItemDialogHarness);
+        await dialog.confirm();
 
         expectPutPortalNavigationItem(
           'nav-item-1',
@@ -1352,8 +1353,8 @@ describe('PortalNavigationItemsComponent', () => {
       it('should unpublish the item from the "More Actions" menu', async () => {
         await harness.unpublishNodeById('nav-item-1');
 
-        const confirmDialog = await rootLoader.getHarness(GioConfirmDialogHarness);
-        await confirmDialog.confirm();
+        const dialog = await rootLoader.getHarness(PublishNavigationItemDialogHarness);
+        await dialog.confirm();
 
         expectPutPortalNavigationItem(
           'nav-item-1',
@@ -1395,8 +1396,9 @@ describe('PortalNavigationItemsComponent', () => {
       it('should publish the item when "Publish" button is clicked', async () => {
         await harness.clickPublishButton();
 
-        const confirmDialog = await rootLoader.getHarness(GioConfirmDialogHarness);
-        await confirmDialog.confirm();
+        const dialog = await rootLoader.getHarness(PublishNavigationItemDialogHarness);
+        expect(await dialog.isPropagationCheckboxVisible()).toBe(false);
+        await dialog.confirm();
 
         expectPutPortalNavigationItem(
           'nav-item-1',
@@ -1412,11 +1414,22 @@ describe('PortalNavigationItemsComponent', () => {
         expectGetPageContent('nav-item-1-content', 'This is the content of Nav Item 1');
       });
 
+      it('should not publish the item when dialog is cancelled', async () => {
+        await harness.clickPublishButton();
+
+        const dialog = await rootLoader.getHarness(PublishNavigationItemDialogHarness);
+        await dialog.cancel();
+
+        httpTestingController.expectNone(
+          request => request.method === 'PUT' && request.url === `${CONSTANTS_TESTING.env.v2BaseURL}/portal-navigation-items/nav-item-1`,
+        );
+      });
+
       it('should publish item when publish action is clicked in More Actions dropdown', async () => {
         await harness.publishNodeById('nav-item-1');
 
-        const confirmDialog = await rootLoader.getHarness(GioConfirmDialogHarness);
-        await confirmDialog.confirm();
+        const dialog = await rootLoader.getHarness(PublishNavigationItemDialogHarness);
+        await dialog.confirm();
 
         expectPutPortalNavigationItem(
           'nav-item-1',
@@ -1447,9 +1460,10 @@ describe('PortalNavigationItemsComponent', () => {
       it('should show dialog and publish folder when confirmed', async () => {
         await harness.publishNodeById('folder-1');
 
-        const confirmDialog = await rootLoader.getHarness(GioConfirmDialogHarness);
-        expect(document.body.textContent).toContain('will also publish all nested documentation and APIs');
-        await confirmDialog.confirm();
+        const dialog = await rootLoader.getHarness(PublishNavigationItemDialogHarness);
+        expect(await dialog.isPropagationCheckboxChecked()).toBe(false);
+        expect(await dialog.getContentText()).toContain('Also publish all nested documentation and APIs');
+        await dialog.confirm();
 
         expectPutPortalNavigationItem(
           'folder-1',
@@ -1458,6 +1472,82 @@ describe('PortalNavigationItemsComponent', () => {
         );
 
         await expectGetNavigationItems(fakePortalNavigationItemsResponse({ items: [unpublishedFolder] }));
+      });
+
+      it('should send propagation query parameter when checkbox is selected', async () => {
+        await harness.publishNodeById('folder-1');
+
+        const dialog = await rootLoader.getHarness(PublishNavigationItemDialogHarness);
+        await dialog.checkPropagationCheckbox();
+        await dialog.confirm();
+
+        expectPutPortalNavigationItem(
+          'folder-1',
+          { ...unpublishedFolder, published: true },
+          fakePortalNavigationFolder({ id: 'folder-1', published: true }),
+          { propagatePublishToChildren: true },
+        );
+
+        await expectGetNavigationItems(fakePortalNavigationItemsResponse({ items: [unpublishedFolder] }));
+      });
+    });
+
+    describe('unpublishing a published folder', () => {
+      const publishedFolder = fakePortalNavigationFolder({
+        id: 'folder-1',
+        title: 'My Folder',
+        published: true,
+      });
+
+      beforeEach(async () => {
+        await expectGetNavigationItems(fakePortalNavigationItemsResponse({ items: [publishedFolder] }));
+      });
+
+      it('should not show propagation checkbox and should unpublish folder when confirmed', async () => {
+        const node = { id: publishedFolder.id, label: publishedFolder.title, type: publishedFolder.type, data: publishedFolder };
+        component.onNodeMenuAction({ action: 'unpublish', itemType: 'FOLDER', node });
+
+        const dialog = await rootLoader.getHarness(PublishNavigationItemDialogHarness);
+        expect(await dialog.isPropagationCheckboxVisible()).toBe(false);
+        expect(await dialog.getContentText()).toContain('will also unpublish all nested documentation and APIs');
+        await dialog.confirm();
+
+        expectPutPortalNavigationItem(
+          'folder-1',
+          { ...publishedFolder, published: false },
+          fakePortalNavigationFolder({ id: 'folder-1', published: false }),
+        );
+
+        await expectGetNavigationItems(fakePortalNavigationItemsResponse({ items: [publishedFolder] }));
+      });
+    });
+
+    describe('publishing an unpublished link', () => {
+      const unpublishedLink = fakePortalNavigationLink({
+        id: 'link-1',
+        title: 'My Link',
+        published: false,
+      });
+
+      beforeEach(async () => {
+        await expectGetNavigationItems(fakePortalNavigationItemsResponse({ items: [unpublishedLink] }));
+      });
+
+      it('should not show propagation checkbox and should publish link when confirmed', async () => {
+        const node = { id: unpublishedLink.id, label: unpublishedLink.title, type: unpublishedLink.type, data: unpublishedLink };
+        component.onNodeMenuAction({ action: 'publish', itemType: 'LINK', node });
+
+        const dialog = await rootLoader.getHarness(PublishNavigationItemDialogHarness);
+        expect(await dialog.isPropagationCheckboxVisible()).toBe(false);
+        await dialog.confirm();
+
+        expectPutPortalNavigationItem(
+          'link-1',
+          { ...unpublishedLink, published: true },
+          fakePortalNavigationLink({ id: 'link-1', published: true }),
+        );
+
+        await expectGetNavigationItems(fakePortalNavigationItemsResponse({ items: [unpublishedLink] }));
       });
     });
 
@@ -1479,9 +1569,9 @@ describe('PortalNavigationItemsComponent', () => {
         expect(openDialogsAfterClick).toHaveLength(1);
         await openDialogsAfterClick[0].confirm();
 
-        const openDialogsAfterDiscard = await rootLoader.getAllHarnesses(GioConfirmDialogHarness);
-        expect(openDialogsAfterDiscard).toHaveLength(1);
-        await openDialogsAfterDiscard[0].confirm();
+        const publishDialogsAfterDiscard = await rootLoader.getAllHarnesses(PublishNavigationItemDialogHarness);
+        expect(publishDialogsAfterDiscard).toHaveLength(1);
+        await publishDialogsAfterDiscard[0].confirm();
 
         expectPutPortalNavigationItem('nav-item-1', { ...unpublishedNavItem, published: true }, fakePortalNavigationPage({}));
         await expectGetNavigationItems(fakePortalNavigationItemsResponse({ items: [unpublishedNavItem] }));
@@ -1505,9 +1595,9 @@ describe('PortalNavigationItemsComponent', () => {
         expect(openDialogsAfterClick).toHaveLength(1);
         await openDialogsAfterClick[0].confirm();
 
-        const openDialogsAfterDiscard = await rootLoader.getAllHarnesses(GioConfirmDialogHarness);
-        expect(openDialogsAfterDiscard).toHaveLength(1);
-        await openDialogsAfterDiscard[0].confirm();
+        const publishDialogsAfterDiscard = await rootLoader.getAllHarnesses(PublishNavigationItemDialogHarness);
+        expect(publishDialogsAfterDiscard).toHaveLength(1);
+        await publishDialogsAfterDiscard[0].confirm();
 
         expectPutPortalNavigationItem('nav-item-1', { ...unpublishedNavItem, published: true }, fakePortalNavigationPage({}));
         await expectGetNavigationItems(fakePortalNavigationItemsResponse({ items: [unpublishedNavItem] }));
@@ -1531,9 +1621,9 @@ describe('PortalNavigationItemsComponent', () => {
         expect(openDialogsAfterClick).toHaveLength(1);
         await openDialogsAfterClick[0].confirm();
 
-        const openDialogsAfterDiscard = await rootLoader.getAllHarnesses(GioConfirmDialogHarness);
-        expect(openDialogsAfterDiscard).toHaveLength(1);
-        await openDialogsAfterDiscard[0].confirm();
+        const publishDialogsAfterDiscard = await rootLoader.getAllHarnesses(PublishNavigationItemDialogHarness);
+        expect(publishDialogsAfterDiscard).toHaveLength(1);
+        await publishDialogsAfterDiscard[0].confirm();
 
         expectPutPortalNavigationItem('nav-item-1', { ...publishedNavItem, published: false }, fakePortalNavigationPage({}));
         await expectGetNavigationItems(fakePortalNavigationItemsResponse({ items: [publishedNavItem] }));
@@ -1557,9 +1647,9 @@ describe('PortalNavigationItemsComponent', () => {
         expect(openDialogsAfterClick).toHaveLength(1);
         await openDialogsAfterClick[0].confirm();
 
-        const openDialogsAfterDiscard = await rootLoader.getAllHarnesses(GioConfirmDialogHarness);
-        expect(openDialogsAfterDiscard).toHaveLength(1);
-        await openDialogsAfterDiscard[0].confirm();
+        const publishDialogsAfterDiscard = await rootLoader.getAllHarnesses(PublishNavigationItemDialogHarness);
+        expect(publishDialogsAfterDiscard).toHaveLength(1);
+        await publishDialogsAfterDiscard[0].confirm();
 
         expectPutPortalNavigationItem('nav-item-1', { ...publishedNavItem, published: false }, fakePortalNavigationPage({}));
         await expectGetNavigationItems(fakePortalNavigationItemsResponse({ items: [publishedNavItem] }));
@@ -2576,12 +2666,23 @@ describe('PortalNavigationItemsComponent', () => {
     req.flush('Server error', { status, statusText: 'Internal Server Error' });
   }
 
-  function expectPutPortalNavigationItem(id: string, expectedBody: UpdatePortalNavigationItem, response: PortalNavigationItem) {
+  function expectPutPortalNavigationItem(
+    id: string,
+    expectedBody: UpdatePortalNavigationItem,
+    response: PortalNavigationItem,
+    options: { propagatePublishToChildren?: boolean } = {},
+  ) {
+    const queryString = options.propagatePublishToChildren ? '?propagatePublishToChildren=true' : '';
     const req = httpTestingController.expectOne({
       method: 'PUT',
-      url: `${CONSTANTS_TESTING.env.v2BaseURL}/portal-navigation-items/${id}`,
+      url: `${CONSTANTS_TESTING.env.v2BaseURL}/portal-navigation-items/${id}${queryString}`,
     });
     expect(req.request.body).toEqual(expectedBody);
+    if (options.propagatePublishToChildren) {
+      expect(req.request.params.get('propagatePublishToChildren')).toBe('true');
+    } else {
+      expect(req.request.params.has('propagatePublishToChildren')).toBe(false);
+    }
     req.flush(response);
   }
 
@@ -2901,7 +3002,8 @@ describe('PortalNavigationItemsComponent', () => {
         const component = fixture.componentInstance;
         component.onNodeMenuAction({ action: 'publish', itemType: 'API', node });
 
-        const dialog = await rootLoader.getHarness(GioConfirmDialogHarness);
+        const dialog = await rootLoader.getHarness(PublishNavigationItemDialogHarness);
+        expect(await dialog.isPropagationCheckboxChecked()).toBe(false);
         await dialog.confirm();
         fixture.detectChanges();
 
@@ -2915,11 +3017,33 @@ describe('PortalNavigationItemsComponent', () => {
         );
         await expectGetNavigationItems(fakeResponse);
       });
+      it('should send propagation query parameter when checkbox is selected', async () => {
+        const node = { id: api.id, label: api.title, type: api.type, data: api };
+        const component = fixture.componentInstance;
+        component.onNodeMenuAction({ action: 'publish', itemType: 'API', node });
+
+        const dialog = await rootLoader.getHarness(PublishNavigationItemDialogHarness);
+        await dialog.checkPropagationCheckbox();
+        await dialog.confirm();
+        fixture.detectChanges();
+
+        expectPutPortalNavigationItem(
+          api.id,
+          fakeUpdateApiPortalNavigationItem({
+            ...api,
+            published: true,
+          }),
+          api,
+          { propagatePublishToChildren: true },
+        );
+        await expectGetNavigationItems(fakeResponse);
+      });
       it('should change state from static button', async () => {
         await harness.clickPublishButton();
 
-        const confirmDialog = await rootLoader.getHarness(GioConfirmDialogHarness);
-        await confirmDialog.confirm();
+        const dialog = await rootLoader.getHarness(PublishNavigationItemDialogHarness);
+        expect(await dialog.isPropagationCheckboxChecked()).toBe(false);
+        await dialog.confirm();
 
         expectPutPortalNavigationItem(
           api.id,
@@ -2951,7 +3075,8 @@ describe('PortalNavigationItemsComponent', () => {
         const component = fixture.componentInstance;
         component.onNodeMenuAction({ action: 'unpublish', itemType: 'API', node });
 
-        const dialog = await rootLoader.getHarness(GioConfirmDialogHarness);
+        const dialog = await rootLoader.getHarness(PublishNavigationItemDialogHarness);
+        expect(await dialog.isPropagationCheckboxVisible()).toBe(false);
         await dialog.confirm();
         fixture.detectChanges();
 
@@ -2968,8 +3093,8 @@ describe('PortalNavigationItemsComponent', () => {
       it('should change state from static button', async () => {
         await harness.clickUnpublishButton();
 
-        const confirmDialog = await rootLoader.getHarness(GioConfirmDialogHarness);
-        await confirmDialog.confirm();
+        const dialog = await rootLoader.getHarness(PublishNavigationItemDialogHarness);
+        await dialog.confirm();
 
         expectPutPortalNavigationItem(
           api.id,

--- a/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.ts
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.ts
@@ -21,8 +21,6 @@ import {
   GioCardEmptyStateModule,
   GioConfirmAndValidateDialogComponent,
   GioConfirmAndValidateDialogData,
-  GioConfirmDialogComponent,
-  GioConfirmDialogData,
 } from '@gravitee/ui-particles-angular';
 import { Component, computed, DestroyRef, HostListener, inject, NgZone, Signal, signal, viewChild } from '@angular/core';
 import { MatButtonModule } from '@angular/material/button';
@@ -51,6 +49,11 @@ import {
   ApiSectionEditorDialogData,
 } from './api-section-editor-dialog/api-section-editor-dialog.component';
 import { OpenApiConfigDialogComponent, OpenApiConfigDialogData } from './openapi-config-dialog/openapi-config-dialog.component';
+import {
+  PublishNavigationItemDialogComponent,
+  PublishNavigationItemDialogData,
+  PublishNavigationItemDialogResult,
+} from './publish-navigation-item-dialog/publish-navigation-item-dialog.component';
 
 import { PortalHeaderComponent } from '../components/header/portal-header.component';
 import { EmptyStateComponent } from '../../shared/components/empty-state/empty-state.component';
@@ -538,8 +541,16 @@ export class PortalNavigationItemsComponent implements HasUnsavedChanges {
     );
   }
 
-  private update(portalNavigationItemId: string, updatePortalNavigationItem: UpdatePortalNavigationItem): Observable<PortalNavigationItem> {
-    return this.portalNavigationItemsService.updateNavigationItem(portalNavigationItemId, updatePortalNavigationItem);
+  private update(
+    portalNavigationItemId: string,
+    updatePortalNavigationItem: UpdatePortalNavigationItem,
+    propagatePublishToChildren = false,
+  ): Observable<PortalNavigationItem> {
+    return this.portalNavigationItemsService.updateNavigationItem(
+      portalNavigationItemId,
+      updatePortalNavigationItem,
+      propagatePublishToChildren,
+    );
   }
 
   private navigateToItemByNavId(navId: string): void {
@@ -690,20 +701,27 @@ export class PortalNavigationItemsComponent implements HasUnsavedChanges {
 
   private handlePublishToggle(navItem: PortalNavigationItem): void {
     this.matDialog
-      .open<GioConfirmDialogComponent, GioConfirmDialogData, boolean>(GioConfirmDialogComponent, {
-        width: GIO_DIALOG_WIDTH.SMALL,
-        data: this.getPublishDialogData(navItem),
-        role: 'alertdialog',
-        id: 'managePublishNavigationItemConfirmDialog',
-      })
+      .open<PublishNavigationItemDialogComponent, PublishNavigationItemDialogData, PublishNavigationItemDialogResult>(
+        PublishNavigationItemDialogComponent,
+        {
+          width: GIO_DIALOG_WIDTH.SMALL,
+          data: { navItem },
+          role: 'alertdialog',
+          id: 'managePublishNavigationItemConfirmDialog',
+        },
+      )
       .afterClosed()
       .pipe(
-        filter(confirmed => !!confirmed),
-        switchMap(() =>
-          this.update(navItem.id, {
-            ...navItem,
-            published: !navItem.published,
-          }),
+        filter((result): result is PublishNavigationItemDialogResult => !!result?.confirmed),
+        switchMap(result =>
+          this.update(
+            navItem.id,
+            {
+              ...navItem,
+              published: !navItem.published,
+            },
+            result.propagatePublishToChildren,
+          ),
         ),
         tap(() => this.refreshMenuList.next(1)),
         catchError(() => {
@@ -713,28 +731,6 @@ export class PortalNavigationItemsComponent implements HasUnsavedChanges {
         takeUntilDestroyed(this.destroyRef),
       )
       .subscribe();
-  }
-
-  private getPublishDialogData(navItem: PortalNavigationItem): GioConfirmDialogData {
-    const isPublished = navItem.published;
-    const typeLabel = navItem.type === 'API' ? 'API' : navItem.type.toLowerCase();
-    const isContainer = navItem.type === 'FOLDER' || navItem.type === 'API';
-
-    const action = isPublished ? 'Unpublish' : 'Publish';
-    const pastAction = `${action.toLowerCase()}ed`;
-    const warning = isContainer
-      ? isPublished
-        ? ` Unpublishing this ${typeLabel} will also unpublish all nested documentation and APIs. This action cannot be undone automatically. Do you want to proceed?`
-        : ` Publishing this ${typeLabel} will also publish all nested documentation and APIs. Do you want to proceed?`
-      : '';
-
-    const contentScope = isContainer ? ' and its content ' : ' ';
-
-    return {
-      title: `${action} "${navItem.title}" ${typeLabel}?`,
-      content: `This ${typeLabel}${contentScope}will be ${pastAction}. This change will be visible in the Developer Portal.${warning}`,
-      confirmButton: action,
-    };
   }
 
   private confirmDeleteAction(event: NodeMenuActionEvent) {

--- a/gravitee-apim-console-webui/src/portal/navigation-items/publish-navigation-item-dialog/publish-navigation-item-dialog.component.html
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/publish-navigation-item-dialog/publish-navigation-item-dialog.component.html
@@ -1,0 +1,35 @@
+<!--
+
+    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<div mat-dialog-title class="title">{{ title() }}</div>
+
+<form [formGroup]="form" (ngSubmit)="onConfirm()">
+  <mat-dialog-content class="publish-navigation-item-dialog">
+    <p class="publish-navigation-item-dialog__message">{{ message() }}</p>
+
+    @if (showPropagationCheckbox()) {
+      <mat-checkbox formControlName="propagatePublishToChildren" data-testid="propagate-publish-to-children-checkbox">
+        {{ propagationCheckboxLabel() }}
+      </mat-checkbox>
+    }
+  </mat-dialog-content>
+
+  <mat-dialog-actions align="end">
+    <button mat-button type="button" (click)="onCancel()">Cancel</button>
+    <button mat-flat-button color="primary" type="submit">{{ action() }}</button>
+  </mat-dialog-actions>
+</form>

--- a/gravitee-apim-console-webui/src/portal/navigation-items/publish-navigation-item-dialog/publish-navigation-item-dialog.component.scss
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/publish-navigation-item-dialog/publish-navigation-item-dialog.component.scss
@@ -1,0 +1,21 @@
+@use '@angular/material' as mat;
+@use '@gravitee/ui-particles-angular' as gio;
+@use 'sass:map';
+
+$typography: map.get(gio.$mat-theme, typography);
+
+.title {
+  @include mat.m2-typography-level($typography, headline-6);
+}
+
+.publish-navigation-item-dialog {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+
+  &__message {
+    @include mat.m2-typography-level($typography, body-2);
+    color: mat.m2-get-color-from-palette(gio.$mat-dove-palette, 'darker80');
+    margin: 0;
+  }
+}

--- a/gravitee-apim-console-webui/src/portal/navigation-items/publish-navigation-item-dialog/publish-navigation-item-dialog.component.spec.ts
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/publish-navigation-item-dialog/publish-navigation-item-dialog.component.spec.ts
@@ -1,0 +1,114 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+
+import { PublishNavigationItemDialogComponent, PublishNavigationItemDialogData } from './publish-navigation-item-dialog.component';
+import { PublishNavigationItemDialogHarness } from './publish-navigation-item-dialog.harness';
+
+import {
+  fakePortalNavigationApi,
+  fakePortalNavigationFolder,
+  fakePortalNavigationPage,
+  PortalNavigationItem,
+} from '../../../entities/management-api-v2';
+
+describe('PublishNavigationItemDialogComponent', () => {
+  let fixture: ComponentFixture<PublishNavigationItemDialogComponent>;
+  let harness: PublishNavigationItemDialogHarness;
+  let dialogRefClose: jest.Mock;
+  let dialogData: PublishNavigationItemDialogData;
+
+  beforeEach(async () => {
+    dialogRefClose = jest.fn();
+
+    await TestBed.configureTestingModule({
+      imports: [NoopAnimationsModule, PublishNavigationItemDialogComponent],
+      providers: [
+        { provide: MatDialogRef, useValue: { close: dialogRefClose } },
+        { provide: MAT_DIALOG_DATA, useFactory: () => dialogData },
+      ],
+    }).compileComponents();
+  });
+
+  it('should show propagation checkbox for publishing a folder and return selected value', async () => {
+    await createComponent(fakePortalNavigationFolder({ title: 'My Folder', published: false }));
+
+    expect(await harness.isPropagationCheckboxChecked()).toBe(false);
+    expect(await harness.getContentText()).toContain('Also publish all nested documentation and APIs');
+
+    await harness.checkPropagationCheckbox();
+    await harness.confirm();
+
+    expect(dialogRefClose).toHaveBeenCalledWith({
+      confirmed: true,
+      propagatePublishToChildren: true,
+    });
+  });
+
+  it('should show propagation checkbox for publishing an API', async () => {
+    await createComponent(fakePortalNavigationApi({ title: 'My API', published: false }));
+
+    expect(await harness.isPropagationCheckboxVisible()).toBe(true);
+    expect(await harness.getContentText()).toContain('Also publish all nested documentation');
+    expect(await harness.getContentText()).not.toContain('and APIs');
+  });
+
+  it('should not show propagation checkbox for publishing a page', async () => {
+    await createComponent(fakePortalNavigationPage({ title: 'My Page', published: false }));
+
+    expect(await harness.isPropagationCheckboxVisible()).toBe(false);
+
+    await harness.confirm();
+
+    expect(dialogRefClose).toHaveBeenCalledWith({
+      confirmed: true,
+      propagatePublishToChildren: false,
+    });
+  });
+
+  it('should not show propagation checkbox for unpublishing a container', async () => {
+    await createComponent(fakePortalNavigationFolder({ title: 'My Folder', published: true }));
+
+    expect(await harness.isPropagationCheckboxVisible()).toBe(false);
+    expect(await harness.getContentText()).toContain('will also unpublish all nested documentation and APIs');
+  });
+
+  it('should describe API unpublish propagation without nested APIs', async () => {
+    await createComponent(fakePortalNavigationApi({ title: 'My API', published: true }));
+
+    expect(await harness.isPropagationCheckboxVisible()).toBe(false);
+    expect(await harness.getContentText()).toContain('will also unpublish all nested documentation');
+    expect(await harness.getContentText()).not.toContain('and APIs');
+  });
+
+  it('should close without result when cancelled', async () => {
+    await createComponent(fakePortalNavigationFolder({ title: 'My Folder', published: false }));
+
+    await harness.cancel();
+
+    expect(dialogRefClose).toHaveBeenCalledWith();
+  });
+
+  async function createComponent(navItem: PortalNavigationItem): Promise<void> {
+    dialogData = { navItem };
+    fixture = TestBed.createComponent(PublishNavigationItemDialogComponent);
+    fixture.detectChanges();
+    harness = await TestbedHarnessEnvironment.harnessForFixture(fixture, PublishNavigationItemDialogHarness);
+  }
+});

--- a/gravitee-apim-console-webui/src/portal/navigation-items/publish-navigation-item-dialog/publish-navigation-item-dialog.component.ts
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/publish-navigation-item-dialog/publish-navigation-item-dialog.component.ts
@@ -1,0 +1,93 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Component, computed, inject, signal } from '@angular/core';
+import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
+import { MatButtonModule } from '@angular/material/button';
+import { MatCheckboxModule } from '@angular/material/checkbox';
+import { MAT_DIALOG_DATA, MatDialogModule, MatDialogRef } from '@angular/material/dialog';
+
+import { PortalNavigationItem } from '../../../entities/management-api-v2';
+
+export interface PublishNavigationItemDialogData {
+  navItem: PortalNavigationItem;
+}
+
+export interface PublishNavigationItemDialogResult {
+  confirmed: true;
+  propagatePublishToChildren: boolean;
+}
+
+interface PublishNavigationItemDialogFormControls {
+  propagatePublishToChildren: FormControl<boolean>;
+}
+
+type PublishNavigationItemDialogForm = FormGroup<PublishNavigationItemDialogFormControls>;
+
+@Component({
+  selector: 'publish-navigation-item-dialog',
+  imports: [MatDialogModule, ReactiveFormsModule, MatButtonModule, MatCheckboxModule],
+  templateUrl: './publish-navigation-item-dialog.component.html',
+  styleUrls: ['./publish-navigation-item-dialog.component.scss'],
+})
+export class PublishNavigationItemDialogComponent {
+  private readonly dialogRef = inject(MatDialogRef<PublishNavigationItemDialogComponent, PublishNavigationItemDialogResult>);
+  private readonly data: PublishNavigationItemDialogData = inject(MAT_DIALOG_DATA);
+
+  private readonly navItem = signal(this.data.navItem);
+  readonly form: PublishNavigationItemDialogForm = new FormGroup<PublishNavigationItemDialogFormControls>({
+    propagatePublishToChildren: new FormControl(false, { nonNullable: true }),
+  });
+
+  readonly isContainer = computed(() => this.navItem().type === 'FOLDER' || this.navItem().type === 'API');
+  readonly typeLabel = computed(() => (this.navItem().type === 'API' ? 'API' : this.navItem().type.toLowerCase()));
+  readonly isPublishing = computed(() => !this.navItem().published);
+  readonly action = computed(() => (this.isPublishing() ? 'Publish' : 'Unpublish'));
+  readonly showPropagationCheckbox = computed(() => this.isPublishing() && this.isContainer());
+  readonly title = computed(() => `${this.action()} "${this.navItem().title}" ${this.typeLabel()}?`);
+  readonly pastAction = computed(() => `${this.action().toLowerCase()}ed`);
+  readonly contentScope = computed(() => (this.isContainer() ? ' and its content ' : ' '));
+  readonly propagatedItemsLabel = computed(() =>
+    this.navItem().type === 'FOLDER' ? 'nested documentation and APIs' : 'nested documentation',
+  );
+  readonly propagationCheckboxLabel = computed(() => `Also publish all ${this.propagatedItemsLabel()}`);
+  readonly warning = computed(() => {
+    if (!this.isContainer()) {
+      return '';
+    }
+    return this.isPublishing()
+      ? ` Publishing this ${this.typeLabel()} will also publish all ${this.propagatedItemsLabel()}. Do you want to proceed?`
+      : ` Unpublishing this ${this.typeLabel()} will also unpublish all ${this.propagatedItemsLabel()}. This action cannot be undone automatically. Do you want to proceed?`;
+  });
+  readonly messageWithPropagation = computed(
+    () => `This ${this.typeLabel()} will be ${this.pastAction()}. This change will be visible in the Developer Portal.`,
+  );
+  readonly messageWithoutPropagation = computed(
+    () =>
+      `This ${this.typeLabel()}${this.contentScope()}will be ${this.pastAction()}. This change will be visible in the Developer Portal.${this.warning()}`,
+  );
+  readonly message = computed(() => (this.showPropagationCheckbox() ? this.messageWithPropagation() : this.messageWithoutPropagation()));
+
+  onConfirm(): void {
+    this.dialogRef.close({
+      confirmed: true,
+      propagatePublishToChildren: this.showPropagationCheckbox() ? this.form.controls.propagatePublishToChildren.value : false,
+    });
+  }
+
+  onCancel(): void {
+    this.dialogRef.close();
+  }
+}

--- a/gravitee-apim-console-webui/src/portal/navigation-items/publish-navigation-item-dialog/publish-navigation-item-dialog.harness.ts
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/publish-navigation-item-dialog/publish-navigation-item-dialog.harness.ts
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ComponentHarness } from '@angular/cdk/testing';
+import { MatButtonHarness } from '@angular/material/button/testing';
+import { MatCheckboxHarness } from '@angular/material/checkbox/testing';
+
+export class PublishNavigationItemDialogHarness extends ComponentHarness {
+  static readonly hostSelector = 'publish-navigation-item-dialog';
+
+  private readonly locateConfirmButton = this.locatorFor(MatButtonHarness.with({ text: /Publish|Unpublish/ }));
+  private readonly locateCancelButton = this.locatorFor(MatButtonHarness.with({ text: 'Cancel' }));
+  private readonly locateContent = this.locatorFor('.publish-navigation-item-dialog');
+  private readonly locatePropagationCheckbox = this.locatorForOptional(
+    MatCheckboxHarness.with({ selector: '[data-testid="propagate-publish-to-children-checkbox"]' }),
+  );
+
+  async confirm(): Promise<void> {
+    const confirmButton = await this.locateConfirmButton();
+    return confirmButton.click();
+  }
+
+  async cancel(): Promise<void> {
+    const cancelButton = await this.locateCancelButton();
+    return cancelButton.click();
+  }
+
+  async getContentText(): Promise<string> {
+    const content = await this.locateContent();
+    return content.text();
+  }
+
+  async isPropagationCheckboxVisible(): Promise<boolean> {
+    const propagationCheckbox = await this.locatePropagationCheckbox();
+    return propagationCheckbox !== null;
+  }
+
+  async isPropagationCheckboxChecked(): Promise<boolean> {
+    const propagationCheckbox = await this.locatePropagationCheckbox();
+    if (!propagationCheckbox) {
+      throw new Error('Propagation checkbox is not visible');
+    }
+    return propagationCheckbox.isChecked();
+  }
+
+  async checkPropagationCheckbox(): Promise<void> {
+    const propagationCheckbox = await this.locatePropagationCheckbox();
+    if (!propagationCheckbox) {
+      throw new Error('Propagation checkbox is not visible');
+    }
+    return propagationCheckbox.check();
+  }
+}

--- a/gravitee-apim-console-webui/src/services-ngx/portal-navigation-item.service.spec.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/portal-navigation-item.service.spec.ts
@@ -29,6 +29,7 @@ import {
   fakeNewFolderPortalNavigationItem,
   fakeNewLinkPortalNavigationItem,
   fakeNewApiPortalNavigationItem,
+  fakeUpdateFolderPortalNavigationItem,
 } from '../entities/management-api-v2';
 
 describe('PortalNavigationItemService', () => {
@@ -179,6 +180,62 @@ describe('PortalNavigationItemService', () => {
       });
       expect(req.request.body).toEqual({ ids });
       req.flush(null);
+    });
+  });
+
+  describe('updateNavigationItem', () => {
+    it('should update a navigation item without propagation query parameter by default', done => {
+      const updateItem = fakeUpdateFolderPortalNavigationItem();
+      const updatedItem = fakePortalNavigationFolder({ id: 'folder-1' });
+
+      service.updateNavigationItem(updatedItem.id, updateItem).subscribe(response => {
+        expect(response).toEqual(updatedItem);
+        done();
+      });
+
+      const req = httpTestingController.expectOne({
+        method: 'PUT',
+        url: `${CONSTANTS_TESTING.env.v2BaseURL}/portal-navigation-items/${updatedItem.id}`,
+      });
+      expect(req.request.body).toEqual(updateItem);
+      expect(req.request.params.has('propagatePublishToChildren')).toBe(false);
+      req.flush(updatedItem);
+    });
+
+    it('should update a navigation item without propagation query parameter when disabled', done => {
+      const updateItem = fakeUpdateFolderPortalNavigationItem();
+      const updatedItem = fakePortalNavigationFolder({ id: 'folder-1' });
+
+      service.updateNavigationItem(updatedItem.id, updateItem, false).subscribe(response => {
+        expect(response).toEqual(updatedItem);
+        done();
+      });
+
+      const req = httpTestingController.expectOne({
+        method: 'PUT',
+        url: `${CONSTANTS_TESTING.env.v2BaseURL}/portal-navigation-items/${updatedItem.id}`,
+      });
+      expect(req.request.body).toEqual(updateItem);
+      expect(req.request.params.has('propagatePublishToChildren')).toBe(false);
+      req.flush(updatedItem);
+    });
+
+    it('should update a navigation item with propagation query parameter when enabled', done => {
+      const updateItem = fakeUpdateFolderPortalNavigationItem();
+      const updatedItem = fakePortalNavigationFolder({ id: 'folder-1' });
+
+      service.updateNavigationItem(updatedItem.id, updateItem, true).subscribe(response => {
+        expect(response).toEqual(updatedItem);
+        done();
+      });
+
+      const req = httpTestingController.expectOne({
+        method: 'PUT',
+        url: `${CONSTANTS_TESTING.env.v2BaseURL}/portal-navigation-items/${updatedItem.id}?propagatePublishToChildren=true`,
+      });
+      expect(req.request.body).toEqual(updateItem);
+      expect(req.request.params.get('propagatePublishToChildren')).toBe('true');
+      req.flush(updatedItem);
     });
   });
 });

--- a/gravitee-apim-console-webui/src/services-ngx/portal-navigation-item.service.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/portal-navigation-item.service.ts
@@ -54,10 +54,14 @@ export class PortalNavigationItemService {
   public updateNavigationItem(
     portalNavigationItemId: string,
     updatePortalNavigationItem: UpdatePortalNavigationItem,
+    propagatePublishToChildren = false,
   ): Observable<PortalNavigationItem> {
+    const params = propagatePublishToChildren ? { propagatePublishToChildren } : {};
+
     return this.http.put<PortalNavigationItem>(
       `${this.constants.env.v2BaseURL}/portal-navigation-items/${portalNavigationItemId}`,
       updatePortalNavigationItem,
+      { params },
     );
   }
 


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/EXT-145

## Description

Adds frontend support for choosing whether publishing a Developer Portal navigation container should also publish its descendants.

## Changes

- Adds a propagation checkbox to the publish confirmation dialog for `FOLDER` and `API` navigation items.
- Sends `propagatePublishToChildren=true` only when the checkbox is selected.
- Keeps the default publish behavior as single-item publish when the checkbox is not selected.
- Keeps `PAGE` and `LINK` publish dialogs unchanged.
- Keeps unpublish and delete dialogs without a propagation checkbox.


https://github.com/user-attachments/assets/6aa7fab3-ccfe-47d4-b06c-092d1c544c9d



