### PR TITLE
chore(4.11.x): bump gravitee-plugin from 5.1.2 to 5.1.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
         <gravitee-node.version>8.0.6</gravitee-node.version>
         <gravitee-notifier-api.version>2.0.0</gravitee-notifier-api.version>
         <gravitee-platform-repository-api.version>1.4.0</gravitee-platform-repository-api.version>
-        <gravitee-plugin.version>5.1.2</gravitee-plugin.version>
+        <gravitee-plugin.version>5.1.3</gravitee-plugin.version>
         <gravitee-plugin-common-configurations.version>1.1.0</gravitee-plugin-common-configurations.version>
         <gravitee-policy-api.version>1.11.0</gravitee-policy-api.version>
         <gravitee-reporter-api.version>2.1.0</gravitee-reporter-api.version>


### PR DESCRIPTION
## Summary

Bumps **[gravitee-io/gravitee-plugin](https://github.com/gravitee-io/gravitee-plugin)** from `5.1.2` to `5.1.3` on branch `4.11.x`.

This pulls in the fix for EL evaluation in `Set<String>` configuration fields (e.g. Kafka endpoint `producer.topics` / `consumer.topics`).

## Changelog

See the [releases](https://github.com/gravitee-io/gravitee-plugin/releases) page for details.

## Jira

[APIM-14232](https://gravitee.atlassian.net/browse/APIM-14232)

[APIM-14232]: https://gravitee.atlassian.net/browse/APIM-14232?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ