### PR TITLE
feat(observability): add analytics endpoints to Gamma surface

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/analytics/engine/api/query/Filter.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/analytics/engine/api/query/Filter.java
@@ -66,6 +66,7 @@ public record Filter(Filter.Name name, Operator operator, Object value) {
         EDGE_MODEL,
         EDGE_TOOL,
         NATIVE_CONNECTION_STATUS,
+        URI,
     }
 
     public enum Operator {

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/analytics/engine/api/query/Filter.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/analytics/engine/api/query/Filter.java
@@ -67,6 +67,7 @@ public record Filter(Filter.Name name, Operator operator, Object value) {
         EDGE_TOOL,
         NATIVE_CONNECTION_STATUS,
         URI,
+        ENTRYPOINT,
     }
 
     public enum Operator {

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/analytics/engine/adapter/FilterAdapter.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/analytics/engine/adapter/FilterAdapter.java
@@ -60,7 +60,8 @@ public class FilterAdapter {
         Filter.Name.MCP_PROXY_METHOD,
         Filter.Name.MCP_PROXY_TOOL,
         Filter.Name.MCP_PROXY_RESOURCE,
-        Filter.Name.MCP_PROXY_PROMPT
+        Filter.Name.MCP_PROXY_PROMPT,
+        Filter.Name.URI
     );
 
     static final List<Filter.Name> MESSAGE_FILTER_NAMES = List.of(

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/analytics/engine/adapter/FilterAdapter.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/analytics/engine/adapter/FilterAdapter.java
@@ -61,7 +61,8 @@ public class FilterAdapter {
         Filter.Name.MCP_PROXY_TOOL,
         Filter.Name.MCP_PROXY_RESOURCE,
         Filter.Name.MCP_PROXY_PROMPT,
-        Filter.Name.URI
+        Filter.Name.URI,
+        Filter.Name.ENTRYPOINT
     );
 
     static final List<Filter.Name> MESSAGE_FILTER_NAMES = List.of(
@@ -112,12 +113,19 @@ public class FilterAdapter {
 
     public JsonArray adaptForHTTP(Query query) {
         var jsonFilters = JsonArray.of(TimeRangeAdapter.adapt(query));
+        boolean hasEntrypointFilter = false;
         for (var filter : query.filters()) {
             if (shouldAdaptForHTTP(filter)) {
                 jsonFilters.add(filter(filter));
+                if (filter.name() == Filter.Name.ENTRYPOINT) {
+                    hasEntrypointFilter = true;
+                }
             }
         }
-        return jsonFilters.add(httpFilter());
+        if (!hasEntrypointFilter) {
+            jsonFilters.add(httpFilter());
+        }
+        return jsonFilters;
     }
 
     public JsonArray adaptForMessageConnexion(Query query) {

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/analytics/engine/adapter/HTTPFieldResolver.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/analytics/engine/adapter/HTTPFieldResolver.java
@@ -82,6 +82,7 @@ public class HTTPFieldResolver implements FieldResolver {
             case Filter.Name.EDGE_TOOL -> "additional-metrics.keyword_edge_tool";
             case Filter.Name.API_PRODUCT -> "api-product-id";
             case Filter.Name.URI -> "uri";
+            case Filter.Name.ENTRYPOINT -> "entrypoint-id";
             default -> throw new UnsupportedOperationException("not an HTTP filter");
         };
     }

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/analytics/engine/adapter/HTTPFieldResolver.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/analytics/engine/adapter/HTTPFieldResolver.java
@@ -81,6 +81,7 @@ public class HTTPFieldResolver implements FieldResolver {
             case Filter.Name.EDGE_MODEL -> "additional-metrics.keyword_edge_model";
             case Filter.Name.EDGE_TOOL -> "additional-metrics.keyword_edge_tool";
             case Filter.Name.API_PRODUCT -> "api-product-id";
+            case Filter.Name.URI -> "uri";
             default -> throw new UnsupportedOperationException("not an HTTP filter");
         };
     }

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/analytics/engine/adapter/FilterAdapterTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/analytics/engine/adapter/FilterAdapterTest.java
@@ -370,5 +370,53 @@ class FilterAdapterTest {
 
             assertThat(existsField).isEqualTo(ENTRYPOINT_FIELD);
         }
+
+        @Test
+        void should_skip_default_http_filter_when_entrypoint_filter_is_present() throws JsonProcessingException {
+            var entrypointValues = List.of("mcp-proxy");
+            var filters = List.of(new Filter(Filter.Name.ENTRYPOINT, Filter.Operator.IN, entrypointValues));
+            var metrics = List.of(new MetricMeasuresQuery(Metric.HTTP_REQUESTS, Set.of(Measure.COUNT)));
+            var query = new MeasuresQuery(buildTimeRange(), filters, metrics);
+
+            var queryString = new HTTPMeasuresQueryAdapter().adapt(query);
+            var jsonQuery = JSON.readTree(queryString);
+
+            var filterArray = jsonQuery.at("/query/bool/filter");
+            assertThat(filterArray.isArray()).isTrue();
+
+            var termsFilter = jsonQuery.at("/query/bool/filter/1/terms/entrypoint-id");
+            assertThat(termsFilter.isMissingNode()).isFalse();
+            assertThat(termsFilter.isArray()).isTrue();
+            assertThat(termsFilter.get(0).asText()).isEqualTo("mcp-proxy");
+
+            boolean hasHardcodedHttpFilter = false;
+            for (var node : filterArray) {
+                if (node.has("bool") && node.get("bool").has("should")) {
+                    hasHardcodedHttpFilter = true;
+                }
+            }
+            assertThat(hasHardcodedHttpFilter)
+                .as("Hardcoded httpFilter() should NOT be present when ENTRYPOINT filter is explicit")
+                .isFalse();
+        }
+
+        @Test
+        void should_add_default_http_filter_when_no_entrypoint_filter() throws JsonProcessingException {
+            var filters = List.of(new Filter(Filter.Name.API, Filter.Operator.EQ, API_ID));
+            var metrics = List.of(new MetricMeasuresQuery(Metric.HTTP_REQUESTS, Set.of(Measure.COUNT)));
+            var query = new MeasuresQuery(buildTimeRange(), filters, metrics);
+
+            var queryString = new HTTPMeasuresQueryAdapter().adapt(query);
+            var jsonQuery = JSON.readTree(queryString);
+
+            var filterArray = jsonQuery.at("/query/bool/filter");
+            boolean hasHttpFilter = false;
+            for (var node : filterArray) {
+                if (node.has("bool") && node.get("bool").has("should")) {
+                    hasHttpFilter = true;
+                }
+            }
+            assertThat(hasHttpFilter).as("Default httpFilter() should be present when no ENTRYPOINT filter is provided").isTrue();
+        }
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-analytics.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-analytics.yaml
@@ -1443,6 +1443,8 @@ components:
                 - EDGE_MODEL
                 - EDGE_TOOL
                 - NATIVE_CONNECTION_STATUS
+                - URI
+                - ENTRYPOINT
             description: Available filter names for filtering analytics data
 
         Operator:

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/analytics_engine/model/FilterSpec.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/analytics_engine/model/FilterSpec.java
@@ -76,5 +76,6 @@ public record FilterSpec(
         EDGE_TOOL,
         API_TYPE,
         NATIVE_CONNECTION_STATUS,
+        URI,
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/analytics_engine/model/FilterSpec.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/analytics_engine/model/FilterSpec.java
@@ -77,5 +77,6 @@ public record FilterSpec(
         API_TYPE,
         NATIVE_CONNECTION_STATUS,
         URI,
+        ENTRYPOINT,
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/analytics_engine/processors/BucketNamesPostProcessorImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/analytics_engine/processors/BucketNamesPostProcessorImpl.java
@@ -19,6 +19,7 @@ import io.gravitee.apim.core.analytics_engine.domain_service.BucketNamesPostProc
 import io.gravitee.apim.core.analytics_engine.model.*;
 import io.gravitee.apim.core.api.model.Api;
 import io.gravitee.apim.infra.domain_service.analytics_engine.mapper.ApiMapper;
+import io.gravitee.common.http.HttpMethod;
 import io.gravitee.repository.analytics.engine.api.query.HttpStatusCodeGroups;
 import io.gravitee.repository.management.api.ApiRepository;
 import io.gravitee.repository.management.api.search.ApiCriteria;
@@ -43,6 +44,47 @@ public class BucketNamesPostProcessorImpl implements BucketNamesPostProcessor {
     private static final String UNKNOWN_APPLICATION = "Unknown";
 
     private static final Map<String, String> STATUS_CODE_GROUP_FROM_ES_KEY = HttpStatusCodeGroups.esBucketKeyToGroupLabel();
+
+    private static final Map<String, String> HTTP_METHOD_BY_CODE = buildHttpMethodCodeMap();
+
+    private static final Map<String, String> HTTP_STATUS_LABELS = Map.ofEntries(
+        Map.entry("100", "100 Continue"),
+        Map.entry("101", "101 Switching Protocols"),
+        Map.entry("200", "200 OK"),
+        Map.entry("201", "201 Created"),
+        Map.entry("202", "202 Accepted"),
+        Map.entry("204", "204 No Content"),
+        Map.entry("301", "301 Moved Permanently"),
+        Map.entry("302", "302 Found"),
+        Map.entry("304", "304 Not Modified"),
+        Map.entry("307", "307 Temporary Redirect"),
+        Map.entry("308", "308 Permanent Redirect"),
+        Map.entry("400", "400 Bad Request"),
+        Map.entry("401", "401 Unauthorized"),
+        Map.entry("403", "403 Forbidden"),
+        Map.entry("404", "404 Not Found"),
+        Map.entry("405", "405 Method Not Allowed"),
+        Map.entry("408", "408 Request Timeout"),
+        Map.entry("409", "409 Conflict"),
+        Map.entry("413", "413 Payload Too Large"),
+        Map.entry("415", "415 Unsupported Media Type"),
+        Map.entry("422", "422 Unprocessable Entity"),
+        Map.entry("429", "429 Too Many Requests"),
+        Map.entry("500", "500 Internal Server Error"),
+        Map.entry("501", "501 Not Implemented"),
+        Map.entry("502", "502 Bad Gateway"),
+        Map.entry("503", "503 Service Unavailable"),
+        Map.entry("504", "504 Gateway Timeout")
+    );
+
+    private static Map<String, String> buildHttpMethodCodeMap() {
+        var methods = HttpMethod.values();
+        var map = new java.util.HashMap<String, String>(methods.length);
+        for (var m : methods) {
+            map.put(String.valueOf(m.code()), m.name());
+        }
+        return Map.copyOf(map);
+    }
 
     private final ApiRepository apiRepository;
     private final ApplicationService applicationSearchService;
@@ -109,6 +151,8 @@ public class BucketNamesPostProcessorImpl implements BucketNamesPostProcessor {
     FacetBucketResponse mapFacetBucket(AnalyticsQueryContext context, List<FacetSpec.Name> facets, FacetBucketResponse bucket) {
         var bucketName = switch (facets.getFirst()) {
             case FacetSpec.Name.HTTP_STATUS_CODE_GROUP -> STATUS_CODE_GROUP_FROM_ES_KEY.getOrDefault(bucket.key(), bucket.key());
+            case FacetSpec.Name.HTTP_METHOD -> HTTP_METHOD_BY_CODE.getOrDefault(bucket.key(), bucket.key());
+            case FacetSpec.Name.HTTP_STATUS -> HTTP_STATUS_LABELS.getOrDefault(bucket.key(), bucket.key());
             case FacetSpec.Name.API -> {
                 var name = context.apiNamesById().get(bucket.key());
                 yield name != null ? name : bucket.key();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/query_service/analytics_engine/FilterValuesQueryServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/query_service/analytics_engine/FilterValuesQueryServiceImpl.java
@@ -112,6 +112,7 @@ public class FilterValuesQueryServiceImpl implements FilterValuesQueryService {
             case MCP_PROXY_RESOURCE -> "additional-metrics.keyword_mcp-proxy_resources/read";
             case MCP_PROXY_PROMPT -> "additional-metrics.keyword_mcp-proxy_prompts/get";
             case API_PRODUCT -> "api-product-id";
+            case URI -> "uri";
             default -> throw new UnsupportedOperationException("No ES field mapping for filter: " + filterName);
         };
     }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/analytics_engine/processors/BucketNamesProcessorTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/analytics_engine/processors/BucketNamesProcessorTest.java
@@ -234,7 +234,7 @@ class BucketNamesProcessorTest {
         }
 
         @Test
-        void should_update_api_and_unmappable_facets() {
+        void should_update_application_and_http_status_facets() {
             var innerBucket1 = newUnnamedBucketResponse("200");
             var innerBucket2 = newUnnamedBucketResponse("204");
             var facetBucketResponse = newUnnamedBucketResponse(APPLICATION_ID1, List.of(innerBucket1, innerBucket2));
@@ -243,11 +243,26 @@ class BucketNamesProcessorTest {
 
             var mappedResponse = processor.mapBucketNames(context, List.of(APPLICATION, HTTP_STATUS), response);
 
-            var innerNamedBucket1 = getBucketResponseWithDefaultName(innerBucket1);
-            var innerNamedBucket2 = getBucketResponseWithDefaultName(innerBucket2);
+            var innerNamedBucket1 = new FacetBucketResponse("200", "200 OK", null, innerBucket1.measures());
+            var innerNamedBucket2 = new FacetBucketResponse("204", "204 No Content", null, innerBucket2.measures());
             var expectedResponse = facetsResponse(
                 getNamedApplicationBucketResponse(facetBucketResponse, List.of(innerNamedBucket1, innerNamedBucket2))
             );
+
+            assertThat(mappedResponse).isEqualTo(expectedResponse);
+        }
+
+        @Test
+        void should_map_http_method_codes_to_names() {
+            var bucket1 = newUnnamedBucketResponse("3");
+            var bucket2 = newUnnamedBucketResponse("7");
+            var response = facetsResponse(bucket1, bucket2);
+
+            var mappedResponse = processor.mapBucketNames(context, List.of(HTTP_METHOD), response);
+
+            var expected1 = new FacetBucketResponse("3", "GET", null, bucket1.measures());
+            var expected2 = new FacetBucketResponse("7", "POST", null, bucket2.measures());
+            var expectedResponse = facetsResponse(expected1, expected2);
 
             assertThat(mappedResponse).isEqualTo(expectedResponse);
         }
@@ -461,7 +476,7 @@ class BucketNamesProcessorTest {
         }
 
         @Test
-        void should_update_api_and_unmappable_facets() {
+        void should_update_application_and_http_status_facets() {
             var innerBucket1 = newUnnamedBucketResponse("200");
             var innerBucket2 = newUnnamedBucketResponse("204");
             var facetBucketResponse = newUnnamedBucketResponse(APPLICATION_ID1, List.of(innerBucket1, innerBucket2));
@@ -470,8 +485,8 @@ class BucketNamesProcessorTest {
 
             var mappedResponse = processor.mapBucketNames(context, List.of(APPLICATION, HTTP_STATUS), response);
 
-            var innerNamedBucket1 = getBucketResponseWithDefaultName(innerBucket1);
-            var innerNamedBucket2 = getBucketResponseWithDefaultName(innerBucket2);
+            var innerNamedBucket1 = new FacetBucketResponse("200", "200 OK", null, innerBucket1.measures());
+            var innerNamedBucket2 = new FacetBucketResponse("204", "204 No Content", null, innerBucket2.measures());
             var expectedResponse = timeSeriesResponse(
                 FIXED_TIME_KEY,
                 FIXED_TIMESTAMP,

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-container/src/main/java/io/gravitee/rest/api/standalone/spring/StandaloneConfiguration.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-standalone/gravitee-apim-rest-api-standalone-container/src/main/java/io/gravitee/rest/api/standalone/spring/StandaloneConfiguration.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.rest.api.standalone.spring;
 
+import io.gravitee.gamma.rest.infra.config.GammaAnalyticsConfiguration;
 import io.gravitee.gamma.rest.infra.config.GammaLogsConfiguration;
 import io.gravitee.gamma.rest.infra.config.GammaObservabilityFilterConfiguration;
 import io.gravitee.gamma.rest.infra.config.GammaTracingConfiguration;
@@ -49,6 +50,7 @@ import org.springframework.context.annotation.Import;
         GammaTracingConfiguration.class,
         GammaObservabilityFilterConfiguration.class,
         GammaLogsConfiguration.class,
+        GammaAnalyticsConfiguration.class,
     }
 )
 public class StandaloneConfiguration {

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/GammaModuleApplication.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/GammaModuleApplication.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.core.util.JacksonFeature;
 import io.gravitee.gamma.rest.resources.GammaRootResource;
 import io.gravitee.gamma.rest.resources.GammaUIResource;
 import io.gravitee.gamma.rest.resources.OpenAPIResource;
+import io.gravitee.gamma.rest.resources.observability.analytics.AnalyticsResource;
 import io.gravitee.gamma.rest.resources.observability.filters.ObservabilityFiltersResource;
 import io.gravitee.gamma.rest.resources.observability.logs.LogsResource;
 import io.gravitee.gamma.rest.resources.tracing.TracingResource;
@@ -60,6 +61,7 @@ public class GammaModuleApplication extends ResourceConfig {
         register(TracingResource.class);
         register(ObservabilityFiltersResource.class);
         register(LogsResource.class);
+        register(AnalyticsResource.class);
 
         register(MultiPartFeature.class);
         register(PayloadInputBodyReader.class);

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/analytics/model/AnalyticsFacetMetricQuery.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/analytics/model/AnalyticsFacetMetricQuery.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gamma.rest.core.observability.analytics.model;
+
+import java.util.List;
+
+/**
+ * Framework-independent metric spec for the facets and time-series endpoints. Carries optional
+ * sorting directives in addition to the aggregation functions.
+ *
+ * @param metricName  Metric identifier (e.g. "HTTP_REQUESTS").
+ * @param measures    Aggregation functions to compute (e.g. "COUNT", "AVG").
+ * @param sorts       Optional sort directives applied to facet buckets.
+ */
+public record AnalyticsFacetMetricQuery(String metricName, List<String> measures, List<AnalyticsSortSpec> sorts) {}

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/analytics/model/AnalyticsMetricQuery.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/analytics/model/AnalyticsMetricQuery.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gamma.rest.core.observability.analytics.model;
+
+import java.util.List;
+
+/**
+ * Framework-independent metric spec for the measures endpoint. String-typed so the core layer
+ * stays free from analytics-engine enums — the adapter translates names at the boundary.
+ *
+ * @param metricName  Metric identifier (e.g. "HTTP_REQUESTS", "LLM_PROMPT_TOKEN_SENT").
+ * @param measures    Aggregation functions to compute (e.g. "COUNT", "AVG", "P99").
+ */
+public record AnalyticsMetricQuery(String metricName, List<String> measures) {}

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/analytics/model/AnalyticsNumberRange.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/analytics/model/AnalyticsNumberRange.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gamma.rest.core.observability.analytics.model;
+
+/**
+ * A numeric range for facet/time-series bucketing.
+ *
+ * @param from Lower bound (inclusive).
+ * @param to   Upper bound (exclusive).
+ */
+public record AnalyticsNumberRange(Number from, Number to) {}

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/analytics/model/AnalyticsSortSpec.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/analytics/model/AnalyticsSortSpec.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gamma.rest.core.observability.analytics.model;
+
+/**
+ * Sort directive for a facet metric query.
+ *
+ * @param measure Aggregation function name used as the sort key (e.g. "COUNT").
+ * @param order   Sort direction ("ASC" or "DESC").
+ */
+public record AnalyticsSortSpec(String measure, String order) {}

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/analytics/port/service_provider/ObservabilityAnalyticsDataPort.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/analytics/port/service_provider/ObservabilityAnalyticsDataPort.java
@@ -70,4 +70,8 @@ public interface ObservabilityAnalyticsDataPort {
         List<AnalyticsFacetMetricQuery> metrics,
         List<AnalyticsNumberRange> ranges
     ) {}
+
+    JsonNode emptyMeasuresResponse();
+    JsonNode emptyFacetsResponse();
+    JsonNode emptyTimeSeriesResponse();
 }

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/analytics/port/service_provider/ObservabilityAnalyticsDataPort.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/analytics/port/service_provider/ObservabilityAnalyticsDataPort.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gamma.rest.core.observability.analytics.port.service_provider;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.gravitee.gamma.rest.core.observability.analytics.model.AnalyticsFacetMetricQuery;
+import io.gravitee.gamma.rest.core.observability.analytics.model.AnalyticsMetricQuery;
+import io.gravitee.gamma.rest.core.observability.analytics.model.AnalyticsNumberRange;
+import io.gravitee.gamma.rest.core.observability.analytics.use_case.AnalyticsRequestPipeline;
+import io.gravitee.gamma.rest.core.observability.logs.port.service_provider.ObservabilityLogsDataPort.AccessibleApi;
+import java.util.List;
+
+/**
+ * Core-side port onto the analytics computation engine. Uses only Gamma-native types so the core
+ * layer stays independent of the APIM analytics-engine model. The infra adapter handles all
+ * translation to the platform compute use cases.
+ *
+ * <p>Responses are returned as {@link JsonNode} so the rich, nested APIM response hierarchy flows
+ * through without requiring duplicate records in the Gamma core. Jackson serializes the node tree
+ * directly to the HTTP response body.
+ *
+ * @author GraviteeSource Team
+ */
+public interface ObservabilityAnalyticsDataPort {
+    List<AccessibleApi> loadAccessibleApis(String organizationId, String environmentId);
+
+    JsonNode computeMeasures(MeasuresQuery query);
+
+    record MeasuresQuery(
+        String organizationId,
+        String environmentId,
+        AnalyticsRequestPipeline.PreparedScope scope,
+        List<AnalyticsMetricQuery> metrics
+    ) {}
+
+    JsonNode computeFacets(FacetsQuery query);
+
+    record FacetsQuery(
+        String organizationId,
+        String environmentId,
+        AnalyticsRequestPipeline.PreparedScope scope,
+        List<String> facets,
+        Integer limit,
+        List<AnalyticsFacetMetricQuery> metrics,
+        List<AnalyticsNumberRange> ranges
+    ) {}
+
+    JsonNode computeTimeSeries(TimeSeriesQuery query);
+
+    record TimeSeriesQuery(
+        String organizationId,
+        String environmentId,
+        AnalyticsRequestPipeline.PreparedScope scope,
+        Long interval,
+        List<String> facets,
+        Integer facetSize,
+        List<AnalyticsFacetMetricQuery> metrics,
+        List<AnalyticsNumberRange> ranges
+    ) {}
+}

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/analytics/use_case/AnalyticsRequestPipeline.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/analytics/use_case/AnalyticsRequestPipeline.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gamma.rest.core.observability.analytics.use_case;
+
+import io.gravitee.apim.core.DomainService;
+import io.gravitee.apim.core.exception.ValidationDomainException;
+import io.gravitee.gamma.rest.core.observability.analytics.port.service_provider.ObservabilityAnalyticsDataPort;
+import io.gravitee.gamma.rest.core.observability.filter.domain_service.ObservabilityFilterValidator;
+import io.gravitee.gamma.rest.core.observability.filter.model.ApiType;
+import io.gravitee.gamma.rest.core.observability.filter.model.FilterCondition;
+import io.gravitee.gamma.rest.core.observability.filter.model.FilterOperator;
+import io.gravitee.gamma.rest.core.observability.filter.model.Signal;
+import io.gravitee.gamma.rest.core.observability.logs.domain_service.AccessibleApiScopeDomainService;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import lombok.AllArgsConstructor;
+
+/**
+ * Shared pipeline for the three analytics use cases: validates incoming filter conditions against
+ * the {@link Signal#ANALYTICS} catalog, computes the RBAC-scoped API set, applies default
+ * entrypoint scoping, and returns a prepared scope using only Gamma-native types. All APIM
+ * analytics-engine type translation is deferred to the infra adapter.
+ *
+ * @author GraviteeSource Team
+ */
+@DomainService
+@AllArgsConstructor
+public class AnalyticsRequestPipeline {
+
+    static final Set<ApiType> ANALYTICS_SUPPORTED_API_TYPES = ApiType.ALL;
+
+    static final Set<String> DEFAULT_ENTRYPOINT_IDS = Set.of("http-get", "http-post", "http-proxy", "llm-proxy", "mcp-proxy");
+
+    private final ObservabilityFilterValidator filterValidator;
+    private final AccessibleApiScopeDomainService accessibleApiScope;
+
+    /**
+     * Validated and RBAC-scoped request data, expressed entirely in Gamma-native types. The infra
+     * adapter is responsible for translating {@link #filters()} to the analytics-engine model.
+     */
+    public record PreparedScope(Instant from, Instant to, List<FilterCondition> filters, Set<String> apiIds) {}
+
+    public PreparedScope prepare(
+        String organizationId,
+        String environmentId,
+        List<FilterCondition> rawFilters,
+        Instant from,
+        Instant to,
+        ObservabilityAnalyticsDataPort analyticsDataPort
+    ) {
+        var conditions = rawFilters != null ? rawFilters : List.<FilterCondition>of();
+
+        filterValidator.validate(conditions, Signal.ANALYTICS);
+        validateTimeRange(from, to);
+
+        var accessibleApis = analyticsDataPort.loadAccessibleApis(organizationId, environmentId);
+        var userApiFilter = extractApiFilter(conditions);
+        var scope = accessibleApiScope.computeScope(accessibleApis, ANALYTICS_SUPPORTED_API_TYPES, userApiFilter);
+
+        var effectiveConditions = applyDefaultEntrypointScoping(removeApiConditions(conditions));
+
+        var allFilters = new ArrayList<>(effectiveConditions);
+        if (!scope.apiIds().isEmpty()) {
+            allFilters.add(new FilterCondition("API", FilterOperator.IN, List.copyOf(scope.apiIds())));
+        }
+
+        return new PreparedScope(from, to, List.copyOf(allFilters), scope.apiIds());
+    }
+
+    private static void validateTimeRange(Instant from, Instant to) {
+        if (from != null && to != null && from.isAfter(to)) {
+            throw new ValidationDomainException("Invalid time range: 'from' must be before 'to'.");
+        }
+    }
+
+    private static Set<String> extractApiFilter(List<FilterCondition> conditions) {
+        return conditions
+            .stream()
+            .filter(c -> "API".equals(c.name()))
+            .flatMap(c -> c.values().stream())
+            .collect(Collectors.toSet());
+    }
+
+    private static List<FilterCondition> removeApiConditions(List<FilterCondition> conditions) {
+        return conditions
+            .stream()
+            .filter(c -> !"API".equals(c.name()))
+            .toList();
+    }
+
+    private static List<FilterCondition> applyDefaultEntrypointScoping(List<FilterCondition> conditions) {
+        boolean hasEntrypoint = conditions.stream().anyMatch(c -> "ENTRYPOINT".equals(c.name()));
+        if (hasEntrypoint) {
+            return conditions;
+        }
+        var result = new ArrayList<>(conditions);
+        result.add(new FilterCondition("ENTRYPOINT", FilterOperator.IN, List.copyOf(DEFAULT_ENTRYPOINT_IDS)));
+        return List.copyOf(result);
+    }
+}

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/analytics/use_case/AnalyticsRequestPipeline.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/analytics/use_case/AnalyticsRequestPipeline.java
@@ -54,7 +54,13 @@ public class AnalyticsRequestPipeline {
      * Validated and RBAC-scoped request data, expressed entirely in Gamma-native types. The infra
      * adapter is responsible for translating {@link #filters()} to the analytics-engine model.
      */
-    public record PreparedScope(Instant from, Instant to, List<FilterCondition> filters, Set<String> apiIds) {}
+    public record PreparedScope(Instant from, Instant to, List<FilterCondition> filters, Set<String> apiIds) {
+        static final PreparedScope EMPTY = new PreparedScope(null, null, List.of(), Set.of());
+
+        public boolean isEmpty() {
+            return this == EMPTY;
+        }
+    }
 
     public PreparedScope prepare(
         String organizationId,
@@ -72,6 +78,10 @@ public class AnalyticsRequestPipeline {
         var accessibleApis = analyticsDataPort.loadAccessibleApis(organizationId, environmentId);
         var userApiFilter = extractApiFilter(conditions);
         var scope = accessibleApiScope.computeScope(accessibleApis, ANALYTICS_SUPPORTED_API_TYPES, userApiFilter);
+
+        if (scope.apiIds().isEmpty() && !userApiFilter.isEmpty()) {
+            return PreparedScope.EMPTY;
+        }
 
         var effectiveConditions = applyDefaultEntrypointScoping(removeApiConditions(conditions));
 

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/analytics/use_case/ComputeObservabilityFacetsUseCase.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/analytics/use_case/ComputeObservabilityFacetsUseCase.java
@@ -55,6 +55,10 @@ public class ComputeObservabilityFacetsUseCase {
     public Output execute(Input input) {
         var scope = pipeline.prepare(input.organizationId, input.environmentId, input.filters, input.from, input.to, analyticsDataPort);
 
+        if (scope.isEmpty()) {
+            return new Output(analyticsDataPort.emptyFacetsResponse());
+        }
+
         var query = new ObservabilityAnalyticsDataPort.FacetsQuery(
             input.organizationId,
             input.environmentId,

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/analytics/use_case/ComputeObservabilityFacetsUseCase.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/analytics/use_case/ComputeObservabilityFacetsUseCase.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gamma.rest.core.observability.analytics.use_case;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.gravitee.apim.core.UseCase;
+import io.gravitee.gamma.rest.core.observability.analytics.model.AnalyticsFacetMetricQuery;
+import io.gravitee.gamma.rest.core.observability.analytics.model.AnalyticsNumberRange;
+import io.gravitee.gamma.rest.core.observability.analytics.port.service_provider.ObservabilityAnalyticsDataPort;
+import io.gravitee.gamma.rest.core.observability.filter.model.FilterCondition;
+import java.time.Instant;
+import java.util.List;
+import lombok.AllArgsConstructor;
+
+/**
+ * Computes analytics facets via the shared engine, applying the unified Gamma filter vocabulary
+ * and RBAC scoping.
+ *
+ * @author GraviteeSource Team
+ */
+@UseCase
+@AllArgsConstructor
+public class ComputeObservabilityFacetsUseCase {
+
+    private final ObservabilityAnalyticsDataPort analyticsDataPort;
+    private final AnalyticsRequestPipeline pipeline;
+
+    public record Input(
+        String organizationId,
+        String environmentId,
+        List<FilterCondition> filters,
+        Instant from,
+        Instant to,
+        List<AnalyticsFacetMetricQuery> metrics,
+        List<String> facets,
+        Integer limit,
+        List<AnalyticsNumberRange> ranges
+    ) {}
+
+    public record Output(JsonNode response) {}
+
+    public Output execute(Input input) {
+        var scope = pipeline.prepare(input.organizationId, input.environmentId, input.filters, input.from, input.to, analyticsDataPort);
+
+        var query = new ObservabilityAnalyticsDataPort.FacetsQuery(
+            input.organizationId,
+            input.environmentId,
+            scope,
+            input.facets,
+            input.limit,
+            input.metrics,
+            input.ranges
+        );
+        return new Output(analyticsDataPort.computeFacets(query));
+    }
+}

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/analytics/use_case/ComputeObservabilityMeasuresUseCase.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/analytics/use_case/ComputeObservabilityMeasuresUseCase.java
@@ -51,6 +51,10 @@ public class ComputeObservabilityMeasuresUseCase {
     public Output execute(Input input) {
         var scope = pipeline.prepare(input.organizationId, input.environmentId, input.filters, input.from, input.to, analyticsDataPort);
 
+        if (scope.isEmpty()) {
+            return new Output(analyticsDataPort.emptyMeasuresResponse());
+        }
+
         var query = new ObservabilityAnalyticsDataPort.MeasuresQuery(input.organizationId, input.environmentId, scope, input.metrics);
         return new Output(analyticsDataPort.computeMeasures(query));
     }

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/analytics/use_case/ComputeObservabilityMeasuresUseCase.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/analytics/use_case/ComputeObservabilityMeasuresUseCase.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gamma.rest.core.observability.analytics.use_case;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.gravitee.apim.core.UseCase;
+import io.gravitee.gamma.rest.core.observability.analytics.model.AnalyticsMetricQuery;
+import io.gravitee.gamma.rest.core.observability.analytics.port.service_provider.ObservabilityAnalyticsDataPort;
+import io.gravitee.gamma.rest.core.observability.filter.model.FilterCondition;
+import java.time.Instant;
+import java.util.List;
+import lombok.AllArgsConstructor;
+
+/**
+ * Computes analytics measures via the shared engine, applying the unified Gamma filter vocabulary
+ * and RBAC scoping.
+ *
+ * @author GraviteeSource Team
+ */
+@UseCase
+@AllArgsConstructor
+public class ComputeObservabilityMeasuresUseCase {
+
+    private final ObservabilityAnalyticsDataPort analyticsDataPort;
+    private final AnalyticsRequestPipeline pipeline;
+
+    public record Input(
+        String organizationId,
+        String environmentId,
+        List<FilterCondition> filters,
+        Instant from,
+        Instant to,
+        List<AnalyticsMetricQuery> metrics
+    ) {}
+
+    public record Output(JsonNode response) {}
+
+    public Output execute(Input input) {
+        var scope = pipeline.prepare(input.organizationId, input.environmentId, input.filters, input.from, input.to, analyticsDataPort);
+
+        var query = new ObservabilityAnalyticsDataPort.MeasuresQuery(input.organizationId, input.environmentId, scope, input.metrics);
+        return new Output(analyticsDataPort.computeMeasures(query));
+    }
+}

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/analytics/use_case/ComputeObservabilityTimeSeriesUseCase.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/analytics/use_case/ComputeObservabilityTimeSeriesUseCase.java
@@ -56,6 +56,10 @@ public class ComputeObservabilityTimeSeriesUseCase {
     public Output execute(Input input) {
         var scope = pipeline.prepare(input.organizationId, input.environmentId, input.filters, input.from, input.to, analyticsDataPort);
 
+        if (scope.isEmpty()) {
+            return new Output(analyticsDataPort.emptyTimeSeriesResponse());
+        }
+
         var query = new ObservabilityAnalyticsDataPort.TimeSeriesQuery(
             input.organizationId,
             input.environmentId,

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/analytics/use_case/ComputeObservabilityTimeSeriesUseCase.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/analytics/use_case/ComputeObservabilityTimeSeriesUseCase.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gamma.rest.core.observability.analytics.use_case;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.gravitee.apim.core.UseCase;
+import io.gravitee.gamma.rest.core.observability.analytics.model.AnalyticsFacetMetricQuery;
+import io.gravitee.gamma.rest.core.observability.analytics.model.AnalyticsNumberRange;
+import io.gravitee.gamma.rest.core.observability.analytics.port.service_provider.ObservabilityAnalyticsDataPort;
+import io.gravitee.gamma.rest.core.observability.filter.model.FilterCondition;
+import java.time.Instant;
+import java.util.List;
+import lombok.AllArgsConstructor;
+
+/**
+ * Computes analytics time-series via the shared engine, applying the unified Gamma filter vocabulary
+ * and RBAC scoping.
+ *
+ * @author GraviteeSource Team
+ */
+@UseCase
+@AllArgsConstructor
+public class ComputeObservabilityTimeSeriesUseCase {
+
+    private final ObservabilityAnalyticsDataPort analyticsDataPort;
+    private final AnalyticsRequestPipeline pipeline;
+
+    public record Input(
+        String organizationId,
+        String environmentId,
+        List<FilterCondition> filters,
+        Instant from,
+        Instant to,
+        Long interval,
+        List<AnalyticsFacetMetricQuery> metrics,
+        List<String> facets,
+        Integer facetSize,
+        List<AnalyticsNumberRange> ranges
+    ) {}
+
+    public record Output(JsonNode response) {}
+
+    public Output execute(Input input) {
+        var scope = pipeline.prepare(input.organizationId, input.environmentId, input.filters, input.from, input.to, analyticsDataPort);
+
+        var query = new ObservabilityAnalyticsDataPort.TimeSeriesQuery(
+            input.organizationId,
+            input.environmentId,
+            scope,
+            input.interval,
+            input.facets,
+            input.facetSize,
+            input.metrics,
+            input.ranges
+        );
+        return new Output(analyticsDataPort.computeTimeSeries(query));
+    }
+}

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/filter/model/StaticFilters.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/filter/model/StaticFilters.java
@@ -61,6 +61,8 @@ public enum StaticFilters {
     TENANT("Tenant", FilterType.KEYWORD, Defs.EQ_IN, null, null, Defs.ANALYTICS, Defs.GATEWAY_TYPES),
     ZONE("Zone", FilterType.KEYWORD, Defs.EQ_IN, null, null, Defs.ANALYTICS, Defs.GATEWAY_TYPES),
 
+    ENTRYPOINT("Entrypoint", FilterType.KEYWORD, Defs.EQ_IN, null, null, Defs.LOGS_ANALYTICS, ApiType.ALL),
+
     // --- HTTP -----------------------------------------------------------------------------------
     HTTP_METHOD("HTTP Method", FilterType.ENUM, Defs.EQ_IN, Defs.HTTP_METHODS, null, Defs.LOGS_ANALYTICS, Defs.HTTP_LLM_MCP),
     HTTP_STATUS("Status Code", FilterType.NUMBER, Defs.NUMBER_OPS, null, new Range(100, 599), Defs.LOGS_ANALYTICS, Defs.HTTP_LLM_MCP),

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/infra/adapter/ObservabilityAnalyticsDataPortAdapter.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/infra/adapter/ObservabilityAnalyticsDataPortAdapter.java
@@ -1,0 +1,233 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gamma.rest.infra.adapter;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.gravitee.apim.core.analytics_engine.model.FacetMetricMeasuresRequest;
+import io.gravitee.apim.core.analytics_engine.model.FacetSpec;
+import io.gravitee.apim.core.analytics_engine.model.FacetsRequest;
+import io.gravitee.apim.core.analytics_engine.model.Filter;
+import io.gravitee.apim.core.analytics_engine.model.FilterSpec;
+import io.gravitee.apim.core.analytics_engine.model.MeasuresRequest;
+import io.gravitee.apim.core.analytics_engine.model.MetricMeasuresRequest;
+import io.gravitee.apim.core.analytics_engine.model.MetricSpec;
+import io.gravitee.apim.core.analytics_engine.model.TimeRange;
+import io.gravitee.apim.core.analytics_engine.model.TimeSeriesRequest;
+import io.gravitee.apim.core.analytics_engine.use_case.ComputeFacetsUseCase;
+import io.gravitee.apim.core.analytics_engine.use_case.ComputeMeasuresUseCase;
+import io.gravitee.apim.core.analytics_engine.use_case.ComputeTimeSeriesUseCase;
+import io.gravitee.apim.core.audit.model.AuditActor;
+import io.gravitee.apim.core.audit.model.AuditInfo;
+import io.gravitee.apim.core.observability.model.NumberRange;
+import io.gravitee.apim.core.user.domain_service.UserContextLoader;
+import io.gravitee.apim.core.user.model.UserContext;
+import io.gravitee.gamma.rest.core.observability.analytics.model.AnalyticsFacetMetricQuery;
+import io.gravitee.gamma.rest.core.observability.analytics.model.AnalyticsMetricQuery;
+import io.gravitee.gamma.rest.core.observability.analytics.model.AnalyticsNumberRange;
+import io.gravitee.gamma.rest.core.observability.analytics.model.AnalyticsSortSpec;
+import io.gravitee.gamma.rest.core.observability.analytics.port.service_provider.ObservabilityAnalyticsDataPort;
+import io.gravitee.gamma.rest.core.observability.analytics.use_case.AnalyticsRequestPipeline;
+import io.gravitee.gamma.rest.core.observability.filter.model.ApiType;
+import io.gravitee.gamma.rest.core.observability.filter.model.FilterCondition;
+import io.gravitee.gamma.rest.core.observability.filter.model.FilterOperator;
+import io.gravitee.gamma.rest.core.observability.logs.port.service_provider.ObservabilityLogsDataPort.AccessibleApi;
+import io.gravitee.rest.api.idp.api.authentication.UserDetails;
+import java.util.Collections;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+/**
+ * Adapter bridging the Gamma analytics port to the APIM analytics compute use cases. Translates
+ * Gamma-native types to the analytics-engine model, builds the {@link AuditInfo} from the ambient
+ * request context, and serializes APIM responses to {@link JsonNode} for framework independence.
+ *
+ * @author GraviteeSource Team
+ */
+@RequiredArgsConstructor
+public class ObservabilityAnalyticsDataPortAdapter implements ObservabilityAnalyticsDataPort {
+
+    private final ComputeMeasuresUseCase computeMeasuresUseCase;
+    private final ComputeFacetsUseCase computeFacetsUseCase;
+    private final ComputeTimeSeriesUseCase computeTimeSeriesUseCase;
+    private final UserContextLoader userContextLoader;
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public List<AccessibleApi> loadAccessibleApis(String organizationId, String environmentId) {
+        var auditInfo = currentAuditInfo(organizationId, environmentId);
+        var userContext = userContextLoader.loadApis(new UserContext(auditInfo));
+        return userContext
+            .apis()
+            .orElseGet(Collections::emptyList)
+            .stream()
+            .map(api -> new AccessibleApi(api.getId(), api.getName(), toGammaApiType(api.getType())))
+            .toList();
+    }
+
+    @Override
+    public JsonNode computeMeasures(MeasuresQuery query) {
+        var auditInfo = currentAuditInfo(query.organizationId(), query.environmentId());
+        var apimRequest = new MeasuresRequest(toTimeRange(query.scope()), translateFilters(query.scope()), toApimMetrics(query.metrics()));
+        var response = computeMeasuresUseCase.execute(new ComputeMeasuresUseCase.Input(auditInfo, apimRequest)).response();
+        return objectMapper.valueToTree(response);
+    }
+
+    @Override
+    public JsonNode computeFacets(FacetsQuery query) {
+        var auditInfo = currentAuditInfo(query.organizationId(), query.environmentId());
+        var apimRequest = new FacetsRequest(
+            toTimeRange(query.scope()),
+            translateFilters(query.scope()),
+            toApimFacetMetrics(query.metrics()),
+            toApimFacetNames(query.facets()),
+            query.limit(),
+            toApimRanges(query.ranges())
+        );
+        var response = computeFacetsUseCase.execute(new ComputeFacetsUseCase.Input(auditInfo, apimRequest)).response();
+        return objectMapper.valueToTree(response);
+    }
+
+    @Override
+    public JsonNode computeTimeSeries(TimeSeriesQuery query) {
+        var auditInfo = currentAuditInfo(query.organizationId(), query.environmentId());
+        var apimRequest = new TimeSeriesRequest(
+            toTimeRange(query.scope()),
+            query.interval(),
+            translateFilters(query.scope()),
+            toApimFacetMetrics(query.metrics()),
+            toApimFacetNames(query.facets()),
+            query.facetSize(),
+            toApimRanges(query.ranges())
+        );
+        var response = computeTimeSeriesUseCase.execute(new ComputeTimeSeriesUseCase.Input(auditInfo, apimRequest)).response();
+        return objectMapper.valueToTree(response);
+    }
+
+    // ---- Translation: Gamma → APIM ----
+
+    private static TimeRange toTimeRange(AnalyticsRequestPipeline.PreparedScope scope) {
+        return new TimeRange(scope.from(), scope.to());
+    }
+
+    private static List<Filter> translateFilters(AnalyticsRequestPipeline.PreparedScope scope) {
+        return scope.filters().stream().map(ObservabilityAnalyticsDataPortAdapter::translateFilter).toList();
+    }
+
+    private static Filter translateFilter(FilterCondition condition) {
+        var name = FilterSpec.Name.valueOf(condition.name());
+        var operator = io.gravitee.apim.core.observability.model.FilterOperator.valueOf(condition.operator().name());
+        Object value = (condition.operator() == FilterOperator.IN || condition.operator() == FilterOperator.NOT_IN)
+            ? condition.values()
+            : (condition.values() != null && !condition.values().isEmpty() ? condition.values().getFirst() : null);
+        return new Filter(name, operator, value);
+    }
+
+    private static List<MetricMeasuresRequest> toApimMetrics(List<AnalyticsMetricQuery> metrics) {
+        if (metrics == null) {
+            return List.of();
+        }
+        return metrics
+            .stream()
+            .map(m ->
+                new MetricMeasuresRequest(
+                    MetricSpec.Name.valueOf(m.metricName()),
+                    m.measures().stream().map(MetricSpec.Measure::valueOf).toList()
+                )
+            )
+            .toList();
+    }
+
+    private static List<FacetMetricMeasuresRequest> toApimFacetMetrics(List<AnalyticsFacetMetricQuery> metrics) {
+        if (metrics == null) {
+            return List.of();
+        }
+        return metrics
+            .stream()
+            .map(m ->
+                new FacetMetricMeasuresRequest(
+                    MetricSpec.Name.valueOf(m.metricName()),
+                    m.measures().stream().map(MetricSpec.Measure::valueOf).toList(),
+                    toApimSorts(m.sorts())
+                )
+            )
+            .toList();
+    }
+
+    private static List<FacetMetricMeasuresRequest.Sort> toApimSorts(List<AnalyticsSortSpec> sorts) {
+        if (sorts == null) {
+            return List.of();
+        }
+        return sorts
+            .stream()
+            .map(s ->
+                new FacetMetricMeasuresRequest.Sort(
+                    MetricSpec.Measure.valueOf(s.measure()),
+                    FacetMetricMeasuresRequest.Sort.Order.valueOf(s.order())
+                )
+            )
+            .toList();
+    }
+
+    private static List<FacetSpec.Name> toApimFacetNames(List<String> facets) {
+        if (facets == null) {
+            return List.of();
+        }
+        return facets.stream().map(FacetSpec.Name::valueOf).toList();
+    }
+
+    private static List<NumberRange> toApimRanges(List<AnalyticsNumberRange> ranges) {
+        if (ranges == null) {
+            return List.of();
+        }
+        return ranges
+            .stream()
+            .map(r -> new NumberRange(r.from(), r.to()))
+            .toList();
+    }
+
+    // ---- Audit / Security ----
+
+    private static AuditInfo currentAuditInfo(String organizationId, String environmentId) {
+        var authentication = SecurityContextHolder.getContext().getAuthentication();
+        AuditActor actor;
+        if (authentication != null && authentication.getPrincipal() instanceof UserDetails user) {
+            actor = AuditActor.builder().userId(user.getUsername()).userSource(user.getSource()).userSourceId(user.getSourceId()).build();
+        } else {
+            String userId = (authentication != null && authentication.getPrincipal() != null)
+                ? authentication.getPrincipal().toString()
+                : "unknown";
+            actor = AuditActor.builder().userId(userId).build();
+        }
+        return AuditInfo.builder().organizationId(organizationId).environmentId(environmentId).actor(actor).build();
+    }
+
+    private static ApiType toGammaApiType(io.gravitee.definition.model.v4.ApiType definitionType) {
+        if (definitionType == null) {
+            return null;
+        }
+        return switch (definitionType) {
+            case PROXY -> ApiType.HTTP_PROXY;
+            case MESSAGE -> ApiType.MESSAGE;
+            case LLM_PROXY -> ApiType.LLM;
+            case MCP_PROXY -> ApiType.MCP;
+            case NATIVE -> ApiType.NATIVE;
+            case EDGE -> ApiType.EDGE;
+            case A2A_PROXY -> null;
+        };
+    }
+}

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/infra/adapter/ObservabilityAnalyticsDataPortAdapter.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/infra/adapter/ObservabilityAnalyticsDataPortAdapter.java
@@ -20,13 +20,16 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.gravitee.apim.core.analytics_engine.model.FacetMetricMeasuresRequest;
 import io.gravitee.apim.core.analytics_engine.model.FacetSpec;
 import io.gravitee.apim.core.analytics_engine.model.FacetsRequest;
+import io.gravitee.apim.core.analytics_engine.model.FacetsResponse;
 import io.gravitee.apim.core.analytics_engine.model.Filter;
 import io.gravitee.apim.core.analytics_engine.model.FilterSpec;
 import io.gravitee.apim.core.analytics_engine.model.MeasuresRequest;
+import io.gravitee.apim.core.analytics_engine.model.MeasuresResponse;
 import io.gravitee.apim.core.analytics_engine.model.MetricMeasuresRequest;
 import io.gravitee.apim.core.analytics_engine.model.MetricSpec;
 import io.gravitee.apim.core.analytics_engine.model.TimeRange;
 import io.gravitee.apim.core.analytics_engine.model.TimeSeriesRequest;
+import io.gravitee.apim.core.analytics_engine.model.TimeSeriesResponse;
 import io.gravitee.apim.core.analytics_engine.use_case.ComputeFacetsUseCase;
 import io.gravitee.apim.core.analytics_engine.use_case.ComputeMeasuresUseCase;
 import io.gravitee.apim.core.analytics_engine.use_case.ComputeTimeSeriesUseCase;
@@ -116,6 +119,21 @@ public class ObservabilityAnalyticsDataPortAdapter implements ObservabilityAnaly
         );
         var response = computeTimeSeriesUseCase.execute(new ComputeTimeSeriesUseCase.Input(auditInfo, apimRequest)).response();
         return objectMapper.valueToTree(response);
+    }
+
+    @Override
+    public JsonNode emptyMeasuresResponse() {
+        return objectMapper.valueToTree(new MeasuresResponse(List.of()));
+    }
+
+    @Override
+    public JsonNode emptyFacetsResponse() {
+        return objectMapper.valueToTree(new FacetsResponse(List.of()));
+    }
+
+    @Override
+    public JsonNode emptyTimeSeriesResponse() {
+        return objectMapper.valueToTree(new TimeSeriesResponse(List.of()));
     }
 
     // ---- Translation: Gamma → APIM ----

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/infra/config/GammaAnalyticsConfiguration.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/infra/config/GammaAnalyticsConfiguration.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gamma.rest.infra.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.gravitee.apim.core.DomainService;
+import io.gravitee.apim.core.UseCase;
+import io.gravitee.apim.core.analytics_engine.use_case.ComputeFacetsUseCase;
+import io.gravitee.apim.core.analytics_engine.use_case.ComputeMeasuresUseCase;
+import io.gravitee.apim.core.analytics_engine.use_case.ComputeTimeSeriesUseCase;
+import io.gravitee.apim.core.user.domain_service.UserContextLoader;
+import io.gravitee.gamma.rest.core.observability.analytics.port.service_provider.ObservabilityAnalyticsDataPort;
+import io.gravitee.gamma.rest.infra.adapter.ObservabilityAnalyticsDataPortAdapter;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.FilterType;
+
+/**
+ * Spring wiring for the observability analytics domain. Picks up the Gamma analytics use cases and
+ * the shared {@code AnalyticsRequestPipeline} via {@link ComponentScan}, and declares the data port
+ * adapter as a bean that delegates to the APIM compute use cases (already in the parent context).
+ *
+ * @author GraviteeSource Team
+ */
+@Configuration
+@ComponentScan(
+    basePackages = "io.gravitee.gamma.rest.core.observability.analytics",
+    includeFilters = {
+        @ComponentScan.Filter(type = FilterType.ANNOTATION, value = UseCase.class),
+        @ComponentScan.Filter(type = FilterType.ANNOTATION, value = DomainService.class),
+    }
+)
+public class GammaAnalyticsConfiguration {
+
+    @Bean
+    public ObservabilityAnalyticsDataPort observabilityAnalyticsDataPort(
+        ComputeMeasuresUseCase computeMeasuresUseCase,
+        ComputeFacetsUseCase computeFacetsUseCase,
+        ComputeTimeSeriesUseCase computeTimeSeriesUseCase,
+        UserContextLoader userContextLoader,
+        ObjectMapper objectMapper
+    ) {
+        return new ObservabilityAnalyticsDataPortAdapter(
+            computeMeasuresUseCase,
+            computeFacetsUseCase,
+            computeTimeSeriesUseCase,
+            userContextLoader,
+            objectMapper
+        );
+    }
+}

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/resources/GammaRootResource.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/resources/GammaRootResource.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.gamma.rest.resources;
 
+import io.gravitee.gamma.rest.resources.observability.analytics.AnalyticsResource;
 import io.gravitee.gamma.rest.resources.observability.filters.ObservabilityFiltersResource;
 import io.gravitee.gamma.rest.resources.observability.logs.LogsResource;
 import io.gravitee.gamma.rest.resources.tracing.TracingResource;
@@ -68,5 +69,15 @@ public class GammaRootResource {
     @Path("/organizations/{orgId}/environments/{envId}/observability/logs")
     public LogsResource getLogsResource() {
         return resourceContext.getResource(LogsResource.class);
+    }
+
+    /**
+     * Analytics computation endpoints (measures, facets, time-series) consuming the unified filter
+     * vocabulary and delegating to the proven APIM analytics engine. Server-side RBAC scoping via
+     * {@code AccessibleApiScopeDomainService}. See {@link AnalyticsResource} for the contract.
+     */
+    @Path("/organizations/{orgId}/environments/{envId}/observability/analytics")
+    public AnalyticsResource getAnalyticsResource() {
+        return resourceContext.getResource(AnalyticsResource.class);
     }
 }

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/resources/observability/analytics/AnalyticsResource.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/resources/observability/analytics/AnalyticsResource.java
@@ -1,0 +1,187 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gamma.rest.resources.observability.analytics;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.gravitee.common.http.MediaType;
+import io.gravitee.gamma.rest.core.observability.analytics.use_case.ComputeObservabilityFacetsUseCase;
+import io.gravitee.gamma.rest.core.observability.analytics.use_case.ComputeObservabilityMeasuresUseCase;
+import io.gravitee.gamma.rest.core.observability.analytics.use_case.ComputeObservabilityTimeSeriesUseCase;
+import io.gravitee.gamma.rest.core.observability.filter.model.FilterCondition;
+import io.gravitee.gamma.rest.resources.observability.analytics.dto.AnalyticsFacetsRequestDto;
+import io.gravitee.gamma.rest.resources.observability.analytics.dto.AnalyticsMeasuresRequestDto;
+import io.gravitee.gamma.rest.resources.observability.analytics.dto.AnalyticsTimeSeriesRequestDto;
+import io.gravitee.gamma.rest.resources.observability.analytics.dto.FacetMetricQueryDto;
+import io.gravitee.gamma.rest.resources.observability.analytics.dto.MetricQueryDto;
+import io.gravitee.gamma.rest.resources.observability.analytics.dto.NumberRangeDto;
+import io.gravitee.gamma.rest.resources.observability.logs.dto.FilterConditionDto;
+import io.gravitee.rest.api.model.permissions.RolePermission;
+import io.gravitee.rest.api.model.permissions.RolePermissionAction;
+import io.gravitee.rest.api.service.PermissionService;
+import io.gravitee.rest.api.service.common.ExecutionContext;
+import io.gravitee.rest.api.service.common.GraviteeContext;
+import io.gravitee.rest.api.service.exceptions.ForbiddenAccessException;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import java.util.List;
+
+/**
+ * Analytics computation endpoints under
+ * {@code /gamma/organizations/{orgId}/environments/{envId}/observability/analytics}.
+ *
+ * <p>Consumes the unified Gamma filter vocabulary ({@code FilterCondition[]}) validated against the
+ * {@code ANALYTICS} signal and delegates to the proven APIM analytics engine. Server-side RBAC
+ * scoping ensures the caller only sees metrics for APIs they can read.
+ *
+ * @author GraviteeSource Team
+ */
+public class AnalyticsResource {
+
+    @Inject
+    private ComputeObservabilityMeasuresUseCase computeMeasuresUseCase;
+
+    @Inject
+    private ComputeObservabilityFacetsUseCase computeFacetsUseCase;
+
+    @Inject
+    private ComputeObservabilityTimeSeriesUseCase computeTimeSeriesUseCase;
+
+    @Inject
+    private PermissionService permissionService;
+
+    @POST
+    @Path("/measures")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public JsonNode computeMeasures(AnalyticsMeasuresRequestDto request) {
+        checkReadObservabilityPermission();
+
+        var ctx = GraviteeContext.getExecutionContext();
+        var output = computeMeasuresUseCase.execute(
+            new ComputeObservabilityMeasuresUseCase.Input(
+                ctx.getOrganizationId(),
+                ctx.getEnvironmentId(),
+                toFilters(request != null ? request.filters() : null),
+                request != null && request.timeRange() != null ? request.timeRange().from() : null,
+                request != null && request.timeRange() != null ? request.timeRange().to() : null,
+                toMetrics(request != null ? request.metrics() : null)
+            )
+        );
+        return output.response();
+    }
+
+    @POST
+    @Path("/facets")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public JsonNode computeFacets(AnalyticsFacetsRequestDto request) {
+        checkReadObservabilityPermission();
+
+        var ctx = GraviteeContext.getExecutionContext();
+        var output = computeFacetsUseCase.execute(
+            new ComputeObservabilityFacetsUseCase.Input(
+                ctx.getOrganizationId(),
+                ctx.getEnvironmentId(),
+                toFilters(request != null ? request.filters() : null),
+                request != null && request.timeRange() != null ? request.timeRange().from() : null,
+                request != null && request.timeRange() != null ? request.timeRange().to() : null,
+                toFacetMetrics(request != null ? request.metrics() : null),
+                request != null && request.facets() != null ? request.facets() : List.of(),
+                request != null ? request.limit() : null,
+                toRanges(request != null ? request.ranges() : null)
+            )
+        );
+        return output.response();
+    }
+
+    @POST
+    @Path("/time-series")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public JsonNode computeTimeSeries(AnalyticsTimeSeriesRequestDto request) {
+        checkReadObservabilityPermission();
+
+        var ctx = GraviteeContext.getExecutionContext();
+        var output = computeTimeSeriesUseCase.execute(
+            new ComputeObservabilityTimeSeriesUseCase.Input(
+                ctx.getOrganizationId(),
+                ctx.getEnvironmentId(),
+                toFilters(request != null ? request.filters() : null),
+                request != null && request.timeRange() != null ? request.timeRange().from() : null,
+                request != null && request.timeRange() != null ? request.timeRange().to() : null,
+                request != null ? request.interval() : null,
+                toFacetMetrics(request != null ? request.metrics() : null),
+                request != null && request.facets() != null ? request.facets() : List.of(),
+                request != null ? request.facetSize() : null,
+                toRanges(request != null ? request.ranges() : null)
+            )
+        );
+        return output.response();
+    }
+
+    private static List<FilterCondition> toFilters(List<FilterConditionDto> dtos) {
+        if (dtos == null) {
+            return List.of();
+        }
+        return dtos.stream().map(FilterConditionDto::toCore).toList();
+    }
+
+    private static List<io.gravitee.gamma.rest.core.observability.analytics.model.AnalyticsMetricQuery> toMetrics(
+        List<MetricQueryDto> dtos
+    ) {
+        if (dtos == null) {
+            return List.of();
+        }
+        return dtos.stream().map(MetricQueryDto::toCore).toList();
+    }
+
+    private static List<io.gravitee.gamma.rest.core.observability.analytics.model.AnalyticsFacetMetricQuery> toFacetMetrics(
+        List<FacetMetricQueryDto> dtos
+    ) {
+        if (dtos == null) {
+            return List.of();
+        }
+        return dtos.stream().map(FacetMetricQueryDto::toCore).toList();
+    }
+
+    private static List<io.gravitee.gamma.rest.core.observability.analytics.model.AnalyticsNumberRange> toRanges(
+        List<NumberRangeDto> dtos
+    ) {
+        if (dtos == null) {
+            return List.of();
+        }
+        return dtos.stream().map(NumberRangeDto::toCore).toList();
+    }
+
+    private void checkReadObservabilityPermission() {
+        ExecutionContext executionContext = GraviteeContext.getExecutionContext();
+        String environmentId = executionContext.getEnvironmentId();
+        boolean allowed =
+            permissionService.hasPermission(
+                executionContext,
+                RolePermission.ENVIRONMENT_DASHBOARD,
+                environmentId,
+                RolePermissionAction.READ
+            ) ||
+            permissionService.hasPermission(executionContext, RolePermission.ENVIRONMENT_API, environmentId, RolePermissionAction.READ);
+        if (!allowed) {
+            throw new ForbiddenAccessException();
+        }
+    }
+}

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/resources/observability/analytics/dto/AnalyticsFacetsRequestDto.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/resources/observability/analytics/dto/AnalyticsFacetsRequestDto.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gamma.rest.resources.observability.analytics.dto;
+
+import io.gravitee.gamma.rest.resources.observability.logs.dto.FilterConditionDto;
+import io.gravitee.gamma.rest.resources.observability.logs.dto.SearchLogsRequestDto.TimeRangeDto;
+import java.util.List;
+
+/**
+ * POST body for {@code /observability/analytics/facets}.
+ */
+public record AnalyticsFacetsRequestDto(
+    TimeRangeDto timeRange,
+    List<FilterConditionDto> filters,
+    List<FacetMetricQueryDto> metrics,
+    List<String> facets,
+    Integer limit,
+    List<NumberRangeDto> ranges
+) {}

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/resources/observability/analytics/dto/AnalyticsMeasuresRequestDto.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/resources/observability/analytics/dto/AnalyticsMeasuresRequestDto.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gamma.rest.resources.observability.analytics.dto;
+
+import io.gravitee.gamma.rest.resources.observability.logs.dto.FilterConditionDto;
+import io.gravitee.gamma.rest.resources.observability.logs.dto.SearchLogsRequestDto.TimeRangeDto;
+import java.util.List;
+
+/**
+ * POST body for {@code /observability/analytics/measures}.
+ */
+public record AnalyticsMeasuresRequestDto(TimeRangeDto timeRange, List<FilterConditionDto> filters, List<MetricQueryDto> metrics) {}

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/resources/observability/analytics/dto/AnalyticsTimeSeriesRequestDto.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/resources/observability/analytics/dto/AnalyticsTimeSeriesRequestDto.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gamma.rest.resources.observability.analytics.dto;
+
+import io.gravitee.gamma.rest.resources.observability.logs.dto.FilterConditionDto;
+import io.gravitee.gamma.rest.resources.observability.logs.dto.SearchLogsRequestDto.TimeRangeDto;
+import java.util.List;
+
+/**
+ * POST body for {@code /observability/analytics/time-series}.
+ */
+public record AnalyticsTimeSeriesRequestDto(
+    TimeRangeDto timeRange,
+    List<FilterConditionDto> filters,
+    Long interval,
+    List<FacetMetricQueryDto> metrics,
+    List<String> facets,
+    Integer facetSize,
+    List<NumberRangeDto> ranges
+) {}

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/resources/observability/analytics/dto/FacetMetricQueryDto.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/resources/observability/analytics/dto/FacetMetricQueryDto.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gamma.rest.resources.observability.analytics.dto;
+
+import io.gravitee.gamma.rest.core.observability.analytics.model.AnalyticsFacetMetricQuery;
+import java.util.List;
+
+/**
+ * Wire shape for a metric query on the facets and time-series endpoints.
+ */
+public record FacetMetricQueryDto(String name, List<String> measures, List<SortSpecDto> sorts) {
+    public AnalyticsFacetMetricQuery toCore() {
+        return new AnalyticsFacetMetricQuery(
+            name,
+            measures != null ? measures : List.of(),
+            sorts != null ? sorts.stream().map(SortSpecDto::toCore).toList() : List.of()
+        );
+    }
+}

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/resources/observability/analytics/dto/MetricQueryDto.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/resources/observability/analytics/dto/MetricQueryDto.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gamma.rest.resources.observability.analytics.dto;
+
+import io.gravitee.gamma.rest.core.observability.analytics.model.AnalyticsMetricQuery;
+import java.util.List;
+
+/**
+ * Wire shape for a metric query on the measures endpoint.
+ */
+public record MetricQueryDto(String name, List<String> measures) {
+    public AnalyticsMetricQuery toCore() {
+        return new AnalyticsMetricQuery(name, measures != null ? measures : List.of());
+    }
+}

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/resources/observability/analytics/dto/NumberRangeDto.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/resources/observability/analytics/dto/NumberRangeDto.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gamma.rest.resources.observability.analytics.dto;
+
+import io.gravitee.gamma.rest.core.observability.analytics.model.AnalyticsNumberRange;
+
+/**
+ * Wire shape for a numeric range on the facets and time-series endpoints.
+ */
+public record NumberRangeDto(Number from, Number to) {
+    public AnalyticsNumberRange toCore() {
+        return new AnalyticsNumberRange(from, to);
+    }
+}

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/resources/observability/analytics/dto/SortSpecDto.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/resources/observability/analytics/dto/SortSpecDto.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gamma.rest.resources.observability.analytics.dto;
+
+import io.gravitee.gamma.rest.core.observability.analytics.model.AnalyticsSortSpec;
+
+/**
+ * Wire shape for a sort directive on a facet metric query.
+ */
+public record SortSpecDto(String measure, String order) {
+    public AnalyticsSortSpec toCore() {
+        return new AnalyticsSortSpec(measure, order);
+    }
+}

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/resources/openapi/observability/openapi-observability.yaml
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/resources/openapi/observability/openapi-observability.yaml
@@ -43,6 +43,18 @@ tags:
           Filter conditions reference the shared filter catalog narrowed to the `LOGS` signal.
           When no explicit entrypoint filter is supplied, the server injects the canonical HTTP
           entrypoints so table totals match the analytics dashboard.
+    - name: Analytics
+      description: |
+          Environment-wide analytics computation: aggregate measures, faceted breakdowns, and
+          time-series histograms. Backed by the Elasticsearch analytics engine.
+
+          Filter conditions reference the shared filter catalog narrowed to the `ANALYTICS` signal.
+          RBAC scoping ensures the caller only sees metrics for APIs they have read access to.
+          When no explicit `ENTRYPOINT` filter is supplied, the server injects the canonical HTTP
+          entrypoints (`http-get`, `http-post`, `http-proxy`, `llm-proxy`, `mcp-proxy`).
+
+          All three endpoints return opaque JSON produced by the APIM analytics engine — the
+          response schemas below document the stable structure but additional fields may appear.
 
 paths:
     /organizations/{orgId}/environments/{envId}/observability/filters/definition:
@@ -109,6 +121,12 @@ paths:
                                                   max: 599
                                               signals: ["LOGS", "ANALYTICS"]
                                               apiTypes: ["HTTP_PROXY", "LLM"]
+                                            - name: "ENTRYPOINT"
+                                              label: "Entrypoint"
+                                              type: "keyword"
+                                              operators: ["EQ", "IN"]
+                                              signals: ["LOGS", "ANALYTICS"]
+                                              apiTypes: ["HTTP_PROXY", "LLM", "MESSAGE", "MCP", "NATIVE", "EDGE"]
                                             - name: "API"
                                               label: "API"
                                               type: "keyword"
@@ -714,6 +732,289 @@ paths:
                                 httpStatus: 403
                                 message: "Insufficient permissions to access observability data."
 
+    /organizations/{orgId}/environments/{envId}/observability/analytics/measures:
+        parameters:
+            - $ref: "#/components/parameters/orgIdParam"
+            - $ref: "#/components/parameters/envIdParam"
+        post:
+            tags:
+                - Analytics
+            summary: Compute aggregate measures
+            description: |
+                Returns aggregate metric values (e.g. request count, average response time) for the
+                given time range and filter set. Use this endpoint to populate summary cards and KPI
+                panels in the dashboard.
+
+                **RBAC scoping**: only metrics from APIs the caller can read are included.
+
+                **Filter validation**: conditions are validated against the `ANALYTICS` signal catalog.
+            operationId: computeObservabilityMeasures
+            requestBody:
+                required: true
+                content:
+                    application/json:
+                        schema:
+                            $ref: "#/components/schemas/AnalyticsMeasuresRequest"
+                        examples:
+                            simple-count:
+                                summary: Count all HTTP requests
+                                value:
+                                    timeRange:
+                                        from: "2026-06-10T00:00:00Z"
+                                        to: "2026-06-11T00:00:00Z"
+                                    filters: []
+                                    metrics:
+                                        - name: "HTTP_REQUESTS"
+                                          measures: ["COUNT"]
+                            entrypoint-filter:
+                                summary: MCP requests only (entrypoint filter)
+                                value:
+                                    timeRange:
+                                        from: "2026-06-10T00:00:00Z"
+                                        to: "2026-06-11T00:00:00Z"
+                                    filters:
+                                        - name: "ENTRYPOINT"
+                                          operator: "IN"
+                                          value: ["mcp-proxy"]
+                                    metrics:
+                                        - name: "HTTP_REQUESTS"
+                                          measures: ["COUNT"]
+                            multi-metric:
+                                summary: Count and response time stats
+                                value:
+                                    timeRange:
+                                        from: "2026-06-10T00:00:00Z"
+                                        to: "2026-06-11T00:00:00Z"
+                                    filters:
+                                        - name: "HTTP_STATUS"
+                                          operator: "EQ"
+                                          value: "200"
+                                    metrics:
+                                        - name: "HTTP_REQUESTS"
+                                          measures: ["COUNT"]
+                                        - name: "HTTP_GATEWAY_RESPONSE_TIME"
+                                          measures: ["AVG", "P99"]
+            responses:
+                "200":
+                    description: Aggregated metric measures.
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/MeasuresResponse"
+                            examples:
+                                single-metric:
+                                    summary: Single metric result
+                                    value:
+                                        metrics:
+                                            - name: "HTTP_REQUESTS"
+                                              unit: "NUMBER"
+                                              measures:
+                                                  - name: "COUNT"
+                                                    value: 42
+                "400":
+                    description: Invalid filter condition or time range.
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/Error"
+                "403":
+                    description: Insufficient permissions.
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/Error"
+                            example:
+                                httpStatus: 403
+                                message: "Insufficient permissions to access observability data."
+
+    /organizations/{orgId}/environments/{envId}/observability/analytics/facets:
+        parameters:
+            - $ref: "#/components/parameters/orgIdParam"
+            - $ref: "#/components/parameters/envIdParam"
+        post:
+            tags:
+                - Analytics
+            summary: Compute faceted metric breakdowns
+            description: |
+                Returns metric values broken down by one or more facet dimensions (e.g. per API,
+                per HTTP status code group, per method). Facet buckets form a tree: leaf nodes carry
+                measures, group nodes carry nested buckets.
+
+                Use `limit` to cap the number of buckets per facet. Use `ranges` for numeric
+                range bucketing (e.g. status code groups 1xx/2xx/3xx/4xx/5xx).
+            operationId: computeObservabilityFacets
+            requestBody:
+                required: true
+                content:
+                    application/json:
+                        schema:
+                            $ref: "#/components/schemas/AnalyticsFacetsRequest"
+                        examples:
+                            by-api:
+                                summary: Request count per API (top 10)
+                                value:
+                                    timeRange:
+                                        from: "2026-06-10T00:00:00Z"
+                                        to: "2026-06-11T00:00:00Z"
+                                    filters: []
+                                    metrics:
+                                        - name: "HTTP_REQUESTS"
+                                          measures: ["COUNT"]
+                                          sorts:
+                                              - measure: "COUNT"
+                                                order: "DESC"
+                                    facets: ["API"]
+                                    limit: 10
+                            by-status-with-ranges:
+                                summary: Status code group distribution
+                                value:
+                                    timeRange:
+                                        from: "2026-06-10T00:00:00Z"
+                                        to: "2026-06-11T00:00:00Z"
+                                    metrics:
+                                        - name: "HTTP_REQUESTS"
+                                          measures: ["COUNT"]
+                                    facets: ["HTTP_STATUS"]
+                                    ranges:
+                                        - from: 100
+                                          to: 199
+                                        - from: 200
+                                          to: 299
+                                        - from: 300
+                                          to: 399
+                                        - from: 400
+                                          to: 499
+                                        - from: 500
+                                          to: 599
+            responses:
+                "200":
+                    description: Faceted metric results.
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/FacetsResponse"
+                            examples:
+                                by-api:
+                                    summary: Per-API request count
+                                    value:
+                                        metrics:
+                                            - metric: "HTTP_REQUESTS"
+                                              unit: "NUMBER"
+                                              buckets:
+                                                  - key: "67e246cb-ab02-4da4-8f47-f9fa3e061d6b"
+                                                    name: null
+                                                    measures:
+                                                        - name: "COUNT"
+                                                          value: 30
+                                                  - key: "a1b2c3d4-0000-1111-2222-333344445555"
+                                                    name: null
+                                                    measures:
+                                                        - name: "COUNT"
+                                                          value: 12
+                "400":
+                    description: Invalid filter condition, facet name, or time range.
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/Error"
+                "403":
+                    description: Insufficient permissions.
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/Error"
+                            example:
+                                httpStatus: 403
+                                message: "Insufficient permissions to access observability data."
+
+    /organizations/{orgId}/environments/{envId}/observability/analytics/time-series:
+        parameters:
+            - $ref: "#/components/parameters/orgIdParam"
+            - $ref: "#/components/parameters/envIdParam"
+        post:
+            tags:
+                - Analytics
+            summary: Compute time-series histograms
+            description: |
+                Returns metric values bucketed by time intervals (e.g. per minute, per hour).
+                Use this endpoint to build line charts and histograms in the dashboard.
+
+                Each time bucket may optionally contain nested facet buckets when `facets` is
+                provided, enabling per-API or per-status time-series breakdowns.
+
+                `interval` is in milliseconds (e.g. `60000` for 1 minute, `3600000` for 1 hour).
+            operationId: computeObservabilityTimeSeries
+            requestBody:
+                required: true
+                content:
+                    application/json:
+                        schema:
+                            $ref: "#/components/schemas/AnalyticsTimeSeriesRequest"
+                        examples:
+                            hourly-histogram:
+                                summary: Hourly request count
+                                value:
+                                    timeRange:
+                                        from: "2026-06-10T00:00:00Z"
+                                        to: "2026-06-11T00:00:00Z"
+                                    filters: []
+                                    interval: 3600000
+                                    metrics:
+                                        - name: "HTTP_REQUESTS"
+                                          measures: ["COUNT"]
+                            with-facets:
+                                summary: Per-minute with API facet breakdown
+                                value:
+                                    timeRange:
+                                        from: "2026-06-10T12:00:00Z"
+                                        to: "2026-06-10T13:00:00Z"
+                                    interval: 60000
+                                    metrics:
+                                        - name: "HTTP_REQUESTS"
+                                          measures: ["COUNT"]
+                                    facets: ["API"]
+                                    facetSize: 5
+            responses:
+                "200":
+                    description: Time-series metric results.
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/TimeSeriesResponse"
+                            examples:
+                                hourly:
+                                    summary: Hourly buckets
+                                    value:
+                                        metrics:
+                                            - name: "HTTP_REQUESTS"
+                                              unit: "NUMBER"
+                                              buckets:
+                                                  - key: "2026-06-10T00:00:00Z"
+                                                    timestamp: 1749513600000
+                                                    measures:
+                                                        - name: "COUNT"
+                                                          value: 7
+                                                  - key: "2026-06-10T01:00:00Z"
+                                                    timestamp: 1749517200000
+                                                    measures:
+                                                        - name: "COUNT"
+                                                          value: 12
+                "400":
+                    description: Invalid filter condition, interval, or time range.
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/Error"
+                "403":
+                    description: Insufficient permissions.
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/Error"
+                            example:
+                                httpStatus: 403
+                                message: "Insufficient permissions to access observability data."
+
 components:
     securitySchemes:
         CookieAuth:
@@ -1299,6 +1600,315 @@ components:
                         $ref: "#/components/schemas/LogEntry"
                 pagination:
                     $ref: "#/components/schemas/Pagination"
+
+        MetricQuery:
+            type: object
+            description: A metric to compute with its requested measures. Used by the measures endpoint.
+            required: [name, measures]
+            properties:
+                name:
+                    type: string
+                    description: |
+                        Metric name from the analytics engine catalog (e.g. `HTTP_REQUESTS`,
+                        `HTTP_GATEWAY_RESPONSE_TIME`, `HTTP_ERRORS`, `LLM_PROMPT_TOTAL_TOKEN`).
+                    example: "HTTP_REQUESTS"
+                measures:
+                    type: array
+                    description: |
+                        Aggregation functions to apply. Valid values: `COUNT`, `AVG`, `MIN`, `MAX`,
+                        `SUM`, `P50`, `P90`, `P95`, `P99`, `PERCENTAGE`.
+                    items:
+                        type: string
+                    example: ["COUNT"]
+
+        SortSpec:
+            type: object
+            description: Sort directive for facet metric buckets.
+            required: [measure, order]
+            properties:
+                measure:
+                    type: string
+                    description: Name of the measure to sort by (must be present in the metric's `measures` list).
+                    example: "COUNT"
+                order:
+                    type: string
+                    description: Sort direction.
+                    enum: [ASC, DESC]
+                    example: "DESC"
+
+        FacetMetricQuery:
+            type: object
+            description: |
+                A metric to compute with its measures and optional sort directives. Used by the
+                facets and time-series endpoints.
+            required: [name, measures]
+            properties:
+                name:
+                    type: string
+                    description: Metric name from the analytics engine catalog.
+                    example: "HTTP_REQUESTS"
+                measures:
+                    type: array
+                    items:
+                        type: string
+                    example: ["COUNT"]
+                sorts:
+                    type: array
+                    nullable: true
+                    description: Sort directives for bucket ordering. Only applies to facets.
+                    items:
+                        $ref: "#/components/schemas/SortSpec"
+
+        NumberRange:
+            type: object
+            description: Numeric range for bucket-based aggregations (e.g. status code groups).
+            properties:
+                from:
+                    type: number
+                    description: Lower bound (inclusive).
+                    example: 200
+                to:
+                    type: number
+                    description: Upper bound (exclusive).
+                    example: 300
+
+        AnalyticsMeasuresRequest:
+            type: object
+            description: Request body for the measures endpoint.
+            required: [metrics]
+            properties:
+                timeRange:
+                    $ref: "#/components/schemas/TimeRange"
+                filters:
+                    type: array
+                    description: Filter conditions validated against the ANALYTICS signal catalog.
+                    items:
+                        $ref: "#/components/schemas/FilterCondition"
+                metrics:
+                    type: array
+                    description: One or more metrics to compute.
+                    items:
+                        $ref: "#/components/schemas/MetricQuery"
+
+        AnalyticsFacetsRequest:
+            type: object
+            description: Request body for the facets endpoint.
+            required: [metrics, facets]
+            properties:
+                timeRange:
+                    $ref: "#/components/schemas/TimeRange"
+                filters:
+                    type: array
+                    items:
+                        $ref: "#/components/schemas/FilterCondition"
+                metrics:
+                    type: array
+                    description: Metrics to compute per facet bucket.
+                    items:
+                        $ref: "#/components/schemas/FacetMetricQuery"
+                facets:
+                    type: array
+                    description: |
+                        Facet dimensions to break down by (e.g. `API`, `HTTP_STATUS`,
+                        `HTTP_METHOD`, `APPLICATION`, `PLAN`, `GATEWAY`, `LLM_PROXY_MODEL`).
+                    items:
+                        type: string
+                    example: ["API"]
+                limit:
+                    type: integer
+                    nullable: true
+                    description: Maximum number of buckets per facet.
+                    example: 10
+                ranges:
+                    type: array
+                    nullable: true
+                    description: Numeric ranges for bucket-based aggregations.
+                    items:
+                        $ref: "#/components/schemas/NumberRange"
+
+        AnalyticsTimeSeriesRequest:
+            type: object
+            description: Request body for the time-series endpoint.
+            required: [metrics, interval]
+            properties:
+                timeRange:
+                    $ref: "#/components/schemas/TimeRange"
+                filters:
+                    type: array
+                    items:
+                        $ref: "#/components/schemas/FilterCondition"
+                interval:
+                    type: integer
+                    format: int64
+                    description: Time bucket size in milliseconds (e.g. `60000` for 1 minute, `3600000` for 1 hour).
+                    example: 3600000
+                metrics:
+                    type: array
+                    description: Metrics to compute per time bucket.
+                    items:
+                        $ref: "#/components/schemas/FacetMetricQuery"
+                facets:
+                    type: array
+                    nullable: true
+                    description: Optional facet dimensions for nested breakdown within each time bucket.
+                    items:
+                        type: string
+                facetSize:
+                    type: integer
+                    nullable: true
+                    description: Maximum facet values per time bucket.
+                    example: 5
+                ranges:
+                    type: array
+                    nullable: true
+                    items:
+                        $ref: "#/components/schemas/NumberRange"
+
+        MeasureValue:
+            type: object
+            description: A single aggregated measure result.
+            properties:
+                name:
+                    type: string
+                    description: Measure name (e.g. `COUNT`, `AVG`, `P99`).
+                    example: "COUNT"
+                value:
+                    type: number
+                    description: Computed value.
+                    example: 42
+
+        MetricResult:
+            type: object
+            description: Result for one metric in a measures response.
+            properties:
+                name:
+                    type: string
+                    description: Metric name.
+                    example: "HTTP_REQUESTS"
+                unit:
+                    type: string
+                    description: Unit of the metric values.
+                    example: "NUMBER"
+                measures:
+                    type: array
+                    items:
+                        $ref: "#/components/schemas/MeasureValue"
+
+        MeasuresResponse:
+            type: object
+            description: Response from the measures endpoint.
+            properties:
+                metrics:
+                    type: array
+                    items:
+                        $ref: "#/components/schemas/MetricResult"
+
+        FacetBucket:
+            type: object
+            description: |
+                A facet bucket. Leaf buckets carry `measures`; group buckets carry nested `buckets`.
+            properties:
+                key:
+                    type: string
+                    description: Raw bucket key from the analytics engine (e.g. API id, HTTP method code, status code).
+                name:
+                    type: string
+                    nullable: true
+                    description: |
+                        Human-readable label for the key. Enriched server-side for known facets:
+                        `API` → API display name, `APPLICATION` → application name,
+                        `HTTP_METHOD` → method name (GET, POST, …),
+                        `HTTP_STATUS` → labeled code (200 OK, 404 Not Found, …),
+                        `HTTP_STATUS_CODE_GROUP` → group label (2XX, 4XX, …).
+                        Falls back to the raw key for unmapped facets.
+                buckets:
+                    type: array
+                    nullable: true
+                    description: Nested sub-buckets (for multi-level faceting).
+                    items:
+                        $ref: "#/components/schemas/FacetBucket"
+                measures:
+                    type: array
+                    nullable: true
+                    items:
+                        $ref: "#/components/schemas/MeasureValue"
+
+        FacetMetricResult:
+            type: object
+            description: Result for one metric in a facets response.
+            properties:
+                metric:
+                    type: string
+                    description: Metric name.
+                    example: "HTTP_REQUESTS"
+                unit:
+                    type: string
+                    example: "NUMBER"
+                buckets:
+                    type: array
+                    items:
+                        $ref: "#/components/schemas/FacetBucket"
+
+        FacetsResponse:
+            type: object
+            description: Response from the facets endpoint.
+            properties:
+                metrics:
+                    type: array
+                    items:
+                        $ref: "#/components/schemas/FacetMetricResult"
+
+        TimeSeriesBucket:
+            type: object
+            description: A time-series bucket with optional nested facet buckets.
+            properties:
+                key:
+                    type: string
+                    description: ISO-8601 timestamp of the bucket start.
+                    example: "2026-06-10T00:00:00Z"
+                name:
+                    type: string
+                    nullable: true
+                timestamp:
+                    type: integer
+                    format: int64
+                    description: Bucket start as epoch milliseconds.
+                    example: 1749513600000
+                buckets:
+                    type: array
+                    nullable: true
+                    description: Nested facet buckets within this time bucket.
+                    items:
+                        $ref: "#/components/schemas/FacetBucket"
+                measures:
+                    type: array
+                    nullable: true
+                    items:
+                        $ref: "#/components/schemas/MeasureValue"
+
+        TimeSeriesMetricResult:
+            type: object
+            description: Result for one metric in a time-series response.
+            properties:
+                name:
+                    type: string
+                    example: "HTTP_REQUESTS"
+                unit:
+                    type: string
+                    example: "NUMBER"
+                buckets:
+                    type: array
+                    items:
+                        $ref: "#/components/schemas/TimeSeriesBucket"
+
+        TimeSeriesResponse:
+            type: object
+            description: Response from the time-series endpoint.
+            properties:
+                metrics:
+                    type: array
+                    items:
+                        $ref: "#/components/schemas/TimeSeriesMetricResult"
 
         Error:
             type: object

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/test/java/io/gravitee/gamma/rest/core/observability/analytics/use_case/AnalyticsRequestPipelineTest.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/test/java/io/gravitee/gamma/rest/core/observability/analytics/use_case/AnalyticsRequestPipelineTest.java
@@ -1,0 +1,238 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gamma.rest.core.observability.analytics.use_case;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.apim.core.exception.ValidationDomainException;
+import io.gravitee.gamma.rest.core.observability.analytics.port.service_provider.ObservabilityAnalyticsDataPort;
+import io.gravitee.gamma.rest.core.observability.filter.domain_service.ObservabilityFilterValidator;
+import io.gravitee.gamma.rest.core.observability.filter.exception.UnsupportedObservabilityFilterException;
+import io.gravitee.gamma.rest.core.observability.filter.model.ApiType;
+import io.gravitee.gamma.rest.core.observability.filter.model.FilterCondition;
+import io.gravitee.gamma.rest.core.observability.filter.model.FilterOperator;
+import io.gravitee.gamma.rest.core.observability.filter.model.FilterSpec;
+import io.gravitee.gamma.rest.core.observability.filter.model.FilterType;
+import io.gravitee.gamma.rest.core.observability.filter.model.Signal;
+import io.gravitee.gamma.rest.core.observability.filter.port.service_provider.FilterRegistry;
+import io.gravitee.gamma.rest.core.observability.logs.domain_service.AccessibleApiScopeDomainService;
+import io.gravitee.gamma.rest.core.observability.logs.port.service_provider.ObservabilityLogsDataPort.AccessibleApi;
+import java.time.Instant;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class AnalyticsRequestPipelineTest {
+
+    private static final String ORG_ID = "org-1";
+    private static final String ENV_ID = "env-1";
+
+    @Mock
+    private ObservabilityAnalyticsDataPort analyticsDataPort;
+
+    @Mock
+    private FilterRegistry filterRegistry;
+
+    private AnalyticsRequestPipeline pipeline;
+
+    @BeforeEach
+    void setUp() {
+        var accessibleApiScope = new AccessibleApiScopeDomainService();
+        var filterValidator = new ObservabilityFilterValidator(filterRegistry);
+        pipeline = new AnalyticsRequestPipeline(filterValidator, accessibleApiScope);
+
+        when(filterRegistry.getFilters(any(), any())).thenReturn(
+            List.of(
+                new FilterSpec(
+                    "API",
+                    "API",
+                    FilterType.KEYWORD,
+                    List.of(FilterOperator.EQ, FilterOperator.IN),
+                    null,
+                    null,
+                    Set.of(Signal.LOGS, Signal.ANALYTICS),
+                    ApiType.ALL
+                ),
+                new FilterSpec(
+                    "HTTP_STATUS",
+                    "Status Code",
+                    FilterType.NUMBER,
+                    List.of(FilterOperator.EQ, FilterOperator.GTE, FilterOperator.LTE),
+                    null,
+                    new FilterSpec.Range(100, 599),
+                    Set.of(Signal.LOGS, Signal.ANALYTICS),
+                    Set.of(ApiType.HTTP_PROXY)
+                ),
+                new FilterSpec(
+                    "ENTRYPOINT",
+                    "Entrypoint",
+                    FilterType.KEYWORD,
+                    List.of(FilterOperator.IN),
+                    null,
+                    null,
+                    Set.of(Signal.LOGS, Signal.ANALYTICS),
+                    ApiType.ALL
+                )
+            )
+        );
+    }
+
+    @Nested
+    class Scoping {
+
+        @Test
+        void should_compute_scope_from_accessible_apis() {
+            when(analyticsDataPort.loadAccessibleApis(ORG_ID, ENV_ID)).thenReturn(
+                List.of(
+                    new AccessibleApi("api-proxy", "Proxy API", ApiType.HTTP_PROXY),
+                    new AccessibleApi("api-llm", "LLM API", ApiType.LLM)
+                )
+            );
+
+            var scope = pipeline.prepare(ORG_ID, ENV_ID, List.of(), null, null, analyticsDataPort);
+
+            assertThat(scope.apiIds()).containsExactlyInAnyOrder("api-proxy", "api-llm");
+        }
+
+        @Test
+        void should_intersect_user_api_filter_with_accessible_apis() {
+            when(analyticsDataPort.loadAccessibleApis(ORG_ID, ENV_ID)).thenReturn(
+                List.of(new AccessibleApi("api-1", "API 1", ApiType.HTTP_PROXY), new AccessibleApi("api-2", "API 2", ApiType.HTTP_PROXY))
+            );
+
+            var filters = List.of(new FilterCondition("API", FilterOperator.EQ, List.of("api-1")));
+            var scope = pipeline.prepare(ORG_ID, ENV_ID, filters, null, null, analyticsDataPort);
+
+            assertThat(scope.apiIds()).containsExactly("api-1");
+        }
+
+        @Test
+        void should_return_empty_scope_when_no_accessible_apis() {
+            when(analyticsDataPort.loadAccessibleApis(ORG_ID, ENV_ID)).thenReturn(List.of());
+
+            var scope = pipeline.prepare(ORG_ID, ENV_ID, List.of(), null, null, analyticsDataPort);
+
+            assertThat(scope.apiIds()).isEmpty();
+        }
+    }
+
+    @Nested
+    class FilterValidation {
+
+        @Test
+        void should_reject_unknown_filter_name() {
+            var filters = List.of(new FilterCondition("UNKNOWN", FilterOperator.EQ, List.of("val")));
+
+            assertThatThrownBy(() -> pipeline.prepare(ORG_ID, ENV_ID, filters, null, null, analyticsDataPort)).isInstanceOf(
+                UnsupportedObservabilityFilterException.class
+            );
+        }
+
+        @Test
+        void should_reject_unsupported_operator() {
+            var filters = List.of(new FilterCondition("HTTP_STATUS", FilterOperator.CONTAINS, List.of("200")));
+
+            assertThatThrownBy(() -> pipeline.prepare(ORG_ID, ENV_ID, filters, null, null, analyticsDataPort)).isInstanceOf(
+                UnsupportedObservabilityFilterException.class
+            );
+        }
+    }
+
+    @Nested
+    class TimeRange {
+
+        @Test
+        void should_reject_inverted_time_range() {
+            var from = Instant.parse("2026-06-11T12:00:00Z");
+            var to = Instant.parse("2026-06-10T12:00:00Z");
+
+            assertThatThrownBy(() -> pipeline.prepare(ORG_ID, ENV_ID, List.of(), from, to, analyticsDataPort))
+                .isInstanceOf(ValidationDomainException.class)
+                .hasMessageContaining("from");
+        }
+
+        @Test
+        void should_preserve_valid_time_range() {
+            when(analyticsDataPort.loadAccessibleApis(ORG_ID, ENV_ID)).thenReturn(
+                List.of(new AccessibleApi("api-1", "API 1", ApiType.HTTP_PROXY))
+            );
+
+            var from = Instant.parse("2026-06-10T00:00:00Z");
+            var to = Instant.parse("2026-06-11T00:00:00Z");
+            var scope = pipeline.prepare(ORG_ID, ENV_ID, List.of(), from, to, analyticsDataPort);
+
+            assertThat(scope.from()).isEqualTo(from);
+            assertThat(scope.to()).isEqualTo(to);
+        }
+    }
+
+    @Nested
+    class DefaultEntrypointScoping {
+
+        @Test
+        void should_inject_default_entrypoint_filter_when_none_provided() {
+            when(analyticsDataPort.loadAccessibleApis(ORG_ID, ENV_ID)).thenReturn(
+                List.of(new AccessibleApi("api-1", "API 1", ApiType.HTTP_PROXY))
+            );
+
+            var scope = pipeline.prepare(ORG_ID, ENV_ID, List.of(), null, null, analyticsDataPort);
+
+            var entrypoint = scope
+                .filters()
+                .stream()
+                .filter(c -> "ENTRYPOINT".equals(c.name()))
+                .findFirst();
+            assertThat(entrypoint).isPresent();
+            assertThat(entrypoint.get().values()).containsExactlyInAnyOrder(
+                "http-get",
+                "http-post",
+                "http-proxy",
+                "llm-proxy",
+                "mcp-proxy"
+            );
+        }
+
+        @Test
+        void should_preserve_user_entrypoint_filter_when_provided() {
+            when(analyticsDataPort.loadAccessibleApis(ORG_ID, ENV_ID)).thenReturn(
+                List.of(new AccessibleApi("api-1", "API 1", ApiType.HTTP_PROXY))
+            );
+
+            var filters = List.of(new FilterCondition("ENTRYPOINT", FilterOperator.IN, List.of("http-proxy")));
+            var scope = pipeline.prepare(ORG_ID, ENV_ID, filters, null, null, analyticsDataPort);
+
+            var entrypoints = scope
+                .filters()
+                .stream()
+                .filter(c -> "ENTRYPOINT".equals(c.name()))
+                .toList();
+            assertThat(entrypoints).hasSize(1);
+            assertThat(entrypoints.getFirst().values()).containsExactly("http-proxy");
+        }
+    }
+}

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/test/java/io/gravitee/gamma/rest/core/observability/analytics/use_case/AnalyticsRequestPipelineTest.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/test/java/io/gravitee/gamma/rest/core/observability/analytics/use_case/AnalyticsRequestPipelineTest.java
@@ -139,6 +139,19 @@ class AnalyticsRequestPipelineTest {
 
             assertThat(scope.apiIds()).isEmpty();
         }
+
+        @Test
+        void should_return_empty_scope_when_user_filters_unknown_api() {
+            when(analyticsDataPort.loadAccessibleApis(ORG_ID, ENV_ID)).thenReturn(
+                List.of(new AccessibleApi("api-1", "API 1", ApiType.HTTP_PROXY))
+            );
+
+            var filters = List.of(new FilterCondition("API", FilterOperator.IN, List.of("non-existent-api")));
+            var scope = pipeline.prepare(ORG_ID, ENV_ID, filters, null, null, analyticsDataPort);
+
+            assertThat(scope.isEmpty()).isTrue();
+            assertThat(scope.apiIds()).isEmpty();
+        }
     }
 
     @Nested

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/test/java/io/gravitee/gamma/rest/core/observability/analytics/use_case/ComputeObservabilityMeasuresUseCaseTest.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/test/java/io/gravitee/gamma/rest/core/observability/analytics/use_case/ComputeObservabilityMeasuresUseCaseTest.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gamma.rest.core.observability.analytics.use_case;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import io.gravitee.gamma.rest.core.observability.analytics.model.AnalyticsMetricQuery;
+import io.gravitee.gamma.rest.core.observability.analytics.port.service_provider.ObservabilityAnalyticsDataPort;
+import io.gravitee.gamma.rest.core.observability.filter.domain_service.ObservabilityFilterValidator;
+import io.gravitee.gamma.rest.core.observability.filter.exception.UnsupportedObservabilityFilterException;
+import io.gravitee.gamma.rest.core.observability.filter.model.ApiType;
+import io.gravitee.gamma.rest.core.observability.filter.model.FilterCondition;
+import io.gravitee.gamma.rest.core.observability.filter.model.FilterOperator;
+import io.gravitee.gamma.rest.core.observability.filter.model.FilterSpec;
+import io.gravitee.gamma.rest.core.observability.filter.model.FilterType;
+import io.gravitee.gamma.rest.core.observability.filter.model.Signal;
+import io.gravitee.gamma.rest.core.observability.filter.port.service_provider.FilterRegistry;
+import io.gravitee.gamma.rest.core.observability.logs.domain_service.AccessibleApiScopeDomainService;
+import io.gravitee.gamma.rest.core.observability.logs.port.service_provider.ObservabilityLogsDataPort.AccessibleApi;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class ComputeObservabilityMeasuresUseCaseTest {
+
+    private static final String ORG_ID = "org-1";
+    private static final String ENV_ID = "env-1";
+
+    @Mock
+    private ObservabilityAnalyticsDataPort analyticsDataPort;
+
+    @Mock
+    private FilterRegistry filterRegistry;
+
+    private ComputeObservabilityMeasuresUseCase useCase;
+
+    @BeforeEach
+    void setUp() {
+        var accessibleApiScope = new AccessibleApiScopeDomainService();
+        var filterValidator = new ObservabilityFilterValidator(filterRegistry);
+        var pipeline = new AnalyticsRequestPipeline(filterValidator, accessibleApiScope);
+        useCase = new ComputeObservabilityMeasuresUseCase(analyticsDataPort, pipeline);
+
+        when(filterRegistry.getFilters(any(), any())).thenReturn(
+            List.of(
+                new FilterSpec(
+                    "API",
+                    "API",
+                    FilterType.KEYWORD,
+                    List.of(FilterOperator.EQ, FilterOperator.IN),
+                    null,
+                    null,
+                    Set.of(Signal.LOGS, Signal.ANALYTICS),
+                    ApiType.ALL
+                ),
+                new FilterSpec(
+                    "HTTP_STATUS",
+                    "Status Code",
+                    FilterType.NUMBER,
+                    List.of(FilterOperator.EQ, FilterOperator.GTE, FilterOperator.LTE),
+                    null,
+                    new FilterSpec.Range(100, 599),
+                    Set.of(Signal.LOGS, Signal.ANALYTICS),
+                    Set.of(ApiType.HTTP_PROXY)
+                )
+            )
+        );
+    }
+
+    @Nested
+    class HappyPath {
+
+        @Test
+        void should_delegate_to_port_with_prepared_scope_and_metrics() {
+            when(analyticsDataPort.loadAccessibleApis(ORG_ID, ENV_ID)).thenReturn(
+                List.of(new AccessibleApi("api-1", "API 1", ApiType.HTTP_PROXY))
+            );
+            JsonNode fakeResponse = JsonNodeFactory.instance.objectNode().put("metrics", "ok");
+            when(analyticsDataPort.computeMeasures(any())).thenReturn(fakeResponse);
+
+            var metrics = List.of(new AnalyticsMetricQuery("HTTP_REQUESTS", List.of("COUNT")));
+            var output = useCase.execute(new ComputeObservabilityMeasuresUseCase.Input(ORG_ID, ENV_ID, List.of(), null, null, metrics));
+
+            assertThat(output.response()).isEqualTo(fakeResponse);
+
+            var captor = ArgumentCaptor.forClass(ObservabilityAnalyticsDataPort.MeasuresQuery.class);
+            verify(analyticsDataPort).computeMeasures(captor.capture());
+            assertThat(captor.getValue().metrics()).hasSize(1);
+            assertThat(captor.getValue().metrics().getFirst().metricName()).isEqualTo("HTTP_REQUESTS");
+            assertThat(captor.getValue().scope().apiIds()).containsExactly("api-1");
+        }
+    }
+
+    @Nested
+    class FilterValidation {
+
+        @Test
+        void should_reject_unknown_filter() {
+            var filters = List.of(new FilterCondition("UNKNOWN", FilterOperator.EQ, List.of("val")));
+            var metrics = List.of(new AnalyticsMetricQuery("HTTP_REQUESTS", List.of("COUNT")));
+
+            assertThatThrownBy(() ->
+                useCase.execute(new ComputeObservabilityMeasuresUseCase.Input(ORG_ID, ENV_ID, filters, null, null, metrics))
+            ).isInstanceOf(UnsupportedObservabilityFilterException.class);
+        }
+    }
+
+    @Nested
+    class RBACScoping {
+
+        @Test
+        void should_intersect_user_api_filter_with_accessible_scope() {
+            when(analyticsDataPort.loadAccessibleApis(ORG_ID, ENV_ID)).thenReturn(
+                List.of(new AccessibleApi("api-1", "API 1", ApiType.HTTP_PROXY), new AccessibleApi("api-2", "API 2", ApiType.HTTP_PROXY))
+            );
+            JsonNode fakeResponse = JsonNodeFactory.instance.objectNode();
+            when(analyticsDataPort.computeMeasures(any())).thenReturn(fakeResponse);
+
+            var filters = List.of(new FilterCondition("API", FilterOperator.IN, List.of("api-1")));
+            var metrics = List.of(new AnalyticsMetricQuery("HTTP_REQUESTS", List.of("COUNT")));
+            useCase.execute(new ComputeObservabilityMeasuresUseCase.Input(ORG_ID, ENV_ID, filters, null, null, metrics));
+
+            var captor = ArgumentCaptor.forClass(ObservabilityAnalyticsDataPort.MeasuresQuery.class);
+            verify(analyticsDataPort).computeMeasures(captor.capture());
+            assertThat(captor.getValue().scope().apiIds()).containsExactly("api-1");
+        }
+    }
+}

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/test/java/io/gravitee/gamma/rest/core/observability/analytics/use_case/ComputeObservabilityMeasuresUseCaseTest.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/test/java/io/gravitee/gamma/rest/core/observability/analytics/use_case/ComputeObservabilityMeasuresUseCaseTest.java
@@ -153,5 +153,21 @@ class ComputeObservabilityMeasuresUseCaseTest {
             verify(analyticsDataPort).computeMeasures(captor.capture());
             assertThat(captor.getValue().scope().apiIds()).containsExactly("api-1");
         }
+
+        @Test
+        void should_return_empty_response_when_user_filters_unknown_api() {
+            when(analyticsDataPort.loadAccessibleApis(ORG_ID, ENV_ID)).thenReturn(
+                List.of(new AccessibleApi("api-1", "API 1", ApiType.HTTP_PROXY))
+            );
+            JsonNode emptyResponse = JsonNodeFactory.instance.objectNode().putArray("metrics");
+            when(analyticsDataPort.emptyMeasuresResponse()).thenReturn(emptyResponse);
+
+            var filters = List.of(new FilterCondition("API", FilterOperator.IN, List.of("non-existent-api")));
+            var metrics = List.of(new AnalyticsMetricQuery("HTTP_REQUESTS", List.of("COUNT")));
+            var output = useCase.execute(new ComputeObservabilityMeasuresUseCase.Input(ORG_ID, ENV_ID, filters, null, null, metrics));
+
+            assertThat(output.response()).isEqualTo(emptyResponse);
+            verify(analyticsDataPort).emptyMeasuresResponse();
+        }
     }
 }

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/test/java/io/gravitee/gamma/rest/core/observability/filter/SpiFilterRegistryTest.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/test/java/io/gravitee/gamma/rest/core/observability/filter/SpiFilterRegistryTest.java
@@ -170,7 +170,7 @@ class SpiFilterRegistryTest {
         // HTTP-only and LLM_MODEL (LLM-only) are all excluded by one axis or the other.
         List<FilterSpec> result = registry.getFilters(Set.of(Signal.LOGS), Set.of(ApiType.NATIVE));
 
-        assertThat(result).extracting(FilterSpec::name).containsExactly("API", "APPLICATION", "PLAN", "API_TYPE");
+        assertThat(result).extracting(FilterSpec::name).containsExactly("API", "APPLICATION", "PLAN", "ENTRYPOINT", "API_TYPE");
     }
 
     private static FilterRegistry registryWith(FilterContributor... contributors) {


### PR DESCRIPTION
## Summary

Adds three Gamma observability analytics endpoints (measures, facets, time-series) under `/observability/analytics/`, backed by the existing Elasticsearch analytics engine and the unified filter catalog. Also fixes data-quality issues found during local integration testing and promotes `ENTRYPOINT` to a first-class filter.

Refs [GMA-586](https://gravitee.atlassian.net/browse/GMA-586)

## Changes

### New analytics endpoints (Gamma)

All paths are relative to `/gamma/organizations/{orgId}/environments/{envId}/observability`.

| Method | Path | Description |
|--------|------|-------------|
| `POST` | `/analytics/measures` | Returns aggregate metric values (e.g. `HTTP_REQUESTS` COUNT, `HTTP_GATEWAY_RESPONSE_TIME` AVG/P99) for a time range and filter set. Used for KPI cards and summary panels. RBAC-scoped; filters validated against the `ANALYTICS` signal catalog. |
| `POST` | `/analytics/facets` | Returns metrics broken down by facet dimensions (API, HTTP status, method, …). Supports `limit`, `sorts`, and numeric `ranges`. Bucket `name` fields are enriched server-side (API name, method label, status label). |
| `POST` | `/analytics/time-series` | Returns time-bucketed histograms (`interval` in ms) with optional per-facet breakdown (`facets`, `facetSize`). Sum of buckets matches measures under the same filters. |

**Implementation highlights:**
- `AnalyticsResource` (JAX-RS) + three use cases delegating to `ObservabilityAnalyticsDataPort`
- Shared `AnalyticsRequestPipeline`: filter validation, RBAC API scoping, default entrypoint injection
- `ObservabilityAnalyticsDataPortAdapter` bridges Gamma types to APIM `Compute*UseCase`
- Documented in `openapi-observability.yaml` (Analytics tag + request/response schemas)

### Data quality fixes (found during testing)

- **Empty RBAC scope returned all data** (AM-6): filtering by an unknown API ID now short-circuits to an empty response instead of an unscoped ES query.
- **HTTP_METHOD facet labels**: bucket names now map ES `HttpMethod.code()` values to readable names (GET, POST, …).
- **HTTP_STATUS facet labels**: status codes now return labeled names (`200 OK`, `404 Not Found`, …).

### ENTRYPOINT filter (Option B — full stack)

- Added `ENTRYPOINT` to `FilterSpec.Name`, `Filter.Name`, `StaticFilters`, and Management V2 `FilterName` OpenAPI enum
- `HTTPFieldResolver`: `ENTRYPOINT → entrypoint-id`
- `FilterAdapter.adaptForHTTP()`: skips hardcoded `httpFilter()` when an explicit `ENTRYPOINT` filter is present (V2 console unchanged)
- Users can narrow analytics to specific entrypoints (`mcp-proxy`, `llm-proxy`, …); default remains the 5 canonical HTTP entrypoints

### Documentation

- Updated `openapi-observability.yaml`: Analytics paths, `ENTRYPOINT` catalog entry + example, enriched `FacetBucket.name` description

## Test plan

- [x] Unit tests: `AnalyticsRequestPipelineTest`, `ComputeObservabilityMeasuresUseCaseTest`, `FilterAdapterTest`, `BucketNamesProcessorTest`, `SpiFilterRegistryTest`
- [x] Local integration — cross-endpoint coherence (30-day window, ~6,140 requests): **8/8 checks pass** (measures, facets, time-series vs log search)
- [x] ENTRYPOINT filter (wide range, ~1.6M requests): `mcp-proxy` 1,779 · `llm-proxy` 2,817 · combined 4,596 · unknown API → empty
- [x] Facet labels: HTTP_METHOD and HTTP_STATUS human-readable names verified

<img width="995" height="840" alt="Screenshot 2026-06-17 at 14 34 47" src="https://github.com/user-attachments/assets/3913c8a5-8ca0-4c02-9126-772d512b9437" />
<img width="1000" height="881" alt="Screenshot 2026-06-17 at 14 35 12" src="https://github.com/user-attachments/assets/106651b5-e4e6-4cf3-a821-2cd820a1fda6" />
<img width="1004" height="795" alt="Screenshot 2026-06-17 at 14 35 26" src="https://github.com/user-attachments/assets/097137f5-bed9-44c9-a99a-8d184d3bdced" />




## Reviewer notes

The most impactful ES change is conditional `httpFilter()` in `FilterAdapter.adaptForHTTP()`. Safe because the V2 console never sends `ENTRYPOINT`, and Gamma always sends either a user filter or the default 5 entrypoints via the pipeline.

[GMA-586]: https://gravitee.atlassian.net/browse/GMA-586?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ