### PR TITLE
feat(portal): wire ApiKeysListComponent and fix the keys table for Native Kafka

### DIFF
--- a/gravitee-apim-portal-webui-next/src/app/api/api-details/api-tab-subscriptions/subscriptions-details/subscriptions-details.component.html
+++ b/gravitee-apim-portal-webui-next/src/app/api/api-details/api-tab-subscriptions/subscriptions-details/subscriptions-details.component.html
@@ -54,7 +54,6 @@
           [clientId]="detailsVM.result.clientId"
           [clientSecret]="detailsVM.result.clientSecret"
           [apiType]="detailsVM.result.api?.type"
-          [apiKeyConfigUsername]="detailsVM.result.apiKeyConfigUsername"
           (apiKeyRevoked)="reloadSubscriptionDetails()"
           (apiKeyRenewed)="reloadSubscriptionDetails()"
         />

--- a/gravitee-apim-portal-webui-next/src/app/api/api-details/api-tab-subscriptions/subscriptions-details/subscriptions-details.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/app/api/api-details/api-tab-subscriptions/subscriptions-details/subscriptions-details.component.spec.ts
@@ -406,6 +406,11 @@ describe('SubscriptionsDetailsComponent', () => {
       expect(await apiAccess.getPlainConfig()).toContain(`username="${API_KEY_HASH}"`);
       expect(await apiAccess.getPlainConfig()).toContain(`password="${API_KEY}"`);
     });
+
+    it('should show the api keys table', async () => {
+      const apiAccess = await harnessLoader.getHarness(ApiAccessHarness);
+      expect(await apiAccess.getApiKey()).toStrictEqual(API_KEY);
+    });
   });
 
   describe('When user does not have API Plan READ permission', () => {

--- a/gravitee-apim-portal-webui-next/src/app/api/api-details/api-tab-subscriptions/subscriptions-details/subscriptions-details.component.ts
+++ b/gravitee-apim-portal-webui-next/src/app/api/api-details/api-tab-subscriptions/subscriptions-details/subscriptions-details.component.ts
@@ -66,7 +66,6 @@ interface SubscriptionDetailsData {
   createdAt?: string;
   updatedAt?: string;
   apiKeys?: SubscriptionDataKeys[];
-  apiKeyConfigUsername?: string;
   entrypointUrls?: string[];
   clientId?: string;
   clientSecret?: string;
@@ -258,14 +257,10 @@ export class SubscriptionsDetailsComponent implements OnInit {
 
           if (subscription.status === 'ACCEPTED') {
             if (plan.securityType === 'API_KEY' && subscription.api) {
-              const apiKeyItem = subscription?.keys?.length ? subscription.keys[0] : undefined;
-              const apiKeyConfigUsername = apiKeyItem?.hash ?? '';
-
               return {
                 result: {
                   ...subscriptionDetails,
                   apiKeys: subscription.keys ?? [],
-                  apiKeyConfigUsername,
                 },
               };
             } else if (plan.securityType === 'OAUTH2' || plan.securityType === 'JWT') {

--- a/gravitee-apim-portal-webui-next/src/components/api-access/api-access.component.html
+++ b/gravitee-apim-portal-webui-next/src/components/api-access/api-access.component.html
@@ -26,12 +26,12 @@
               mat-stroked-button
               type="button"
               matTooltip="Renew API Key"
-              i18n-matTooltip="@@subscriptionDetailsRenewApiKeyTooltip"
+              i18n-matTooltip="@@apiKeyRenewTooltip"
               [disabled]="isRenewingApiKey()"
               data-testid="renew-api-key-button"
               (click)="renewApiKey()"
             >
-              <span class="next-gen-small-bold" i18n="@@subscriptionDetailsRenewApiKey">Renew API Key</span>
+              <span class="next-gen-small-bold" i18n="@@apiKeyRenew">Renew API Key</span>
             </button>
           }
         </div>
@@ -46,7 +46,7 @@
         }
         @if (planSecurity === 'API_KEY') {
           <app-api-keys-list
-            [apiKeys]="apiKeyRows()"
+            [apiKeys]="apiKeys"
             [canManageApiKey]="canManageApiKey"
             [isRevokeDisabled]="isRevokingApiKey() || isRevokeApiKeyDialogOpen()"
             [feedback]="apiKeyFeedback()"

--- a/gravitee-apim-portal-webui-next/src/components/api-access/api-access.component.html
+++ b/gravitee-apim-portal-webui-next/src/components/api-access/api-access.component.html
@@ -44,74 +44,26 @@
             <app-copy-code id="client-secret" title="Client Secret" [text]="clientSecret" mode="PASSWORD" />
           }
         }
-        @if (apiType === 'NATIVE') {
-          <app-native-kafka-api-access
-            [entrypointUrls]="entrypointUrlValues()"
-            [planSecurity]="planSecurity"
-            [apiKey]="primaryApiKey()"
-            [apiKeyConfigUsername]="resolvedApiKeyConfigUsername()"
-            [clientId]="clientId ?? ''"
+        @if (planSecurity === 'API_KEY') {
+          <app-api-keys-list
+            [apiKeys]="apiKeyRows()"
+            [canManageApiKey]="canManageApiKey"
+            [isRevokeDisabled]="isRevokingApiKey() || isRevokeApiKeyDialogOpen()"
+            [feedback]="apiKeyFeedback()"
+            (revokeApiKey)="revokeApiKeyRow($event)"
           />
-        } @else {
-          @if (planSecurity === 'API_KEY') {
-            <div class="api-access__copy-code-content__api-keys-list">
-              <div class="next-gen-h5" i18n="@@subscriptionDetailsApiAccessApiKeysHeader">API keys</div>
-              @if (apiKeyRenewFeedback(); as renewFeedback) {
-                <div
-                  class="next-gen-body api-access__renew-feedback"
-                  [class.api-access__renew-feedback--error]="renewFeedback.type === 'error'"
-                  [class.api-access__renew-feedback--success]="renewFeedback.type === 'success'"
-                  [attr.role]="renewFeedback.type === 'error' ? 'alert' : null"
-                  [attr.aria-live]="renewFeedback.type === 'success' ? 'polite' : null"
-                  data-testid="renew-api-key-feedback"
-                >
-                  {{ renewFeedback.message }}
-                </div>
-              }
-              @if (apiKeyRows().length > 0) {
-                <app-paginated-table
-                  [columns]="apiKeysColumns"
-                  [rows]="displayedApiKeyRows()"
-                  [totalElements]="totalApiKeyElements()"
-                  [currentPage]="apiKeysCurrentPage()"
-                  [pageSize]="apiKeysPageSize()"
-                  [pageSizeOptions]="apiKeysPageSizeOptions"
-                  [navigable]="false"
-                  (pageChange)="onApiKeysPageChange($event)"
-                  (pageSizeChange)="onApiKeysPageSizeChange($event)"
-                >
-                  <ng-template appTableCell="status" let-apiKey>
-                    <mat-icon
-                      [svgIcon]="apiKey.statusIcon"
-                      [attr.aria-label]="apiKey.statusLabel"
-                      [attr.data-status-icon]="apiKey.statusIcon"
-                      data-testid="api-key-status-icon"
-                    />
-                  </ng-template>
-                  <ng-template appTableCell="revoke" let-apiKey>
-                    @if (canManageApiKey && apiKey.isActive) {
-                      <button
-                        mat-icon-button
-                        type="button"
-                        color="warn"
-                        [disabled]="isRevokingApiKey || isRevokeApiKeyDialogOpen"
-                        matTooltip="Revoke"
-                        i18n-matTooltip="@@subscriptionDetailsApiAccessRevokeTooltip"
-                        [attr.aria-label]="apiKey.revokeAriaLabel"
-                        [attr.data-api-key]="apiKey.key"
-                        data-testid="api-key-revoke-button"
-                        (click)="revokeApiKeyRow(apiKey)"
-                      >
-                        <mat-icon svgIcon="gio:x-circle" />
-                      </button>
-                    }
-                  </ng-template>
-                </app-paginated-table>
-              } @else {
-                <div class="next-gen-body" i18n="@@subscriptionDetailsApiAccessApiKeysEmpty">No API keys available.</div>
-              }
-            </div>
+        }
+        @if (apiType === 'NATIVE') {
+          @if (shouldShowNativeAccessContent()) {
+            <app-native-kafka-api-access
+              [entrypointUrls]="entrypointUrlValues()"
+              [planSecurity]="planSecurity"
+              [apiKey]="primaryApiKey()"
+              [apiKeyConfigUsername]="resolvedApiKeyConfigUsername()"
+              [clientId]="clientId ?? ''"
+            />
           }
+        } @else {
           @if (shouldShowApiAccessContent()) {
             <div class="api-access__copy-code-content__calling-api">
               <div class="next-gen-h5" i18n="@@subscriptionDetailsApiAccessCallingTheApi">Calling the API</div>

--- a/gravitee-apim-portal-webui-next/src/components/api-access/api-access.component.scss
+++ b/gravitee-apim-portal-webui-next/src/components/api-access/api-access.component.scss
@@ -13,8 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-@use '../../scss/theme' as app-theme;
-
 :host {
   width: 100%;
 }
@@ -51,26 +49,10 @@
     flex-flow: column;
     gap: 32px;
 
-    &__api-keys-list {
-      display: flex;
-      flex-flow: column;
-      gap: 8px;
-    }
-
     &__calling-api {
       display: flex;
       flex-flow: column;
       gap: 8px;
-    }
-  }
-
-  &__renew-feedback {
-    &--success {
-      color: app-theme.$primary-main-color;
-    }
-
-    &--error {
-      color: app-theme.$error-main-color;
     }
   }
 }

--- a/gravitee-apim-portal-webui-next/src/components/api-access/api-access.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/components/api-access/api-access.component.spec.ts
@@ -255,9 +255,9 @@ describe('ApiAccessComponent', () => {
           fixture.detectChanges();
 
           expect(apiKeyRenewedSpy).toHaveBeenCalled();
-          expect(getRenewApiKeyFeedbackText()).toContain('API key renewed successfully. You can now use it to access the API.');
-          expect(getRenewApiKeyFeedbackAttribute('aria-live')).toBe('polite');
-          expect(getRenewApiKeyFeedbackAttribute('role')).toBeNull();
+          expect(getApiKeyFeedbackText()).toContain('API key renewed successfully. You can now use it to access the API.');
+          expect(getApiKeyFeedbackAttribute('aria-live')).toBe('polite');
+          expect(getApiKeyFeedbackAttribute('role')).toBeNull();
         });
 
         it('should not call renew service when dialog is canceled', async () => {
@@ -301,9 +301,9 @@ describe('ApiAccessComponent', () => {
           fixture.detectChanges();
 
           expect(apiKeyRenewedSpy).not.toHaveBeenCalled();
-          expect(getRenewApiKeyFeedbackText()).toContain('Failed to renew API key. Please try again.');
-          expect(getRenewApiKeyFeedbackAttribute('role')).toBe('alert');
-          expect(getRenewApiKeyFeedbackAttribute('aria-live')).toBeNull();
+          expect(getApiKeyFeedbackText()).toContain('Failed to renew API key. Please try again.');
+          expect(getApiKeyFeedbackAttribute('role')).toBe('alert');
+          expect(getApiKeyFeedbackAttribute('aria-live')).toBeNull();
         });
 
         it('should not call renew service when subscription id is missing', async () => {
@@ -633,8 +633,11 @@ describe('ApiAccessComponent', () => {
             status: 500,
             statusText: 'Server Error',
           });
+          fixture.detectChanges();
 
           expect(apiKeyRevokedSpy).not.toHaveBeenCalled();
+          expect(getApiKeyFeedbackText()).toContain('Failed to revoke API key. Please try again.');
+          expect(getApiKeyFeedbackAttribute('role')).toBe('alert');
         });
 
         it('should not call revoke service when subscription id is missing', async () => {
@@ -719,16 +722,16 @@ describe('ApiAccessComponent', () => {
         component.subscription = { status: 'ACCEPTED' } as Subscription;
       });
       describe('API Key', () => {
-        it('should show api key, config, producer and consumer calls', async () => {
+        it('should show api keys table, config, producer and consumer calls', async () => {
           component.planSecurity = 'API_KEY';
           component.apiKeys = [{ key: 'api-key', hash: 'hash-username', application: { id: 'app-id', name: 'app-name' } }];
-          component.apiKeyConfigUsername = 'hash-username';
 
           fixture.detectChanges();
-          expect(await apiKeysTableShown()).toBeFalsy();
+          expect(await apiKeysTableShown()).toBeTruthy();
+          expect(await revokeApiKeyButtonShown()).toBeTruthy();
+          expect(await renewApiKeyButtonShown()).toBeTruthy();
           expect(await baseUrlShown()).toBeFalsy();
           expect(await commandLineShown()).toBeFalsy();
-          expect(await revokeApiKeyButtonShown()).toBeFalsy();
 
           expect(await apiKeyUsernameShown()).toBeTruthy();
           expect(await apiKeyPasswordShown()).toBeTruthy();
@@ -739,7 +742,7 @@ describe('ApiAccessComponent', () => {
           const plainConfiguration = await getPlainConfiguration();
           const plainConfigurationContent = await plainConfiguration?.host().then(host => host.text());
           expect(plainConfigurationContent).toContain('api-key');
-          expect(plainConfigurationContent).toContain(component.apiKeyConfigUsername);
+          expect(plainConfigurationContent).toContain('hash-username');
 
           const configTabs = await getApiKeyPropertiesConfiguration();
           expect(await configTabs.getTabs().then(tabs => tabs.length)).toEqual(3);
@@ -765,11 +768,111 @@ describe('ApiAccessComponent', () => {
           expect(await consumerCommandShown()).toBeTruthy();
         });
 
+        it('should display active and inactive api key status icons', async () => {
+          component.planSecurity = 'API_KEY';
+          component.subscription = { id: 'subscription-id', status: 'ACCEPTED' } as Subscription;
+          component.apiKeys = [
+            { key: 'active-api-key', hash: 'active-hash', application: { id: 'app-id', name: 'app-name' } },
+            {
+              key: 'revoked-api-key',
+              revoked_at: '2024-04-19T10:33:29Z',
+              application: { id: 'app-id', name: 'app-name' },
+            },
+          ];
+
+          fixture.detectChanges();
+
+          expect(getApiKeyStatusIcons()).toEqual(['gio:check-circled-outline', 'gio:x-circle']);
+          expect(getApiKeyRevokeButtonApiKeys()).toEqual(['active-api-key']);
+        });
+
+        it('should hide kafka configuration but keep api keys table and renew button when no active api key remains', async () => {
+          component.planSecurity = 'API_KEY';
+          component.subscription = { id: 'subscription-id', status: 'ACCEPTED' } as Subscription;
+          component.apiKeys = [
+            {
+              key: 'revoked-api-key',
+              revoked_at: '2024-04-19T10:33:29Z',
+              application: { id: 'app-id', name: 'app-name' },
+            },
+          ];
+
+          fixture.detectChanges();
+
+          expect(await apiKeysTableShown()).toBeTruthy();
+          expect(await renewApiKeyButtonShown()).toBeTruthy();
+          expect(await revokeApiKeyButtonShown()).toBeFalsy();
+          expect(await apiKeyUsernameShown()).toBeFalsy();
+          expect(await apiKeyPasswordShown()).toBeFalsy();
+          expect(await plainConfigurationShown()).toBeFalsy();
+        });
+
+        it('should use the active api key hash as configuration username when the first key is inactive', async () => {
+          component.planSecurity = 'API_KEY';
+          component.subscription = { id: 'subscription-id', status: 'ACCEPTED' } as Subscription;
+          component.apiKeys = [
+            {
+              key: 'revoked-api-key',
+              hash: 'revoked-hash',
+              revoked_at: '2024-04-19T10:33:29Z',
+              application: { id: 'app-id', name: 'app-name' },
+            },
+            { key: 'active-api-key', hash: 'active-hash', application: { id: 'app-id', name: 'app-name' } },
+          ];
+
+          fixture.detectChanges();
+
+          const plainConfiguration = await getPlainConfiguration();
+          const plainConfigurationContent = await plainConfiguration?.host().then(host => host.text());
+          expect(plainConfigurationContent).toContain('active-api-key');
+          expect(plainConfigurationContent).toContain('active-hash');
+          expect(plainConfigurationContent).not.toContain('revoked-hash');
+        });
+
+        it('should open confirmation dialog and call revoke service after confirmation', async () => {
+          component.planSecurity = 'API_KEY';
+          component.subscription = { id: 'subscription-id', status: 'ACCEPTED' } as Subscription;
+          component.apiKeys = [{ key: 'api-key', hash: 'hash-username', application: { id: 'app-id', name: 'app-name' } }];
+          const apiKeyRevokedSpy = jest.spyOn(component.apiKeyRevoked, 'emit');
+
+          fixture.detectChanges();
+
+          const revokeButton = await getRevokeApiKeyButton();
+          expect(revokeButton).toBeTruthy();
+
+          await revokeButton!.click();
+          const confirmDialog = await rootLoader.getHarness(ConfirmDialogHarness);
+          await confirmDialog.confirm();
+          expectRevokeApiKeyRequest('subscription-id', 'api-key').flush(null);
+
+          expect(apiKeyRevokedSpy).toHaveBeenCalled();
+        });
+
+        it('should show renew feedback after successful renewal', async () => {
+          component.planSecurity = 'API_KEY';
+          component.subscription = { id: 'subscription-id', status: 'ACCEPTED' } as Subscription;
+          component.apiKeys = [{ key: 'api-key', hash: 'hash-username', application: { id: 'app-id', name: 'app-name' } }];
+          const apiKeyRenewedSpy = jest.spyOn(component.apiKeyRenewed, 'emit');
+
+          fixture.detectChanges();
+
+          const renewButton = await getRenewApiKeyButton();
+          expect(renewButton).toBeTruthy();
+
+          await renewButton!.click();
+          const confirmDialog = await rootLoader.getHarness(ConfirmDialogHarness);
+          await confirmDialog.confirm();
+          expectRenewApiKeyRequest('subscription-id').flush(null);
+          fixture.detectChanges();
+
+          expect(apiKeyRenewedSpy).toHaveBeenCalled();
+          expect(getApiKeyFeedbackText()).toContain('API key renewed successfully. You can now use it to access the API.');
+        });
+
         describe('Multiple Entrypoint URLs', () => {
           it('should show api key, config, producer and consumer calls', async () => {
             component.planSecurity = 'API_KEY';
             component.apiKeys = [{ key: 'api-key', hash: 'hash-username', application: { id: 'app-id', name: 'app-name' } }];
-            component.apiKeyConfigUsername = 'hash-username';
             component.entrypointUrls = ['my-entrypoint-url-1', 'my-entrypoint-url-2'];
 
             fixture.detectChanges();
@@ -818,6 +921,26 @@ describe('ApiAccessComponent', () => {
           expect(await getCommandExamples()).toBeTruthy();
           expect(await producerCommandShown()).toBeTruthy();
           expect(await consumerCommandShown()).toBeFalsy();
+        });
+      });
+    });
+    describe.each(['MESSAGE', 'A2A_PROXY', 'LLM_PROXY', 'MCP_PROXY'] as const)('%s API', apiType => {
+      describe('API Key', () => {
+        it('should show api keys table, revoke button and calling the API content', async () => {
+          component.apiType = apiType;
+          component.planSecurity = 'API_KEY';
+          component.subscription = { id: 'subscription-id', status: 'ACCEPTED' } as Subscription;
+          component.entrypointUrls = ['my-entrypoint-url'];
+          component.apiKeys = [{ key: 'api-key', application: { id: 'app-id', name: 'app-name' } }];
+
+          fixture.detectChanges();
+
+          expect(await apiKeysTableShown()).toBeTruthy();
+          expect(await revokeApiKeyButtonShown()).toBeTruthy();
+          expect(await renewApiKeyButtonShown()).toBeTruthy();
+          expect(await baseUrlShown()).toBeTruthy();
+          expect(await commandLineShown()).toBeTruthy();
+          expect(await commandLineContains('X-My-Apikey: api-key')).toBeTruthy();
         });
       });
     });
@@ -936,15 +1059,15 @@ describe('ApiAccessComponent', () => {
   async function getRenewApiKeyTooltip() {
     return await harnessLoader.getHarnessOrNull(MatTooltipHarness.with({ selector: '[data-testid="renew-api-key-button"]' }));
   }
-  function getRenewApiKeyFeedback() {
-    return fixture.debugElement.query(By.css('[data-testid="renew-api-key-feedback"]'));
+  function getApiKeyFeedback() {
+    return fixture.debugElement.query(By.css('[data-testid="api-key-feedback"]'));
   }
-  function getRenewApiKeyFeedbackText() {
-    const element = getRenewApiKeyFeedback()?.nativeElement as HTMLElement | undefined;
+  function getApiKeyFeedbackText() {
+    const element = getApiKeyFeedback()?.nativeElement as HTMLElement | undefined;
     return element?.textContent?.trim();
   }
-  function getRenewApiKeyFeedbackAttribute(attribute: string) {
-    const element = getRenewApiKeyFeedback()?.nativeElement as HTMLElement | undefined;
+  function getApiKeyFeedbackAttribute(attribute: string) {
+    const element = getApiKeyFeedback()?.nativeElement as HTMLElement | undefined;
     return element?.getAttribute(attribute) ?? null;
   }
   function getApiKeyRevokeButtonApiKeys() {

--- a/gravitee-apim-portal-webui-next/src/components/api-access/api-access.component.ts
+++ b/gravitee-apim-portal-webui-next/src/components/api-access/api-access.component.ts
@@ -24,11 +24,11 @@ import { MatTooltip } from '@angular/material/tooltip';
 import { filter, tap } from 'rxjs';
 import { finalize } from 'rxjs/operators';
 
-import { ApiKeyFeedback, ApiKeysListComponent, ApiKeyTableRow } from './api-keys-list/api-keys-list.component';
+import { ApiKeyFeedback, ApiKeysListComponent } from './api-keys-list/api-keys-list.component';
 import { NativeKafkaApiAccessComponent } from './native-kafka-api-access/native-kafka-api-access.component';
 import { ApiType } from '../../entities/api/api';
 import { PlanSecurityEnum } from '../../entities/plan/plan';
-import { Subscription, SubscriptionDataKeys } from '../../entities/subscription/subscription';
+import { isActiveApiKey, Subscription, SubscriptionDataKeys } from '../../entities/subscription/subscription';
 import { ConfigService } from '../../services/config.service';
 import { SubscriptionKeysService } from '../../services/subscription-keys.service';
 import { ConfirmDialogComponent, ConfirmDialogData } from '../confirm-dialog/confirm-dialog.component';
@@ -147,23 +147,7 @@ export class ApiAccessComponent {
   protected readonly isRenewApiKeyDialogOpen = signal(false);
 
   protected readonly entrypointUrlValues = computed(() => this.entrypointUrlsInput() ?? []);
-  protected readonly apiKeyRows = computed<ApiKeyTableRow[]>(() =>
-    this.apiKeysInput().map(apiKey => {
-      const isActive = this.isActiveApiKey(apiKey);
-      return {
-        statusIcon: isActive ? 'gio:check-circled-outline' : 'gio:x-circle',
-        statusLabel: isActive
-          ? $localize`:@@subscriptionDetailsApiAccessApiKeysStatusActive:Active API key`
-          : $localize`:@@subscriptionDetailsApiAccessApiKeysStatusInactive:Inactive API key`,
-        revokeAriaLabel: $localize`:@@subscriptionDetailsApiAccessRevokeAriaLabel:Revoke API key ${apiKey.key ?? ''}:apiKey:`,
-        isActive,
-        key: apiKey.key ?? '',
-        createdAt: apiKey.created_at,
-        closedAt: apiKey.revoked_at ?? apiKey.expire_at,
-      };
-    }),
-  );
-  protected readonly activeApiKey = computed(() => this.apiKeysInput().find(apiKey => this.isActiveApiKey(apiKey)));
+  protected readonly activeApiKey = computed(() => this.apiKeysInput().find(apiKey => isActiveApiKey(apiKey)));
   protected readonly hasActiveApiKey = computed(() => !!this.activeApiKey());
   protected readonly primaryApiKey = computed(() => this.activeApiKey()?.key ?? '');
   protected readonly resolvedApiKeyConfigUsername = computed(() => this.activeApiKey()?.hash ?? '');
@@ -198,16 +182,17 @@ export class ApiAccessComponent {
 
   curlCmd = computed(() => this.formatCurlCommandLine(this.selectedEntrypointUrlValue(), this.planSecurityInput(), this.primaryApiKey()));
 
-  protected revokeApiKeyRow(apiKey: ApiKeyTableRow): void {
-    if (!this.canManageApiKeyInput() || this.isRevokingApiKey() || this.isRevokeApiKeyDialogOpen() || !apiKey.isActive || !apiKey.key) {
+  protected revokeApiKeyRow(apiKey: SubscriptionDataKeys): void {
+    const key = apiKey.key;
+    if (!this.canManageApiKeyInput() || this.isRevokingApiKey() || this.isRevokeApiKeyDialogOpen() || !isActiveApiKey(apiKey) || !key) {
       return;
     }
 
     const dialogData: ConfirmDialogData = {
-      title: $localize`:@@subscriptionDetailsCloseApiKeyDialogTitle:Close this API key?`,
-      content: $localize`:@@subscriptionDetailsCloseApiKeyDialogContent:Applications using it will no longer be able to access the API.`,
-      confirmLabel: $localize`:@@subscriptionDetailsCloseApiKeyDialogConfirm:Yes, revoke`,
-      cancelLabel: $localize`:@@subscriptionDetailsCloseApiKeyDialogCancel:Cancel`,
+      title: $localize`:@@apiKeyRevokeDialogTitle:Close this API key?`,
+      content: $localize`:@@apiKeyRevokeDialogContent:Applications using it will no longer be able to access the API.`,
+      confirmLabel: $localize`:@@apiKeyRevokeDialogConfirm:Yes, revoke`,
+      cancelLabel: $localize`:@@apiKeyRevokeDialogCancel:Cancel`,
     };
 
     this.isRevokeApiKeyDialogOpen.set(true);
@@ -223,7 +208,7 @@ export class ApiAccessComponent {
         filter(confirmed => !!confirmed),
         takeUntilDestroyed(this.destroyRef),
       )
-      .subscribe(() => this.executeApiKeyRevocation(apiKey.key));
+      .subscribe(() => this.executeApiKeyRevocation(key));
   }
 
   protected renewApiKey(): void {
@@ -232,10 +217,10 @@ export class ApiAccessComponent {
     }
 
     const dialogData: ConfirmDialogData = {
-      title: $localize`:@@subscriptionDetailsRenewApiKeyDialogTitle:Renew API Key?`,
-      content: $localize`:@@subscriptionDetailsRenewApiKeyDialogContent:API Key renewal will eventually deprecate the current key`,
-      confirmLabel: $localize`:@@subscriptionDetailsRenewApiKeyDialogConfirm:Yes, renew`,
-      cancelLabel: $localize`:@@subscriptionDetailsRenewApiKeyDialogCancel:Cancel`,
+      title: $localize`:@@apiKeyRenewDialogTitle:Renew API Key?`,
+      content: $localize`:@@apiKeyRenewDialogContent:API Key renewal will eventually deprecate the current key`,
+      confirmLabel: $localize`:@@apiKeyRenewDialogConfirm:Yes, renew`,
+      cancelLabel: $localize`:@@apiKeyRenewDialogCancel:Cancel`,
     };
 
     this.isRenewApiKeyDialogOpen.set(true);
@@ -252,18 +237,6 @@ export class ApiAccessComponent {
         takeUntilDestroyed(this.destroyRef),
       )
       .subscribe(() => this.executeApiKeyRenewal());
-  }
-
-  private isActiveApiKey(apiKey: SubscriptionDataKeys): boolean {
-    if (apiKey.revoked_at) {
-      return false;
-    }
-
-    if (!apiKey.expire_at) {
-      return true;
-    }
-
-    return new Date(apiKey.expire_at).getTime() > Date.now();
   }
 
   private executeApiKeyRevocation(apiKey: string): void {
@@ -285,13 +258,13 @@ export class ApiAccessComponent {
           this.apiKeyRevoked.emit();
           this.apiKeyFeedback.set({
             type: 'success',
-            message: $localize`:@@subscriptionDetailsApiAccessRevokeSuccess:API key revoked successfully. Applications using it will no longer be able to access the API.`,
+            message: $localize`:@@apiKeyRevokeSuccess:API key revoked successfully. Applications using it will no longer be able to access the API.`,
           });
         },
         error: () => {
           this.apiKeyFeedback.set({
             type: 'error',
-            message: $localize`:@@subscriptionDetailsApiAccessRevokeError:Failed to revoke API key. Please try again.`,
+            message: $localize`:@@apiKeyRevokeError:Failed to revoke API key. Please try again.`,
           });
         },
       });
@@ -316,13 +289,13 @@ export class ApiAccessComponent {
           this.apiKeyRenewed.emit();
           this.apiKeyFeedback.set({
             type: 'success',
-            message: $localize`:@@subscriptionDetailsApiAccessRenewSuccess:API key renewed successfully. You can now use it to access the API.`,
+            message: $localize`:@@apiKeyRenewSuccess:API key renewed successfully. You can now use it to access the API.`,
           });
         },
         error: () => {
           this.apiKeyFeedback.set({
             type: 'error',
-            message: $localize`:@@subscriptionDetailsApiAccessRenewError:Failed to renew API key. Please try again.`,
+            message: $localize`:@@apiKeyRenewError:Failed to renew API key. Please try again.`,
           });
         },
       });

--- a/gravitee-apim-portal-webui-next/src/components/api-access/api-access.component.ts
+++ b/gravitee-apim-portal-webui-next/src/components/api-access/api-access.component.ts
@@ -15,17 +15,16 @@
  */
 import { Component, computed, DestroyRef, inject, Input, model, output, signal } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
-import { MatButton, MatIconButton } from '@angular/material/button';
+import { MatButton } from '@angular/material/button';
 import { MatCard, MatCardContent, MatCardHeader } from '@angular/material/card';
 import { MatDialog } from '@angular/material/dialog';
 import { MatFormFieldModule } from '@angular/material/form-field';
-import { MatIcon } from '@angular/material/icon';
 import { MatSelectModule } from '@angular/material/select';
-import { MatSnackBar, MatSnackBarConfig, MatSnackBarModule } from '@angular/material/snack-bar';
 import { MatTooltip } from '@angular/material/tooltip';
 import { filter, tap } from 'rxjs';
 import { finalize } from 'rxjs/operators';
 
+import { ApiKeyFeedback, ApiKeysListComponent, ApiKeyTableRow } from './api-keys-list/api-keys-list.component';
 import { NativeKafkaApiAccessComponent } from './native-kafka-api-access/native-kafka-api-access.component';
 import { ApiType } from '../../entities/api/api';
 import { PlanSecurityEnum } from '../../entities/plan/plan';
@@ -35,23 +34,6 @@ import { SubscriptionKeysService } from '../../services/subscription-keys.servic
 import { ConfirmDialogComponent, ConfirmDialogData } from '../confirm-dialog/confirm-dialog.component';
 import { CopyCodeIconComponent } from '../copy-code/copy-code-icon/copy-code-icon/copy-code-icon.component';
 import { CopyCodeComponent } from '../copy-code/copy-code.component';
-import { PaginatedTableComponent, TableColumn } from '../paginated-table/paginated-table.component';
-import { TableCellDirective } from '../paginated-table/table-cell.directive';
-
-interface ApiKeyTableRow {
-  statusIcon: 'gio:check-circled-outline' | 'gio:x-circle';
-  statusLabel: string;
-  revokeAriaLabel: string;
-  isActive: boolean;
-  key: string;
-  createdAt?: string;
-  closedAt?: string;
-}
-
-interface ApiKeyRenewFeedback {
-  type: 'success' | 'error';
-  message: string;
-}
 
 @Component({
   selector: 'app-api-access',
@@ -60,17 +42,13 @@ interface ApiKeyRenewFeedback {
     MatCardContent,
     MatCardHeader,
     MatButton,
-    MatIconButton,
+    ApiKeysListComponent,
     CopyCodeComponent,
     NativeKafkaApiAccessComponent,
     MatFormFieldModule,
-    MatIcon,
     MatSelectModule,
-    MatSnackBarModule,
     MatTooltip,
     CopyCodeIconComponent,
-    PaginatedTableComponent,
-    TableCellDirective,
   ],
   templateUrl: './api-access.component.html',
   styleUrl: './api-access.component.scss',
@@ -78,7 +56,6 @@ interface ApiKeyRenewFeedback {
 export class ApiAccessComponent {
   private readonly configService = inject(ConfigService);
   private readonly subscriptionKeysService = inject(SubscriptionKeysService);
-  private readonly snackBar = inject(MatSnackBar);
   private readonly dialog = inject(MatDialog);
   private readonly destroyRef = inject(DestroyRef);
 
@@ -107,15 +84,6 @@ export class ApiAccessComponent {
 
   get apiKeys(): SubscriptionDataKeys[] {
     return this.apiKeysInput();
-  }
-
-  @Input()
-  set apiKeyConfigUsername(value: string | undefined) {
-    this.apiKeyConfigUsernameInput.set(value);
-  }
-
-  get apiKeyConfigUsername(): string | undefined {
-    return this.apiKeyConfigUsernameInput();
   }
 
   @Input()
@@ -166,25 +134,15 @@ export class ApiAccessComponent {
   apiKeyRevoked = output<void>();
   apiKeyRenewed = output<void>();
 
-  protected readonly apiKeysColumns: TableColumn[] = [
-    { id: 'status', label: $localize`:@@subscriptionDetailsApiAccessApiKeysColumnStatus:Status` },
-    { id: 'key', label: $localize`:@@subscriptionDetailsApiAccessApiKeysColumnKey:Key` },
-    { id: 'createdAt', label: $localize`:@@subscriptionDetailsApiAccessApiKeysColumnCreatedAt:Created At`, type: 'date-time' },
-    { id: 'closedAt', label: $localize`:@@subscriptionDetailsApiAccessApiKeysColumnRevokedAt:Revoked/Expired At`, type: 'date-time' },
-    { id: 'revoke', label: '' },
-  ];
-  protected readonly apiKeysPageSizeOptions = [5, 10, 25];
-
   private readonly planSecurityInput = signal<PlanSecurityEnum | undefined>(undefined);
   private readonly subscriptionInput = signal<Subscription | undefined>(undefined);
   private readonly apiKeysInput = signal<SubscriptionDataKeys[]>([]);
-  private readonly apiKeyConfigUsernameInput = signal<string | undefined>(undefined);
   private readonly apiTypeInput = signal<ApiType | undefined>(undefined);
   private readonly entrypointUrlsInput = signal<string[] | undefined>(undefined);
   private readonly clientIdInput = signal<string | undefined>(undefined);
   private readonly clientSecretInput = signal<string | undefined>(undefined);
   private readonly canManageApiKeyInput = signal(false);
-  protected readonly apiKeyRenewFeedback = signal<ApiKeyRenewFeedback | undefined>(undefined);
+  protected readonly apiKeyFeedback = signal<ApiKeyFeedback | undefined>(undefined);
   protected readonly isRenewingApiKey = signal(false);
   protected readonly isRenewApiKeyDialogOpen = signal(false);
 
@@ -207,23 +165,13 @@ export class ApiAccessComponent {
   );
   protected readonly activeApiKey = computed(() => this.apiKeysInput().find(apiKey => this.isActiveApiKey(apiKey)));
   protected readonly hasActiveApiKey = computed(() => !!this.activeApiKey());
-  protected readonly totalApiKeyElements = computed(() => this.apiKeyRows().length);
-  protected readonly apiKeysPageSize = signal(5);
-  private readonly requestedApiKeysCurrentPage = signal(1);
-  protected readonly lastValidApiKeysPage = computed(() => Math.max(1, Math.ceil(this.totalApiKeyElements() / this.apiKeysPageSize())));
-  protected readonly apiKeysCurrentPage = computed(() => Math.min(this.requestedApiKeysCurrentPage(), this.lastValidApiKeysPage()));
-  protected readonly displayedApiKeyRows = computed(() => {
-    const startIndex = (this.apiKeysCurrentPage() - 1) * this.apiKeysPageSize();
-    const endIndex = startIndex + this.apiKeysPageSize();
-    return this.apiKeyRows().slice(startIndex, endIndex);
-  });
   protected readonly primaryApiKey = computed(() => this.activeApiKey()?.key ?? '');
-  protected readonly resolvedApiKeyConfigUsername = computed(() => this.apiKeyConfigUsernameInput() ?? this.activeApiKey()?.hash ?? '');
-  protected readonly shouldShowApiAccessContent = computed(
-    () =>
-      this.entrypointUrlValues().length > 0 &&
-      (this.planSecurityInput() !== 'API_KEY' || this.subscriptionInput()?.status !== 'ACCEPTED' || this.hasActiveApiKey()),
+  protected readonly resolvedApiKeyConfigUsername = computed(() => this.activeApiKey()?.hash ?? '');
+  protected readonly hasUsableApiKeyAccess = computed(
+    () => this.planSecurityInput() !== 'API_KEY' || this.subscriptionInput()?.status !== 'ACCEPTED' || this.hasActiveApiKey(),
   );
+  protected readonly shouldShowApiAccessContent = computed(() => this.entrypointUrlValues().length > 0 && this.hasUsableApiKeyAccess());
+  protected readonly shouldShowNativeAccessContent = computed(() => this.hasUsableApiKeyAccess());
   protected readonly hasApiAccessContent = computed(() => {
     if (this.apiTypeInput() === 'NATIVE') {
       return true;
@@ -238,12 +186,8 @@ export class ApiAccessComponent {
     const isAccessVisible = this.subscriptionInput()?.status === 'ACCEPTED' || this.planSecurityInput() === 'KEY_LESS';
     return isAccessVisible ? this.hasApiAccessContent() : true;
   });
-  protected isRevokingApiKey = false;
-  protected isRevokeApiKeyDialogOpen = false;
-  private readonly defaultSnackBarOptions: MatSnackBarConfig = {
-    duration: 5000,
-    horizontalPosition: 'end',
-  };
+  protected readonly isRevokingApiKey = signal(false);
+  protected readonly isRevokeApiKeyDialogOpen = signal(false);
 
   selectedEntrypointUrl = model<string>('');
   protected readonly selectedEntrypointUrlValue = computed(() => {
@@ -254,17 +198,8 @@ export class ApiAccessComponent {
 
   curlCmd = computed(() => this.formatCurlCommandLine(this.selectedEntrypointUrlValue(), this.planSecurityInput(), this.primaryApiKey()));
 
-  protected onApiKeysPageChange(page: number): void {
-    this.requestedApiKeysCurrentPage.set(page);
-  }
-
-  protected onApiKeysPageSizeChange(pageSize: number): void {
-    this.apiKeysPageSize.set(pageSize);
-    this.requestedApiKeysCurrentPage.set(1);
-  }
-
   protected revokeApiKeyRow(apiKey: ApiKeyTableRow): void {
-    if (!this.canManageApiKeyInput() || this.isRevokingApiKey || this.isRevokeApiKeyDialogOpen || !apiKey.isActive || !apiKey.key) {
+    if (!this.canManageApiKeyInput() || this.isRevokingApiKey() || this.isRevokeApiKeyDialogOpen() || !apiKey.isActive || !apiKey.key) {
       return;
     }
 
@@ -275,7 +210,7 @@ export class ApiAccessComponent {
       cancelLabel: $localize`:@@subscriptionDetailsCloseApiKeyDialogCancel:Cancel`,
     };
 
-    this.isRevokeApiKeyDialogOpen = true;
+    this.isRevokeApiKeyDialogOpen.set(true);
     this.dialog
       .open<ConfirmDialogComponent, ConfirmDialogData, boolean>(ConfirmDialogComponent, {
         role: 'alertdialog',
@@ -284,7 +219,7 @@ export class ApiAccessComponent {
       })
       .afterClosed()
       .pipe(
-        tap(() => (this.isRevokeApiKeyDialogOpen = false)),
+        tap(() => this.isRevokeApiKeyDialogOpen.set(false)),
         filter(confirmed => !!confirmed),
         takeUntilDestroyed(this.destroyRef),
       )
@@ -337,34 +272,27 @@ export class ApiAccessComponent {
       return;
     }
 
-    this.isRevokingApiKey = true;
+    this.isRevokingApiKey.set(true);
+    this.apiKeyFeedback.set(undefined);
     this.subscriptionKeysService
       .revoke(subscriptionId, apiKey)
       .pipe(
-        finalize(() => (this.isRevokingApiKey = false)),
+        finalize(() => this.isRevokingApiKey.set(false)),
         takeUntilDestroyed(this.destroyRef),
       )
       .subscribe({
         next: () => {
           this.apiKeyRevoked.emit();
-          this.snackBar.open(
-            $localize`:@@subscriptionDetailsApiAccessRevokeSuccess:API key revoked successfully. Applications using it will no longer be able to access the API.`,
-            undefined,
-            {
-              ...this.defaultSnackBarOptions,
-              panelClass: 'gio-snack-bar-success',
-            },
-          );
+          this.apiKeyFeedback.set({
+            type: 'success',
+            message: $localize`:@@subscriptionDetailsApiAccessRevokeSuccess:API key revoked successfully. Applications using it will no longer be able to access the API.`,
+          });
         },
         error: () => {
-          this.snackBar.open(
-            $localize`:@@subscriptionDetailsApiAccessRevokeError:Failed to revoke API key. Please try again.`,
-            $localize`:@@subscriptionDetailsApiAccessRevokeErrorClose:Close`,
-            {
-              ...this.defaultSnackBarOptions,
-              panelClass: 'gio-snack-bar-error',
-            },
-          );
+          this.apiKeyFeedback.set({
+            type: 'error',
+            message: $localize`:@@subscriptionDetailsApiAccessRevokeError:Failed to revoke API key. Please try again.`,
+          });
         },
       });
   }
@@ -376,7 +304,7 @@ export class ApiAccessComponent {
     }
 
     this.isRenewingApiKey.set(true);
-    this.apiKeyRenewFeedback.set(undefined);
+    this.apiKeyFeedback.set(undefined);
     this.subscriptionKeysService
       .renew(subscriptionId)
       .pipe(
@@ -386,13 +314,13 @@ export class ApiAccessComponent {
       .subscribe({
         next: () => {
           this.apiKeyRenewed.emit();
-          this.apiKeyRenewFeedback.set({
+          this.apiKeyFeedback.set({
             type: 'success',
             message: $localize`:@@subscriptionDetailsApiAccessRenewSuccess:API key renewed successfully. You can now use it to access the API.`,
           });
         },
         error: () => {
-          this.apiKeyRenewFeedback.set({
+          this.apiKeyFeedback.set({
             type: 'error',
             message: $localize`:@@subscriptionDetailsApiAccessRenewError:Failed to renew API key. Please try again.`,
           });

--- a/gravitee-apim-portal-webui-next/src/components/api-access/api-keys-list/api-keys-list.component.html
+++ b/gravitee-apim-portal-webui-next/src/components/api-access/api-keys-list/api-keys-list.component.html
@@ -16,7 +16,7 @@
 
 -->
 <div class="api-keys-list">
-  <div class="next-gen-h5" i18n="@@subscriptionDetailsApiAccessApiKeysHeader">API keys</div>
+  <div class="next-gen-h5" i18n="@@apiKeysListHeader">API keys</div>
   @if (feedback(); as message) {
     <div
       class="next-gen-body api-keys-list__feedback"
@@ -57,11 +57,11 @@
             color="warn"
             [disabled]="isRevokeDisabled()"
             matTooltip="Revoke"
-            i18n-matTooltip="@@subscriptionDetailsApiAccessRevokeTooltip"
+            i18n-matTooltip="@@apiKeysListRevokeTooltip"
             [attr.aria-label]="apiKey.revokeAriaLabel"
             [attr.data-api-key]="apiKey.key"
             data-testid="api-key-revoke-button"
-            (click)="revokeApiKey.emit(apiKey)"
+            (click)="revokeApiKey.emit(apiKey.originalKey)"
           >
             <mat-icon svgIcon="gio:x-circle" />
           </button>
@@ -69,8 +69,6 @@
       </ng-template>
     </app-paginated-table>
   } @else {
-    <div class="next-gen-body" i18n="@@subscriptionDetailsApiAccessApiKeysEmpty" data-testid="api-keys-empty-message">
-      No API keys available.
-    </div>
+    <div class="next-gen-body" i18n="@@apiKeysListEmpty" data-testid="api-keys-empty-message">No API keys available.</div>
   }
 </div>

--- a/gravitee-apim-portal-webui-next/src/components/api-access/api-keys-list/api-keys-list.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/components/api-access/api-keys-list/api-keys-list.component.spec.ts
@@ -17,8 +17,9 @@ import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { MatIconTestingModule } from '@angular/material/icon/testing';
 
-import { ApiKeyFeedback, ApiKeysListComponent, ApiKeyTableRow } from './api-keys-list.component';
+import { ApiKeyFeedback, ApiKeysListComponent } from './api-keys-list.component';
 import { ApiKeysListHarness } from './api-keys-list.harness';
+import { SubscriptionDataKeys } from '../../../entities/subscription';
 import { AppTestingModule } from '../../../testing/app-testing.module';
 
 describe('ApiKeysListComponent', () => {
@@ -26,31 +27,25 @@ describe('ApiKeysListComponent', () => {
   let fixture: ComponentFixture<ApiKeysListComponent>;
   let harness: ApiKeysListHarness;
 
-  function activeApiKeyRow(key: string): ApiKeyTableRow {
+  function activeApiKey(key: string): SubscriptionDataKeys {
     return {
-      statusIcon: 'gio:check-circled-outline',
-      statusLabel: 'Active API key',
-      revokeAriaLabel: `Revoke API key ${key}`,
-      isActive: true,
       key,
-      createdAt: '2024-04-17T10:33:29Z',
+      created_at: '2024-04-17T10:33:29Z',
+      application: { id: 'app-id', name: 'app-name' },
     };
   }
 
-  function inactiveApiKeyRow(key: string): ApiKeyTableRow {
+  function revokedApiKey(key: string): SubscriptionDataKeys {
     return {
-      statusIcon: 'gio:x-circle',
-      statusLabel: 'Inactive API key',
-      revokeAriaLabel: `Revoke API key ${key}`,
-      isActive: false,
       key,
-      createdAt: '2024-04-17T10:33:29Z',
-      closedAt: '2024-04-19T10:33:29Z',
+      created_at: '2024-04-17T10:33:29Z',
+      revoked_at: '2024-04-19T10:33:29Z',
+      application: { id: 'app-id', name: 'app-name' },
     };
   }
 
   async function init(params?: {
-    apiKeys?: ApiKeyTableRow[];
+    apiKeys?: SubscriptionDataKeys[];
     canManageApiKey?: boolean;
     isRevokeDisabled?: boolean;
     feedback?: ApiKeyFeedback;
@@ -77,7 +72,7 @@ describe('ApiKeysListComponent', () => {
   });
 
   it('should display api keys with their status icons', async () => {
-    await init({ apiKeys: [activeApiKeyRow('active-api-key'), inactiveApiKeyRow('revoked-api-key')] });
+    await init({ apiKeys: [activeApiKey('active-api-key'), revokedApiKey('revoked-api-key')] });
 
     expect(await harness.isTableShown()).toBeTruthy();
     expect(await harness.getKeyAt(0)).toEqual('active-api-key');
@@ -86,7 +81,7 @@ describe('ApiKeysListComponent', () => {
   });
 
   it('should show revoke button only for active api keys', async () => {
-    await init({ apiKeys: [activeApiKeyRow('active-api-key'), inactiveApiKeyRow('revoked-api-key')] });
+    await init({ apiKeys: [activeApiKey('active-api-key'), revokedApiKey('revoked-api-key')] });
 
     const revokeButtons = await harness.getRevokeButtons();
     expect(revokeButtons).toHaveLength(1);
@@ -94,13 +89,13 @@ describe('ApiKeysListComponent', () => {
   });
 
   it('should hide revoke buttons when the user cannot manage api keys', async () => {
-    await init({ apiKeys: [activeApiKeyRow('active-api-key')], canManageApiKey: false });
+    await init({ apiKeys: [activeApiKey('active-api-key')], canManageApiKey: false });
 
     expect(await harness.getRevokeButtons()).toHaveLength(0);
   });
 
   it('should disable revoke buttons when revocation is disabled', async () => {
-    await init({ apiKeys: [activeApiKeyRow('active-api-key')], isRevokeDisabled: true });
+    await init({ apiKeys: [activeApiKey('active-api-key')], isRevokeDisabled: true });
 
     const revokeButtons = await harness.getRevokeButtons();
     expect(revokeButtons).toHaveLength(1);
@@ -108,7 +103,7 @@ describe('ApiKeysListComponent', () => {
   });
 
   it('should emit revokeApiKey when a revoke button is clicked', async () => {
-    await init({ apiKeys: [activeApiKeyRow('active-api-key')] });
+    await init({ apiKeys: [activeApiKey('active-api-key')] });
     const revokeApiKeySpy = jest.spyOn(component.revokeApiKey, 'emit');
 
     await harness.clickRevoke('active-api-key');
@@ -118,7 +113,7 @@ describe('ApiKeysListComponent', () => {
 
   it('should show success feedback politely', async () => {
     await init({
-      apiKeys: [activeApiKeyRow('active-api-key')],
+      apiKeys: [activeApiKey('active-api-key')],
       feedback: { type: 'success', message: 'API key renewed successfully.' },
     });
 
@@ -129,7 +124,7 @@ describe('ApiKeysListComponent', () => {
 
   it('should show error feedback as an alert', async () => {
     await init({
-      apiKeys: [activeApiKeyRow('active-api-key')],
+      apiKeys: [activeApiKey('active-api-key')],
       feedback: { type: 'error', message: 'Failed to renew API key.' },
     });
 
@@ -139,7 +134,7 @@ describe('ApiKeysListComponent', () => {
   });
 
   describe('pagination', () => {
-    const apiKeys = Array.from({ length: 7 }, (_, index) => activeApiKeyRow(`api-key-${index + 1}`));
+    const apiKeys = Array.from({ length: 7 }, (_, index) => activeApiKey(`api-key-${index + 1}`));
 
     it('should display the first page of api keys by default', async () => {
       await init({ apiKeys });

--- a/gravitee-apim-portal-webui-next/src/components/api-access/api-keys-list/api-keys-list.component.ts
+++ b/gravitee-apim-portal-webui-next/src/components/api-access/api-keys-list/api-keys-list.component.ts
@@ -18,10 +18,11 @@ import { MatIconButton } from '@angular/material/button';
 import { MatIcon } from '@angular/material/icon';
 import { MatTooltip } from '@angular/material/tooltip';
 
+import { isActiveApiKey, SubscriptionDataKeys } from '../../../entities/subscription/subscription';
 import { PaginatedTableComponent, TableColumn } from '../../paginated-table/paginated-table.component';
 import { TableCellDirective } from '../../paginated-table/table-cell.directive';
 
-export interface ApiKeyTableRow {
+interface ApiKeyRow {
   statusIcon: 'gio:check-circled-outline' | 'gio:x-circle';
   statusLabel: string;
   revokeAriaLabel: string;
@@ -29,6 +30,7 @@ export interface ApiKeyTableRow {
   key: string;
   createdAt?: string;
   closedAt?: string;
+  originalKey: SubscriptionDataKeys;
 }
 
 export interface ApiKeyFeedback {
@@ -43,31 +45,32 @@ export interface ApiKeyFeedback {
   styleUrl: './api-keys-list.component.scss',
 })
 export class ApiKeysListComponent {
-  apiKeys = input.required<ApiKeyTableRow[]>();
+  apiKeys = input.required<SubscriptionDataKeys[]>();
   canManageApiKey = input(false);
   isRevokeDisabled = input(false);
   feedback = input<ApiKeyFeedback | undefined>(undefined);
 
-  revokeApiKey = output<ApiKeyTableRow>();
+  revokeApiKey = output<SubscriptionDataKeys>();
 
   protected readonly columns: TableColumn[] = [
-    { id: 'status', label: $localize`:@@subscriptionDetailsApiAccessApiKeysColumnStatus:Status` },
-    { id: 'key', label: $localize`:@@subscriptionDetailsApiAccessApiKeysColumnKey:Key` },
-    { id: 'createdAt', label: $localize`:@@subscriptionDetailsApiAccessApiKeysColumnCreatedAt:Created At`, type: 'date-time' },
-    { id: 'closedAt', label: $localize`:@@subscriptionDetailsApiAccessApiKeysColumnRevokedAt:Revoked/Expired At`, type: 'date-time' },
+    { id: 'status', label: $localize`:@@apiKeysListColumnStatus:Status` },
+    { id: 'key', label: $localize`:@@apiKeysListColumnKey:Key` },
+    { id: 'createdAt', label: $localize`:@@apiKeysListColumnCreatedAt:Created At`, type: 'date-time' },
+    { id: 'closedAt', label: $localize`:@@apiKeysListColumnRevokedAt:Revoked/Expired At`, type: 'date-time' },
     { id: 'revoke', label: '' },
   ];
   protected readonly pageSizeOptions = [5, 10, 25];
   protected readonly pageSize = signal(5);
   private readonly requestedCurrentPage = signal(1);
 
-  protected readonly totalElements = computed(() => this.apiKeys().length);
+  protected readonly rows = computed<ApiKeyRow[]>(() => this.apiKeys().map(apiKey => this.toRow(apiKey)));
+  protected readonly totalElements = computed(() => this.rows().length);
   protected readonly lastValidPage = computed(() => Math.max(1, Math.ceil(this.totalElements() / this.pageSize())));
   protected readonly currentPage = computed(() => Math.min(this.requestedCurrentPage(), this.lastValidPage()));
   protected readonly displayedRows = computed(() => {
     const startIndex = (this.currentPage() - 1) * this.pageSize();
     const endIndex = startIndex + this.pageSize();
-    return this.apiKeys().slice(startIndex, endIndex);
+    return this.rows().slice(startIndex, endIndex);
   });
 
   protected onPageChange(page: number): void {
@@ -77,5 +80,21 @@ export class ApiKeysListComponent {
   protected onPageSizeChange(pageSize: number): void {
     this.pageSize.set(pageSize);
     this.requestedCurrentPage.set(1);
+  }
+
+  private toRow(apiKey: SubscriptionDataKeys): ApiKeyRow {
+    const isActive = isActiveApiKey(apiKey);
+    return {
+      statusIcon: isActive ? 'gio:check-circled-outline' : 'gio:x-circle',
+      statusLabel: isActive
+        ? $localize`:@@apiKeysListStatusActive:Active API key`
+        : $localize`:@@apiKeysListStatusInactive:Inactive API key`,
+      revokeAriaLabel: $localize`:@@apiKeysListRevokeAriaLabel:Revoke API key ${apiKey.key ?? ''}:apiKey:`,
+      isActive,
+      key: apiKey.key ?? '',
+      createdAt: apiKey.created_at,
+      closedAt: apiKey.revoked_at ?? apiKey.expire_at,
+      originalKey: apiKey,
+    };
   }
 }

--- a/gravitee-apim-portal-webui-next/src/entities/subscription/subscription.ts
+++ b/gravitee-apim-portal-webui-next/src/entities/subscription/subscription.ts
@@ -62,6 +62,18 @@ export interface SubscriptionDataKeys {
   };
 }
 
+export function isActiveApiKey(apiKey: SubscriptionDataKeys): boolean {
+  if (apiKey.revoked_at) {
+    return false;
+  }
+
+  if (!apiKey.expire_at) {
+    return true;
+  }
+
+  return new Date(apiKey.expire_at).getTime() > Date.now();
+}
+
 export interface CreateSubscription {
   api_key_mode?: 'SHARED' | 'EXCLUSIVE' | 'UNSPECIFIED';
   application: string;


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/EXT-120

## Description

Wires the extracted `ApiKeysListComponent` into the subscription API access and makes the keys table show for Native Kafka, where it was previously hidden.

## Additional context

<img width="1920" height="878" alt="Capture d’écran 2026-06-16 à 09 55 27" src="https://github.com/user-attachments/assets/8ad98c1e-1b34-4c77-a314-e2351af88d2b" />
