### PR TITLE
fix(portal): normalize OAS 3.1 type arrays when show_url is enabled

### DIFF
--- a/gravitee-apim-portal-webui-next/src/components/page/page-swagger/page-swagger.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/components/page/page-swagger/page-swagger.component.spec.ts
@@ -14,12 +14,14 @@
  * limitations under the License.
  */
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import SwaggerUI from 'swagger-ui';
 
 import { PageSwaggerComponent } from './page-swagger.component';
 import { fakePage } from '../../../entities/page/page.fixtures';
 import { AppTestingModule } from '../../../testing/app-testing.module';
 
 jest.mock('swagger-ui', () => jest.fn(() => ({ initOAuth: jest.fn() })));
+const SwaggerUIMock = jest.mocked(SwaggerUI);
 
 type WithNormalizeTypeArrays = { normalizeTypeArrays: (obj: unknown) => unknown };
 
@@ -69,6 +71,41 @@ describe('PageSwaggerComponent', () => {
     component.page = fakePage({ type: 'SWAGGER', content: undefined });
     component.ngOnChanges();
     expect(component).toBeTruthy();
+  });
+
+  describe('show_url normalization', () => {
+    it('should register normalizeSpecPlugin when show_url is enabled', () => {
+      SwaggerUIMock.mockClear();
+
+      component.page = fakePage({
+        type: 'SWAGGER',
+        content: '{}',
+        configuration: { show_url: true },
+        _links: { content: 'http://example.com/spec.json' },
+      });
+      component.ngOnChanges();
+
+      const options = SwaggerUIMock.mock.calls[0][0];
+      expect(options.url).toBe('http://example.com/spec.json');
+      expect(options.spec).toBeUndefined();
+      expect(options.plugins!.length).toBeGreaterThan(0);
+    });
+
+    it('should not register normalizeSpecPlugin when show_url is disabled', () => {
+      SwaggerUIMock.mockClear();
+
+      component.page = fakePage({
+        type: 'SWAGGER',
+        content: '{}',
+        configuration: { show_url: false },
+      });
+      component.ngOnChanges();
+
+      const options = SwaggerUIMock.mock.calls[0][0];
+      expect(options.url).toBeUndefined();
+      // Only disabledTryItOutPlugin and disabledAuthorizationPlugin should be present, not normalizeSpecPlugin
+      expect(options.plugins).toHaveLength(2);
+    });
   });
 
   describe('normalizeTypeArrays', () => {

--- a/gravitee-apim-portal-webui-next/src/components/page/page-swagger/page-swagger.component.ts
+++ b/gravitee-apim-portal-webui-next/src/components/page/page-swagger/page-swagger.component.ts
@@ -65,6 +65,7 @@ export class PageSwaggerComponent implements OnChanges {
       if (pageConfiguration.show_url) {
         config.url = this.page._links?.content;
         config.spec = undefined;
+        plugins.push(this.normalizeSpecPlugin());
       }
       if (this.page.configuration?.disable_syntax_highlight) {
         config.syntaxHighlight = false;
@@ -132,6 +133,21 @@ export class PageSwaggerComponent implements OnChanges {
       }
     }
     return result;
+  }
+
+  private normalizeSpecPlugin(): SwaggerUIPlugin {
+    const normalize = (obj: unknown) => this.normalizeTypeArrays(obj);
+    return () => ({
+      statePlugins: {
+        spec: {
+          wrapActions: {
+            updateJsonSpec: (oriAction: (spec: Record<string, unknown>) => void) => (spec: Record<string, unknown>) => {
+              return oriAction(normalize(spec) as Record<string, unknown>);
+            },
+          },
+        },
+      },
+    });
   }
 
   private disabledTryItOutPlugin() {

--- a/gravitee-apim-portal-webui/src/app/components/gv-page-swaggerui/gv-page-swaggerui.component.spec.ts
+++ b/gravitee-apim-portal-webui/src/app/components/gv-page-swaggerui/gv-page-swaggerui.component.spec.ts
@@ -38,6 +38,22 @@ describe('GvPageSwaggerUIComponent', () => {
     expect(component).toBeTruthy();
   });
 
+  describe('normalizeSpecPlugin', () => {
+    it('should return a plugin that normalizes type arrays via updateJsonSpec', () => {
+      const pluginFactory = component['normalizeSpecPlugin']();
+      const plugin = pluginFactory();
+      const oriAction = jest.fn(spec => spec);
+      const wrappedAction = plugin.statePlugins.spec.wrapActions.updateJsonSpec(oriAction);
+
+      const spec = { paths: { '/test': { get: { parameters: [{ schema: { type: ['integer', 'string'] } }] } } } };
+      wrappedAction(spec);
+
+      expect(oriAction).toHaveBeenCalledWith({
+        paths: { '/test': { get: { parameters: [{ schema: { type: 'string' } }] } } },
+      });
+    });
+  });
+
   describe('normalizeTypeArrays', () => {
     it('should flatten a single-element type array to that type', () => {
       expect(component['normalizeTypeArrays']({ type: ['integer'] })).toEqual({ type: 'integer' });

--- a/gravitee-apim-portal-webui/src/app/components/gv-page-swaggerui/gv-page-swaggerui.component.ts
+++ b/gravitee-apim-portal-webui/src/app/components/gv-page-swaggerui/gv-page-swaggerui.component.ts
@@ -97,6 +97,7 @@ export class GvPageSwaggerUIComponent implements OnInit, OnDestroy {
       if (page.configuration.show_url) {
         config.url = page._links.content;
         config.spec = undefined;
+        plugins.push(this.normalizeSpecPlugin());
       }
       if (page.configuration?.disable_syntax_highlight) {
         config.syntaxHighlight = false;
@@ -175,6 +176,21 @@ export class GvPageSwaggerUIComponent implements OnInit, OnDestroy {
         authorizeBtn: () => () => null,
       },
     };
+  }
+
+  private normalizeSpecPlugin(): SwaggerUIPlugin {
+    const normalize = (obj: any) => this.normalizeTypeArrays(obj);
+    return () => ({
+      statePlugins: {
+        spec: {
+          wrapActions: {
+            updateJsonSpec: (oriAction: (spec: Record<string, any>) => void) => (spec: Record<string, any>) => {
+              return oriAction(normalize(spec));
+            },
+          },
+        },
+      },
+    });
   }
 
   private isTryItEnabled(page: Page) {


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-14431

## Description

When "Show URL to download content" (show_url) is enabled on an API documentation page, the normalizeTypeArrays fix from APIM-14231 is bypassed because Swagger UI fetches the raw spec directly from the URL instead of using the normalized inline spec.

This adds a Swagger UI plugin (normalizeSpecPlugin) that hooks into wrapActions.updateJsonSpec to normalize OAS 3.1 type arrays after the spec is fetched via URL, preventing the "Required field is not provided" validation error in the "Try it out" form.



## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

