### PR TITLE
fix(gateway): ship writable models directory in distribution

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/src/main/assembly/plugin-assembly-distribution.xml
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/src/main/assembly/plugin-assembly-distribution.xml
@@ -95,6 +95,15 @@
         </fileSet>
 
         <fileSet>
+            <directory>src/main/resources/models</directory>
+            <outputDirectory>models</outputDirectory>
+            <excludes>
+                <exclude>*</exclude>
+            </excludes>
+            <fileMode>644</fileMode>
+        </fileSet>
+
+        <fileSet>
             <directory>src/main/resources/plugins</directory>
             <outputDirectory>plugins</outputDirectory>
             <includes>

--- a/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/src/main/resources/models/.gitignore
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-standalone/gravitee-apim-gateway-standalone-distribution/src/main/resources/models/.gitignore
@@ -1,0 +1,4 @@
+# Disregard this entire folder
+*
+# Except this .gitignore file
+!.gitignore


### PR DESCRIPTION
## Issue

[APIM-14259](https://gravitee.atlassian.net/browse/APIM-14259)

## Why

The `graviteeio/apim-gateway` Debian (and Alpine) image does not pre-create a `$GRAVITEE_HOME/models` directory owned by the Gravitee process (UID 1001). When AI Mesh resources such as the AI Prompt Guard Rails policy or AI Model Text Classification try to download model files at startup, they call `createDirectories(...)` on `/opt/graviteeio-gateway/models` and receive a `java.nio.file.AccessDeniedException`. The gateway then falls back to a temp directory, so models are re-downloaded on every container restart.

The root cause is that `COPY --chown=graviteeio:graviteeio ./distribution` in the Dockerfile only chowns the copied contents; the parent `$GRAVITEEIO_HOME` directory remains `root:root 755`. Directories that already ship inside the distribution (e.g. `logs`, `metrics`) arrive `graviteeio`-owned and writable — the `models` directory simply never shipped.

## What changed

- Added `src/main/resources/models/.gitignore` to the gateway standalone distribution module, mirroring the existing pattern used by `logs/` and `metrics/`, so git tracks the otherwise-empty source directory.
- Added a `models` fileSet to `plugin-assembly-distribution.xml` that emits an empty `models/` directory into the assembly output, excluding the `.gitignore` placeholder. The directory arrives `graviteeio`-owned (0755) via the existing `COPY ./distribution` + `chgrp/chmod` chain in the Dockerfile — no Dockerfile changes needed.

## User-facing impact

Users running the official gateway Debian or Alpine image with AI Mesh policies (AI Prompt Guard Rails, AI Model Text Classification) will no longer see `AccessDeniedException` at startup. Models will persist across container restarts in `/opt/graviteeio-gateway/models` instead of being re-downloaded into a temp directory on each boot.

Users who already mount a volume at `/opt/graviteeio-gateway/models` as a workaround are unaffected — the mount continues to shadow the shipped directory.

## Gotchas / Follow-up

The Helm chart already mounts an unconditional `emptyDir` volume at `/opt/graviteeio-gateway/models` (`helm/templates/gateway/gateway-deployment.yaml:291`), which shadows the shipped directory in Kubernetes. This change does not affect the Helm path; it covers bare-Docker and standalone distribution scenarios where no volume is mounted.

[APIM-14259]: https://gravitee.atlassian.net/browse/APIM-14259?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ