### PR TITLE
fix(cluster): correct Kafka multi-connection SASL/SSL displayIf path

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/resources/cluster/kafka-cluster-configuration-schema-form.json
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/resources/cluster/kafka-cluster-configuration-schema-form.json
@@ -266,7 +266,7 @@
       "gioConfig": {
         "displayIf": {
           "$eq": {
-            "../protocol": ["SASL_PLAINTEXT", "SASL_SSL"]
+            "./protocol": ["SASL_PLAINTEXT", "SASL_SSL"]
           }
         }
       }
@@ -304,7 +304,7 @@
               "gioConfig": {
                 "displayIf": {
                   "$eq": {
-                    "../protocol": ["SASL_SSL", "SSL"]
+                    "./protocol": ["SASL_SSL", "SSL"]
                   }
                 }
               }


### PR DESCRIPTION
## Problem

When creating or editing a **multi-connection Kafka cluster** (`KAFKA_CLUSTER`), the SASL and SSL configuration blocks never appear after selecting a `SASL_*` / `SSL` security protocol. The Standalone cluster type is unaffected.

## Cause

`kafka-cluster-configuration-schema-form.json` gates the SASL and SSL blocks on a `displayIf` keyed to `../protocol`. In the graphene JsonSchemaForm path syntax, `../X` pops one level from the hosting field's parent — so from a field under `connections.*.security`, `../protocol` resolves to `connections.*.protocol`. The actual field is the sibling `connections.*.security.protocol`, so the condition never matches and the blocks stay hidden.

## Fix

Use `./protocol` (the sibling of the conditional block) for both conditions. The standalone schema already uses the absolute `value.security.protocol` and is left untouched.

## Verification

Reproduced and verified against the real `@gravitee/graphene-core` renderer (Node + jsdom): with `../protocol`, setting `connections.0.security.protocol = SASL_SSL` left **SASL Configuration** / **SSL Options** hidden; with `./protocol` they appear on selection and hide for `PLAINTEXT`.
