### PR TITLE
fix: correct debug request path and pathInfo handling

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/reactive/core/context/AbstractRequest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/reactive/core/context/AbstractRequest.java
@@ -32,6 +32,8 @@ import io.reactivex.rxjava3.core.FlowableTransformer;
 import io.reactivex.rxjava3.core.Maybe;
 import io.reactivex.rxjava3.core.MaybeTransformer;
 import io.reactivex.rxjava3.core.Single;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import javax.net.ssl.SSLSession;
 
 /**
@@ -198,26 +200,39 @@ public abstract class AbstractRequest implements MutableRequest, HttpRequestInte
     @Override
     public MutableRequest contextPath(String contextPath) {
         this.contextPath = contextPath;
-        if (contextPath == null || contextPath.isEmpty()) {
-            this.pathInfo = path();
-        } else if (path().length() > 1) {
-            this.pathInfo = path().substring(contextPath.length() - 1);
-        } else {
-            this.pathInfo = "";
-        }
+        updatePathInfoFromContextPath(contextPath);
         return this;
     }
 
     @Override
     public MutableRequest debugContextPath(String contextPath) {
-        if (this.contextPath != null) {
-            if (!this.path.endsWith("/") && this.contextPath.endsWith("/")) {
-                this.path += "/";
+        String currentPath = path();
+        if (this.contextPath != null && currentPath != null) {
+            if (!currentPath.endsWith("/") && this.contextPath.endsWith("/")) {
+                final String contextPathWithoutTrailingSlash = this.contextPath.substring(0, this.contextPath.length() - 1);
+                if (currentPath.equals(contextPathWithoutTrailingSlash)) {
+                    currentPath += "/";
+                }
             }
-            this.path = this.path.replaceFirst(this.contextPath, contextPath);
+            this.path = currentPath.replaceFirst(Pattern.quote(this.contextPath), Matcher.quoteReplacement(contextPath));
         }
         this.contextPath = contextPath;
+        updatePathInfoFromContextPath(contextPath);
         return this;
+    }
+
+    private void updatePathInfoFromContextPath(String contextPath) {
+        final String currentPath = path();
+        if (currentPath == null) {
+            return;
+        }
+        if (contextPath == null || contextPath.isEmpty()) {
+            this.pathInfo = currentPath;
+        } else if (currentPath.length() > 1) {
+            this.pathInfo = currentPath.substring(contextPath.length() - 1);
+        } else {
+            this.pathInfo = "";
+        }
     }
 
     @Override

--- a/gravitee-apim-gateway/gravitee-apim-gateway-core/src/test/java/io/gravitee/gateway/reactive/core/context/AbstractRequestTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-core/src/test/java/io/gravitee/gateway/reactive/core/context/AbstractRequestTest.java
@@ -124,6 +124,15 @@ class AbstractRequestTest {
         }
 
         @Test
+        void global_path_is_null() {
+            cut.contextPath = "/uuid-12345-contextPath/";
+            cut.debugContextPath("/contextPath/");
+            assertThat(cut.contextPath).isEqualTo("/contextPath/");
+            assertThat(cut.path).isNull();
+            assertThat(cut.pathInfo).isNull();
+        }
+
+        @Test
         void global_context_path_ends_with_slash_and_global_path_ends_with_slash() {
             cut.contextPath = "/uuid-12345-contextPath/";
             cut.path = "/uuid-12345-contextPath/";
@@ -160,7 +169,41 @@ class AbstractRequestTest {
             String contextPath = "/contextPath/";
             cut.debugContextPath(contextPath);
             assertThat(cut.contextPath).isEqualTo("/contextPath/");
-            assertThat(cut.path).isEqualTo("/contextPath/v1/");
+            assertThat(cut.path).isEqualTo("/contextPath/v1");
+            assertThat(cut.pathInfo).isEqualTo("/v1");
+        }
+
+        @Test
+        void should_keep_path_and_path_info_consistent_for_subpath_without_trailing_slash() {
+            cut.contextPath = "/uuid-12345-v3/debug-slash-repro/";
+            cut.path = "/uuid-12345-v3/debug-slash-repro/anything/8077";
+            cut.pathInfo = "/anything/8077";
+            cut.debugContextPath("/v3/debug-slash-repro/");
+            assertThat(cut.path).isEqualTo("/v3/debug-slash-repro/anything/8077");
+            assertThat(cut.pathInfo).isEqualTo("/anything/8077");
+        }
+
+        @Test
+        void should_compute_path_info_when_path_is_lazy_loaded() {
+            AbstractRequest lazyPathRequest = new AbstractRequest() {
+                private boolean loaded;
+
+                @Override
+                public String path() {
+                    if (!loaded) {
+                        this.path = "/uuid-12345-contextPath/anything/8077";
+                        loaded = true;
+                    }
+                    return path;
+                }
+            };
+
+            lazyPathRequest.contextPath("/uuid-12345-contextPath/");
+            assertThat(lazyPathRequest.pathInfo()).isEqualTo("/anything/8077");
+
+            lazyPathRequest.debugContextPath("/contextPath/");
+            assertThat(lazyPathRequest.path()).isEqualTo("/contextPath/anything/8077");
+            assertThat(lazyPathRequest.pathInfo()).isEqualTo("/anything/8077");
         }
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/test/java/io/gravitee/gateway/reactive/debug/handlers/api/DebugSyncApiReactorTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-debug/src/test/java/io/gravitee/gateway/reactive/debug/handlers/api/DebugSyncApiReactorTest.java
@@ -64,7 +64,7 @@ public class DebugSyncApiReactorTest {
             assertAll(
                 () -> assertThat(context.request().path()).isEqualTo("/test/v1/"),
                 () -> assertThat(context.request().contextPath()).isEqualTo("/test/"),
-                () -> assertThat(context.request().pathInfo()).isEqualTo("/v1")
+                () -> assertThat(context.request().pathInfo()).isEqualTo("/v1/")
             );
         }
 
@@ -83,9 +83,30 @@ public class DebugSyncApiReactorTest {
             context.metrics(Metrics.builder().build());
             debugSyncApiReactor.handleProcess(context);
             assertAll(
-                () -> assertThat(context.request().path()).isEqualTo("/test/v1/"),
+                () -> assertThat(context.request().path()).isEqualTo("/test/v1"),
                 () -> assertThat(context.request().contextPath()).isEqualTo("/test/"),
                 () -> assertThat(context.request().pathInfo()).isEqualTo("/v1")
+            );
+        }
+
+        @Test
+        public void path_with_multi_segment_subpath_without_trailing_slash() {
+            MutableRequest request = new AbstractRequest() {
+                {
+                    MultiMap multiMap = HeadersMultiMap.headers();
+                    this.headers = new VertxHttpHeaders(multiMap);
+                    this.path = "/uuid-12345-v3/debug-slash-repro/anything/8077";
+                    this.contextPath = "/uuid-12345-v3/debug-slash-repro/";
+                    this.pathInfo = "/anything/8077";
+                }
+            };
+            MutableExecutionContext context = new DebugExecutionContext(request, null);
+            context.metrics(Metrics.builder().build());
+            debugSyncApiReactor.handleProcess(context);
+            assertAll(
+                () -> assertThat(context.request().path()).isEqualTo("/v3/debug-slash-repro/anything/8077"),
+                () -> assertThat(context.request().contextPath()).isEqualTo("/v3/debug-slash-repro/"),
+                () -> assertThat(context.request().pathInfo()).isEqualTo("/anything/8077")
             );
         }
     }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-14071

## Description

Fix debugContextPath() to avoid appending a trailing slash on subpaths, recompute pathInfo after stripping the debug event ID, and resolve path via path() so lazy-loaded Vert.x requests do not leave pathInfo null
during flow matching.

### Before Fix
<img width="1012" height="535" alt="image" src="https://github.com/user-attachments/assets/947ebba0-47ba-44d9-9f60-117748c90178" />


### After Fix
<img width="1728" height="929" alt="Screenshot 2026-06-16 at 3 09 31 PM" src="https://github.com/user-attachments/assets/1284ed57-3c19-403b-8565-98165df26b80" />



