### PR TITLE
chore(4.12.x): bump gravitee-gamma-module-esm from 1.0.0-alpha.1 to 1.0.0-alpha.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -339,7 +339,7 @@
         <!-- Gamma plugins -->
         <gravitee-gamma-module-aim.version>1.0.0-alpha.153</gravitee-gamma-module-aim.version>
         <gravitee-gamma-module-authz.version>1.0.0-alpha.19</gravitee-gamma-module-authz.version>
-        <gravitee-gamma-module-esm.version>1.0.0-alpha.1</gravitee-gamma-module-esm.version>
+        <gravitee-gamma-module-esm.version>1.0.0-alpha.4</gravitee-gamma-module-esm.version>
 
         <!-- Authz plugins -->
         <gravitee-service-authz-pdp.version>1.0.0-alpha.5</gravitee-service-authz-pdp.version>


### PR DESCRIPTION
## Summary

Bumps **[gravitee-io/gravitee-gamma-module-esm](https://github.com/gravitee-io/gravitee-gamma-module-esm)** from `1.0.0-alpha.1` to `1.0.0-alpha.4` on branch `4.12.x`.

Labeled `apply-on-master` to forward-port to `master`.

## Changelog

See the [releases](https://github.com/gravitee-io/gravitee-gamma-module-esm/releases) page for details.

## Jira

[GMA-669](https://gravitee.atlassian.net/browse/GMA-669)

[GMA-669]: https://gravitee.atlassian.net/browse/GMA-669?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ