### PR TITLE
feat(portal): add api keys list component

### DIFF
--- a/gravitee-apim-portal-webui-next/src/components/api-access/api-keys-list/api-keys-list.component.html
+++ b/gravitee-apim-portal-webui-next/src/components/api-access/api-keys-list/api-keys-list.component.html
@@ -1,0 +1,76 @@
+<!--
+
+    Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<div class="api-keys-list">
+  <div class="next-gen-h5" i18n="@@subscriptionDetailsApiAccessApiKeysHeader">API keys</div>
+  @if (feedback(); as message) {
+    <div
+      class="next-gen-body api-keys-list__feedback"
+      [class.api-keys-list__feedback--error]="message.type === 'error'"
+      [class.api-keys-list__feedback--success]="message.type === 'success'"
+      [attr.role]="message.type === 'error' ? 'alert' : null"
+      [attr.aria-live]="message.type === 'success' ? 'polite' : null"
+      data-testid="api-key-feedback"
+    >
+      {{ message.message }}
+    </div>
+  }
+  @if (apiKeys().length > 0) {
+    <app-paginated-table
+      [columns]="columns"
+      [rows]="displayedRows()"
+      [totalElements]="totalElements()"
+      [currentPage]="currentPage()"
+      [pageSize]="pageSize()"
+      [pageSizeOptions]="pageSizeOptions"
+      [navigable]="false"
+      (pageChange)="onPageChange($event)"
+      (pageSizeChange)="onPageSizeChange($event)"
+    >
+      <ng-template appTableCell="status" let-apiKey>
+        <mat-icon
+          [svgIcon]="apiKey.statusIcon"
+          [attr.aria-label]="apiKey.statusLabel"
+          [attr.data-status-icon]="apiKey.statusIcon"
+          data-testid="api-key-status-icon"
+        />
+      </ng-template>
+      <ng-template appTableCell="revoke" let-apiKey>
+        @if (canManageApiKey() && apiKey.isActive) {
+          <button
+            mat-icon-button
+            type="button"
+            color="warn"
+            [disabled]="isRevokeDisabled()"
+            matTooltip="Revoke"
+            i18n-matTooltip="@@subscriptionDetailsApiAccessRevokeTooltip"
+            [attr.aria-label]="apiKey.revokeAriaLabel"
+            [attr.data-api-key]="apiKey.key"
+            data-testid="api-key-revoke-button"
+            (click)="revokeApiKey.emit(apiKey)"
+          >
+            <mat-icon svgIcon="gio:x-circle" />
+          </button>
+        }
+      </ng-template>
+    </app-paginated-table>
+  } @else {
+    <div class="next-gen-body" i18n="@@subscriptionDetailsApiAccessApiKeysEmpty" data-testid="api-keys-empty-message">
+      No API keys available.
+    </div>
+  }
+</div>

--- a/gravitee-apim-portal-webui-next/src/components/api-access/api-keys-list/api-keys-list.component.scss
+++ b/gravitee-apim-portal-webui-next/src/components/api-access/api-keys-list/api-keys-list.component.scss
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@use '../../../scss/theme' as app-theme;
+
+.api-keys-list {
+  display: flex;
+  flex-flow: column;
+  gap: 8px;
+
+  &__feedback {
+    &--success {
+      color: app-theme.$primary-main-color;
+    }
+
+    &--error {
+      color: app-theme.$error-main-color;
+    }
+  }
+}

--- a/gravitee-apim-portal-webui-next/src/components/api-access/api-keys-list/api-keys-list.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/components/api-access/api-keys-list/api-keys-list.component.spec.ts
@@ -1,0 +1,171 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MatIconTestingModule } from '@angular/material/icon/testing';
+
+import { ApiKeyFeedback, ApiKeysListComponent, ApiKeyTableRow } from './api-keys-list.component';
+import { ApiKeysListHarness } from './api-keys-list.harness';
+import { AppTestingModule } from '../../../testing/app-testing.module';
+
+describe('ApiKeysListComponent', () => {
+  let component: ApiKeysListComponent;
+  let fixture: ComponentFixture<ApiKeysListComponent>;
+  let harness: ApiKeysListHarness;
+
+  function activeApiKeyRow(key: string): ApiKeyTableRow {
+    return {
+      statusIcon: 'gio:check-circled-outline',
+      statusLabel: 'Active API key',
+      revokeAriaLabel: `Revoke API key ${key}`,
+      isActive: true,
+      key,
+      createdAt: '2024-04-17T10:33:29Z',
+    };
+  }
+
+  function inactiveApiKeyRow(key: string): ApiKeyTableRow {
+    return {
+      statusIcon: 'gio:x-circle',
+      statusLabel: 'Inactive API key',
+      revokeAriaLabel: `Revoke API key ${key}`,
+      isActive: false,
+      key,
+      createdAt: '2024-04-17T10:33:29Z',
+      closedAt: '2024-04-19T10:33:29Z',
+    };
+  }
+
+  async function init(params?: {
+    apiKeys?: ApiKeyTableRow[];
+    canManageApiKey?: boolean;
+    isRevokeDisabled?: boolean;
+    feedback?: ApiKeyFeedback;
+  }) {
+    await TestBed.configureTestingModule({
+      imports: [ApiKeysListComponent, AppTestingModule, MatIconTestingModule],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ApiKeysListComponent);
+    component = fixture.componentInstance;
+    fixture.componentRef.setInput('apiKeys', params?.apiKeys ?? []);
+    fixture.componentRef.setInput('canManageApiKey', params?.canManageApiKey ?? true);
+    fixture.componentRef.setInput('isRevokeDisabled', params?.isRevokeDisabled ?? false);
+    fixture.componentRef.setInput('feedback', params?.feedback);
+    fixture.detectChanges();
+    harness = await TestbedHarnessEnvironment.harnessForFixture(fixture, ApiKeysListHarness);
+  }
+
+  it('should show empty message when there are no api keys', async () => {
+    await init({ apiKeys: [] });
+
+    expect(await harness.isTableShown()).toBeFalsy();
+    expect(await harness.getEmptyMessage()).toContain('No API keys available.');
+  });
+
+  it('should display api keys with their status icons', async () => {
+    await init({ apiKeys: [activeApiKeyRow('active-api-key'), inactiveApiKeyRow('revoked-api-key')] });
+
+    expect(await harness.isTableShown()).toBeTruthy();
+    expect(await harness.getKeyAt(0)).toEqual('active-api-key');
+    expect(await harness.getKeyAt(1)).toEqual('revoked-api-key');
+    expect(await harness.getStatusIcons()).toEqual(['gio:check-circled-outline', 'gio:x-circle']);
+  });
+
+  it('should show revoke button only for active api keys', async () => {
+    await init({ apiKeys: [activeApiKeyRow('active-api-key'), inactiveApiKeyRow('revoked-api-key')] });
+
+    const revokeButtons = await harness.getRevokeButtons();
+    expect(revokeButtons).toHaveLength(1);
+    expect(await (await revokeButtons[0].host()).getAttribute('data-api-key')).toEqual('active-api-key');
+  });
+
+  it('should hide revoke buttons when the user cannot manage api keys', async () => {
+    await init({ apiKeys: [activeApiKeyRow('active-api-key')], canManageApiKey: false });
+
+    expect(await harness.getRevokeButtons()).toHaveLength(0);
+  });
+
+  it('should disable revoke buttons when revocation is disabled', async () => {
+    await init({ apiKeys: [activeApiKeyRow('active-api-key')], isRevokeDisabled: true });
+
+    const revokeButtons = await harness.getRevokeButtons();
+    expect(revokeButtons).toHaveLength(1);
+    expect(await revokeButtons[0].isDisabled()).toBeTruthy();
+  });
+
+  it('should emit revokeApiKey when a revoke button is clicked', async () => {
+    await init({ apiKeys: [activeApiKeyRow('active-api-key')] });
+    const revokeApiKeySpy = jest.spyOn(component.revokeApiKey, 'emit');
+
+    await harness.clickRevoke('active-api-key');
+
+    expect(revokeApiKeySpy).toHaveBeenCalledWith(expect.objectContaining({ key: 'active-api-key' }));
+  });
+
+  it('should show success feedback politely', async () => {
+    await init({
+      apiKeys: [activeApiKeyRow('active-api-key')],
+      feedback: { type: 'success', message: 'API key renewed successfully.' },
+    });
+
+    expect(await harness.getFeedbackText()).toContain('API key renewed successfully.');
+    expect(await harness.getFeedbackAttribute('aria-live')).toEqual('polite');
+    expect(await harness.getFeedbackAttribute('role')).toBeNull();
+  });
+
+  it('should show error feedback as an alert', async () => {
+    await init({
+      apiKeys: [activeApiKeyRow('active-api-key')],
+      feedback: { type: 'error', message: 'Failed to renew API key.' },
+    });
+
+    expect(await harness.getFeedbackText()).toContain('Failed to renew API key.');
+    expect(await harness.getFeedbackAttribute('role')).toEqual('alert');
+    expect(await harness.getFeedbackAttribute('aria-live')).toBeNull();
+  });
+
+  describe('pagination', () => {
+    const apiKeys = Array.from({ length: 7 }, (_, index) => activeApiKeyRow(`api-key-${index + 1}`));
+
+    it('should display the first page of api keys by default', async () => {
+      await init({ apiKeys });
+
+      expect(await harness.getDisplayedKeys()).toEqual(['api-key-1', 'api-key-2', 'api-key-3', 'api-key-4', 'api-key-5']);
+    });
+
+    it('should display the next page of api keys when navigating', async () => {
+      await init({ apiKeys });
+
+      const pagination = await harness.getPagination();
+      expect(pagination).toBeTruthy();
+      await (await pagination!.getNextPageButton()).click();
+
+      expect(await harness.getDisplayedKeys()).toEqual(['api-key-6', 'api-key-7']);
+    });
+
+    it('should display all api keys and reset to the first page when increasing the page size', async () => {
+      await init({ apiKeys });
+
+      const pagination = await harness.getPagination();
+      await (await pagination!.getNextPageButton()).click();
+      await pagination!.changePageSize(10);
+
+      expect(await harness.getDisplayedKeys()).toHaveLength(7);
+      expect(await (await pagination!.getCurrentPaginationPage()).getText()).toEqual('1');
+    });
+  });
+});

--- a/gravitee-apim-portal-webui-next/src/components/api-access/api-keys-list/api-keys-list.component.ts
+++ b/gravitee-apim-portal-webui-next/src/components/api-access/api-keys-list/api-keys-list.component.ts
@@ -1,0 +1,81 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Component, computed, input, output, signal } from '@angular/core';
+import { MatIconButton } from '@angular/material/button';
+import { MatIcon } from '@angular/material/icon';
+import { MatTooltip } from '@angular/material/tooltip';
+
+import { PaginatedTableComponent, TableColumn } from '../../paginated-table/paginated-table.component';
+import { TableCellDirective } from '../../paginated-table/table-cell.directive';
+
+export interface ApiKeyTableRow {
+  statusIcon: 'gio:check-circled-outline' | 'gio:x-circle';
+  statusLabel: string;
+  revokeAriaLabel: string;
+  isActive: boolean;
+  key: string;
+  createdAt?: string;
+  closedAt?: string;
+}
+
+export interface ApiKeyFeedback {
+  type: 'success' | 'error';
+  message: string;
+}
+
+@Component({
+  selector: 'app-api-keys-list',
+  imports: [MatIcon, MatIconButton, MatTooltip, PaginatedTableComponent, TableCellDirective],
+  templateUrl: './api-keys-list.component.html',
+  styleUrl: './api-keys-list.component.scss',
+})
+export class ApiKeysListComponent {
+  apiKeys = input.required<ApiKeyTableRow[]>();
+  canManageApiKey = input(false);
+  isRevokeDisabled = input(false);
+  feedback = input<ApiKeyFeedback | undefined>(undefined);
+
+  revokeApiKey = output<ApiKeyTableRow>();
+
+  protected readonly columns: TableColumn[] = [
+    { id: 'status', label: $localize`:@@subscriptionDetailsApiAccessApiKeysColumnStatus:Status` },
+    { id: 'key', label: $localize`:@@subscriptionDetailsApiAccessApiKeysColumnKey:Key` },
+    { id: 'createdAt', label: $localize`:@@subscriptionDetailsApiAccessApiKeysColumnCreatedAt:Created At`, type: 'date-time' },
+    { id: 'closedAt', label: $localize`:@@subscriptionDetailsApiAccessApiKeysColumnRevokedAt:Revoked/Expired At`, type: 'date-time' },
+    { id: 'revoke', label: '' },
+  ];
+  protected readonly pageSizeOptions = [5, 10, 25];
+  protected readonly pageSize = signal(5);
+  private readonly requestedCurrentPage = signal(1);
+
+  protected readonly totalElements = computed(() => this.apiKeys().length);
+  protected readonly lastValidPage = computed(() => Math.max(1, Math.ceil(this.totalElements() / this.pageSize())));
+  protected readonly currentPage = computed(() => Math.min(this.requestedCurrentPage(), this.lastValidPage()));
+  protected readonly displayedRows = computed(() => {
+    const startIndex = (this.currentPage() - 1) * this.pageSize();
+    const endIndex = startIndex + this.pageSize();
+    return this.apiKeys().slice(startIndex, endIndex);
+  });
+
+  protected onPageChange(page: number): void {
+    this.requestedCurrentPage.set(page);
+  }
+
+  protected onPageSizeChange(pageSize: number): void {
+    this.pageSize.set(pageSize);
+    this.requestedCurrentPage.set(1);
+  }
+}

--- a/gravitee-apim-portal-webui-next/src/components/api-access/api-keys-list/api-keys-list.harness.ts
+++ b/gravitee-apim-portal-webui-next/src/components/api-access/api-keys-list/api-keys-list.harness.ts
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2024 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ComponentHarness } from '@angular/cdk/testing';
+import { MatButtonHarness } from '@angular/material/button/testing';
+
+import { PaginatedTableHarness } from '../../paginated-table/paginated-table.harness';
+import { PaginationHarness } from '../../pagination/pagination.harness';
+
+export class ApiKeysListHarness extends ComponentHarness {
+  public static readonly hostSelector = 'app-api-keys-list';
+
+  protected locateTable = this.locatorForOptional(PaginatedTableHarness);
+  protected locatePagination = this.locatorForOptional(PaginationHarness);
+  protected locateRevokeButtons = this.locatorForAll(MatButtonHarness.with({ selector: '[data-testid="api-key-revoke-button"]' }));
+  protected locateFeedback = this.locatorForOptional('[data-testid="api-key-feedback"]');
+  protected locateStatusIcons = this.locatorForAll('[data-testid="api-key-status-icon"]');
+  protected locateKeyCells = this.locatorForAll('td.mat-column-key');
+
+  public async isTableShown(): Promise<boolean> {
+    return !!(await this.locateTable());
+  }
+
+  public async getKeyAt(rowIndex: number): Promise<string> {
+    const table = await this.locateTable();
+    const keyCell = await table?.getCellElement(rowIndex, 'key');
+    return (await keyCell?.text())?.trim() ?? '';
+  }
+
+  public async getStatusIcons(): Promise<string[]> {
+    const icons = await this.locateStatusIcons();
+    const statuses = await Promise.all(icons.map(icon => icon.getAttribute('data-status-icon')));
+    return statuses.map(status => status ?? '');
+  }
+
+  public async getRevokeButtons(): Promise<MatButtonHarness[]> {
+    return this.locateRevokeButtons();
+  }
+
+  public async clickRevoke(apiKey: string): Promise<void> {
+    const revokeButton = await this.locatorFor(MatButtonHarness.with({ selector: `[data-api-key="${apiKey}"]` }))();
+    return revokeButton.click();
+  }
+
+  public async getDisplayedKeys(): Promise<string[]> {
+    const keyCells = await this.locateKeyCells();
+    return Promise.all(keyCells.map(cell => cell.text().then(text => text.trim())));
+  }
+
+  public async getPagination(): Promise<PaginationHarness | null> {
+    return this.locatePagination();
+  }
+
+  public async getFeedbackText(): Promise<string | undefined> {
+    const feedback = await this.locateFeedback();
+    return (await feedback?.text())?.trim();
+  }
+
+  public async getFeedbackAttribute(attribute: string): Promise<string | null> {
+    const feedback = await this.locateFeedback();
+    return feedback ? feedback.getAttribute(attribute) : null;
+  }
+
+  public async getEmptyMessage(): Promise<string | undefined> {
+    const emptyMessage = await this.locatorForOptional('[data-testid="api-keys-empty-message"]')();
+    return (await emptyMessage?.text())?.trim();
+  }
+}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/EXT-120

## Description

Adds a standalone, presentational `ApiKeysListComponent`, extracted from `ApiAccessComponent`: a paginated table of a subscription's API keys (status, key, created/closed dates) with a per-row **Revoke** button on active keys and an accessible inline feedback banner. 

A follow-up PR wires it into `ApiAccessComponent`.