### PR TITLE
feat(portal): persist portalNavigation on Portal entity and gate sync…

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/Portal.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/management/model/Portal.java
@@ -35,4 +35,5 @@ public class Portal {
     private String environmentId;
     private String organizationId;
     private String name;
+    private String portalNavigation;
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcPortalRepository.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/java/io/gravitee/repository/jdbc/management/JdbcPortalRepository.java
@@ -44,6 +44,7 @@ public class JdbcPortalRepository extends JdbcAbstractCrudRepository<Portal, Str
             .addColumn("environment_id", Types.NVARCHAR, String.class)
             .addColumn("organization_id", Types.NVARCHAR, String.class)
             .addColumn("name", Types.NVARCHAR, String.class)
+            .addColumn("portal_navigation", Types.NVARCHAR, String.class)
             .build();
     }
 

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_12_0/18_add_portal_navigation_to_portals.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/changelogs/v4_12_0/18_add_portal_navigation_to_portals.yml
@@ -1,0 +1,13 @@
+databaseChangeLog:
+  - changeSet:
+      id: 4.12.0_18_add_portal_navigation_to_portals
+      author: GraviteeSource Team
+      changes:
+        - addColumn:
+            tableName: ${gravitee_prefix}portals
+            columns:
+              - column:
+                  name: portal_navigation
+                  type: nclob
+                  constraints:
+                    nullable: true

--- a/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/master.yml
+++ b/gravitee-apim-repository/gravitee-apim-repository-jdbc/src/main/resources/liquibase/master.yml
@@ -377,3 +377,5 @@ databaseChangeLog:
         - file: liquibase/changelogs/v4_12_0/15_add_environment_id_to_am_connections.yml
     - include:
         - file: liquibase/changelogs/v4_12_0/16_add_automation_metadata_to_portal_page_contents.yml
+    - include:
+        - file: liquibase/changelogs/v4_12_0/18_add_portal_navigation_to_portals.yml

--- a/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/model/PortalMongo.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-mongodb/src/main/java/io/gravitee/repository/mongodb/management/internal/model/PortalMongo.java
@@ -34,4 +34,5 @@ public class PortalMongo {
     private String environmentId;
     private String organizationId;
     private String name;
+    private String portalNavigation;
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal/domain_service/PortalNavigationSyncDomainService.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal/domain_service/PortalNavigationSyncDomainService.java
@@ -54,7 +54,7 @@ public class PortalNavigationSyncDomainService {
     private final PortalNavigationItemsQueryService queryService;
     private final PortalPageContentCrudService pageContentCrudService;
 
-    public void sync(AuditInfo auditInfo, PortalId portalId, List<NavigationPath> desired) {
+    public void sync(AuditInfo auditInfo, PortalId portalId, List<NavigationPath> previouslyPersisted, List<NavigationPath> desired) {
         final var currentFolders = queryService.search(
             PortalNavigationItemQueryCriteria.builder()
                 .environmentId(auditInfo.environmentId())
@@ -62,7 +62,11 @@ public class PortalNavigationSyncDomainService {
                 .type(PortalNavigationItemType.FOLDER)
                 .build()
         );
-        final var plan = NavigationSyncPlanner.plan(desired == null ? List.of() : desired, currentFolders);
+        final var plan = NavigationSyncPlanner.plan(
+            desired == null ? List.of() : desired,
+            currentFolders,
+            previouslyPersisted == null ? List.of() : previouslyPersisted
+        );
         execute(plan, auditInfo, portalId);
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal/domain_service/navigation/plan/NavigationSyncPlanner.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal/domain_service/navigation/plan/NavigationSyncPlanner.java
@@ -36,6 +36,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -46,10 +47,22 @@ public final class NavigationSyncPlanner {
 
     private NavigationSyncPlanner() {}
 
-    public static NavigationSyncPlan plan(List<NavigationPath> desired, List<PortalNavigationItem> currentFolders) {
+    /**
+     * Diffs the desired navigation against what is currently in the tree, restricting deletes
+     * to paths that were previously persisted on the Portal entity.
+     *
+     * <p>Folders present in the tree but not in {@code previouslyPersisted} are treated as
+     * "unmanaged" (created outside the automation API) and are left untouched.
+     */
+    public static NavigationSyncPlan plan(
+        List<NavigationPath> desired,
+        List<PortalNavigationItem> currentFolders,
+        List<NavigationPath> previouslyPersisted
+    ) {
         final var desiredFolders = computeDesiredFolders(desired);
         final var currentByPath = indexByPath(currentFolders);
         final var desiredPaths = desiredFolders.stream().map(DesiredFolder::path).collect(Collectors.toSet());
+        final var managedPaths = expandToFullPaths(previouslyPersisted);
         final var depthOrder = Comparator.comparingInt((FolderMutation m) -> PathExpander.depth(m.desired().path()));
 
         final var mutations = desiredFolders
@@ -63,10 +76,20 @@ public final class NavigationSyncPlanner {
             .entrySet()
             .stream()
             .filter(e -> !desiredPaths.contains(e.getKey()))
+            .filter(e -> managedPaths.contains(e.getKey()))
             .map(Map.Entry::getValue)
             .map(DeleteFolder::new);
 
         return new NavigationSyncPlan(Stream.<NavigationAction>concat(mutations, deletes).toList());
+    }
+
+    private static Set<String> expandToFullPaths(List<NavigationPath> previouslyPersisted) {
+        if (previouslyPersisted == null) return Set.of();
+        return previouslyPersisted
+            .stream()
+            .flatMap(e -> PathExpander.expand(e.path()).stream())
+            .map(PathExpander.PathEntry::fullPath)
+            .collect(Collectors.toSet());
     }
 
     /** Reconstructs the path of every current folder by walking from its root, using {@code segment} (fallback to {@code title}). */

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal/model/Portal.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal/model/Portal.java
@@ -16,6 +16,7 @@
 package io.gravitee.apim.core.portal.model;
 
 import jakarta.annotation.Nonnull;
+import java.util.List;
 import lombok.Getter;
 
 @Getter
@@ -33,21 +34,34 @@ public class Portal {
     @Nonnull
     private final String name;
 
-    private Portal(PortalId id, String environmentId, String organizationId, String name) {
+    @Nonnull
+    private final List<NavigationPath> portalNavigation;
+
+    private Portal(PortalId id, String environmentId, String organizationId, String name, List<NavigationPath> portalNavigation) {
         this.id = id;
         this.environmentId = environmentId;
         this.organizationId = organizationId;
         this.name = name;
+        this.portalNavigation = portalNavigation == null ? List.of() : List.copyOf(portalNavigation);
     }
 
-    /** New portal with a random id. */
+    /** New portal with a random id and no navigation. */
     public static Portal create(String environmentId, String organizationId, String name) {
-        return new Portal(PortalId.random(), environmentId, organizationId, name);
+        return new Portal(PortalId.random(), environmentId, organizationId, name, List.of());
     }
 
     /** Reconstitute a portal from a known id (HRID-derived, persistence, etc.). */
     public static Portal of(PortalId id, String environmentId, String organizationId, String name) {
-        return new Portal(id, environmentId, organizationId, name);
+        return new Portal(id, environmentId, organizationId, name, List.of());
+    }
+
+    /** Reconstitute a portal with a persisted navigation array. */
+    public static Portal of(PortalId id, String environmentId, String organizationId, String name, List<NavigationPath> portalNavigation) {
+        return new Portal(id, environmentId, organizationId, name, portalNavigation);
+    }
+
+    public Portal withNavigation(List<NavigationPath> portalNavigation) {
+        return new Portal(this.id, this.environmentId, this.organizationId, this.name, portalNavigation);
     }
 
     @Override

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal/use_case/CreateOrUpdatePortalUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal/use_case/CreateOrUpdatePortalUseCase.java
@@ -19,7 +19,6 @@ import io.gravitee.apim.core.UseCase;
 import io.gravitee.apim.core.audit.model.AuditInfo;
 import io.gravitee.apim.core.exception.ValidationDomainException;
 import io.gravitee.apim.core.portal.crud_service.PortalCrudService;
-import io.gravitee.apim.core.portal.domain_service.PortalNavigationListingDomainService;
 import io.gravitee.apim.core.portal.domain_service.PortalNavigationSyncDomainService;
 import io.gravitee.apim.core.portal.domain_service.ValidatePortalDomainService;
 import io.gravitee.apim.core.portal.model.NavigationPath;
@@ -39,7 +38,6 @@ public class CreateOrUpdatePortalUseCase {
     private final ValidatePortalDomainService validator;
     private final PortalCrudService portalCrudService;
     private final PortalNavigationSyncDomainService portalNavigationSyncDomainService;
-    private final PortalNavigationListingDomainService portalNavigationListingDomainService;
     private final PortalPageContentQueryService portalPageContentQueryService;
     private final PortalDocumentationSyncDomainService portalDocumentationSyncDomainService;
 
@@ -65,14 +63,14 @@ public class CreateOrUpdatePortalUseCase {
         var warnings = validation.warning().orElseGet(List::of);
 
         var sanitized = validation.value().orElseThrow(() -> new ValidationDomainException("Unable to sanitize portal"));
-        var portal = sanitized.portal();
-        var existing = portalCrudService.findByIdAndEnvironmentId(portal.getId(), input.auditInfo().environmentId());
-        var saved = existing.isPresent() ? portalCrudService.update(portal) : portalCrudService.create(portal);
-        portalNavigationSyncDomainService.sync(input.auditInfo(), portal.getId(), sanitized.navigation());
+        var existing = portalCrudService.findByIdAndEnvironmentId(sanitized.portal().getId(), input.auditInfo().environmentId());
+        var previouslyPersisted = existing.map(Portal::getPortalNavigation).orElseGet(List::of);
+        var portalToSave = sanitized.portal().withNavigation(sanitized.navigation());
+        var saved = existing.isPresent() ? portalCrudService.update(portalToSave) : portalCrudService.create(portalToSave);
+        portalNavigationSyncDomainService.sync(input.auditInfo(), saved.getId(), previouslyPersisted, sanitized.navigation());
         portalPageContentQueryService
-            .findByReference(input.auditInfo().environmentId(), AutomationMetadata.ReferenceType.PORTAL, portal.getId().toString())
+            .findByReference(input.auditInfo().environmentId(), AutomationMetadata.ReferenceType.PORTAL, saved.getId().toString())
             .forEach(pc -> portalDocumentationSyncDomainService.materialize(input.auditInfo(), pc));
-        var navigation = portalNavigationListingDomainService.listAsNavigationPaths(input.auditInfo().environmentId());
-        return new Output(saved, navigation, warnings);
+        return new Output(saved, saved.getPortalNavigation(), warnings);
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal/use_case/GetPortalUseCase.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/portal/use_case/GetPortalUseCase.java
@@ -18,7 +18,6 @@ package io.gravitee.apim.core.portal.use_case;
 import io.gravitee.apim.core.UseCase;
 import io.gravitee.apim.core.audit.model.AuditInfo;
 import io.gravitee.apim.core.portal.crud_service.PortalCrudService;
-import io.gravitee.apim.core.portal.domain_service.PortalNavigationListingDomainService;
 import io.gravitee.apim.core.portal.exception.PortalNotFoundException;
 import io.gravitee.apim.core.portal.model.NavigationPath;
 import io.gravitee.apim.core.portal.model.Portal;
@@ -31,7 +30,6 @@ import lombok.RequiredArgsConstructor;
 public class GetPortalUseCase {
 
     private final PortalCrudService portalCrudService;
-    private final PortalNavigationListingDomainService portalNavigationListingDomainService;
 
     public record Input(AuditInfo auditInfo, PortalId portalId) {}
 
@@ -41,7 +39,6 @@ public class GetPortalUseCase {
         var portal = portalCrudService
             .findByIdAndEnvironmentId(input.portalId(), input.auditInfo().environmentId())
             .orElseThrow(() -> new PortalNotFoundException(input.portalId().toString()));
-        var navigation = portalNavigationListingDomainService.listAsNavigationPaths(input.auditInfo().environmentId());
-        return new Output(portal, navigation);
+        return new Output(portal, portal.getPortalNavigation());
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/PortalAdapter.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/PortalAdapter.java
@@ -15,25 +15,85 @@
  */
 package io.gravitee.apim.infra.adapter;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import io.gravitee.apim.core.portal.model.NavigationPath;
 import io.gravitee.apim.core.portal.model.Portal;
 import io.gravitee.apim.core.portal.model.PortalId;
+import io.gravitee.node.logging.NodeLoggerFactory;
+import java.io.IOException;
+import java.util.List;
+import java.util.Optional;
 import org.mapstruct.Mapper;
 import org.mapstruct.factory.Mappers;
+import org.slf4j.Logger;
 
 @Mapper
 public interface PortalAdapter {
+    Logger log = NodeLoggerFactory.getLogger(PortalAdapter.class);
     PortalAdapter INSTANCE = Mappers.getMapper(PortalAdapter.class);
 
     default Portal toEntity(io.gravitee.repository.management.model.Portal portal) {
         if (portal == null) {
             return null;
         }
-        return Portal.of(PortalId.of(portal.getId()), portal.getEnvironmentId(), portal.getOrganizationId(), portal.getName());
+        return Portal.of(
+            PortalId.of(portal.getId()),
+            portal.getEnvironmentId(),
+            portal.getOrganizationId(),
+            portal.getName(),
+            deserializePortalNavigation(portal.getPortalNavigation())
+        );
     }
 
-    io.gravitee.repository.management.model.Portal toRepository(Portal portal);
+    default io.gravitee.repository.management.model.Portal toRepository(Portal portal) {
+        if (portal == null) {
+            return null;
+        }
+        return io.gravitee.repository.management.model.Portal.builder()
+            .id(portal.getId().toString())
+            .environmentId(portal.getEnvironmentId())
+            .organizationId(portal.getOrganizationId())
+            .name(portal.getName())
+            .portalNavigation(serializePortalNavigation(portal.getPortalNavigation()))
+            .build();
+    }
 
-    default String mapPortalId(PortalId id) {
-        return id.toString();
+    TypeReference<List<NavigationPathJson>> NAVIGATION_PATH_LIST = new TypeReference<>() {};
+
+    record NavigationPathJson(String path, String displayName) {
+        static NavigationPathJson from(NavigationPath p) {
+            return new NavigationPathJson(p.path(), p.displayName().orElse(null));
+        }
+
+        NavigationPath toDomain() {
+            return new NavigationPath(path, Optional.ofNullable(displayName));
+        }
+    }
+
+    default String serializePortalNavigation(List<NavigationPath> portalNavigation) {
+        if (portalNavigation == null || portalNavigation.isEmpty()) {
+            return null;
+        }
+        try {
+            return GraviteeJacksonMapper.getInstance().writeValueAsString(portalNavigation.stream().map(NavigationPathJson::from).toList());
+        } catch (IOException ioe) {
+            throw new RuntimeException("Unexpected error while serializing portal portalNavigation", ioe);
+        }
+    }
+
+    default List<NavigationPath> deserializePortalNavigation(String json) {
+        if (json == null || json.isBlank()) {
+            return List.of();
+        }
+        try {
+            return GraviteeJacksonMapper.getInstance()
+                .readValue(json, NAVIGATION_PATH_LIST)
+                .stream()
+                .map(NavigationPathJson::toDomain)
+                .toList();
+        } catch (IOException ioe) {
+            log.error("Unexpected error while deserializing portal portalNavigation", ioe);
+            return List.of();
+        }
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal/domain_service/PortalNavigationListingDomainServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal/domain_service/PortalNavigationListingDomainServiceTest.java
@@ -61,6 +61,7 @@ class PortalNavigationListingDomainServiceTest {
         syncService.sync(
             AUDIT_INFO,
             PORTAL_ID,
+            List.of(),
             List.of(
                 new NavigationPath("/a", Optional.empty()),
                 new NavigationPath("/a/b", Optional.empty()),
@@ -79,6 +80,7 @@ class PortalNavigationListingDomainServiceTest {
         syncService.sync(
             AUDIT_INFO,
             PORTAL_ID,
+            List.of(),
             List.of(
                 new NavigationPath("/projects/alpha", Optional.of("Alpha")),
                 new NavigationPath("/projects/alpha/docs", Optional.empty())
@@ -92,7 +94,7 @@ class PortalNavigationListingDomainServiceTest {
 
     @Test
     void display_name_is_surfaced_when_title_differs_from_segment() {
-        syncService.sync(AUDIT_INFO, PORTAL_ID, List.of(new NavigationPath("/projects/alpha", Optional.of("Alpha"))));
+        syncService.sync(AUDIT_INFO, PORTAL_ID, List.of(), List.of(new NavigationPath("/projects/alpha", Optional.of("Alpha"))));
 
         var result = listingService.listAsNavigationPaths(AUDIT_INFO.environmentId());
 
@@ -105,7 +107,7 @@ class PortalNavigationListingDomainServiceTest {
 
     @Test
     void display_name_is_null_when_title_equals_segment() {
-        syncService.sync(AUDIT_INFO, PORTAL_ID, List.of(new NavigationPath("/a", Optional.empty())));
+        syncService.sync(AUDIT_INFO, PORTAL_ID, List.of(), List.of(new NavigationPath("/a", Optional.empty())));
 
         var result = listingService.listAsNavigationPaths(AUDIT_INFO.environmentId());
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal/domain_service/PortalNavigationSyncDomainServiceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal/domain_service/PortalNavigationSyncDomainServiceTest.java
@@ -69,14 +69,14 @@ class PortalNavigationSyncDomainServiceTest {
 
     @Test
     void empty_input_on_empty_db_is_a_noop() {
-        syncService.sync(AUDIT_INFO, PORTAL_ID, List.of());
+        syncService.sync(AUDIT_INFO, PORTAL_ID, List.of(), List.of());
 
         assertThat(crud.storage()).isEmpty();
     }
 
     @Test
     void single_root_path_creates_one_folder() {
-        syncService.sync(AUDIT_INFO, PORTAL_ID, List.of(new NavigationPath("/a", Optional.empty())));
+        syncService.sync(AUDIT_INFO, PORTAL_ID, List.of(), List.of(new NavigationPath("/a", Optional.empty())));
 
         assertThat(crud.storage()).hasSize(1);
         var folder = (PortalNavigationFolder) crud.storage().get(0);
@@ -92,7 +92,7 @@ class PortalNavigationSyncDomainServiceTest {
 
     @Test
     void display_name_when_provided_becomes_the_title_and_segment_holds_the_path_piece() {
-        syncService.sync(AUDIT_INFO, PORTAL_ID, List.of(new NavigationPath("/a", Optional.of("Alpha"))));
+        syncService.sync(AUDIT_INFO, PORTAL_ID, List.of(), List.of(new NavigationPath("/a", Optional.of("Alpha"))));
 
         assertThat(crud.storage()).hasSize(1);
         var folder = crud.storage().get(0);
@@ -102,7 +102,7 @@ class PortalNavigationSyncDomainServiceTest {
 
     @Test
     void title_falls_back_to_segment_when_no_display_name_provided() {
-        syncService.sync(AUDIT_INFO, PORTAL_ID, List.of(new NavigationPath("/a", Optional.empty())));
+        syncService.sync(AUDIT_INFO, PORTAL_ID, List.of(), List.of(new NavigationPath("/a", Optional.empty())));
 
         assertThat(crud.storage()).hasSize(1);
         var folder = crud.storage().get(0);
@@ -112,7 +112,7 @@ class PortalNavigationSyncDomainServiceTest {
 
     @Test
     void implicit_ancestors_are_created_with_mkdir_p() {
-        syncService.sync(AUDIT_INFO, PORTAL_ID, List.of(new NavigationPath("/a/b/c", Optional.empty())));
+        syncService.sync(AUDIT_INFO, PORTAL_ID, List.of(), List.of(new NavigationPath("/a/b/c", Optional.empty())));
 
         assertThat(crud.storage()).hasSize(3);
         var a = findByPath("/a").orElseThrow();
@@ -134,6 +134,7 @@ class PortalNavigationSyncDomainServiceTest {
         syncService.sync(
             AUDIT_INFO,
             PORTAL_ID,
+            List.of(),
             List.of(
                 new NavigationPath("/a", Optional.empty()),
                 new NavigationPath("/a/b", Optional.empty()),
@@ -157,10 +158,10 @@ class PortalNavigationSyncDomainServiceTest {
             new NavigationPath("/c", Optional.empty())
         );
 
-        syncService.sync(AUDIT_INFO, PORTAL_ID, input);
+        syncService.sync(AUDIT_INFO, PORTAL_ID, List.of(), input);
         var snapshot = new ArrayList<>(crud.storage());
 
-        syncService.sync(AUDIT_INFO, PORTAL_ID, input);
+        syncService.sync(AUDIT_INFO, PORTAL_ID, input, input);
 
         assertThat(crud.storage()).hasSize(snapshot.size());
         for (int i = 0; i < snapshot.size(); i++) {
@@ -170,12 +171,12 @@ class PortalNavigationSyncDomainServiceTest {
 
     @Test
     void folder_ids_are_deterministic_from_audit_portal_and_path() {
-        syncService.sync(AUDIT_INFO, PORTAL_ID, List.of(new NavigationPath("/a/b", Optional.empty())));
+        syncService.sync(AUDIT_INFO, PORTAL_ID, List.of(), List.of(new NavigationPath("/a/b", Optional.empty())));
 
         var idsBefore = crud.storage().stream().map(PortalNavigationItem::getId).toList();
 
         crud.reset();
-        syncService.sync(AUDIT_INFO, PORTAL_ID, List.of(new NavigationPath("/a/b", Optional.empty())));
+        syncService.sync(AUDIT_INFO, PORTAL_ID, List.of(), List.of(new NavigationPath("/a/b", Optional.empty())));
 
         var idsAfter = crud.storage().stream().map(PortalNavigationItem::getId).toList();
         assertThat(idsAfter).isEqualTo(idsBefore);
@@ -185,11 +186,11 @@ class PortalNavigationSyncDomainServiceTest {
     void different_portals_produce_different_folder_ids_for_the_same_path() {
         var otherPortal = PortalId.of("22222222-2222-2222-2222-222222222222");
 
-        syncService.sync(AUDIT_INFO, PORTAL_ID, List.of(new NavigationPath("/a", Optional.empty())));
+        syncService.sync(AUDIT_INFO, PORTAL_ID, List.of(), List.of(new NavigationPath("/a", Optional.empty())));
         var idForPortalOne = findByPath("/a").orElseThrow().getId();
 
         crud.reset();
-        syncService.sync(AUDIT_INFO, otherPortal, List.of(new NavigationPath("/a", Optional.empty())));
+        syncService.sync(AUDIT_INFO, otherPortal, List.of(), List.of(new NavigationPath("/a", Optional.empty())));
         var idForPortalTwo = findByPath("/a").orElseThrow().getId();
 
         assertThat(idForPortalTwo).isNotEqualTo(idForPortalOne);
@@ -197,17 +198,11 @@ class PortalNavigationSyncDomainServiceTest {
 
     @Test
     void reorder_updates_existing_folders() {
-        syncService.sync(
-            AUDIT_INFO,
-            PORTAL_ID,
-            List.of(new NavigationPath("/a/b", Optional.empty()), new NavigationPath("/a/c", Optional.empty()))
-        );
+        var first = List.of(new NavigationPath("/a/b", Optional.empty()), new NavigationPath("/a/c", Optional.empty()));
+        var reordered = List.of(new NavigationPath("/a/c", Optional.empty()), new NavigationPath("/a/b", Optional.empty()));
+        syncService.sync(AUDIT_INFO, PORTAL_ID, List.of(), first);
 
-        syncService.sync(
-            AUDIT_INFO,
-            PORTAL_ID,
-            List.of(new NavigationPath("/a/c", Optional.empty()), new NavigationPath("/a/b", Optional.empty()))
-        );
+        syncService.sync(AUDIT_INFO, PORTAL_ID, first, reordered);
 
         var b = findByPath("/a/b").orElseThrow();
         var c = findByPath("/a/c").orElseThrow();
@@ -217,15 +212,12 @@ class PortalNavigationSyncDomainServiceTest {
     }
 
     @Test
-    void removed_path_is_deleted() {
-        syncService.sync(
-            AUDIT_INFO,
-            PORTAL_ID,
-            List.of(new NavigationPath("/a", Optional.empty()), new NavigationPath("/b", Optional.empty()))
-        );
+    void removed_path_is_deleted_when_previously_managed() {
+        var firstInput = List.of(new NavigationPath("/a", Optional.empty()), new NavigationPath("/b", Optional.empty()));
+        syncService.sync(AUDIT_INFO, PORTAL_ID, List.of(), firstInput);
         assertThat(crud.storage()).hasSize(2);
 
-        syncService.sync(AUDIT_INFO, PORTAL_ID, List.of(new NavigationPath("/a", Optional.empty())));
+        syncService.sync(AUDIT_INFO, PORTAL_ID, firstInput, List.of(new NavigationPath("/a", Optional.empty())));
 
         assertThat(crud.storage()).hasSize(1);
         assertThat(findByPath("/a")).isPresent();
@@ -233,11 +225,39 @@ class PortalNavigationSyncDomainServiceTest {
     }
 
     @Test
+    void unmanaged_folder_is_not_deleted_when_no_longer_desired() {
+        var unmanaged = folderRow("manual", null, 0);
+        unmanaged.markAsRoot();
+        crud.initWith(List.of(unmanaged));
+
+        syncService.sync(AUDIT_INFO, PORTAL_ID, List.of(), List.of());
+
+        assertThat(crud.storage()).contains(unmanaged);
+    }
+
+    @Test
+    void unmanaged_folder_is_not_deleted_even_when_other_managed_paths_change() {
+        var unmanaged = folderRow("manual", null, 0);
+        unmanaged.markAsRoot();
+        crud.initWith(List.of(unmanaged));
+
+        var previously = List.of(new NavigationPath("/managed", Optional.empty()));
+        syncService.sync(AUDIT_INFO, PORTAL_ID, List.of(), previously);
+
+        syncService.sync(AUDIT_INFO, PORTAL_ID, previously, List.of());
+
+        assertThat(findByPath("/manual")).isPresent();
+        assertThat(findByPath("/managed")).isEmpty();
+    }
+
+    @Test
     void rename_via_display_name_updates_title_without_changing_id() {
-        syncService.sync(AUDIT_INFO, PORTAL_ID, List.of(new NavigationPath("/a", Optional.of("Original"))));
+        var original = List.of(new NavigationPath("/a", Optional.of("Original")));
+        var renamed = List.of(new NavigationPath("/a", Optional.of("Renamed")));
+        syncService.sync(AUDIT_INFO, PORTAL_ID, List.of(), original);
         var originalId = crud.storage().get(0).getId();
 
-        syncService.sync(AUDIT_INFO, PORTAL_ID, List.of(new NavigationPath("/a", Optional.of("Renamed"))));
+        syncService.sync(AUDIT_INFO, PORTAL_ID, original, renamed);
 
         assertThat(crud.storage()).hasSize(1);
         var folder = crud.storage().get(0);
@@ -274,7 +294,7 @@ class PortalNavigationSyncDomainServiceTest {
         folderInHomepage.markAsRoot();
         crud.initWith(List.of(pageInTopNavbar, folderInHomepage));
 
-        syncService.sync(AUDIT_INFO, PORTAL_ID, List.of(new NavigationPath("/a", Optional.empty())));
+        syncService.sync(AUDIT_INFO, PORTAL_ID, List.of(), List.of(new NavigationPath("/a", Optional.empty())));
 
         assertThat(crud.storage()).hasSize(3);
         assertThat(crud.storage()).contains(pageInTopNavbar, folderInHomepage);
@@ -290,7 +310,7 @@ class PortalNavigationSyncDomainServiceTest {
         var apiChild = apiRow("api-child", folder.getId(), 2);
         crud.initWith(List.of(folder, pageChild, linkChild, apiChild));
 
-        syncService.sync(AUDIT_INFO, PORTAL_ID, List.of());
+        syncService.sync(AUDIT_INFO, PORTAL_ID, List.of(new NavigationPath("/x", Optional.empty())), List.of());
 
         assertThat(crud.storage()).isEmpty();
     }
@@ -310,7 +330,7 @@ class PortalNavigationSyncDomainServiceTest {
         var pageChild = pageRow("page-child", folder.getId(), 0, contentId);
         crud.initWith(List.of(folder, pageChild));
 
-        syncService.sync(AUDIT_INFO, PORTAL_ID, List.of());
+        syncService.sync(AUDIT_INFO, PORTAL_ID, List.of(new NavigationPath("/x", Optional.empty())), List.of());
 
         assertThat(crud.storage()).isEmpty();
         assertThat(pageContentCrud.storage()).isEmpty();
@@ -325,7 +345,7 @@ class PortalNavigationSyncDomainServiceTest {
         var leafPage = pageRow("leaf", c.getId(), 0, PortalPageContentId.random());
         crud.initWith(List.of(a, b, c, leafPage));
 
-        syncService.sync(AUDIT_INFO, PORTAL_ID, List.of());
+        syncService.sync(AUDIT_INFO, PORTAL_ID, List.of(new NavigationPath("/a/b/c", Optional.empty())), List.of());
 
         assertThat(crud.storage()).isEmpty();
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal/use_case/CreateOrUpdatePortalUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal/use_case/CreateOrUpdatePortalUseCaseTest.java
@@ -27,7 +27,6 @@ import inmemory.PortalPageContentQueryServiceInMemory;
 import io.gravitee.apim.core.audit.model.AuditActor;
 import io.gravitee.apim.core.audit.model.AuditInfo;
 import io.gravitee.apim.core.exception.ValidationDomainException;
-import io.gravitee.apim.core.portal.domain_service.PortalNavigationListingDomainService;
 import io.gravitee.apim.core.portal.domain_service.PortalNavigationSyncDomainService;
 import io.gravitee.apim.core.portal.domain_service.ValidatePortalDomainService;
 import io.gravitee.apim.core.portal.model.NavigationPath;
@@ -68,7 +67,6 @@ class CreateOrUpdatePortalUseCaseTest {
             validator,
             portalCrudService,
             new PortalNavigationSyncDomainService(navCrudService, navQueryService, pageContentCrudService),
-            new PortalNavigationListingDomainService(navQueryService),
             pageContentQueryService,
             new PortalDocumentationSyncDomainService(navCrudService, navQueryService)
         );
@@ -187,5 +185,49 @@ class CreateOrUpdatePortalUseCaseTest {
         );
 
         assertThat(output.errors()).isEmpty();
+    }
+
+    @Test
+    void should_persist_navigation_array_on_portal_row() {
+        var portal = PortalFixtures.aPortal();
+        var input = List.of(new NavigationPath("/a", Optional.of("A")), new NavigationPath("/b", Optional.empty()));
+
+        var output = useCase.execute(new CreateOrUpdatePortalUseCase.Input(AUDIT_INFO, portal, input));
+
+        assertThat(output.portal().getPortalNavigation()).extracting(NavigationPath::path).containsExactly("/a", "/b");
+        assertThat(portalCrudService.storage()).hasSize(1);
+        assertThat(portalCrudService.storage().get(0).getPortalNavigation()).extracting(NavigationPath::path).containsExactly("/a", "/b");
+        assertThat(output.navigation()).isEqualTo(output.portal().getPortalNavigation());
+    }
+
+    @Test
+    void should_use_previously_persisted_to_skip_unmanaged_folders_on_delete() {
+        var portal = PortalFixtures.aPortal();
+        useCase.execute(
+            new CreateOrUpdatePortalUseCase.Input(AUDIT_INFO, portal, List.of(new NavigationPath("/managed", Optional.empty())))
+        );
+        var unmanaged = io.gravitee.apim.core.portal_page.model.PortalNavigationFolder.builder()
+            .id(io.gravitee.apim.core.portal_page.model.PortalNavigationItemId.random())
+            .organizationId(AUDIT_INFO.organizationId())
+            .environmentId(AUDIT_INFO.environmentId())
+            .title("manual")
+            .segment("manual")
+            .area(PortalArea.TOP_NAVBAR)
+            .order(1)
+            .published(true)
+            .visibility(io.gravitee.apim.core.portal_page.model.PortalVisibility.PUBLIC)
+            .build();
+        unmanaged.markAsRoot();
+        navCrudService.initWith(List.of(unmanaged));
+
+        useCase.execute(new CreateOrUpdatePortalUseCase.Input(AUDIT_INFO, portal, List.of()));
+
+        assertThat(navCrudService.storage()).contains(unmanaged);
+        assertThat(
+            navCrudService
+                .storage()
+                .stream()
+                .anyMatch(it -> "managed".equals(it.getTitle()))
+        ).isFalse();
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal/use_case/GetPortalUseCaseTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/core/portal/use_case/GetPortalUseCaseTest.java
@@ -20,13 +20,8 @@ import static org.assertj.core.api.Assertions.catchThrowable;
 
 import fixtures.core.model.PortalFixtures;
 import inmemory.PortalCrudServiceInMemory;
-import inmemory.PortalNavigationItemsCrudServiceInMemory;
-import inmemory.PortalNavigationItemsQueryServiceInMemory;
-import inmemory.PortalPageContentCrudServiceInMemory;
 import io.gravitee.apim.core.audit.model.AuditActor;
 import io.gravitee.apim.core.audit.model.AuditInfo;
-import io.gravitee.apim.core.portal.domain_service.PortalNavigationListingDomainService;
-import io.gravitee.apim.core.portal.domain_service.PortalNavigationSyncDomainService;
 import io.gravitee.apim.core.portal.exception.PortalNotFoundException;
 import io.gravitee.apim.core.portal.model.NavigationPath;
 import io.gravitee.apim.core.portal.model.PortalId;
@@ -48,28 +43,16 @@ class GetPortalUseCaseTest {
         .build();
 
     private final PortalCrudServiceInMemory portalCrudService = new PortalCrudServiceInMemory();
-    private final PortalNavigationItemsCrudServiceInMemory navCrudService = new PortalNavigationItemsCrudServiceInMemory();
-    private final PortalNavigationItemsQueryServiceInMemory navQueryService = new PortalNavigationItemsQueryServiceInMemory(
-        navCrudService.storage()
-    );
-    private final PortalPageContentCrudServiceInMemory pageContentCrudService = new PortalPageContentCrudServiceInMemory();
-    private PortalNavigationSyncDomainService syncDomainService;
     private GetPortalUseCase useCase;
-
-    private PortalNavigationListingDomainService listingDomainService;
 
     @BeforeEach
     void setUp() {
-        syncDomainService = new PortalNavigationSyncDomainService(navCrudService, navQueryService, pageContentCrudService);
-        listingDomainService = new PortalNavigationListingDomainService(navQueryService);
-        useCase = new GetPortalUseCase(portalCrudService, listingDomainService);
+        useCase = new GetPortalUseCase(portalCrudService);
     }
 
     @AfterEach
     void tearDown() {
         portalCrudService.reset();
-        navCrudService.reset();
-        pageContentCrudService.reset();
     }
 
     @Test
@@ -108,17 +91,14 @@ class GetPortalUseCaseTest {
     }
 
     @Test
-    void should_return_navigation_paths_from_stored_folders() {
-        var portal = PortalFixtures.aPortal();
+    void should_return_persisted_navigation_paths() {
+        var navigation = List.of(new NavigationPath("/a", Optional.empty()), new NavigationPath("/a/b", Optional.of("B")));
+        var portal = PortalFixtures.aPortal().withNavigation(navigation);
         portalCrudService.initWith(List.of(portal));
-        syncDomainService.sync(
-            AUDIT_INFO,
-            portal.getId(),
-            List.of(new NavigationPath("/a", Optional.empty()), new NavigationPath("/a/b", Optional.empty()))
-        );
 
         var output = useCase.execute(new GetPortalUseCase.Input(AUDIT_INFO, portal.getId()));
 
         assertThat(output.navigation()).extracting(NavigationPath::path).containsExactly("/a", "/a/b");
+        assertThat(output.navigation().get(1).displayName()).contains("B");
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/adapter/PortalAdapterTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/adapter/PortalAdapterTest.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.infra.adapter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.apim.core.portal.model.NavigationPath;
+import io.gravitee.apim.core.portal.model.Portal;
+import io.gravitee.apim.core.portal.model.PortalId;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class PortalAdapterTest {
+
+    private final PortalAdapter adapter = PortalAdapter.INSTANCE;
+
+    @Nested
+    class PortalNavigationSerialization {
+
+        @Test
+        void round_trip_through_repository_and_back() {
+            var portal = Portal.of(
+                PortalId.of("11111111-1111-1111-1111-111111111111"),
+                "env",
+                "org",
+                "Portal",
+                List.of(new NavigationPath("/a", Optional.of("A")), new NavigationPath("/a/b", Optional.empty()))
+            );
+
+            var roundTripped = adapter.toEntity(adapter.toRepository(portal));
+
+            assertThat(roundTripped.getPortalNavigation()).extracting(NavigationPath::path).containsExactly("/a", "/a/b");
+            assertThat(roundTripped.getPortalNavigation().get(0).displayName()).contains("A");
+            assertThat(roundTripped.getPortalNavigation().get(1).displayName()).isEmpty();
+        }
+
+        @Test
+        void serialize_omits_absent_display_name() {
+            String json = adapter.serializePortalNavigation(List.of(new NavigationPath("/a", Optional.empty())));
+
+            assertThat(json).isEqualTo("[{\"path\":\"/a\"}]");
+        }
+
+        @Test
+        void serialize_includes_display_name_when_present() {
+            String json = adapter.serializePortalNavigation(List.of(new NavigationPath("/a", Optional.of("A"))));
+
+            assertThat(json).isEqualTo("[{\"path\":\"/a\",\"displayName\":\"A\"}]");
+        }
+
+        @Test
+        void serialize_null_when_input_is_null() {
+            assertThat(adapter.serializePortalNavigation(null)).isNull();
+        }
+
+        @Test
+        void serialize_null_when_input_is_empty() {
+            assertThat(adapter.serializePortalNavigation(List.of())).isNull();
+        }
+
+        @Test
+        void deserialize_null_string_to_empty_list() {
+            assertThat(adapter.deserializePortalNavigation(null)).isEmpty();
+        }
+
+        @Test
+        void deserialize_blank_string_to_empty_list() {
+            assertThat(adapter.deserializePortalNavigation("   ")).isEmpty();
+        }
+
+        @Test
+        void deserialize_json_array_to_navigation_paths() {
+            var result = adapter.deserializePortalNavigation("[{\"path\":\"/x\",\"displayName\":\"X\"},{\"path\":\"/y\"}]");
+
+            assertThat(result).extracting(NavigationPath::path).containsExactly("/x", "/y");
+            assertThat(result.get(0).displayName()).contains("X");
+            assertThat(result.get(1).displayName()).isEmpty();
+        }
+
+        @Test
+        void deserialize_malformed_json_returns_empty_list() {
+            assertThat(adapter.deserializePortalNavigation("{not json}")).isEmpty();
+        }
+    }
+
+    @Nested
+    class PortalConversion {
+
+        @Test
+        void to_repository_maps_basic_fields() {
+            var portal = Portal.of(PortalId.of("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"), "env", "org", "Portal");
+
+            var repo = adapter.toRepository(portal);
+
+            assertThat(repo.getId()).isEqualTo("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+            assertThat(repo.getEnvironmentId()).isEqualTo("env");
+            assertThat(repo.getOrganizationId()).isEqualTo("org");
+            assertThat(repo.getName()).isEqualTo("Portal");
+            assertThat(repo.getPortalNavigation()).isNull();
+        }
+
+        @Test
+        void to_entity_returns_null_for_null_input() {
+            assertThat(adapter.toEntity(null)).isNull();
+        }
+
+        @Test
+        void to_repository_returns_null_for_null_input() {
+            assertThat(adapter.toRepository(null)).isNull();
+        }
+    }
+}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/EXT-134

## Description

Persist the navigation array on the Portal entity instead of rebuilding it from the folder tree. Sync planner now only deletes folders it previously created.

What changes

  - Add a portalNavigation JSON column on the portals table.
  - PUT `/portals` writes the array to the Portal row; GET returns it as-is
  - Sync planner takes both the previously persisted and the new list, and only deletes folders that were in the previous one.

  Why it's better

  - Aligned with the API definition changes (PR #17906) which also keep a portalNavigation property on the entity.
  - Idempotency is simpler — no path reconstruction from the folder tree.
  - Folder delete is safer — only removes folders the Portal resource managed, not ones created through webconsole.

