### PR TITLE
feat(api): add portalNavigation field to API definition entity

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/Api.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/Api.java
@@ -173,6 +173,7 @@ public class Api {
     private boolean allowMultiJwtOauth2Subscriptions;
     private ApiLifecycleState apiLifecycleState = ApiLifecycleState.CREATED;
     private String background;
+    private String portalNavigation;
 
     public Api(Api cloned) {
         this.id = cloned.id;
@@ -202,6 +203,7 @@ public class Api {
         this.allowMultiJwtOauth2Subscriptions = cloned.allowMultiJwtOauth2Subscriptions;
         this.integrationId = cloned.integrationId;
         this.syncFrom = cloned.syncFrom;
+        this.portalNavigation = cloned.portalNavigation;
     }
 
     public enum AuditEvent implements Audit.ApiAuditEvent {

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcApiRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcApiRepository.java
@@ -111,6 +111,7 @@ public class JdbcApiRepository extends JdbcAbstractPageableRepository<Api> imple
             .addColumn("disable_membership_notifications", Types.BIT, boolean.class)
             .addColumn("allow_multi_jwt_oauth2_subscriptions", Types.BIT, boolean.class)
             .addColumn("background", Types.NVARCHAR, String.class)
+            .addColumn("portal_navigation", Types.NVARCHAR, String.class)
             .build();
     }
 

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_12_0/17_add_portal_navigation_to_apis.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_12_0/17_add_portal_navigation_to_apis.yml
@@ -1,0 +1,13 @@
+databaseChangeLog:
+  - changeSet:
+      id: 4.12.0_17_add_portal_navigation_to_apis
+      author: GraviteeSource Team
+      changes:
+        - addColumn:
+            tableName: ${gravitee_prefix}apis
+            columns:
+              - column:
+                  name: portal_navigation
+                  type: nclob
+                  constraints:
+                    nullable: true

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/master.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/master.yml
@@ -378,4 +378,6 @@ databaseChangeLog:
     - include:
         - file: liquibase/changelogs/v4_12_0/16_add_automation_metadata_to_portal_page_contents.yml
     - include:
+        - file: liquibase/changelogs/v4_12_0/17_add_portal_navigation_to_apis.yml
+    - include:
         - file: liquibase/changelogs/v4_12_0/18_add_portal_navigation_to_portals.yml

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/model/ApiMongo.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/model/ApiMongo.java
@@ -111,6 +111,8 @@ public class ApiMongo extends DeprecatedAuditable {
 
     private String background;
 
+    private String portalNavigation;
+
     public ApiMongo setIntegrationId(String integrationId) {
         this.integrationId = integrationId;
         return this;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/java/io/gravitee/apim/rest/api/automation/mapper/ApiMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/java/io/gravitee/apim/rest/api/automation/mapper/ApiMapper.java
@@ -196,6 +196,10 @@ public interface ApiMapper {
         return io.gravitee.apim.rest.api.automation.model.PlanSecurityType.valueOf(type.name());
     }
 
+    io.gravitee.apim.core.portal.model.NavigationPath map(io.gravitee.apim.rest.api.automation.model.NavigationPath src);
+
+    io.gravitee.apim.rest.api.automation.model.NavigationPath mapNavigationPath(io.gravitee.apim.core.portal.model.NavigationPath src);
+
     default List<io.gravitee.rest.api.management.v2.rest.model.Selector> mapApiV4SpecSelectors(FlowV4 flowV4) {
         if (flowV4 == null || flowV4.getSelectors() == null) {
             return List.of();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/java/io/gravitee/apim/rest/api/automation/mapper/PortalMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/main/java/io/gravitee/apim/rest/api/automation/mapper/PortalMapper.java
@@ -22,7 +22,6 @@ import io.gravitee.apim.rest.api.automation.model.NavigationPath;
 import io.gravitee.apim.rest.api.automation.model.PortalState;
 import java.util.List;
 import java.util.Objects;
-import java.util.Optional;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.MappingTarget;
@@ -78,7 +77,7 @@ public interface PortalMapper {
         return navigation
             .stream()
             .filter(PortalMapper::isValidNavigationPath)
-            .map(n -> new io.gravitee.apim.core.portal.model.NavigationPath(n.getPath(), Optional.ofNullable(n.getDisplayName())))
+            .map(n -> new io.gravitee.apim.core.portal.model.NavigationPath(n.getPath(), n.getDisplayName()))
             .toList();
     }
 
@@ -89,7 +88,7 @@ public interface PortalMapper {
         return navigation
             .stream()
             .filter(Objects::nonNull)
-            .map(n -> new NavigationPath().path(n.path()).displayName(n.displayName().orElse(null)))
+            .map(n -> new NavigationPath().path(n.path()).displayName(n.displayName()))
             .toList();
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/mapper/ApiMapperTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/mapper/ApiMapperTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.rest.api.automation.mapper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.apim.rest.api.automation.model.NavigationPath;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class ApiMapperTest {
+
+    @Test
+    void should_map_automation_navigation_path_to_core_with_all_fields() {
+        var automation = new NavigationPath().path("/reference").displayName("Reference").order(1);
+
+        var core = ApiMapper.INSTANCE.map(automation);
+
+        SoftAssertions.assertSoftly(soft -> {
+            soft.assertThat(core.path()).isEqualTo("/reference");
+            soft.assertThat(core.displayName()).isEqualTo("Reference");
+            soft.assertThat(core.order()).isEqualTo(1);
+        });
+    }
+
+    @Test
+    void should_map_automation_navigation_path_to_core_with_nulls_when_fields_missing() {
+        var automation = new NavigationPath().path("/guides");
+
+        var core = ApiMapper.INSTANCE.map(automation);
+
+        SoftAssertions.assertSoftly(soft -> {
+            soft.assertThat(core.path()).isEqualTo("/guides");
+            soft.assertThat(core.displayName()).isNull();
+            soft.assertThat(core.order()).isNull();
+        });
+    }
+
+    @Test
+    void should_return_null_when_mapping_null_automation_navigation_path() {
+        assertThat(ApiMapper.INSTANCE.map((NavigationPath) null)).isNull();
+    }
+
+    @Test
+    void should_map_core_navigation_path_to_automation_with_all_fields() {
+        var core = new io.gravitee.apim.core.portal.model.NavigationPath("/reference", "Reference", 1);
+
+        var automation = ApiMapper.INSTANCE.mapNavigationPath(core);
+
+        SoftAssertions.assertSoftly(soft -> {
+            soft.assertThat(automation.getPath()).isEqualTo("/reference");
+            soft.assertThat(automation.getDisplayName()).isEqualTo("Reference");
+            soft.assertThat(automation.getOrder()).isEqualTo(1);
+        });
+    }
+
+    @Test
+    void should_map_core_navigation_path_to_automation_leaving_absent_fields_null() {
+        var core = new io.gravitee.apim.core.portal.model.NavigationPath("/guides", null, null);
+
+        var automation = ApiMapper.INSTANCE.mapNavigationPath(core);
+
+        SoftAssertions.assertSoftly(soft -> {
+            soft.assertThat(automation.getPath()).isEqualTo("/guides");
+            soft.assertThat(automation.getDisplayName()).isNull();
+            soft.assertThat(automation.getOrder()).isNull();
+        });
+    }
+
+    @Test
+    void should_return_null_when_mapping_null_core_navigation_path() {
+        assertThat(ApiMapper.INSTANCE.mapNavigationPath(null)).isNull();
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/resource/PortalResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/resource/PortalResourceTest.java
@@ -32,7 +32,6 @@ import io.gravitee.apim.rest.api.automation.resource.base.AbstractResourceTest;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.core.MediaType;
 import java.util.List;
-import java.util.Optional;
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Nested;
@@ -84,10 +83,7 @@ class PortalResourceTest extends AbstractResourceTest {
         @Test
         void should_return_navigation_alongside_portal() {
             var persisted = Portal.of(PORTAL_ID, ENVIRONMENT, ORGANIZATION, "Default Portal");
-            var navigation = List.of(
-                new NavigationPath("/projects", Optional.empty()),
-                new NavigationPath("/projects/alpha", Optional.of("Alpha"))
-            );
+            var navigation = List.of(new NavigationPath("/projects", null), new NavigationPath("/projects/alpha", "Alpha"));
             when(getPortalUseCase.execute(any())).thenReturn(new GetPortalUseCase.Output(persisted, navigation));
 
             try (var response = rootTarget(HRID).request().accept(MediaType.APPLICATION_JSON_TYPE).get()) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/resource/PortalsResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-automation/gravitee-apim-rest-api-automation-rest/src/test/java/io/gravitee/apim/rest/api/automation/resource/PortalsResourceTest.java
@@ -33,7 +33,6 @@ import jakarta.inject.Inject;
 import jakarta.ws.rs.client.Entity;
 import jakarta.ws.rs.core.MediaType;
 import java.util.List;
-import java.util.Optional;
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Nested;
@@ -160,9 +159,9 @@ class PortalsResourceTest extends AbstractResourceTest {
         void should_pass_navigation_to_use_case_and_echo_in_response() {
             var persisted = Portal.of(PortalId.of("00000000-0000-0000-0000-0000000000a1"), ENVIRONMENT, ORGANIZATION, "Default Portal");
             var echoed = List.of(
-                new NavigationPath("/projects", Optional.empty()),
-                new NavigationPath("/projects/alpha", Optional.of("Alpha")),
-                new NavigationPath("/projects/alpha/docs", Optional.empty())
+                new NavigationPath("/projects", null),
+                new NavigationPath("/projects/alpha", "Alpha"),
+                new NavigationPath("/projects/alpha/docs", null)
             );
             when(createOrUpdatePortalUseCase.execute(any())).thenReturn(
                 new CreateOrUpdatePortalUseCase.Output(persisted, echoed, List.of())
@@ -181,7 +180,7 @@ class PortalsResourceTest extends AbstractResourceTest {
                 assertThat(inputCaptor.getValue().navigation())
                     .extracting(NavigationPath::path)
                     .containsExactly("/projects/alpha", "/projects/alpha/docs");
-                assertThat(inputCaptor.getValue().navigation().get(0).displayName()).isEqualTo(Optional.of("Alpha"));
+                assertThat(inputCaptor.getValue().navigation().get(0).displayName()).isEqualTo("Alpha");
 
                 var state = response.readEntity(PortalState.class);
                 assertThat(state.getNavigation())

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/model/ApiCRDSpec.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/model/ApiCRDSpec.java
@@ -126,6 +126,8 @@ public class ApiCRDSpec {
 
     private boolean allowMultiJwtOauth2Subscriptions;
 
+    private List<io.gravitee.apim.core.portal.model.NavigationPath> portalNavigation;
+
     private Map<String, PageCRD> pages;
 
     public String getDefinitionVersion() {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/model/Api.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/model/Api.java
@@ -143,6 +143,8 @@ public class Api {
 
     private String background;
 
+    private List<io.gravitee.apim.core.portal.model.NavigationPath> portalNavigation;
+
     public boolean isTcpProxy() {
         return apiDefinitionValue instanceof io.gravitee.definition.model.v4.Api v4Api && v4Api.isTcpProxy();
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/model/ApiWithFlows.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/model/ApiWithFlows.java
@@ -59,7 +59,8 @@ public class ApiWithFlows extends Api {
             api.isDisableMembershipNotifications(),
             api.isAllowMultiJwtOauth2Subscriptions(),
             api.getApiLifecycleState(),
-            api.getBackground()
+            api.getBackground(),
+            api.getPortalNavigation()
         );
         this.flows = flows;
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/model/crd/ApiCRDSpec.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/model/crd/ApiCRDSpec.java
@@ -141,6 +141,8 @@ public class ApiCRDSpec {
 
     private PortalNotificationConfigEntity consoleNotificationConfiguration;
 
+    private List<io.gravitee.apim.core.portal.model.NavigationPath> portalNavigation;
+
     public String getDefinitionVersion() {
         return "V4";
     }
@@ -176,7 +178,8 @@ public class ApiCRDSpec {
                 )
             )
             .groups(groups)
-            .allowMultiJwtOauth2Subscriptions(allowMultiJwtOauth2Subscriptions);
+            .allowMultiJwtOauth2Subscriptions(allowMultiJwtOauth2Subscriptions)
+            .portalNavigation(portalNavigation);
     }
 
     /**

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/use_case/ImportApiCRDUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/api/use_case/ImportApiCRDUseCase.java
@@ -264,6 +264,7 @@ public class ImportApiCRDUseCase {
                 updatedApi = updateApiDomainService.update(existingApi.getId(), input.spec, input.auditInfo);
             }
             // update state and definition context because legacy service does not update it
+            // portalNavigation is restored from the spec because the legacy update path does not carry it
             // Why are we getting MANAGEMENT as an origin here ? the API has been saved as kubernetes before
             var api = apiCrudService.update(
                 updatedApi
@@ -275,6 +276,7 @@ public class ImportApiCRDUseCase {
                         )
                     )
                     .lifecycleState(Api.LifecycleState.valueOf(input.spec().getState()))
+                    .portalNavigation(input.spec().getPortalNavigation())
                     .build()
             );
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal/domain_service/PortalNavigationListingDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal/domain_service/PortalNavigationListingDomainService.java
@@ -26,7 +26,6 @@ import io.gravitee.apim.core.portal_page.model.PortalNavigationItemType;
 import io.gravitee.apim.core.portal_page.query_service.PortalNavigationItemsQueryService;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 
 @DomainService
@@ -56,7 +55,7 @@ public class PortalNavigationListingDomainService {
         public void visitFolder(PortalNavigationFolder folder, NavigationPath parentPath) {
             final var nodePath = parentPath.descend(folder.getEffectiveSegment());
             final var displayName = !folder.getEffectiveSegment().equals(folder.getTitle()) ? folder.getTitle() : null;
-            paths.add(new NavigationPath(nodePath.path(), Optional.ofNullable(displayName)));
+            paths.add(new NavigationPath(nodePath.path(), displayName));
         }
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal/domain_service/navigation/PortalNavigationTreeWalker.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal/domain_service/navigation/PortalNavigationTreeWalker.java
@@ -25,13 +25,12 @@ import io.gravitee.apim.core.portal_page.model.PortalNavigationPage;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 /** Pre-order traversal, children sorted by {@code order}. */
 public final class PortalNavigationTreeWalker {
 
-    private static final NavigationPath ROOT = new NavigationPath("", Optional.empty());
+    private static final NavigationPath ROOT = new NavigationPath("", null);
 
     private PortalNavigationTreeWalker() {}
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal/domain_service/navigation/plan/NavigationSyncPlanner.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal/domain_service/navigation/plan/NavigationSyncPlanner.java
@@ -132,8 +132,8 @@ public final class NavigationSyncPlanner {
     private static Map<String, String> explicitDisplayNames(List<NavigationPath> input) {
         return input
             .stream()
-            .filter(e -> e.displayName().isPresent())
-            .collect(Collectors.toMap(NavigationPath::path, e -> e.displayName().orElseThrow(), (first, second) -> first));
+            .filter(e -> e.displayName() != null)
+            .collect(Collectors.toMap(NavigationPath::path, NavigationPath::displayName, (first, second) -> first));
     }
 
     private static Collection<PathExpander.PathEntry> deduplicateByPath(List<NavigationPath> input) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal/model/NavigationPath.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal/model/NavigationPath.java
@@ -17,17 +17,21 @@ package io.gravitee.apim.core.portal.model;
 
 import io.gravitee.apim.core.portal_page.model.Slug;
 import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
 import java.util.Arrays;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
-public record NavigationPath(@Nonnull String path, Optional<String> displayName) {
+public record NavigationPath(@Nonnull String path, @Nullable String displayName, @Nullable Integer order) {
     public NavigationPath {
         path = normalizePath(path);
     }
 
+    public NavigationPath(@Nonnull String path, @Nullable String displayName) {
+        this(path, displayName, null);
+    }
+
     public NavigationPath descend(String childSegment) {
-        return new NavigationPath(this.path + "/" + childSegment, Optional.empty());
+        return new NavigationPath(this.path + "/" + childSegment, null);
     }
 
     private static String normalizePath(String p) {

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/ApiAdapter.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/ApiAdapter.java
@@ -15,9 +15,11 @@
  */
 package io.gravitee.apim.infra.adapter;
 
+import com.fasterxml.jackson.core.type.TypeReference;
 import io.gravitee.apim.core.api.model.Api;
 import io.gravitee.apim.core.api.model.crd.ApiCRDSpec;
 import io.gravitee.apim.core.membership.model.PrimaryOwnerEntity;
+import io.gravitee.apim.core.portal.model.NavigationPath;
 import io.gravitee.definition.model.ApiDefinition;
 import io.gravitee.definition.model.federation.FederatedAgent;
 import io.gravitee.definition.model.federation.FederatedApi;
@@ -35,6 +37,7 @@ import io.gravitee.rest.api.model.v4.api.UpdateApiEntity;
 import io.gravitee.rest.api.model.v4.nativeapi.NativeApiEntity;
 import java.io.IOException;
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
 import org.mapstruct.DecoratedWith;
@@ -52,6 +55,7 @@ public interface ApiAdapter {
     ApiAdapter INSTANCE = Mappers.getMapper(ApiAdapter.class);
 
     @Mapping(target = "apiDefinitionValue", expression = "java(toApiDefinition(source))")
+    @Mapping(target = "portalNavigation", expression = "java(deserializePortalNavigation(source.getPortalNavigation()))")
     Api toCoreModel(io.gravitee.repository.management.model.Api source);
 
     default ApiDefinition toApiDefinition(io.gravitee.repository.management.model.Api source) {
@@ -71,6 +75,7 @@ public interface ApiAdapter {
     Stream<Api> toCoreModelStream(Stream<io.gravitee.repository.management.model.Api> source);
 
     @Mapping(target = "definition", expression = "java(serializeApiDefinition(source))")
+    @Mapping(target = "portalNavigation", expression = "java(serializePortalNavigation(source.getPortalNavigation()))")
     io.gravitee.repository.management.model.Api toRepository(Api source);
 
     Stream<io.gravitee.repository.management.model.Api> toRepositoryStream(Stream<Api> source);
@@ -209,6 +214,31 @@ public interface ApiAdapter {
             return GraviteeJacksonMapper.getInstance().writeValueAsString(value);
         } catch (IOException ioe) {
             throw new RuntimeException("Unexpected error while serializing " + name + " definition", ioe);
+        }
+    }
+
+    TypeReference<List<NavigationPath>> NAVIGATION_PATH_LIST = new TypeReference<>() {};
+
+    default String serializePortalNavigation(List<NavigationPath> portalNavigation) {
+        if (portalNavigation == null || portalNavigation.isEmpty()) {
+            return null;
+        }
+        try {
+            return GraviteeJacksonMapper.getInstance().writeValueAsString(portalNavigation);
+        } catch (IOException ioe) {
+            throw new RuntimeException("Unexpected error while serializing API portalNavigation", ioe);
+        }
+    }
+
+    default List<NavigationPath> deserializePortalNavigation(String json) {
+        if (json == null || json.isBlank()) {
+            return null;
+        }
+        try {
+            return GraviteeJacksonMapper.getInstance().readValue(json, NAVIGATION_PATH_LIST);
+        } catch (IOException ioe) {
+            log.error("Unexpected error while deserializing API portalNavigation", ioe);
+            return null;
         }
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/PortalAdapter.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/PortalAdapter.java
@@ -22,7 +22,6 @@ import io.gravitee.apim.core.portal.model.PortalId;
 import io.gravitee.node.logging.NodeLoggerFactory;
 import java.io.IOException;
 import java.util.List;
-import java.util.Optional;
 import org.mapstruct.Mapper;
 import org.mapstruct.factory.Mappers;
 import org.slf4j.Logger;
@@ -58,24 +57,14 @@ public interface PortalAdapter {
             .build();
     }
 
-    TypeReference<List<NavigationPathJson>> NAVIGATION_PATH_LIST = new TypeReference<>() {};
-
-    record NavigationPathJson(String path, String displayName) {
-        static NavigationPathJson from(NavigationPath p) {
-            return new NavigationPathJson(p.path(), p.displayName().orElse(null));
-        }
-
-        NavigationPath toDomain() {
-            return new NavigationPath(path, Optional.ofNullable(displayName));
-        }
-    }
+    TypeReference<List<NavigationPath>> NAVIGATION_PATH_LIST = new TypeReference<>() {};
 
     default String serializePortalNavigation(List<NavigationPath> portalNavigation) {
         if (portalNavigation == null || portalNavigation.isEmpty()) {
             return null;
         }
         try {
-            return GraviteeJacksonMapper.getInstance().writeValueAsString(portalNavigation.stream().map(NavigationPathJson::from).toList());
+            return GraviteeJacksonMapper.getInstance().writeValueAsString(portalNavigation);
         } catch (IOException ioe) {
             throw new RuntimeException("Unexpected error while serializing portal portalNavigation", ioe);
         }
@@ -86,11 +75,7 @@ public interface PortalAdapter {
             return List.of();
         }
         try {
-            return GraviteeJacksonMapper.getInstance()
-                .readValue(json, NAVIGATION_PATH_LIST)
-                .stream()
-                .map(NavigationPathJson::toDomain)
-                .toList();
+            return GraviteeJacksonMapper.getInstance().readValue(json, NAVIGATION_PATH_LIST);
         } catch (IOException ioe) {
             log.error("Unexpected error while deserializing portal portalNavigation", ioe);
             return List.of();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/analytics_engine/mapper/ApiMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/analytics_engine/mapper/ApiMapper.java
@@ -18,6 +18,7 @@ package io.gravitee.apim.infra.domain_service.analytics_engine.mapper;
 import io.gravitee.apim.core.api.model.Api;
 import java.util.List;
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
 import org.mapstruct.factory.Mappers;
 
 /**
@@ -26,6 +27,9 @@ import org.mapstruct.factory.Mappers;
 @Mapper
 public interface ApiMapper {
     ApiMapper INSTANCE = Mappers.getMapper(ApiMapper.class);
+
+    @Mapping(target = "portalNavigation", ignore = true)
+    Api map(io.gravitee.repository.management.model.Api api);
 
     List<Api> map(List<io.gravitee.repository.management.model.Api> api);
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/api/ApiCRDExportDomainServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/api/ApiCRDExportDomainServiceImpl.java
@@ -80,6 +80,7 @@ public class ApiCRDExportDomainServiceImpl implements ApiCRDExportDomainService 
                 .setGroups(new ArrayList<>(getGroupNames(new HashSet<>(spec.getConsoleNotificationConfiguration().getGroups()))));
         }
 
+        spec.setPortalNavigation(apiCrudService.get(apiId).getPortalNavigation());
         ensureCrossId(spec);
         applyIDExportStrategy(idExport, spec);
         return spec;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal/domain_service/PortalNavigationListingDomainServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal/domain_service/PortalNavigationListingDomainServiceTest.java
@@ -25,7 +25,6 @@ import io.gravitee.apim.core.audit.model.AuditInfo;
 import io.gravitee.apim.core.portal.model.NavigationPath;
 import io.gravitee.apim.core.portal.model.PortalId;
 import java.util.List;
-import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
@@ -63,10 +62,10 @@ class PortalNavigationListingDomainServiceTest {
             PORTAL_ID,
             List.of(),
             List.of(
-                new NavigationPath("/a", Optional.empty()),
-                new NavigationPath("/a/b", Optional.empty()),
-                new NavigationPath("/c", Optional.empty()),
-                new NavigationPath("/c/d", Optional.empty())
+                new NavigationPath("/a", null),
+                new NavigationPath("/a/b", null),
+                new NavigationPath("/c", null),
+                new NavigationPath("/c/d", null)
             )
         );
 
@@ -81,10 +80,7 @@ class PortalNavigationListingDomainServiceTest {
             AUDIT_INFO,
             PORTAL_ID,
             List.of(),
-            List.of(
-                new NavigationPath("/projects/alpha", Optional.of("Alpha")),
-                new NavigationPath("/projects/alpha/docs", Optional.empty())
-            )
+            List.of(new NavigationPath("/projects/alpha", "Alpha"), new NavigationPath("/projects/alpha/docs", null))
         );
 
         var result = listingService.listAsNavigationPaths(AUDIT_INFO.environmentId());
@@ -94,7 +90,7 @@ class PortalNavigationListingDomainServiceTest {
 
     @Test
     void display_name_is_surfaced_when_title_differs_from_segment() {
-        syncService.sync(AUDIT_INFO, PORTAL_ID, List.of(), List.of(new NavigationPath("/projects/alpha", Optional.of("Alpha"))));
+        syncService.sync(AUDIT_INFO, PORTAL_ID, List.of(), List.of(new NavigationPath("/projects/alpha", "Alpha")));
 
         var result = listingService.listAsNavigationPaths(AUDIT_INFO.environmentId());
 
@@ -102,15 +98,15 @@ class PortalNavigationListingDomainServiceTest {
             .filteredOn(p -> "/projects/alpha".equals(p.path()))
             .singleElement()
             .extracting(NavigationPath::displayName)
-            .isEqualTo(Optional.of("Alpha"));
+            .isEqualTo("Alpha");
     }
 
     @Test
     void display_name_is_null_when_title_equals_segment() {
-        syncService.sync(AUDIT_INFO, PORTAL_ID, List.of(), List.of(new NavigationPath("/a", Optional.empty())));
+        syncService.sync(AUDIT_INFO, PORTAL_ID, List.of(), List.of(new NavigationPath("/a", null)));
 
         var result = listingService.listAsNavigationPaths(AUDIT_INFO.environmentId());
 
-        assertThat(result).singleElement().extracting(NavigationPath::displayName).isEqualTo(Optional.empty());
+        assertThat(result).singleElement().extracting(NavigationPath::displayName).isNull();
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal/domain_service/PortalNavigationSyncDomainServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal/domain_service/PortalNavigationSyncDomainServiceTest.java
@@ -76,7 +76,7 @@ class PortalNavigationSyncDomainServiceTest {
 
     @Test
     void single_root_path_creates_one_folder() {
-        syncService.sync(AUDIT_INFO, PORTAL_ID, List.of(), List.of(new NavigationPath("/a", Optional.empty())));
+        syncService.sync(AUDIT_INFO, PORTAL_ID, List.of(), List.of(new NavigationPath("/a", null)));
 
         assertThat(crud.storage()).hasSize(1);
         var folder = (PortalNavigationFolder) crud.storage().get(0);
@@ -92,7 +92,7 @@ class PortalNavigationSyncDomainServiceTest {
 
     @Test
     void display_name_when_provided_becomes_the_title_and_segment_holds_the_path_piece() {
-        syncService.sync(AUDIT_INFO, PORTAL_ID, List.of(), List.of(new NavigationPath("/a", Optional.of("Alpha"))));
+        syncService.sync(AUDIT_INFO, PORTAL_ID, List.of(), List.of(new NavigationPath("/a", "Alpha")));
 
         assertThat(crud.storage()).hasSize(1);
         var folder = crud.storage().get(0);
@@ -102,7 +102,7 @@ class PortalNavigationSyncDomainServiceTest {
 
     @Test
     void title_falls_back_to_segment_when_no_display_name_provided() {
-        syncService.sync(AUDIT_INFO, PORTAL_ID, List.of(), List.of(new NavigationPath("/a", Optional.empty())));
+        syncService.sync(AUDIT_INFO, PORTAL_ID, List.of(), List.of(new NavigationPath("/a", null)));
 
         assertThat(crud.storage()).hasSize(1);
         var folder = crud.storage().get(0);
@@ -112,7 +112,7 @@ class PortalNavigationSyncDomainServiceTest {
 
     @Test
     void implicit_ancestors_are_created_with_mkdir_p() {
-        syncService.sync(AUDIT_INFO, PORTAL_ID, List.of(), List.of(new NavigationPath("/a/b/c", Optional.empty())));
+        syncService.sync(AUDIT_INFO, PORTAL_ID, List.of(), List.of(new NavigationPath("/a/b/c", null)));
 
         assertThat(crud.storage()).hasSize(3);
         var a = findByPath("/a").orElseThrow();
@@ -135,11 +135,7 @@ class PortalNavigationSyncDomainServiceTest {
             AUDIT_INFO,
             PORTAL_ID,
             List.of(),
-            List.of(
-                new NavigationPath("/a", Optional.empty()),
-                new NavigationPath("/a/b", Optional.empty()),
-                new NavigationPath("/a/c", Optional.empty())
-            )
+            List.of(new NavigationPath("/a", null), new NavigationPath("/a/b", null), new NavigationPath("/a/c", null))
         );
 
         var a = findByPath("/a").orElseThrow();
@@ -152,11 +148,7 @@ class PortalNavigationSyncDomainServiceTest {
 
     @Test
     void re_sync_with_same_input_is_idempotent() {
-        var input = List.of(
-            new NavigationPath("/a", Optional.of("Alpha")),
-            new NavigationPath("/a/b", Optional.empty()),
-            new NavigationPath("/c", Optional.empty())
-        );
+        var input = List.of(new NavigationPath("/a", "Alpha"), new NavigationPath("/a/b", null), new NavigationPath("/c", null));
 
         syncService.sync(AUDIT_INFO, PORTAL_ID, List.of(), input);
         var snapshot = new ArrayList<>(crud.storage());
@@ -171,12 +163,12 @@ class PortalNavigationSyncDomainServiceTest {
 
     @Test
     void folder_ids_are_deterministic_from_audit_portal_and_path() {
-        syncService.sync(AUDIT_INFO, PORTAL_ID, List.of(), List.of(new NavigationPath("/a/b", Optional.empty())));
+        syncService.sync(AUDIT_INFO, PORTAL_ID, List.of(), List.of(new NavigationPath("/a/b", null)));
 
         var idsBefore = crud.storage().stream().map(PortalNavigationItem::getId).toList();
 
         crud.reset();
-        syncService.sync(AUDIT_INFO, PORTAL_ID, List.of(), List.of(new NavigationPath("/a/b", Optional.empty())));
+        syncService.sync(AUDIT_INFO, PORTAL_ID, List.of(), List.of(new NavigationPath("/a/b", null)));
 
         var idsAfter = crud.storage().stream().map(PortalNavigationItem::getId).toList();
         assertThat(idsAfter).isEqualTo(idsBefore);
@@ -186,11 +178,11 @@ class PortalNavigationSyncDomainServiceTest {
     void different_portals_produce_different_folder_ids_for_the_same_path() {
         var otherPortal = PortalId.of("22222222-2222-2222-2222-222222222222");
 
-        syncService.sync(AUDIT_INFO, PORTAL_ID, List.of(), List.of(new NavigationPath("/a", Optional.empty())));
+        syncService.sync(AUDIT_INFO, PORTAL_ID, List.of(), List.of(new NavigationPath("/a", null)));
         var idForPortalOne = findByPath("/a").orElseThrow().getId();
 
         crud.reset();
-        syncService.sync(AUDIT_INFO, otherPortal, List.of(), List.of(new NavigationPath("/a", Optional.empty())));
+        syncService.sync(AUDIT_INFO, otherPortal, List.of(), List.of(new NavigationPath("/a", null)));
         var idForPortalTwo = findByPath("/a").orElseThrow().getId();
 
         assertThat(idForPortalTwo).isNotEqualTo(idForPortalOne);
@@ -198,8 +190,8 @@ class PortalNavigationSyncDomainServiceTest {
 
     @Test
     void reorder_updates_existing_folders() {
-        var first = List.of(new NavigationPath("/a/b", Optional.empty()), new NavigationPath("/a/c", Optional.empty()));
-        var reordered = List.of(new NavigationPath("/a/c", Optional.empty()), new NavigationPath("/a/b", Optional.empty()));
+        var first = List.of(new NavigationPath("/a/b", null), new NavigationPath("/a/c", null));
+        var reordered = List.of(new NavigationPath("/a/c", null), new NavigationPath("/a/b", null));
         syncService.sync(AUDIT_INFO, PORTAL_ID, List.of(), first);
 
         syncService.sync(AUDIT_INFO, PORTAL_ID, first, reordered);
@@ -213,11 +205,11 @@ class PortalNavigationSyncDomainServiceTest {
 
     @Test
     void removed_path_is_deleted_when_previously_managed() {
-        var firstInput = List.of(new NavigationPath("/a", Optional.empty()), new NavigationPath("/b", Optional.empty()));
+        var firstInput = List.of(new NavigationPath("/a", null), new NavigationPath("/b", null));
         syncService.sync(AUDIT_INFO, PORTAL_ID, List.of(), firstInput);
         assertThat(crud.storage()).hasSize(2);
 
-        syncService.sync(AUDIT_INFO, PORTAL_ID, firstInput, List.of(new NavigationPath("/a", Optional.empty())));
+        syncService.sync(AUDIT_INFO, PORTAL_ID, firstInput, List.of(new NavigationPath("/a", null)));
 
         assertThat(crud.storage()).hasSize(1);
         assertThat(findByPath("/a")).isPresent();
@@ -241,7 +233,7 @@ class PortalNavigationSyncDomainServiceTest {
         unmanaged.markAsRoot();
         crud.initWith(List.of(unmanaged));
 
-        var previously = List.of(new NavigationPath("/managed", Optional.empty()));
+        var previously = List.of(new NavigationPath("/managed", null));
         syncService.sync(AUDIT_INFO, PORTAL_ID, List.of(), previously);
 
         syncService.sync(AUDIT_INFO, PORTAL_ID, previously, List.of());
@@ -252,8 +244,8 @@ class PortalNavigationSyncDomainServiceTest {
 
     @Test
     void rename_via_display_name_updates_title_without_changing_id() {
-        var original = List.of(new NavigationPath("/a", Optional.of("Original")));
-        var renamed = List.of(new NavigationPath("/a", Optional.of("Renamed")));
+        var original = List.of(new NavigationPath("/a", "Original"));
+        var renamed = List.of(new NavigationPath("/a", "Renamed"));
         syncService.sync(AUDIT_INFO, PORTAL_ID, List.of(), original);
         var originalId = crud.storage().get(0).getId();
 
@@ -294,7 +286,7 @@ class PortalNavigationSyncDomainServiceTest {
         folderInHomepage.markAsRoot();
         crud.initWith(List.of(pageInTopNavbar, folderInHomepage));
 
-        syncService.sync(AUDIT_INFO, PORTAL_ID, List.of(), List.of(new NavigationPath("/a", Optional.empty())));
+        syncService.sync(AUDIT_INFO, PORTAL_ID, List.of(), List.of(new NavigationPath("/a", null)));
 
         assertThat(crud.storage()).hasSize(3);
         assertThat(crud.storage()).contains(pageInTopNavbar, folderInHomepage);
@@ -310,7 +302,7 @@ class PortalNavigationSyncDomainServiceTest {
         var apiChild = apiRow("api-child", folder.getId(), 2);
         crud.initWith(List.of(folder, pageChild, linkChild, apiChild));
 
-        syncService.sync(AUDIT_INFO, PORTAL_ID, List.of(new NavigationPath("/x", Optional.empty())), List.of());
+        syncService.sync(AUDIT_INFO, PORTAL_ID, List.of(new NavigationPath("/x", null)), List.of());
 
         assertThat(crud.storage()).isEmpty();
     }
@@ -330,7 +322,7 @@ class PortalNavigationSyncDomainServiceTest {
         var pageChild = pageRow("page-child", folder.getId(), 0, contentId);
         crud.initWith(List.of(folder, pageChild));
 
-        syncService.sync(AUDIT_INFO, PORTAL_ID, List.of(new NavigationPath("/x", Optional.empty())), List.of());
+        syncService.sync(AUDIT_INFO, PORTAL_ID, List.of(new NavigationPath("/x", null)), List.of());
 
         assertThat(crud.storage()).isEmpty();
         assertThat(pageContentCrud.storage()).isEmpty();
@@ -345,7 +337,7 @@ class PortalNavigationSyncDomainServiceTest {
         var leafPage = pageRow("leaf", c.getId(), 0, PortalPageContentId.random());
         crud.initWith(List.of(a, b, c, leafPage));
 
-        syncService.sync(AUDIT_INFO, PORTAL_ID, List.of(new NavigationPath("/a/b/c", Optional.empty())), List.of());
+        syncService.sync(AUDIT_INFO, PORTAL_ID, List.of(new NavigationPath("/a/b/c", null)), List.of());
 
         assertThat(crud.storage()).isEmpty();
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal/model/NavigationPathTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal/model/NavigationPathTest.java
@@ -17,7 +17,6 @@ package io.gravitee.apim.core.portal.model;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.util.Optional;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
@@ -27,36 +26,36 @@ class NavigationPathTest {
 
     @Test
     void accepts_single_segment() {
-        assertThat(new NavigationPath("/a", Optional.empty()).path()).isEqualTo("/a");
+        assertThat(new NavigationPath("/a", null).path()).isEqualTo("/a");
     }
 
     @Test
     void accepts_multi_segment() {
-        assertThat(new NavigationPath("/a/b/c", Optional.empty()).path()).isEqualTo("/a/b/c");
+        assertThat(new NavigationPath("/a/b/c", null).path()).isEqualTo("/a/b/c");
     }
 
     @Test
     void strips_trailing_slash() {
-        assertThat(new NavigationPath("/a/b/", Optional.empty()).path()).isEqualTo("/a/b");
+        assertThat(new NavigationPath("/a/b/", null).path()).isEqualTo("/a/b");
     }
 
     @Test
     void descend_appends_child_segment() {
-        assertThat(new NavigationPath("/docs", Optional.empty()).descend("getting-started").path()).isEqualTo("/docs/getting-started");
+        assertThat(new NavigationPath("/docs", null).descend("getting-started").path()).isEqualTo("/docs/getting-started");
     }
 
     @Test
     void descend_from_empty_root_produces_leading_slash_path() {
-        assertThat(new NavigationPath("", Optional.empty()).descend("docs").path()).isEqualTo("/docs");
+        assertThat(new NavigationPath("", null).descend("docs").path()).isEqualTo("/docs");
     }
 
     @Test
     void descend_clears_display_name() {
-        assertThat(new NavigationPath("/docs", Optional.of("Documentation")).descend("api").displayName()).isEmpty();
+        assertThat(new NavigationPath("/docs", "Documentation").descend("api").displayName()).isNull();
     }
 
     @Test
     void normalizes_segment_casing_and_spaces() {
-        assertThat(new NavigationPath("/Docs/Getting Started", Optional.empty()).path()).isEqualTo("/docs/getting-started");
+        assertThat(new NavigationPath("/Docs/Getting Started", null).path()).isEqualTo("/docs/getting-started");
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal/use_case/CreateOrUpdatePortalUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal/use_case/CreateOrUpdatePortalUseCaseTest.java
@@ -35,7 +35,6 @@ import io.gravitee.apim.core.portal_page.domain_service.PortalDocumentationSyncD
 import io.gravitee.apim.core.portal_page.model.PortalArea;
 import io.gravitee.apim.core.portal_page.model.PortalNavigationItemType;
 import java.util.List;
-import java.util.Optional;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
@@ -143,7 +142,7 @@ class CreateOrUpdatePortalUseCaseTest {
             new CreateOrUpdatePortalUseCase.Input(
                 AUDIT_INFO,
                 portal,
-                List.of(new NavigationPath("/projects/alpha", Optional.of("Alpha")), new NavigationPath("/projects/beta", Optional.empty()))
+                List.of(new NavigationPath("/projects/alpha", "Alpha"), new NavigationPath("/projects/beta", null))
             )
         );
 
@@ -168,7 +167,7 @@ class CreateOrUpdatePortalUseCaseTest {
                 new CreateOrUpdatePortalUseCase.Input(
                     AUDIT_INFO,
                     portal,
-                    List.of(new NavigationPath("/valid", Optional.empty()), new NavigationPath("bad-path", Optional.empty()))
+                    List.of(new NavigationPath("/valid", null), new NavigationPath("bad-path", null))
                 )
             )
         )
@@ -180,9 +179,7 @@ class CreateOrUpdatePortalUseCaseTest {
     void should_return_empty_errors_when_navigation_is_valid() {
         var portal = PortalFixtures.aPortal();
 
-        var output = useCase.execute(
-            new CreateOrUpdatePortalUseCase.Input(AUDIT_INFO, portal, List.of(new NavigationPath("/docs", Optional.empty())))
-        );
+        var output = useCase.execute(new CreateOrUpdatePortalUseCase.Input(AUDIT_INFO, portal, List.of(new NavigationPath("/docs", null))));
 
         assertThat(output.errors()).isEmpty();
     }
@@ -190,7 +187,7 @@ class CreateOrUpdatePortalUseCaseTest {
     @Test
     void should_persist_navigation_array_on_portal_row() {
         var portal = PortalFixtures.aPortal();
-        var input = List.of(new NavigationPath("/a", Optional.of("A")), new NavigationPath("/b", Optional.empty()));
+        var input = List.of(new NavigationPath("/a", "A"), new NavigationPath("/b", null));
 
         var output = useCase.execute(new CreateOrUpdatePortalUseCase.Input(AUDIT_INFO, portal, input));
 
@@ -203,9 +200,7 @@ class CreateOrUpdatePortalUseCaseTest {
     @Test
     void should_use_previously_persisted_to_skip_unmanaged_folders_on_delete() {
         var portal = PortalFixtures.aPortal();
-        useCase.execute(
-            new CreateOrUpdatePortalUseCase.Input(AUDIT_INFO, portal, List.of(new NavigationPath("/managed", Optional.empty())))
-        );
+        useCase.execute(new CreateOrUpdatePortalUseCase.Input(AUDIT_INFO, portal, List.of(new NavigationPath("/managed", null))));
         var unmanaged = io.gravitee.apim.core.portal_page.model.PortalNavigationFolder.builder()
             .id(io.gravitee.apim.core.portal_page.model.PortalNavigationItemId.random())
             .organizationId(AUDIT_INFO.organizationId())

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal/use_case/GetPortalUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal/use_case/GetPortalUseCaseTest.java
@@ -26,7 +26,6 @@ import io.gravitee.apim.core.portal.exception.PortalNotFoundException;
 import io.gravitee.apim.core.portal.model.NavigationPath;
 import io.gravitee.apim.core.portal.model.PortalId;
 import java.util.List;
-import java.util.Optional;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
@@ -92,13 +91,13 @@ class GetPortalUseCaseTest {
 
     @Test
     void should_return_persisted_navigation_paths() {
-        var navigation = List.of(new NavigationPath("/a", Optional.empty()), new NavigationPath("/a/b", Optional.of("B")));
+        var navigation = List.of(new NavigationPath("/a", null), new NavigationPath("/a/b", "B"));
         var portal = PortalFixtures.aPortal().withNavigation(navigation);
         portalCrudService.initWith(List.of(portal));
 
         var output = useCase.execute(new GetPortalUseCase.Input(AUDIT_INFO, portal.getId()));
 
         assertThat(output.navigation()).extracting(NavigationPath::path).containsExactly("/a", "/a/b");
-        assertThat(output.navigation().get(1).displayName()).contains("B");
+        assertThat(output.navigation().get(1).displayName()).isEqualTo("B");
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal/use_case/ValidatePortalUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal/use_case/ValidatePortalUseCaseTest.java
@@ -25,7 +25,6 @@ import io.gravitee.apim.core.portal.model.Portal;
 import io.gravitee.apim.core.portal.model.PortalId;
 import io.gravitee.rest.api.service.common.HRIDToUUID;
 import java.util.List;
-import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
@@ -61,7 +60,7 @@ class ValidatePortalUseCaseTest {
             new CreateOrUpdatePortalUseCase.Input(
                 AUDIT_INFO,
                 PORTAL,
-                List.of(new NavigationPath("/docs", Optional.empty()), new NavigationPath("/docs/getting-started", Optional.empty()))
+                List.of(new NavigationPath("/docs", null), new NavigationPath("/docs/getting-started", null))
             )
         );
 
@@ -75,7 +74,7 @@ class ValidatePortalUseCaseTest {
             new CreateOrUpdatePortalUseCase.Input(
                 AUDIT_INFO,
                 PORTAL,
-                List.of(new NavigationPath("/valid", Optional.empty()), new NavigationPath("bad-path", Optional.empty()))
+                List.of(new NavigationPath("/valid", null), new NavigationPath("bad-path", null))
             )
         );
 
@@ -84,7 +83,7 @@ class ValidatePortalUseCaseTest {
 
     @Test
     void should_echo_navigation_in_output() {
-        var nav = List.of(new NavigationPath("/docs", Optional.empty()));
+        var nav = List.of(new NavigationPath("/docs", null));
         var output = useCase.execute(new CreateOrUpdatePortalUseCase.Input(AUDIT_INFO, PORTAL, nav));
 
         assertThat(output.navigation()).containsExactlyElementsOf(nav);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/adapter/ApiAdapterTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/adapter/ApiAdapterTest.java
@@ -469,6 +469,99 @@ class ApiAdapterTest {
         }
     }
 
+    @Nested
+    class PortalNavigation {
+
+        @Test
+        void should_round_trip_portal_navigation_through_repository_and_back() {
+            var paths = List.of(
+                new io.gravitee.apim.core.portal.model.NavigationPath("/reference", "Reference", 1),
+                new io.gravitee.apim.core.portal.model.NavigationPath("/guides", null, 2),
+                new io.gravitee.apim.core.portal.model.NavigationPath("/guides/quickstart", null, null)
+            );
+            var model = ApiFixtures.aProxyApiV4().toBuilder().portalNavigation(paths).build();
+
+            var repo = ApiAdapter.INSTANCE.toRepository(model);
+            var back = ApiAdapter.INSTANCE.toCoreModel(repo);
+
+            assertThat(back.getPortalNavigation()).isEqualTo(paths);
+        }
+
+        @Test
+        void should_serialize_portal_navigation_omitting_absent_optionals() {
+            var paths = List.of(
+                new io.gravitee.apim.core.portal.model.NavigationPath("/reference", "Reference", 1),
+                new io.gravitee.apim.core.portal.model.NavigationPath("/guides", null, null)
+            );
+            var model = ApiFixtures.aProxyApiV4().toBuilder().portalNavigation(paths).build();
+
+            var repo = ApiAdapter.INSTANCE.toRepository(model);
+
+            assertThat(repo.getPortalNavigation()).isEqualTo(
+                "[{\"path\":\"/reference\",\"displayName\":\"Reference\",\"order\":1},{\"path\":\"/guides\"}]"
+            );
+        }
+
+        @Test
+        void should_serialize_null_when_portal_navigation_is_null() {
+            var model = ApiFixtures.aProxyApiV4().toBuilder().portalNavigation(null).build();
+
+            var repo = ApiAdapter.INSTANCE.toRepository(model);
+
+            assertThat(repo.getPortalNavigation()).isNull();
+        }
+
+        @Test
+        void should_serialize_null_when_portal_navigation_is_empty() {
+            var model = ApiFixtures.aProxyApiV4().toBuilder().portalNavigation(List.of()).build();
+
+            var repo = ApiAdapter.INSTANCE.toRepository(model);
+
+            assertThat(repo.getPortalNavigation()).isNull();
+        }
+
+        @Test
+        void should_deserialize_null_to_null_portal_navigation() {
+            var repo = apiV4().portalNavigation(null).build();
+
+            var model = ApiAdapter.INSTANCE.toCoreModel(repo);
+
+            assertThat(model.getPortalNavigation()).isNull();
+        }
+
+        @Test
+        void should_deserialize_blank_to_null_portal_navigation() {
+            var repo = apiV4().portalNavigation("   ").build();
+
+            var model = ApiAdapter.INSTANCE.toCoreModel(repo);
+
+            assertThat(model.getPortalNavigation()).isNull();
+        }
+
+        @Test
+        void should_deserialize_json_array_to_navigation_paths() {
+            var repo = apiV4()
+                .portalNavigation("[{\"path\":\"/reference\",\"displayName\":\"Reference\",\"order\":1},{\"path\":\"/guides\"}]")
+                .build();
+
+            var model = ApiAdapter.INSTANCE.toCoreModel(repo);
+
+            assertThat(model.getPortalNavigation()).containsExactly(
+                new io.gravitee.apim.core.portal.model.NavigationPath("/reference", "Reference", 1),
+                new io.gravitee.apim.core.portal.model.NavigationPath("/guides", null, null)
+            );
+        }
+
+        @Test
+        void should_return_null_when_portal_navigation_json_is_malformed() {
+            var repo = apiV4().portalNavigation("not-json").build();
+
+            var model = ApiAdapter.INSTANCE.toCoreModel(repo);
+
+            assertThat(model.getPortalNavigation()).isNull();
+        }
+    }
+
     private Api.ApiBuilder apiV4() {
         return Api.builder()
             .id("my-id")

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/adapter/PortalAdapterTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/adapter/PortalAdapterTest.java
@@ -42,26 +42,26 @@ class PortalAdapterTest {
                 "env",
                 "org",
                 "Portal",
-                List.of(new NavigationPath("/a", Optional.of("A")), new NavigationPath("/a/b", Optional.empty()))
+                List.of(new NavigationPath("/a", "A"), new NavigationPath("/a/b", null))
             );
 
             var roundTripped = adapter.toEntity(adapter.toRepository(portal));
 
             assertThat(roundTripped.getPortalNavigation()).extracting(NavigationPath::path).containsExactly("/a", "/a/b");
-            assertThat(roundTripped.getPortalNavigation().get(0).displayName()).contains("A");
-            assertThat(roundTripped.getPortalNavigation().get(1).displayName()).isEmpty();
+            assertThat(roundTripped.getPortalNavigation().get(0).displayName()).isEqualTo("A");
+            assertThat(roundTripped.getPortalNavigation().get(1).displayName()).isNull();
         }
 
         @Test
         void serialize_omits_absent_display_name() {
-            String json = adapter.serializePortalNavigation(List.of(new NavigationPath("/a", Optional.empty())));
+            String json = adapter.serializePortalNavigation(List.of(new NavigationPath("/a", null)));
 
             assertThat(json).isEqualTo("[{\"path\":\"/a\"}]");
         }
 
         @Test
         void serialize_includes_display_name_when_present() {
-            String json = adapter.serializePortalNavigation(List.of(new NavigationPath("/a", Optional.of("A"))));
+            String json = adapter.serializePortalNavigation(List.of(new NavigationPath("/a", "A")));
 
             assertThat(json).isEqualTo("[{\"path\":\"/a\",\"displayName\":\"A\"}]");
         }
@@ -91,8 +91,8 @@ class PortalAdapterTest {
             var result = adapter.deserializePortalNavigation("[{\"path\":\"/x\",\"displayName\":\"X\"},{\"path\":\"/y\"}]");
 
             assertThat(result).extracting(NavigationPath::path).containsExactly("/x", "/y");
-            assertThat(result.get(0).displayName()).contains("X");
-            assertThat(result.get(1).displayName()).isEmpty();
+            assertThat(result.get(0).displayName()).isEqualTo("X");
+            assertThat(result.get(1).displayName()).isNull();
         }
 
         @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/api/ApiCRDExportDomainServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/api/ApiCRDExportDomainServiceImplTest.java
@@ -19,6 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.argThat;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -109,6 +110,7 @@ class ApiCRDExportDomainServiceImplTest {
             groupQueryServiceInMemory,
             notificationCRDDomainService
         );
+        lenient().when(apiCrudService.get(API_ID)).thenReturn(new Api());
     }
 
     @Test
@@ -126,7 +128,7 @@ class ApiCRDExportDomainServiceImplTest {
             false
         );
 
-        verify(apiCrudService, times(1)).get(API_ID);
+        verify(apiCrudService, times(2)).get(API_ID);
 
         verify(apiCrudService, times(1)).update(argThat(api -> StringUtils.isNotBlank(api.getCrossId())));
 


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/EXT-134

## Description

Adds an optional `portalNavigation` field to the API definition entity (Automation API). It declares the API's own internal doc-folder tree — persisted on the API record so a later slice can consume it during portal navigation tree sync.
  
  - Add `portalNavigation: List<NavigationPath>` to `ApiCRDSpec` and core `Api`; wire through `toApiBuilder()` (kept **out** of the gateway definition).
  - Extend `core.NavigationPath` with an optional `order`.
  - Persist via a new `portal_navigation` JSON column on `apis` (Liquibase + JDBC + Mongo).
  - `ApiAdapter` serialises/deserialises the field; `ImportApiCRDUseCase.update` carries it over.
  - `ApiCRDExportDomainServiceImpl` populates it on GET so PUT/GET round-trips.
  - Thread the field through the v2 REST ↔ automation mapper chain.

  ## Out of scope

  - Rendering / nav-tree materialisation — next slice (API documentation)


