### PR TITLE
feat(api-product): persist and validate API Product sharding tags

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/ApiProduct.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/ApiProduct.java
@@ -42,6 +42,7 @@ public class ApiProduct {
     private String version;
     private List<String> apiIds;
     private Set<String> groups;
+    private Set<String> tags;
     private Date createdAt;
     private Date updatedAt;
     private boolean disableMembershipNotifications;

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcApiProductRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcApiProductRepository.java
@@ -41,11 +41,13 @@ public class JdbcApiProductRepository extends JdbcAbstractCrudRepository<ApiProd
 
     private final String API_PRODUCT_APIS;
     private final String API_PRODUCT_GROUPS;
+    private final String API_PRODUCT_TAGS;
 
     JdbcApiProductRepository(@Value("${management.jdbc.prefix:}") String tablePrefix) {
         super(tablePrefix, "api_products");
         API_PRODUCT_APIS = getTableNameFor("api_product_apis");
         API_PRODUCT_GROUPS = getTableNameFor("api_product_groups");
+        API_PRODUCT_TAGS = getTableNameFor("api_product_tags");
     }
 
     @Override
@@ -74,6 +76,7 @@ public class JdbcApiProductRepository extends JdbcAbstractCrudRepository<ApiProd
             jdbcTemplate.update(getOrm().buildInsertPreparedStatementCreator(apiProduct));
             storeApiIds(apiProduct, false);
             storeGroupIds(apiProduct, false);
+            storeTags(apiProduct, false);
             return findById(apiProduct.getId()).orElse(null);
         } catch (final Exception ex) {
             throw new TechnicalException("Failed to create api product", ex);
@@ -87,6 +90,7 @@ public class JdbcApiProductRepository extends JdbcAbstractCrudRepository<ApiProd
             jdbcTemplate.update(getOrm().buildUpdatePreparedStatementCreator(apiProduct, apiProduct.getId()));
             storeApiIds(apiProduct, true);
             storeGroupIds(apiProduct, true);
+            storeTags(apiProduct, true);
             return findById(apiProduct.getId()).orElseThrow(() ->
                 new IllegalStateException(String.format("No api product found with id [%s]", apiProduct.getId()))
             );
@@ -114,6 +118,8 @@ public class JdbcApiProductRepository extends JdbcAbstractCrudRepository<ApiProd
                 id
             );
             apiProduct.setGroups(groupIds.isEmpty() ? null : new HashSet<>(groupIds));
+            List<String> tags = getTags(id);
+            apiProduct.setTags(tags.isEmpty() ? null : new HashSet<>(tags));
             return Optional.of(apiProduct);
         }
         return opt;
@@ -138,6 +144,7 @@ public class JdbcApiProductRepository extends JdbcAbstractCrudRepository<ApiProd
             );
             List<ApiProduct> aggregated = aggregateApiProducts(apiProducts);
             enrichWithGroupIds(aggregated);
+            enrichWithTags(aggregated);
             return new HashSet<>(aggregated);
         } catch (final Exception ex) {
             throw new TechnicalException("Failed to find all api products", ex);
@@ -165,6 +172,7 @@ public class JdbcApiProductRepository extends JdbcAbstractCrudRepository<ApiProd
             );
             List<ApiProduct> aggregated = aggregateApiProducts(apiProducts);
             enrichWithGroupIds(aggregated);
+            enrichWithTags(aggregated);
             return aggregated.isEmpty() ? Optional.empty() : Optional.of(aggregated.get(0));
         } catch (final Exception ex) {
             throw new TechnicalException("Failed to find api product by environment and name", ex);
@@ -192,6 +200,7 @@ public class JdbcApiProductRepository extends JdbcAbstractCrudRepository<ApiProd
             );
             List<ApiProduct> aggregatedByEnv = aggregateApiProducts(apiProducts);
             enrichWithGroupIds(aggregatedByEnv);
+            enrichWithTags(aggregatedByEnv);
             return new HashSet<>(aggregatedByEnv);
         } catch (final Exception ex) {
             throw new TechnicalException("Failed to find api products by environment", ex);
@@ -204,6 +213,7 @@ public class JdbcApiProductRepository extends JdbcAbstractCrudRepository<ApiProd
         try {
             jdbcTemplate.update("DELETE FROM " + API_PRODUCT_APIS + " WHERE api_product_id = ?", id);
             jdbcTemplate.update("DELETE FROM " + API_PRODUCT_GROUPS + " WHERE api_product_id = ?", id);
+            jdbcTemplate.update("DELETE FROM " + API_PRODUCT_TAGS + " WHERE api_product_id = ?", id);
             jdbcTemplate.update(getOrm().getDeleteSql(), id);
         } catch (final Exception ex) {
             throw new TechnicalException("Failed to delete api product", ex);
@@ -242,6 +252,7 @@ public class JdbcApiProductRepository extends JdbcAbstractCrudRepository<ApiProd
             );
             List<ApiProduct> aggregated = needApiJoin ? aggregateApiProducts(apiProducts) : apiProducts;
             enrichWithGroupIds(aggregated);
+            enrichWithTags(aggregated);
             return aggregated;
         } catch (final Exception ex) {
             throw new TechnicalException("Failed to search api products", ex);
@@ -271,6 +282,7 @@ public class JdbcApiProductRepository extends JdbcAbstractCrudRepository<ApiProd
             );
             List<ApiProduct> aggregatedByApiId = aggregateApiProducts(apiProducts);
             enrichWithGroupIds(aggregatedByApiId);
+            enrichWithTags(aggregatedByApiId);
             return new HashSet<>(aggregatedByApiId);
         } catch (final Exception ex) {
             throw new TechnicalException("Failed to find api products by apiId", ex);
@@ -317,6 +329,7 @@ public class JdbcApiProductRepository extends JdbcAbstractCrudRepository<ApiProd
             );
             List<ApiProduct> aggregatedByApiIds = aggregateApiProducts(apiProducts);
             enrichWithGroupIds(aggregatedByApiIds);
+            enrichWithTags(aggregatedByApiIds);
             return new HashSet<>(aggregatedByApiIds);
         } catch (final Exception ex) {
             throw new TechnicalException("Failed to find api products by api ids", ex);
@@ -351,6 +364,7 @@ public class JdbcApiProductRepository extends JdbcAbstractCrudRepository<ApiProd
             );
             List<ApiProduct> aggregatedByIds = aggregateApiProducts(apiProducts);
             enrichWithGroupIds(aggregatedByIds);
+            enrichWithTags(aggregatedByIds);
             return new HashSet<>(aggregatedByIds);
         } catch (final Exception ex) {
             throw new TechnicalException("Failed to find api products by ids", ex);
@@ -512,6 +526,50 @@ public class JdbcApiProductRepository extends JdbcAbstractCrudRepository<ApiProd
                 }
             );
         }
+    }
+
+    private List<String> getTags(String apiProductId) {
+        return jdbcTemplate.query(
+            "SELECT tag FROM " + API_PRODUCT_TAGS + " WHERE api_product_id = ?",
+            (ResultSet rs, int rowNum) -> rs.getString("tag"),
+            apiProductId
+        );
+    }
+
+    private void storeTags(ApiProduct apiProduct, boolean deleteFirst) throws TechnicalException {
+        try {
+            if (deleteFirst) {
+                jdbcTemplate.update("DELETE FROM " + API_PRODUCT_TAGS + " WHERE api_product_id = ?", apiProduct.getId());
+            }
+            List<String> filteredTags = getOrm().filterStrings(apiProduct.getTags());
+            if (!filteredTags.isEmpty()) {
+                jdbcTemplate.batchUpdate(
+                    "INSERT INTO " + API_PRODUCT_TAGS + " ( api_product_id, tag ) VALUES ( ?, ? )",
+                    getOrm().getBatchStringSetter(apiProduct.getId(), filteredTags)
+                );
+            }
+        } catch (final Exception ex) {
+            throw new TechnicalException("Failed to store api product tags", ex);
+        }
+    }
+
+    private void enrichWithTags(List<ApiProduct> products) {
+        if (products == null || products.isEmpty()) {
+            return;
+        }
+        List<String> productIds = products.stream().map(ApiProduct::getId).toList();
+        Map<String, Set<String>> tagsByProductId = new HashMap<>();
+        jdbcTemplate.query(
+            "SELECT api_product_id, tag FROM " + API_PRODUCT_TAGS + " WHERE api_product_id IN (" + getOrm().buildInClause(productIds) + ")",
+            rs -> {
+                tagsByProductId.computeIfAbsent(rs.getString("api_product_id"), k -> new HashSet<>()).add(rs.getString("tag"));
+            },
+            productIds.toArray()
+        );
+        products.forEach(p -> {
+            Set<String> tags = tagsByProductId.get(p.getId());
+            p.setTags(tags == null || tags.isEmpty() ? null : tags);
+        });
     }
 
     private void enrichWithGroupIds(List<ApiProduct> products) {

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_12_0/19_add_api_product_tags_table.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_12_0/19_add_api_product_tags_table.yml
@@ -1,0 +1,28 @@
+databaseChangeLog:
+  - changeSet:
+      id: 4.12.0_19_add_api_product_tags_table
+      author: GraviteeSource Team
+      changes:
+        - createTable:
+            tableName: ${gravitee_prefix}api_product_tags
+            columns:
+              - column:
+                  name: api_product_id
+                  type: nvarchar(64)
+                  constraints:
+                    nullable: false
+                    primaryKey: true
+                    primaryKeyName: pk_${gravitee_prefix}api_product_tags
+              - column:
+                  name: tag
+                  type: nvarchar(64)
+                  constraints:
+                    nullable: false
+                    primaryKey: true
+                    primaryKeyName: pk_${gravitee_prefix}api_product_tags
+        - createIndex:
+            indexName: idx_${gravitee_prefix}api_product_tags_tag
+            tableName: ${gravitee_prefix}api_product_tags
+            columns:
+              - column:
+                  name: tag

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/master.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/master.yml
@@ -381,3 +381,5 @@ databaseChangeLog:
         - file: liquibase/changelogs/v4_12_0/17_add_portal_navigation_to_apis.yml
     - include:
         - file: liquibase/changelogs/v4_12_0/18_add_portal_navigation_to_portals.yml
+    - include:
+        - file: liquibase/changelogs/v4_12_0/19_add_api_product_tags_table.yml

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/test/java/io/gravitee/repository/jdbc/JdbcTestRepositoryInitializer.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/test/java/io/gravitee/repository/jdbc/JdbcTestRepositoryInitializer.java
@@ -53,6 +53,7 @@ public class JdbcTestRepositoryInitializer implements TestRepositoryInitializer 
         "api_tags",
         "api_categories",
         "api_product_apis",
+        "api_product_tags",
         "api_products",
         "applications",
         "application_groups",

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/model/ApiProductMongo.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/model/ApiProductMongo.java
@@ -18,6 +18,7 @@ package io.gravitee.repository.mongodb.management.internal.model;
 import io.gravitee.repository.management.model.ApiProduct;
 import java.util.Date;
 import java.util.List;
+import java.util.Set;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
@@ -47,6 +48,7 @@ public class ApiProductMongo {
     private String version;
     private List<String> apiIds;
     private List<String> groups;
+    private Set<String> tags;
     private Date createdAt;
     private Date updatedAt;
     private boolean disableMembershipNotifications;

--- a/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/ApiProductRepositoryTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-test/src/test/java/io/gravitee/repository/management/ApiProductRepositoryTest.java
@@ -88,7 +88,28 @@ public class ApiProductRepositoryTest extends AbstractManagementRepositoryTest {
             softly.assertThat(found.getCreatedAt().getTime()).isEqualTo(1_470_157_767_000L);
             softly.assertThat(found.getUpdatedAt()).isNotNull();
             softly.assertThat(found.getUpdatedAt().getTime()).isEqualTo(1_470_157_767_000L);
+            softly.assertThat(found.getTags()).isNull();
         });
+    }
+
+    @Test
+    public void shouldReturnConsistentTagsBetweenFindByIdAndFindByEnvironmentId() throws TechnicalException {
+        var date = new Date();
+        var uuid = UUID.random().toString();
+        ApiProduct apiProduct = createApiProduct(uuid, date, "my-env", "tagged-api-product", "1.0.0", List.of("api1"));
+        apiProduct.setTags(Set.of("internal", "external"));
+        apiProductsRepository.create(apiProduct);
+
+        ApiProduct byId = apiProductsRepository.findById(uuid).orElseThrow();
+        ApiProduct byEnvironment = apiProductsRepository
+            .findByEnvironmentId("my-env")
+            .stream()
+            .filter(p -> uuid.equals(p.getId()))
+            .findFirst()
+            .orElseThrow();
+
+        assertThat(byId.getTags()).containsExactlyInAnyOrder("internal", "external");
+        assertThat(byEnvironment.getTags()).isEqualTo(byId.getTags());
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/spring/ResourceContextConfiguration.java
@@ -72,6 +72,7 @@ import io.gravitee.apim.core.api.use_case.PatchApiUseCase.ApiV4Deserializer;
 import io.gravitee.apim.core.api.use_case.RollbackApiUseCase;
 import io.gravitee.apim.core.api.use_case.WsdlToImportApiUseCase;
 import io.gravitee.apim.core.api_key.domain_service.ReconcileApiKeysDomainService;
+import io.gravitee.apim.core.api_product.domain_service.ApiProductTagsValidationDomainService;
 import io.gravitee.apim.core.apim.service_provider.ApimProductInfo;
 import io.gravitee.apim.core.application.domain_service.ValidateApplicationCRDDomainService;
 import io.gravitee.apim.core.application.domain_service.ValidateApplicationSettingsDomainService;
@@ -577,6 +578,11 @@ public class ResourceContextConfiguration {
     @Bean
     public PolicyValidationDomainService policyValidationDomainService() {
         return mock(PolicyValidationDomainService.class);
+    }
+
+    @Bean
+    public ApiProductTagsValidationDomainService apiProductTagsValidationDomainService() {
+        return mock(ApiProductTagsValidationDomainService.class);
     }
 
     @Bean

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/ApiProductPlanMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/ApiProductPlanMapper.java
@@ -26,22 +26,17 @@ import io.gravitee.rest.api.management.v2.rest.model.UpdateGenericApiProductPlan
 import io.gravitee.rest.api.model.v4.plan.GenericPlanEntity;
 import io.gravitee.rest.api.model.v4.plan.PlanEntity;
 import java.util.ArrayList;
-import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 import java.util.stream.Collectors;
-import org.mapstruct.AfterMapping;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
-import org.mapstruct.MappingTarget;
 import org.mapstruct.Named;
-import org.mapstruct.NullValueMappingStrategy;
 import org.mapstruct.factory.Mappers;
 
-@Mapper(
-    uses = { ConfigurationSerializationMapper.class, DateMapper.class, FlowMapper.class },
-    nullValueIterableMappingStrategy = NullValueMappingStrategy.RETURN_DEFAULT
-)
+@Mapper(uses = { ConfigurationSerializationMapper.class, DateMapper.class, FlowMapper.class })
 public interface ApiProductPlanMapper {
     ApiProductPlanMapper INSTANCE = Mappers.getMapper(ApiProductPlanMapper.class);
 
@@ -104,17 +99,14 @@ public interface ApiProductPlanMapper {
     BasePlan map(GenericPlanEntity plan);
 
     @Mapping(target = "securityConfiguration", source = "security.configuration", qualifiedByName = "serializeConfiguration")
+    @Mapping(target = "tags", source = "tags", qualifiedByName = "mapPlanUpdateTags")
     PlanUpdates mapToPlanUpdates(UpdateGenericApiProductPlan updatePlanV4);
 
-    /**
-     * API Products don't send tags in update requests. Set tags to empty set so PlanUpdates.applyTo()
-     * receives non-null and sets result to empty (matching DB), avoiding false deploy banner on cosmetic changes.
-     */
-    @AfterMapping
-    @SuppressWarnings("unused")
-    default void setEmptyTagsForApiProductUpdate(UpdateGenericApiProductPlan source, @MappingTarget PlanUpdates target) {
-        if (target.getTags() == null) {
-            target.setTags(Collections.emptySet());
+    @Named("mapPlanUpdateTags")
+    default Set<String> mapPlanUpdateTags(List<String> tags) {
+        if (CollectionUtils.isEmpty(tags)) {
+            return null;
         }
+        return new HashSet<>(tags);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-api-products.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-api-products.yaml
@@ -2039,6 +2039,14 @@ components:
           example:
             - "api-1"
             - "api-2"
+        tags:
+          type: array
+          description: The list of sharding tags associated with this API Product.
+          items:
+            type: string
+          example:
+            - "eu"
+            - "secured-edge"
       required:
         - name
         - version
@@ -2087,6 +2095,14 @@ components:
           type: boolean
           description: Disable membership notifications.
           default: false
+        tags:
+          type: array
+          description: The list of sharding tags associated with this API Product.
+          items:
+            type: string
+          example:
+            - "eu"
+            - "secured-edge"
       required:
         - name
         - version
@@ -2149,6 +2165,14 @@ components:
           type: boolean
           description: Disable membership notifications.
           default: false
+        tags:
+          type: array
+          description: The list of sharding tags associated with this API Product.
+          items:
+            type: string
+          example:
+            - "eu"
+            - "secured-edge"
 
     ApiProductDeploymentState:
       type: string
@@ -2532,6 +2556,13 @@ components:
         selectionRule:
           type: string
           description: An optional EL expression that will be evaluated at request time to select this plan.
+        tags:
+          type: array
+          description: The list of sharding tags associated with this plan.
+          items:
+            type: string
+          example:
+            - "eu"
         security:
           type: object
           properties:

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/mapper/ApiProductPlanMapperTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/mapper/ApiProductPlanMapperTest.java
@@ -19,6 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.gravitee.apim.core.plan.model.PlanUpdates;
 import io.gravitee.rest.api.management.v2.rest.model.UpdateGenericApiProductPlan;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 
 class ApiProductPlanMapperTest {
@@ -26,9 +27,7 @@ class ApiProductPlanMapperTest {
     private final ApiProductPlanMapper apiProductPlanMapper = ApiProductPlanMapper.INSTANCE;
 
     @Test
-    void mapToPlanUpdates_should_set_empty_tags_when_source_has_null_tags() {
-        // API Products don't send tags in update requests - tags are null after mapping.
-        // @AfterMapping sets tags to empty set so PlanUpdates.applyTo() matches DB and deploy banner is correct.
+    void mapToPlanUpdates_should_leave_tags_null_when_source_omits_tags() {
         var updatePlan = new UpdateGenericApiProductPlan();
         updatePlan.setName("Updated Plan");
         updatePlan.setDescription("Updated description");
@@ -36,9 +35,19 @@ class ApiProductPlanMapperTest {
         PlanUpdates result = apiProductPlanMapper.mapToPlanUpdates(updatePlan);
 
         assertThat(result).isNotNull();
-        assertThat(result.getTags()).isNotNull();
-        assertThat(result.getTags()).isEmpty();
+        assertThat(result.getTags()).isNull();
         assertThat(result.getName()).isEqualTo("Updated Plan");
         assertThat(result.getDescription()).isEqualTo("Updated description");
+    }
+
+    @Test
+    void mapToPlanUpdates_should_map_explicit_plan_tags() {
+        var updatePlan = new UpdateGenericApiProductPlan();
+        updatePlan.setName("Updated Plan");
+        updatePlan.setTags(List.of("internal"));
+
+        PlanUpdates result = apiProductPlanMapper.mapToPlanUpdates(updatePlan);
+
+        assertThat(result.getTags()).containsExactly("internal");
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api_product/ApiProductResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api_product/ApiProductResourceTest.java
@@ -48,10 +48,12 @@ import io.gravitee.rest.api.model.permissions.RolePermission;
 import io.gravitee.rest.api.model.permissions.RolePermissionAction;
 import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.exceptions.InvalidDataException;
+import io.gravitee.rest.api.service.exceptions.TagNotAllowedException;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.core.Response;
 import java.time.ZonedDateTime;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -221,6 +223,19 @@ class ApiProductResourceTest extends AbstractResourceTest {
     @Nested
     class UpdateApiProductTest {
 
+        @BeforeEach
+        void initUpdateApiProductTests() {
+            // OpenAPI UpdateApiProduct serializes tags as [] by default; the resource loads the existing
+            // product for tag validation whenever tags are present in the request body.
+            when(getApiProductByIdUseCase.execute(any())).thenReturn(
+                GetApiProductsUseCase.Output.single(
+                    Optional.of(
+                        ApiProduct.builder().id(API_PRODUCT_ID).environmentId(ENV_ID).name("Existing Product").tags(Set.of()).build()
+                    )
+                )
+            );
+        }
+
         @Test
         void should_update_api_product() {
             ApiProduct updatedApiProduct = ApiProduct.builder()
@@ -316,6 +331,19 @@ class ApiProductResourceTest extends AbstractResourceTest {
             shouldReturn403(RolePermission.API_PRODUCT_DEFINITION, API_PRODUCT_ID, RolePermissionAction.UPDATE, () ->
                 rootTarget().request().put(json(""))
             );
+        }
+
+        @Test
+        void should_return_400_when_user_not_allowed_to_use_restricted_tag() {
+            when(updateApiProductUseCase.execute(any())).thenThrow(new TagNotAllowedException(new String[] { "restricted-tag" }));
+
+            var updatePayload = new io.gravitee.rest.api.management.v2.rest.model.UpdateApiProduct();
+            updatePayload.setName("Updated Product");
+            updatePayload.setTags(List.of("restricted-tag"));
+
+            try (Response response = rootTarget().request().put(json(updatePayload))) {
+                assertThat(response.getStatus()).isEqualTo(BAD_REQUEST_400);
+            }
         }
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api_product/ApiProductsResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api_product/ApiProductsResourceTest.java
@@ -47,6 +47,7 @@ import io.gravitee.rest.api.model.EnvironmentEntity;
 import io.gravitee.rest.api.model.permissions.RolePermission;
 import io.gravitee.rest.api.model.permissions.RolePermissionAction;
 import io.gravitee.rest.api.service.common.GraviteeContext;
+import io.gravitee.rest.api.service.exceptions.TagNotAllowedException;
 import io.gravitee.rest.api.service.notification.ApiProductHook;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.core.GenericType;
@@ -262,6 +263,20 @@ class ApiProductsResourceTest extends AbstractResourceTest {
             shouldReturn403(RolePermission.ENVIRONMENT_API_PRODUCT, ENV_ID, RolePermissionAction.CREATE, () ->
                 rootTarget().request().post(json(new CreateApiProduct()))
             );
+        }
+
+        @Test
+        void should_return_400_when_user_not_allowed_to_use_restricted_tag() {
+            when(createApiProductUseCase.execute(any())).thenThrow(new TagNotAllowedException(new String[] { "restricted-tag" }));
+
+            CreateApiProduct createApiProduct = new CreateApiProduct();
+            createApiProduct.setName("My API Product");
+            createApiProduct.setVersion("1.0.0");
+            createApiProduct.setTags(List.of("restricted-tag"));
+
+            final Response response = rootTarget().request().post(json(createApiProduct));
+
+            assertThat(response.getStatus()).isEqualTo(BAD_REQUEST_400);
         }
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/spring/ResourceContextConfiguration.java
@@ -88,6 +88,7 @@ import io.gravitee.apim.core.api.use_case.ValidateApiCRDUseCase;
 import io.gravitee.apim.core.api.use_case.WsdlToImportApiUseCase;
 import io.gravitee.apim.core.api.use_case.WsdlToUpdateApiUseCase;
 import io.gravitee.apim.core.api_key.domain_service.ReconcileApiKeysDomainService;
+import io.gravitee.apim.core.api_product.domain_service.ApiProductTagsValidationDomainService;
 import io.gravitee.apim.core.api_product.use_case.CreateApiProductUseCase;
 import io.gravitee.apim.core.api_product.use_case.DeleteApiProductUseCase;
 import io.gravitee.apim.core.api_product.use_case.DeployApiProductUseCase;
@@ -1683,5 +1684,15 @@ public class ResourceContextConfiguration {
     @Bean
     public ValidatePortalListingDomainService validatePortalListingDomainService() {
         return new ValidatePortalListingDomainService();
+    }
+
+    @Bean
+    public io.gravitee.rest.api.service.v4.validation.TagsValidationService tagsValidationService() {
+        return mock(io.gravitee.rest.api.service.v4.validation.TagsValidationService.class);
+    }
+
+    @Bean
+    public ApiProductTagsValidationDomainService apiProductTagsValidationDomainService() {
+        return mock(ApiProductTagsValidationDomainService.class);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/spring/ResourceContextConfiguration.java
@@ -67,6 +67,7 @@ import io.gravitee.apim.core.api.use_case.PatchApiUseCase.ApiV4Deserializer;
 import io.gravitee.apim.core.api.use_case.RollbackApiUseCase;
 import io.gravitee.apim.core.api.use_case.WsdlToImportApiUseCase;
 import io.gravitee.apim.core.api_key.domain_service.ReconcileApiKeysDomainService;
+import io.gravitee.apim.core.api_product.domain_service.ApiProductTagsValidationDomainService;
 import io.gravitee.apim.core.api_product.use_case.GetApiProductsUseCase;
 import io.gravitee.apim.core.api_product.use_case.TransferApiProductOwnershipUseCase;
 import io.gravitee.apim.core.apim.service_provider.ApimProductInfo;
@@ -828,6 +829,11 @@ public class ResourceContextConfiguration {
     @Bean
     public PolicyValidationDomainService policyValidationDomainService() {
         return mock(PolicyValidationDomainService.class);
+    }
+
+    @Bean
+    public ApiProductTagsValidationDomainService apiProductTagsValidationDomainService() {
+        return mock(ApiProductTagsValidationDomainService.class);
     }
 
     @Bean

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/spring/ResourceContextConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-portal/gravitee-apim-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/spring/ResourceContextConfiguration.java
@@ -72,6 +72,7 @@ import io.gravitee.apim.core.api.use_case.PatchApiUseCase.ApiV4Fields;
 import io.gravitee.apim.core.api.use_case.RollbackApiUseCase;
 import io.gravitee.apim.core.api.use_case.WsdlToImportApiUseCase;
 import io.gravitee.apim.core.api_key.domain_service.ReconcileApiKeysDomainService;
+import io.gravitee.apim.core.api_product.domain_service.ApiProductTagsValidationDomainService;
 import io.gravitee.apim.core.api_product.use_case.TransferApiProductOwnershipUseCase;
 import io.gravitee.apim.core.apim.service_provider.ApimProductInfo;
 import io.gravitee.apim.core.application.domain_service.ValidateApplicationSettingsDomainService;
@@ -824,6 +825,11 @@ public class ResourceContextConfiguration {
     @Bean
     public PolicyValidationDomainService policyValidationDomainService() {
         return mock(PolicyValidationDomainService.class);
+    }
+
+    @Bean
+    public ApiProductTagsValidationDomainService apiProductTagsValidationDomainService() {
+        return mock(ApiProductTagsValidationDomainService.class);
     }
 
     @Bean

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/domain_service/ApiProductTagDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/domain_service/ApiProductTagDomainService.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.api_product.domain_service;
+
+import io.gravitee.apim.core.DomainService;
+import io.gravitee.apim.core.api_product.crud_service.ApiProductCrudService;
+import io.gravitee.apim.core.api_product.model.ApiProduct;
+import io.gravitee.apim.core.api_product.query_service.ApiProductQueryService;
+import io.gravitee.apim.core.audit.model.AuditInfo;
+import io.gravitee.apim.core.plan.crud_service.PlanCrudService;
+import io.gravitee.apim.core.plan.query_service.PlanQueryService;
+import io.gravitee.apim.core.utils.CollectionUtils;
+import io.gravitee.rest.api.model.v4.plan.GenericPlanEntity;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+import lombok.CustomLog;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * Handles tag lifecycle operations for API Products and their plans.
+ */
+@DomainService
+@RequiredArgsConstructor
+@CustomLog
+public class ApiProductTagDomainService {
+
+    private final ApiProductQueryService apiProductQueryService;
+    private final ApiProductCrudService apiProductCrudService;
+    private final PlanQueryService planQueryService;
+    private final PlanCrudService planCrudService;
+    private final ApiProductTagsValidationDomainService apiProductTagsValidationDomainService;
+
+    public void validateTagsOnCreate(AuditInfo auditInfo, Set<String> tags) {
+        if (CollectionUtils.isEmpty(tags)) {
+            return;
+        }
+        validateTags(auditInfo, null, tags);
+    }
+
+    public void validateTagsOnUpdate(AuditInfo auditInfo, Set<String> existingTags, Set<String> newTags) {
+        if (newTags == null) {
+            return;
+        }
+        validateTags(auditInfo, existingTags, newTags);
+    }
+
+    private void validateTags(AuditInfo auditInfo, Set<String> existingTags, Set<String> newTags) {
+        apiProductTagsValidationDomainService.validateAndSanitize(
+            auditInfo.organizationId(),
+            auditInfo.environmentId(),
+            existingTags,
+            newTags
+        );
+    }
+
+    /**
+     * Remove a deleted tag key from all API Products and their plans in the given environment.
+     * Called when an organization-level tag is deleted.
+     * <p>
+     * Idempotent: safe to re-run after a partial failure (e.g. product updated but plan cleanup
+     * interrupted). Plan cleanup runs for every product in the environment, not only when the
+     * product still carries the tag.
+     */
+    public void deleteTagFromApiProducts(String environmentId, String tagKey) {
+        Set<ApiProduct> products = apiProductQueryService.findByEnvironmentId(environmentId);
+
+        for (ApiProduct product : products) {
+            if (product.getTags() != null && product.getTags().contains(tagKey)) {
+                removeTagFromProduct(product, tagKey);
+                apiProductCrudService.update(product);
+            }
+            removeTagFromProductPlans(product.getId(), tagKey);
+        }
+    }
+
+    private void removeTagFromProduct(ApiProduct product, String tagKey) {
+        Set<String> updatedTags = new HashSet<>(product.getTags());
+        updatedTags.remove(tagKey);
+        log.info("Removing deleted tag [{}] from API Product [{}]", tagKey, product.getId());
+        product.setTags(updatedTags.isEmpty() ? null : updatedTags);
+    }
+
+    private void removeTagFromProductPlans(String productId, String tagKey) {
+        var plans = planQueryService.findAllByReferenceIdAndReferenceType(productId, GenericPlanEntity.ReferenceType.API_PRODUCT);
+
+        for (var plan : plans) {
+            var planDef = plan.getPlanDefinitionHttpV4();
+            if (planDef == null || planDef.getTags() == null || !planDef.getTags().contains(tagKey)) {
+                continue;
+            }
+            Set<String> updatedTags = planDef
+                .getTags()
+                .stream()
+                .filter(tagToRemove -> !tagToRemove.equals(tagKey))
+                .collect(Collectors.toSet());
+            log.info("Removing deleted tag [{}] from plan [{}] of API Product [{}]", tagKey, plan.getId(), productId);
+            planDef.setTags(updatedTags.isEmpty() ? null : updatedTags);
+            planCrudService.update(plan);
+        }
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/domain_service/ApiProductTagsValidationDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/domain_service/ApiProductTagsValidationDomainService.java
@@ -13,25 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.apim.core.api_product.model;
+package io.gravitee.apim.core.api_product.domain_service;
 
-import java.util.List;
 import java.util.Set;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
-import lombok.experimental.SuperBuilder;
 
-@Data
-@Builder
-@NoArgsConstructor
-@AllArgsConstructor
-public class CreateApiProduct {
-
-    private String name;
-    private String description;
-    private String version;
-    private List<String> apiIds;
-    private Set<String> tags;
+public interface ApiProductTagsValidationDomainService {
+    void validateAndSanitize(String organizationId, String environmentId, Set<String> existingTags, Set<String> newTags);
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/domain_service/DeployApiProductDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/domain_service/DeployApiProductDomainService.java
@@ -55,6 +55,7 @@ public class DeployApiProductDomainService {
             .version(apiProduct.getVersion())
             .apiIds(apiProduct.getApiIds())
             .environmentId(apiProduct.getEnvironmentId())
+            .tags(apiProduct.getTags())
             .plans(plans)
             .build();
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/model/ApiProduct.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/model/ApiProduct.java
@@ -43,6 +43,7 @@ public class ApiProduct {
     private String version;
     private Set<String> apiIds;
     private Set<String> groups;
+    private Set<String> tags;
     private ZonedDateTime createdAt;
     private ZonedDateTime updatedAt;
     private PrimaryOwnerEntity primaryOwner;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/model/ApiProductDeploymentPayload.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/model/ApiProductDeploymentPayload.java
@@ -36,5 +36,6 @@ public class ApiProductDeploymentPayload {
     private String version;
     private Set<String> apiIds;
     private String environmentId;
+    private Set<String> tags;
     private List<Plan> plans;
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/model/UpdateApiProduct.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/model/UpdateApiProduct.java
@@ -34,6 +34,7 @@ public class UpdateApiProduct {
     private String version;
     private Set<String> apiIds;
     private Set<String> groups;
+    private Set<String> tags;
     private ZonedDateTime updatedAt;
     private Boolean disableMembershipNotifications;
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/use_case/CreateApiProductUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/use_case/CreateApiProductUseCase.java
@@ -21,6 +21,7 @@ import static java.util.stream.Collectors.toSet;
 import io.gravitee.apim.core.UseCase;
 import io.gravitee.apim.core.api_product.crud_service.ApiProductCrudService;
 import io.gravitee.apim.core.api_product.domain_service.ApiProductIndexerDomainService;
+import io.gravitee.apim.core.api_product.domain_service.ApiProductTagDomainService;
 import io.gravitee.apim.core.api_product.domain_service.DeployApiProductDomainService;
 import io.gravitee.apim.core.api_product.domain_service.ValidateApiProductService;
 import io.gravitee.apim.core.api_product.model.ApiProduct;
@@ -65,6 +66,7 @@ public class CreateApiProductUseCase {
     private final NotificationConfigCrudService notificationConfigCrudService;
     private final DeployApiProductDomainService deployApiProductDomainService;
     private final GroupQueryService groupQueryService;
+    private final ApiProductTagDomainService apiProductTagDomainService;
 
     public record Input(CreateApiProduct createApiProduct, AuditInfo auditInfo) {}
 
@@ -84,6 +86,8 @@ public class CreateApiProductUseCase {
         }
 
         Set<String> apiIds = apiIdsList == null || apiIdsList.isEmpty() ? Set.of() : Set.copyOf(apiIdsList);
+        Set<String> tags = payload.getTags() != null ? Set.copyOf(payload.getTags()) : null;
+        apiProductTagDomainService.validateTagsOnCreate(auditInfo, tags);
 
         ApiProduct apiProduct = ApiProduct.builder()
             .id(UuidString.generateRandom())
@@ -92,6 +96,7 @@ public class CreateApiProductUseCase {
             .description(payload.getDescription())
             .version(payload.getVersion())
             .apiIds(apiIds)
+            .tags(tags)
             .createdAt(now)
             .updatedAt(now)
             .build();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/use_case/GetApiProductsUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/use_case/GetApiProductsUseCase.java
@@ -128,7 +128,12 @@ public class GetApiProductsUseCase {
                 return product;
             }
 
-            if (!apiIdsUnchanged(product.getApiIds(), deployedProduct.getApiIds())) {
+            if (!setsEqual(product.getApiIds(), deployedProduct.getApiIds())) {
+                product.setDeploymentState(ApiProduct.DeploymentState.NEED_REDEPLOY);
+                return product;
+            }
+
+            if (!setsEqual(product.getTags(), deployedProduct.getTags())) {
                 product.setDeploymentState(ApiProduct.DeploymentState.NEED_REDEPLOY);
                 return product;
             }
@@ -155,10 +160,9 @@ public class GetApiProductsUseCase {
     }
 
     /**
-     * True if the list of APIs in the product is unchanged compared to the deployed version.
-     * NEED_REDEPLOY when apiIds change (user must deploy to sync gateway).
+     * True when two sets carry the same elements (e.g. apiIds or sharding tags vs last deploy payload).
      */
-    private static boolean apiIdsUnchanged(Set<String> current, Set<String> deployed) {
+    private static boolean setsEqual(Set<String> current, Set<String> deployed) {
         if (current == null && deployed == null) return true;
         if (current == null || deployed == null) return false;
         return current.size() == deployed.size() && current.containsAll(deployed);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/use_case/UpdateApiProductUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api_product/use_case/UpdateApiProductUseCase.java
@@ -21,7 +21,7 @@ import io.gravitee.apim.core.UseCase;
 import io.gravitee.apim.core.api.domain_service.ApiStateDomainService;
 import io.gravitee.apim.core.api_product.crud_service.ApiProductCrudService;
 import io.gravitee.apim.core.api_product.domain_service.ApiProductIndexerDomainService;
-import io.gravitee.apim.core.api_product.domain_service.DeployApiProductDomainService;
+import io.gravitee.apim.core.api_product.domain_service.ApiProductTagDomainService;
 import io.gravitee.apim.core.api_product.domain_service.ValidateApiProductService;
 import io.gravitee.apim.core.api_product.exception.ApiProductNotFoundException;
 import io.gravitee.apim.core.api_product.model.ApiProduct;
@@ -32,19 +32,23 @@ import io.gravitee.apim.core.audit.model.ApiProductAuditLogEntity;
 import io.gravitee.apim.core.audit.model.AuditInfo;
 import io.gravitee.apim.core.audit.model.AuditProperties;
 import io.gravitee.apim.core.audit.model.event.ApiProductAuditEvent;
-import io.gravitee.apim.core.exception.ValidationDomainException;
 import io.gravitee.apim.core.license.domain_service.LicenseDomainService;
 import io.gravitee.apim.core.membership.domain_service.ApiProductPrimaryOwnerDomainService;
 import io.gravitee.apim.core.membership.exception.ApiProductPrimaryOwnerNotFoundException;
 import io.gravitee.apim.core.membership.model.PrimaryOwnerEntity;
 import io.gravitee.apim.core.notification.domain_service.TriggerNotificationDomainService;
 import io.gravitee.apim.core.notification.model.hook.ApiProductUpdatedHookContext;
+import io.gravitee.apim.core.plan.crud_service.PlanCrudService;
+import io.gravitee.apim.core.plan.model.Plan;
+import io.gravitee.apim.core.plan.query_service.PlanQueryService;
 import io.gravitee.common.utils.TimeProvider;
+import io.gravitee.rest.api.model.v4.plan.GenericPlanEntity;
 import io.gravitee.rest.api.service.exceptions.ForbiddenFeatureException;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 import lombok.CustomLog;
 import lombok.RequiredArgsConstructor;
 
@@ -61,8 +65,10 @@ public class UpdateApiProductUseCase {
     private final LicenseDomainService licenseDomainService;
     private final ApiProductIndexerDomainService apiProductIndexerDomainService;
     private final ApiProductPrimaryOwnerDomainService apiProductPrimaryOwnerDomainService;
-    private final DeployApiProductDomainService deployApiProductDomainService;
     private final TriggerNotificationDomainService triggerNotificationDomainService;
+    private final PlanQueryService planQueryService;
+    private final PlanCrudService planCrudService;
+    private final ApiProductTagDomainService apiProductTagDomainService;
 
     public Output execute(Input input) {
         if (!licenseDomainService.isApiProductDeploymentAllowed(input.auditInfo().organizationId())) {
@@ -101,9 +107,16 @@ public class UpdateApiProductUseCase {
             }
         }
 
+        if (updateApiProduct.getTags() != null) {
+            apiProductTagDomainService.validateTagsOnUpdate(input.auditInfo(), existingApiProduct.getTags(), updateApiProduct.getTags());
+            existingApiProduct.setTags(updateApiProduct.getTags().isEmpty() ? Set.of() : Set.copyOf(updateApiProduct.getTags()));
+        }
+
         existingApiProduct.update(updateApiProduct);
 
         ApiProduct updated = apiProductCrudService.update(existingApiProduct);
+
+        autoCleanOrphanedPlanTags(updated, beforeUpdate.getTags());
 
         PrimaryOwnerEntity primaryOwner = null;
         try {
@@ -116,16 +129,8 @@ public class UpdateApiProductUseCase {
         }
         apiProductIndexerDomainService.index(oneShotIndexation(input.auditInfo()), updated, primaryOwner);
 
-        try {
-            validateApiProductService.validateForDeploy(updated);
-            deployApiProductDomainService.deploy(input.auditInfo(), updated);
-        } catch (ValidationDomainException e) {
-            log.warn("API Product [{}] was updated but not deployed to the gateway. {}", updated.getId(), e.getMessage());
-        }
         createAuditLog(beforeUpdate, updated, input.auditInfo());
-        // The notification fires regardless of whether the subsequent re-deploy succeeded: the
-        // data update (name, description, API list, …) always completes before the deploy attempt,
-        // so "API Product Updated" accurately reflects that the stored record changed.
+        // Notification reflects the persisted record change; gateway deploy is explicit via DeployApiProductUseCase.
         triggerNotificationDomainService.triggerApiProductNotification(
             input.auditInfo().organizationId(),
             input.auditInfo().environmentId(),
@@ -141,6 +146,56 @@ public class UpdateApiProductUseCase {
     }
 
     public record Output(ApiProduct apiProduct) {}
+
+    /**
+     * When tags are removed from the product, strip plan tags that are no longer present
+     * in the product's tag set. Only triggers when at least one previously-existing tag
+     * was removed (i.e. the effective set shrank or shifted).
+     */
+    private void autoCleanOrphanedPlanTags(ApiProduct updatedProduct, Set<String> previousProductTags) {
+        Set<String> currentProductTags = updatedProduct.getTags();
+        if (!hasRemovedTags(previousProductTags, currentProductTags)) {
+            return;
+        }
+
+        planQueryService
+            .findAllByReferenceIdAndReferenceType(updatedProduct.getId(), GenericPlanEntity.ReferenceType.API_PRODUCT)
+            .forEach(plan -> removeOrphanedTagsFromPlan(plan, updatedProduct.getId(), currentProductTags));
+    }
+
+    private static boolean hasRemovedTags(Set<String> previousTags, Set<String> currentTags) {
+        if (previousTags == null || previousTags.isEmpty()) {
+            return false;
+        }
+        if (currentTags == null || currentTags.isEmpty()) {
+            return true;
+        }
+        return !currentTags.containsAll(previousTags);
+    }
+
+    private void removeOrphanedTagsFromPlan(Plan plan, String productId, Set<String> currentProductTags) {
+        var planDef = plan.getPlanDefinitionHttpV4();
+        if (planDef == null || planDef.getTags() == null || planDef.getTags().isEmpty()) {
+            return;
+        }
+
+        Set<String> cleanedTags = (currentProductTags == null || currentProductTags.isEmpty())
+            ? Set.of()
+            : planDef.getTags().stream().filter(currentProductTags::contains).collect(Collectors.toSet());
+        if (cleanedTags.size() >= planDef.getTags().size()) {
+            return;
+        }
+
+        log.info(
+            "Auto-cleaning orphaned tags from plan [{}] of API Product [{}]: {} -> {}",
+            plan.getId(),
+            productId,
+            planDef.getTags(),
+            cleanedTags
+        );
+        planDef.setTags(cleanedTags.isEmpty() ? null : cleanedTags);
+        planCrudService.update(plan);
+    }
 
     private void createAuditLog(ApiProduct before, ApiProduct after, AuditInfo auditInfo) {
         auditService.createApiProductAuditLog(

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/plan/domain_service/CreatePlanDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/plan/domain_service/CreatePlanDomainService.java
@@ -212,6 +212,7 @@ public class CreatePlanDomainService {
         }*/
 
         planValidatorDomainService.validatePlanSecurity(plan, auditInfo.organizationId(), auditInfo.environmentId(), null);
+        planValidatorDomainService.validatePlanTagsAgainstApiProductTags(plan.getTags(), apiProduct.getTags());
         planValidatorDomainService.validateGeneralConditionsPageStatus(plan);
         var createdPlan = planCrudService.create(
             plan

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/plan/domain_service/PlanValidatorDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/plan/domain_service/PlanValidatorDomainService.java
@@ -86,9 +86,24 @@ public class PlanValidatorDomainService {
 
             throw new ValidationDomainException(
                 "Plan tags mismatch the tags defined by the API",
-                Map.of("planTags", String.join(",", planTags), "apiTags", String.join(",", apiTags))
+                Map.of("planTags", joinTags(planTags), "apiTags", joinTags(apiTags))
             );
         }
+    }
+
+    public void validatePlanTagsAgainstApiProductTags(Set<String> planTags, Set<String> apiProductTags) {
+        if (!isEmpty(planTags) && (isEmpty(apiProductTags) || planTags.stream().anyMatch(tag -> !apiProductTags.contains(tag)))) {
+            log.debug("Plan rejected, tags {} mismatch the tags defined by the API Product ({})", planTags, apiProductTags);
+
+            throw new ValidationDomainException(
+                "Plan tags mismatch the tags defined by the API Product",
+                Map.of("planTags", joinTags(planTags), "apiProductTags", joinTags(apiProductTags))
+            );
+        }
+    }
+
+    private static String joinTags(Set<String> tags) {
+        return isEmpty(tags) ? "" : String.join(",", tags);
     }
 
     public void validateGeneralConditionsPage(Plan plan, List<Page> pages) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/plan/domain_service/UpdatePlanDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/plan/domain_service/UpdatePlanDomainService.java
@@ -348,7 +348,7 @@ public class UpdatePlanDomainService {
         if (existingPlanStatuses == null) {
             existingPlanStatuses = getPlanStatusMapForApiProduct(apiProduct);
         }
-        updatePreFlightChecksForApiProduct(planToUpdate, existingPlanStatuses, auditInfo);
+        updatePreFlightChecksForApiProduct(planToUpdate, existingPlanStatuses, apiProduct, auditInfo);
 
         Plan existingPlan = planCrudService.getById(planToUpdate.getId());
         Plan updatePlan = existingPlan.update(planToUpdate);
@@ -364,9 +364,15 @@ public class UpdatePlanDomainService {
         return updated;
     }
 
-    private void updatePreFlightChecksForApiProduct(Plan planToUpdate, Map<String, PlanStatus> existingPlanStatuses, AuditInfo auditInfo) {
+    private void updatePreFlightChecksForApiProduct(
+        Plan planToUpdate,
+        Map<String, PlanStatus> existingPlanStatuses,
+        ApiProduct apiProduct,
+        AuditInfo auditInfo
+    ) {
         assertNotClosedStatus(planToUpdate, existingPlanStatuses);
         planValidatorDomainService.validatePlanSecurity(planToUpdate, auditInfo.organizationId(), auditInfo.environmentId(), null);
+        planValidatorDomainService.validatePlanTagsAgainstApiProductTags(planToUpdate.getTags(), apiProduct.getTags());
         planValidatorDomainService.validateGeneralConditionsPageStatus(planToUpdate);
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/plan/model/PlanUpdates.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/plan/model/PlanUpdates.java
@@ -69,7 +69,9 @@ public class PlanUpdates {
             .referenceType(oldPlan.getReferenceType())
             .build();
 
-        result.setPlanTags(tags);
+        if (tags != null) {
+            result.setPlanTags(tags);
+        }
         var definition = result.getPlanDefinitionV4();
         definition.setSelectionRule(selectionRule);
         if (definition.getSecurity() != null) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/api_product/ApiProductTagsValidationDomainServiceLegacyWrapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/api_product/ApiProductTagsValidationDomainServiceLegacyWrapper.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.infra.domain_service.api_product;
+
+import io.gravitee.apim.core.api_product.domain_service.ApiProductTagsValidationDomainService;
+import io.gravitee.rest.api.service.common.ExecutionContext;
+import io.gravitee.rest.api.service.v4.validation.TagsValidationService;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class ApiProductTagsValidationDomainServiceLegacyWrapper implements ApiProductTagsValidationDomainService {
+
+    private final TagsValidationService tagsValidationService;
+
+    @Override
+    public void validateAndSanitize(String organizationId, String environmentId, Set<String> existingTags, Set<String> newTags) {
+        tagsValidationService.validateAndSanitize(new ExecutionContext(organizationId, environmentId), existingTags, newTags);
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/TagServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/TagServiceImpl.java
@@ -22,6 +22,7 @@ import static io.gravitee.repository.management.model.Tag.AuditEvent.TAG_UPDATED
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toSet;
 
+import io.gravitee.apim.core.api_product.domain_service.ApiProductTagDomainService;
 import io.gravitee.common.utils.IdGenerator;
 import io.gravitee.common.utils.UUID;
 import io.gravitee.repository.exceptions.TechnicalException;
@@ -33,6 +34,7 @@ import io.gravitee.rest.api.model.TagEntity;
 import io.gravitee.rest.api.model.TagReferenceType;
 import io.gravitee.rest.api.model.UpdateTagEntity;
 import io.gravitee.rest.api.service.AuditService;
+import io.gravitee.rest.api.service.EnvironmentService;
 import io.gravitee.rest.api.service.GroupService;
 import io.gravitee.rest.api.service.TagService;
 import io.gravitee.rest.api.service.common.ExecutionContext;
@@ -71,6 +73,12 @@ public class TagServiceImpl extends AbstractService implements TagService {
 
     @Autowired
     private GroupService groupService;
+
+    @Autowired
+    private EnvironmentService environmentService;
+
+    @Autowired
+    private ApiProductTagDomainService apiProductTagDomainService;
 
     @Override
     public List<TagEntity> findByReference(String referenceId, TagReferenceType referenceType) {
@@ -212,18 +220,23 @@ public class TagServiceImpl extends AbstractService implements TagService {
             Optional<Tag> tagOptional = tagRepository.findByKeyAndReference(key, referenceId, repoTagReferenceType(referenceType));
 
             if (tagOptional.isPresent()) {
-                String actualTagId = tagOptional.get().getId();
-                tagRepository.delete(actualTagId);
-                // delete all reference on APIs
-                apiTagService.deleteTagFromAPIs(executionContext, actualTagId);
+                Tag tag = tagOptional.get();
+                String tagId = tag.getId();
+                String tagKey = tag.getKey();
+                // Cascade first (idempotent), delete the org tag row last so a retry can complete cleanup.
+                apiTagService.deleteTagFromAPIs(executionContext, tagId);
+                environmentService
+                    .findByOrganization(executionContext.getOrganizationId())
+                    .forEach(env -> apiProductTagDomainService.deleteTagFromApiProducts(env.getId(), tagKey));
+                tagRepository.delete(tagId);
                 auditService.createOrganizationAuditLog(
                     executionContext,
                     AuditService.AuditLogData.builder()
-                        .properties(Collections.singletonMap(TAG, actualTagId))
+                        .properties(Collections.singletonMap(TAG, tagKey))
                         .event(TAG_DELETED)
                         .createdAt(new Date())
                         .oldValue(null)
-                        .newValue(tagOptional.get())
+                        .newValue(tag)
                         .build()
                 );
             }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api_product/domain_service/ApiProductTagDomainServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api_product/domain_service/ApiProductTagDomainServiceTest.java
@@ -1,0 +1,198 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.api_product.domain_service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+
+import fixtures.core.model.PlanFixtures;
+import inmemory.ApiProductCrudServiceInMemory;
+import inmemory.ApiProductQueryServiceInMemory;
+import inmemory.PlanCrudServiceInMemory;
+import inmemory.PlanQueryServiceInMemory;
+import io.gravitee.apim.core.api_product.model.ApiProduct;
+import io.gravitee.apim.core.plan.model.Plan;
+import io.gravitee.definition.model.v4.plan.PlanStatus;
+import io.gravitee.rest.api.model.v4.plan.GenericPlanEntity;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ApiProductTagDomainServiceTest {
+
+    private static final String ENV_ID = "DEFAULT";
+    private static final String PRODUCT_ID = "product-1";
+
+    private final ApiProductCrudServiceInMemory apiProductCrudService = new ApiProductCrudServiceInMemory();
+    private final ApiProductQueryServiceInMemory apiProductQueryService = new ApiProductQueryServiceInMemory();
+    private final PlanQueryServiceInMemory planQueryService = new PlanQueryServiceInMemory();
+    private final PlanCrudServiceInMemory planCrudService = new PlanCrudServiceInMemory();
+
+    @Mock
+    private ApiProductTagsValidationDomainService apiProductTagsValidationDomainService;
+
+    private ApiProductTagDomainService apiProductTagDomainService;
+
+    @BeforeEach
+    void setUp() {
+        apiProductCrudService.reset();
+        apiProductQueryService.reset();
+        planQueryService.reset();
+        planCrudService.reset();
+        apiProductTagDomainService = new ApiProductTagDomainService(
+            apiProductQueryService,
+            apiProductCrudService,
+            planQueryService,
+            planCrudService,
+            apiProductTagsValidationDomainService
+        );
+    }
+
+    @Test
+    void should_validate_tags_on_create_when_tags_are_present() {
+        var auditInfo = io.gravitee.apim.core.audit.model.AuditInfo.builder().organizationId("org-id").environmentId(ENV_ID).build();
+
+        apiProductTagDomainService.validateTagsOnCreate(auditInfo, Set.of("internal"));
+
+        verify(apiProductTagsValidationDomainService).validateAndSanitize(eq("org-id"), eq(ENV_ID), any(), any());
+    }
+
+    @Test
+    void should_skip_validation_on_create_when_tags_are_empty() {
+        var auditInfo = io.gravitee.apim.core.audit.model.AuditInfo.builder().organizationId("org-id").environmentId(ENV_ID).build();
+
+        apiProductTagDomainService.validateTagsOnCreate(auditInfo, Set.of());
+
+        org.mockito.Mockito.verifyNoInteractions(apiProductTagsValidationDomainService);
+    }
+
+    @Test
+    void should_remove_deleted_tag_from_product_and_its_plans() {
+        ApiProduct product = ApiProduct.builder()
+            .id(PRODUCT_ID)
+            .name("Product")
+            .environmentId(ENV_ID)
+            .tags(new HashSet<>(Set.of("internal", "external")))
+            .build();
+        apiProductCrudService.initWith(List.of(product));
+        apiProductQueryService.initWith(List.of(product));
+
+        Plan productPlan = productPlanWithTags("plan-1", Set.of("internal", "external"));
+        planQueryService.initWith(List.of(productPlan));
+        planCrudService.initWith(List.of(productPlan));
+
+        apiProductTagDomainService.deleteTagFromApiProducts(ENV_ID, "external");
+
+        assertThat(apiProductCrudService.get(PRODUCT_ID).getTags()).containsExactly("internal");
+        assertThat(planCrudService.getById("plan-1").getPlanDefinitionHttpV4().getTags()).containsExactly("internal");
+    }
+
+    @Test
+    void should_not_update_product_when_tag_is_not_present() {
+        ApiProduct product = ApiProduct.builder().id(PRODUCT_ID).name("Product").environmentId(ENV_ID).tags(Set.of("internal")).build();
+        apiProductCrudService.initWith(List.of(product));
+        apiProductQueryService.initWith(List.of(product));
+
+        apiProductTagDomainService.deleteTagFromApiProducts(ENV_ID, "external");
+
+        assertThat(apiProductCrudService.get(PRODUCT_ID).getTags()).containsExactly("internal");
+    }
+
+    @Test
+    void should_set_product_tags_to_null_when_last_tag_is_removed() {
+        ApiProduct product = ApiProduct.builder().id(PRODUCT_ID).name("Product").environmentId(ENV_ID).tags(Set.of("internal")).build();
+        apiProductCrudService.initWith(List.of(product));
+        apiProductQueryService.initWith(List.of(product));
+
+        apiProductTagDomainService.deleteTagFromApiProducts(ENV_ID, "internal");
+
+        assertThat(apiProductCrudService.get(PRODUCT_ID).getTags()).isNull();
+    }
+
+    @Test
+    void should_not_remove_tag_when_identifier_does_not_match_stored_tag_key() {
+        ApiProduct product = ApiProduct.builder().id(PRODUCT_ID).name("Product").environmentId(ENV_ID).tags(Set.of("internal")).build();
+        apiProductCrudService.initWith(List.of(product));
+        apiProductQueryService.initWith(List.of(product));
+
+        apiProductTagDomainService.deleteTagFromApiProducts(ENV_ID, "tag-uuid-not-key");
+
+        assertThat(apiProductCrudService.get(PRODUCT_ID).getTags()).containsExactly("internal");
+    }
+
+    @Test
+    void should_clean_plan_tags_even_when_product_tag_was_already_removed() {
+        ApiProduct product = ApiProduct.builder().id(PRODUCT_ID).name("Product").environmentId(ENV_ID).tags(Set.of("internal")).build();
+        apiProductCrudService.initWith(List.of(product));
+        apiProductQueryService.initWith(List.of(product));
+
+        Plan productPlan = productPlanWithTags("plan-1", Set.of("external"));
+        planQueryService.initWith(List.of(productPlan));
+        planCrudService.initWith(List.of(productPlan));
+
+        apiProductTagDomainService.deleteTagFromApiProducts(ENV_ID, "external");
+
+        assertThat(apiProductCrudService.get(PRODUCT_ID).getTags()).containsExactly("internal");
+        assertThat(planCrudService.getById("plan-1").getPlanDefinitionHttpV4().getTags()).isNull();
+    }
+
+    @Test
+    void should_be_idempotent_when_delete_tag_from_api_products_is_called_twice() {
+        ApiProduct product = ApiProduct.builder()
+            .id(PRODUCT_ID)
+            .name("Product")
+            .environmentId(ENV_ID)
+            .tags(new HashSet<>(Set.of("internal", "external")))
+            .build();
+        apiProductCrudService.initWith(List.of(product));
+        apiProductQueryService.initWith(List.of(product));
+
+        Plan productPlan = productPlanWithTags("plan-1", Set.of("external"));
+        planQueryService.initWith(List.of(productPlan));
+        planCrudService.initWith(List.of(productPlan));
+
+        apiProductTagDomainService.deleteTagFromApiProducts(ENV_ID, "external");
+        apiProductTagDomainService.deleteTagFromApiProducts(ENV_ID, "external");
+
+        assertThat(apiProductCrudService.get(PRODUCT_ID).getTags()).containsExactly("internal");
+        assertThat(planCrudService.getById("plan-1").getPlanDefinitionHttpV4().getTags()).isNull();
+    }
+
+    private Plan productPlanWithTags(String planId, Set<String> tags) {
+        var planDefinition = PlanFixtures.aPlanHttpV4()
+            .getPlanDefinitionHttpV4()
+            .toBuilder()
+            .status(PlanStatus.PUBLISHED)
+            .tags(tags)
+            .build();
+        return PlanFixtures.aPlanHttpV4()
+            .toBuilder()
+            .id(planId)
+            .referenceId(PRODUCT_ID)
+            .referenceType(GenericPlanEntity.ReferenceType.API_PRODUCT)
+            .environmentId(ENV_ID)
+            .planDefinitionHttpV4(planDefinition)
+            .build();
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api_product/use_case/CreateApiProductUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api_product/use_case/CreateApiProductUseCaseTest.java
@@ -41,6 +41,7 @@ import inmemory.PlanQueryServiceInMemory;
 import inmemory.RoleQueryServiceInMemory;
 import io.gravitee.apim.core.api.model.Api;
 import io.gravitee.apim.core.api_product.domain_service.ApiProductIndexerDomainService;
+import io.gravitee.apim.core.api_product.domain_service.ApiProductTagDomainService;
 import io.gravitee.apim.core.api_product.domain_service.DeployApiProductDomainService;
 import io.gravitee.apim.core.api_product.domain_service.ValidateApiProductService;
 import io.gravitee.apim.core.api_product.model.CreateApiProduct;
@@ -92,6 +93,7 @@ class CreateApiProductUseCaseTest extends AbstractUseCaseTest {
     private final LicenseManager licenseManager = mock(LicenseManager.class);
     private final ApiProductIndexerDomainService apiProductIndexerDomainService = mock(ApiProductIndexerDomainService.class);
     private final NotificationConfigCrudServiceInMemory notificationConfigCrudService = new NotificationConfigCrudServiceInMemory();
+    private final ApiProductTagDomainService apiProductTagDomainService = mock(ApiProductTagDomainService.class);
 
     private CreateApiProductUseCase createApiProductUseCase;
 
@@ -150,7 +152,8 @@ class CreateApiProductUseCaseTest extends AbstractUseCaseTest {
             apiProductIndexerDomainService,
             notificationConfigCrudService,
             new DeployApiProductDomainService(planQueryService, eventCrudService, eventLatestCrudService),
-            groupQueryService
+            groupQueryService,
+            apiProductTagDomainService
         );
 
         initRoles();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api_product/use_case/GetApiProductsUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api_product/use_case/GetApiProductsUseCaseTest.java
@@ -340,6 +340,30 @@ class GetApiProductsUseCaseTest extends AbstractUseCaseTest {
         }
 
         @Test
+        void should_be_need_redeploy_when_sharding_tags_changed() throws Exception {
+            ApiProduct currentProduct = ApiProduct.builder()
+                .id(API_PRODUCT_ID)
+                .name("Product")
+                .environmentId(ENV_ID)
+                .apiIds(Set.of("api-1"))
+                .tags(Set.of("tag1", "tag2"))
+                .build();
+            apiProductQueryService.initWith(List.of(currentProduct));
+            ApiProduct deployedProduct = ApiProduct.builder()
+                .id(API_PRODUCT_ID)
+                .name("Product")
+                .environmentId(ENV_ID)
+                .apiIds(Set.of("api-1"))
+                .tags(Set.of("tag1"))
+                .build();
+            eventLatestQueryService.initWith(List.of(aDeployApiProductEvent(API_PRODUCT_ID, DEPLOYED_AT, deployedProduct)));
+
+            var output = getApiProductsUseCase.execute(GetApiProductsUseCase.Input.of(ENV_ID, API_PRODUCT_ID, ORG_ID));
+
+            assertThat(output.apiProduct().get().getDeploymentState()).isEqualTo(ApiProduct.DeploymentState.NEED_REDEPLOY);
+        }
+
+        @Test
         void should_be_need_redeploy_when_list_of_apis_in_product_changed() throws Exception {
             ApiProduct currentProduct = ApiProduct.builder()
                 .id(API_PRODUCT_ID)
@@ -372,6 +396,25 @@ class GetApiProductsUseCaseTest extends AbstractUseCaseTest {
             apiProductQueryService.initWith(List.of(product));
             eventLatestQueryService.initWith(List.of(aDeployApiProductEvent(API_PRODUCT_ID, DEPLOYED_AT, product)));
             planQueryService.initWith(List.of(aPublishedApiProductPlan(API_PRODUCT_ID, AFTER_DEPLOY)));
+
+            var output = getApiProductsUseCase.execute(GetApiProductsUseCase.Input.of(ENV_ID, API_PRODUCT_ID, ORG_ID));
+
+            assertThat(output.apiProduct().get().getDeploymentState()).isEqualTo(ApiProduct.DeploymentState.NEED_REDEPLOY);
+        }
+
+        @Test
+        void should_be_need_redeploy_when_plan_tags_modified_after_last_deploy() throws Exception {
+            ApiProduct product = ApiProduct.builder()
+                .id(API_PRODUCT_ID)
+                .name("Product")
+                .environmentId(ENV_ID)
+                .updatedAt(BEFORE_DEPLOY.atZone(ZoneId.systemDefault()))
+                .build();
+            apiProductQueryService.initWith(List.of(product));
+            eventLatestQueryService.initWith(List.of(aDeployApiProductEvent(API_PRODUCT_ID, DEPLOYED_AT, product)));
+            planQueryService.initWith(
+                List.of(aPublishedApiProductPlanWithTags(API_PRODUCT_ID, AFTER_DEPLOY, Set.of("internal", "external")))
+            );
 
             var output = getApiProductsUseCase.execute(GetApiProductsUseCase.Input.of(ENV_ID, API_PRODUCT_ID, ORG_ID));
 
@@ -477,6 +520,10 @@ class GetApiProductsUseCaseTest extends AbstractUseCaseTest {
         }
 
         private Plan aPublishedApiProductPlan(String apiProductId, Instant needRedeployAt) {
+            return aPublishedApiProductPlanWithTags(apiProductId, needRedeployAt, Set.of());
+        }
+
+        private Plan aPublishedApiProductPlanWithTags(String apiProductId, Instant needRedeployAt, Set<String> tags) {
             return Plan.builder()
                 .id("plan-" + apiProductId)
                 .referenceId(apiProductId)
@@ -484,7 +531,11 @@ class GetApiProductsUseCaseTest extends AbstractUseCaseTest {
                 .definitionVersion(DefinitionVersion.V4)
                 .apiType(ApiType.PROXY)
                 .planDefinitionHttpV4(
-                    fixtures.definition.PlanFixtures.HttpV4Definition.anApiKeyV4().toBuilder().status(PlanStatus.PUBLISHED).build()
+                    fixtures.definition.PlanFixtures.HttpV4Definition.anApiKeyV4()
+                        .toBuilder()
+                        .status(PlanStatus.PUBLISHED)
+                        .tags(tags.isEmpty() ? null : tags)
+                        .build()
                 )
                 .needRedeployAt(Date.from(needRedeployAt))
                 .build();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api_product/use_case/UpdateApiProductUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/api_product/use_case/UpdateApiProductUseCaseTest.java
@@ -35,19 +35,18 @@ import inmemory.ApiProductCrudServiceInMemory;
 import inmemory.ApiProductQueryServiceInMemory;
 import inmemory.ApiQueryServiceInMemory;
 import inmemory.LicenseCrudServiceInMemory;
+import inmemory.PlanCrudServiceInMemory;
 import inmemory.PlanQueryServiceInMemory;
 import inmemory.TriggerNotificationDomainServiceInMemory;
 import io.gravitee.apim.core.api.domain_service.ApiStateDomainService;
 import io.gravitee.apim.core.api.model.Api;
 import io.gravitee.apim.core.api_product.domain_service.ApiProductIndexerDomainService;
-import io.gravitee.apim.core.api_product.domain_service.DeployApiProductDomainService;
+import io.gravitee.apim.core.api_product.domain_service.ApiProductTagDomainService;
 import io.gravitee.apim.core.api_product.domain_service.ValidateApiProductService;
 import io.gravitee.apim.core.api_product.exception.ApiProductNotFoundException;
 import io.gravitee.apim.core.api_product.model.ApiProduct;
 import io.gravitee.apim.core.api_product.model.UpdateApiProduct;
 import io.gravitee.apim.core.audit.domain_service.AuditDomainService;
-import io.gravitee.apim.core.event.crud_service.EventCrudService;
-import io.gravitee.apim.core.event.crud_service.EventLatestCrudService;
 import io.gravitee.apim.core.exception.ValidationDomainException;
 import io.gravitee.apim.core.license.domain_service.LicenseDomainService;
 import io.gravitee.apim.core.membership.domain_service.ApiProductPrimaryOwnerDomainService;
@@ -72,20 +71,21 @@ class UpdateApiProductUseCaseTest extends AbstractUseCaseTest {
     private final ApiCrudServiceInMemory apiCrudService = new ApiCrudServiceInMemory();
     private final ApiQueryServiceInMemory apiQueryService = new ApiQueryServiceInMemory(apiCrudService);
     private final PlanQueryServiceInMemory planQueryService = new PlanQueryServiceInMemory();
-    private final EventCrudService eventCrudService = mock(EventCrudService.class);
-    private final EventLatestCrudService eventLatestCrudService = mock(EventLatestCrudService.class);
+    private final PlanCrudServiceInMemory planCrudService = new PlanCrudServiceInMemory();
     private final LicenseManager licenseManager = mock(LicenseManager.class);
     private final ApiStateDomainService apiStateDomainService = mock(ApiStateDomainService.class);
     private final ApiProductIndexerDomainService apiProductIndexerDomainService = mock(ApiProductIndexerDomainService.class);
     private final ApiProductPrimaryOwnerDomainService apiProductPrimaryOwnerDomainService = mock(ApiProductPrimaryOwnerDomainService.class);
     private final TriggerNotificationDomainServiceInMemory triggerNotificationDomainService =
         new TriggerNotificationDomainServiceInMemory();
+    private final ApiProductTagDomainService apiProductTagDomainService = mock(ApiProductTagDomainService.class);
 
     private UpdateApiProductUseCase updateApiProductUseCase;
 
     @BeforeEach
     void setUp() {
         planQueryService.reset();
+        planCrudService.reset();
         triggerNotificationDomainService.reset();
         var auditService = new AuditDomainService(auditCrudService, userCrudService, new JacksonJsonDiffProcessor());
         var validateApiProductService = new ValidateApiProductService(
@@ -104,8 +104,10 @@ class UpdateApiProductUseCaseTest extends AbstractUseCaseTest {
             new LicenseDomainService(new LicenseCrudServiceInMemory(), licenseManager),
             apiProductIndexerDomainService,
             apiProductPrimaryOwnerDomainService,
-            new DeployApiProductDomainService(planQueryService, eventCrudService, eventLatestCrudService),
-            triggerNotificationDomainService
+            triggerNotificationDomainService,
+            planQueryService,
+            planCrudService,
+            apiProductTagDomainService
         );
     }
 
@@ -139,9 +141,6 @@ class UpdateApiProductUseCaseTest extends AbstractUseCaseTest {
             () -> assertThat(output.apiProduct().getApiIds()).containsExactly("api-2") // Replace, not merge
         );
 
-        // Verify DEPLOY event was published
-        verify(eventCrudService).createEvent(eq(ORG_ID), eq(ENV_ID), any(), any(), any(), any());
-        verify(eventLatestCrudService).createOrPatchLatestEvent(eq(ORG_ID), eq("api-product-id"), any());
         verify(apiProductIndexerDomainService).index(any(), eq(output.apiProduct()), any());
     }
 
@@ -525,8 +524,107 @@ class UpdateApiProductUseCaseTest extends AbstractUseCaseTest {
         var output = updateApiProductUseCase.execute(input);
 
         assertThat(output.apiProduct().getApiIds()).containsExactlyInAnyOrder("api-1", "api-2");
-        verify(eventCrudService, never()).createEvent(any(), any(), any(), any(), any(), any());
-        verify(eventLatestCrudService, never()).createOrPatchLatestEvent(any(), any(), any());
+    }
+
+    @Test
+    void should_update_api_product_tags() {
+        ApiProduct existing = ApiProduct.builder()
+            .id("api-product-id")
+            .name("API Product")
+            .version("1.0.0")
+            .tags(Set.of("internal"))
+            .environmentId(ENV_ID)
+            .build();
+        apiProductCrudService.initWith(List.of(existing));
+        apiProductQueryService.initWith(List.of(existing));
+
+        var toUpdate = UpdateApiProduct.builder().tags(Set.of("internal", "external")).build();
+        var output = updateApiProductUseCase.execute(new UpdateApiProductUseCase.Input("api-product-id", toUpdate, AUDIT_INFO));
+
+        assertThat(output.apiProduct().getTags()).containsExactlyInAnyOrder("internal", "external");
+    }
+
+    @Test
+    void should_remove_orphaned_plan_tags_when_product_tags_are_narrowed() {
+        Plan productPlan = productPlanWithTags("product-plan-1", Set.of("internal", "external"));
+        planQueryService.initWith(List.of(productPlan));
+        planCrudService.initWith(List.of(productPlan));
+
+        ApiProduct existing = ApiProduct.builder()
+            .id("api-product-id")
+            .name("API Product")
+            .version("1.0.0")
+            .tags(Set.of("internal", "external"))
+            .environmentId(ENV_ID)
+            .build();
+        apiProductCrudService.initWith(List.of(existing));
+        apiProductQueryService.initWith(List.of(existing));
+
+        var toUpdate = UpdateApiProduct.builder().tags(Set.of("internal")).build();
+        updateApiProductUseCase.execute(new UpdateApiProductUseCase.Input("api-product-id", toUpdate, AUDIT_INFO));
+
+        assertThat(planCrudService.getById("product-plan-1").getPlanDefinitionHttpV4().getTags()).containsExactly("internal");
+    }
+
+    @Test
+    void should_not_modify_plan_tags_when_product_tags_are_expanded() {
+        Plan productPlan = productPlanWithTags("product-plan-1", Set.of("internal"));
+        planQueryService.initWith(List.of(productPlan));
+        planCrudService.initWith(List.of(productPlan));
+
+        ApiProduct existing = ApiProduct.builder()
+            .id("api-product-id")
+            .name("API Product")
+            .version("1.0.0")
+            .tags(Set.of("internal"))
+            .environmentId(ENV_ID)
+            .build();
+        apiProductCrudService.initWith(List.of(existing));
+        apiProductQueryService.initWith(List.of(existing));
+
+        var toUpdate = UpdateApiProduct.builder().tags(Set.of("internal", "external")).build();
+        updateApiProductUseCase.execute(new UpdateApiProductUseCase.Input("api-product-id", toUpdate, AUDIT_INFO));
+
+        assertThat(planCrudService.getById("product-plan-1").getPlanDefinitionHttpV4().getTags()).containsExactly("internal");
+    }
+
+    @Test
+    void should_clear_all_plan_tags_when_product_tags_are_cleared() {
+        Plan productPlan = productPlanWithTags("product-plan-1", Set.of("internal", "external"));
+        planQueryService.initWith(List.of(productPlan));
+        planCrudService.initWith(List.of(productPlan));
+
+        ApiProduct existing = ApiProduct.builder()
+            .id("api-product-id")
+            .name("API Product")
+            .version("1.0.0")
+            .tags(Set.of("internal", "external"))
+            .environmentId(ENV_ID)
+            .build();
+        apiProductCrudService.initWith(List.of(existing));
+        apiProductQueryService.initWith(List.of(existing));
+
+        var toUpdate = UpdateApiProduct.builder().tags(Set.of()).build();
+        updateApiProductUseCase.execute(new UpdateApiProductUseCase.Input("api-product-id", toUpdate, AUDIT_INFO));
+
+        assertThat(planCrudService.getById("product-plan-1").getPlanDefinitionHttpV4().getTags()).isNull();
+    }
+
+    private Plan productPlanWithTags(String planId, Set<String> tags) {
+        var planDefinition = PlanFixtures.aPlanHttpV4()
+            .getPlanDefinitionHttpV4()
+            .toBuilder()
+            .status(PlanStatus.PUBLISHED)
+            .tags(tags)
+            .build();
+        return PlanFixtures.aPlanHttpV4()
+            .toBuilder()
+            .id(planId)
+            .referenceId("api-product-id")
+            .referenceType(GenericPlanEntity.ReferenceType.API_PRODUCT)
+            .environmentId(ENV_ID)
+            .planDefinitionHttpV4(planDefinition)
+            .build();
     }
 
     private void givenPublishedApiProductPlan() {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/plan/domain_service/CreatePlanDomainServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/plan/domain_service/CreatePlanDomainServiceTest.java
@@ -344,6 +344,18 @@ class CreatePlanDomainServiceTest {
         }
 
         @ParameterizedTest
+        @MethodSource("apiProductPlans")
+        void should_throw_when_plan_tags_mismatch_with_tags_defined_in_api_product(ApiProduct api, Plan plan, List<Flow> flows) {
+            var apiProductWithoutTags = api.toBuilder().tags(Set.of()).build();
+
+            var throwable = Assertions.catchThrowable(() -> service.createApiProductPlan(plan, apiProductWithoutTags, AUDIT_INFO));
+
+            assertThat(throwable)
+                .isInstanceOf(ValidationDomainException.class)
+                .hasMessage("Plan tags mismatch the tags defined by the API Product");
+        }
+
+        @ParameterizedTest
         @MethodSource("plans")
         void should_create_plan_with_generated_id_when_no_id_provided(Api api, Plan plan, List<Flow> flows) {
             // Given
@@ -549,6 +561,7 @@ class CreatePlanDomainServiceTest {
                 .environmentId("environment-id")
                 .description("api-product-description")
                 .version("1.0.0")
+                .tags(Set.of(TAG))
                 .createdAt(Instant.parse("2020-02-01T20:22:02.00Z").atZone(ZoneId.systemDefault()))
                 .updatedAt(Instant.parse("2020-02-02T20:22:02.00Z").atZone(ZoneId.systemDefault()));
         }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/plan/domain_service/PlanValidatorDomainServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/plan/domain_service/PlanValidatorDomainServiceTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.core.plan.domain_service;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+
+import inmemory.PageCrudServiceInMemory;
+import inmemory.ParametersQueryServiceInMemory;
+import io.gravitee.apim.core.exception.ValidationDomainException;
+import io.gravitee.apim.core.policy.domain_service.PolicyValidationDomainService;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class PlanValidatorDomainServiceTest {
+
+    private PlanValidatorDomainService cut;
+
+    @BeforeEach
+    void setUp() {
+        cut = new PlanValidatorDomainService(
+            new ParametersQueryServiceInMemory(),
+            mock(PolicyValidationDomainService.class),
+            new PageCrudServiceInMemory()
+        );
+    }
+
+    @Test
+    void should_accept_empty_plan_tags_for_tagless_api_product() {
+        assertThatCode(() -> cut.validatePlanTagsAgainstApiProductTags(Set.of(), null)).doesNotThrowAnyException();
+        assertThatCode(() -> cut.validatePlanTagsAgainstApiProductTags(Set.of(), Set.of())).doesNotThrowAnyException();
+    }
+
+    @Test
+    void should_accept_plan_tags_that_are_subset_of_api_product_tags() {
+        assertThatCode(() ->
+            cut.validatePlanTagsAgainstApiProductTags(Set.of("internal"), Set.of("internal", "external"))
+        ).doesNotThrowAnyException();
+    }
+
+    @Test
+    void should_reject_plan_tags_when_api_product_has_no_tags() {
+        assertThatThrownBy(() -> cut.validatePlanTagsAgainstApiProductTags(Set.of("internal"), null))
+            .isInstanceOf(ValidationDomainException.class)
+            .hasMessage("Plan tags mismatch the tags defined by the API Product");
+
+        assertThatThrownBy(() -> cut.validatePlanTagsAgainstApiProductTags(Set.of("internal"), Set.of()))
+            .isInstanceOf(ValidationDomainException.class)
+            .hasMessage("Plan tags mismatch the tags defined by the API Product");
+    }
+
+    @Test
+    void should_reject_plan_tags_not_defined_on_api_product() {
+        assertThatThrownBy(() -> cut.validatePlanTagsAgainstApiProductTags(Set.of("internal"), Set.of("external")))
+            .isInstanceOf(ValidationDomainException.class)
+            .hasMessage("Plan tags mismatch the tags defined by the API Product");
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/plan/model/PlanUpdatesTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/plan/model/PlanUpdatesTest.java
@@ -20,6 +20,7 @@ import io.gravitee.definition.model.v4.nativeapi.NativePlan;
 import io.gravitee.definition.model.v4.plan.PlanMode;
 import io.gravitee.definition.model.v4.plan.PlanSecurity;
 import io.gravitee.definition.model.v4.plan.PlanStatus;
+import java.util.Set;
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
@@ -94,6 +95,28 @@ class PlanUpdatesTest {
             soft.assertThat(result.getPlanDefinitionNativeV4().getBrokerRangeStart()).isNull();
             soft.assertThat(result.getPlanDefinitionNativeV4().getBrokerRangeEnd()).isNull();
         });
+    }
+
+    @Test
+    void applyTo_should_preserve_plan_tags_when_updates_tags_are_null() {
+        var oldPlan = PlanFixtures.HttpV4.anApiKey().setPlanTags(Set.of("internal"));
+
+        var updates = PlanUpdates.builder().name("new-name").description("new-description").order(1).build();
+
+        var result = updates.applyTo(oldPlan);
+
+        SoftAssertions.assertSoftly(soft -> soft.assertThat(result.getTags()).containsExactly("internal"));
+    }
+
+    @Test
+    void applyTo_should_clear_plan_tags_when_updates_tags_are_empty() {
+        var oldPlan = PlanFixtures.HttpV4.anApiKey().setPlanTags(Set.of("internal"));
+
+        var updates = PlanUpdates.builder().name("new-name").tags(Set.of()).build();
+
+        var result = updates.applyTo(oldPlan);
+
+        SoftAssertions.assertSoftly(soft -> soft.assertThat(result.getTags()).isEmpty());
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/TagServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/TagServiceTest.java
@@ -19,20 +19,26 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
+import io.gravitee.apim.core.api_product.domain_service.ApiProductTagDomainService;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.TagRepository;
 import io.gravitee.repository.management.model.Tag;
+import io.gravitee.rest.api.model.EnvironmentEntity;
 import io.gravitee.rest.api.model.NewTagEntity;
 import io.gravitee.rest.api.model.TagReferenceType;
 import io.gravitee.rest.api.service.AuditService;
+import io.gravitee.rest.api.service.EnvironmentService;
 import io.gravitee.rest.api.service.common.ExecutionContext;
 import io.gravitee.rest.api.service.exceptions.DuplicateTagKeyException;
+import io.gravitee.rest.api.service.v4.ApiTagService;
 import java.util.Collections;
+import java.util.List;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -58,6 +64,15 @@ public class TagServiceTest {
 
     @Mock
     private AuditService auditService;
+
+    @Mock
+    private ApiTagService apiTagService;
+
+    @Mock
+    private EnvironmentService environmentService;
+
+    @Mock
+    private ApiProductTagDomainService apiProductTagDomainService;
 
     @Test
     public void should_create_tag_when_key_does_not_exist() throws TechnicalException {
@@ -122,5 +137,36 @@ public class TagServiceTest {
 
         verify(tagRepository, never()).create(any());
         verifyNoInteractions(auditService);
+    }
+
+    @Test
+    public void should_delete_tag_from_api_products_on_org_tag_delete() throws TechnicalException {
+        var tagKey = "external";
+        var tagId = "tag-uuid";
+        var environmentId = "env-1";
+        var executionContext = new ExecutionContext(REFERENCE_ID, environmentId);
+
+        var tag = new Tag();
+        tag.setId(tagId);
+        tag.setKey(tagKey);
+        tag.setReferenceId(REFERENCE_ID);
+        tag.setReferenceType(io.gravitee.repository.management.model.TagReferenceType.ORGANIZATION);
+
+        var environment = new EnvironmentEntity();
+        environment.setId(environmentId);
+        environment.setOrganizationId(REFERENCE_ID);
+
+        when(
+            tagRepository.findByKeyAndReference(tagKey, REFERENCE_ID, io.gravitee.repository.management.model.TagReferenceType.ORGANIZATION)
+        ).thenReturn(java.util.Optional.of(tag));
+        when(environmentService.findByOrganization(REFERENCE_ID)).thenReturn(List.of(environment));
+
+        tagService.delete(executionContext, tagKey, REFERENCE_ID, REFERENCE_TYPE);
+
+        var inOrder = inOrder(apiTagService, apiProductTagDomainService, tagRepository, auditService);
+        inOrder.verify(apiTagService).deleteTagFromAPIs(executionContext, tagId);
+        inOrder.verify(apiProductTagDomainService).deleteTagFromApiProducts(environmentId, tagKey);
+        inOrder.verify(tagRepository).delete(tagId);
+        inOrder.verify(auditService).createOrganizationAuditLog(eq(executionContext), any());
     }
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-14341
https://gravitee.atlassian.net/browse/APIM-14342

## Description
Backend foundation for API Product sharding tags (PR 1 of 2). Persists product tags, validates plan tags, includes tags in deploy payload, and handles org tag delete cascade. Gateway routing changes are in a follow-up PR.
| Area | Change |
|------|--------|
| **Repository** | `api_product_tags` table (JDBC Liquibase), Mongo `tags` field, enrich on read |
| **Management API** | `tags` on create/update/deploy models; OpenAPI + REST validation |
| **Plan validation** | Plan tags must be ⊆ product tags; reject plan tags on tagless product |
| **Deploy state** | `NEED_REDEPLOY` when product `tags` or `apiIds` differ from last deploy |
| **Product update** | Auto-strip orphaned plan tags when product tags shrink; no auto-deploy on update |
| **Org tag delete** | `ApiProductTagDomainService` removes tag key from all products + plans |
| **Deploy payload** | `DeployApiProductDomainService` includes product `tags` in event |

The testing sheet with screenshots is present in the JIRA tickets mentioned.
