### PR TITLE
chore: update auth0 resource plugin to alpha that support vertx5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -246,7 +246,7 @@
 
         <gravitee-resource-cache.version>3.0.0</gravitee-resource-cache.version>
         <gravitee-resource-oauth2-provider-am.version>5.0.0-alpha.3</gravitee-resource-oauth2-provider-am.version>
-        <gravitee-resource-oauth2-provider-auth0.version>1.0.0</gravitee-resource-oauth2-provider-auth0.version>
+        <gravitee-resource-oauth2-provider-auth0.version>2.0.0-alpha.1</gravitee-resource-oauth2-provider-auth0.version>
         <gravitee-resource-oauth2-provider-entra-id.version>2.0.0-alpha.2</gravitee-resource-oauth2-provider-entra-id.version>
         <gravitee-resource-oauth2-provider-generic.version>6.0.0-alpha.3</gravitee-resource-oauth2-provider-generic.version>
         <gravitee-resource-content-provider-inline.version>1.1.1</gravitee-resource-content-provider-inline.version>


### PR DESCRIPTION
## Description

Bump up the Auth0 resource plugin to the version that supports Vertx5
