### PR TITLE
fix(observability): enforce catalog operators and honor HTTP_STATUS ranges in Gamma logs search

### DIFF
--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/filter/domain_service/ObservabilityFilterValidator.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/filter/domain_service/ObservabilityFilterValidator.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gamma.rest.core.observability.filter.domain_service;
+
+import io.gravitee.apim.core.DomainService;
+import io.gravitee.gamma.rest.core.observability.filter.exception.UnsupportedObservabilityFilterException;
+import io.gravitee.gamma.rest.core.observability.filter.model.FilterCondition;
+import io.gravitee.gamma.rest.core.observability.filter.model.FilterSpec;
+import io.gravitee.gamma.rest.core.observability.filter.model.Signal;
+import io.gravitee.gamma.rest.core.observability.filter.port.service_provider.FilterRegistry;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * Validates incoming {@link FilterCondition}s against the unified filter catalog for a given
+ * {@link Signal}. Centralising this here keeps the catalog the single source of truth and guarantees
+ * that the logs and analytics surfaces enforce the <em>same</em> name / signal / operator rules for a
+ * given filter — a filter and its operators behave identically whichever signal queries it.
+ *
+ * <p>Each condition is rejected (HTTP 400 via {@link UnsupportedObservabilityFilterException}) when:
+ * <ul>
+ *   <li>its {@code name} is not in the catalog,</li>
+ *   <li>the catalog entry does not apply to the requested signal, or</li>
+ *   <li>its {@code operator} is not among the operators the catalog advertises for that filter.</li>
+ * </ul>
+ *
+ * @author GraviteeSource Team
+ */
+@DomainService
+@RequiredArgsConstructor
+public class ObservabilityFilterValidator {
+
+    private final FilterRegistry filterRegistry;
+
+    public void validate(List<FilterCondition> conditions, Signal signal) {
+        if (conditions == null) {
+            return;
+        }
+        Map<String, FilterSpec> specsByName = filterRegistry
+            .getFilters(Set.of(), Set.of())
+            .stream()
+            .collect(Collectors.toMap(FilterSpec::name, spec -> spec, (a, b) -> b));
+
+        for (FilterCondition condition : conditions) {
+            FilterSpec spec = specsByName.get(condition.name());
+            if (spec == null) {
+                throw UnsupportedObservabilityFilterException.unknownName(condition.name());
+            }
+            if (!spec.signals().contains(signal)) {
+                throw UnsupportedObservabilityFilterException.signalMismatch(condition.name(), signal);
+            }
+            if (!spec.operators().contains(condition.operator())) {
+                throw UnsupportedObservabilityFilterException.unsupportedOperator(condition.name(), condition.operator().name());
+            }
+        }
+    }
+}

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/logs/domain_service/AccessibleApiScopeDomainService.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/logs/domain_service/AccessibleApiScopeDomainService.java
@@ -17,6 +17,7 @@ package io.gravitee.gamma.rest.core.observability.logs.domain_service;
 
 import io.gravitee.apim.core.DomainService;
 import io.gravitee.gamma.rest.core.observability.filter.model.ApiType;
+import io.gravitee.gamma.rest.core.observability.logs.model.ApiReference;
 import io.gravitee.gamma.rest.core.observability.logs.port.service_provider.ObservabilityLogsDataPort.AccessibleApi;
 import java.util.List;
 import java.util.Map;
@@ -36,7 +37,12 @@ import java.util.stream.Collectors;
 @DomainService
 public class AccessibleApiScopeDomainService {
 
-    public record ScopedApis(Set<String> apiIds, Map<String, String> apiNamesById) {}
+    /**
+     * @param apiIds   The accessible API ids in scope.
+     * @param apisById Per-API enrichment context (display name + canonical wire {@code apiType}),
+     *                 keyed by API id.
+     */
+    public record ScopedApis(Set<String> apiIds, Map<String, ApiReference> apisById) {}
 
     /**
      * @param accessibleApis   All APIs the caller can read (from the data port).
@@ -57,8 +63,16 @@ public class AccessibleApiScopeDomainService {
 
         var apiList = filtered.toList();
         var ids = apiList.stream().map(AccessibleApi::id).collect(Collectors.toSet());
-        var names = apiList.stream().collect(Collectors.toMap(AccessibleApi::id, AccessibleApi::name, (a, b) -> a));
+        var apisById = apiList
+            .stream()
+            .collect(Collectors.toMap(AccessibleApi::id, AccessibleApiScopeDomainService::toReference, (a, b) -> a));
 
-        return new ScopedApis(ids, names);
+        return new ScopedApis(ids, apisById);
+    }
+
+    private static ApiReference toReference(AccessibleApi api) {
+        // apiType is emitted as the canonical enum name (uppercase, e.g. "HTTP_PROXY") to match the
+        // documented log-row contract and the API_TYPE filter values.
+        return new ApiReference(api.name(), api.type() != null ? api.type().name() : null);
     }
 }

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/logs/model/ApiReference.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/logs/model/ApiReference.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gamma.rest.core.observability.logs.model;
+
+/**
+ * Per-API enrichment context resolved once while computing the query scope and carried alongside the
+ * search query, so the data port can attach display values to each log row without re-loading the API
+ * entities.
+ *
+ * @param name    Human-readable API name.
+ * @param apiType API kind as the canonical wire value (the {@code ApiType} enum name, e.g.
+ *                {@code "HTTP_PROXY"}), matching the {@code apiType} field documented for log rows and
+ *                the {@code API_TYPE} filter values.
+ *
+ * @author GraviteeSource Team
+ */
+public record ApiReference(String name, String apiType) {}

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/logs/model/LogsSearchQuery.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/logs/model/LogsSearchQuery.java
@@ -24,15 +24,16 @@ import lombok.Builder;
 /**
  * Fully resolved search query passed from the use case to the data port. The {@code apiIds} are
  * already intersected with the caller's accessible scope; the {@code conditions} are pre-validated
- * against the filter registry for the {@code LOGS} signal; the {@code apiNamesById} map provides
- * enrichment context so the adapter can attach display names without re-loading the API entities.
+ * against the filter registry for the {@code LOGS} signal; the {@code apisById} map provides
+ * enrichment context (name + apiType) so the adapter can attach display values without re-loading the
+ * API entities.
  *
  * @author GraviteeSource Team
  */
 @Builder
 public record LogsSearchQuery(
     Set<String> apiIds,
-    Map<String, String> apiNamesById,
+    Map<String, ApiReference> apisById,
     List<FilterCondition> conditions,
     Long from,
     Long to,

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/logs/use_case/SearchObservabilityLogsUseCase.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/logs/use_case/SearchObservabilityLogsUseCase.java
@@ -17,12 +17,10 @@ package io.gravitee.gamma.rest.core.observability.logs.use_case;
 
 import io.gravitee.apim.core.UseCase;
 import io.gravitee.apim.core.exception.ValidationDomainException;
-import io.gravitee.gamma.rest.core.observability.filter.exception.UnsupportedObservabilityFilterException;
+import io.gravitee.gamma.rest.core.observability.filter.domain_service.ObservabilityFilterValidator;
 import io.gravitee.gamma.rest.core.observability.filter.model.ApiType;
 import io.gravitee.gamma.rest.core.observability.filter.model.FilterCondition;
-import io.gravitee.gamma.rest.core.observability.filter.model.FilterSpec;
 import io.gravitee.gamma.rest.core.observability.filter.model.Signal;
-import io.gravitee.gamma.rest.core.observability.filter.port.service_provider.FilterRegistry;
 import io.gravitee.gamma.rest.core.observability.logs.domain_service.AccessibleApiScopeDomainService;
 import io.gravitee.gamma.rest.core.observability.logs.model.LogsPage;
 import io.gravitee.gamma.rest.core.observability.logs.model.LogsSearchQuery;
@@ -30,7 +28,6 @@ import io.gravitee.gamma.rest.core.observability.logs.port.service_provider.Obse
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.AllArgsConstructor;
@@ -68,7 +65,7 @@ public class SearchObservabilityLogsUseCase {
     static final Set<String> DEFAULT_ENTRYPOINT_IDS = Set.of("http-get", "http-post", "http-proxy", "llm-proxy", "mcp-proxy");
 
     private final ObservabilityLogsDataPort logsDataPort;
-    private final FilterRegistry filterRegistry;
+    private final ObservabilityFilterValidator filterValidator;
     private final AccessibleApiScopeDomainService accessibleApiScope;
 
     public record Input(
@@ -88,9 +85,8 @@ public class SearchObservabilityLogsUseCase {
         int perPage = resolvePerPage(input);
 
         var conditions = input.filters != null ? input.filters : List.<FilterCondition>of();
-        var filtersByName = buildFilterSpecMap();
 
-        validateConditions(conditions, filtersByName);
+        filterValidator.validate(conditions, Signal.LOGS);
         validateTimeRange(input.from, input.to);
 
         var accessibleApis = logsDataPort.loadAccessibleApis(input.organizationId, input.environmentId);
@@ -106,7 +102,7 @@ public class SearchObservabilityLogsUseCase {
 
         var query = LogsSearchQuery.builder()
             .apiIds(scope.apiIds())
-            .apiNamesById(scope.apiNamesById())
+            .apisById(scope.apisById())
             .conditions(effectiveConditions)
             .from(input.from != null ? input.from.toEpochMilli() : null)
             .to(input.to != null ? input.to.toEpochMilli() : null)
@@ -124,22 +120,6 @@ public class SearchObservabilityLogsUseCase {
 
     private static int resolvePerPage(Input input) {
         return (input.perPage() != null && input.perPage() > 0) ? Math.min(input.perPage(), MAX_PER_PAGE) : DEFAULT_PER_PAGE;
-    }
-
-    private Map<String, FilterSpec> buildFilterSpecMap() {
-        return filterRegistry.getFilters(Set.of(), Set.of()).stream().collect(Collectors.toMap(FilterSpec::name, f -> f, (a, b) -> b));
-    }
-
-    private static void validateConditions(List<FilterCondition> conditions, Map<String, FilterSpec> specsByName) {
-        for (var condition : conditions) {
-            var spec = specsByName.get(condition.name());
-            if (spec == null) {
-                throw UnsupportedObservabilityFilterException.unknownName(condition.name());
-            }
-            if (!spec.signals().contains(Signal.LOGS)) {
-                throw UnsupportedObservabilityFilterException.signalMismatch(condition.name(), Signal.LOGS);
-            }
-        }
     }
 
     private static void validateTimeRange(Instant from, Instant to) {

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/infra/adapter/ObservabilityLogsDataPortAdapter.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/infra/adapter/ObservabilityLogsDataPortAdapter.java
@@ -18,6 +18,7 @@ package io.gravitee.gamma.rest.infra.adapter;
 import io.gravitee.apim.core.api_product.model.ApiProduct;
 import io.gravitee.apim.core.api_product.query_service.ApiProductQueryService;
 import io.gravitee.apim.core.application.crud_service.ApplicationCrudService;
+import io.gravitee.apim.core.exception.ValidationDomainException;
 import io.gravitee.apim.core.gateway.model.BaseInstance;
 import io.gravitee.apim.core.gateway.query_service.InstanceQueryService;
 import io.gravitee.apim.core.log.crud_service.ConnectionLogsCrudService;
@@ -30,6 +31,9 @@ import io.gravitee.definition.model.DefinitionVersion;
 import io.gravitee.gamma.rest.core.observability.filter.exception.UnsupportedObservabilityFilterException;
 import io.gravitee.gamma.rest.core.observability.filter.model.FilterCondition;
 import io.gravitee.gamma.rest.core.observability.filter.model.FilterOperator;
+import io.gravitee.gamma.rest.core.observability.filter.model.FilterSpec;
+import io.gravitee.gamma.rest.core.observability.filter.model.StaticFilters;
+import io.gravitee.gamma.rest.core.observability.logs.model.ApiReference;
 import io.gravitee.gamma.rest.core.observability.logs.model.LogEntry;
 import io.gravitee.gamma.rest.core.observability.logs.model.LogEntryWarning;
 import io.gravitee.gamma.rest.core.observability.logs.model.LogsPage;
@@ -65,6 +69,15 @@ import org.springframework.security.core.context.SecurityContextHolder;
  */
 @RequiredArgsConstructor
 public class ObservabilityLogsDataPortAdapter implements ObservabilityLogsDataPort {
+
+    /**
+     * Inclusive HTTP status bounds, sourced from the unified catalog ({@link StaticFilters#HTTP_STATUS})
+     * so the adapter and the advertised filter range never drift apart. Used both to validate incoming
+     * status values and to bound {@code GTE}/{@code LTE} range expansion.
+     */
+    private static final FilterSpec.Range HTTP_STATUS_RANGE = StaticFilters.HTTP_STATUS.toSpec().range();
+    private static final int HTTP_STATUS_MIN = HTTP_STATUS_RANGE.min().intValue();
+    private static final int HTTP_STATUS_MAX = HTTP_STATUS_RANGE.max().intValue();
 
     private final ConnectionLogsCrudService connectionLogsCrudService;
     private final UserContextLoader userContextLoader;
@@ -103,7 +116,7 @@ public class ObservabilityLogsDataPortAdapter implements ObservabilityLogsDataPo
 
         var entries = rawEntries
             .stream()
-            .map(log -> mapToLogEntry(log, query.apiNamesById()))
+            .map(log -> mapToLogEntry(log, query.apisById()))
             .toList();
         var enriched = enrichWithNames(executionContext, entries);
 
@@ -137,15 +150,22 @@ public class ObservabilityLogsDataPortAdapter implements ObservabilityLogsDataPo
                 case "APPLICATION" -> applicationIds.addAll(values);
                 case "PLAN" -> planIds.addAll(values);
                 case "HTTP_METHOD" -> methods.addAll(values.stream().map(this::toHttpMethod).toList());
-                case "HTTP_STATUS" -> statuses.addAll(values.stream().map(Integer::valueOf).toList());
+                case "HTTP_STATUS" -> addStatusFilter(condition, values, statuses);
                 case "URI" -> {
                     if (!values.isEmpty()) uri = values.getFirst();
                 }
                 case "HTTP_GATEWAY_RESPONSE_TIME" -> {
                     if (!values.isEmpty()) {
                         long val = Long.parseLong(values.getFirst());
-                        if (condition.operator() == FilterOperator.GTE) responseTimeFrom = val;
-                        else if (condition.operator() == FilterOperator.LTE) responseTimeTo = val;
+                        switch (condition.operator()) {
+                            case GTE -> responseTimeFrom = val;
+                            case LTE -> responseTimeTo = val;
+                            case EQ -> {
+                                responseTimeFrom = val;
+                                responseTimeTo = val;
+                            }
+                            default -> throw unexpectedOperator("HTTP_GATEWAY_RESPONSE_TIME", condition.operator());
+                        }
                     }
                 }
                 case "ENTRYPOINT" -> entrypointIds.addAll(values);
@@ -178,10 +198,12 @@ public class ObservabilityLogsDataPortAdapter implements ObservabilityLogsDataPo
         return builder.build();
     }
 
-    private LogEntry mapToLogEntry(BaseConnectionLog log, Map<String, String> apiNamesById) {
+    private LogEntry mapToLogEntry(BaseConnectionLog log, Map<String, ApiReference> apisById) {
+        var apiRef = apisById != null ? apisById.get(log.getApiId()) : null;
         return LogEntry.builder()
             .apiId(log.getApiId())
-            .apiName(apiNamesById.getOrDefault(log.getApiId(), null))
+            .apiName(apiRef != null ? apiRef.name() : null)
+            .apiType(apiRef != null ? apiRef.apiType() : null)
             .timestamp(parseTimestamp(log.getTimestamp()))
             .requestId(log.getRequestId())
             .method(log.getMethod() != null ? log.getMethod().name() : null)
@@ -248,13 +270,23 @@ public class ObservabilityLogsDataPortAdapter implements ObservabilityLogsDataPo
             .map(entry ->
                 entry
                     .toBuilder()
-                    .planName(planNameById.get(entry.planId()))
-                    .applicationName(appNameById.get(entry.applicationId()))
-                    .gatewayHostname(gatewayHostnameById.get(entry.gateway()))
-                    .apiProductName(entry.apiProductId() == null ? "Standalone API" : apiProductNameById.get(entry.apiProductId()))
+                    .planName(lookup(planNameById, entry.planId()))
+                    .applicationName(lookup(appNameById, entry.applicationId()))
+                    .gatewayHostname(lookup(gatewayHostnameById, entry.gateway()))
+                    .apiProductName(entry.apiProductId() == null ? "Standalone API" : lookup(apiProductNameById, entry.apiProductId()))
                     .build()
             )
             .toList();
+    }
+
+    /**
+     * Null-safe map lookup: the enrichment maps fall back to {@link Map#of()} (immutable, which throws
+     * on {@code get(null)}) when there is nothing to resolve, and a log row may carry a null
+     * plan/application/gateway id (e.g. anonymous calls). Guarding here keeps a single missing id from
+     * failing the whole search.
+     */
+    private static String lookup(Map<String, String> namesById, String id) {
+        return id == null ? null : namesById.get(id);
     }
 
     private static Instant parseTimestamp(String timestamp) {
@@ -288,6 +320,54 @@ public class ObservabilityLogsDataPortAdapter implements ObservabilityLogsDataPo
             .stream()
             .map(w -> new LogEntryWarning(w.getComponentType(), w.getComponentName(), w.getKey(), w.getMessage()))
             .toList();
+    }
+
+    /**
+     * Translates an {@code HTTP_STATUS} condition into the logs engine's discrete status set. The
+     * unified catalog advertises {@code EQ}/{@code GTE}/{@code LTE} for this NUMBER filter, but the
+     * logs backend ({@link SearchLogsFilters#statuses()}) only matches discrete codes today, so only
+     * {@code EQ} is translated here. Range operators ({@code GTE}/{@code LTE}) are explicitly rejected
+     * (400) for now rather than silently mistranslated; they will be wired through an ES {@code range}
+     * (shared with {@code HTTP_STATUS_CODE_GROUP}) by GMA-683 — deliberately not via integer expansion,
+     * to avoid a divergent status-translation implementation.
+     */
+    private static void addStatusFilter(FilterCondition condition, List<String> values, Set<Integer> statuses) {
+        if (values.isEmpty()) {
+            return;
+        }
+        if (condition.operator() != FilterOperator.EQ) {
+            throw UnsupportedObservabilityFilterException.unsupportedOperator("HTTP_STATUS", condition.operator().name());
+        }
+        values.forEach(value -> statuses.add(parseHttpStatus(value)));
+    }
+
+    private static int parseHttpStatus(String value) {
+        if (value == null) {
+            throw new ValidationDomainException("Invalid HTTP status code value: null");
+        }
+        int status;
+        try {
+            status = Integer.parseInt(value.trim());
+        } catch (NumberFormatException e) {
+            throw new ValidationDomainException("Invalid HTTP status code value: " + value);
+        }
+        if (status < HTTP_STATUS_MIN || status > HTTP_STATUS_MAX) {
+            throw new ValidationDomainException(
+                "Invalid HTTP status code: " + value + ". Must be between " + HTTP_STATUS_MIN + " and " + HTTP_STATUS_MAX + "."
+            );
+        }
+        return status;
+    }
+
+    /**
+     * Defensive guard: the use case already validates each condition's operator against the catalog
+     * via {@code ObservabilityFilterValidator}, so reaching this means the catalog advertises an
+     * operator the translation does not yet handle — a programming error, not a client error.
+     */
+    private static IllegalStateException unexpectedOperator(String filterName, FilterOperator operator) {
+        return new IllegalStateException(
+            "Operator " + operator + " for filter '" + filterName + "' should have been rejected by filter validation"
+        );
     }
 
     private static io.gravitee.apim.core.audit.model.AuditInfo currentAuditInfo(String organizationId, String environmentId) {

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/infra/config/GammaObservabilityFilterConfiguration.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/infra/config/GammaObservabilityFilterConfiguration.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.gamma.rest.infra.config;
 
+import io.gravitee.apim.core.DomainService;
 import io.gravitee.apim.core.UseCase;
 import io.gravitee.apim.core.analytics_engine.use_case.GetFilterValuesUseCase;
 import io.gravitee.apim.core.analytics_engine.use_case.ResolveFilterLabelsUseCase;
@@ -43,7 +44,10 @@ import org.springframework.context.annotation.FilterType;
 @Configuration
 @ComponentScan(
     basePackages = "io.gravitee.gamma.rest.core.observability.filter",
-    includeFilters = @ComponentScan.Filter(type = FilterType.ANNOTATION, value = UseCase.class)
+    includeFilters = {
+        @ComponentScan.Filter(type = FilterType.ANNOTATION, value = UseCase.class),
+        @ComponentScan.Filter(type = FilterType.ANNOTATION, value = DomainService.class),
+    }
 )
 public class GammaObservabilityFilterConfiguration {
 

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/resources/openapi/observability/openapi-observability.yaml
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/resources/openapi/observability/openapi-observability.yaml
@@ -457,7 +457,7 @@ paths:
                                         to: "2026-06-11T00:00:00Z"
                                     filters:
                                         - name: "HTTP_STATUS"
-                                          operator: "GTE"
+                                          operator: "EQ"
                                           value: "500"
                                         - name: "HTTP_METHOD"
                                           operator: "IN"
@@ -542,7 +542,11 @@ paths:
                         A filter condition is invalid. Possible causes:
                         - Unknown filter name (`observability.filter.unknown_name`)
                         - Filter does not apply to the LOGS signal (`observability.filter.signal_mismatch`)
+                        - Operator not usable for this filter on log search (`observability.filter.unsupported_operator`). This
+                          covers operators absent from the catalog, and catalog operators not yet translated by log search —
+                          currently `HTTP_STATUS` `GTE`/`LTE` (range support is pending; use `EQ` meanwhile).
                         - Filter is valid for LOGS but not yet supported by log search (`observability.filter.search_translation_not_supported`)
+                        - A filter value is malformed or out of range (e.g. an `HTTP_STATUS` outside 100–599)
                         - `from` is after `to` in the time range
                     content:
                         application/json:
@@ -561,12 +565,23 @@ paths:
                                         httpStatus: 400
                                         message: "Filter 'GATEWAY' does not apply to signal LOGS"
                                         technicalCode: "observability.filter.signal_mismatch"
+                                unsupported-operator:
+                                    summary: Operator not usable for this filter on log search
+                                    value:
+                                        httpStatus: 400
+                                        message: "Operator 'GTE' is not supported yet for filter 'HTTP_STATUS'"
+                                        technicalCode: "observability.filter.unsupported_operator"
                                 search-translation-not-supported:
                                     summary: Filter valid for LOGS but not yet translated by log search
                                     value:
                                         httpStatus: 400
                                         message: "Filter 'HTTP_STATUS_CODE_GROUP' is not yet supported for log search"
                                         technicalCode: "observability.filter.search_translation_not_supported"
+                                invalid-filter-value:
+                                    summary: Malformed or out-of-range filter value
+                                    value:
+                                        httpStatus: 400
+                                        message: "Invalid HTTP status code: 1000. Must be between 100 and 599."
                                 invalid-time-range:
                                     summary: Invalid time range (from > to)
                                     value:

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/test/java/io/gravitee/gamma/rest/core/observability/filter/domain_service/ObservabilityFilterValidatorTest.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/test/java/io/gravitee/gamma/rest/core/observability/filter/domain_service/ObservabilityFilterValidatorTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gamma.rest.core.observability.filter.domain_service;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.gamma.rest.core.observability.filter.exception.UnsupportedObservabilityFilterException;
+import io.gravitee.gamma.rest.core.observability.filter.model.ApiType;
+import io.gravitee.gamma.rest.core.observability.filter.model.FilterCondition;
+import io.gravitee.gamma.rest.core.observability.filter.model.FilterOperator;
+import io.gravitee.gamma.rest.core.observability.filter.model.FilterSpec;
+import io.gravitee.gamma.rest.core.observability.filter.model.FilterType;
+import io.gravitee.gamma.rest.core.observability.filter.model.Signal;
+import io.gravitee.gamma.rest.core.observability.filter.port.service_provider.FilterRegistry;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class ObservabilityFilterValidatorTest {
+
+    @Mock
+    private FilterRegistry filterRegistry;
+
+    private ObservabilityFilterValidator validator;
+
+    @BeforeEach
+    void setUp() {
+        validator = new ObservabilityFilterValidator(filterRegistry);
+        when(filterRegistry.getFilters(any(), any())).thenReturn(
+            List.of(
+                new FilterSpec(
+                    "HTTP_STATUS",
+                    "Status Code",
+                    FilterType.NUMBER,
+                    List.of(FilterOperator.EQ, FilterOperator.GTE, FilterOperator.LTE),
+                    null,
+                    new FilterSpec.Range(100, 599),
+                    Set.of(Signal.LOGS, Signal.ANALYTICS),
+                    Set.of(ApiType.HTTP_PROXY)
+                ),
+                new FilterSpec(
+                    "GATEWAY",
+                    "Gateway",
+                    FilterType.KEYWORD,
+                    List.of(FilterOperator.EQ, FilterOperator.IN),
+                    null,
+                    null,
+                    Set.of(Signal.ANALYTICS),
+                    ApiType.ALL
+                )
+            )
+        );
+    }
+
+    @Test
+    void should_pass_a_valid_condition() {
+        var conditions = List.of(new FilterCondition("HTTP_STATUS", FilterOperator.GTE, List.of("400")));
+
+        assertThatCode(() -> validator.validate(conditions, Signal.LOGS)).doesNotThrowAnyException();
+    }
+
+    @Test
+    void should_reject_an_unknown_filter_name() {
+        var conditions = List.of(new FilterCondition("UNKNOWN", FilterOperator.EQ, List.of("x")));
+
+        assertThatThrownBy(() -> validator.validate(conditions, Signal.LOGS))
+            .isInstanceOf(UnsupportedObservabilityFilterException.class)
+            .hasMessageContaining("UNKNOWN");
+    }
+
+    @Test
+    void should_reject_a_filter_not_applicable_to_the_signal() {
+        var conditions = List.of(new FilterCondition("GATEWAY", FilterOperator.EQ, List.of("gw-1")));
+
+        assertThatThrownBy(() -> validator.validate(conditions, Signal.LOGS))
+            .isInstanceOf(UnsupportedObservabilityFilterException.class)
+            .hasMessageContaining("GATEWAY");
+    }
+
+    @Test
+    void should_reject_an_operator_not_advertised_for_the_filter() {
+        var conditions = List.of(new FilterCondition("HTTP_STATUS", FilterOperator.CONTAINS, List.of("200")));
+
+        assertThatThrownBy(() -> validator.validate(conditions, Signal.LOGS))
+            .isInstanceOf(UnsupportedObservabilityFilterException.class)
+            .hasMessageContaining("CONTAINS");
+    }
+}

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/test/java/io/gravitee/gamma/rest/core/observability/logs/domain_service/AccessibleApiScopeDomainServiceTest.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/test/java/io/gravitee/gamma/rest/core/observability/logs/domain_service/AccessibleApiScopeDomainServiceTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gamma.rest.core.observability.logs.domain_service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.gamma.rest.core.observability.filter.model.ApiType;
+import io.gravitee.gamma.rest.core.observability.logs.port.service_provider.ObservabilityLogsDataPort.AccessibleApi;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class AccessibleApiScopeDomainServiceTest {
+
+    private final AccessibleApiScopeDomainService service = new AccessibleApiScopeDomainService();
+
+    @Test
+    void should_keep_only_apis_of_the_wanted_types() {
+        var accessible = List.of(
+            new AccessibleApi("api-proxy", "Proxy API", ApiType.HTTP_PROXY),
+            new AccessibleApi("api-message", "Message API", ApiType.MESSAGE)
+        );
+
+        var scope = service.computeScope(accessible, Set.of(ApiType.HTTP_PROXY), null);
+
+        assertThat(scope.apiIds()).containsExactly("api-proxy");
+        assertThat(scope.apisById()).containsOnlyKeys("api-proxy");
+    }
+
+    @Test
+    void should_expose_api_type_as_the_canonical_uppercase_wire_value() {
+        var accessible = List.of(new AccessibleApi("api-1", "Petstore", ApiType.HTTP_PROXY));
+
+        var scope = service.computeScope(accessible, Set.of(ApiType.HTTP_PROXY), null);
+
+        var ref = scope.apisById().get("api-1");
+        assertThat(ref.name()).isEqualTo("Petstore");
+        // Must match the documented log-row apiType and the API_TYPE filter enum values (uppercase).
+        assertThat(ref.apiType()).isEqualTo("HTTP_PROXY");
+    }
+
+    @Test
+    void should_intersect_with_the_user_supplied_api_filter() {
+        var accessible = List.of(
+            new AccessibleApi("api-1", "API 1", ApiType.HTTP_PROXY),
+            new AccessibleApi("api-2", "API 2", ApiType.HTTP_PROXY)
+        );
+
+        var scope = service.computeScope(accessible, Set.of(ApiType.HTTP_PROXY), Set.of("api-1"));
+
+        assertThat(scope.apiIds()).containsExactly("api-1");
+    }
+}

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/test/java/io/gravitee/gamma/rest/core/observability/logs/use_case/SearchObservabilityLogsUseCaseTest.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/test/java/io/gravitee/gamma/rest/core/observability/logs/use_case/SearchObservabilityLogsUseCaseTest.java
@@ -24,6 +24,7 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import io.gravitee.apim.core.exception.ValidationDomainException;
+import io.gravitee.gamma.rest.core.observability.filter.domain_service.ObservabilityFilterValidator;
 import io.gravitee.gamma.rest.core.observability.filter.exception.UnsupportedObservabilityFilterException;
 import io.gravitee.gamma.rest.core.observability.filter.model.ApiType;
 import io.gravitee.gamma.rest.core.observability.filter.model.FilterCondition;
@@ -71,7 +72,8 @@ class SearchObservabilityLogsUseCaseTest {
     @BeforeEach
     void setUp() {
         accessibleApiScope = new AccessibleApiScopeDomainService();
-        useCase = new SearchObservabilityLogsUseCase(logsDataPort, filterRegistry, accessibleApiScope);
+        var filterValidator = new ObservabilityFilterValidator(filterRegistry);
+        useCase = new SearchObservabilityLogsUseCase(logsDataPort, filterValidator, accessibleApiScope);
 
         when(filterRegistry.getFilters(any(), any())).thenReturn(
             List.of(
@@ -196,6 +198,16 @@ class SearchObservabilityLogsUseCaseTest {
         @Test
         void should_reject_filter_whose_signals_exclude_logs() {
             var filters = List.of(new FilterCondition("GATEWAY", FilterOperator.EQ, List.of("gw-1")));
+
+            assertThatThrownBy(() ->
+                useCase.execute(new SearchObservabilityLogsUseCase.Input(ORG_ID, ENV_ID, filters, null, null, 1, 20))
+            ).isInstanceOf(UnsupportedObservabilityFilterException.class);
+            verifyNoInteractions(logsDataPort);
+        }
+
+        @Test
+        void should_reject_operator_not_advertised_by_the_catalog() {
+            var filters = List.of(new FilterCondition("HTTP_STATUS", FilterOperator.CONTAINS, List.of("200")));
 
             assertThatThrownBy(() ->
                 useCase.execute(new SearchObservabilityLogsUseCase.Input(ORG_ID, ENV_ID, filters, null, null, 1, 20))

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/test/java/io/gravitee/gamma/rest/infra/adapter/ObservabilityLogsDataPortAdapterTest.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/test/java/io/gravitee/gamma/rest/infra/adapter/ObservabilityLogsDataPortAdapterTest.java
@@ -15,33 +15,48 @@
  */
 package io.gravitee.gamma.rest.infra.adapter;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
 
 import io.gravitee.apim.core.api_product.query_service.ApiProductQueryService;
 import io.gravitee.apim.core.application.crud_service.ApplicationCrudService;
+import io.gravitee.apim.core.exception.ValidationDomainException;
 import io.gravitee.apim.core.gateway.query_service.InstanceQueryService;
 import io.gravitee.apim.core.log.crud_service.ConnectionLogsCrudService;
 import io.gravitee.apim.core.plan.crud_service.PlanCrudService;
 import io.gravitee.apim.core.user.domain_service.UserContextLoader;
+import io.gravitee.common.http.HttpMethod;
 import io.gravitee.gamma.rest.core.observability.filter.exception.UnsupportedObservabilityFilterException;
 import io.gravitee.gamma.rest.core.observability.filter.model.FilterCondition;
 import io.gravitee.gamma.rest.core.observability.filter.model.FilterOperator;
+import io.gravitee.gamma.rest.core.observability.logs.model.ApiReference;
 import io.gravitee.gamma.rest.core.observability.logs.model.LogsSearchQuery;
+import io.gravitee.rest.api.model.analytics.SearchLogsFilters;
+import io.gravitee.rest.api.model.v4.log.SearchLogsResponse;
+import io.gravitee.rest.api.model.v4.log.connection.BaseConnectionLog;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 class ObservabilityLogsDataPortAdapterTest {
+
+    private static final String ORG = "org-1";
+    private static final String ENV = "env-1";
 
     @Mock
     private ConnectionLogsCrudService connectionLogsCrudService;
@@ -77,18 +92,198 @@ class ObservabilityLogsDataPortAdapterTest {
 
     @Test
     void should_reject_filter_not_translatable_to_log_search() {
-        var query = LogsSearchQuery.builder()
-            .apiIds(Set.of("api-1"))
-            .apiNamesById(Map.of("api-1", "API 1"))
-            .conditions(List.of(new FilterCondition("HTTP_STATUS_CODE_GROUP", FilterOperator.IN, List.of("2XX"))))
-            .page(1)
-            .perPage(20)
-            .build();
+        var query = queryWith(new FilterCondition("HTTP_STATUS_CODE_GROUP", FilterOperator.IN, List.of("2XX")));
 
-        assertThatThrownBy(() -> adapter.searchLogs("org-1", "env-1", query))
+        assertThatThrownBy(() -> adapter.searchLogs(ORG, ENV, query))
             .isInstanceOf(UnsupportedObservabilityFilterException.class)
             .hasMessageContaining("HTTP_STATUS_CODE_GROUP");
 
         verifyNoInteractions(connectionLogsCrudService);
+    }
+
+    @Test
+    void should_propagate_api_type_onto_log_rows() {
+        when(connectionLogsCrudService.searchApiConnectionLogs(any(), any(SearchLogsFilters.class), any(), any())).thenReturn(
+            new SearchLogsResponse<>(1, List.of(BaseConnectionLog.builder().apiId("api-1").build()))
+        );
+
+        var page = adapter.searchLogs(ORG, ENV, queryWith());
+
+        assertThat(page.data()).hasSize(1);
+        assertThat(page.data().getFirst().apiType()).isEqualTo("HTTP_PROXY");
+        assertThat(page.data().getFirst().apiName()).isEqualTo("API 1");
+    }
+
+    @Nested
+    class HttpStatusFilter {
+
+        @Test
+        void should_translate_eq_to_single_status() {
+            stubEmptySearchResult();
+            var query = queryWith(new FilterCondition("HTTP_STATUS", FilterOperator.EQ, List.of("200")));
+
+            adapter.searchLogs(ORG, ENV, query);
+
+            assertThat(captureSearchFilters().statuses()).containsExactly(200);
+        }
+
+        @Test
+        void should_reject_gte_until_range_translation_lands() {
+            // Interim: range operators on HTTP_STATUS are rejected (400) until GMA-683 wires an ES range.
+            var query = queryWith(new FilterCondition("HTTP_STATUS", FilterOperator.GTE, List.of("500")));
+
+            assertThatThrownBy(() -> adapter.searchLogs(ORG, ENV, query))
+                .isInstanceOf(UnsupportedObservabilityFilterException.class)
+                .hasMessageContaining("HTTP_STATUS");
+
+            verifyNoInteractions(connectionLogsCrudService);
+        }
+
+        @Test
+        void should_reject_lte_until_range_translation_lands() {
+            var query = queryWith(new FilterCondition("HTTP_STATUS", FilterOperator.LTE, List.of("299")));
+
+            assertThatThrownBy(() -> adapter.searchLogs(ORG, ENV, query))
+                .isInstanceOf(UnsupportedObservabilityFilterException.class)
+                .hasMessageContaining("HTTP_STATUS");
+
+            verifyNoInteractions(connectionLogsCrudService);
+        }
+
+        @Test
+        void should_reject_out_of_range_status_code() {
+            var query = queryWith(new FilterCondition("HTTP_STATUS", FilterOperator.EQ, List.of("1000")));
+
+            assertThatThrownBy(() -> adapter.searchLogs(ORG, ENV, query))
+                .isInstanceOf(ValidationDomainException.class)
+                .hasMessageContaining("1000");
+        }
+
+        @Test
+        void should_reject_status_code_below_minimum() {
+            var query = queryWith(new FilterCondition("HTTP_STATUS", FilterOperator.EQ, List.of("99")));
+
+            assertThatThrownBy(() -> adapter.searchLogs(ORG, ENV, query))
+                .isInstanceOf(ValidationDomainException.class)
+                .hasMessageContaining("99");
+        }
+
+        @Test
+        void should_reject_non_numeric_status_code() {
+            var query = queryWith(new FilterCondition("HTTP_STATUS", FilterOperator.EQ, List.of("abc")));
+
+            assertThatThrownBy(() -> adapter.searchLogs(ORG, ENV, query))
+                .isInstanceOf(ValidationDomainException.class)
+                .hasMessageContaining("abc");
+        }
+    }
+
+    @Nested
+    class ResponseTimeFilter {
+
+        @Test
+        void should_translate_gte_to_response_time_from() {
+            stubEmptySearchResult();
+            var query = queryWith(new FilterCondition("HTTP_GATEWAY_RESPONSE_TIME", FilterOperator.GTE, List.of("100")));
+
+            adapter.searchLogs(ORG, ENV, query);
+
+            var ranges = captureSearchFilters().responseTimeRanges();
+            assertThat(ranges).hasSize(1);
+            assertThat(ranges.getFirst().from()).isEqualTo(100L);
+            assertThat(ranges.getFirst().to()).isNull();
+        }
+
+        @Test
+        void should_translate_lte_to_response_time_to() {
+            stubEmptySearchResult();
+            var query = queryWith(new FilterCondition("HTTP_GATEWAY_RESPONSE_TIME", FilterOperator.LTE, List.of("500")));
+
+            adapter.searchLogs(ORG, ENV, query);
+
+            var ranges = captureSearchFilters().responseTimeRanges();
+            assertThat(ranges).hasSize(1);
+            assertThat(ranges.getFirst().from()).isNull();
+            assertThat(ranges.getFirst().to()).isEqualTo(500L);
+        }
+
+        @Test
+        void should_translate_eq_to_exact_range() {
+            stubEmptySearchResult();
+            var query = queryWith(new FilterCondition("HTTP_GATEWAY_RESPONSE_TIME", FilterOperator.EQ, List.of("250")));
+
+            adapter.searchLogs(ORG, ENV, query);
+
+            var ranges = captureSearchFilters().responseTimeRanges();
+            assertThat(ranges).hasSize(1);
+            assertThat(ranges.getFirst().from()).isEqualTo(250L);
+            assertThat(ranges.getFirst().to()).isEqualTo(250L);
+        }
+    }
+
+    @Nested
+    class OtherFilters {
+
+        @Test
+        void should_translate_http_method() {
+            stubEmptySearchResult();
+            var query = queryWith(new FilterCondition("HTTP_METHOD", FilterOperator.EQ, List.of("GET")));
+
+            adapter.searchLogs(ORG, ENV, query);
+
+            assertThat(captureSearchFilters().methods()).containsExactly(HttpMethod.GET);
+        }
+
+        @Test
+        void should_fallback_to_other_for_unknown_method() {
+            stubEmptySearchResult();
+            var query = queryWith(new FilterCondition("HTTP_METHOD", FilterOperator.EQ, List.of("UNKNOWN")));
+
+            adapter.searchLogs(ORG, ENV, query);
+
+            assertThat(captureSearchFilters().methods()).containsExactly(HttpMethod.OTHER);
+        }
+
+        @Test
+        void should_translate_application_filter() {
+            stubEmptySearchResult();
+            var query = queryWith(new FilterCondition("APPLICATION", FilterOperator.IN, List.of("app-1", "app-2")));
+
+            adapter.searchLogs(ORG, ENV, query);
+
+            assertThat(captureSearchFilters().applicationIds()).containsExactlyInAnyOrder("app-1", "app-2");
+        }
+
+        @Test
+        void should_translate_uri_filter() {
+            stubEmptySearchResult();
+            var query = queryWith(new FilterCondition("URI", FilterOperator.EQ, List.of("/api/v1/users")));
+
+            adapter.searchLogs(ORG, ENV, query);
+
+            assertThat(captureSearchFilters().uri()).isEqualTo("/api/v1/users");
+        }
+    }
+
+    private LogsSearchQuery queryWith(FilterCondition... conditions) {
+        return LogsSearchQuery.builder()
+            .apiIds(Set.of("api-1"))
+            .apisById(Map.of("api-1", new ApiReference("API 1", "HTTP_PROXY")))
+            .conditions(List.of(conditions))
+            .page(1)
+            .perPage(20)
+            .build();
+    }
+
+    private void stubEmptySearchResult() {
+        when(connectionLogsCrudService.searchApiConnectionLogs(any(), any(SearchLogsFilters.class), any(), any())).thenReturn(
+            new SearchLogsResponse<>(0, List.of())
+        );
+    }
+
+    private SearchLogsFilters captureSearchFilters() {
+        var captor = ArgumentCaptor.forClass(SearchLogsFilters.class);
+        verify(connectionLogsCrudService).searchApiConnectionLogs(any(), captor.capture(), any(), any());
+        return captor.getValue();
     }
 }


### PR DESCRIPTION
## Summary
Follow-up to the review feedback on #17824 (GMA-423, already merged). It makes the unified observability filter catalog the single source of truth so a filter behaves identically across the logs and (future) analytics signals — same name, same operators — and fixes the contract mismatches found during the post-merge audit.

## Changes
- **Operator validation moved to core.** New `ObservabilityFilterValidator` domain service validates each condition's name, signal *and* operator against the catalog. The use case delegates to it instead of the previous partial check (name + signal only), so unsupported operators are rejected uniformly for every filter.
- **`HTTP_STATUS`**: `EQ` is translated to the discrete status set, and malformed / out-of-range values now return `400` instead of `500` (bounds read from the catalog). **Range operators (`GTE`/`LTE`) are explicitly rejected (400) for now** rather than silently mistranslated — they will be wired through an ES `range` (shared with `HTTP_STATUS_CODE_GROUP`) by **GMA-683**, deliberately *not* via integer expansion, to avoid a divergent status-translation implementation.
- **`HTTP_GATEWAY_RESPONSE_TIME` supports `EQ`** (exact range), matching the catalog. This filter has native range support in the logs backend (`responseTimeRanges`).
- **`apiType` propagated onto log rows** as the canonical uppercase wire value (`HTTP_PROXY`, …), matching the OpenAPI contract and the `API_TYPE` filter values. The two parallel scope maps (`apiNamesById` / `apiTypesById`) are collapsed into a single `ApiReference`.
- **Latent NPE fixed**: enriching a row with a null plan/application/gateway id crashed the whole search (`Map.of().get(null)`); lookups are now null-safe.
- **OpenAPI** updated to document the `400` causes (unsupported/not-yet-translated operator, invalid filter value).

## Backend / API changes
| Endpoint | Method | Change | Request example | Response example |
|----------|--------|--------|-----------------|------------------|
| `/gamma/.../observability/logs/search` | `POST` | `HTTP_STATUS` `EQ` translated; invalid value → 400 | `{ "filters": [{ "name": "HTTP_STATUS", "operator": "EQ", "value": "500" }] }` | `200` page of rows with `status == 500` |
| `/gamma/.../observability/logs/search` | `POST` | `HTTP_STATUS` `GTE`/`LTE` → 400 (interim, pending GMA-683) | `{ "filters": [{ "name": "HTTP_STATUS", "operator": "GTE", "value": "500" }] }` | `{ "httpStatus": 400, "technicalCode": "observability.filter.unsupported_operator" }` |
| `/gamma/.../observability/logs/search` | `POST` | unsupported operator → 400 | `{ "filters": [{ "name": "HTTP_STATUS", "operator": "CONTAINS", "value": "200" }] }` | `{ "httpStatus": 400, "technicalCode": "observability.filter.unsupported_operator" }` |
| `/gamma/.../observability/logs/search` | `POST` | `apiType` now populated (uppercase) | `{}` | `{ "data": [{ "apiType": "HTTP_PROXY", ... }] }` |

## Reviewer notes
- **Architectural split**: validation lives in **core** (catalog-driven, shared by signals) while translation stays in the **infra adapter** (logs-backend-specific). `ObservabilityFilterValidator` is signal-agnostic so the upcoming Gamma analytics endpoints (GMA-586) can reuse it with `Signal.ANALYTICS`.
- **HTTP_STATUS range is intentionally deferred to GMA-683**, which adds a shared ES-range util (`StatusCodeGroups`) used by both the analytics `FilterAdapter` and the logs `SearchMetricsQueryAdapter`. Doing integer expansion here would create the exact divergent implementation GMA-683 forbids. Per epic GMA-420: "extend, never mutate shared adapters".

## Test plan
- [ ] `mvn -pl gravitee-gamma/gravitee-gamma-rest-api test` (146 tests green)
- [ ] `HTTP_STATUS` `EQ` translates to the expected status; out-of-range / non-numeric → `400`
- [ ] `HTTP_STATUS` `GTE`/`LTE` → `400` (interim) with `observability.filter.unsupported_operator`
- [ ] An operator absent from the catalog (e.g. `CONTAINS`) → `400`
- [ ] `HTTP_GATEWAY_RESPONSE_TIME` with `EQ` produces an exact range
- [ ] Log rows expose `apiType` as the uppercase enum name
- [ ] A row with null plan/application/gateway no longer fails the search

Refs GMA-423, GMA-683