### PR TITLE
feat(observability): add single log detail endpoint GET /observability/logs/{requestId}

### DIFF
--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/logs/exception/LogDetailNotFoundException.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/logs/exception/LogDetailNotFoundException.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gamma.rest.core.observability.logs.exception;
+
+import io.gravitee.apim.core.exception.NotFoundDomainException;
+
+/**
+ * Raised when the log detail endpoint cannot find the requested log — either because the id does
+ * not exist, or because the caller's {@code apiId} scope does not match (404 collapse to prevent
+ * cross-API existence probing). The apim {@code NotFoundDomainExceptionMapper} translates this to
+ * HTTP 404.
+ *
+ * @author GraviteeSource Team
+ */
+public class LogDetailNotFoundException extends NotFoundDomainException {
+
+    public LogDetailNotFoundException(String requestId, String apiId) {
+        super("Log " + requestId + " not found for API " + apiId, requestId);
+    }
+}

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/logs/exception/MissingLogScopeException.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/logs/exception/MissingLogScopeException.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gamma.rest.core.observability.logs.exception;
+
+import io.gravitee.apim.core.exception.ValidationDomainException;
+
+/**
+ * Raised when a required scope dimension on the log detail endpoint — currently {@code apiId} — is
+ * missing or blank. The apim {@code ValidationDomainExceptionMapper} translates this to HTTP 400.
+ *
+ * @author GraviteeSource Team
+ */
+public class MissingLogScopeException extends ValidationDomainException {
+
+    public MissingLogScopeException(String dimensionName) {
+        super("Required scope dimension '" + dimensionName + "' is missing", "observability.log.scope.missing");
+    }
+}

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/logs/model/HttpPayload.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/logs/model/HttpPayload.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gamma.rest.core.observability.logs.model;
+
+import java.util.List;
+import java.util.Map;
+import lombok.Builder;
+
+/**
+ * HTTP request or response content from the {@code v4-log} index. Used for both entrypoint and
+ * endpoint payloads in the merged log detail. Request payloads carry {@code method} and {@code uri};
+ * response payloads carry {@code status}.
+ *
+ * @author GraviteeSource Team
+ */
+@Builder
+public record HttpPayload(String method, String uri, Integer status, Map<String, List<String>> headers, String body) {}

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/logs/model/LogDetail.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/logs/model/LogDetail.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gamma.rest.core.observability.logs.model;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import lombok.Builder;
+
+/**
+ * Merged log detail combining enriched metadata from the {@code v4-metrics} index and HTTP
+ * payloads (headers + body) from the {@code v4-log} index. Returned by
+ * {@code GET /observability/logs/{requestId}?apiId=}.
+ *
+ * <p>Fields mirror the union of today's two per-API management-v2 detail endpoints
+ * ({@code /apis/{apiId}/logs/{requestId}} and {@code /apis/{apiId}/analytics/{requestId}}) so the
+ * frontend can drop the dual-fetch workaround and load the full record in a single lazy call.
+ *
+ * @author GraviteeSource Team
+ */
+@Builder
+public record LogDetail(
+    // Identifiers
+    String requestId,
+    String apiId,
+    String transactionId,
+    String clientIdentifier,
+    Instant timestamp,
+    Boolean requestEnded,
+    // Enriched metadata (v4-metrics)
+    String method,
+    String uri,
+    Integer status,
+    String endpoint,
+    String host,
+    String planId,
+    String planName,
+    String applicationId,
+    String applicationName,
+    String gateway,
+    String gatewayHostname,
+    String gatewayIp,
+    String remoteAddress,
+    Long requestContentLength,
+    Long responseContentLength,
+    Long gatewayLatency,
+    Long gatewayResponseTime,
+    Long endpointResponseTime,
+    String message,
+    String errorKey,
+    String errorComponentName,
+    String errorComponentType,
+    List<LogEntryWarning> warnings,
+    Map<String, Object> additionalMetrics,
+    // HTTP payloads (v4-log)
+    HttpPayload entrypointRequest,
+    HttpPayload entrypointResponse,
+    HttpPayload endpointRequest,
+    HttpPayload endpointResponse
+) {}

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/logs/port/service_provider/ObservabilityLogsDataPort.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/logs/port/service_provider/ObservabilityLogsDataPort.java
@@ -16,9 +16,11 @@
 package io.gravitee.gamma.rest.core.observability.logs.port.service_provider;
 
 import io.gravitee.gamma.rest.core.observability.filter.model.ApiType;
+import io.gravitee.gamma.rest.core.observability.logs.model.LogDetail;
 import io.gravitee.gamma.rest.core.observability.logs.model.LogsPage;
 import io.gravitee.gamma.rest.core.observability.logs.model.LogsSearchQuery;
 import java.util.List;
+import java.util.Optional;
 
 /**
  * Core-side port onto the logs data store and the RBAC-scoped API inventory. The infra adapter
@@ -46,4 +48,11 @@ public interface ObservabilityLogsDataPort {
      * queried.
      */
     LogsPage searchLogs(String organizationId, String environmentId, LogsSearchQuery query);
+
+    /**
+     * Fetches a single merged log detail for the given request id and API. Combines enriched
+     * metadata from the {@code v4-metrics} index with HTTP payloads (headers + body) from the
+     * {@code v4-log} index. Returns empty when neither index contains a matching document.
+     */
+    Optional<LogDetail> getLogDetail(String organizationId, String environmentId, String apiId, String requestId);
 }

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/logs/use_case/GetObservabilityLogDetailUseCase.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/logs/use_case/GetObservabilityLogDetailUseCase.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gamma.rest.core.observability.logs.use_case;
+
+import io.gravitee.apim.core.UseCase;
+import io.gravitee.gamma.rest.core.observability.logs.model.LogDetail;
+import io.gravitee.gamma.rest.core.observability.logs.port.service_provider.ObservabilityLogsDataPort;
+import java.util.Optional;
+import lombok.AllArgsConstructor;
+
+/**
+ * Fetches a single merged log detail by request id and API scope. The heavy counterpart of
+ * {@link SearchObservabilityLogsUseCase}: combines enriched metadata from the {@code v4-metrics}
+ * index and HTTP payloads (headers + body) from the {@code v4-log} index into one
+ * {@link LogDetail}.
+ *
+ * <p>Authorization ({@code API_LOG[READ]} with 404 collapse) is enforced at the REST layer before
+ * this use case is invoked — the use case assumes the caller is allowed to read logs for the given
+ * API.
+ *
+ * @author GraviteeSource Team
+ */
+@UseCase
+@AllArgsConstructor
+public class GetObservabilityLogDetailUseCase {
+
+    private final ObservabilityLogsDataPort logsDataPort;
+
+    public record Input(String organizationId, String environmentId, String apiId, String requestId) {}
+
+    public record Output(Optional<LogDetail> detail) {}
+
+    public Output execute(Input input) {
+        var detail = logsDataPort.getLogDetail(input.organizationId, input.environmentId, input.apiId, input.requestId);
+        return new Output(detail);
+    }
+}

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/infra/adapter/ObservabilityLogsDataPortAdapter.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/infra/adapter/ObservabilityLogsDataPortAdapter.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.gamma.rest.infra.adapter;
 
+import io.gravitee.apim.core.analytics.query_service.AnalyticsQueryService;
 import io.gravitee.apim.core.api_product.model.ApiProduct;
 import io.gravitee.apim.core.api_product.query_service.ApiProductQueryService;
 import io.gravitee.apim.core.application.crud_service.ApplicationCrudService;
@@ -34,6 +35,8 @@ import io.gravitee.gamma.rest.core.observability.filter.model.FilterOperator;
 import io.gravitee.gamma.rest.core.observability.filter.model.FilterSpec;
 import io.gravitee.gamma.rest.core.observability.filter.model.StaticFilters;
 import io.gravitee.gamma.rest.core.observability.logs.model.ApiReference;
+import io.gravitee.gamma.rest.core.observability.logs.model.HttpPayload;
+import io.gravitee.gamma.rest.core.observability.logs.model.LogDetail;
 import io.gravitee.gamma.rest.core.observability.logs.model.LogEntry;
 import io.gravitee.gamma.rest.core.observability.logs.model.LogEntryWarning;
 import io.gravitee.gamma.rest.core.observability.logs.model.LogsPage;
@@ -46,7 +49,12 @@ import io.gravitee.rest.api.model.analytics.SearchLogsFilters;
 import io.gravitee.rest.api.model.common.PageableImpl;
 import io.gravitee.rest.api.model.v4.log.connection.BaseConnectionLog;
 import io.gravitee.rest.api.model.v4.log.connection.ConnectionDiagnosticModel;
+import io.gravitee.rest.api.model.v4.log.connection.ConnectionLogDetail;
 import io.gravitee.rest.api.service.common.ExecutionContext;
+import io.gravitee.rest.api.service.exceptions.ApplicationNotFoundException;
+import io.gravitee.rest.api.service.exceptions.InstanceNotFoundException;
+import io.gravitee.rest.api.service.exceptions.PlanNotFoundException;
+import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
 import java.time.Instant;
 import java.time.OffsetDateTime;
 import java.time.format.DateTimeParseException;
@@ -56,8 +64,10 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
+import lombok.CustomLog;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.context.SecurityContextHolder;
 
@@ -68,6 +78,7 @@ import org.springframework.security.core.context.SecurityContextHolder;
  *
  * @author GraviteeSource Team
  */
+@CustomLog
 @RequiredArgsConstructor
 public class ObservabilityLogsDataPortAdapter implements ObservabilityLogsDataPort {
 
@@ -81,6 +92,7 @@ public class ObservabilityLogsDataPortAdapter implements ObservabilityLogsDataPo
     private static final int HTTP_STATUS_MAX = HTTP_STATUS_RANGE.max().intValue();
 
     private final ConnectionLogsCrudService connectionLogsCrudService;
+    private final AnalyticsQueryService analyticsQueryService;
     private final UserContextLoader userContextLoader;
     private final PlanCrudService planCrudService;
     private final ApplicationCrudService applicationCrudService;
@@ -122,6 +134,130 @@ public class ObservabilityLogsDataPortAdapter implements ObservabilityLogsDataPo
         var enriched = enrichWithNames(executionContext, entries);
 
         return new LogsPage(enriched, result.total());
+    }
+
+    @Override
+    public Optional<LogDetail> getLogDetail(String organizationId, String environmentId, String apiId, String requestId) {
+        var executionContext = new ExecutionContext(organizationId, environmentId);
+
+        var metricsOpt = analyticsQueryService.findApiMetricsDetail(executionContext, apiId, requestId);
+        var logDetailOpt = connectionLogsCrudService.searchApiConnectionLog(executionContext, apiId, requestId);
+
+        if (metricsOpt.isEmpty() && logDetailOpt.isEmpty()) {
+            return Optional.empty();
+        }
+
+        var builder = LogDetail.builder().requestId(requestId).apiId(apiId);
+
+        metricsOpt.ifPresent(metrics -> {
+            builder
+                .timestamp(parseTimestamp(metrics.getTimestamp()))
+                .transactionId(metrics.getTransactionId())
+                .method(metrics.getMethod() != null ? metrics.getMethod().name() : null)
+                .uri(metrics.getUri())
+                .status(metrics.getStatus())
+                .endpoint(metrics.getEndpoint())
+                .host(metrics.getHost())
+                .planId(metrics.getPlanId())
+                .applicationId(metrics.getApplicationId())
+                .gateway(metrics.getGateway())
+                .remoteAddress(metrics.getRemoteAddress())
+                .requestContentLength(metrics.getRequestContentLength())
+                .responseContentLength(metrics.getResponseContentLength())
+                .gatewayLatency(metrics.getGatewayLatency())
+                .gatewayResponseTime(metrics.getGatewayResponseTime())
+                .endpointResponseTime(metrics.getEndpointResponseTime())
+                .message(metrics.getMessage())
+                .errorKey(metrics.getErrorKey())
+                .errorComponentName(metrics.getErrorComponentName())
+                .errorComponentType(metrics.getErrorComponentType())
+                .warnings(mapWarnings(metrics.getWarnings()))
+                .additionalMetrics(metrics.getAdditionalMetrics() != null ? metrics.getAdditionalMetrics() : Map.of());
+
+            var names = resolveDetailNames(executionContext, metrics);
+            builder
+                .planName(names.planName)
+                .applicationName(names.applicationName)
+                .gatewayHostname(names.gatewayHostname)
+                .gatewayIp(names.gatewayIp);
+        });
+
+        logDetailOpt.ifPresent(log -> {
+            builder
+                .clientIdentifier(log.getClientIdentifier())
+                .requestEnded(log.isRequestEnded())
+                .entrypointRequest(mapRequest(log.getEntrypointRequest()))
+                .entrypointResponse(mapResponse(log.getEntrypointResponse()))
+                .endpointRequest(mapRequest(log.getEndpointRequest()))
+                .endpointResponse(mapResponse(log.getEndpointResponse()));
+
+            if (metricsOpt.isEmpty()) {
+                builder.timestamp(parseTimestamp(log.getTimestamp()));
+            }
+        });
+
+        return Optional.of(builder.build());
+    }
+
+    private record ResolvedNames(String planName, String applicationName, String gatewayHostname, String gatewayIp) {}
+
+    private ResolvedNames resolveDetailNames(
+        ExecutionContext executionContext,
+        io.gravitee.rest.api.model.v4.analytics.ApiMetricsDetail metrics
+    ) {
+        String planName = null;
+        String applicationName = null;
+        String gatewayHostname = null;
+        String gatewayIp = null;
+
+        if (metrics.getPlanId() != null) {
+            try {
+                planName = planCrudService.getById(metrics.getPlanId()).getName();
+            } catch (PlanNotFoundException | TechnicalManagementException e) {
+                log.debug("Could not resolve plan name for planId={}", metrics.getPlanId(), e);
+            }
+        }
+
+        if (metrics.getApplicationId() != null) {
+            try {
+                applicationName = applicationCrudService
+                    .findById(metrics.getApplicationId(), executionContext.getEnvironmentId())
+                    .getName();
+            } catch (ApplicationNotFoundException | TechnicalManagementException e) {
+                log.debug("Could not resolve application name for applicationId={}", metrics.getApplicationId(), e);
+            }
+        }
+
+        if (metrics.getGateway() != null) {
+            try {
+                var instance = instanceQueryService.findById(executionContext, metrics.getGateway());
+                gatewayHostname = instance.getHostname();
+                gatewayIp = instance.getIp();
+            } catch (InstanceNotFoundException e) {
+                log.debug("Could not resolve gateway hostname for gatewayId={}", metrics.getGateway(), e);
+            }
+        }
+
+        return new ResolvedNames(planName, applicationName, gatewayHostname, gatewayIp);
+    }
+
+    private static HttpPayload mapRequest(ConnectionLogDetail.Request request) {
+        if (request == null) {
+            return null;
+        }
+        return HttpPayload.builder()
+            .method(request.getMethod())
+            .uri(request.getUri())
+            .headers(request.getHeaders())
+            .body(request.getBody())
+            .build();
+    }
+
+    private static HttpPayload mapResponse(ConnectionLogDetail.Response response) {
+        if (response == null) {
+            return null;
+        }
+        return HttpPayload.builder().status(response.getStatus()).headers(response.getHeaders()).body(response.getBody()).build();
     }
 
     private SearchLogsFilters buildSearchFilters(LogsSearchQuery query) {

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/infra/config/GammaLogsConfiguration.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/infra/config/GammaLogsConfiguration.java
@@ -17,6 +17,7 @@ package io.gravitee.gamma.rest.infra.config;
 
 import io.gravitee.apim.core.DomainService;
 import io.gravitee.apim.core.UseCase;
+import io.gravitee.apim.core.analytics.query_service.AnalyticsQueryService;
 import io.gravitee.apim.core.api_product.query_service.ApiProductQueryService;
 import io.gravitee.apim.core.application.crud_service.ApplicationCrudService;
 import io.gravitee.apim.core.gateway.query_service.InstanceQueryService;
@@ -49,6 +50,7 @@ public class GammaLogsConfiguration {
     @Bean
     public ObservabilityLogsDataPort observabilityLogsDataPort(
         ConnectionLogsCrudService connectionLogsCrudService,
+        AnalyticsQueryService analyticsQueryService,
         UserContextLoader userContextLoader,
         PlanCrudService planCrudService,
         ApplicationCrudService applicationCrudService,
@@ -57,6 +59,7 @@ public class GammaLogsConfiguration {
     ) {
         return new ObservabilityLogsDataPortAdapter(
             connectionLogsCrudService,
+            analyticsQueryService,
             userContextLoader,
             planCrudService,
             applicationCrudService,

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/resources/observability/logs/LogsResource.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/resources/observability/logs/LogsResource.java
@@ -17,8 +17,12 @@ package io.gravitee.gamma.rest.resources.observability.logs;
 
 import io.gravitee.common.http.MediaType;
 import io.gravitee.gamma.rest.core.observability.filter.model.FilterCondition;
+import io.gravitee.gamma.rest.core.observability.logs.exception.LogDetailNotFoundException;
+import io.gravitee.gamma.rest.core.observability.logs.exception.MissingLogScopeException;
+import io.gravitee.gamma.rest.core.observability.logs.use_case.GetObservabilityLogDetailUseCase;
 import io.gravitee.gamma.rest.core.observability.logs.use_case.SearchObservabilityLogsUseCase;
 import io.gravitee.gamma.rest.resources.observability.logs.dto.FilterConditionDto;
+import io.gravitee.gamma.rest.resources.observability.logs.dto.LogDetailDto;
 import io.gravitee.gamma.rest.resources.observability.logs.dto.LogEntryDto;
 import io.gravitee.gamma.rest.resources.observability.logs.dto.SearchLogsRequestDto;
 import io.gravitee.gamma.rest.resources.tracing.dto.PaginatedResponseDto;
@@ -30,14 +34,17 @@ import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.exceptions.ForbiddenAccessException;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.GET;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.Response;
 import java.util.List;
 
 /**
- * Environment-wide logs search endpoint, mounted under
+ * Environment-wide logs endpoints, mounted under
  * {@code /gamma/organizations/{orgId}/environments/{envId}/observability/logs} by
  * {@code GammaRootResource}.
  *
@@ -47,12 +54,19 @@ import java.util.List;
  *       {@code timeRange} and optional filter conditions. Pagination is 1-based in the query
  *       string. Response uses the shared paginated envelope
  *       {@code { data, pagination: { totalCount, page, pageCount } }}.</li>
+ *   <li>{@code GET /{requestId}?apiId=} — single merged log detail. {@code apiId} is required as a
+ *       security defense (same pattern as the trace detail endpoint): prevents cross-API existence
+ *       probing. Merges enriched metadata from {@code v4-metrics} with HTTP payloads from
+ *       {@code v4-log}. Returns 404 when not found or permission denied (collapse).</li>
  * </ul>
  *
  * <h2>Authorization</h2>
- * Same coarse env-level guard as the filter catalog: the caller must be able to read dashboards
- * or APIs in the current environment, otherwise {@code 403}. Row-level scoping (which APIs the
- * caller sees) is handled server-side by the use case via {@code AccessibleApiScopeDomainService}.
+ * <ul>
+ *   <li><b>Search:</b> env-level guard ({@code ENVIRONMENT_DASHBOARD:READ} or
+ *       {@code ENVIRONMENT_API:READ}). Row-level scoping handled by
+ *       {@code AccessibleApiScopeDomainService}.</li>
+ *   <li><b>Detail:</b> {@code API_LOG[READ]} on the given {@code apiId}, with 404 collapse.</li>
+ * </ul>
  *
  * @author GraviteeSource Team
  */
@@ -60,6 +74,9 @@ public class LogsResource {
 
     @Inject
     private SearchObservabilityLogsUseCase searchLogsUseCase;
+
+    @Inject
+    private GetObservabilityLogDetailUseCase getLogDetailUseCase;
 
     @Inject
     private PermissionService permissionService;
@@ -95,6 +112,47 @@ public class LogsResource {
 
         List<LogEntryDto> data = output.data().data().stream().map(LogEntryDto::from).toList();
         return PaginatedResponseDto.of(data, output.data().totalCount(), output.page(), output.perPage());
+    }
+
+    /**
+     * Fetches a single merged log detail by request id. {@code apiId} is required as a security
+     * defense: prevents cross-API existence probing (a known request id from API_B cannot be read
+     * via API_A). Permission is {@code API_LOG[READ]} on the given API; 404 collapse when the log
+     * doesn't exist OR the caller can't access that API.
+     */
+    @GET
+    @Path("/{requestId}")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response getLogDetail(@PathParam("requestId") String requestId, @QueryParam("apiId") String apiId) {
+        requireParam("apiId", apiId);
+        checkApiLogReadPermissionOrCollapse(apiId, requestId);
+
+        var ctx = GraviteeContext.getExecutionContext();
+        var output = getLogDetailUseCase.execute(
+            new GetObservabilityLogDetailUseCase.Input(ctx.getOrganizationId(), ctx.getEnvironmentId(), apiId, requestId)
+        );
+        return output
+            .detail()
+            .map(detail -> Response.ok(LogDetailDto.from(detail)).build())
+            .orElseThrow(() -> new LogDetailNotFoundException(requestId, apiId));
+    }
+
+    private static void requireParam(String name, String value) {
+        if (value == null || value.isBlank()) {
+            throw new MissingLogScopeException(name);
+        }
+    }
+
+    /**
+     * Checks {@code API_LOG[READ]} on the given API. Returns 404 (not 403) when denied, so the
+     * response is indistinguishable from "log doesn't exist" — prevents cross-API existence probing.
+     */
+    private void checkApiLogReadPermissionOrCollapse(String apiId, String requestId) {
+        ExecutionContext ctx = GraviteeContext.getExecutionContext();
+        boolean allowed = permissionService.hasPermission(ctx, RolePermission.API_LOG, apiId, RolePermissionAction.READ);
+        if (!allowed) {
+            throw new LogDetailNotFoundException(requestId, apiId);
+        }
     }
 
     private void checkReadObservabilityPermission() {

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/resources/observability/logs/dto/LogDetailDto.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/resources/observability/logs/dto/LogDetailDto.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gamma.rest.resources.observability.logs.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.gravitee.gamma.rest.core.observability.logs.model.HttpPayload;
+import io.gravitee.gamma.rest.core.observability.logs.model.LogDetail;
+import io.gravitee.gamma.rest.core.observability.logs.model.LogEntryWarning;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Wire shape for the merged log detail returned by {@code GET /observability/logs/{requestId}}.
+ * Null fields are omitted to keep the payload lean.
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record LogDetailDto(
+    String requestId,
+    String apiId,
+    String transactionId,
+    String clientIdentifier,
+    Instant timestamp,
+    Boolean requestEnded,
+    String method,
+    String uri,
+    Integer status,
+    String endpoint,
+    String host,
+    String planId,
+    String planName,
+    String applicationId,
+    String applicationName,
+    String gateway,
+    String gatewayHostname,
+    String gatewayIp,
+    String remoteAddress,
+    Long requestContentLength,
+    Long responseContentLength,
+    Long gatewayLatency,
+    Long gatewayResponseTime,
+    Long endpointResponseTime,
+    String message,
+    String errorKey,
+    String errorComponentName,
+    String errorComponentType,
+    List<LogEntryDto.WarningDto> warnings,
+    Map<String, Object> additionalMetrics,
+    HttpPayloadDto entrypointRequest,
+    HttpPayloadDto entrypointResponse,
+    HttpPayloadDto endpointRequest,
+    HttpPayloadDto endpointResponse
+) {
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public record HttpPayloadDto(String method, String uri, Integer status, Map<String, List<String>> headers, String body) {
+        public static HttpPayloadDto from(HttpPayload payload) {
+            if (payload == null) {
+                return null;
+            }
+            return new HttpPayloadDto(payload.method(), payload.uri(), payload.status(), payload.headers(), payload.body());
+        }
+    }
+
+    public static LogDetailDto from(LogDetail detail) {
+        return new LogDetailDto(
+            detail.requestId(),
+            detail.apiId(),
+            detail.transactionId(),
+            detail.clientIdentifier(),
+            detail.timestamp(),
+            detail.requestEnded(),
+            detail.method(),
+            detail.uri(),
+            detail.status(),
+            detail.endpoint(),
+            detail.host(),
+            detail.planId(),
+            detail.planName(),
+            detail.applicationId(),
+            detail.applicationName(),
+            detail.gateway(),
+            detail.gatewayHostname(),
+            detail.gatewayIp(),
+            detail.remoteAddress(),
+            detail.requestContentLength(),
+            detail.responseContentLength(),
+            detail.gatewayLatency(),
+            detail.gatewayResponseTime(),
+            detail.endpointResponseTime(),
+            detail.message(),
+            detail.errorKey(),
+            detail.errorComponentName(),
+            detail.errorComponentType(),
+            detail.warnings() != null ? detail.warnings().stream().map(LogEntryDto.WarningDto::from).toList() : null,
+            detail.additionalMetrics(),
+            HttpPayloadDto.from(detail.entrypointRequest()),
+            HttpPayloadDto.from(detail.entrypointResponse()),
+            HttpPayloadDto.from(detail.endpointRequest()),
+            HttpPayloadDto.from(detail.endpointResponse())
+        );
+    }
+}

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/resources/openapi/observability/openapi-observability.yaml
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/resources/openapi/observability/openapi-observability.yaml
@@ -353,6 +353,125 @@ paths:
                                 httpStatus: 403
                                 message: "Insufficient permissions to access observability metadata."
 
+    /organizations/{orgId}/environments/{envId}/observability/logs/{requestId}:
+        parameters:
+            - $ref: "#/components/parameters/orgIdParam"
+            - $ref: "#/components/parameters/envIdParam"
+        get:
+            tags:
+                - Logs
+            summary: Get a single merged log detail
+            description: |
+                Returns a single complete connection log by request id, merging enriched metadata
+                from the `v4-metrics` index with HTTP payloads (headers + body) from the `v4-log`
+                index. This is the heavy, lazy companion of the search endpoint — intended to be
+                called when a user clicks a row in the logs table.
+
+                **`apiId` is required** as a security defense: a known request id from API_B cannot
+                be read via API_A. The server verifies `API_LOG[READ]` on the given API and returns
+                404 (collapsed) when the log doesn't exist OR the caller can't access that API —
+                so cross-API existence cannot be probed.
+
+                **No search time-window needed** — the detail is resolved by request id alone.
+
+                **Enrichment**: plan name, application name, gateway hostname and IP are resolved
+                server-side.
+            operationId: getObservabilityLogDetail
+            parameters:
+                - name: requestId
+                  in: path
+                  required: true
+                  description: Unique identifier of the gateway request.
+                  example: req-abc-123
+                  schema:
+                      type: string
+                - name: apiId
+                  in: query
+                  required: true
+                  description: |
+                      API identifier scoping the request. Required as a security defense — prevents
+                      cross-API existence probing and enables Elasticsearch routing.
+                  example: 67e246cb-ab02-4da4-8f47-f9fa3e061d6b
+                  schema:
+                      type: string
+            responses:
+                "200":
+                    description: The full merged log detail.
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/LogDetail"
+                            examples:
+                                full-detail:
+                                    summary: Complete log detail with metadata and payloads
+                                    value:
+                                        requestId: "req-abc-123"
+                                        apiId: "67e246cb-ab02-4da4-8f47-f9fa3e061d6b"
+                                        transactionId: "txn-xyz-789"
+                                        timestamp: "2026-06-10T14:32:01Z"
+                                        requestEnded: true
+                                        method: "GET"
+                                        uri: "/pets/42"
+                                        status: 200
+                                        endpoint: "https://backend.example.com/pets/42"
+                                        host: "api.example.com"
+                                        planId: "plan-001"
+                                        planName: "Gold"
+                                        applicationId: "app-001"
+                                        applicationName: "Mobile App"
+                                        gateway: "gw-eu-1"
+                                        gatewayHostname: "gateway-eu-west-1.example.com"
+                                        gatewayIp: "10.0.1.42"
+                                        remoteAddress: "203.0.113.42"
+                                        requestContentLength: 0
+                                        responseContentLength: 256
+                                        gatewayLatency: 3
+                                        gatewayResponseTime: 12
+                                        endpointResponseTime: 9
+                                        entrypointRequest:
+                                            method: "GET"
+                                            uri: "/pets/42"
+                                            headers:
+                                                Accept: ["application/json"]
+                                                X-Gravitee-Transaction-Id: ["txn-xyz-789"]
+                                        entrypointResponse:
+                                            status: 200
+                                            headers:
+                                                Content-Type: ["application/json"]
+                                            body: '{"id": 42, "name": "Fido"}'
+                                        endpointRequest:
+                                            method: "GET"
+                                            uri: "https://backend.example.com/pets/42"
+                                            headers:
+                                                Accept: ["application/json"]
+                                        endpointResponse:
+                                            status: 200
+                                            headers:
+                                                Content-Type: ["application/json"]
+                                            body: '{"id": 42, "name": "Fido"}'
+                "400":
+                    description: Missing or blank `apiId` query parameter.
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/Error"
+                            example:
+                                httpStatus: 400
+                                message: "Required scope dimension 'apiId' is missing"
+                                technicalCode: "observability.log.scope.missing"
+                "404":
+                    description: |
+                        The log does not exist for the given request id and API scope, OR the caller
+                        does not have `API_LOG[READ]` permission on the API. Both cases return 404
+                        to prevent cross-API existence probing.
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/Error"
+                            example:
+                                httpStatus: 404
+                                message: "Log req-abc-123 not found for API 67e246cb-ab02-4da4-8f47-f9fa3e061d6b"
+
     /organizations/{orgId}/environments/{envId}/observability/logs/search:
         parameters:
             - $ref: "#/components/parameters/orgIdParam"
@@ -869,6 +988,168 @@ components:
                           items:
                               type: string
                     example: "200"
+
+        LogDetail:
+            type: object
+            description: |
+                Full merged log detail combining enriched metadata from the `v4-metrics` index
+                and HTTP payloads (headers + body) from the `v4-log` index. Returned by
+                `GET /observability/logs/{requestId}?apiId=`.
+            properties:
+                requestId:
+                    type: string
+                    description: Unique identifier of the gateway request.
+                    example: "req-abc-123"
+                apiId:
+                    type: string
+                    description: Identifier of the API that handled the request.
+                    example: "67e246cb-ab02-4da4-8f47-f9fa3e061d6b"
+                transactionId:
+                    type: string
+                    description: Correlation id shared across chained requests.
+                    example: "txn-xyz-789"
+                clientIdentifier:
+                    type: string
+                    description: Client identifier extracted by the gateway.
+                timestamp:
+                    type: string
+                    format: date-time
+                    description: ISO-8601 instant the request was received.
+                    example: "2026-06-10T14:32:01Z"
+                requestEnded:
+                    type: boolean
+                    description: Whether the full request/response cycle completed.
+                method:
+                    type: string
+                    description: HTTP method of the client request.
+                    example: "GET"
+                uri:
+                    type: string
+                    description: Request URI path.
+                    example: "/pets/42"
+                status:
+                    type: integer
+                    description: HTTP status code returned to the client.
+                    example: 200
+                endpoint:
+                    type: string
+                    description: Backend endpoint the request was proxied to.
+                host:
+                    type: string
+                    description: Host header value from the client request.
+                planId:
+                    type: string
+                    description: Identifier of the plan the request was matched to.
+                planName:
+                    type: string
+                    description: Display name of the plan (enriched server-side).
+                    example: "Gold"
+                applicationId:
+                    type: string
+                    description: Identifier of the consuming application.
+                applicationName:
+                    type: string
+                    description: Display name of the application (enriched server-side).
+                    example: "Mobile App"
+                gateway:
+                    type: string
+                    description: Identifier of the gateway instance.
+                gatewayHostname:
+                    type: string
+                    description: Hostname of the gateway instance (enriched server-side).
+                    example: "gateway-eu-west-1.example.com"
+                gatewayIp:
+                    type: string
+                    description: IP address of the gateway instance (enriched server-side).
+                    example: "10.0.1.42"
+                remoteAddress:
+                    type: string
+                    description: IP address of the client.
+                    example: "203.0.113.42"
+                requestContentLength:
+                    type: integer
+                    format: int64
+                    description: Content length of the client request body in bytes.
+                responseContentLength:
+                    type: integer
+                    format: int64
+                    description: Content length of the response body in bytes.
+                gatewayLatency:
+                    type: integer
+                    format: int64
+                    description: Gateway processing latency in milliseconds (excluding backend time).
+                gatewayResponseTime:
+                    type: integer
+                    format: int64
+                    description: Total response time measured by the gateway in milliseconds.
+                    example: 12
+                endpointResponseTime:
+                    type: integer
+                    format: int64
+                    description: Backend response time in milliseconds.
+                    example: 9
+                message:
+                    type: string
+                    description: Error or diagnostic message.
+                errorKey:
+                    type: string
+                    description: Machine-readable error key.
+                errorComponentName:
+                    type: string
+                    description: Name of the component that produced the error.
+                errorComponentType:
+                    type: string
+                    description: Type of the component that produced the error.
+                warnings:
+                    type: array
+                    items:
+                        $ref: "#/components/schemas/LogEntryWarning"
+                additionalMetrics:
+                    type: object
+                    description: Extra metrics attached by plugins or custom policies.
+                    additionalProperties: true
+                entrypointRequest:
+                    $ref: "#/components/schemas/HttpPayload"
+                entrypointResponse:
+                    $ref: "#/components/schemas/HttpPayload"
+                endpointRequest:
+                    $ref: "#/components/schemas/HttpPayload"
+                endpointResponse:
+                    $ref: "#/components/schemas/HttpPayload"
+
+        HttpPayload:
+            type: object
+            description: |
+                HTTP request or response content from the `v4-log` index. Request payloads carry
+                `method` and `uri`; response payloads carry `status`. All fields are nullable —
+                only the fields relevant to the payload direction are populated.
+            properties:
+                method:
+                    type: string
+                    description: HTTP method (present on request payloads).
+                    example: "GET"
+                uri:
+                    type: string
+                    description: Request URI (present on request payloads).
+                    example: "/pets/42"
+                status:
+                    type: integer
+                    description: HTTP status code (present on response payloads).
+                    example: 200
+                headers:
+                    type: object
+                    description: HTTP headers as a map of header name to list of values.
+                    additionalProperties:
+                        type: array
+                        items:
+                            type: string
+                    example:
+                        Content-Type: ["application/json"]
+                        Accept: ["application/json"]
+                body:
+                    type: string
+                    description: HTTP body content.
+                    example: '{"id": 42, "name": "Fido"}'
 
         LogEntry:
             type: object

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/test/java/io/gravitee/gamma/rest/core/observability/logs/use_case/GetObservabilityLogDetailUseCaseTest.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/test/java/io/gravitee/gamma/rest/core/observability/logs/use_case/GetObservabilityLogDetailUseCaseTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gamma.rest.core.observability.logs.use_case;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.gamma.rest.core.observability.logs.model.HttpPayload;
+import io.gravitee.gamma.rest.core.observability.logs.model.LogDetail;
+import io.gravitee.gamma.rest.core.observability.logs.port.service_provider.ObservabilityLogsDataPort;
+import java.time.Instant;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class GetObservabilityLogDetailUseCaseTest {
+
+    private static final String ORG_ID = "org-1";
+    private static final String ENV_ID = "env-1";
+    private static final String API_ID = "api-1";
+    private static final String REQUEST_ID = "req-123";
+
+    @Mock
+    private ObservabilityLogsDataPort logsDataPort;
+
+    @InjectMocks
+    private GetObservabilityLogDetailUseCase useCase;
+
+    @Test
+    void should_return_detail_when_found() {
+        // Given
+        var detail = LogDetail.builder()
+            .requestId(REQUEST_ID)
+            .apiId(API_ID)
+            .timestamp(Instant.parse("2026-06-10T14:32:01Z"))
+            .status(200)
+            .method("GET")
+            .uri("/pets/42")
+            .planName("Gold")
+            .entrypointRequest(HttpPayload.builder().method("GET").uri("/pets/42").build())
+            .build();
+        when(logsDataPort.getLogDetail(ORG_ID, ENV_ID, API_ID, REQUEST_ID)).thenReturn(Optional.of(detail));
+
+        // When
+        var output = useCase.execute(new GetObservabilityLogDetailUseCase.Input(ORG_ID, ENV_ID, API_ID, REQUEST_ID));
+
+        // Then
+        assertThat(output.detail()).isPresent();
+        assertThat(output.detail().get().requestId()).isEqualTo(REQUEST_ID);
+        assertThat(output.detail().get().status()).isEqualTo(200);
+        assertThat(output.detail().get().entrypointRequest().method()).isEqualTo("GET");
+        verify(logsDataPort).getLogDetail(ORG_ID, ENV_ID, API_ID, REQUEST_ID);
+    }
+
+    @Test
+    void should_return_empty_when_not_found() {
+        // Given
+        when(logsDataPort.getLogDetail(ORG_ID, ENV_ID, API_ID, REQUEST_ID)).thenReturn(Optional.empty());
+
+        // When
+        var output = useCase.execute(new GetObservabilityLogDetailUseCase.Input(ORG_ID, ENV_ID, API_ID, REQUEST_ID));
+
+        // Then
+        assertThat(output.detail()).isEmpty();
+    }
+}

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/test/java/io/gravitee/gamma/rest/infra/adapter/ObservabilityLogsDataPortAdapterTest.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/test/java/io/gravitee/gamma/rest/infra/adapter/ObservabilityLogsDataPortAdapterTest.java
@@ -22,6 +22,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
+import io.gravitee.apim.core.analytics.query_service.AnalyticsQueryService;
 import io.gravitee.apim.core.api_product.query_service.ApiProductQueryService;
 import io.gravitee.apim.core.application.crud_service.ApplicationCrudService;
 import io.gravitee.apim.core.exception.ValidationDomainException;
@@ -62,6 +63,9 @@ class ObservabilityLogsDataPortAdapterTest {
     private ConnectionLogsCrudService connectionLogsCrudService;
 
     @Mock
+    private AnalyticsQueryService analyticsQueryService;
+
+    @Mock
     private UserContextLoader userContextLoader;
 
     @Mock
@@ -82,6 +86,7 @@ class ObservabilityLogsDataPortAdapterTest {
     void setUp() {
         adapter = new ObservabilityLogsDataPortAdapter(
             connectionLogsCrudService,
+            analyticsQueryService,
             userContextLoader,
             planCrudService,
             applicationCrudService,

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/test/java/io/gravitee/gamma/rest/resource/observability/logs/LogsResourceTest.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/test/java/io/gravitee/gamma/rest/resource/observability/logs/LogsResourceTest.java
@@ -17,6 +17,7 @@ package io.gravitee.gamma.rest.resource.observability.logs;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.verify;
@@ -25,13 +26,18 @@ import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import io.gravitee.common.http.HttpStatusCode;
+import io.gravitee.gamma.rest.core.observability.logs.model.HttpPayload;
+import io.gravitee.gamma.rest.core.observability.logs.model.LogDetail;
 import io.gravitee.gamma.rest.core.observability.logs.model.LogEntry;
 import io.gravitee.gamma.rest.core.observability.logs.model.LogsPage;
+import io.gravitee.gamma.rest.core.observability.logs.use_case.GetObservabilityLogDetailUseCase;
 import io.gravitee.gamma.rest.core.observability.logs.use_case.SearchObservabilityLogsUseCase;
 import io.gravitee.gamma.rest.resource.AbstractResourceTest;
 import io.gravitee.gamma.rest.resource.observability.logs.LogsResourceTest.LogsTestConfiguration;
 import io.gravitee.gamma.rest.spring.ResourceContextConfiguration;
 import io.gravitee.rest.api.model.EnvironmentEntity;
+import io.gravitee.rest.api.model.permissions.RolePermission;
+import io.gravitee.rest.api.model.permissions.RolePermissionAction;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.client.Entity;
 import jakarta.ws.rs.core.MediaType;
@@ -39,6 +45,7 @@ import jakarta.ws.rs.core.Response;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
@@ -57,6 +64,9 @@ class LogsResourceTest extends AbstractResourceTest {
     @Inject
     private SearchObservabilityLogsUseCase searchLogsUseCase;
 
+    @Inject
+    private GetObservabilityLogDetailUseCase getLogDetailUseCase;
+
     @Override
     protected String contextPath() {
         return "/organizations/" + ORGANIZATION + "/environments/" + ENVIRONMENT + "/observability/logs";
@@ -72,7 +82,7 @@ class LogsResourceTest extends AbstractResourceTest {
 
     @AfterEach
     void resetUseCases() {
-        reset(searchLogsUseCase);
+        reset(searchLogsUseCase, getLogDetailUseCase);
     }
 
     @Nested
@@ -163,12 +173,98 @@ class LogsResourceTest extends AbstractResourceTest {
         }
     }
 
+    @Nested
+    class GetLogDetail {
+
+        private static final String API_ID = "api-1";
+        private static final String REQUEST_ID = "req-123";
+
+        @Test
+        void should_return_200_with_merged_detail() {
+            var detail = LogDetail.builder()
+                .requestId(REQUEST_ID)
+                .apiId(API_ID)
+                .transactionId("txn-1")
+                .timestamp(Instant.parse("2026-06-10T14:32:01Z"))
+                .status(200)
+                .method("GET")
+                .uri("/pets/42")
+                .planName("Gold")
+                .applicationName("Mobile App")
+                .gatewayHostname("gw-eu.example.com")
+                .gatewayResponseTime(12L)
+                .entrypointRequest(
+                    HttpPayload.builder().method("GET").uri("/pets/42").headers(Map.of("Accept", List.of("application/json"))).build()
+                )
+                .entrypointResponse(HttpPayload.builder().status(200).body("{\"id\":42}").build())
+                .build();
+            when(getLogDetailUseCase.execute(any())).thenReturn(new GetObservabilityLogDetailUseCase.Output(Optional.of(detail)));
+
+            Response response = rootTarget(REQUEST_ID).queryParam("apiId", API_ID).request().get();
+
+            assertThat(response.getStatus()).isEqualTo(HttpStatusCode.OK_200);
+            JsonNode body = response.readEntity(JsonNode.class);
+            assertThat(body.get("requestId").asText()).isEqualTo(REQUEST_ID);
+            assertThat(body.get("apiId").asText()).isEqualTo(API_ID);
+            assertThat(body.get("status").asInt()).isEqualTo(200);
+            assertThat(body.get("planName").asText()).isEqualTo("Gold");
+            assertThat(body.get("entrypointRequest").get("method").asText()).isEqualTo("GET");
+            assertThat(body.get("entrypointResponse").get("body").asText()).isEqualTo("{\"id\":42}");
+        }
+
+        @Test
+        void should_return_400_when_apiId_is_missing() {
+            Response response = rootTarget(REQUEST_ID).request().get();
+
+            assertThat(response.getStatus()).isEqualTo(HttpStatusCode.BAD_REQUEST_400);
+            verifyNoInteractions(getLogDetailUseCase);
+        }
+
+        @Test
+        void should_return_404_when_log_not_found() {
+            when(getLogDetailUseCase.execute(any())).thenReturn(new GetObservabilityLogDetailUseCase.Output(Optional.empty()));
+
+            Response response = rootTarget(REQUEST_ID).queryParam("apiId", API_ID).request().get();
+
+            assertThat(response.getStatus()).isEqualTo(HttpStatusCode.NOT_FOUND_404);
+        }
+
+        @Test
+        void should_return_404_when_caller_has_no_api_log_permission() {
+            when(permissionService.hasPermission(any(), eq(RolePermission.API_LOG), eq(API_ID), eq(RolePermissionAction.READ))).thenReturn(
+                false
+            );
+
+            Response response = rootTarget(REQUEST_ID).queryParam("apiId", API_ID).request().get();
+
+            assertThat(response.getStatus()).isEqualTo(HttpStatusCode.NOT_FOUND_404);
+            verifyNoInteractions(getLogDetailUseCase);
+        }
+
+        @Test
+        void should_forward_apiId_and_requestId_to_use_case() {
+            when(getLogDetailUseCase.execute(any())).thenReturn(new GetObservabilityLogDetailUseCase.Output(Optional.empty()));
+
+            rootTarget(REQUEST_ID).queryParam("apiId", API_ID).request().get();
+
+            var captor = ArgumentCaptor.forClass(GetObservabilityLogDetailUseCase.Input.class);
+            verify(getLogDetailUseCase).execute(captor.capture());
+            assertThat(captor.getValue().apiId()).isEqualTo(API_ID);
+            assertThat(captor.getValue().requestId()).isEqualTo(REQUEST_ID);
+        }
+    }
+
     @Configuration
     static class LogsTestConfiguration {
 
         @Bean
         SearchObservabilityLogsUseCase searchObservabilityLogsUseCase() {
             return mock(SearchObservabilityLogsUseCase.class);
+        }
+
+        @Bean
+        GetObservabilityLogDetailUseCase getObservabilityLogDetailUseCase() {
+            return mock(GetObservabilityLogDetailUseCase.class);
         }
     }
 }


### PR DESCRIPTION
## Summary

Add a new Gamma endpoint `GET /observability/logs/{requestId}?apiId=` that merges enriched metadata from the `v4-metrics` index with HTTP payloads (headers + body) from the `v4-log` index into a single response. This allows the frontend to load the full log record in a single lazy call instead of the current dual-fetch workaround.

Closes [GMA-424](https://gravitee.atlassian.net/browse/GMA-424)

## Changes

- **Core layer**: new `LogDetail` and `HttpPayload` domain models, `GetObservabilityLogDetailUseCase`, `LogDetailNotFoundException` and `MissingLogScopeException` exceptions
- **Port**: added `getLogDetail` method to `ObservabilityLogsDataPort`
- **Infra**: implemented `getLogDetail` in `ObservabilityLogsDataPortAdapter` with plan/application/gateway name enrichment; updated `GammaLogsConfiguration` to inject `AnalyticsQueryService`
- **REST**: `GET /{requestId}?apiId=` endpoint on `LogsResource` with `API_LOG[READ]` permission check and 404 collapse (permission denied is indistinguishable from not found)
- **OpenAPI**: new endpoint definition + `LogDetail` and `HttpPayload` schemas
- **Tests**: use case unit tests, adapter constructor update, resource tests (200 merged detail, 400 missing apiId, 404 not found, 404 permission denied, input forwarding)

## Backend / API changes

| Endpoint | Method | Change | Request example | Response example |
|----------|--------|--------|-----------------|------------------|
| `/gamma/.../observability/logs/{requestId}` | `GET` | **New** — single merged log detail | `?apiId=67e246cb-...` | `{ "requestId": "req-123", "status": 200, "planName": "Gold", "entrypointRequest": { "method": "GET", ... } }` |

## Test plan

- [ ] `GET /observability/logs/{requestId}?apiId=<valid>` returns 200 with merged metadata + HTTP payloads
- [ ] `GET /observability/logs/{requestId}` (no apiId) returns 400
- [ ] `GET /observability/logs/{requestId}?apiId=<no-permission>` returns 404 (not 403)
- [ ] `GET /observability/logs/{requestId}?apiId=<valid>` with non-existent requestId returns 404
- [ ] Partial data: when v4-log is empty but v4-metrics exists, returns 200 with metadata only (payload fields omitted)
- [ ] Partial data: when v4-metrics is empty but v4-log exists, returns 200 with payloads only (metadata fields omitted)
- [ ] Enrichment: plan name, application name, gateway hostname/IP are resolved from their respective services

[GMA-424]: https://gravitee.atlassian.net/browse/GMA-424?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ