### PR TITLE
feat: integrate ESM gamma module into APIM 4.12.x

### DIFF
--- a/gravitee-apim-distribution/pom.xml
+++ b/gravitee-apim-distribution/pom.xml
@@ -1734,6 +1734,19 @@
                         </exclusion>
                     </exclusions>
                 </dependency>
+                <dependency>
+                    <groupId>com.graviteesource.gamma.module</groupId>
+                    <artifactId>gravitee-gamma-module-esm</artifactId>
+                    <version>${gravitee-gamma-module-esm.version}</version>
+                    <type>zip</type>
+                    <scope>runtime</scope>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>*</groupId>
+                            <artifactId>*</artifactId>
+                        </exclusion>
+                    </exclusions>
+                </dependency>
 
                 <!-- Reporters -->
                 <dependency>

--- a/gravitee-gamma/gravitee-gamma-control-plane-webui/src/features/modules/modules.icons.ts
+++ b/gravitee-gamma/gravitee-gamma-control-plane-webui/src/features/modules/modules.icons.ts
@@ -17,6 +17,7 @@ import {
     GioAgentManagementIcon,
     GioApiManagementIcon,
     GioAuthorizationIcon,
+    GioEventApiManagementIcon,
     GioHomeIcon,
     GioPlatformIcon,
 } from '@gravitee/graphene-core/icons';
@@ -33,4 +34,5 @@ export const MODULE_ICONS: Record<string, LucideIcon> = {
     apim: GioApiManagementIcon,
     platform: GioPlatformIcon,
     authz: GioAuthorizationIcon,
+    esm: GioEventApiManagementIcon,
 };

--- a/gravitee-gamma/gravitee-gamma-control-plane-webui/src/pages/home/HomePage.spec.tsx
+++ b/gravitee-gamma/gravitee-gamma-control-plane-webui/src/pages/home/HomePage.spec.tsx
@@ -33,6 +33,7 @@ const ALL_MODULES: readonly GammaModule[] = [
         remoteName: 'gravitee_gamma_module_authz',
         exposedModule: 'App',
     },
+    { id: 'esm', name: 'ESM Module', version: '1.0.0', remoteName: 'gravitee_gamma_module_esm', exposedModule: 'App' },
 ];
 
 function renderHome(modules: readonly GammaModule[]) {
@@ -83,11 +84,17 @@ describe('HomePage', () => {
         seedMetricHandlers();
     });
 
-    it('should render all four module headings when all modules are present', async () => {
+    it('should render all module headings when all modules are present', async () => {
         renderHome(ALL_MODULES);
 
         await waitFor(() => {
-            for (const name of ['Agent Management', 'API Management', 'Platform Management', 'Authorization Management']) {
+            for (const name of [
+                'Agent Management',
+                'API Management',
+                'Platform Management',
+                'Authorization Management',
+                'Event Stream Management',
+            ]) {
                 expect(screen.getByRole('heading', { level: 3, name })).toBeTruthy();
             }
         });

--- a/gravitee-gamma/gravitee-gamma-control-plane-webui/src/pages/home/components/application-card/applications.ts
+++ b/gravitee-gamma/gravitee-gamma-control-plane-webui/src/pages/home/components/application-card/applications.ts
@@ -20,7 +20,7 @@ import type { Accent } from '../accents';
 
 /** Plugin ids of modules we render a card for. Must match `plugin.properties#id` of
  *  the corresponding Gamma module (`gravitee-gamma-module-<id>`). */
-export type ModuleId = 'aim' | 'apim' | 'platform' | 'authz';
+export type ModuleId = 'aim' | 'apim' | 'platform' | 'authz' | 'esm';
 
 export interface Application {
     readonly title: string;
@@ -71,6 +71,14 @@ export const APPLICATIONS: readonly Application[] = [
         Icon: MODULE_ICONS['authz'],
         accent: 'success',
         emptyState: { cta: 'Create your first policy', ctaPath: 'policies/new' },
+    },
+    {
+        title: 'Event Stream Management',
+        description: 'Register Kafka clusters, expose governed Kafka services, and federate them into an event mesh.',
+        moduleId: 'esm',
+        Icon: MODULE_ICONS['esm'],
+        accent: 'muted',
+        emptyState: { cta: 'Register a cluster', ctaPath: 'clusters' },
     },
 ];
 

--- a/gravitee-gamma/gravitee-gamma-control-plane-webui/src/shared/components/ShellLayout.tsx
+++ b/gravitee-gamma/gravitee-gamma-control-plane-webui/src/shared/components/ShellLayout.tsx
@@ -54,6 +54,7 @@ const MODULE_DESCRIPTIONS: Record<string, { label: string; description: string }
     apim: { label: 'API Management', description: 'Design, deploy, and govern HTTP APIs' },
     platform: { label: 'Platform Management', description: 'Apps, subscriptions, and usage' },
     authz: { label: 'Authorization Management', description: 'Fine-grained authorization policies' },
+    esm: { label: 'Event Stream Management', description: 'Manage Kafka clusters, services, and event mesh' },
 };
 
 function buildAppDefinitions(modules: readonly GammaModule[]) {

--- a/pom.xml
+++ b/pom.xml
@@ -339,6 +339,7 @@
         <!-- Gamma plugins -->
         <gravitee-gamma-module-aim.version>1.0.0-alpha.149</gravitee-gamma-module-aim.version>
         <gravitee-gamma-module-authz.version>1.0.0-alpha.15</gravitee-gamma-module-authz.version>
+        <gravitee-gamma-module-esm.version>1.0.0-alpha.1</gravitee-gamma-module-esm.version>
 
         <!-- Authz plugins -->
         <gravitee-service-authz-pdp.version>1.0.0-alpha.5</gravitee-service-authz-pdp.version>


### PR DESCRIPTION
## Summary

Integrates the published **ESM gamma module** (`com.graviteesource.gamma.module:gravitee-gamma-module-esm:1.0.0-alpha.1`) into APIM **4.12.x** and brands it in the control-plane console, so Event Stream Management — Kafka cluster, virtual cluster (mesh) and Kafka Service management — ships, is discovered/federated, and is presented like the other modules.

## Changes

**Distribution** (mirrors the existing `aim` / `authz` pattern):
- `pom.xml` — new `<gravitee-gamma-module-esm.version>1.0.0-alpha.1</…>` property.
- `gravitee-apim-distribution/pom.xml` — runtime `zip` dependency on `gravitee-gamma-module-esm`.

**Console branding** (`gravitee-gamma-control-plane-webui`) — the console keys the app switcher + home-page cards off the module `id`; `esm` was unregistered, so it showed a fallback globe + the raw "ESM Module" name on both lines. Registered it:
- App switcher (`ShellLayout`) — label **Event Stream Management**, description *Manage Kafka clusters, services, and event mesh*.
- Shared icon map (`modules.icons`) — `esm → GioEventApiManagementIcon`.
- Home page card (`applications`) — new ESM `Application` entry (extends the `ModuleId` union) + updated `HomePage.spec`.

## Notes

- The **first** distribution integration is manual on purpose: the `bump-from-module.yml` automation only *replaces* an existing `<module>.version` property. Future ESM releases auto-bump.
- The bump automation + console registry both target `master` too; a matching change on `master` will be needed there (follow-up).

Refs: GMA-647
