### PR TITLE
feat: shared entity-id foundation (slug + type registry + parser)

### DIFF
--- a/gravitee-gamma/gravitee-gamma-definition-model/pom.xml
+++ b/gravitee-gamma/gravitee-gamma-definition-model/pom.xml
@@ -60,6 +60,11 @@
             <artifactId>lombok</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>

--- a/gravitee-gamma/gravitee-gamma-definition-model/src/main/java/io/gravitee/gamma/definition/entityid/EntityId.java
+++ b/gravitee-gamma/gravitee-gamma-definition-model/src/main/java/io/gravitee/gamma/definition/entityid/EntityId.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gamma.definition.entityid;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import java.util.regex.Pattern;
+
+/**
+ * A parsed {@code entityId} (ADR-037): the string {@code <type>.<slug>} used by authz, lineage and the UI. The one
+ * parsing rule for everyone is "split on the first dot": the type is the first segment, the slug is everything after
+ * it (so a scoped slug keeps its parent, e.g. {@code mcp-tool} + {@code github.list_pull_request}).
+ *
+ * <p>The environment is a separate dimension and never part of the string; a cross-environment reference is the pair
+ * {@code (environment, entityId)}.
+ */
+public record EntityId(String type, String slug) {
+    /** A single slug segment: lowercase, digits, underscore, dash. */
+    private static final Pattern SEGMENT = Pattern.compile("[a-z0-9_-]+");
+    /** A dotted path of slug segments (the slug of a scoped id keeps its parent). */
+    private static final Pattern SLUG_PATH = Pattern.compile("[a-z0-9_-]+(?:\\.[a-z0-9_-]+)*");
+    /** The full {@code <type>.<slug>} string: at least two segments. */
+    private static final Pattern FORMAT = Pattern.compile("[a-z0-9_-]+(?:\\.[a-z0-9_-]+)+");
+
+    public EntityId {
+        if (type == null || !SEGMENT.matcher(type).matches()) {
+            throw new IllegalArgumentException("type must be a slug segment: " + type);
+        }
+        if (slug == null || !SLUG_PATH.matcher(slug).matches()) {
+            throw new IllegalArgumentException("slug must be a dotted path of slug segments: " + slug);
+        }
+    }
+
+    /** Whether {@code value} is a well-formed {@code <type>.<slug>} string. */
+    public static boolean isValid(String value) {
+        return value != null && FORMAT.matcher(value).matches();
+    }
+
+    /** The full {@code <type>.<slug>} string. This is the JSON form: a single self-contained token, never a pair. */
+    @JsonValue
+    public String value() {
+        return type + "." + slug;
+    }
+
+    /**
+     * The last segment of the slug. A consumer that already holds the parent context (e.g. the PEP of a specific
+     * MCP proxy) can match on this alone instead of the full hierarchical id.
+     */
+    public String lastSegment() {
+        int dot = slug.lastIndexOf('.');
+        return dot < 0 ? slug : slug.substring(dot + 1);
+    }
+
+    /** Parse {@code <type>.<slug>} by splitting on the first dot. Also the JSON deserializer (from the string form). */
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+    public static EntityId parse(String value) {
+        if (value == null) {
+            throw new IllegalArgumentException("entityId must not be null");
+        }
+        int dot = value.indexOf('.');
+        if (dot <= 0 || dot == value.length() - 1) {
+            throw new IllegalArgumentException("entityId must be '<type>.<slug>': " + value);
+        }
+        return new EntityId(value.substring(0, dot), value.substring(dot + 1));
+    }
+
+    /** Build a top-level id, slugging the name. */
+    public static EntityId of(String type, String name) {
+        return new EntityId(type, requireSlug(name));
+    }
+
+    /** Build a scoped id {@code <type>.<parentSlug>.<slug>}; the parent slug is taken as-is (already a slug). */
+    public static EntityId scoped(String type, String parentSlug, String name) {
+        if (parentSlug == null || parentSlug.isBlank()) {
+            throw new IllegalArgumentException("parentSlug must not be blank");
+        }
+        return new EntityId(type, parentSlug + "." + requireSlug(name));
+    }
+
+    private static String requireSlug(String name) {
+        String slug = EntitySlug.toSlug(name);
+        if (slug == null) {
+            throw new IllegalArgumentException("name does not produce a slug: " + name);
+        }
+        return slug;
+    }
+}

--- a/gravitee-gamma/gravitee-gamma-definition-model/src/main/java/io/gravitee/gamma/definition/entityid/EntitySlug.java
+++ b/gravitee-gamma/gravitee-gamma-definition-model/src/main/java/io/gravitee/gamma/definition/entityid/EntitySlug.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gamma.definition.entityid;
+
+import java.text.Normalizer;
+import java.util.Locale;
+import java.util.regex.Pattern;
+
+/**
+ * Canonical slug rule shared by every Gamma module (ADR-037), so the same name always yields the same slug.
+ * NFD normalize, drop combining marks, lowercase, replace anything outside {@code [a-z0-9_-]} with {@code -},
+ * then trim leading/trailing dashes.
+ *
+ * <p>The dot is reserved as the {@code <type>.<slug>} separator and is therefore <strong>not</strong> part of the
+ * allow-set: {@code claude.ai} becomes {@code claude-ai} and {@code gpt-3.5} becomes {@code gpt-3-5}. This is the
+ * single source of truth that the per-module sluggers (catalog, proxy, authz) delegate to.
+ */
+public final class EntitySlug {
+
+    private static final Pattern COMBINING_MARKS = Pattern.compile("\\p{M}");
+    private static final Pattern NON_SLUG = Pattern.compile("[^a-z0-9_-]+");
+    private static final Pattern REPEATED_DASHES = Pattern.compile("-{2,}");
+    private static final Pattern TRIM_DASHES = Pattern.compile("^-+|-+$");
+
+    private EntitySlug() {}
+
+    public static String toSlug(String value) {
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+        String normalized = Normalizer.normalize(value, Normalizer.Form.NFD);
+        normalized = COMBINING_MARKS.matcher(normalized).replaceAll("");
+        String slug = normalized.toLowerCase(Locale.ROOT);
+        slug = NON_SLUG.matcher(slug).replaceAll("-");
+        slug = REPEATED_DASHES.matcher(slug).replaceAll("-");
+        slug = TRIM_DASHES.matcher(slug).replaceAll("");
+        return slug.isEmpty() ? null : slug;
+    }
+
+    /** On create: an explicit slug wins, otherwise derive it from the name. */
+    public static String orSlug(String explicit, String fallbackName) {
+        return explicit != null ? toSlug(explicit) : toSlug(fallbackName);
+    }
+
+    /** On update: an explicit slug wins, otherwise keep the existing one, otherwise derive it from the name. */
+    public static String orKeep(String explicit, String existing, String fallbackName) {
+        if (explicit != null) {
+            return toSlug(explicit);
+        }
+        if (existing != null) {
+            return existing;
+        }
+        return toSlug(fallbackName);
+    }
+}

--- a/gravitee-gamma/gravitee-gamma-definition-model/src/main/java/io/gravitee/gamma/definition/entityid/EntityType.java
+++ b/gravitee-gamma/gravitee-gamma-definition-model/src/main/java/io/gravitee/gamma/definition/entityid/EntityType.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gamma.definition.entityid;
+
+/**
+ * A registered entity-id type (ADR-037): the first segment of an {@code entityId}, its identity family, and, for
+ * entities that only exist under a parent, the parent's type. A scoped type produces hierarchical ids such as
+ * {@code mcp-tool.<server>.<tool>}.
+ *
+ * @param token the type token (the first segment of the entityId, e.g. {@code mcp-server})
+ * @param family how the slug is produced
+ * @param parentToken the parent type token for scoped types, or {@code null} for top-level types
+ */
+public record EntityType(String token, IdentityFamily family, String parentToken) {
+    public EntityType {
+        if (token == null || token.isBlank()) {
+            throw new IllegalArgumentException("token must not be blank");
+        }
+        if (!token.equals(EntitySlug.toSlug(token))) {
+            throw new IllegalArgumentException("token must be a valid slug: " + token);
+        }
+        if (family == null) {
+            throw new IllegalArgumentException("family must not be null");
+        }
+    }
+
+    public boolean isScoped() {
+        return parentToken != null;
+    }
+
+    /** Build a top-level id for this type, slugging the name. Fails for scoped types (use {@link #id(String, String)}). */
+    public EntityId id(String name) {
+        if (isScoped()) {
+            throw new IllegalArgumentException("type '" + token + "' is scoped, a parent slug is required");
+        }
+        return EntityId.of(token, name);
+    }
+
+    /** Build a scoped id {@code <token>.<parentSlug>.<slug>}. Fails for top-level types (use {@link #id(String)}). */
+    public EntityId id(String parentSlug, String name) {
+        if (!isScoped()) {
+            throw new IllegalArgumentException("type '" + token + "' is not scoped, no parent slug expected");
+        }
+        return EntityId.scoped(token, parentSlug, name);
+    }
+
+    public static EntityType nameSeeded(String token) {
+        return new EntityType(token, IdentityFamily.NAME_SEEDED, null);
+    }
+
+    public static EntityType scoped(String token, String parentToken) {
+        return new EntityType(token, IdentityFamily.NAME_SEEDED, parentToken);
+    }
+
+    public static EntityType recomputable(String token) {
+        return new EntityType(token, IdentityFamily.RECOMPUTABLE, null);
+    }
+}

--- a/gravitee-gamma/gravitee-gamma-definition-model/src/main/java/io/gravitee/gamma/definition/entityid/EntityTypeRegistry.java
+++ b/gravitee-gamma/gravitee-gamma-definition-model/src/main/java/io/gravitee/gamma/definition/entityid/EntityTypeRegistry.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gamma.definition.entityid;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * The single registry of entity-id types shared across Gamma modules (ADR-037). It records, per type, the token,
+ * its identity family and (for scoped types) its parent, which is enough for any consumer to parse and resolve an id
+ * from the registry alone. Construction rejects duplicate tokens and scoped types whose parent is not registered.
+ *
+ * <p>{@link #DEFAULT} is the canonical set. It supersedes the per-module token constants (e.g. the authz
+ * {@code mcp.} / {@code api.} / {@code agent.} prefixes), which map onto the granular tokens here.
+ */
+public final class EntityTypeRegistry {
+
+    public static final EntityTypeRegistry DEFAULT = new EntityTypeRegistry(
+        List.of(
+            // Catalog kinds.
+            EntityType.nameSeeded("model"),
+            EntityType.nameSeeded("knowledge"),
+            EntityType.nameSeeded("skill"),
+            EntityType.nameSeeded("mcp-server"),
+            EntityType.nameSeeded("agent"),
+            EntityType.nameSeeded("api-tool"),
+            // Children of an MCP server: mcp-tool.<server>.<tool>.
+            EntityType.scoped("mcp-tool", "mcp-server"),
+            EntityType.scoped("mcp-prompt", "mcp-server"),
+            EntityType.scoped("mcp-resource", "mcp-server"),
+            // Deployed gateways.
+            EntityType.nameSeeded("mcp-proxy"),
+            EntityType.nameSeeded("llm-proxy"),
+            EntityType.nameSeeded("a2a-proxy"),
+            // Workload identity, rebuilt by the gateway PEP from the clientId.
+            EntityType.recomputable("agent-identity")
+        )
+    );
+
+    private final Map<String, EntityType> byToken;
+
+    public EntityTypeRegistry(List<EntityType> types) {
+        Map<String, EntityType> map = new LinkedHashMap<>();
+        for (EntityType type : types) {
+            if (map.putIfAbsent(type.token(), type) != null) {
+                throw new IllegalArgumentException("duplicate entity-id token: " + type.token());
+            }
+        }
+        for (EntityType type : map.values()) {
+            if (type.isScoped() && !map.containsKey(type.parentToken())) {
+                throw new IllegalArgumentException(
+                    "scoped type '" + type.token() + "' references unknown parent '" + type.parentToken() + "'"
+                );
+            }
+        }
+        this.byToken = Map.copyOf(map);
+    }
+
+    public Optional<EntityType> find(String token) {
+        return Optional.ofNullable(byToken.get(token));
+    }
+
+    /**
+     * Parse {@code entityId} and resolve its registered type, so a consumer gets the family and parent from the
+     * registry alone. Empty if the type token is not registered.
+     *
+     * @throws IllegalArgumentException if the string is not {@code <type>.<slug>}
+     */
+    public Optional<EntityType> resolve(String entityId) {
+        return find(EntityId.parse(entityId).type());
+    }
+
+    public boolean contains(String token) {
+        return byToken.containsKey(token);
+    }
+
+    public List<EntityType> all() {
+        return List.copyOf(byToken.values());
+    }
+}

--- a/gravitee-gamma/gravitee-gamma-definition-model/src/main/java/io/gravitee/gamma/definition/entityid/IdentityFamily.java
+++ b/gravitee-gamma/gravitee-gamma-definition-model/src/main/java/io/gravitee/gamma/definition/entityid/IdentityFamily.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gamma.definition.entityid;
+
+/**
+ * How a type's slug is produced (ADR-037).
+ */
+public enum IdentityFamily {
+    /** Slug derived from the display name (catalog kinds, proxies). */
+    NAME_SEEDED,
+    /**
+     * Slug derived from a stable attribute so a consumer can rebuild it (e.g. {@code agent-identity} from the
+     * {@code clientId} in the JWT). The seeding attribute may be a UUID, so the no-UUID rule does not apply here.
+     */
+    RECOMPUTABLE,
+}

--- a/gravitee-gamma/gravitee-gamma-definition-model/src/test/java/io/gravitee/gamma/definition/entityid/EntityIdTest.java
+++ b/gravitee-gamma/gravitee-gamma-definition-model/src/test/java/io/gravitee/gamma/definition/entityid/EntityIdTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gamma.definition.entityid;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+class EntityIdTest {
+
+    @Test
+    void parses_on_the_first_dot_so_a_scoped_slug_keeps_its_parent() {
+        EntityId id = EntityId.parse("mcp-tool.github.list_pull_request");
+        assertThat(id.type()).isEqualTo("mcp-tool");
+        assertThat(id.slug()).isEqualTo("github.list_pull_request");
+        assertThat(id.lastSegment()).isEqualTo("list_pull_request");
+        assertThat(id.value()).isEqualTo("mcp-tool.github.list_pull_request");
+    }
+
+    @Test
+    void last_segment_of_a_top_level_id_is_the_whole_slug() {
+        assertThat(EntityId.parse("mcp-server.github").lastSegment()).isEqualTo("github");
+    }
+
+    @Test
+    void of_slugs_the_name() {
+        assertThat(EntityId.of("model", "GPT-4o").value()).isEqualTo("model.gpt-4o");
+    }
+
+    @Test
+    void scoped_builds_the_hierarchical_form() {
+        EntityId id = EntityId.scoped("mcp-tool", "github", "list_pull_request");
+        assertThat(id.value()).isEqualTo("mcp-tool.github.list_pull_request");
+        assertThat(id.lastSegment()).isEqualTo("list_pull_request");
+    }
+
+    @Test
+    void rejects_strings_without_a_usable_dot() {
+        assertThatThrownBy(() -> EntityId.parse("github")).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> EntityId.parse(".github")).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> EntityId.parse("mcp-server.")).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void rejects_a_name_that_produces_no_slug() {
+        assertThatThrownBy(() -> EntityId.of("model", "...")).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void rejects_segments_that_are_not_slugs() {
+        assertThatThrownBy(() -> EntityId.parse("MCP.foo")).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> EntityId.parse("model.Foo Bar")).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void is_valid_checks_the_full_format() {
+        assertThat(EntityId.isValid("mcp-tool.github.list_pull_request")).isTrue();
+        assertThat(EntityId.isValid("github")).isFalse();
+        assertThat(EntityId.isValid("model.GPT")).isFalse();
+        assertThat(EntityId.isValid(null)).isFalse();
+    }
+
+    @Test
+    void serializes_to_the_string_form_and_back() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+        EntityId id = EntityId.parse("mcp-tool.github.list_pull_request");
+        String json = mapper.writeValueAsString(id);
+        assertThat(json).isEqualTo("\"mcp-tool.github.list_pull_request\"");
+        assertThat(mapper.readValue(json, EntityId.class)).isEqualTo(id);
+    }
+}

--- a/gravitee-gamma/gravitee-gamma-definition-model/src/test/java/io/gravitee/gamma/definition/entityid/EntitySlugTest.java
+++ b/gravitee-gamma/gravitee-gamma-definition-model/src/test/java/io/gravitee/gamma/definition/entityid/EntitySlugTest.java
@@ -18,8 +18,40 @@ package io.gravitee.gamma.definition.entityid;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 class EntitySlugTest {
+
+    /**
+     * Coupling guard: {@link EntitySlug#toSlug} and {@link EntityId}'s slug validation live in separate classes with
+     * separate regexes. Any non-null slug must always build a valid entityId, so a future edit to either side can't
+     * silently diverge.
+     */
+    @ParameterizedTest
+    @ValueSource(
+        strings = {
+            "Crème Brûlée",
+            "claude.ai",
+            "gpt-3.5",
+            "list_pull_requests",
+            "GitHub MCP!!",
+            "  spaced out  ",
+            "-leading-dash-",
+            "_under_score_",
+            "日本語モデル",
+            "a..b",
+            "***",
+            "v1.2.3-beta",
+            "Smart Router #1",
+        }
+    )
+    void toSlug_output_is_always_a_valid_entity_id_segment(String name) {
+        String slug = EntitySlug.toSlug(name);
+        if (slug != null) {
+            assertThat(EntityId.isValid("model." + slug)).as("toSlug(\"%s\") = \"%s\" must be a valid entityId slug", name, slug).isTrue();
+        }
+    }
 
     @Test
     void lowercases_and_strips_accents() {

--- a/gravitee-gamma/gravitee-gamma-definition-model/src/test/java/io/gravitee/gamma/definition/entityid/EntitySlugTest.java
+++ b/gravitee-gamma/gravitee-gamma-definition-model/src/test/java/io/gravitee/gamma/definition/entityid/EntitySlugTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gamma.definition.entityid;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class EntitySlugTest {
+
+    @Test
+    void lowercases_and_strips_accents() {
+        assertThat(EntitySlug.toSlug("Crème Brûlée")).isEqualTo("creme-brulee");
+    }
+
+    @Test
+    void drops_the_dot_from_the_allow_set() {
+        assertThat(EntitySlug.toSlug("claude.ai")).isEqualTo("claude-ai");
+        assertThat(EntitySlug.toSlug("gpt-3.5")).isEqualTo("gpt-3-5");
+    }
+
+    @Test
+    void keeps_digits_underscore_and_dash() {
+        assertThat(EntitySlug.toSlug("list_pull_requests")).isEqualTo("list_pull_requests");
+        assertThat(EntitySlug.toSlug("gpt-4o")).isEqualTo("gpt-4o");
+    }
+
+    @Test
+    void collapses_disallowed_runs_and_trims_dashes() {
+        assertThat(EntitySlug.toSlug("  Hello, World!  ")).isEqualTo("hello-world");
+    }
+
+    @Test
+    void collapses_repeated_separators() {
+        assertThat(EntitySlug.toSlug("a -- b")).isEqualTo("a-b");
+        assertThat(EntitySlug.toSlug("a---b")).isEqualTo("a-b");
+    }
+
+    @Test
+    void returns_null_for_blank_or_empty_result() {
+        assertThat(EntitySlug.toSlug(null)).isNull();
+        assertThat(EntitySlug.toSlug("   ")).isNull();
+        assertThat(EntitySlug.toSlug("...")).isNull();
+    }
+
+    @Test
+    void or_slug_prefers_explicit_then_name() {
+        assertThat(EntitySlug.orSlug("Explicit Id", "The Name")).isEqualTo("explicit-id");
+        assertThat(EntitySlug.orSlug(null, "The Name")).isEqualTo("the-name");
+    }
+
+    @Test
+    void or_keep_prefers_explicit_then_existing_then_name() {
+        assertThat(EntitySlug.orKeep("New Id", "existing", "The Name")).isEqualTo("new-id");
+        assertThat(EntitySlug.orKeep(null, "existing", "The Name")).isEqualTo("existing");
+        assertThat(EntitySlug.orKeep(null, null, "The Name")).isEqualTo("the-name");
+    }
+}

--- a/gravitee-gamma/gravitee-gamma-definition-model/src/test/java/io/gravitee/gamma/definition/entityid/EntityTypeRegistryTest.java
+++ b/gravitee-gamma/gravitee-gamma-definition-model/src/test/java/io/gravitee/gamma/definition/entityid/EntityTypeRegistryTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gamma.definition.entityid;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class EntityTypeRegistryTest {
+
+    @Test
+    void default_registry_is_valid_and_exposes_its_tokens() {
+        assertThat(EntityTypeRegistry.DEFAULT.all())
+            .extracting(EntityType::token)
+            .contains("mcp-server", "mcp-tool", "mcp-proxy", "llm-proxy", "a2a-proxy", "agent-identity");
+    }
+
+    @Test
+    void records_family_and_parent() {
+        assertThat(EntityTypeRegistry.DEFAULT.find("mcp-tool")).hasValueSatisfying(type -> {
+            assertThat(type.family()).isEqualTo(IdentityFamily.NAME_SEEDED);
+            assertThat(type.parentToken()).isEqualTo("mcp-server");
+            assertThat(type.isScoped()).isTrue();
+        });
+        assertThat(EntityTypeRegistry.DEFAULT.find("agent-identity")).hasValueSatisfying(type ->
+            assertThat(type.family()).isEqualTo(IdentityFamily.RECOMPUTABLE)
+        );
+    }
+
+    @Test
+    void every_scoped_parent_is_registered() {
+        for (EntityType type : EntityTypeRegistry.DEFAULT.all()) {
+            if (type.isScoped()) {
+                assertThat(EntityTypeRegistry.DEFAULT.contains(type.parentToken())).isTrue();
+            }
+        }
+    }
+
+    @Test
+    void find_is_empty_for_unknown_token() {
+        assertThat(EntityTypeRegistry.DEFAULT.find("mcp")).isEmpty();
+    }
+
+    @Test
+    void resolve_parses_then_looks_up_the_type() {
+        assertThat(EntityTypeRegistry.DEFAULT.resolve("mcp-tool.github.list_pull_request")).hasValueSatisfying(type -> {
+            assertThat(type.token()).isEqualTo("mcp-tool");
+            assertThat(type.parentToken()).isEqualTo("mcp-server");
+        });
+    }
+
+    @Test
+    void resolve_is_empty_for_an_unregistered_type() {
+        assertThat(EntityTypeRegistry.DEFAULT.resolve("mcp.github")).isEmpty();
+    }
+
+    @Test
+    void resolve_throws_on_a_malformed_id() {
+        assertThatThrownBy(() -> EntityTypeRegistry.DEFAULT.resolve("github")).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void rejects_duplicate_tokens() {
+        assertThatThrownBy(() -> new EntityTypeRegistry(List.of(EntityType.nameSeeded("model"), EntityType.nameSeeded("model"))))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("duplicate");
+    }
+
+    @Test
+    void rejects_scoped_type_with_unknown_parent() {
+        assertThatThrownBy(() -> new EntityTypeRegistry(List.of(EntityType.scoped("mcp-tool", "mcp-server"))))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("unknown parent");
+    }
+}

--- a/gravitee-gamma/gravitee-gamma-definition-model/src/test/java/io/gravitee/gamma/definition/entityid/EntityTypeTest.java
+++ b/gravitee-gamma/gravitee-gamma-definition-model/src/test/java/io/gravitee/gamma/definition/entityid/EntityTypeTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gamma.definition.entityid;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+
+class EntityTypeTest {
+
+    @Test
+    void name_seeded_builds_a_top_level_id() {
+        assertThat(EntityType.nameSeeded("model").id("GPT-4o").value()).isEqualTo("model.gpt-4o");
+    }
+
+    @Test
+    void scoped_builds_a_hierarchical_id() {
+        assertThat(EntityType.scoped("mcp-tool", "mcp-server").id("github", "list_pull_request").value()).isEqualTo(
+            "mcp-tool.github.list_pull_request"
+        );
+    }
+
+    @Test
+    void name_seeded_rejects_a_parent_slug() {
+        assertThatThrownBy(() -> EntityType.nameSeeded("model").id("parent", "x")).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void scoped_requires_a_parent_slug() {
+        assertThatThrownBy(() -> EntityType.scoped("mcp-tool", "mcp-server").id("x")).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void rejects_a_token_that_is_not_a_slug() {
+        assertThatThrownBy(() -> EntityType.nameSeeded("MCP")).isInstanceOf(IllegalArgumentException.class);
+    }
+}


### PR DESCRIPTION
Foundation for ADR-037 (GMA-473): the shared entity-id helpers in `gravitee-gamma-definition-model` (reaches management, the gateway and the authz PEP).

Draft: not for merge before the ADR is Approved and the migration is coordinated.

- `EntitySlug` - the shared slug rule (the dot is the separator, so dropped from the allow-set)
- `EntityType` + `IdentityFamily` + `EntityTypeRegistry` - the token registry (name-seeded vs recomputable, parent for scoped types), seeded + uniqueness check
- `EntityId` - parse/build `<type>.<slug>`, serialized as a single string

https://gravitee.atlassian.net/browse/GMA-473
