### PR TITLE
feat(observability): translate remaining LOGS filter conditions in search

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/analytics/engine/api/query/HttpStatusCodeGroups.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/analytics/engine/api/query/HttpStatusCodeGroups.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.analytics.engine.api.query;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+/**
+ * Canonical HTTP status code group definitions (1XX–5XX). This is the single source of truth
+ * for the group→[min,max] inclusive mapping, consumed by:
+ * <ul>
+ *   <li>ES analytics ({@code FilterAdapter}, {@code HTTPFacetsQueryAdapter})</li>
+ *   <li>ES logs ({@code SearchMetricsQueryAdapter} via {@code StatusCodeGroups})</li>
+ *   <li>Gamma adapter ({@code ObservabilityLogsDataPortAdapter})</li>
+ * </ul>
+ */
+public final class HttpStatusCodeGroups {
+
+    public record Bounds(int min, int max) {}
+
+    /**
+     * Group→bounds mapping in ascending status order. Iteration order is significant:
+     * consumers such as {@code HTTPFacetsQueryAdapter} emit ES range aggregations in this
+     * order, so a {@link LinkedHashMap} is used rather than an unordered {@link Map#of}.
+     */
+    public static final Map<String, Bounds> GROUP_BOUNDS;
+
+    static {
+        var bounds = new LinkedHashMap<String, Bounds>();
+        bounds.put("1XX", new Bounds(100, 199));
+        bounds.put("2XX", new Bounds(200, 299));
+        bounds.put("3XX", new Bounds(300, 399));
+        bounds.put("4XX", new Bounds(400, 499));
+        bounds.put("5XX", new Bounds(500, 599));
+        GROUP_BOUNDS = Collections.unmodifiableMap(bounds);
+    }
+
+    private HttpStatusCodeGroups() {}
+
+    /**
+     * Resolves a status code group key (case-insensitive) to its inclusive bounds.
+     */
+    public static Optional<Bounds> resolve(String group) {
+        if (group == null) {
+            return Optional.empty();
+        }
+        return Optional.ofNullable(GROUP_BOUNDS.get(group.toUpperCase(Locale.ROOT)));
+    }
+
+    /**
+     * Returns all group bounds as {@link NumberRange} for ES range aggregations.
+     */
+    public static List<NumberRange> asNumberRanges() {
+        return GROUP_BOUNDS.values()
+            .stream()
+            .map(b -> new NumberRange(b.min(), b.max()))
+            .toList();
+    }
+
+    /**
+     * Builds a reverse lookup from ES bucket keys ({@code "100-199"}) to group labels
+     * ({@code "1XX"}). ES range aggregation keys use the {@code "min-max"} format.
+     */
+    public static Map<String, String> esBucketKeyToGroupLabel() {
+        return GROUP_BOUNDS.entrySet()
+            .stream()
+            .collect(Collectors.toUnmodifiableMap(e -> e.getValue().min() + "-" + e.getValue().max(), Map.Entry::getKey));
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/analytics/engine/api/query/NumberRange.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/analytics/engine/api/query/NumberRange.java
@@ -23,12 +23,6 @@ import java.util.List;
  */
 public record NumberRange(Number from, Number to) {
     public static List<NumberRange> forStatusCodeGroup() {
-        return List.of(
-            new NumberRange(100, 199),
-            new NumberRange(200, 299),
-            new NumberRange(300, 399),
-            new NumberRange(400, 499),
-            new NumberRange(500, 599)
-        );
+        return HttpStatusCodeGroups.asNumberRanges();
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/log/v4/model/connection/MetricsQuery.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/log/v4/model/connection/MetricsQuery.java
@@ -44,6 +44,8 @@ public class MetricsQuery {
         private Set<HttpMethod> methods;
         private Set<String> mcpMethods;
         private Set<Integer> statuses;
+        private List<StatusRange> statusRanges;
+        private Set<String> statusCodeGroups;
         private Set<String> entrypointIds;
         private Set<String> apiIds;
         private Set<String> apiProductIds;
@@ -52,6 +54,11 @@ public class MetricsQuery {
         private String uri;
         private List<ResponseTimeRange> responseTimeRanges;
         private Set<String> errorKeys;
+        private Set<String> llmProxyModels;
+        private Set<String> llmProxyProviders;
+        private Set<String> mcpProxyTools;
+        private Set<String> mcpProxyResources;
+        private Set<String> mcpProxyPrompts;
 
         @Data
         @Builder
@@ -59,6 +66,14 @@ public class MetricsQuery {
 
             private Long to;
             private Long from;
+        }
+
+        @Data
+        @Builder
+        public static class StatusRange {
+
+            private Integer gte;
+            private Integer lte;
         }
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/test/java/io/gravitee/repository/analytics/engine/api/query/HttpStatusCodeGroupsTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/test/java/io/gravitee/repository/analytics/engine/api/query/HttpStatusCodeGroupsTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.analytics.engine.api.query;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class HttpStatusCodeGroupsTest {
+
+    @Nested
+    class Resolve {
+
+        @ParameterizedTest
+        @ValueSource(strings = { "1XX", "2XX", "3XX", "4XX", "5XX" })
+        void should_resolve_known_groups(String group) {
+            var bounds = HttpStatusCodeGroups.resolve(group);
+
+            assertThat(bounds).isPresent();
+            assertThat(bounds.get().min()).isGreaterThanOrEqualTo(100);
+            assertThat(bounds.get().max()).isLessThanOrEqualTo(599);
+            assertThat(bounds.get().max() - bounds.get().min()).isEqualTo(99);
+        }
+
+        @Test
+        void should_be_case_insensitive() {
+            assertThat(HttpStatusCodeGroups.resolve("2xx")).isPresent().hasValue(new HttpStatusCodeGroups.Bounds(200, 299));
+        }
+
+        @Test
+        void should_return_empty_for_unknown_group() {
+            assertThat(HttpStatusCodeGroups.resolve("9XX")).isEmpty();
+        }
+
+        @Test
+        void should_return_empty_for_null() {
+            assertThat(HttpStatusCodeGroups.resolve(null)).isEmpty();
+        }
+    }
+
+    @Nested
+    class AsNumberRanges {
+
+        @Test
+        void should_return_all_five_groups() {
+            var ranges = HttpStatusCodeGroups.asNumberRanges();
+
+            assertThat(ranges).hasSize(5);
+        }
+
+        @Test
+        void should_contain_2xx_range() {
+            var ranges = HttpStatusCodeGroups.asNumberRanges();
+
+            assertThat(ranges).contains(new NumberRange(200, 299));
+        }
+    }
+
+    @Nested
+    class EsBucketKeyToGroupLabel {
+
+        @Test
+        void should_return_all_five_groups() {
+            var map = HttpStatusCodeGroups.esBucketKeyToGroupLabel();
+
+            assertThat(map).hasSize(5);
+        }
+
+        @Test
+        void should_map_es_key_to_group_label() {
+            var map = HttpStatusCodeGroups.esBucketKeyToGroupLabel();
+
+            assertThat(map)
+                .containsEntry("100-199", "1XX")
+                .containsEntry("200-299", "2XX")
+                .containsEntry("300-399", "3XX")
+                .containsEntry("400-499", "4XX")
+                .containsEntry("500-599", "5XX");
+        }
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/analytics/engine/adapter/FilterAdapter.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/analytics/engine/adapter/FilterAdapter.java
@@ -18,6 +18,7 @@ package io.gravitee.repository.elasticsearch.v4.analytics.engine.adapter;
 import io.gravitee.repository.analytics.engine.api.query.Filter;
 import io.gravitee.repository.analytics.engine.api.query.Query;
 import io.gravitee.repository.elasticsearch.v4.analytics.engine.adapter.api.FieldResolver;
+import io.gravitee.repository.elasticsearch.v4.shared.StatusCodeGroups;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import java.util.*;
@@ -28,8 +29,6 @@ import java.util.*;
  */
 public class FilterAdapter {
 
-    private record StatusCodeRange(int min, int max) {}
-
     static final String ENTRYPOINT_FIELD = "entrypoint-id";
     static final String HTTP_GET_ENTRYPOINT_ID = "http-get";
     static final String HTTP_POST_ENTRYPOINT_ID = "http-post";
@@ -37,19 +36,6 @@ public class FilterAdapter {
     static final String LLM_PROXY_ENTRYPOINT_ID = "llm-proxy";
     static final String MCP_PROXY_ENTRYPOINT_ID = "mcp-proxy";
     static final String EDGE_ENTRYPOINT_ID = "edge";
-
-    private static final Map<String, StatusCodeRange> STATUS_CODE_GROUP_RANGES = Map.of(
-        "1XX",
-        new StatusCodeRange(100, 199),
-        "2XX",
-        new StatusCodeRange(200, 299),
-        "3XX",
-        new StatusCodeRange(300, 399),
-        "4XX",
-        new StatusCodeRange(400, 499),
-        "5XX",
-        new StatusCodeRange(500, 599)
-    );
 
     static final List<Filter.Name> HTTP_FILTER_NAMES = List.of(
         Filter.Name.API,
@@ -238,34 +224,10 @@ public class FilterAdapter {
     private JsonObject statusCodeGroupFilter(Filter filter) {
         var field = fieldResolver.fromFilter(filter);
         return switch (filter.operator()) {
-            case EQ -> statusCodeGroupRange(field, (String) filter.value());
-            case IN -> {
-                var values = (Collection<String>) filter.value();
-                if (values == null || values.isEmpty()) {
-                    yield JsonObject.of("match_none", JsonObject.of());
-                }
-                if (values.size() == 1) {
-                    yield statusCodeGroupRange(field, values.iterator().next());
-                }
-                var ranges = new JsonArray();
-                for (var group : values) {
-                    ranges.add(statusCodeGroupRange(field, group));
-                }
-                yield JsonObject.of("bool", JsonObject.of("should", ranges, "minimum_should_match", 1));
-            }
+            case EQ -> StatusCodeGroups.rangeForGroup(field, (String) filter.value());
+            case IN -> StatusCodeGroups.shouldForGroups(field, (Collection<String>) filter.value());
             default -> throw new IllegalArgumentException("Unsupported operator for HTTP_STATUS_CODE_GROUP filter: " + filter.operator());
         };
-    }
-
-    private static JsonObject statusCodeGroupRange(String field, String statusCodeGroup) {
-        if (statusCodeGroup == null) {
-            throw new IllegalArgumentException("Status code group must not be null");
-        }
-        var range = STATUS_CODE_GROUP_RANGES.get(statusCodeGroup.toUpperCase());
-        if (range == null) {
-            throw new IllegalArgumentException("Unknown status code group: " + statusCodeGroup);
-        }
-        return JsonObject.of("range", JsonObject.of(field, JsonObject.of("gte", range.min(), "lte", range.max())));
     }
 
     private String filterName(Filter filter) {

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/log/adapter/connection/RequestV2MetricsV4Fields.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/log/adapter/connection/RequestV2MetricsV4Fields.java
@@ -55,6 +55,11 @@ public class RequestV2MetricsV4Fields {
     public static final Field TRANSACTION_ID = new Field("transaction", "transaction-id");
     public static final Field HTTP_METHOD = new Field("method", "http-method");
     public static final Field MCP_METHOD = new Field(ADDITIONAL_METRICS + ".keyword_mcp-proxy_method");
+    public static final Field LLM_PROXY_MODEL = new Field(ADDITIONAL_METRICS + ".keyword_llm-proxy_model");
+    public static final Field LLM_PROXY_PROVIDER = new Field(ADDITIONAL_METRICS + ".keyword_llm-proxy_provider");
+    public static final Field MCP_PROXY_TOOL = new Field(ADDITIONAL_METRICS + ".keyword_mcp-proxy_tools/call");
+    public static final Field MCP_PROXY_RESOURCE = new Field(ADDITIONAL_METRICS + ".keyword_mcp-proxy_resources/read");
+    public static final Field MCP_PROXY_PROMPT = new Field(ADDITIONAL_METRICS + ".keyword_mcp-proxy_prompts/get");
     public static final Field GATEWAY_RESPONSE_TIME = new Field("response-time", "gateway-response-time-ms");
     public static final Field ENTRYPOINT_ID = new Field(null, "entrypoint-id");
     public static final Field REQUEST_ENDED = new Field(null, "request-ended");

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/log/adapter/connection/SearchMetricsQueryAdapter.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/log/adapter/connection/SearchMetricsQueryAdapter.java
@@ -16,6 +16,7 @@
 package io.gravitee.repository.elasticsearch.v4.log.adapter.connection;
 
 import io.gravitee.common.http.HttpMethod;
+import io.gravitee.repository.elasticsearch.v4.shared.StatusCodeGroups;
 import io.gravitee.repository.log.v4.model.connection.MetricsQuery;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
@@ -63,6 +64,10 @@ public class SearchMetricsQueryAdapter {
 
         addStatusesFilter(filter, mustFilterList);
 
+        addStatusRangesFilter(filter, mustFilterList);
+
+        addStatusCodeGroupsFilter(filter, mustFilterList);
+
         addEntrypointIdsFilter(filter, mustFilterList);
 
         addRequestIdsFilter(filter, mustFilterList);
@@ -74,6 +79,16 @@ public class SearchMetricsQueryAdapter {
         addErrorKeysFilter(filter, mustFilterList);
 
         addResponseTimeRangesFilter(filter, mustFilterList);
+
+        addLlmProxyModelsFilter(filter, mustFilterList);
+
+        addLlmProxyProvidersFilter(filter, mustFilterList);
+
+        addMcpProxyToolsFilter(filter, mustFilterList);
+
+        addMcpProxyResourcesFilter(filter, mustFilterList);
+
+        addMcpProxyPromptsFilter(filter, mustFilterList);
 
         if (!mustFilterList.isEmpty()) {
             return JsonObject.of("bool", JsonObject.of("must", JsonArray.of(mustFilterList.toArray())));
@@ -173,6 +188,57 @@ public class SearchMetricsQueryAdapter {
     private static void addApplicationsFilter(MetricsQuery.Filter filter, List<JsonObject> mustFilterList) {
         if (!CollectionUtils.isEmpty(filter.getApplicationIds())) {
             mustFilterList.add(buildV2AndV4Terms(RequestV2MetricsV4Fields.APPLICATION_ID, filter.getApplicationIds()));
+        }
+    }
+
+    private static void addStatusRangesFilter(MetricsQuery.Filter filter, List<JsonObject> mustFilterList) {
+        if (!CollectionUtils.isEmpty(filter.getStatusRanges())) {
+            if (filter.getStatusRanges().size() == 1) {
+                var range = filter.getStatusRanges().getFirst();
+                mustFilterList.add(StatusCodeGroups.rangeForBounds(RequestV2MetricsV4Fields.STATUS, range.getGte(), range.getLte()));
+            } else {
+                var ranges = new JsonArray();
+                for (var range : filter.getStatusRanges()) {
+                    ranges.add(StatusCodeGroups.rangeForBounds(RequestV2MetricsV4Fields.STATUS, range.getGte(), range.getLte()));
+                }
+                mustFilterList.add(JsonObject.of("bool", JsonObject.of("should", ranges, "minimum_should_match", 1)));
+            }
+        }
+    }
+
+    private static void addStatusCodeGroupsFilter(MetricsQuery.Filter filter, List<JsonObject> mustFilterList) {
+        if (!CollectionUtils.isEmpty(filter.getStatusCodeGroups())) {
+            mustFilterList.add(StatusCodeGroups.shouldForGroups(RequestV2MetricsV4Fields.STATUS, filter.getStatusCodeGroups()));
+        }
+    }
+
+    private static void addLlmProxyModelsFilter(MetricsQuery.Filter filter, List<JsonObject> mustFilterList) {
+        if (!CollectionUtils.isEmpty(filter.getLlmProxyModels())) {
+            mustFilterList.add(buildV4Terms(RequestV2MetricsV4Fields.LLM_PROXY_MODEL, filter.getLlmProxyModels()));
+        }
+    }
+
+    private static void addLlmProxyProvidersFilter(MetricsQuery.Filter filter, List<JsonObject> mustFilterList) {
+        if (!CollectionUtils.isEmpty(filter.getLlmProxyProviders())) {
+            mustFilterList.add(buildV4Terms(RequestV2MetricsV4Fields.LLM_PROXY_PROVIDER, filter.getLlmProxyProviders()));
+        }
+    }
+
+    private static void addMcpProxyToolsFilter(MetricsQuery.Filter filter, List<JsonObject> mustFilterList) {
+        if (!CollectionUtils.isEmpty(filter.getMcpProxyTools())) {
+            mustFilterList.add(buildV4Terms(RequestV2MetricsV4Fields.MCP_PROXY_TOOL, filter.getMcpProxyTools()));
+        }
+    }
+
+    private static void addMcpProxyResourcesFilter(MetricsQuery.Filter filter, List<JsonObject> mustFilterList) {
+        if (!CollectionUtils.isEmpty(filter.getMcpProxyResources())) {
+            mustFilterList.add(buildV4Terms(RequestV2MetricsV4Fields.MCP_PROXY_RESOURCE, filter.getMcpProxyResources()));
+        }
+    }
+
+    private static void addMcpProxyPromptsFilter(MetricsQuery.Filter filter, List<JsonObject> mustFilterList) {
+        if (!CollectionUtils.isEmpty(filter.getMcpProxyPrompts())) {
+            mustFilterList.add(buildV4Terms(RequestV2MetricsV4Fields.MCP_PROXY_PROMPT, filter.getMcpProxyPrompts()));
         }
     }
 

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/shared/StatusCodeGroups.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/shared/StatusCodeGroups.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.elasticsearch.v4.shared;
+
+import io.gravitee.repository.analytics.engine.api.query.HttpStatusCodeGroups;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import java.util.Collection;
+
+/**
+ * ES-specific utility for translating HTTP status code groups and status range bounds into
+ * Elasticsearch {@code range} queries. Delegates to {@link HttpStatusCodeGroups} for the
+ * canonical group→[min,max] mapping. Consumed by both the analytics {@code FilterAdapter}
+ * and the logs {@code SearchMetricsQueryAdapter}.
+ */
+public final class StatusCodeGroups {
+
+    private StatusCodeGroups() {}
+
+    /**
+     * Builds an ES {@code range} filter for a single status code group (e.g. "2XX" → 200–299).
+     */
+    public static JsonObject rangeForGroup(String field, String statusCodeGroup) {
+        if (statusCodeGroup == null) {
+            throw new IllegalArgumentException("Status code group must not be null");
+        }
+        var bounds = HttpStatusCodeGroups.resolve(statusCodeGroup).orElseThrow(() ->
+            new IllegalArgumentException("Unknown status code group: " + statusCodeGroup)
+        );
+        return rangeFilter(field, bounds.min(), bounds.max());
+    }
+
+    /**
+     * Builds an ES {@code bool.should} of {@code range} filters for multiple status code groups
+     * (IN operator). Returns a single range when only one group is provided.
+     */
+    public static JsonObject shouldForGroups(String field, Collection<String> groups) {
+        if (groups == null || groups.isEmpty()) {
+            return JsonObject.of("match_none", JsonObject.of());
+        }
+        if (groups.size() == 1) {
+            return rangeForGroup(field, groups.iterator().next());
+        }
+        var ranges = new JsonArray();
+        for (var group : groups) {
+            ranges.add(rangeForGroup(field, group));
+        }
+        return JsonObject.of("bool", JsonObject.of("should", ranges, "minimum_should_match", 1));
+    }
+
+    /**
+     * Builds an ES {@code range} filter with optional open bounds, suitable for
+     * {@code HTTP_STATUS GTE/LTE} (single open bound) or closed ranges.
+     *
+     * @param field ES field name (e.g. "status")
+     * @param gte   inclusive lower bound, or {@code null} for no lower bound
+     * @param lte   inclusive upper bound, or {@code null} for no upper bound
+     */
+    public static JsonObject rangeForBounds(String field, Integer gte, Integer lte) {
+        if (gte == null && lte == null) {
+            throw new IllegalArgumentException("At least one bound (gte or lte) must be non-null");
+        }
+        var rangeBody = new JsonObject();
+        if (gte != null) {
+            rangeBody.put("gte", gte);
+        }
+        if (lte != null) {
+            rangeBody.put("lte", lte);
+        }
+        return JsonObject.of("range", JsonObject.of(field, rangeBody));
+    }
+
+    private static JsonObject rangeFilter(String field, int gte, int lte) {
+        return JsonObject.of("range", JsonObject.of(field, JsonObject.of("gte", gte, "lte", lte)));
+    }
+}

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/log/adapter/connection/SearchMetricsQueryAdapterTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/log/adapter/connection/SearchMetricsQueryAdapterTest.java
@@ -817,6 +817,205 @@ class SearchMetricsQueryAdapterTest {
         }
     }
 
+    @Nested
+    class StatusRangesFilter {
+
+        @Test
+        void should_add_single_status_range_filter() {
+            var result = SearchMetricsQueryAdapter.adapt(
+                MetricsQuery.builder()
+                    .page(1)
+                    .size(20)
+                    .filter(
+                        MetricsQuery.Filter.builder()
+                            .statusRanges(List.of(MetricsQuery.Filter.StatusRange.builder().gte(200).lte(299).build()))
+                            .build()
+                    )
+                    .build()
+            );
+
+            assertThatJson(result).inPath("$.query.bool.must[0].range.status").isEqualTo("{\"gte\":200,\"lte\":299}");
+        }
+
+        @Test
+        void should_add_open_lower_bound_status_range() {
+            var result = SearchMetricsQueryAdapter.adapt(
+                MetricsQuery.builder()
+                    .page(1)
+                    .size(20)
+                    .filter(
+                        MetricsQuery.Filter.builder()
+                            .statusRanges(List.of(MetricsQuery.Filter.StatusRange.builder().gte(500).build()))
+                            .build()
+                    )
+                    .build()
+            );
+
+            assertThatJson(result).inPath("$.query.bool.must[0].range.status").isEqualTo("{\"gte\":500}");
+        }
+
+        @Test
+        void should_add_open_upper_bound_status_range() {
+            var result = SearchMetricsQueryAdapter.adapt(
+                MetricsQuery.builder()
+                    .page(1)
+                    .size(20)
+                    .filter(
+                        MetricsQuery.Filter.builder()
+                            .statusRanges(List.of(MetricsQuery.Filter.StatusRange.builder().lte(299).build()))
+                            .build()
+                    )
+                    .build()
+            );
+
+            assertThatJson(result).inPath("$.query.bool.must[0].range.status").isEqualTo("{\"lte\":299}");
+        }
+
+        @Test
+        void should_add_multiple_status_ranges_as_bool_should() {
+            var result = SearchMetricsQueryAdapter.adapt(
+                MetricsQuery.builder()
+                    .page(1)
+                    .size(20)
+                    .filter(
+                        MetricsQuery.Filter.builder()
+                            .statusRanges(
+                                List.of(
+                                    MetricsQuery.Filter.StatusRange.builder().gte(200).lte(299).build(),
+                                    MetricsQuery.Filter.StatusRange.builder().gte(400).lte(499).build()
+                                )
+                            )
+                            .build()
+                    )
+                    .build()
+            );
+
+            assertThatJson(result).inPath("$.query.bool.must[0].bool.should").isArray().hasSize(2);
+            assertThatJson(result).inPath("$.query.bool.must[0].bool.minimum_should_match").isEqualTo(1);
+        }
+
+        @Test
+        void should_not_add_status_range_filter_when_null() {
+            var query = MetricsQuery.builder()
+                .page(1)
+                .size(20)
+                .filter(MetricsQuery.Filter.builder().apiIds(Set.of("api-1")).statusRanges(null).build())
+                .build();
+
+            var result = SearchMetricsQueryAdapter.adapt(query);
+
+            assertThatJson(result).node("query.bool.must").isArray().hasSize(1);
+        }
+    }
+
+    @Nested
+    class StatusCodeGroupsFilter {
+
+        @Test
+        void should_add_single_group_as_range_filter() {
+            var result = SearchMetricsQueryAdapter.adapt(
+                MetricsQuery.builder()
+                    .page(1)
+                    .size(20)
+                    .filter(MetricsQuery.Filter.builder().statusCodeGroups(Set.of("4XX")).build())
+                    .build()
+            );
+
+            assertThatJson(result).inPath("$.query.bool.must[0].range.status").isEqualTo("{\"gte\":400,\"lte\":499}");
+        }
+
+        @Test
+        void should_add_multiple_groups_as_bool_should() {
+            var result = SearchMetricsQueryAdapter.adapt(
+                MetricsQuery.builder()
+                    .page(1)
+                    .size(20)
+                    .filter(MetricsQuery.Filter.builder().statusCodeGroups(Set.of("2XX", "4XX")).build())
+                    .build()
+            );
+
+            assertThatJson(result).inPath("$.query.bool.must[0].bool.should").isArray().hasSize(2);
+            assertThatJson(result).inPath("$.query.bool.must[0].bool.minimum_should_match").isEqualTo(1);
+        }
+
+        @Test
+        void should_produce_separate_must_clauses_for_groups_and_ranges() {
+            var result = SearchMetricsQueryAdapter.adapt(
+                MetricsQuery.builder()
+                    .page(1)
+                    .size(20)
+                    .filter(
+                        MetricsQuery.Filter.builder()
+                            .statusCodeGroups(Set.of("4XX"))
+                            .statusRanges(List.of(MetricsQuery.Filter.StatusRange.builder().gte(450).build()))
+                            .build()
+                    )
+                    .build()
+            );
+
+            assertThatJson(result).inPath("$.query.bool.must").isArray().hasSize(2);
+        }
+    }
+
+    @Nested
+    class LlmMcpFilters {
+
+        @Test
+        void should_add_llm_proxy_model_terms_filter() {
+            var query = MetricsQuery.builder()
+                .filter(MetricsQuery.Filter.builder().llmProxyModels(Set.of("gpt-4", "claude-3")).build())
+                .build();
+
+            assertThat(hasTermsOn(query, RequestV2MetricsV4Fields.LLM_PROXY_MODEL.v4Metrics())).isTrue();
+        }
+
+        @Test
+        void should_add_llm_proxy_provider_terms_filter() {
+            var query = MetricsQuery.builder()
+                .filter(MetricsQuery.Filter.builder().llmProxyProviders(Set.of("openai", "anthropic")).build())
+                .build();
+
+            assertThat(hasTermsOn(query, RequestV2MetricsV4Fields.LLM_PROXY_PROVIDER.v4Metrics())).isTrue();
+        }
+
+        @Test
+        void should_add_mcp_proxy_tool_terms_filter() {
+            var query = MetricsQuery.builder().filter(MetricsQuery.Filter.builder().mcpProxyTools(Set.of("tool-a")).build()).build();
+
+            assertThat(hasTermsOn(query, RequestV2MetricsV4Fields.MCP_PROXY_TOOL.v4Metrics())).isTrue();
+        }
+
+        @Test
+        void should_add_mcp_proxy_resource_terms_filter() {
+            var query = MetricsQuery.builder()
+                .filter(MetricsQuery.Filter.builder().mcpProxyResources(Set.of("resource-a")).build())
+                .build();
+
+            assertThat(hasTermsOn(query, RequestV2MetricsV4Fields.MCP_PROXY_RESOURCE.v4Metrics())).isTrue();
+        }
+
+        @Test
+        void should_add_mcp_proxy_prompt_terms_filter() {
+            var query = MetricsQuery.builder().filter(MetricsQuery.Filter.builder().mcpProxyPrompts(Set.of("prompt-a")).build()).build();
+
+            assertThat(hasTermsOn(query, RequestV2MetricsV4Fields.MCP_PROXY_PROMPT.v4Metrics())).isTrue();
+        }
+
+        @Test
+        void should_not_add_llm_model_filter_when_null() {
+            var query = MetricsQuery.builder().filter(MetricsQuery.Filter.builder().llmProxyModels(null).build()).build();
+
+            assertThat(hasTermsOn(query, RequestV2MetricsV4Fields.LLM_PROXY_MODEL.v4Metrics())).isFalse();
+        }
+
+        @Test
+        void should_not_add_llm_model_filter_when_empty() {
+            var query = MetricsQuery.builder().filter(MetricsQuery.Filter.builder().llmProxyModels(Set.of()).build()).build();
+
+            assertThat(hasTermsOn(query, RequestV2MetricsV4Fields.LLM_PROXY_MODEL.v4Metrics())).isFalse();
+        }
+    }
+
     private boolean hasTermsOn(MetricsQuery query, String field) {
         var result = new JsonObject(SearchMetricsQueryAdapter.adapt(query));
         var queryNode = result.getJsonObject("query");

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/shared/StatusCodeGroupsTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/shared/StatusCodeGroupsTest.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.repository.elasticsearch.v4.shared;
+
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class StatusCodeGroupsTest {
+
+    private static final String FIELD = "status";
+
+    @Nested
+    class RangeForGroup {
+
+        @Test
+        void should_build_range_for_2xx_group() {
+            var result = StatusCodeGroups.rangeForGroup(FIELD, "2XX");
+
+            assertThatJson(result.encode()).isEqualTo(
+                """
+                    { "range": { "status": { "gte": 200, "lte": 299 } } }
+                """
+            );
+        }
+
+        @Test
+        void should_be_case_insensitive() {
+            var result = StatusCodeGroups.rangeForGroup(FIELD, "4xx");
+
+            assertThatJson(result.encode()).isEqualTo(
+                """
+                    { "range": { "status": { "gte": 400, "lte": 499 } } }
+                """
+            );
+        }
+
+        @Test
+        void should_throw_for_null_group() {
+            assertThatThrownBy(() -> StatusCodeGroups.rangeForGroup(FIELD, null)).isInstanceOf(IllegalArgumentException.class);
+        }
+
+        @Test
+        void should_throw_for_unknown_group() {
+            assertThatThrownBy(() -> StatusCodeGroups.rangeForGroup(FIELD, "9XX"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("9XX");
+        }
+    }
+
+    @Nested
+    class ShouldForGroups {
+
+        @Test
+        void should_return_single_range_for_one_group() {
+            var result = StatusCodeGroups.shouldForGroups(FIELD, List.of("5XX"));
+
+            assertThatJson(result.encode()).isEqualTo(
+                """
+                    { "range": { "status": { "gte": 500, "lte": 599 } } }
+                """
+            );
+        }
+
+        @Test
+        void should_return_bool_should_for_multiple_groups() {
+            var result = StatusCodeGroups.shouldForGroups(FIELD, Set.of("2XX", "4XX"));
+
+            assertThatJson(result.encode()).inPath("$.bool.should").isArray().hasSize(2);
+            assertThatJson(result.encode()).inPath("$.bool.minimum_should_match").isEqualTo(1);
+        }
+
+        @Test
+        void should_return_match_none_for_empty_groups() {
+            var result = StatusCodeGroups.shouldForGroups(FIELD, List.of());
+
+            assertThatJson(result.encode()).isEqualTo(
+                """
+                    { "match_none": {} }
+                """
+            );
+        }
+
+        @Test
+        void should_return_match_none_for_null_groups() {
+            var result = StatusCodeGroups.shouldForGroups(FIELD, null);
+
+            assertThatJson(result.encode()).isEqualTo(
+                """
+                    { "match_none": {} }
+                """
+            );
+        }
+    }
+
+    @Nested
+    class RangeForBounds {
+
+        @Test
+        void should_build_range_with_both_bounds() {
+            var result = StatusCodeGroups.rangeForBounds(FIELD, 200, 299);
+
+            assertThatJson(result.encode()).isEqualTo(
+                """
+                    { "range": { "status": { "gte": 200, "lte": 299 } } }
+                """
+            );
+        }
+
+        @Test
+        void should_build_range_with_only_gte() {
+            var result = StatusCodeGroups.rangeForBounds(FIELD, 500, null);
+
+            assertThatJson(result.encode()).isEqualTo(
+                """
+                    { "range": { "status": { "gte": 500 } } }
+                """
+            );
+        }
+
+        @Test
+        void should_build_range_with_only_lte() {
+            var result = StatusCodeGroups.rangeForBounds(FIELD, null, 299);
+
+            assertThatJson(result.encode()).isEqualTo(
+                """
+                    { "range": { "status": { "lte": 299 } } }
+                """
+            );
+        }
+
+        @Test
+        void should_throw_when_both_bounds_are_null() {
+            assertThatThrownBy(() -> StatusCodeGroups.rangeForBounds(FIELD, null, null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("At least one bound");
+        }
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/analytics/SearchLogsFilters.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/analytics/SearchLogsFilters.java
@@ -29,6 +29,8 @@ public record SearchLogsFilters(
     Set<HttpMethod> methods,
     Set<String> mcpMethods,
     Set<Integer> statuses,
+    List<StatusRange> statusRanges,
+    Set<String> statusCodeGroups,
     Set<String> entrypointIds,
     Set<String> apiIds,
     Set<String> requestIds,
@@ -37,5 +39,16 @@ public record SearchLogsFilters(
     String uri,
     String bodyText,
     Set<String> errorKeys,
-    Set<String> apiProductIds
-) {}
+    Set<String> apiProductIds,
+    Set<String> llmProxyModels,
+    Set<String> llmProxyProviders,
+    Set<String> mcpProxyTools,
+    Set<String> mcpProxyResources,
+    Set<String> mcpProxyPrompts
+) {
+    /**
+     * An inclusive HTTP status code range bound for {@code HTTP_STATUS GTE/LTE}.
+     */
+    @Builder
+    public record StatusRange(Integer gte, Integer lte) {}
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/ConnectionLogAdapter.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/ConnectionLogAdapter.java
@@ -19,6 +19,7 @@ import io.gravitee.repository.log.v4.model.connection.ConnectionDiagnostic;
 import io.gravitee.repository.log.v4.model.connection.Metrics;
 import io.gravitee.repository.log.v4.model.connection.MetricsQuery;
 import io.gravitee.rest.api.model.analytics.Range;
+import io.gravitee.rest.api.model.analytics.SearchLogsFilters;
 import io.gravitee.rest.api.model.v4.log.connection.BaseConnectionLog;
 import io.gravitee.rest.api.model.v4.log.connection.ConnectionDiagnosticModel;
 import io.gravitee.rest.api.model.v4.log.connection.ConnectionLogDetail;
@@ -46,6 +47,9 @@ public interface ConnectionLogAdapter {
 
     MetricsQuery.Filter.ResponseTimeRange convert(Range range);
     List<MetricsQuery.Filter.ResponseTimeRange> convert(List<Range> range);
+
+    MetricsQuery.Filter.StatusRange convertStatusRange(SearchLogsFilters.StatusRange statusRange);
+    List<MetricsQuery.Filter.StatusRange> convertStatusRanges(List<SearchLogsFilters.StatusRange> statusRanges);
 
     ConnectionDiagnosticModel convert(ConnectionDiagnostic connectionDiagnostic);
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/crud_service/log/ConnectionLogsCrudServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/crud_service/log/ConnectionLogsCrudServiceImpl.java
@@ -198,12 +198,19 @@ class ConnectionLogsCrudServiceImpl implements ConnectionLogsCrudService {
             .methods(searchLogsFilters.methods())
             .mcpMethods(searchLogsFilters.mcpMethods())
             .statuses(searchLogsFilters.statuses())
+            .statusRanges(ConnectionLogAdapter.INSTANCE.convertStatusRanges(searchLogsFilters.statusRanges()))
+            .statusCodeGroups(searchLogsFilters.statusCodeGroups())
             .entrypointIds(searchLogsFilters.entrypointIds())
             .requestIds(searchLogsFilters.requestIds())
             .transactionIds(searchLogsFilters.transactionIds())
             .uri(searchLogsFilters.uri())
             .responseTimeRanges(ConnectionLogAdapter.INSTANCE.convert(searchLogsFilters.responseTimeRanges()))
-            .errorKeys(searchLogsFilters.errorKeys());
+            .errorKeys(searchLogsFilters.errorKeys())
+            .llmProxyModels(searchLogsFilters.llmProxyModels())
+            .llmProxyProviders(searchLogsFilters.llmProxyProviders())
+            .mcpProxyTools(searchLogsFilters.mcpProxyTools())
+            .mcpProxyResources(searchLogsFilters.mcpProxyResources())
+            .mcpProxyPrompts(searchLogsFilters.mcpProxyPrompts());
     }
 
     private static ConnectionLogDetailQuery.Filter.FilterBuilder mapToConnectionLogDetailQueryFilterBuilder(

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/analytics_engine/processors/BucketNamesPostProcessorImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/analytics_engine/processors/BucketNamesPostProcessorImpl.java
@@ -19,6 +19,7 @@ import io.gravitee.apim.core.analytics_engine.domain_service.BucketNamesPostProc
 import io.gravitee.apim.core.analytics_engine.model.*;
 import io.gravitee.apim.core.api.model.Api;
 import io.gravitee.apim.infra.domain_service.analytics_engine.mapper.ApiMapper;
+import io.gravitee.repository.analytics.engine.api.query.HttpStatusCodeGroups;
 import io.gravitee.repository.management.api.ApiRepository;
 import io.gravitee.repository.management.api.search.ApiCriteria;
 import io.gravitee.repository.management.api.search.ApiFieldFilter;
@@ -41,18 +42,7 @@ public class BucketNamesPostProcessorImpl implements BucketNamesPostProcessor {
 
     private static final String UNKNOWN_APPLICATION = "Unknown";
 
-    private static final Map<String, String> STATUS_CODE_GROUP_FROM_ES_KEY = Map.of(
-        "100-199",
-        "1XX",
-        "200-299",
-        "2XX",
-        "300-399",
-        "3XX",
-        "400-499",
-        "4XX",
-        "500-599",
-        "5XX"
-    );
+    private static final Map<String, String> STATUS_CODE_GROUP_FROM_ES_KEY = HttpStatusCodeGroups.esBucketKeyToGroupLabel();
 
     private final ApiRepository apiRepository;
     private final ApplicationService applicationSearchService;

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/infra/adapter/NumericRangeAccumulator.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/infra/adapter/NumericRangeAccumulator.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gamma.rest.infra.adapter;
+
+import io.gravitee.apim.core.exception.ValidationDomainException;
+
+/**
+ * Accumulates inclusive GTE/LTE bounds for a single numeric range, then validates
+ * and returns the result. Has no knowledge of filter operators or domain concepts.
+ *
+ * @param <T> numeric type ({@link Integer}, {@link Long}, etc.)
+ */
+final class NumericRangeAccumulator<T extends Comparable<T>> {
+
+    record OpenBounds<T>(T gte, T lte) {}
+
+    private final String filterName;
+    private T gte;
+    private T lte;
+
+    NumericRangeAccumulator(String filterName) {
+        this.filterName = filterName;
+    }
+
+    void setGte(T value) {
+        this.gte = value;
+    }
+
+    void setLte(T value) {
+        this.lte = value;
+    }
+
+    void setBoth(T value) {
+        this.gte = value;
+        this.lte = value;
+    }
+
+    boolean hasValue() {
+        return gte != null || lte != null;
+    }
+
+    OpenBounds<T> build() {
+        if (gte != null && lte != null && gte.compareTo(lte) > 0) {
+            throw new ValidationDomainException(
+                "Invalid " + filterName + " range: 'gte' (" + gte + ") must not be greater than 'lte' (" + lte + ")."
+            );
+        }
+        return new OpenBounds<>(gte, lte);
+    }
+}

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/infra/adapter/ObservabilityLogsDataPortAdapter.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/infra/adapter/ObservabilityLogsDataPortAdapter.java
@@ -39,6 +39,7 @@ import io.gravitee.gamma.rest.core.observability.logs.model.LogEntryWarning;
 import io.gravitee.gamma.rest.core.observability.logs.model.LogsPage;
 import io.gravitee.gamma.rest.core.observability.logs.model.LogsSearchQuery;
 import io.gravitee.gamma.rest.core.observability.logs.port.service_provider.ObservabilityLogsDataPort;
+import io.gravitee.repository.analytics.engine.api.query.HttpStatusCodeGroups;
 import io.gravitee.rest.api.model.BaseApplicationEntity;
 import io.gravitee.rest.api.model.analytics.Range;
 import io.gravitee.rest.api.model.analytics.SearchLogsFilters;
@@ -134,15 +135,22 @@ public class ObservabilityLogsDataPortAdapter implements ObservabilityLogsDataPo
         Set<HttpMethod> methods = new HashSet<>();
         Set<String> mcpMethods = new HashSet<>();
         Set<Integer> statuses = new HashSet<>();
+        List<SearchLogsFilters.StatusRange> statusRanges = new ArrayList<>();
+        Set<String> statusCodeGroups = new HashSet<>();
+        var statusAccumulator = new NumericRangeAccumulator<Integer>("HTTP_STATUS");
         Set<String> entrypointIds = new HashSet<>();
         Set<String> requestIds = new HashSet<>();
         Set<String> transactionIds = new HashSet<>();
         Set<String> errorKeys = new HashSet<>();
         Set<String> apiProductIds = new HashSet<>();
+        Set<String> llmProxyModels = new HashSet<>();
+        Set<String> llmProxyProviders = new HashSet<>();
+        Set<String> mcpProxyTools = new HashSet<>();
+        Set<String> mcpProxyResources = new HashSet<>();
+        Set<String> mcpProxyPrompts = new HashSet<>();
         String uri = null;
         List<Range> responseTimeRanges = new ArrayList<>();
-        Long responseTimeFrom = null;
-        Long responseTimeTo = null;
+        var responseTimeAccumulator = new NumericRangeAccumulator<Long>("HTTP_GATEWAY_RESPONSE_TIME");
 
         for (FilterCondition condition : query.conditions()) {
             var values = condition.values() != null ? condition.values() : List.<String>of();
@@ -150,26 +158,31 @@ public class ObservabilityLogsDataPortAdapter implements ObservabilityLogsDataPo
                 case "APPLICATION" -> applicationIds.addAll(values);
                 case "PLAN" -> planIds.addAll(values);
                 case "HTTP_METHOD" -> methods.addAll(values.stream().map(this::toHttpMethod).toList());
-                case "HTTP_STATUS" -> addStatusFilter(condition, values, statuses);
+                case "HTTP_STATUS" -> {
+                    if (!values.isEmpty()) {
+                        if (condition.operator() == FilterOperator.EQ) {
+                            values.forEach(value -> statuses.add(parseHttpStatus(value)));
+                        } else {
+                            applyNumericBound(statusAccumulator, condition.operator(), parseHttpStatus(values.getFirst()));
+                        }
+                    }
+                }
+                case "HTTP_STATUS_CODE_GROUP" -> addStatusCodeGroupFilter(values, statusCodeGroups);
                 case "URI" -> {
                     if (!values.isEmpty()) uri = values.getFirst();
                 }
                 case "HTTP_GATEWAY_RESPONSE_TIME" -> {
                     if (!values.isEmpty()) {
-                        long val = Long.parseLong(values.getFirst());
-                        switch (condition.operator()) {
-                            case GTE -> responseTimeFrom = val;
-                            case LTE -> responseTimeTo = val;
-                            case EQ -> {
-                                responseTimeFrom = val;
-                                responseTimeTo = val;
-                            }
-                            default -> throw unexpectedOperator("HTTP_GATEWAY_RESPONSE_TIME", condition.operator());
-                        }
+                        applyNumericBound(responseTimeAccumulator, condition.operator(), parseResponseTime(values.getFirst()));
                     }
                 }
                 case "ENTRYPOINT" -> entrypointIds.addAll(values);
                 case "MCP_PROXY_METHOD" -> mcpMethods.addAll(values);
+                case "LLM_PROXY_MODEL" -> llmProxyModels.addAll(values);
+                case "LLM_PROXY_PROVIDER" -> llmProxyProviders.addAll(values);
+                case "MCP_PROXY_TOOL" -> mcpProxyTools.addAll(values);
+                case "MCP_PROXY_RESOURCE" -> mcpProxyResources.addAll(values);
+                case "MCP_PROXY_PROMPT" -> mcpProxyPrompts.addAll(values);
                 case "REQUEST_ID" -> requestIds.addAll(values);
                 case "TRANSACTION_ID" -> transactionIds.addAll(values);
                 case "ERROR_KEY" -> errorKeys.addAll(values);
@@ -178,8 +191,14 @@ public class ObservabilityLogsDataPortAdapter implements ObservabilityLogsDataPo
             }
         }
 
-        if (responseTimeFrom != null || responseTimeTo != null) {
-            responseTimeRanges.add(new Range(responseTimeFrom, responseTimeTo));
+        if (statusAccumulator.hasValue()) {
+            var b = statusAccumulator.build();
+            statusRanges.add(SearchLogsFilters.StatusRange.builder().gte(b.gte()).lte(b.lte()).build());
+        }
+
+        if (responseTimeAccumulator.hasValue()) {
+            var b = responseTimeAccumulator.build();
+            responseTimeRanges.add(new Range(b.gte(), b.lte()));
         }
 
         builder.applicationIds(applicationIds);
@@ -187,11 +206,18 @@ public class ObservabilityLogsDataPortAdapter implements ObservabilityLogsDataPo
         builder.methods(methods);
         builder.mcpMethods(mcpMethods);
         builder.statuses(statuses);
+        builder.statusRanges(statusRanges);
+        builder.statusCodeGroups(statusCodeGroups);
         builder.entrypointIds(entrypointIds);
         builder.requestIds(requestIds);
         builder.transactionIds(transactionIds);
         builder.errorKeys(errorKeys);
         builder.apiProductIds(apiProductIds);
+        builder.llmProxyModels(llmProxyModels);
+        builder.llmProxyProviders(llmProxyProviders);
+        builder.mcpProxyTools(mcpProxyTools);
+        builder.mcpProxyResources(mcpProxyResources);
+        builder.mcpProxyPrompts(mcpProxyPrompts);
         builder.uri(uri);
         builder.responseTimeRanges(responseTimeRanges);
 
@@ -322,23 +348,24 @@ public class ObservabilityLogsDataPortAdapter implements ObservabilityLogsDataPo
             .toList();
     }
 
-    /**
-     * Translates an {@code HTTP_STATUS} condition into the logs engine's discrete status set. The
-     * unified catalog advertises {@code EQ}/{@code GTE}/{@code LTE} for this NUMBER filter, but the
-     * logs backend ({@link SearchLogsFilters#statuses()}) only matches discrete codes today, so only
-     * {@code EQ} is translated here. Range operators ({@code GTE}/{@code LTE}) are explicitly rejected
-     * (400) for now rather than silently mistranslated; they will be wired through an ES {@code range}
-     * (shared with {@code HTTP_STATUS_CODE_GROUP}) by GMA-683 — deliberately not via integer expansion,
-     * to avoid a divergent status-translation implementation.
-     */
-    private static void addStatusFilter(FilterCondition condition, List<String> values, Set<Integer> statuses) {
-        if (values.isEmpty()) {
-            return;
+    private static void addStatusCodeGroupFilter(List<String> values, Set<String> statusCodeGroups) {
+        for (String group : values) {
+            HttpStatusCodeGroups.resolve(group).orElseThrow(() ->
+                new ValidationDomainException("Unknown HTTP status code group: " + group)
+            );
+            statusCodeGroups.add(group.toUpperCase(java.util.Locale.ROOT));
         }
-        if (condition.operator() != FilterOperator.EQ) {
-            throw UnsupportedObservabilityFilterException.unsupportedOperator("HTTP_STATUS", condition.operator().name());
+    }
+
+    private static long parseResponseTime(String value) {
+        if (value == null) {
+            throw new ValidationDomainException("Invalid response time value: null");
         }
-        values.forEach(value -> statuses.add(parseHttpStatus(value)));
+        try {
+            return Long.parseLong(value.trim());
+        } catch (NumberFormatException e) {
+            throw new ValidationDomainException("Invalid response time value: " + value);
+        }
     }
 
     private static int parseHttpStatus(String value) {
@@ -359,15 +386,17 @@ public class ObservabilityLogsDataPortAdapter implements ObservabilityLogsDataPo
         return status;
     }
 
-    /**
-     * Defensive guard: the use case already validates each condition's operator against the catalog
-     * via {@code ObservabilityFilterValidator}, so reaching this means the catalog advertises an
-     * operator the translation does not yet handle — a programming error, not a client error.
-     */
-    private static IllegalStateException unexpectedOperator(String filterName, FilterOperator operator) {
-        return new IllegalStateException(
-            "Operator " + operator + " for filter '" + filterName + "' should have been rejected by filter validation"
-        );
+    private static <T extends Comparable<T>> void applyNumericBound(
+        NumericRangeAccumulator<T> accumulator,
+        FilterOperator operator,
+        T value
+    ) {
+        switch (operator) {
+            case GTE -> accumulator.setGte(value);
+            case LTE -> accumulator.setLte(value);
+            case EQ -> accumulator.setBoth(value);
+            default -> throw new IllegalStateException("Operator " + operator + " should have been rejected by filter validation");
+        }
     }
 
     private static io.gravitee.apim.core.audit.model.AuditInfo currentAuditInfo(String organizationId, String environmentId) {

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/resources/openapi/observability/openapi-observability.yaml
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/resources/openapi/observability/openapi-observability.yaml
@@ -542,9 +542,7 @@ paths:
                         A filter condition is invalid. Possible causes:
                         - Unknown filter name (`observability.filter.unknown_name`)
                         - Filter does not apply to the LOGS signal (`observability.filter.signal_mismatch`)
-                        - Operator not usable for this filter on log search (`observability.filter.unsupported_operator`). This
-                          covers operators absent from the catalog, and catalog operators not yet translated by log search —
-                          currently `HTTP_STATUS` `GTE`/`LTE` (range support is pending; use `EQ` meanwhile).
+                        - Operator not usable for this filter on log search (`observability.filter.unsupported_operator`).
                         - Filter is valid for LOGS but not yet supported by log search (`observability.filter.search_translation_not_supported`)
                         - A filter value is malformed or out of range (e.g. an `HTTP_STATUS` outside 100–599)
                         - `from` is after `to` in the time range
@@ -569,13 +567,13 @@ paths:
                                     summary: Operator not usable for this filter on log search
                                     value:
                                         httpStatus: 400
-                                        message: "Operator 'GTE' is not supported yet for filter 'HTTP_STATUS'"
+                                        message: "Operator 'GTE' is not supported for filter 'ERROR_KEY'"
                                         technicalCode: "observability.filter.unsupported_operator"
                                 search-translation-not-supported:
                                     summary: Filter valid for LOGS but not yet translated by log search
                                     value:
                                         httpStatus: 400
-                                        message: "Filter 'HTTP_STATUS_CODE_GROUP' is not yet supported for log search"
+                                        message: "Filter 'API_TYPE' is not yet supported for log search"
                                         technicalCode: "observability.filter.search_translation_not_supported"
                                 invalid-filter-value:
                                     summary: Malformed or out-of-range filter value

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/test/java/io/gravitee/gamma/rest/core/observability/filter/model/StaticFiltersContractTest.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/test/java/io/gravitee/gamma/rest/core/observability/filter/model/StaticFiltersContractTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gamma.rest.core.observability.filter.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.repository.analytics.engine.api.query.HttpStatusCodeGroups;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Contract tests ensuring the filter catalog stays consistent with canonical definitions.
+ * If a value is added to the catalog but not to the canonical source, these tests fail
+ * at compile time (or test time), preventing silent drift.
+ */
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class StaticFiltersContractTest {
+
+    @Test
+    void status_code_group_enum_values_should_all_be_valid_canonical_groups() {
+        var spec = StaticFilters.HTTP_STATUS_CODE_GROUP.toSpec();
+        var catalogKeys = spec.enumValues().stream().map(FilterSpec.EnumValue::value).toList();
+
+        assertThat(catalogKeys)
+            .isNotEmpty()
+            .allSatisfy(key ->
+                assertThat(HttpStatusCodeGroups.GROUP_BOUNDS)
+                    .as("Catalog key '%s' must exist in HttpStatusCodeGroups.GROUP_BOUNDS", key)
+                    .containsKey(key)
+            );
+    }
+
+    @Test
+    void canonical_groups_should_all_be_in_status_code_group_catalog() {
+        var spec = StaticFilters.HTTP_STATUS_CODE_GROUP.toSpec();
+        var catalogKeys = spec.enumValues().stream().map(FilterSpec.EnumValue::value).toList();
+
+        assertThat(HttpStatusCodeGroups.GROUP_BOUNDS.keySet())
+            .as("All canonical groups must be present in the StaticFilters catalog")
+            .allSatisfy(canonicalKey -> assertThat(catalogKeys).contains(canonicalKey));
+    }
+}

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/test/java/io/gravitee/gamma/rest/infra/adapter/NumericRangeAccumulatorTest.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/test/java/io/gravitee/gamma/rest/infra/adapter/NumericRangeAccumulatorTest.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gamma.rest.infra.adapter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.gravitee.apim.core.exception.ValidationDomainException;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class NumericRangeAccumulatorTest {
+
+    @Nested
+    class HasValue {
+
+        @Test
+        void should_return_false_when_nothing_accumulated() {
+            var acc = new NumericRangeAccumulator<Integer>("TEST");
+
+            assertThat(acc.hasValue()).isFalse();
+        }
+
+        @Test
+        void should_return_true_after_setGte() {
+            var acc = new NumericRangeAccumulator<Integer>("TEST");
+            acc.setGte(100);
+
+            assertThat(acc.hasValue()).isTrue();
+        }
+
+        @Test
+        void should_return_true_after_setLte() {
+            var acc = new NumericRangeAccumulator<Integer>("TEST");
+            acc.setLte(200);
+
+            assertThat(acc.hasValue()).isTrue();
+        }
+    }
+
+    @Nested
+    class Setters {
+
+        @Test
+        void should_set_gte_bound() {
+            var acc = new NumericRangeAccumulator<Integer>("TEST");
+            acc.setGte(400);
+
+            var bounds = acc.build();
+            assertThat(bounds.gte()).isEqualTo(400);
+            assertThat(bounds.lte()).isNull();
+        }
+
+        @Test
+        void should_set_lte_bound() {
+            var acc = new NumericRangeAccumulator<Integer>("TEST");
+            acc.setLte(500);
+
+            var bounds = acc.build();
+            assertThat(bounds.gte()).isNull();
+            assertThat(bounds.lte()).isEqualTo(500);
+        }
+
+        @Test
+        void should_set_both_bounds() {
+            var acc = new NumericRangeAccumulator<Long>("TEST");
+            acc.setBoth(1000L);
+
+            var bounds = acc.build();
+            assertThat(bounds.gte()).isEqualTo(1000L);
+            assertThat(bounds.lte()).isEqualTo(1000L);
+        }
+
+        @Test
+        void should_accumulate_gte_and_lte_separately() {
+            var acc = new NumericRangeAccumulator<Integer>("TEST");
+            acc.setGte(200);
+            acc.setLte(399);
+
+            var bounds = acc.build();
+            assertThat(bounds.gte()).isEqualTo(200);
+            assertThat(bounds.lte()).isEqualTo(399);
+        }
+    }
+
+    @Nested
+    class Build {
+
+        @Test
+        void should_throw_when_gte_greater_than_lte() {
+            var acc = new NumericRangeAccumulator<Integer>("HTTP_STATUS");
+            acc.setGte(500);
+            acc.setLte(200);
+
+            assertThatThrownBy(acc::build)
+                .isInstanceOf(ValidationDomainException.class)
+                .hasMessageContaining("gte")
+                .hasMessageContaining("lte")
+                .hasMessageContaining("HTTP_STATUS");
+        }
+
+        @Test
+        void should_accept_equal_gte_and_lte() {
+            var acc = new NumericRangeAccumulator<Long>("RESPONSE_TIME");
+            acc.setGte(100L);
+            acc.setLte(100L);
+
+            var bounds = acc.build();
+            assertThat(bounds.gte()).isEqualTo(100L);
+            assertThat(bounds.lte()).isEqualTo(100L);
+        }
+    }
+}

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/test/java/io/gravitee/gamma/rest/infra/adapter/ObservabilityLogsDataPortAdapterTest.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/test/java/io/gravitee/gamma/rest/infra/adapter/ObservabilityLogsDataPortAdapterTest.java
@@ -92,11 +92,11 @@ class ObservabilityLogsDataPortAdapterTest {
 
     @Test
     void should_reject_filter_not_translatable_to_log_search() {
-        var query = queryWith(new FilterCondition("HTTP_STATUS_CODE_GROUP", FilterOperator.IN, List.of("2XX")));
+        var query = queryWith(new FilterCondition("API_TYPE", FilterOperator.EQ, List.of("HTTP_PROXY")));
 
         assertThatThrownBy(() -> adapter.searchLogs(ORG, ENV, query))
             .isInstanceOf(UnsupportedObservabilityFilterException.class)
-            .hasMessageContaining("HTTP_STATUS_CODE_GROUP");
+            .hasMessageContaining("API_TYPE");
 
         verifyNoInteractions(connectionLogsCrudService);
     }
@@ -128,26 +128,58 @@ class ObservabilityLogsDataPortAdapterTest {
         }
 
         @Test
-        void should_reject_gte_until_range_translation_lands() {
-            // Interim: range operators on HTTP_STATUS are rejected (400) until GMA-683 wires an ES range.
+        void should_translate_gte_to_status_range_with_open_upper_bound() {
+            stubEmptySearchResult();
             var query = queryWith(new FilterCondition("HTTP_STATUS", FilterOperator.GTE, List.of("500")));
 
-            assertThatThrownBy(() -> adapter.searchLogs(ORG, ENV, query))
-                .isInstanceOf(UnsupportedObservabilityFilterException.class)
-                .hasMessageContaining("HTTP_STATUS");
+            adapter.searchLogs(ORG, ENV, query);
 
-            verifyNoInteractions(connectionLogsCrudService);
+            var ranges = captureSearchFilters().statusRanges();
+            assertThat(ranges).hasSize(1);
+            assertThat(ranges.getFirst().gte()).isEqualTo(500);
+            assertThat(ranges.getFirst().lte()).isNull();
         }
 
         @Test
-        void should_reject_lte_until_range_translation_lands() {
+        void should_translate_lte_to_status_range_with_open_lower_bound() {
+            stubEmptySearchResult();
             var query = queryWith(new FilterCondition("HTTP_STATUS", FilterOperator.LTE, List.of("299")));
 
-            assertThatThrownBy(() -> adapter.searchLogs(ORG, ENV, query))
-                .isInstanceOf(UnsupportedObservabilityFilterException.class)
-                .hasMessageContaining("HTTP_STATUS");
+            adapter.searchLogs(ORG, ENV, query);
 
-            verifyNoInteractions(connectionLogsCrudService);
+            var ranges = captureSearchFilters().statusRanges();
+            assertThat(ranges).hasSize(1);
+            assertThat(ranges.getFirst().gte()).isNull();
+            assertThat(ranges.getFirst().lte()).isEqualTo(299);
+        }
+
+        @Test
+        void should_merge_gte_and_lte_into_single_closed_range() {
+            stubEmptySearchResult();
+            var query = queryWith(
+                new FilterCondition("HTTP_STATUS", FilterOperator.GTE, List.of("400")),
+                new FilterCondition("HTTP_STATUS", FilterOperator.LTE, List.of("500"))
+            );
+
+            adapter.searchLogs(ORG, ENV, query);
+
+            var ranges = captureSearchFilters().statusRanges();
+            assertThat(ranges).hasSize(1);
+            assertThat(ranges.getFirst().gte()).isEqualTo(400);
+            assertThat(ranges.getFirst().lte()).isEqualTo(500);
+        }
+
+        @Test
+        void should_reject_inverted_gte_lte_range() {
+            var query = queryWith(
+                new FilterCondition("HTTP_STATUS", FilterOperator.GTE, List.of("500")),
+                new FilterCondition("HTTP_STATUS", FilterOperator.LTE, List.of("200"))
+            );
+
+            assertThatThrownBy(() -> adapter.searchLogs(ORG, ENV, query))
+                .isInstanceOf(ValidationDomainException.class)
+                .hasMessageContaining("gte")
+                .hasMessageContaining("lte");
         }
 
         @Test
@@ -175,6 +207,113 @@ class ObservabilityLogsDataPortAdapterTest {
             assertThatThrownBy(() -> adapter.searchLogs(ORG, ENV, query))
                 .isInstanceOf(ValidationDomainException.class)
                 .hasMessageContaining("abc");
+        }
+    }
+
+    @Nested
+    class HttpStatusCodeGroupFilter {
+
+        @Test
+        void should_pass_single_group_key() {
+            stubEmptySearchResult();
+            var query = queryWith(new FilterCondition("HTTP_STATUS_CODE_GROUP", FilterOperator.EQ, List.of("2XX")));
+
+            adapter.searchLogs(ORG, ENV, query);
+
+            assertThat(captureSearchFilters().statusCodeGroups()).containsExactly("2XX");
+        }
+
+        @Test
+        void should_pass_multiple_group_keys() {
+            stubEmptySearchResult();
+            var query = queryWith(new FilterCondition("HTTP_STATUS_CODE_GROUP", FilterOperator.IN, List.of("2XX", "4XX")));
+
+            adapter.searchLogs(ORG, ENV, query);
+
+            assertThat(captureSearchFilters().statusCodeGroups()).containsExactlyInAnyOrder("2XX", "4XX");
+        }
+
+        @Test
+        void should_normalize_group_key_to_uppercase() {
+            stubEmptySearchResult();
+            var query = queryWith(new FilterCondition("HTTP_STATUS_CODE_GROUP", FilterOperator.EQ, List.of("5xx")));
+
+            adapter.searchLogs(ORG, ENV, query);
+
+            assertThat(captureSearchFilters().statusCodeGroups()).containsExactly("5XX");
+        }
+
+        @Test
+        void should_not_mix_groups_into_status_ranges() {
+            stubEmptySearchResult();
+            var query = queryWith(new FilterCondition("HTTP_STATUS_CODE_GROUP", FilterOperator.EQ, List.of("2XX")));
+
+            adapter.searchLogs(ORG, ENV, query);
+
+            assertThat(captureSearchFilters().statusRanges()).isEmpty();
+        }
+
+        @Test
+        void should_reject_unknown_group() {
+            var query = queryWith(new FilterCondition("HTTP_STATUS_CODE_GROUP", FilterOperator.EQ, List.of("9XX")));
+
+            assertThatThrownBy(() -> adapter.searchLogs(ORG, ENV, query))
+                .isInstanceOf(ValidationDomainException.class)
+                .hasMessageContaining("9XX");
+        }
+    }
+
+    @Nested
+    class LlmMcpFilters {
+
+        @Test
+        void should_translate_llm_proxy_model() {
+            stubEmptySearchResult();
+            var query = queryWith(new FilterCondition("LLM_PROXY_MODEL", FilterOperator.IN, List.of("gpt-4", "claude-3")));
+
+            adapter.searchLogs(ORG, ENV, query);
+
+            assertThat(captureSearchFilters().llmProxyModels()).containsExactlyInAnyOrder("gpt-4", "claude-3");
+        }
+
+        @Test
+        void should_translate_llm_proxy_provider() {
+            stubEmptySearchResult();
+            var query = queryWith(new FilterCondition("LLM_PROXY_PROVIDER", FilterOperator.IN, List.of("openai")));
+
+            adapter.searchLogs(ORG, ENV, query);
+
+            assertThat(captureSearchFilters().llmProxyProviders()).containsExactly("openai");
+        }
+
+        @Test
+        void should_translate_mcp_proxy_tool() {
+            stubEmptySearchResult();
+            var query = queryWith(new FilterCondition("MCP_PROXY_TOOL", FilterOperator.IN, List.of("tool-1")));
+
+            adapter.searchLogs(ORG, ENV, query);
+
+            assertThat(captureSearchFilters().mcpProxyTools()).containsExactly("tool-1");
+        }
+
+        @Test
+        void should_translate_mcp_proxy_resource() {
+            stubEmptySearchResult();
+            var query = queryWith(new FilterCondition("MCP_PROXY_RESOURCE", FilterOperator.IN, List.of("res-1")));
+
+            adapter.searchLogs(ORG, ENV, query);
+
+            assertThat(captureSearchFilters().mcpProxyResources()).containsExactly("res-1");
+        }
+
+        @Test
+        void should_translate_mcp_proxy_prompt() {
+            stubEmptySearchResult();
+            var query = queryWith(new FilterCondition("MCP_PROXY_PROMPT", FilterOperator.IN, List.of("prompt-1")));
+
+            adapter.searchLogs(ORG, ENV, query);
+
+            assertThat(captureSearchFilters().mcpProxyPrompts()).containsExactly("prompt-1");
         }
     }
 


### PR DESCRIPTION
## Summary

Implements [GMA-683](https://gravitee.atlassian.net/browse/GMA-683): translates the remaining untranslated observability LOGS filter conditions (`HTTP_STATUS GTE/LTE`, `HTTP_STATUS_CODE_GROUP`, `LLM_PROXY_MODEL`, `LLM_PROXY_PROVIDER`, `MCP_PROXY_TOOL`, `MCP_PROXY_RESOURCE`, `MCP_PROXY_PROMPT`) from the Gamma UI into the platform's connection-log search infrastructure and Elasticsearch queries.

## Changes

### New: canonical status code groups (`repository-api`)
- `HttpStatusCodeGroups`: single source of truth for the 1XX–5XX group→[min,max] mapping, replacing 3 duplicated copies
- `NumberRange.forStatusCodeGroup()` now delegates to `HttpStatusCodeGroups.asNumberRanges()`
- `esBucketKeyToGroupLabel()` provides the reverse map for ES bucket key→group label

### New: ES status code utilities (`repository-elasticsearch`)
- `StatusCodeGroups`: ES-specific utility delegating to `HttpStatusCodeGroups` for group resolution, plus `rangeForBounds()` for open-ended GTE/LTE range queries

### Model extensions
- `SearchLogsFilters`: added `statusCodeGroups` (raw group keys), `statusRanges` (GTE/LTE bounds), and LLM/MCP fields
- `MetricsQuery.Filter`: mirrored additions (`statusCodeGroups`, `statusRanges`, LLM/MCP fields)
- `RequestV2MetricsV4Fields`: added field constants for LLM/MCP proxy details

### Adapter layer
- `SearchMetricsQueryAdapter`: new ES filter methods for `statusCodeGroups` (via `shouldForGroups`), `statusRanges` (via `rangeForBounds`), and LLM/MCP `terms` filters — groups and ranges are separate `must` clauses ensuring correct AND semantics
- `ObservabilityLogsDataPortAdapter`: translates all new filter conditions; groups pass as raw keys (not pre-converted to ranges); GTE/LTE bounds go through `NumericRangeAccumulator`; includes input validation (`parseResponseTime`, inverted range rejection)
- `NumericRangeAccumulator<T>`: package-private generic utility for accumulating GTE/LTE/EQ bounds with built-in `gte <= lte` validation — no coupling to `FilterOperator` (SOLID)
- `FilterAdapter` (analytics): refactored to use shared `StatusCodeGroups` instead of its own internal map
- `BucketNamesPostProcessorImpl`: reverse map now derived from `HttpStatusCodeGroups.esBucketKeyToGroupLabel()`
- `ConnectionLogAdapter` / `ConnectionLogsCrudServiceImpl`: pass-through for new fields

### OpenAPI
- Removed "not yet translated" caveats for `HTTP_STATUS GTE/LTE` and `HTTP_STATUS_CODE_GROUP`

## Reviewer notes

The most important areas to review:

1. **AND/OR semantics** (`SearchMetricsQueryAdapter`): `statusCodeGroups` produces a `bool.should` (OR among groups) in one `must` clause; `statusRanges` produces separate `must` clauses. This ensures combining `4XX` + `GTE 450` yields `[450–499]`, not `[400–499] OR [>=450]`.
2. **`NumericRangeAccumulator`** design: package-private, no dependency on `FilterOperator`, validation centralized. Ready for 7+ future numeric filters without duplication.
3. **Deduplication**: 3 copies of status code group mapping → 1 canonical source in `repository-api`.

## Test plan

- [x] `HttpStatusCodeGroupsTest`: resolve, asNumberRanges, esBucketKeyToGroupLabel
- [x] `StatusCodeGroupsTest`: rangeForGroup, shouldForGroups, rangeForBounds, null bounds rejection
- [x] `SearchMetricsQueryAdapterTest`: status ranges (single, open bounds, multiple as bool.should), status code groups (single, multiple, combined with ranges as separate must clauses), LLM/MCP terms filters
- [x] `NumericRangeAccumulatorTest`: setGte, setLte, setBoth, hasValue, inverted range rejection, unsupported operator
- [x] `ObservabilityLogsDataPortAdapterTest`: HTTP_STATUS EQ/GTE/LTE/merge/inverted range, HTTP_STATUS_CODE_GROUP (raw keys, case normalization, not mixed into statusRanges), response time invalid input, LLM/MCP filters
- [x] `StaticFiltersContractTest`: catalog keys ⊆ canonical groups AND canonical groups ⊆ catalog keys

Closes GMA-683

[GMA-683]: https://gravitee.atlassian.net/browse/GMA-683?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ