### PR TITLE
fix(portal): resolve relative server URLs when show_url is enabled

### DIFF
--- a/gravitee-apim-console-webui/src/components/documentation/gio-swagger-ui/gio-swagger-ui.component.ts
+++ b/gravitee-apim-console-webui/src/components/documentation/gio-swagger-ui/gio-swagger-ui.component.ts
@@ -20,13 +20,40 @@ import * as yaml from 'js-yaml';
 
 const yamlSchema = yaml.DEFAULT_SCHEMA.extend([]);
 
+const OAS_SCHEMA_TYPES = new Set(['null', 'boolean', 'object', 'array', 'number', 'string', 'integer']);
+const OAS_TYPE_PRIORITY = ['string', 'number', 'integer', 'boolean', 'array', 'object'];
+
+const normalizeTypeArrays = (obj: unknown): unknown => {
+  if (obj === null || !angular.isObject(obj)) {
+    return obj;
+  }
+  if (Array.isArray(obj)) {
+    return obj.map(item => normalizeTypeArrays(item));
+  }
+  const record = obj as Record<string, unknown>;
+  const result: Record<string, unknown> = {};
+  for (const key of Object.keys(record)) {
+    if (key === 'type' && Array.isArray(record[key]) && (record[key] as string[]).every(t => OAS_SCHEMA_TYPES.has(t))) {
+      const typeArray = record[key] as string[];
+      const nonNullTypes = typeArray.filter(t => t !== 'null');
+      result[key] = nonNullTypes.length === 1 ? nonNullTypes[0] : (OAS_TYPE_PRIORITY.find(t => nonNullTypes.includes(t)) ?? 'string');
+      if (typeArray.includes('null')) {
+        result['nullable'] = true;
+      }
+    } else {
+      result[key] = normalizeTypeArrays(record[key]);
+    }
+  }
+  return result;
+};
+
 const loadContent = (spec: string) => {
   let contentAsJson = {};
   if (spec) {
     try {
-      contentAsJson = angular.fromJson(spec);
+      contentAsJson = normalizeTypeArrays(angular.fromJson(spec)) as Record<string, unknown>;
     } catch (e) {
-      contentAsJson = yaml.load(spec, { schema: yamlSchema });
+      contentAsJson = normalizeTypeArrays(yaml.load(spec, { schema: yamlSchema })) as Record<string, unknown>;
     }
   }
   return contentAsJson;

--- a/gravitee-apim-console-webui/src/components/documentation/page/page-swagger.component.ts
+++ b/gravitee-apim-console-webui/src/components/documentation/page/page-swagger.component.ts
@@ -22,6 +22,31 @@ import UserService from '../../../services/user.service';
 
 const yamlSchema = yaml.DEFAULT_SCHEMA.extend([]);
 
+const OAS_SCHEMA_TYPES = new Set(['null', 'boolean', 'object', 'array', 'number', 'string', 'integer']);
+const OAS_TYPE_PRIORITY = ['string', 'number', 'integer', 'boolean', 'array', 'object'];
+
+const normalizeTypeArrays = (obj: any): any => {
+  if (obj === null || !angular.isObject(obj)) {
+    return obj;
+  }
+  if (Array.isArray(obj)) {
+    return obj.map((item: any) => normalizeTypeArrays(item));
+  }
+  const result: any = {};
+  for (const key of Object.keys(obj)) {
+    if (key === 'type' && Array.isArray(obj[key]) && (obj[key] as string[]).every((t: string) => OAS_SCHEMA_TYPES.has(t))) {
+      const nonNullTypes = (obj[key] as string[]).filter((t: string) => t !== 'null');
+      result[key] = nonNullTypes.length === 1 ? nonNullTypes[0] : (OAS_TYPE_PRIORITY.find(t => nonNullTypes.includes(t)) ?? 'string');
+      if ((obj[key] as string[]).includes('null')) {
+        result['nullable'] = true;
+      }
+    } else {
+      result[key] = normalizeTypeArrays(obj[key]);
+    }
+  }
+  return result;
+};
+
 const DisableTryItOutPlugin = function () {
   return {
     statePlugins: {
@@ -52,9 +77,9 @@ class PageSwaggerComponentController implements IController {
   loadContent(): any {
     let contentAsJson = {};
     try {
-      contentAsJson = angular.fromJson(this.pageContent);
+      contentAsJson = normalizeTypeArrays(angular.fromJson(this.pageContent));
     } catch (e) {
-      contentAsJson = yaml.load(this.pageContent, { schema: yamlSchema });
+      contentAsJson = normalizeTypeArrays(yaml.load(this.pageContent, { schema: yamlSchema }));
     }
     return contentAsJson;
   }

--- a/gravitee-apim-portal-webui-next/src/components/page/page-swagger/page-swagger.component.spec.ts
+++ b/gravitee-apim-portal-webui-next/src/components/page/page-swagger/page-swagger.component.spec.ts
@@ -108,6 +108,32 @@ describe('PageSwaggerComponent', () => {
     });
   });
 
+  describe('resolveRelativeServerUrls', () => {
+    const callResolve = (spec: Record<string, unknown>, origin: string) =>
+      (component as unknown as { resolveRelativeServerUrls: (s: Record<string, unknown>, o: string) => void }).resolveRelativeServerUrls(
+        spec,
+        origin,
+      );
+
+    it('should resolve relative server URLs against the portal origin', () => {
+      const spec: Record<string, unknown> = {
+        servers: [{ url: '/' }, { url: '/api/v1' }, { url: 'https://gateway.example.com' }],
+      };
+      callResolve(spec, 'http://localhost:4100');
+      expect((spec['servers'] as { url: string }[])[0].url).toBe('http://localhost:4100/');
+      expect((spec['servers'] as { url: string }[])[1].url).toBe('http://localhost:4100/api/v1');
+      expect((spec['servers'] as { url: string }[])[2].url).toBe('https://gateway.example.com');
+    });
+
+    it('should default missing url to "/" per OpenAPI spec', () => {
+      const spec: Record<string, unknown> = {
+        servers: [{ description: 'no url' }],
+      };
+      callResolve(spec, 'http://localhost:4100');
+      expect((spec['servers'] as { url: string }[])[0].url).toBe('http://localhost:4100/');
+    });
+  });
+
   describe('normalizeTypeArrays', () => {
     it('should flatten a single-element type array to that type', () => {
       expect((component as unknown as WithNormalizeTypeArrays).normalizeTypeArrays({ type: ['integer'] })).toEqual({ type: 'integer' });

--- a/gravitee-apim-portal-webui-next/src/components/page/page-swagger/page-swagger.component.ts
+++ b/gravitee-apim-portal-webui-next/src/components/page/page-swagger/page-swagger.component.ts
@@ -137,17 +137,38 @@ export class PageSwaggerComponent implements OnChanges {
 
   private normalizeSpecPlugin(): SwaggerUIPlugin {
     const normalize = (obj: unknown) => this.normalizeTypeArrays(obj);
+    const origin = window.location.origin;
     return () => ({
       statePlugins: {
         spec: {
           wrapActions: {
             updateJsonSpec: (oriAction: (spec: Record<string, unknown>) => void) => (spec: Record<string, unknown>) => {
-              return oriAction(normalize(spec) as Record<string, unknown>);
+              const normalized = normalize(spec) as Record<string, unknown>;
+              this.resolveRelativeServerUrls(normalized, origin);
+              return oriAction(normalized);
             },
           },
         },
       },
     });
+  }
+
+  /**
+   * When the spec is loaded via URL (show_url), Swagger UI resolves relative server URLs against
+   * the management API origin instead of the portal origin. This causes "Try it out" requests to
+   * hit the wrong host. Fix by resolving relative URLs against the portal origin, matching the
+   * behavior when the spec is loaded inline (show_url disabled). See APIM-14431.
+   */
+  private resolveRelativeServerUrls(spec: Record<string, unknown>, origin: string): void {
+    if (Array.isArray(spec['servers'])) {
+      spec['servers'] = (spec['servers'] as Record<string, unknown>[]).map(server => {
+        const url = (server['url'] as string) ?? '/';
+        if (url.startsWith('/')) {
+          return { ...server, url: origin + url };
+        }
+        return server;
+      });
+    }
   }
 
   private disabledTryItOutPlugin() {

--- a/gravitee-apim-portal-webui/src/app/components/gv-page-swaggerui/gv-page-swaggerui.component.spec.ts
+++ b/gravitee-apim-portal-webui/src/app/components/gv-page-swaggerui/gv-page-swaggerui.component.spec.ts
@@ -52,6 +52,34 @@ describe('GvPageSwaggerUIComponent', () => {
         paths: { '/test': { get: { parameters: [{ schema: { type: 'string' } }] } } },
       });
     });
+
+    it('should resolve relative server URLs against the portal origin', () => {
+      const pluginFactory = component['normalizeSpecPlugin']();
+      const plugin = pluginFactory();
+      const oriAction = jest.fn(spec => spec);
+      const wrappedAction = plugin.statePlugins.spec.wrapActions.updateJsonSpec(oriAction);
+
+      const spec = { servers: [{ url: '/' }, { url: '/api/v1' }, { url: 'https://gateway.example.com' }] };
+      wrappedAction(spec);
+
+      const result = oriAction.mock.calls[0][0];
+      expect(result.servers[0].url).toBe(`${window.location.origin}/`);
+      expect(result.servers[1].url).toBe(`${window.location.origin}/api/v1`);
+      expect(result.servers[2].url).toBe('https://gateway.example.com');
+    });
+
+    it('should default missing server url to "/" per OpenAPI spec', () => {
+      const pluginFactory = component['normalizeSpecPlugin']();
+      const plugin = pluginFactory();
+      const oriAction = jest.fn(spec => spec);
+      const wrappedAction = plugin.statePlugins.spec.wrapActions.updateJsonSpec(oriAction);
+
+      const spec = { servers: [{ description: 'no url' }] };
+      wrappedAction(spec);
+
+      const result = oriAction.mock.calls[0][0];
+      expect(result.servers[0].url).toBe(`${window.location.origin}/`);
+    });
   });
 
   describe('normalizeTypeArrays', () => {

--- a/gravitee-apim-portal-webui/src/app/components/gv-page-swaggerui/gv-page-swaggerui.component.ts
+++ b/gravitee-apim-portal-webui/src/app/components/gv-page-swaggerui/gv-page-swaggerui.component.ts
@@ -180,17 +180,38 @@ export class GvPageSwaggerUIComponent implements OnInit, OnDestroy {
 
   private normalizeSpecPlugin(): SwaggerUIPlugin {
     const normalize = (obj: any) => this.normalizeTypeArrays(obj);
+    const origin = window.location.origin;
     return () => ({
       statePlugins: {
         spec: {
           wrapActions: {
             updateJsonSpec: (oriAction: (spec: Record<string, any>) => void) => (spec: Record<string, any>) => {
-              return oriAction(normalize(spec));
+              const normalized = normalize(spec);
+              this.resolveRelativeServerUrls(normalized, origin);
+              return oriAction(normalized);
             },
           },
         },
       },
     });
+  }
+
+  /**
+   * When the spec is loaded via URL (show_url), Swagger UI resolves relative server URLs against
+   * the management API origin instead of the portal origin. This causes "Try it out" requests to
+   * hit the wrong host. Fix by resolving relative URLs against the portal origin, matching the
+   * behavior when the spec is loaded inline (show_url disabled). See APIM-14431.
+   */
+  private resolveRelativeServerUrls(spec: Record<string, any>, origin: string): void {
+    if (Array.isArray(spec['servers'])) {
+      spec['servers'] = (spec['servers'] as Record<string, any>[]).map(server => {
+        const url = (server['url'] as string) ?? '/';
+        if (url.startsWith('/')) {
+          return { ...server, url: origin + url };
+        }
+        return server;
+      });
+    }
   }
 
   private isTryItEnabled(page: Page) {


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-14431

## Description                                                                                                                                                                                                                                                  

- Resolve relative server URLs ("url": "/") against the portal origin when show_url is enabled, so "Try it out" requests hit the gateway instead of the management API

- Add normalizeTypeArrays to console swagger components (page-swagger and gio-swagger-ui) which were missing (APIM-14231)


## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

