### PR TITLE
fix(console): refresh My Account avatar on update

### DIFF
--- a/gravitee-apim-console-webui/src/services-ngx/current-user.service.spec.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/current-user.service.spec.ts
@@ -19,6 +19,7 @@ import { TestBed } from '@angular/core/testing';
 import { CurrentUserService } from './current-user.service';
 
 import { CONSTANTS_TESTING, GioTestingModule } from '../shared/testing';
+import { User } from '../entities/user/user';
 
 describe('CurrentUserService', () => {
   let httpTestingController: HttpTestingController;
@@ -52,6 +53,31 @@ describe('CurrentUserService', () => {
           url: `${CONSTANTS_TESTING.org.baseURL}/user/tags`,
         })
         .flush(fakeTags);
+    });
+  });
+
+  describe('getUserPictureUrl', () => {
+    const user = { id: 'user-id' } as User;
+
+    it('should point at the avatar endpoint with a stable cache-bust token by default', () => {
+      const url = currentUserService.getUserPictureUrl(user);
+
+      expect(url).toContain(`${CONSTANTS_TESTING.org.baseURL}/user/avatar`);
+      expect(url).toContain('cacheBust=0');
+    });
+
+    it('should change the cache-bust token after updateCurrent so the browser re-fetches the avatar', () => {
+      const before = currentUserService.getUserPictureUrl(user);
+
+      currentUserService.updateCurrent();
+
+      const after = currentUserService.getUserPictureUrl(user);
+      expect(after).not.toEqual(before);
+      expect(after).not.toContain('cacheBust=0');
+    });
+
+    it('should return undefined when the user has no id', () => {
+      expect(currentUserService.getUserPictureUrl({} as User)).toBeUndefined();
     });
   });
 });

--- a/gravitee-apim-console-webui/src/services-ngx/current-user.service.ts
+++ b/gravitee-apim-console-webui/src/services-ngx/current-user.service.ts
@@ -28,6 +28,10 @@ import { hashStringToCode } from '../services/string.service';
 export class CurrentUserService {
   private updateCurrentUser$ = new Subject<void>();
   private currentUser: Observable<User> | null;
+  // Cache-busting token for the avatar URL. Stays stable across navigations (so the browser can
+  // cache the avatar) and only changes when the current user is refreshed after an update, forcing
+  // the browser to re-fetch the new picture instead of serving the cached one.
+  private avatarCacheBust = 0;
 
   constructor(
     private readonly http: HttpClient,
@@ -51,7 +55,7 @@ export class CurrentUserService {
 
   getUserPictureUrl(user: User): string {
     if (user && user.id) {
-      return `${this.constants.org.baseURL}/user/avatar?${hashStringToCode(user.id)}`;
+      return `${this.constants.org.baseURL}/user/avatar?${hashStringToCode(user.id)}&cacheBust=${this.avatarCacheBust}`;
     }
   }
 
@@ -59,6 +63,8 @@ export class CurrentUserService {
     this.currentUser = null;
   }
   updateCurrent() {
+    // Bust the avatar cache so consumers rebuild the picture URL and re-fetch the new image.
+    this.avatarCacheBust = Date.now();
     this.updateCurrentUser$.next();
   }
 }

--- a/gravitee-apim-console-webui/src/services/user.service.spec.ts
+++ b/gravitee-apim-console-webui/src/services/user.service.spec.ts
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import UserService from './user.service';
+
+describe('UserService avatar cache busting', () => {
+  const BASE_URL = '/management/organizations/DEFAULT';
+  let userService: any;
+  let httpPut: jest.Mock;
+
+  beforeEach(() => {
+    httpPut = jest.fn(() => Promise.resolve({ data: {} }));
+    const $http = { put: httpPut };
+    const constants = { org: { baseURL: BASE_URL } };
+    const stringService = { hashCode: () => 123 };
+
+    // Constructor order: $http, $q, Constants, RoleService, PermPermissionStore,
+    // ApplicationService, ApiService, EnvironmentService, $location, $window, StringService, $rootScope
+    userService = new (UserService as any)($http, {}, constants, {}, {}, {}, {}, {}, {}, {}, stringService, {});
+    userService.currentUser = { id: 'user-id' };
+  });
+
+  it('should build the avatar URL with a stable cache-bust token by default', () => {
+    expect(userService.currentUserPicture()).toBe(`${BASE_URL}/user/avatar?123&cacheBust=0`);
+  });
+
+  it('should change the cache-bust token after a successful save so the browser re-fetches the avatar', async () => {
+    const before = userService.currentUserPicture();
+
+    await userService.save({ username: 'paula' });
+
+    const after = userService.currentUserPicture();
+    expect(httpPut).toHaveBeenCalled();
+    expect(after).not.toEqual(before);
+    expect(after).not.toContain('cacheBust=0');
+  });
+
+  it('should return undefined when there is no current user', () => {
+    userService.currentUser = undefined;
+    expect(userService.currentUserPicture()).toBeUndefined();
+  });
+});

--- a/gravitee-apim-console-webui/src/services/user.service.ts
+++ b/gravitee-apim-console-webui/src/services/user.service.ts
@@ -33,6 +33,9 @@ class UserService {
    */
   public currentUser: User;
   private isLogout = false;
+  // Cache-busting token for the avatar URL. Stays 0 (stable, cacheable) until the user saves their
+  // profile, then changes so the browser re-fetches the updated picture instead of the cached one.
+  private avatarCacheBust = 0;
 
   constructor(
     private $http: ng.IHttpService,
@@ -240,7 +243,7 @@ class UserService {
 
   currentUserPicture(): string {
     if (this.currentUser && this.currentUser.id) {
-      return `${this.Constants.org.baseURL}/user/avatar?${this.StringService.hashCode(this.currentUser.id)}`;
+      return `${this.Constants.org.baseURL}/user/avatar?${this.StringService.hashCode(this.currentUser.id)}&cacheBust=${this.avatarCacheBust}`;
     }
   }
 
@@ -260,15 +263,22 @@ class UserService {
   }
 
   save(user): ng.IPromise<any> {
-    return this.$http.put(`${this.Constants.org.baseURL}/user/`, {
-      username: user.username,
-      picture: user.picture,
-      newsletter: user.newsletter,
-      email: user.email,
-      firstname: user.firstname,
-      lastname: user.lastname,
-      customFields: user.customFields,
-    });
+    return this.$http
+      .put(`${this.Constants.org.baseURL}/user/`, {
+        username: user.username,
+        picture: user.picture,
+        newsletter: user.newsletter,
+        email: user.email,
+        firstname: user.firstname,
+        lastname: user.lastname,
+        customFields: user.customFields,
+      })
+      .then(response => {
+        // The picture may have changed: bust the avatar cache so currentUserPicture() returns a
+        // fresh URL and the browser re-fetches the new image without requiring a hard refresh.
+        this.avatarCacheBust = Date.now();
+        return response;
+      });
   }
 
   subscribeNewsletter(email): ng.IPromise<any> {

--- a/gravitee-apim-console-webui/src/user/my-accout/user.controller.spec.ts
+++ b/gravitee-apim-console-webui/src/user/my-accout/user.controller.spec.ts
@@ -1,0 +1,88 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+// UserController is typed with `angular.material.IDialogService`; pull in the @types/angular-material
+// augmentation so the controller type-checks here regardless of test compilation order.
+import type {} from 'angular-material';
+
+import UserController from './user.controller';
+
+describe('UserController (my account)', () => {
+  let userService: any;
+  let notificationService: any;
+  let controller: UserController;
+
+  beforeEach(() => {
+    userService = {
+      save: jest.fn(() => Promise.resolve()),
+      currentUserPicture: jest.fn(),
+    };
+    notificationService = { show: jest.fn(), showError: jest.fn() };
+
+    controller = new UserController(userService, notificationService, {} as any, {} as any, {} as any);
+    controller['onSaved'] = jest.fn();
+  });
+
+  describe('save', () => {
+    it('should send an empty picture to remove the avatar when "Use default" cleared a previously set picture', () => {
+      // "Use default" clears both picture and picture_url; there was an original picture on load.
+      controller['originalPicture'] = '/management/organizations/DEFAULT/user/avatar?123&cacheBust=0';
+      controller['user'] = { picture: null, picture_url: null } as any;
+
+      controller.save();
+
+      expect(userService.save).toHaveBeenCalledWith(expect.objectContaining({ picture: '' }));
+    });
+
+    it('should not alter the picture on a normal save when the avatar URL is still present', () => {
+      controller['originalPicture'] = '/management/organizations/DEFAULT/user/avatar?123&cacheBust=0';
+      controller['user'] = { picture: null, picture_url: '/management/organizations/DEFAULT/user/avatar?123&cacheBust=0' } as any;
+
+      controller.save();
+
+      expect(userService.save).toHaveBeenCalledWith(expect.objectContaining({ picture: null }));
+    });
+
+    it('should not send an empty picture when there was no original picture to remove', () => {
+      controller['originalPicture'] = undefined;
+      controller['user'] = { picture: null, picture_url: null } as any;
+
+      controller.save();
+
+      expect(userService.save).toHaveBeenCalledWith(expect.objectContaining({ picture: null }));
+    });
+  });
+
+  describe('$onChanges', () => {
+    it('should recompute the picture URL (with the refreshed cache-bust token) when the user is rebound after a save', () => {
+      userService.currentUserPicture.mockReturnValue('/management/organizations/DEFAULT/user/avatar?123&cacheBust=999');
+      controller['user'] = { id: 'user-id' } as any;
+
+      controller.$onChanges({ user: { currentValue: controller['user'] } } as any);
+
+      expect((controller['user'] as any).picture_url).toBe('/management/organizations/DEFAULT/user/avatar?123&cacheBust=999');
+      expect(controller['originalPicture']).toBe('/management/organizations/DEFAULT/user/avatar?123&cacheBust=999');
+    });
+
+    it('should do nothing when the user binding did not change', () => {
+      controller['user'] = { id: 'user-id', picture_url: 'unchanged' } as any;
+
+      controller.$onChanges({});
+
+      expect((controller['user'] as any).picture_url).toBe('unchanged');
+      expect(userService.currentUserPicture).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/gravitee-apim-console-webui/src/user/my-accout/user.controller.ts
+++ b/gravitee-apim-console-webui/src/user/my-accout/user.controller.ts
@@ -63,7 +63,23 @@ class UserController {
     }
   }
 
+  $onChanges(changes: angular.IOnChangesObject) {
+    // After a save, the parent reloads the current user and rebinds it here. Recompute the picture
+    // URL so it picks up the refreshed (cache-busted) avatar URL and the new image is shown without
+    // requiring a hard page refresh.
+    if (changes.user && this.user) {
+      const pictureUrl = this.getUserPicture();
+      this.originalPicture = pictureUrl;
+      this.user.picture_url = pictureUrl;
+    }
+  }
+
   save() {
+    // "Use default" clears the picture URL that was present on load. Translate that into an explicit
+    // empty string so the backend removes the avatar — a null/absent picture means "leave unchanged".
+    if (this.originalPicture && this.user.picture == null && this.user.picture_url == null) {
+      this.user.picture = '';
+    }
     this.UserService.save(this.user)
       .then(() => {
         this.NotificationService.show('User has been updated successfully');

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/organization/CurrentUserResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/organization/CurrentUserResource.java
@@ -296,12 +296,14 @@ public class CurrentUserResource extends AbstractResource {
         final ExecutionContext executionContext = GraviteeContext.getExecutionContext();
         UserEntity userEntity = userService.findById(executionContext, getAuthenticatedUser());
         try {
-            if (user.getPicture() != null) {
-                user.setPicture(ImageUtils.verifyAndRescale(user.getPicture()).toBase64());
-            } else {
-                // preserve the picture if the input picture is empty
+            final String picture = user.getPicture();
+            if (picture != null && !picture.isEmpty()) {
+                user.setPicture(ImageUtils.verifyAndRescale(picture).toBase64());
+            } else if (picture == null) {
+                // preserve the picture when no picture is provided
                 user.setPicture(userEntity.getPicture());
             }
+            // an empty picture is an explicit request to remove it ("Use default"): leave it empty
         } catch (InvalidImageException e) {
             throw new BadRequestException("Invalid image format : " + e.getMessage());
         }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/CurrentUserResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/CurrentUserResourceTest.java
@@ -34,7 +34,9 @@ import io.gravitee.rest.api.model.EnvironmentEntity;
 import io.gravitee.rest.api.model.MembershipEntity;
 import io.gravitee.rest.api.model.MembershipMemberType;
 import io.gravitee.rest.api.model.MembershipReferenceType;
+import io.gravitee.rest.api.model.UpdateUserEntity;
 import io.gravitee.rest.api.model.UserEntity;
+import jakarta.ws.rs.client.Entity;
 import jakarta.ws.rs.core.Response;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -44,6 +46,7 @@ import java.util.Map;
 import java.util.Set;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -202,6 +205,53 @@ public class CurrentUserResourceTest extends AbstractResourceTest {
         final Response response = orgTarget().path("/login").request().post(null);
         assertThat(response.getStatus()).isEqualTo(HttpStatusCode.UNAUTHORIZED_401);
         assertThat(response.readEntity(Object.class)).isNull();
+    }
+
+    @Test
+    public void shouldRemovePictureWhenEmptyPictureProvided() {
+        Mockito.reset(userService);
+
+        final UserDetails userDetails = new UserDetails(USER_NAME, "PASSWORD", Collections.emptyList());
+        userDetails.setId(ID);
+        setCurrentUserDetails(new Date(), userDetails);
+
+        final UserEntity existing = new UserEntity();
+        existing.setId(ID);
+        existing.setPicture("data:image/png;base64,EXISTING");
+        when(userService.findById(any(), eq(USER_NAME))).thenReturn(existing);
+        when(userService.update(any(), eq(ID), any(UpdateUserEntity.class))).thenReturn(existing);
+
+        final Response response = orgTarget().request().put(Entity.json(Map.of("picture", "")));
+
+        assertThat(response.getStatus()).isEqualTo(HttpStatusCode.OK_200);
+
+        final ArgumentCaptor<UpdateUserEntity> captor = ArgumentCaptor.forClass(UpdateUserEntity.class);
+        verify(userService).update(any(), eq(ID), captor.capture());
+        // An empty picture is forwarded untouched (not "preserved") so the service can clear it.
+        assertThat(captor.getValue().getPicture()).isEmpty();
+    }
+
+    @Test
+    public void shouldPreserveExistingPictureWhenNoPictureProvided() {
+        Mockito.reset(userService);
+
+        final UserDetails userDetails = new UserDetails(USER_NAME, "PASSWORD", Collections.emptyList());
+        userDetails.setId(ID);
+        setCurrentUserDetails(new Date(), userDetails);
+
+        final UserEntity existing = new UserEntity();
+        existing.setId(ID);
+        existing.setPicture("data:image/png;base64,EXISTING");
+        when(userService.findById(any(), eq(USER_NAME))).thenReturn(existing);
+        when(userService.update(any(), eq(ID), any(UpdateUserEntity.class))).thenReturn(existing);
+
+        final Response response = orgTarget().request().put(Entity.json(Map.of("firstname", "paula")));
+
+        assertThat(response.getStatus()).isEqualTo(HttpStatusCode.OK_200);
+
+        final ArgumentCaptor<UpdateUserEntity> captor = ArgumentCaptor.forClass(UpdateUserEntity.class);
+        verify(userService).update(any(), eq(ID), captor.capture());
+        assertThat(captor.getValue().getPicture()).isEqualTo("data:image/png;base64,EXISTING");
     }
 
     private void setCurrentUserDetails(Date now, final UserDetails userDetails) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/UserServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/UserServiceImpl.java
@@ -1135,8 +1135,10 @@ public class UserServiceImpl extends AbstractService implements UserService, Ini
             user.setUpdatedAt(new Date());
 
             // Set variant fields
-            if (updateUserEntity.getPicture() != null) {
-                user.setPicture(updateUserEntity.getPicture());
+            final String picture = updateUserEntity.getPicture();
+            if (picture != null) {
+                // An empty picture is an explicit request to remove it ("Use default").
+                user.setPicture(picture.isEmpty() ? null : picture);
             }
 
             if (updateUserEntity.getFirstname() != null) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/UserServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/UserServiceTest.java
@@ -801,6 +801,68 @@ public class UserServiceTest {
     }
 
     @Test
+    public void shouldRemovePictureWhenEmptyPictureProvided() throws TechnicalException {
+        final String USER_ID = "myuserid";
+
+        User user = new User();
+        user.setId(USER_ID);
+        user.setSource("gravitee");
+        user.setSourceId("my.user@acme.fr");
+        user.setOrganizationId(ORGANIZATION);
+        user.setPicture("data:image/png;base64,EXISTING");
+
+        when(userRepository.update(any(User.class))).thenAnswer(returnsFirstArg());
+        when(userRepository.findById(USER_ID)).thenReturn(Optional.of(user));
+        when(updateUser.getPicture()).thenReturn("");
+
+        userService.update(EXECUTION_CONTEXT, USER_ID, updateUser);
+
+        // An empty picture is an explicit "Use default" request: the stored picture must be cleared.
+        verify(userRepository).update(argThat(userToUpdate -> userToUpdate.getPicture() == null));
+    }
+
+    @Test
+    public void shouldKeepExistingPictureWhenNoPictureProvided() throws TechnicalException {
+        final String USER_ID = "myuserid";
+
+        User user = new User();
+        user.setId(USER_ID);
+        user.setSource("gravitee");
+        user.setSourceId("my.user@acme.fr");
+        user.setOrganizationId(ORGANIZATION);
+        user.setPicture("data:image/png;base64,EXISTING");
+
+        when(userRepository.update(any(User.class))).thenAnswer(returnsFirstArg());
+        when(userRepository.findById(USER_ID)).thenReturn(Optional.of(user));
+        when(updateUser.getPicture()).thenReturn(null);
+
+        userService.update(EXECUTION_CONTEXT, USER_ID, updateUser);
+
+        // A null picture means "leave unchanged": the existing picture must be preserved.
+        verify(userRepository).update(argThat(userToUpdate -> "data:image/png;base64,EXISTING".equals(userToUpdate.getPicture())));
+    }
+
+    @Test
+    public void shouldUpdatePictureWhenNonEmptyPictureProvided() throws TechnicalException {
+        final String USER_ID = "myuserid";
+
+        User user = new User();
+        user.setId(USER_ID);
+        user.setSource("gravitee");
+        user.setSourceId("my.user@acme.fr");
+        user.setOrganizationId(ORGANIZATION);
+        user.setPicture("data:image/png;base64,OLD");
+
+        when(userRepository.update(any(User.class))).thenAnswer(returnsFirstArg());
+        when(userRepository.findById(USER_ID)).thenReturn(Optional.of(user));
+        when(updateUser.getPicture()).thenReturn("data:image/png;base64,NEW");
+
+        userService.update(EXECUTION_CONTEXT, USER_ID, updateUser);
+
+        verify(userRepository).update(argThat(userToUpdate -> "data:image/png;base64,NEW".equals(userToUpdate.getPicture())));
+    }
+
+    @Test
     public void shouldNotUpdateUser_EmailAlreadyInUse() throws TechnicalException {
         assertThrows(InvalidUserException.class, () -> {
             final String USER_ID = "myuserid";


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-14409

## Description

Updating the account avatar didn't show without a hard refresh, and "Use default" never actually removed the avatar.

**Changes**

Avatar URL now carries a cache-bust token that changes on save, so the new image appears immediately in the account screen and the top-right menu — no hard refresh.
"Use default" now sends an explicit empty picture; the backend treats an empty picture as a removal (empty → cleared) while null still means "leave unchanged."

**Touched**: console (current-user.service, user.service, account user.controller) + rest-api (CurrentUserResource, UserServiceImpl), with frontend + backend unit tests.

**Tested**: verified locally end-to-end — upload persists and refreshes both avatars live; "Use default" removes and persists.
## Additional context

https://github.com/user-attachments/assets/6fbbf747-fc33-4a00-a884-6fe63f5df86c


<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

