### PR TITLE
feat(portal): add collapsible preview panel to navigation items edito…

### DIFF
--- a/gravitee-apim-console-webui/src/portal/components/asyncapi-editor/asyncapi-editor.component.html
+++ b/gravitee-apim-console-webui/src/portal/components/asyncapi-editor/asyncapi-editor.component.html
@@ -25,7 +25,9 @@
       [disabled]="disabled"
     ></gio-monaco-editor>
   </div>
-  <div class="content__editor__cell">
-    <asyncapi-component [schema]="_value" cssImportPath="assets/style/asyncapi-console-preview.css"></asyncapi-component>
-  </div>
+  @if (showPreview()) {
+    <div class="content__editor__cell">
+      <asyncapi-component [schema]="_value" cssImportPath="assets/style/asyncapi-console-preview.css"></asyncapi-component>
+    </div>
+  }
 </div>

--- a/gravitee-apim-console-webui/src/portal/components/asyncapi-editor/asyncapi-editor.component.scss
+++ b/gravitee-apim-console-webui/src/portal/components/asyncapi-editor/asyncapi-editor.component.scss
@@ -28,9 +28,7 @@ $outline-color: mat.m2-get-color-from-palette(gio.$mat-space-palette, lighter80)
 
 .content {
   &__editor {
-    display: grid;
-    grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
-    grid-template-rows: 1fr;
+    display: flex;
     gap: 8px;
     flex: 1;
     min-height: 0;
@@ -39,6 +37,7 @@ $outline-color: mat.m2-get-color-from-palette(gio.$mat-space-palette, lighter80)
   }
 
   &__editor__cell {
+    flex: 1;
     border: 1px solid $outline-color;
     border-radius: 4px;
     min-height: 0;

--- a/gravitee-apim-console-webui/src/portal/components/asyncapi-editor/asyncapi-editor.component.spec.ts
+++ b/gravitee-apim-console-webui/src/portal/components/asyncapi-editor/asyncapi-editor.component.spec.ts
@@ -24,7 +24,7 @@ import { AsyncApiEditorComponent } from './asyncapi-editor.component';
 import { AsyncApiEditorHarness } from './asyncapi-editor.harness';
 
 @Component({
-  template: ` <asyncapi-editor [formControl]="contentControl" /> `,
+  template: ` <asyncapi-editor [formControl]="contentControl" [showPreview]="showPreview" /> `,
   standalone: true,
   imports: [AsyncApiEditorComponent, ReactiveFormsModule],
 })
@@ -32,6 +32,7 @@ class TestHostComponent {
   @ViewChild(AsyncApiEditorComponent) asyncApiEditor!: AsyncApiEditorComponent;
 
   contentControl = new FormControl<string | null>('asyncapi: 3.0.0');
+  showPreview = true;
 }
 
 describe('AsyncApiEditorComponent', () => {
@@ -55,7 +56,7 @@ describe('AsyncApiEditorComponent', () => {
 
     expect(asyncApiEditor).toBeTruthy();
     expect(await asyncApiEditor.hasMonacoEditor()).toBe(true);
-    expect(await asyncApiEditor.hasPreview()).toBe(true);
+    expect(await asyncApiEditor.getPreview()).not.toBeNull();
   });
 
   it('should default to an empty value when writeValue receives null', async () => {
@@ -91,5 +92,20 @@ describe('AsyncApiEditorComponent', () => {
 
     expect(host.asyncApiEditor.disabled).toBe(true);
     expect(await asyncApiEditor.isMonacoEditorDisabled()).toBe(true);
+  });
+
+  describe('showPreview input', () => {
+    it('should render asyncapi-component when showPreview is true (default)', async () => {
+      const asyncApiEditor = await loader.getHarness(AsyncApiEditorHarness);
+      expect(await asyncApiEditor.getPreview()).not.toBeNull();
+    });
+
+    it('should not render asyncapi-component when showPreview is false', async () => {
+      host.showPreview = false;
+      fixture.detectChanges();
+
+      const asyncApiEditor = await loader.getHarness(AsyncApiEditorHarness);
+      expect(await asyncApiEditor.getPreview()).toBeNull();
+    });
   });
 });

--- a/gravitee-apim-console-webui/src/portal/components/asyncapi-editor/asyncapi-editor.component.ts
+++ b/gravitee-apim-console-webui/src/portal/components/asyncapi-editor/asyncapi-editor.component.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Component, CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
+import { Component, CUSTOM_ELEMENTS_SCHEMA, input } from '@angular/core';
 import { ControlValueAccessor, FormsModule, NG_VALUE_ACCESSOR } from '@angular/forms';
 import { GioMonacoEditorModule } from '@gravitee/ui-particles-angular';
 
@@ -33,6 +33,8 @@ import { GioMonacoEditorModule } from '@gravitee/ui-particles-angular';
   imports: [FormsModule, GioMonacoEditorModule],
 })
 export class AsyncApiEditorComponent implements ControlValueAccessor {
+  showPreview = input(true);
+
   _value = '';
   private _disabled = false;
 

--- a/gravitee-apim-console-webui/src/portal/components/asyncapi-editor/asyncapi-editor.harness.ts
+++ b/gravitee-apim-console-webui/src/portal/components/asyncapi-editor/asyncapi-editor.harness.ts
@@ -20,7 +20,7 @@ export class AsyncApiEditorHarness extends ComponentHarness {
   static readonly hostSelector = 'asyncapi-editor';
 
   private readonly getMonacoEditor = this.locatorFor(GioMonacoEditorHarness);
-  private readonly getPreview = this.locatorForOptional('asyncapi-component');
+  private readonly getPreviewOptional = this.locatorForOptional('asyncapi-component');
 
   async getValue(): Promise<string> {
     return this.getMonacoEditor().then(editor => editor.getValue());
@@ -40,7 +40,7 @@ export class AsyncApiEditorHarness extends ComponentHarness {
       .catch(() => false);
   }
 
-  async hasPreview(): Promise<boolean> {
-    return this.getPreview().then(preview => !!preview);
+  async getPreview() {
+    return this.getPreviewOptional();
   }
 }

--- a/gravitee-apim-console-webui/src/portal/components/openapi-editor/openapi-editor.component.html
+++ b/gravitee-apim-console-webui/src/portal/components/openapi-editor/openapi-editor.component.html
@@ -25,20 +25,22 @@
       [disabled]="disabled"
     ></gio-monaco-editor>
   </div>
-  <div class="content__editor__cell">
-    @if (isRedocViewer()) {
-      <gio-redoc [spec]="_value" [tryItURL]="swaggerTryItURL()"></gio-redoc>
-    } @else {
-      <gio-swagger-ui
-        [spec]="_value"
-        [tryItURL]="swaggerTryItURL()"
-        [docExpansion]="swaggerDocExpansion()"
-        [displayOperationId]="swaggerDisplayOperationId()"
-        [filter]="swaggerFilter()"
-        [showExtensions]="swaggerShowExtensions()"
-        [showCommonExtensions]="swaggerShowCommonExtensions()"
-        [maxDisplayedTags]="swaggerMaxDisplayedTags()"
-      ></gio-swagger-ui>
-    }
-  </div>
+  @if (showPreview()) {
+    <div class="content__editor__cell">
+      @if (isRedocViewer()) {
+        <gio-redoc [spec]="_value" [tryItURL]="swaggerTryItURL()"></gio-redoc>
+      } @else {
+        <gio-swagger-ui
+          [spec]="_value"
+          [tryItURL]="swaggerTryItURL()"
+          [docExpansion]="swaggerDocExpansion()"
+          [displayOperationId]="swaggerDisplayOperationId()"
+          [filter]="swaggerFilter()"
+          [showExtensions]="swaggerShowExtensions()"
+          [showCommonExtensions]="swaggerShowCommonExtensions()"
+          [maxDisplayedTags]="swaggerMaxDisplayedTags()"
+        ></gio-swagger-ui>
+      }
+    </div>
+  }
 </div>

--- a/gravitee-apim-console-webui/src/portal/components/openapi-editor/openapi-editor.component.scss
+++ b/gravitee-apim-console-webui/src/portal/components/openapi-editor/openapi-editor.component.scss
@@ -28,9 +28,7 @@ $outline-color: mat.m2-get-color-from-palette(gio.$mat-space-palette, lighter80)
 
 .content {
   &__editor {
-    display: grid;
-    grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
-    grid-template-rows: 1fr;
+    display: flex;
     gap: 10px;
     flex: 1;
     min-height: 0;
@@ -39,6 +37,7 @@ $outline-color: mat.m2-get-color-from-palette(gio.$mat-space-palette, lighter80)
   }
 
   &__editor__cell {
+    flex: 1;
     border: 1px solid $outline-color;
     border-radius: 4px;
     min-height: 0;

--- a/gravitee-apim-console-webui/src/portal/components/openapi-editor/openapi-editor.component.spec.ts
+++ b/gravitee-apim-console-webui/src/portal/components/openapi-editor/openapi-editor.component.spec.ts
@@ -31,7 +31,7 @@ import {
 } from '../../../entities/management-api-v2/portalPageContent/openApiViewerConfiguration';
 
 @Component({
-  template: ` <openapi-editor [formControl]="contentControl" [configuration]="configuration" /> `,
+  template: ` <openapi-editor [formControl]="contentControl" [configuration]="configuration" [showPreview]="showPreview" /> `,
   standalone: true,
   imports: [OpenApiEditorComponent, ReactiveFormsModule],
 })
@@ -39,6 +39,7 @@ class TestHostComponent {
   readonly editor = viewChild.required(OpenApiEditorComponent);
   contentControl = new FormControl('openapi: 3.0.0\ninfo:\n  title: Test');
   configuration: Partial<OpenApiViewerConfiguration> | null = null;
+  showPreview = true;
 }
 
 describe('OpenApiEditorComponent', () => {
@@ -113,5 +114,20 @@ describe('OpenApiEditorComponent', () => {
     fixture.detectChanges();
 
     expect(host.editor().swaggerTryItURL()).toBe('');
+  });
+
+  describe('showPreview input', () => {
+    it('should render gio-swagger-ui when showPreview is true (default)', async () => {
+      const openApiEditor = await loader.getHarness(OpenApiEditorHarness);
+      expect(await openApiEditor.getPreview()).not.toBeNull();
+    });
+
+    it('should not render gio-swagger-ui when showPreview is false', async () => {
+      host.showPreview = false;
+      fixture.detectChanges();
+
+      const openApiEditor = await loader.getHarness(OpenApiEditorHarness);
+      expect(await openApiEditor.getPreview()).toBeNull();
+    });
   });
 });

--- a/gravitee-apim-console-webui/src/portal/components/openapi-editor/openapi-editor.component.ts
+++ b/gravitee-apim-console-webui/src/portal/components/openapi-editor/openapi-editor.component.ts
@@ -40,6 +40,7 @@ import {
 })
 export class OpenApiEditorComponent implements ControlValueAccessor {
   configuration = input<Partial<OpenApiViewerConfiguration> | null>(null);
+  showPreview = input(true);
 
   _value = '';
   private _disabled = false;

--- a/gravitee-apim-console-webui/src/portal/components/openapi-editor/openapi-editor.harness.ts
+++ b/gravitee-apim-console-webui/src/portal/components/openapi-editor/openapi-editor.harness.ts
@@ -17,4 +17,11 @@ import { ComponentHarness } from '@angular/cdk/testing';
 
 export class OpenApiEditorHarness extends ComponentHarness {
   static hostSelector = 'openapi-editor';
+
+  private readonly getSwaggerPreviewOptional = this.locatorForOptional('gio-swagger-ui');
+  private readonly getRedocPreviewOptional = this.locatorForOptional('gio-redoc');
+
+  async getPreview() {
+    return (await this.getSwaggerPreviewOptional()) ?? (await this.getRedocPreviewOptional());
+  }
 }

--- a/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.html
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.html
@@ -85,6 +85,9 @@
         </div>
       }
       <div class="panel-header__actions" *gioPermission="{ anyOf: ['environment-documentation-u'] }">
+        <mat-slide-toggle data-testid="preview-toggle" [checked]="isPreviewVisible()" (change)="isPreviewVisible.set($event.checked)">
+          Preview
+        </mat-slide-toggle>
         @if (currentPageContentType() === 'OPENAPI') {
           <button [disabled]="actionsDisabled()" mat-stroked-button (click)="onConfigure()">Configure</button>
         }
@@ -107,22 +110,27 @@
             <div class="empty-editor">
               <mat-card appearance="outlined"> </mat-card>
 
-              <hr />
-
-              <mat-card appearance="outlined"> </mat-card>
+              @if (isPreviewVisible()) {
+                <hr />
+                <mat-card appearance="outlined"> </mat-card>
+              }
             </div>
           } @else if (contentLoadError()) {
             <ng-container *ngTemplateOutlet="pageNotFound"></ng-container>
           } @else {
             @switch (currentPageContentType()) {
               @case ('OPENAPI') {
-                <openapi-editor [formControl]="contentControl" [configuration]="currentPageConfiguration()" />
+                <openapi-editor
+                  [formControl]="contentControl"
+                  [configuration]="currentPageConfiguration()"
+                  [showPreview]="isPreviewVisible()"
+                />
               }
               @case ('ASYNCAPI') {
-                <asyncapi-editor [formControl]="contentControl" />
+                <asyncapi-editor [formControl]="contentControl" [showPreview]="isPreviewVisible()" />
               }
               @default {
-                <gmd-editor [formControl]="contentControl" />
+                <gmd-editor [formControl]="contentControl" [showPreview]="isPreviewVisible()" />
               }
             }
           }
@@ -157,17 +165,18 @@
       </mat-card-content>
     </mat-card>
 
-    <hr />
-
-    <mat-card appearance="outlined" class="empty-state">
-      <mat-card-content>
-        <empty-state
-          iconName="gio:monitor"
-          title="Preview"
-          message="Use the page preview to see exactly how your content will look before you publish it."
-        />
-      </mat-card-content>
-    </mat-card>
+    @if (isPreviewVisible()) {
+      <hr />
+      <mat-card appearance="outlined" class="empty-state">
+        <mat-card-content>
+          <empty-state
+            iconName="gio:monitor"
+            title="Preview"
+            message="Use the page preview to see exactly how your content will look before you publish it."
+          />
+        </mat-card-content>
+      </mat-card>
+    }
   </div>
 </ng-template>
 

--- a/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.scss
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.scss
@@ -73,6 +73,7 @@ $outline-color: mat.m2-get-color-from-palette(gio.$mat-space-palette, lighter80)
 
   &__actions {
     display: flex;
+    align-items: center;
     gap: 8px;
 
     &__add {
@@ -160,7 +161,7 @@ $outline-color: mat.m2-get-color-from-palette(gio.$mat-space-palette, lighter80)
   }
 
   mat-card {
-    width: 50%;
+    flex: 1;
   }
 }
 

--- a/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.spec.ts
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.spec.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { ConfigureTestingGraviteeMarkdownEditor } from '@gravitee/gravitee-markdown';
+import { ConfigureTestingGraviteeMarkdownEditor, GraviteeMarkdownViewerHarness } from '@gravitee/gravitee-markdown';
 
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { MatDialog } from '@angular/material/dialog';
@@ -2985,6 +2985,50 @@ describe('PortalNavigationItemsComponent', () => {
         );
         await expectGetNavigationItems(fakeResponse);
       });
+    });
+  });
+
+  describe('preview toggle', () => {
+    const page1 = fakePortalNavigationPage({
+      id: 'page-1',
+      title: 'Page 1',
+      portalPageContentId: 'content-1',
+    });
+    const page2 = fakePortalNavigationPage({
+      id: 'page-2',
+      title: 'Page 2',
+      portalPageContentId: 'content-2',
+    });
+
+    beforeEach(async () => {
+      await expectGetNavigationItems(fakePortalNavigationItemsResponse({ items: [page1, page2] }));
+      expectGetPageContent('content-1', 'Page 1 content');
+    });
+
+    it('should show and hide the preview when toggle is clicked', async () => {
+      expect(await rootLoader.getHarnessOrNull(GraviteeMarkdownViewerHarness)).not.toBeNull();
+
+      await harness.clickPreviewToggle();
+      expect(await rootLoader.getHarnessOrNull(GraviteeMarkdownViewerHarness)).toBeNull();
+
+      await harness.clickPreviewToggle();
+      expect(await rootLoader.getHarnessOrNull(GraviteeMarkdownViewerHarness)).not.toBeNull();
+    });
+
+    it('should hide the preview when toggle is turned off', async () => {
+      await harness.clickPreviewToggle();
+
+      expect(await rootLoader.getHarnessOrNull(GraviteeMarkdownViewerHarness)).toBeNull();
+    });
+
+    it('should retain preview visibility state when a different navigation item is selected', async () => {
+      await harness.clickPreviewToggle();
+      expect(await harness.isPreviewVisible()).toBe(false);
+
+      await harness.selectNavigationItemByTitle('Page 2');
+      expectGetPageContent('content-2', 'Page 2 content');
+
+      expect(await harness.isPreviewVisible()).toBe(false);
     });
   });
 });

--- a/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.ts
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.component.ts
@@ -26,6 +26,7 @@ import {
 } from '@gravitee/ui-particles-angular';
 import { Component, computed, DestroyRef, HostListener, inject, NgZone, Signal, signal, viewChild } from '@angular/core';
 import { MatButtonModule } from '@angular/material/button';
+import { MatSlideToggleModule } from '@angular/material/slide-toggle';
 import { AbstractControl, FormControl, ReactiveFormsModule, ValidationErrors, ValidatorFn } from '@angular/forms';
 import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, Router } from '@angular/router';
@@ -96,6 +97,7 @@ type AsyncApiSpecValidationError = {
     EmptyStateComponent,
     GioCardEmptyStateModule,
     MatButtonModule,
+    MatSlideToggleModule,
     FlatTreeComponent,
     GioPermissionModule,
     MatMenuModule,
@@ -195,6 +197,7 @@ export class PortalNavigationItemsComponent implements HasUnsavedChanges {
   private readonly MIN_PANEL_WIDTH = 280;
   private readonly MAX_PANEL_WIDTH = 600;
   panelWidth = signal(400);
+  isPreviewVisible = signal(true);
   initialContent = signal('');
 
   readonly currentPageContentType = signal<PortalPageContentType | null>(null);

--- a/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.harness.ts
+++ b/gravitee-apim-console-webui/src/portal/navigation-items/portal-navigation-items.harness.ts
@@ -18,6 +18,7 @@ import { GraviteeMarkdownEditorHarness } from '@gravitee/gravitee-markdown';
 import { ComponentHarness } from '@angular/cdk/testing';
 import { MatButtonHarness } from '@angular/material/button/testing';
 import { MatMenuHarness, MatMenuItemHarness } from '@angular/material/menu/testing';
+import { MatSlideToggleHarness } from '@angular/material/slide-toggle/testing';
 import { DivHarness } from '@gravitee/ui-particles-angular/testing';
 
 import { EmptyStateComponentHarness } from '../../shared/components/empty-state/empty-state.component.harness';
@@ -28,6 +29,7 @@ export class PortalNavigationItemsHarness extends ComponentHarness {
   static hostSelector = 'portal-navigation-items';
 
   private getAddButton = this.locatorFor(MatButtonHarness.with({ selector: '[aria-label="Add new section"]' }));
+  private getPreviewToggle = this.locatorFor(MatSlideToggleHarness.with({ selector: '[data-testid="preview-toggle"]' }));
   private getEditButton = this.locatorFor(MatButtonHarness.with({ text: /Edit/i }));
   private getSaveButton = this.locatorFor(MatButtonHarness.with({ text: /Save/i }));
   private readonly getConfigureButtonOptional = this.locatorForOptional(MatButtonHarness.with({ text: /^Configure$/ }));
@@ -54,6 +56,16 @@ export class PortalNavigationItemsHarness extends ComponentHarness {
 
   async getAddButtonHarness(): Promise<MatButtonHarness> {
     return this.getAddButton();
+  }
+
+  async clickPreviewToggle(): Promise<void> {
+    const toggle = await this.getPreviewToggle();
+    return toggle.toggle();
+  }
+
+  async isPreviewVisible(): Promise<boolean> {
+    const toggle = await this.getPreviewToggle();
+    return toggle.isChecked();
   }
 
   async clickAddButton(): Promise<void> {

--- a/gravitee-apim-webui-libs/gravitee-markdown/src/lib/gravitee-markdown-editor/gravitee-markdown-editor.component.html
+++ b/gravitee-apim-webui-libs/gravitee-markdown/src/lib/gravitee-markdown-editor/gravitee-markdown-editor.component.html
@@ -23,8 +23,10 @@
     (valueChange)="onValueChange($event)"
     (touched)="onTouched()"
   />
-  <hr class="hr" />
-  <div class="container__inner-border">
-    <gmd-viewer [content]="value" />
-  </div>
+  @if (showPreview()) {
+    <hr class="hr" />
+    <div class="container__inner-border">
+      <gmd-viewer [content]="value" />
+    </div>
+  }
 </div>

--- a/gravitee-apim-webui-libs/gravitee-markdown/src/lib/gravitee-markdown-editor/gravitee-markdown-editor.component.scss
+++ b/gravitee-apim-webui-libs/gravitee-markdown/src/lib/gravitee-markdown-editor/gravitee-markdown-editor.component.scss
@@ -27,7 +27,7 @@ $token-mapping: overrides.tokens();
   &__inner-border {
     position: relative;
     overflow: auto;
-    width: calc(50% - 6.5px);
+    flex: 1;
     padding: 16px;
     border: 1px solid token-utils.slot(container-outline-color, $token-mapping);
     border-radius: 4px;

--- a/gravitee-apim-webui-libs/gravitee-markdown/src/lib/gravitee-markdown-editor/gravitee-markdown-editor.component.spec.ts
+++ b/gravitee-apim-webui-libs/gravitee-markdown/src/lib/gravitee-markdown-editor/gravitee-markdown-editor.component.spec.ts
@@ -25,10 +25,11 @@ import { GraviteeMarkdownViewerHarness } from '../gravitee-markdown-viewer/publi
 @Component({
   selector: 'gmd-test-component',
   imports: [GraviteeMarkdownEditorModule, ReactiveFormsModule],
-  template: `<gmd-editor [formControl]="editorControl" />`,
+  template: `<gmd-editor [formControl]="editorControl" [showPreview]="showPreview" />`,
 })
 class TestComponent {
   public editorControl = new FormControl('');
+  public showPreview = true;
 }
 
 describe('GraviteeMarkdownEditorComponent', () => {
@@ -96,6 +97,21 @@ describe('GraviteeMarkdownEditorComponent', () => {
       await editorHarness.setEditorValue(newValue);
 
       expect(component.editorControl.value).toBe(newValue);
+    });
+  });
+
+  describe('showPreview input', () => {
+    it('should render gmd-viewer when showPreview is true (default)', async () => {
+      const viewerHarness = await loader.getHarnessOrNull(GraviteeMarkdownViewerHarness);
+      expect(viewerHarness).not.toBeNull();
+    });
+
+    it('should not render gmd-viewer when showPreview is false', async () => {
+      component.showPreview = false;
+      fixture.detectChanges();
+
+      const viewerHarness = await loader.getHarnessOrNull(GraviteeMarkdownViewerHarness);
+      expect(viewerHarness).toBeNull();
     });
   });
 });

--- a/gravitee-apim-webui-libs/gravitee-markdown/src/lib/gravitee-markdown-editor/gravitee-markdown-editor.component.ts
+++ b/gravitee-apim-webui-libs/gravitee-markdown/src/lib/gravitee-markdown-editor/gravitee-markdown-editor.component.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { ChangeDetectorRef, Component, forwardRef } from '@angular/core';
+import { ChangeDetectorRef, Component, forwardRef, input } from '@angular/core';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 import { isString } from 'lodash';
 
@@ -32,6 +32,8 @@ import { isString } from 'lodash';
   ],
 })
 export class GraviteeMarkdownEditorComponent implements ControlValueAccessor {
+  showPreview = input(true);
+
   value = '';
   isDisabled = false;
 


### PR DESCRIPTION

Adds a slide toggle ("Preview") to the editor panel header that shows/hides the live preview column across all page types.

**Behaviour**

Toggle defaults to ON (preview visible)
State is page-level — persists when switching between navigation items
Editor always expands to fill the full panel width when preview is hidden

<img width="1723" height="878" alt="image" src="https://github.com/user-attachments/assets/b0144e70-625f-4f2d-a4a8-c395d5e3913c" />
<img width="1722" height="901" alt="image" src="https://github.com/user-attachments/assets/1a2d3a98-e5cd-4648-aa68-91e2d5df6b44" />
