### PR TITLE
feat: upgrade gravitee-policy-generate-http-signature version to 1.5.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -190,7 +190,7 @@
         <gravitee-policy-data-cache.version>2.0.0-alpha.2</gravitee-policy-data-cache.version>
         <gravitee-policy-data-logging-masking.version>3.1.2</gravitee-policy-data-logging-masking.version>
         <gravitee-policy-dynamic-routing.version>1.13.0</gravitee-policy-dynamic-routing.version>
-        <gravitee-policy-generate-http-signature.version>1.5.0</gravitee-policy-generate-http-signature.version>
+        <gravitee-policy-generate-http-signature.version>1.5.1</gravitee-policy-generate-http-signature.version>
         <gravitee-policy-generate-jwt.version>1.8.0</gravitee-policy-generate-jwt.version>
         <gravitee-policy-geoip-filtering.version>2.2.2</gravitee-policy-geoip-filtering.version>
         <gravitee-policy-groovy.version>4.3.2</gravitee-policy-groovy.version>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/EXT-40

## Description

Updating the policy version after fixing bugs.

