### PR TITLE
test(tracing): widen Jaeger trace polling to 60s to stabilize flaky OTel test

### DIFF
--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/tracing/OpenTelemetryTracingV4IntegrationTest.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/tracing/OpenTelemetryTracingV4IntegrationTest.java
@@ -159,7 +159,7 @@ class OpenTelemetryTracingV4IntegrationTest extends AbstractGatewayTest {
         );
 
         await()
-            .atMost(30, SECONDS)
+            .atMost(60, SECONDS)
             .untilAsserted(() -> {
                 var client = container.client(vertx.getDelegate());
                 var response = client
@@ -220,7 +220,7 @@ class OpenTelemetryTracingV4IntegrationTest extends AbstractGatewayTest {
             "policy-message-flow-ready"
         );
         await()
-            .atMost(30, SECONDS)
+            .atMost(60, SECONDS)
             .untilAsserted(() -> {
                 var client = container.client(vertx.getDelegate());
                 var response = client


### PR DESCRIPTION
## What
Bump the Jaeger trace-polling Awaitility timeout from `30s` to `60s` in `OpenTelemetryTracingV4IntegrationTest` (both `/api/traces` polls). The SSE message-count poll is left unchanged.

## Why
`should_trace_request_on_http_api` polls Jaeger for spans exported **asynchronously** by the OTel `BatchSpanProcessor` (hardcoded ~5s schedule delay in gravitee-node) + gRPC export + Jaeger ingest. Under CI load the 30s window is occasionally too tight, so the test flakes. The surefire rerun (`rerunFailingTestsCount=3`) then emits `<rerunError>` nodes that break CircleCI's JUnit result upload:
```
failed uploading test results: ... invalid testcase element: rerunError
```
This aligns the container-backed tracing test with the **60s** timeout already used by the broker integration tests (Kafka / RabbitMQ / MQTT5 / Solace).

## Validation
The identical change on the 4.8.x backport (#17853) made the OTel test pass — it was previously the failing testcase on that pipeline.

## Notes
The 4.8.x→4.12.x backports of #17811 received this fix directly, so no backport labels are needed here.