### PR TITLE
chore(master): bump gravitee-reactor-native-kafka from 7.0.0-alpha.23 to 7.0.0-alpha.24

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -307,7 +307,7 @@
         <gravitee-resource-schema-registry-embedded.version>1.0.0-alpha.1</gravitee-resource-schema-registry-embedded.version>
         <gravitee-resource-storage-azure-blob.version>1.1.0</gravitee-resource-storage-azure-blob.version>
         <gravitee-reactor-message.version>11.0.0-alpha.4</gravitee-reactor-message.version>
-        <gravitee-reactor-native-kafka.version>7.0.0-alpha.23</gravitee-reactor-native-kafka.version>
+        <gravitee-reactor-native-kafka.version>7.0.0-alpha.24</gravitee-reactor-native-kafka.version>
         <gravitee-reactor-mcp-proxy.version>3.0.0-feat-mcp-studio-schema-SNAPSHOT</gravitee-reactor-mcp-proxy.version>
         <gravitee-reactor-llm-proxy.version>3.0.0-alpha.6</gravitee-reactor-llm-proxy.version>
         <gravitee-reactor-a2a-proxy.version>1.0.0</gravitee-reactor-a2a-proxy.version>


### PR DESCRIPTION
## Summary

Bumps the following on `master`:

- **[gravitee-io/gravitee-reactor-native-kafka](https://github.com/gravitee-io/gravitee-reactor-native-kafka)** `7.0.0-alpha.23` -> `7.0.0-alpha.24`
