### PR TITLE
feat(gateway): apply API Product sharding tags at runtime

### DIFF
--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/ReactableApiProduct.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/ReactableApiProduct.java
@@ -58,6 +58,7 @@ public class ReactableApiProduct implements Reactable, Serializable {
     private Date deployedAt;
 
     private List<Plan> plans;
+    private Set<String> tags;
 
     @Override
     public boolean enabled() {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/manager/ApiManager.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/manager/ApiManager.java
@@ -17,6 +17,7 @@ package io.gravitee.gateway.handlers.api.manager;
 
 import io.gravitee.gateway.reactor.ReactableApi;
 import java.util.Collection;
+import java.util.Set;
 
 /**
  * This manager interface acts as a bridge between the source of {@link ReactableApi} (*.json files in case of
@@ -54,4 +55,15 @@ public interface ApiManager {
      * @return A deployed {@link ReactableApi}
      */
     ReactableApi<?> get(String apiId);
+
+    /**
+     * Re-evaluates shard eligibility for the given API IDs after a product change.
+     * Any deployed API that is no longer eligible will be undeployed.
+     * Intended to be called <em>after</em> a member-API resync so that deploy
+     * happens before undeploy, avoiding an unnecessary bounce.
+     *
+     * @param productId the product that changed (for logging)
+     * @param apiIds    the member API IDs to re-evaluate
+     */
+    void reEvaluateAfterProductChange(String productId, Set<String> apiIds);
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/manager/impl/ApiManagerImpl.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/manager/impl/ApiManagerImpl.java
@@ -24,6 +24,8 @@ import io.gravitee.definition.model.DefinitionVersion;
 import io.gravitee.definition.model.Plugin;
 import io.gravitee.gateway.env.GatewayConfiguration;
 import io.gravitee.gateway.handlers.api.definition.Api;
+import io.gravitee.gateway.handlers.api.event.ApiProductChangedEvent;
+import io.gravitee.gateway.handlers.api.event.ApiProductEventType;
 import io.gravitee.gateway.handlers.api.manager.ActionOnApi;
 import io.gravitee.gateway.handlers.api.manager.ApiManager;
 import io.gravitee.gateway.handlers.api.manager.Deployer;
@@ -38,16 +40,20 @@ import io.gravitee.secrets.api.discovery.Definition;
 import io.gravitee.secrets.api.discovery.DefinitionMetadata;
 import io.gravitee.secrets.api.event.SecretDiscoveryEvent;
 import io.gravitee.secrets.api.event.SecretDiscoveryEventType;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.stream.Collectors;
 import lombok.CustomLog;
 import org.slf4j.MDC;
@@ -61,10 +67,13 @@ public class ApiManagerImpl implements ApiManager {
 
     private static final int PARALLELISM = Runtime.getRuntime().availableProcessors() * 2;
 
+    private static final Set<String> SUPPORTED_SECRET_DEFINITION_KINDS = Set.of(API_V4_DEFINITION_KIND, NATIVE_API_V4_DEFINITION_KIND);
+
     private final EventManager eventManager;
     private final GatewayConfiguration gatewayConfiguration;
     private final LicenseManager licenseManager;
     private final Map<String, ReactableApi<?>> apis = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<String, Lock> apiLocks = new ConcurrentHashMap<>();
     private final Map<Class<? extends ReactableApi<?>>, ? extends Deployer<?>> deployers;
     private final ApiProductRegistry apiProductRegistry;
 
@@ -104,45 +113,81 @@ public class ApiManagerImpl implements ApiManager {
             )
         );
 
-        // Listen to secret discovery events to update APIs when secrets change
+        subscribeToSecretDiscoveryEvents();
+        subscribeToApiProductEventsIfNeeded();
+    }
+
+    private void subscribeToSecretDiscoveryEvents() {
         eventManager.subscribeForEvents(
             event -> {
                 if (event.content() instanceof SecretDiscoveryEvent secretDiscoveryEvent) {
-                    if (secretDiscoveryEvent.definition() instanceof Definition definition) {
-                        if (!List.of(API_V4_DEFINITION_KIND, NATIVE_API_V4_DEFINITION_KIND).contains(definition.kind())) {
-                            // We only handle API V4 and Native API definitions
-                            log.debug(
-                                "Received SecretDiscoveryEvent for definition {} with kind {}, but we only handle API V4 and Native API definitions",
-                                definition.id(),
-                                definition.kind()
-                            );
-                            return;
-                        }
-
-                        ReactableApi<?> api = apis.get(definition.id());
-                        if (api != null) {
-                            MDC.put("api", api.getId());
-
-                            log.info("Secret value changed for API {}, updating it", definition.id());
-                            eventManager.publishEvent(ReactorEvent.UPDATE, api);
-
-                            log.info("{} has been updated", api);
-                            MDC.remove("api");
-                        } else {
-                            log.trace(
-                                "Received SecretDiscoveryEvent for API {}, but it is not found in the API manager. Unable to update it",
-                                definition.id()
-                            );
-                        }
-                    }
+                    onSecretDiscoveryValueChanged(secretDiscoveryEvent);
                 }
             },
             SecretDiscoveryEventType.VALUE_CHANGED
         );
     }
 
+    private void onSecretDiscoveryValueChanged(SecretDiscoveryEvent secretDiscoveryEvent) {
+        if (!(secretDiscoveryEvent.definition() instanceof Definition definition)) {
+            return;
+        }
+        if (!SUPPORTED_SECRET_DEFINITION_KINDS.contains(definition.kind())) {
+            log.debug(
+                "Received SecretDiscoveryEvent for definition {} with kind {}, but we only handle API V4 and Native API definitions",
+                definition.id(),
+                definition.kind()
+            );
+            return;
+        }
+        updateApiOnSecretChange(definition);
+    }
+
+    private void updateApiOnSecretChange(Definition definition) {
+        ReactableApi<?> api = apis.get(definition.id());
+        if (api == null) {
+            log.trace(
+                "Received SecretDiscoveryEvent for API {}, but it is not found in the API manager. Unable to update it",
+                definition.id()
+            );
+            return;
+        }
+        MDC.put("api", api.getId());
+        try {
+            log.info("Secret value changed for API {}, updating it", definition.id());
+            eventManager.publishEvent(ReactorEvent.UPDATE, api);
+            log.info("{} has been updated", api);
+        } finally {
+            MDC.remove("api");
+        }
+    }
+
+    private void subscribeToApiProductEventsIfNeeded() {
+        if (apiProductRegistry == null) {
+            return;
+        }
+        eventManager.subscribeForEvents(
+            event -> {
+                if (event.content() instanceof ApiProductChangedEvent productEvent) {
+                    onApiProductUndeploy(productEvent);
+                }
+            },
+            ApiProductEventType.UNDEPLOY
+        );
+    }
+
+    private void onApiProductUndeploy(ApiProductChangedEvent productEvent) {
+        if (productEvent.getApiIds() == null) {
+            return;
+        }
+        reEvaluateApisAfterProductChange(productEvent.getProductId(), productEvent.getApiIds());
+    }
+
     private boolean register(ReactableApi<?> api, boolean force) {
-        // Get deployed API
+        return withPerApiLock(api.getId(), () -> doRegister(api, force));
+    }
+
+    private boolean doRegister(ReactableApi<?> api, boolean force) {
         ReactableApi<?> deployedApi = get(api.getId());
 
         List<Plugin> plugins;
@@ -165,34 +210,27 @@ public class ApiManagerImpl implements ApiManager {
             return false;
         }
 
-        // Keep the check of Sharding Tags for io.gravitee.gateway.services.localregistry.LocalApiDefinitionRegistry
-        if (gatewayConfiguration.hasMatchingTags(api.getTags())) {
+        if (isApiShardEligible(api)) {
             boolean apiToDeploy = deployedApi == null || force;
             boolean apiToUpdate =
                 !apiToDeploy &&
                 (deployedApi.getDeployedAt().before(api.getDeployedAt()) && !Objects.equals(deployedApi.getRevision(), api.getRevision()));
 
-            // if API will be deployed or updated
             if (apiToDeploy || apiToUpdate) {
                 Deployer deployer = deployers.get(api.getClass());
                 deployer.initialize(api);
             }
 
-            // API is not yet deployed, so let's do it
             if (apiToDeploy) {
                 deploy(api);
                 return true;
-            }
-            // API has to be updated, so update it
-            else if (apiToUpdate) {
+            } else if (apiToUpdate) {
                 update(api);
                 return true;
             }
         } else {
             log.debug("The API {} has been ignored because not in configured tags {}", api.getName(), api.getTags());
 
-            // Check that the API was not previously deployed with other tags
-            // In that case, we must undeploy it
             if (deployedApi != null) {
                 undeploy(api.getId());
             }
@@ -205,25 +243,38 @@ public class ApiManagerImpl implements ApiManager {
     public ActionOnApi requiredActionFor(final ReactableApi<?> reactableApi) {
         ReactableApi<?> deployedApi = get(reactableApi.getId());
         if (!reactableApi.enabled()) {
+            log.debug("requiredActionFor [{}]: UNDEPLOY (disabled)", reactableApi.getId());
             return ActionOnApi.UNDEPLOY;
         }
 
-        if (gatewayConfiguration.hasMatchingTags(reactableApi.getTags())) {
+        if (isApiShardEligible(reactableApi)) {
             boolean apiToDeploy = deployedApi == null;
             boolean apiToUpdate =
                 !apiToDeploy &&
                 (deployedApi.getDeployedAt().before(reactableApi.getDeployedAt()) &&
                     !Objects.equals(deployedApi.getRevision(), reactableApi.getRevision()));
 
-            // API will be deployed or updated
             if (apiToDeploy || apiToUpdate) {
+                log.debug(
+                    "requiredActionFor [{}]: DEPLOY (shard-eligible, toDeploy={}, toUpdate={})",
+                    reactableApi.getId(),
+                    apiToDeploy,
+                    apiToUpdate
+                );
                 return ActionOnApi.DEPLOY;
             }
+            log.debug("requiredActionFor [{}]: NONE (shard-eligible but already up-to-date)", reactableApi.getId());
         } else if (deployedApi != null) {
-            // Undeploy if previously deployed with other tags
+            log.debug("requiredActionFor [{}]: UNDEPLOY (no longer eligible)", reactableApi.getId());
             return ActionOnApi.UNDEPLOY;
+        } else {
+            log.debug(
+                "requiredActionFor [{}]: NONE — not shard-eligible (tags={}, env={})",
+                reactableApi.getId(),
+                reactableApi.getTags(),
+                reactableApi.getEnvironmentId()
+            );
         }
-        // Nothing to do
         return ActionOnApi.NONE;
     }
 
@@ -234,38 +285,44 @@ public class ApiManagerImpl implements ApiManager {
 
     @Override
     public void unregister(String apiId) {
-        undeploy(apiId);
+        withPerApiLock(apiId, () -> undeploy(apiId));
     }
 
     @Override
     public void refresh() {
-        if (!apis.isEmpty()) {
-            final long begin = System.currentTimeMillis();
-
-            log.info("Starting apis refresh. {} apis to be refreshed.", apis.size());
-
-            // Create an executor to parallelize a refresh for all the apis.
-            final ExecutorService refreshAllExecutor = createExecutor(Math.min(PARALLELISM, apis.size()));
-
-            final List<Callable<Boolean>> toInvoke = apis
-                .values()
-                .stream()
-                .map(api -> ((Callable<Boolean>) () -> register(api, true)))
-                .collect(Collectors.toList());
-
-            try {
-                refreshAllExecutor.invokeAll(toInvoke);
-                refreshAllExecutor.shutdown();
-                while (!refreshAllExecutor.awaitTermination(100, TimeUnit.MILLISECONDS));
-            } catch (InterruptedException e) {
-                log.error("Unable to refresh apis", e);
-                Thread.currentThread().interrupt();
-            } finally {
-                refreshAllExecutor.shutdown();
-            }
-
-            log.info("Apis refresh done in {}ms", (System.currentTimeMillis() - begin));
+        if (apis.isEmpty()) {
+            return;
         }
+
+        final long begin = System.currentTimeMillis();
+
+        List<ReactableApi<?>> allApis = new ArrayList<>(apis.values());
+
+        log.info("Starting apis refresh. {} deployed apis to be refreshed.", apis.size());
+
+        if (allApis.isEmpty()) {
+            return;
+        }
+
+        final ExecutorService refreshAllExecutor = createExecutor(Math.min(PARALLELISM, allApis.size()));
+
+        final List<Callable<Boolean>> toInvoke = allApis
+            .stream()
+            .map(api -> ((Callable<Boolean>) () -> register(api, true)))
+            .collect(Collectors.toList());
+
+        try {
+            refreshAllExecutor.invokeAll(toInvoke);
+            refreshAllExecutor.shutdown();
+            while (!refreshAllExecutor.awaitTermination(100, TimeUnit.MILLISECONDS));
+        } catch (InterruptedException e) {
+            log.error("Unable to refresh apis", e);
+            Thread.currentThread().interrupt();
+        } finally {
+            refreshAllExecutor.shutdown();
+        }
+
+        log.info("Apis refresh done in {}ms", (System.currentTimeMillis() - begin));
     }
 
     private void deploy(ReactableApi api) {
@@ -354,6 +411,22 @@ public class ApiManagerImpl implements ApiManager {
         MDC.remove("api");
     }
 
+    private boolean isApiShardEligible(ReactableApi<?> api) {
+        if (gatewayConfiguration.hasMatchingTags(api.getTags())) {
+            return true;
+        }
+        boolean productMatch = isIncludedInApiProductWithPlans(api);
+        if (!productMatch) {
+            log.debug(
+                "API [{}] (tags={}) not shard-eligible: no matching gateway tags and no API Product plan entries found (env={})",
+                api.getId(),
+                api.getTags(),
+                api.getEnvironmentId()
+            );
+        }
+        return productMatch;
+    }
+
     private boolean isIncludedInApiProductWithPlans(ReactableApi<?> api) {
         if (apiProductRegistry == null || api.getEnvironmentId() == null) {
             return false;
@@ -363,6 +436,45 @@ public class ApiManagerImpl implements ApiManager {
             api.getEnvironmentId()
         );
         return apiProductPlanEntries != null && !apiProductPlanEntries.isEmpty();
+    }
+
+    @Override
+    public void reEvaluateAfterProductChange(String productId, Set<String> apiIds) {
+        reEvaluateApisAfterProductChange(productId, apiIds);
+    }
+
+    private void reEvaluateApisAfterProductChange(String productId, Set<String> apiIds) {
+        log.debug("Re-evaluating {} API(s) after API Product [{}] change", apiIds.size(), productId);
+        for (String apiId : apiIds) {
+            withPerApiLock(apiId, () -> {
+                ReactableApi<?> deployedApi = apis.get(apiId);
+                if (deployedApi != null && !isApiShardEligible(deployedApi)) {
+                    log.info("API [{}] no longer eligible after API Product [{}] change — undeploying", apiId, productId);
+                    undeploy(apiId);
+                }
+            });
+        }
+    }
+
+    private void withPerApiLock(String apiId, Runnable action) {
+        withPerApiLock(apiId, () -> {
+            action.run();
+            return null;
+        });
+    }
+
+    private <T> T withPerApiLock(String apiId, Callable<T> action) {
+        Lock lock = apiLocks.computeIfAbsent(apiId, k -> new ReentrantLock());
+        lock.lock();
+        try {
+            return action.call();
+        } catch (RuntimeException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new IllegalStateException("Failed to execute locked action for API [" + apiId + "]", e);
+        } finally {
+            lock.unlock();
+        }
     }
 
     private void undeploy(String apiId) {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/manager/impl/ApiProductManagerImpl.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/manager/impl/ApiProductManagerImpl.java
@@ -16,16 +16,20 @@
 package io.gravitee.gateway.handlers.api.manager.impl;
 
 import io.gravitee.common.event.EventManager;
+import io.gravitee.gateway.env.GatewayConfiguration;
 import io.gravitee.gateway.handlers.api.ReactableApiProduct;
 import io.gravitee.gateway.handlers.api.event.ApiProductChangedEvent;
 import io.gravitee.gateway.handlers.api.event.ApiProductEventType;
 import io.gravitee.gateway.handlers.api.manager.ApiProductManager;
 import io.gravitee.gateway.handlers.api.registry.ApiProductRegistry;
+import io.gravitee.gateway.handlers.api.sharding.ApiProductShardingFilter;
 import io.gravitee.node.api.license.LicenseManager;
 import io.reactivex.rxjava3.core.Completable;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import lombok.CustomLog;
 
@@ -39,12 +43,19 @@ public class ApiProductManagerImpl implements ApiProductManager {
     private final ApiProductRegistry apiProductRegistry;
     private final EventManager eventManager;
     private final LicenseManager licenseManager;
+    private final GatewayConfiguration gatewayConfiguration;
     private final Map<String, ReactableApiProduct> apiProducts = new ConcurrentHashMap<>();
 
-    public ApiProductManagerImpl(ApiProductRegistry apiProductRegistry, EventManager eventManager, LicenseManager licenseManager) {
+    public ApiProductManagerImpl(
+        ApiProductRegistry apiProductRegistry,
+        EventManager eventManager,
+        LicenseManager licenseManager,
+        GatewayConfiguration gatewayConfiguration
+    ) {
         this.apiProductRegistry = apiProductRegistry;
         this.eventManager = eventManager;
         this.licenseManager = licenseManager;
+        this.gatewayConfiguration = gatewayConfiguration;
     }
 
     @Override
@@ -80,6 +91,18 @@ public class ApiProductManagerImpl implements ApiProductManager {
                 "The API Product [{}] can not be deployed because it is not allowed by the current license (universe tier)",
                 apiProduct.getName()
             );
+            return Completable.complete();
+        }
+
+        if (!ApiProductShardingFilter.matchesProductTags(gatewayConfiguration, apiProduct.getTags())) {
+            log.debug(
+                "The API Product [{}] has been ignored because not in configured gateway tags {}",
+                apiProduct.getName(),
+                apiProduct.getTags()
+            );
+            if (get(apiProduct.getId()) != null) {
+                undeploy(apiProduct.getId());
+            }
             return Completable.complete();
         }
 
@@ -124,16 +147,28 @@ public class ApiProductManagerImpl implements ApiProductManager {
     private Completable update(ReactableApiProduct apiProduct, Completable doBeforeEmit) {
         log.debug("Updating API Product [{}]", apiProduct.getId());
 
+        ReactableApiProduct previousProduct = apiProducts.get(apiProduct.getId());
+        Set<String> previousApiIds = previousProduct != null && previousProduct.getApiIds() != null
+            ? previousProduct.getApiIds()
+            : Set.of();
+
         apiProducts.put(apiProduct.getId(), apiProduct);
         apiProductRegistry.register(apiProduct);
 
-        Completable emit = Completable.fromRunnable(() -> {
-            if (apiProduct.getApiIds() != null && !apiProduct.getApiIds().isEmpty()) {
-                emitApiProductChangedEvent(ApiProductEventType.UPDATE, apiProduct);
-            }
-            log.info("API Product [{}] has been updated", apiProduct.getId());
-        });
+        Completable emit = Completable.fromRunnable(() -> publishApiProductUpdateEvent(apiProduct, previousApiIds));
         return (doBeforeEmit != null ? doBeforeEmit : Completable.complete()).andThen(emit);
+    }
+
+    private void publishApiProductUpdateEvent(ReactableApiProduct apiProduct, Set<String> previousApiIds) {
+        Set<String> allAffectedApiIds = new HashSet<>(previousApiIds);
+        if (apiProduct.getApiIds() != null) {
+            allAffectedApiIds.addAll(apiProduct.getApiIds());
+        }
+        if (!allAffectedApiIds.isEmpty()) {
+            ApiProductChangedEvent event = new ApiProductChangedEvent(apiProduct.getId(), apiProduct.getEnvironmentId(), allAffectedApiIds);
+            eventManager.publishEvent(ApiProductEventType.UPDATE, event);
+        }
+        log.info("API Product [{}] has been updated", apiProduct.getId());
     }
 
     private void undeploy(String apiProductId) {

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/registry/ApiProductRegistryKey.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/registry/ApiProductRegistryKey.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.handlers.api.registry;
+
+/**
+ * Composite map key for {@link ApiProductRegistry} entries.
+ * Product lookups and removals are always environment-scoped; pairing both identifiers
+ * avoids collisions when the same gateway hosts multiple environments and gives
+ * correct {@code equals}/{@code hashCode} semantics for the registry's {@code ConcurrentHashMap}.
+ */
+public record ApiProductRegistryKey(String apiProductId, String environmentId) {}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/registry/impl/ApiProductRegistryImpl.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/registry/impl/ApiProductRegistryImpl.java
@@ -18,13 +18,19 @@ package io.gravitee.gateway.handlers.api.registry.impl;
 import com.google.common.annotations.VisibleForTesting;
 import io.gravitee.definition.model.v4.plan.Plan;
 import io.gravitee.definition.model.v4.plan.PlanStatus;
+import io.gravitee.gateway.env.GatewayConfiguration;
 import io.gravitee.gateway.handlers.api.ReactableApiProduct;
 import io.gravitee.gateway.handlers.api.registry.ApiProductRegistry;
+import io.gravitee.gateway.handlers.api.registry.ApiProductRegistryKey;
+import io.gravitee.gateway.handlers.api.sharding.ApiProductShardingFilter;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 import lombok.CustomLog;
 
 /**
@@ -34,8 +40,19 @@ import lombok.CustomLog;
 @CustomLog
 public class ApiProductRegistryImpl implements ApiProductRegistry {
 
+    private record ApiEnvironmentKey(String environmentId, String apiId) {}
+
     @VisibleForTesting
     protected final Map<ApiProductRegistryKey, ReactableApiProduct> registry = new ConcurrentHashMap<>();
+
+    private volatile Map<ApiEnvironmentKey, List<ApiProductPlanEntry>> planEntriesByApi = Map.of();
+
+    private final ReadWriteLock indexLock = new ReentrantReadWriteLock();
+    private final GatewayConfiguration gatewayConfiguration;
+
+    public ApiProductRegistryImpl(GatewayConfiguration gatewayConfiguration) {
+        this.gatewayConfiguration = gatewayConfiguration;
+    }
 
     @Override
     public ReactableApiProduct get(String apiProductId, String environmentId) {
@@ -52,15 +69,8 @@ public class ApiProductRegistryImpl implements ApiProductRegistry {
         log.debug("Registering API Product [{}] for environment [{}]", apiProduct.getId(), apiProduct.getEnvironmentId());
 
         ApiProductRegistryKey key = new ApiProductRegistryKey(apiProduct.getId(), apiProduct.getEnvironmentId());
-        ReactableApiProduct previousApiProduct = registry.put(key, apiProduct);
-
-        if (previousApiProduct != null) {
-            log.debug(
-                "API Product [{}] was already registered for environment [{}]; replaced with new version",
-                apiProduct.getId(),
-                apiProduct.getEnvironmentId()
-            );
-        }
+        ReactableApiProduct previous = registry.put(key, apiProduct);
+        updateIndexForProduct(previous, apiProduct);
     }
 
     @Override
@@ -72,49 +82,124 @@ public class ApiProductRegistryImpl implements ApiProductRegistry {
 
         if (removed != null) {
             log.debug("API Product [{}] removed from environment [{}]", apiProductId, environmentId);
+            removeIndexForProduct(removed);
         } else {
             log.debug("API Product [{}] was not found in registry for environment [{}]", apiProductId, environmentId);
         }
     }
 
-    /**
-     * Clear all API Products from the registry.
-     * Used for cleanup during shutdown or testing.
-     */
     public void clear() {
         log.debug("Clearing all API Products from registry");
         registry.clear();
+        indexLock.writeLock().lock();
+        try {
+            planEntriesByApi = Map.of();
+        } finally {
+            indexLock.writeLock().unlock();
+        }
     }
 
     @Override
     public List<ApiProductPlanEntry> getApiProductPlanEntriesForApi(String apiId, String environmentId) {
-        List<ApiProductPlanEntry> entries = new ArrayList<>();
-
         if (apiId == null || environmentId == null) {
-            return entries;
+            return List.of();
         }
+        List<ApiProductPlanEntry> entries = planEntriesByApi.get(new ApiEnvironmentKey(environmentId, apiId));
+        return entries != null ? List.copyOf(entries) : List.of();
+    }
 
-        for (ReactableApiProduct product : registry.values()) {
-            if (
-                product.getEnvironmentId() != null &&
-                product.getEnvironmentId().equals(environmentId) &&
-                product.getApiIds() != null &&
-                product.getApiIds().contains(apiId) &&
-                product.getPlans() != null
-            ) {
-                for (Plan plan : product.getPlans()) {
-                    if (plan.getStatus() == PlanStatus.PUBLISHED || plan.getStatus() == PlanStatus.DEPRECATED) {
-                        entries.add(new ApiProductPlanEntry(product.getId(), plan));
-                    }
+    private void updateIndexForProduct(ReactableApiProduct previous, ReactableApiProduct current) {
+        indexLock.writeLock().lock();
+        try {
+            Map<ApiEnvironmentKey, List<ApiProductPlanEntry>> mutable = new HashMap<>(planEntriesByApi);
+            if (previous != null) {
+                removeProductFromMutableIndex(mutable, previous);
+            }
+            addProductToMutableIndex(mutable, current);
+            planEntriesByApi = Map.copyOf(mutable);
+        } finally {
+            indexLock.writeLock().unlock();
+        }
+        log.debug("API Product registry index updated for product [{}]: {} API entries total", current.getId(), planEntriesByApi.size());
+    }
+
+    private void removeIndexForProduct(ReactableApiProduct product) {
+        indexLock.writeLock().lock();
+        try {
+            Map<ApiEnvironmentKey, List<ApiProductPlanEntry>> mutable = new HashMap<>(planEntriesByApi);
+            removeProductFromMutableIndex(mutable, product);
+            planEntriesByApi = Map.copyOf(mutable);
+        } finally {
+            indexLock.writeLock().unlock();
+        }
+        log.debug(
+            "API Product registry index updated after removing product [{}]: {} API entries total",
+            product.getId(),
+            planEntriesByApi.size()
+        );
+    }
+
+    private void addProductToMutableIndex(Map<ApiEnvironmentKey, List<ApiProductPlanEntry>> index, ReactableApiProduct product) {
+        if (!ApiProductShardingFilter.matchesProductTags(gatewayConfiguration, product.getTags())) {
+            log.debug(
+                "API Product [{}] skipped during indexing: product tags {} do not match gateway sharding tags",
+                product.getId(),
+                product.getTags()
+            );
+            return;
+        }
+        if (product.getEnvironmentId() == null || product.getApiIds() == null || product.getPlans() == null) {
+            return;
+        }
+        for (String apiId : product.getApiIds()) {
+            for (Plan plan : product.getPlans()) {
+                addPlanToIndexIfEligible(index, product, apiId, plan);
+            }
+        }
+    }
+
+    private void addPlanToIndexIfEligible(
+        Map<ApiEnvironmentKey, List<ApiProductPlanEntry>> index,
+        ReactableApiProduct product,
+        String apiId,
+        Plan plan
+    ) {
+        if (plan.getStatus() != PlanStatus.PUBLISHED && plan.getStatus() != PlanStatus.DEPRECATED) {
+            return;
+        }
+        if (!ApiProductShardingFilter.matchesPlanTags(gatewayConfiguration, plan.getTags())) {
+            log.debug(
+                "Plan [{}] of product [{}] skipped: plan tags {} do not match gateway tags",
+                plan.getId(),
+                product.getId(),
+                plan.getTags()
+            );
+            return;
+        }
+        ApiProductPlanEntry entry = new ApiProductPlanEntry(product.getId(), plan);
+        List<ApiProductPlanEntry> entries = index.computeIfAbsent(new ApiEnvironmentKey(product.getEnvironmentId(), apiId), k ->
+            new ArrayList<>()
+        );
+        entries.add(entry);
+    }
+
+    private static void removeProductFromMutableIndex(
+        Map<ApiEnvironmentKey, List<ApiProductPlanEntry>> index,
+        ReactableApiProduct product
+    ) {
+        if (product.getEnvironmentId() == null || product.getApiIds() == null) {
+            return;
+        }
+        String productId = product.getId();
+        for (String apiId : product.getApiIds()) {
+            ApiEnvironmentKey key = new ApiEnvironmentKey(product.getEnvironmentId(), apiId);
+            List<ApiProductPlanEntry> entries = index.get(key);
+            if (entries != null) {
+                entries.removeIf(e -> productId.equals(e.apiProductId()));
+                if (entries.isEmpty()) {
+                    index.remove(key);
                 }
             }
         }
-
-        return entries;
     }
-
-    /**
-     * Registry key combining API Product ID and Environment ID for scoping.
-     */
-    record ApiProductRegistryKey(String apiProductId, String environmentId) {}
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/sharding/ApiProductShardingFilter.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/sharding/ApiProductShardingFilter.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.handlers.api.sharding;
+
+import io.gravitee.gateway.env.GatewayConfiguration;
+import java.util.Set;
+
+/**
+ * Sharding tag matching for API Products and API Product plans (aligned with API sharding in gateway).
+ *
+ * <p>Follows the same rules as APIs: tagless gateways retrieve everything; tagged gateways
+ * only retrieve entities whose tags match.
+ */
+public final class ApiProductShardingFilter {
+
+    private ApiProductShardingFilter() {}
+
+    public static boolean matchesProductTags(GatewayConfiguration gatewayConfiguration, Set<String> productTags) {
+        return gatewayConfiguration.hasMatchingTags(productTags);
+    }
+
+    public static boolean matchesPlanTags(GatewayConfiguration gatewayConfiguration, Set<String> planTags) {
+        if (planTags == null || planTags.isEmpty()) {
+            return true;
+        }
+        return gatewayConfiguration.hasMatchingTags(planTags);
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/spring/ApiProductConfiguration.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/spring/ApiProductConfiguration.java
@@ -16,6 +16,7 @@
 package io.gravitee.gateway.handlers.api.spring;
 
 import io.gravitee.common.event.EventManager;
+import io.gravitee.gateway.env.GatewayConfiguration;
 import io.gravitee.gateway.handlers.api.manager.ApiProductManager;
 import io.gravitee.gateway.handlers.api.manager.impl.ApiProductManagerImpl;
 import io.gravitee.gateway.handlers.api.registry.ApiProductRegistry;
@@ -32,16 +33,17 @@ import org.springframework.context.annotation.Configuration;
 public class ApiProductConfiguration {
 
     @Bean
-    public ApiProductRegistry apiProductRegistry() {
-        return new ApiProductRegistryImpl();
+    public ApiProductRegistry apiProductRegistry(GatewayConfiguration gatewayConfiguration) {
+        return new ApiProductRegistryImpl(gatewayConfiguration);
     }
 
     @Bean
     public ApiProductManager apiProductManager(
         ApiProductRegistry apiProductRegistry,
         EventManager eventManager,
-        LicenseManager licenseManager
+        LicenseManager licenseManager,
+        GatewayConfiguration gatewayConfiguration
     ) {
-        return new ApiProductManagerImpl(apiProductRegistry, eventManager, licenseManager);
+        return new ApiProductManagerImpl(apiProductRegistry, eventManager, licenseManager, gatewayConfiguration);
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/handlers/api/manager/ApiManagerImplTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/handlers/api/manager/ApiManagerImplTest.java
@@ -62,6 +62,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.SneakyThrows;
 import org.junit.jupiter.api.BeforeEach;

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/handlers/api/manager/impl/ApiManagerImplApiProductListenerTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/handlers/api/manager/impl/ApiManagerImplApiProductListenerTest.java
@@ -1,0 +1,263 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.handlers.api.manager.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.common.event.EventListener;
+import io.gravitee.common.event.EventManager;
+import io.gravitee.common.event.impl.SimpleEvent;
+import io.gravitee.common.util.DataEncryptor;
+import io.gravitee.definition.model.v4.listener.http.HttpListener;
+import io.gravitee.definition.model.v4.listener.http.Path;
+import io.gravitee.definition.model.v4.plan.PlanStatus;
+import io.gravitee.gateway.env.GatewayConfiguration;
+import io.gravitee.gateway.handlers.api.event.ApiProductChangedEvent;
+import io.gravitee.gateway.handlers.api.event.ApiProductEventType;
+import io.gravitee.gateway.handlers.api.registry.ApiProductRegistry;
+import io.gravitee.gateway.reactor.ReactorEvent;
+import io.gravitee.node.api.license.LicenseManager;
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class ApiManagerImplApiProductListenerTest {
+
+    @Mock
+    private EventManager eventManager;
+
+    @Mock
+    private GatewayConfiguration gatewayConfiguration;
+
+    @Mock
+    private LicenseManager licenseManager;
+
+    @Mock
+    private DataEncryptor dataEncryptor;
+
+    @Mock
+    private ApiProductRegistry apiProductRegistry;
+
+    private ApiManagerImpl apiManager;
+    private ArgumentCaptor<EventListener<ApiProductEventType, ApiProductChangedEvent>> listenerCaptor;
+
+    @BeforeEach
+    void setUp() {
+        lenient().when(gatewayConfiguration.hasMatchingTags(any())).thenReturn(false);
+        apiManager = new ApiManagerImpl(eventManager, gatewayConfiguration, licenseManager, dataEncryptor, apiProductRegistry);
+        listenerCaptor = ArgumentCaptor.forClass(EventListener.class);
+        verify(eventManager).subscribeForEvents(listenerCaptor.capture(), eq(ApiProductEventType.UNDEPLOY));
+    }
+
+    @Test
+    void should_undeploy_product_only_api_on_product_undeploy_event() {
+        var api = buildProductOnlyApi();
+
+        when(apiProductRegistry.getApiProductPlanEntriesForApi(eq("api-test"), eq("env-1"))).thenReturn(
+            List.of(
+                new ApiProductRegistry.ApiProductPlanEntry(
+                    "product-1",
+                    io.gravitee.definition.model.v4.plan.Plan.builder()
+                        .id("plan-test")
+                        .name("TestPlan")
+                        .status(PlanStatus.PUBLISHED)
+                        .build()
+                )
+            )
+        );
+        apiManager.register(api);
+        verify(eventManager).publishEvent(ReactorEvent.DEPLOY, api);
+
+        when(apiProductRegistry.getApiProductPlanEntriesForApi(eq("api-test"), eq("env-1"))).thenReturn(List.of());
+
+        listenerCaptor
+            .getValue()
+            .onEvent(new SimpleEvent<>(ApiProductEventType.UNDEPLOY, new ApiProductChangedEvent("product-1", "env-1", Set.of("api-test"))));
+
+        verify(eventManager).publishEvent(ReactorEvent.UNDEPLOY, api);
+        assertThat(apiManager.apis()).isEmpty();
+    }
+
+    @Test
+    void should_ignore_product_undeploy_event_with_null_api_ids() {
+        var api = buildProductOnlyApi();
+
+        when(apiProductRegistry.getApiProductPlanEntriesForApi(eq("api-test"), eq("env-1"))).thenReturn(
+            List.of(
+                new ApiProductRegistry.ApiProductPlanEntry(
+                    "product-1",
+                    io.gravitee.definition.model.v4.plan.Plan.builder().id("plan-test").status(PlanStatus.PUBLISHED).build()
+                )
+            )
+        );
+        apiManager.register(api);
+
+        listenerCaptor
+            .getValue()
+            .onEvent(new SimpleEvent<>(ApiProductEventType.UNDEPLOY, new ApiProductChangedEvent("product-1", "env-1", null)));
+
+        assertThat(apiManager.apis()).hasSize(1);
+    }
+
+    @Test
+    void should_keep_api_deployed_when_product_undeploy_does_not_remove_eligibility() {
+        var api = buildProductOnlyApi();
+
+        when(apiProductRegistry.getApiProductPlanEntriesForApi(eq("api-test"), eq("env-1"))).thenReturn(
+            List.of(
+                new ApiProductRegistry.ApiProductPlanEntry(
+                    "product-1",
+                    io.gravitee.definition.model.v4.plan.Plan.builder().id("plan-test").status(PlanStatus.PUBLISHED).build()
+                )
+            )
+        );
+        apiManager.register(api);
+
+        listenerCaptor
+            .getValue()
+            .onEvent(new SimpleEvent<>(ApiProductEventType.UNDEPLOY, new ApiProductChangedEvent("product-1", "env-1", Set.of("api-test"))));
+
+        verify(eventManager, never()).publishEvent(ReactorEvent.UNDEPLOY, api);
+        assertThat(apiManager.apis()).hasSize(1);
+    }
+
+    @Test
+    void should_re_evaluate_after_product_change_via_public_api() {
+        var api = buildProductOnlyApi();
+
+        when(apiProductRegistry.getApiProductPlanEntriesForApi(eq("api-test"), eq("env-1"))).thenReturn(
+            List.of(
+                new ApiProductRegistry.ApiProductPlanEntry(
+                    "product-1",
+                    io.gravitee.definition.model.v4.plan.Plan.builder().id("plan-test").status(PlanStatus.PUBLISHED).build()
+                )
+            )
+        );
+        apiManager.register(api);
+        verify(eventManager).publishEvent(ReactorEvent.DEPLOY, api);
+
+        when(apiProductRegistry.getApiProductPlanEntriesForApi(eq("api-test"), eq("env-1"))).thenReturn(List.of());
+
+        apiManager.reEvaluateAfterProductChange("product-1", Set.of("api-test"));
+
+        verify(eventManager).publishEvent(ReactorEvent.UNDEPLOY, api);
+        assertThat(apiManager.apis()).isEmpty();
+    }
+
+    @Test
+    void should_serialize_product_undeploy_with_concurrent_register() throws Exception {
+        var api = buildProductOnlyApi();
+
+        when(apiProductRegistry.getApiProductPlanEntriesForApi(eq("api-test"), eq("env-1"))).thenReturn(
+            List.of(
+                new ApiProductRegistry.ApiProductPlanEntry(
+                    "product-1",
+                    io.gravitee.definition.model.v4.plan.Plan.builder().id("plan-test").status(PlanStatus.PUBLISHED).build()
+                )
+            )
+        );
+        apiManager.register(api);
+
+        when(apiProductRegistry.getApiProductPlanEntriesForApi(eq("api-test"), eq("env-1"))).thenReturn(List.of());
+
+        CountDownLatch undeployInsideHandler = new CountDownLatch(1);
+        CountDownLatch releaseUndeploy = new CountDownLatch(1);
+        CountDownLatch registerCompleted = new CountDownLatch(1);
+
+        doAnswer(invocation -> {
+            if (invocation.getArgument(0) == ReactorEvent.UNDEPLOY) {
+                undeployInsideHandler.countDown();
+                releaseUndeploy.await(5, TimeUnit.SECONDS);
+            }
+            return null;
+        })
+            .when(eventManager)
+            .publishEvent(any(), any());
+
+        Thread productUndeployThread = new Thread(() ->
+            listenerCaptor
+                .getValue()
+                .onEvent(
+                    new SimpleEvent<>(ApiProductEventType.UNDEPLOY, new ApiProductChangedEvent("product-1", "env-1", Set.of("api-test")))
+                )
+        );
+        productUndeployThread.start();
+
+        assertThat(undeployInsideHandler.await(5, TimeUnit.SECONDS)).isTrue();
+        assertThat(apiManager.apis()).isEmpty();
+
+        when(apiProductRegistry.getApiProductPlanEntriesForApi(eq("api-test"), eq("env-1"))).thenReturn(
+            List.of(
+                new ApiProductRegistry.ApiProductPlanEntry(
+                    "product-1",
+                    io.gravitee.definition.model.v4.plan.Plan.builder().id("plan-test").status(PlanStatus.PUBLISHED).build()
+                )
+            )
+        );
+
+        Thread registerThread = new Thread(() -> {
+            apiManager.register(buildProductOnlyApi());
+            registerCompleted.countDown();
+        });
+        registerThread.start();
+
+        assertThat(registerCompleted.await(200, TimeUnit.MILLISECONDS)).isFalse();
+
+        releaseUndeploy.countDown();
+        productUndeployThread.join(5_000);
+        registerThread.join(5_000);
+
+        assertThat(registerCompleted.await(5, TimeUnit.SECONDS)).isTrue();
+        assertThat(apiManager.apis()).hasSize(1);
+    }
+
+    private io.gravitee.gateway.reactive.handlers.api.v4.Api buildProductOnlyApi() {
+        HttpListener httpListener = new HttpListener();
+        httpListener.setPaths(List.of(mock(Path.class)));
+
+        var definition = new io.gravitee.definition.model.v4.Api();
+        definition.setId("api-test");
+        definition.setPlans(Collections.emptyList());
+
+        var api = new io.gravitee.gateway.reactive.handlers.api.v4.Api(definition);
+        api.setEnabled(true);
+        api.setEnvironmentId("env-1");
+        api.setDeployedAt(new Date());
+        api.setOrganizationId("org-id");
+        return api;
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/handlers/api/manager/impl/ApiProductManagerImplTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/handlers/api/manager/impl/ApiProductManagerImplTest.java
@@ -26,6 +26,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.gravitee.common.event.EventManager;
+import io.gravitee.gateway.env.GatewayConfiguration;
 import io.gravitee.gateway.handlers.api.ReactableApiProduct;
 import io.gravitee.gateway.handlers.api.event.ApiProductChangedEvent;
 import io.gravitee.gateway.handlers.api.event.ApiProductEventType;
@@ -35,6 +36,8 @@ import io.gravitee.node.api.license.LicenseManager;
 import io.reactivex.rxjava3.core.Completable;
 import java.util.Collection;
 import java.util.Date;
+import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
@@ -42,6 +45,7 @@ import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -66,13 +70,18 @@ class ApiProductManagerImplTest {
     @Mock
     private License license;
 
+    @Mock
+    private GatewayConfiguration gatewayConfiguration;
+
     private ApiProductManagerImpl manager;
 
     @BeforeEach
     void setUp() {
         lenient().when(licenseManager.getOrganizationLicenseOrPlatform(any())).thenReturn(license);
         lenient().when(license.getTier()).thenReturn("universe");
-        manager = new ApiProductManagerImpl(apiProductRegistry, eventManager, licenseManager);
+        lenient().when(gatewayConfiguration.shardingTags()).thenReturn(Optional.of(List.of("internal")));
+        lenient().when(gatewayConfiguration.hasMatchingTags(any())).thenReturn(true);
+        manager = new ApiProductManagerImpl(apiProductRegistry, eventManager, licenseManager, gatewayConfiguration);
     }
 
     @Nested
@@ -340,6 +349,26 @@ class ApiProductManagerImplTest {
         }
 
         @Test
+        void should_emit_update_event_with_union_of_previous_and_current_member_api_ids() {
+            Date oldDate = new Date(System.currentTimeMillis() - 10000);
+            Date newDate = new Date();
+
+            ReactableApiProduct oldProduct = createApiProduct("product-1", "env-1", oldDate);
+            oldProduct.setApiIds(Set.of("api-1", "api-2"));
+
+            ReactableApiProduct newProduct = createApiProduct("product-1", "env-1", newDate);
+            newProduct.setApiIds(Set.of("api-2", "api-3"));
+
+            manager.register(oldProduct);
+
+            ArgumentCaptor<ApiProductChangedEvent> eventCaptor = ArgumentCaptor.forClass(ApiProductChangedEvent.class);
+            manager.register(newProduct);
+
+            verify(eventManager).publishEvent(eq(ApiProductEventType.UPDATE), eventCaptor.capture());
+            assertThat(eventCaptor.getValue().getApiIds()).containsExactlyInAnyOrder("api-1", "api-2", "api-3");
+        }
+
+        @Test
         void should_deploy_successfully_when_no_op_beforeEmit() {
             ReactableApiProduct apiProduct = createApiProduct("product-1", "env-1", new Date());
 
@@ -426,6 +455,65 @@ class ApiProductManagerImplTest {
             thread2.join();
 
             assertThat(manager.getApiProducts()).hasSize(100);
+        }
+    }
+
+    @Nested
+    class ShardingTagFilterTest {
+
+        @Test
+        void should_not_deploy_when_product_tags_do_not_match_gateway() {
+            when(gatewayConfiguration.hasMatchingTags(Set.of("external"))).thenReturn(false);
+
+            ReactableApiProduct apiProduct = createApiProduct("product-1", "env-1", new Date());
+            apiProduct.setTags(Set.of("external"));
+
+            manager.register(apiProduct);
+
+            assertThat(manager.get("product-1")).isNull();
+            verify(apiProductRegistry, never()).register(any());
+        }
+
+        @Test
+        void should_deploy_when_product_tags_match_gateway() {
+            when(gatewayConfiguration.hasMatchingTags(Set.of("internal"))).thenReturn(true);
+
+            ReactableApiProduct apiProduct = createApiProduct("product-1", "env-1", new Date());
+            apiProduct.setTags(Set.of("internal"));
+
+            manager.register(apiProduct);
+
+            assertThat(manager.get("product-1")).isNotNull();
+            verify(apiProductRegistry).register(apiProduct);
+        }
+
+        @Test
+        void should_undeploy_previously_deployed_product_when_tags_change_to_non_matching() {
+            when(gatewayConfiguration.hasMatchingTags(Set.of("internal"))).thenReturn(true);
+            when(gatewayConfiguration.hasMatchingTags(Set.of("external"))).thenReturn(false);
+
+            ReactableApiProduct apiProduct = createApiProduct("product-1", "env-1", new Date(System.currentTimeMillis() - 10000));
+            apiProduct.setTags(Set.of("internal"));
+            manager.register(apiProduct);
+            assertThat(manager.get("product-1")).isNotNull();
+
+            ReactableApiProduct updatedProduct = createApiProduct("product-1", "env-1", new Date());
+            updatedProduct.setTags(Set.of("external"));
+            manager.register(updatedProduct);
+
+            assertThat(manager.get("product-1")).isNull();
+            verify(apiProductRegistry).remove("product-1", "env-1");
+        }
+
+        @Test
+        void should_deploy_product_with_empty_tags_regardless_of_gateway_tags() {
+            ReactableApiProduct apiProduct = createApiProduct("product-1", "env-1", new Date());
+            apiProduct.setTags(null);
+
+            manager.register(apiProduct);
+
+            assertThat(manager.get("product-1")).isNotNull();
+            verify(apiProductRegistry).register(apiProduct);
         }
     }
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/handlers/api/registry/impl/ApiProductRegistryImplTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/handlers/api/registry/impl/ApiProductRegistryImplTest.java
@@ -16,33 +16,46 @@
 package io.gravitee.gateway.handlers.api.registry.impl;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
 
 import io.gravitee.definition.model.v4.plan.Plan;
 import io.gravitee.definition.model.v4.plan.PlanStatus;
+import io.gravitee.gateway.env.GatewayConfiguration;
 import io.gravitee.gateway.handlers.api.ReactableApiProduct;
 import io.gravitee.gateway.handlers.api.registry.ApiProductRegistry;
 import java.util.Collection;
 import java.util.Date;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 /**
  * @author Arpit Mishra (arpit.mishra at graviteesource.com)
  * @author GraviteeSource Team
  */
+@ExtendWith(MockitoExtension.class)
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 class ApiProductRegistryImplTest {
+
+    @Mock
+    private GatewayConfiguration gatewayConfiguration;
 
     private ApiProductRegistryImpl registry;
 
     @BeforeEach
     void setUp() {
-        registry = new ApiProductRegistryImpl();
+        lenient().when(gatewayConfiguration.shardingTags()).thenReturn(Optional.of(List.of("internal")));
+        lenient().when(gatewayConfiguration.hasMatchingTags(any())).thenReturn(true);
+        registry = new ApiProductRegistryImpl(gatewayConfiguration);
     }
 
     @Nested
@@ -334,6 +347,103 @@ class ApiProductRegistryImplTest {
     }
 
     @Nested
+    class ShardingTagFilteringTest {
+
+        @Test
+        void should_exclude_product_when_product_tags_do_not_match_gateway() {
+            lenient().when(gatewayConfiguration.hasMatchingTags(Set.of("external"))).thenReturn(false);
+            lenient().when(gatewayConfiguration.hasMatchingTags(Set.of("internal"))).thenReturn(true);
+
+            ReactableApiProduct product = createApiProduct("product-1", "env-1");
+            product.setTags(Set.of("external"));
+            product.setPlans(List.of(createPlan("plan-1", PlanStatus.PUBLISHED)));
+            registry.register(product);
+
+            List<ApiProductRegistry.ApiProductPlanEntry> entries = registry.getApiProductPlanEntriesForApi("api-1", "env-1");
+            assertThat(entries).isEmpty();
+        }
+
+        @Test
+        void should_include_product_when_product_tags_match_gateway() {
+            lenient().when(gatewayConfiguration.hasMatchingTags(Set.of("internal"))).thenReturn(true);
+
+            ReactableApiProduct product = createApiProduct("product-1", "env-1");
+            product.setTags(Set.of("internal"));
+            product.setPlans(List.of(createPlan("plan-1", PlanStatus.PUBLISHED)));
+            registry.register(product);
+
+            List<ApiProductRegistry.ApiProductPlanEntry> entries = registry.getApiProductPlanEntriesForApi("api-1", "env-1");
+            assertThat(entries).hasSize(1);
+        }
+
+        @Test
+        void should_exclude_plan_when_plan_tags_do_not_match_gateway() {
+            lenient().when(gatewayConfiguration.hasMatchingTags(Set.of("internal"))).thenReturn(true);
+            lenient().when(gatewayConfiguration.hasMatchingTags(Set.of("external"))).thenReturn(false);
+
+            ReactableApiProduct product = createApiProduct("product-1", "env-1");
+            product.setTags(Set.of("internal"));
+
+            Plan planMatching = createPlan("plan-matching", PlanStatus.PUBLISHED);
+            planMatching.setTags(Set.of("internal"));
+            Plan planNotMatching = createPlan("plan-no-match", PlanStatus.PUBLISHED);
+            planNotMatching.setTags(Set.of("external"));
+
+            product.setPlans(List.of(planMatching, planNotMatching));
+            registry.register(product);
+
+            List<ApiProductRegistry.ApiProductPlanEntry> entries = registry.getApiProductPlanEntriesForApi("api-1", "env-1");
+            assertThat(entries).hasSize(1);
+            assertThat(entries.get(0).plan().getId()).isEqualTo("plan-matching");
+        }
+
+        @Test
+        void should_include_plan_with_no_tags_when_product_matches() {
+            lenient().when(gatewayConfiguration.hasMatchingTags(Set.of("internal"))).thenReturn(true);
+
+            ReactableApiProduct product = createApiProduct("product-1", "env-1");
+            product.setTags(Set.of("internal"));
+
+            Plan planNoTags = createPlan("plan-no-tags", PlanStatus.PUBLISHED);
+
+            product.setPlans(List.of(planNoTags));
+            registry.register(product);
+
+            List<ApiProductRegistry.ApiProductPlanEntry> entries = registry.getApiProductPlanEntriesForApi("api-1", "env-1");
+            assertThat(entries).hasSize(1);
+            assertThat(entries.get(0).plan().getId()).isEqualTo("plan-no-tags");
+        }
+
+        @Test
+        void should_handle_multi_product_overlap_for_same_api() {
+            ReactableApiProduct product1 = createApiProduct("product-1", "env-1");
+            product1.setApiIds(Set.of("api-shared"));
+            product1.setPlans(List.of(createPlan("plan-p1", PlanStatus.PUBLISHED)));
+
+            ReactableApiProduct product2 = createApiProduct("product-2", "env-1");
+            product2.setApiIds(Set.of("api-shared"));
+            product2.setPlans(List.of(createPlan("plan-p2", PlanStatus.PUBLISHED)));
+
+            registry.register(product1);
+            registry.register(product2);
+
+            List<ApiProductRegistry.ApiProductPlanEntry> entries = registry.getApiProductPlanEntriesForApi("api-shared", "env-1");
+            assertThat(entries).hasSize(2);
+            assertThat(entries)
+                .extracting(ApiProductRegistry.ApiProductPlanEntry::apiProductId)
+                .containsExactlyInAnyOrder("product-1", "product-2");
+        }
+
+        private Plan createPlan(String id, PlanStatus status) {
+            Plan plan = new Plan();
+            plan.setId(id);
+            plan.setName("Plan " + id);
+            plan.setStatus(status);
+            return plan;
+        }
+    }
+
+    @Nested
     class ConcurrencyTest {
 
         @Test
@@ -359,29 +469,42 @@ class ApiProductRegistryImplTest {
         }
 
         @Test
-        void should_handle_concurrent_reads() throws InterruptedException {
+        void should_handle_concurrent_reads_during_rebuild() throws InterruptedException {
             for (int i = 0; i < 10; i++) {
-                registry.register(createApiProduct("product-" + i, "env-1"));
+                ReactableApiProduct product = createApiProduct("product-" + i, "env-1");
+                product.setPlans(List.of(createPlan("plan-" + i, PlanStatus.PUBLISHED)));
+                registry.register(product);
             }
 
-            Thread thread1 = new Thread(() -> {
-                for (int i = 0; i < 100; i++) {
-                    registry.get("product-5", "env-1");
+            Thread reader = new Thread(() -> {
+                for (int i = 0; i < 1000; i++) {
+                    List<ApiProductRegistry.ApiProductPlanEntry> entries = registry.getApiProductPlanEntriesForApi("api-1", "env-1");
+                    assertThat(entries).isNotNull();
                 }
             });
 
-            Thread thread2 = new Thread(() -> {
-                for (int i = 0; i < 100; i++) {
-                    registry.getAll();
+            Thread writer = new Thread(() -> {
+                for (int i = 10; i < 20; i++) {
+                    ReactableApiProduct product = createApiProduct("product-" + i, "env-1");
+                    product.setPlans(List.of(createPlan("plan-" + i, PlanStatus.PUBLISHED)));
+                    registry.register(product);
                 }
             });
 
-            thread1.start();
-            thread2.start();
-            thread1.join();
-            thread2.join();
+            reader.start();
+            writer.start();
+            reader.join();
+            writer.join();
 
-            assertThat(registry.getAll()).hasSize(10);
+            assertThat(registry.getAll()).hasSize(20);
+        }
+
+        private Plan createPlan(String id, PlanStatus status) {
+            Plan plan = new Plan();
+            plan.setId(id);
+            plan.setName("Plan " + id);
+            plan.setStatus(status);
+            return plan;
         }
     }
 

--- a/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/handlers/api/sharding/ApiProductShardingFilterTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-handlers/gravitee-apim-gateway-handlers-api/src/test/java/io/gravitee/gateway/handlers/api/sharding/ApiProductShardingFilterTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.handlers.api.sharding;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.gateway.env.GatewayConfiguration;
+import java.util.Set;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class ApiProductShardingFilterTest {
+
+    @Mock
+    private GatewayConfiguration gatewayConfiguration;
+
+    @Test
+    void should_match_product_tags_via_gateway_configuration() {
+        when(gatewayConfiguration.hasMatchingTags(Set.of("internal"))).thenReturn(true);
+
+        assertThat(ApiProductShardingFilter.matchesProductTags(gatewayConfiguration, Set.of("internal"))).isTrue();
+    }
+
+    @Test
+    void should_accept_plan_with_no_tags_on_any_matching_gateway() {
+        assertThat(ApiProductShardingFilter.matchesPlanTags(gatewayConfiguration, null)).isTrue();
+        assertThat(ApiProductShardingFilter.matchesPlanTags(gatewayConfiguration, Set.of())).isTrue();
+    }
+
+    @Test
+    void should_delegate_plan_tag_matching_to_gateway_configuration() {
+        when(gatewayConfiguration.hasMatchingTags(Set.of("external"))).thenReturn(false);
+
+        assertThat(ApiProductShardingFilter.matchesPlanTags(gatewayConfiguration, Set.of("external"))).isFalse();
+    }
+
+    @Test
+    void should_match_plan_when_gateway_has_matching_tags() {
+        when(gatewayConfiguration.hasMatchingTags(Set.of("internal"))).thenReturn(true);
+
+        assertThat(ApiProductShardingFilter.matchesPlanTags(gatewayConfiguration, Set.of("internal"))).isTrue();
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/fetcher/LatestEventFetcher.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/fetcher/LatestEventFetcher.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Set;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.CustomLog;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.experimental.Accessors;
@@ -33,6 +34,7 @@ import lombok.experimental.Accessors;
  * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
  * @author GraviteeSource Team
  */
+@CustomLog
 @RequiredArgsConstructor
 public class LatestEventFetcher {
 
@@ -78,6 +80,28 @@ public class LatestEventFetcher {
                 }
             }
         );
+    }
+
+    public List<Event> fetchLatestForApiIds(Set<String> apiIds, Set<String> environments, Set<EventType> eventTypes) {
+        if (apiIds == null || apiIds.isEmpty()) {
+            return List.of();
+        }
+        try {
+            List<Event> events = eventLatestRepository.search(
+                EventCriteria.builder()
+                    .types(eventTypes)
+                    .environments(environments)
+                    .property(Event.EventProperties.API_ID.getValue(), apiIds)
+                    .build(),
+                Event.EventProperties.API_ID,
+                null,
+                null
+            );
+            return events != null ? events : List.of();
+        } catch (Exception e) {
+            log.warn("Failed to batch-fetch latest events for {} API(s): {}", apiIds.size(), e.getMessage());
+            return List.of();
+        }
     }
 
     @Builder

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/mapper/ApiProductMapper.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/mapper/ApiProductMapper.java
@@ -80,6 +80,7 @@ public class ApiProductMapper {
                     .version(payload.getVersion())
                     .apiIds(payload.getApiIds())
                     .environmentId(payload.getEnvironmentId())
+                    .tags(payload.getTags())
                     .deployedAt(new Date(event.getCreatedAt().getTime()))
                     .plans(filteredPlans(payload.getPlans()))
                     .build();
@@ -122,6 +123,7 @@ public class ApiProductMapper {
         private String environmentHrid;
         private String organizationId;
         private String organizationHrid;
+        private Set<String> tags;
         private List<Plan> plans;
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/spring/RepositorySyncConfiguration.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/spring/RepositorySyncConfiguration.java
@@ -18,6 +18,7 @@ package io.gravitee.gateway.services.sync.process.repository.spring;
 import static io.gravitee.gateway.services.sync.SyncConfiguration.DEFAULT_BULK_ITEMS;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.gravitee.common.event.EventManager;
 import io.gravitee.gateway.api.service.ApiKeyService;
 import io.gravitee.gateway.api.service.SubscriptionService;
 import io.gravitee.gateway.env.GatewayConfiguration;
@@ -54,6 +55,7 @@ import io.gravitee.gateway.services.sync.process.repository.synchronizer.api.Api
 import io.gravitee.gateway.services.sync.process.repository.synchronizer.api.ApiSynchronizer;
 import io.gravitee.gateway.services.sync.process.repository.synchronizer.api.AuthzAppender;
 import io.gravitee.gateway.services.sync.process.repository.synchronizer.api.PlanAppender;
+import io.gravitee.gateway.services.sync.process.repository.synchronizer.api.RepositoryApiMemberResyncTrigger;
 import io.gravitee.gateway.services.sync.process.repository.synchronizer.api.SubscriptionAppender;
 import io.gravitee.gateway.services.sync.process.repository.synchronizer.apikey.ApiKeySynchronizer;
 import io.gravitee.gateway.services.sync.process.repository.synchronizer.apiproduct.ApiProductSynchronizer;
@@ -92,6 +94,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Lazy;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
@@ -232,6 +235,16 @@ public class RepositorySyncConfiguration {
             syncDeployerExecutor,
             appenderParallelism
         );
+    }
+
+    @Bean(destroyMethod = "dispose")
+    public RepositoryApiMemberResyncTrigger apiMemberResyncTrigger(
+        @Lazy ApiSynchronizer apiSynchronizer,
+        ApiManager apiManager,
+        @Qualifier("syncDeployerExecutor") ThreadPoolExecutor syncDeployerExecutor,
+        EventManager eventManager
+    ) {
+        return new RepositoryApiMemberResyncTrigger(apiSynchronizer, apiManager, syncDeployerExecutor, eventManager);
     }
 
     @Bean

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/api/ApiSynchronizer.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/api/ApiSynchronizer.java
@@ -23,10 +23,13 @@ import io.gravitee.gateway.services.sync.process.common.synchronizer.Order;
 import io.gravitee.gateway.services.sync.process.repository.RepositorySynchronizer;
 import io.gravitee.gateway.services.sync.process.repository.fetcher.LatestEventFetcher;
 import io.gravitee.gateway.services.sync.process.repository.mapper.ApiMapper;
+import io.gravitee.repository.management.model.Event;
 import io.gravitee.repository.management.model.EventType;
 import io.reactivex.rxjava3.core.Completable;
+import io.reactivex.rxjava3.core.Flowable;
 import io.reactivex.rxjava3.schedulers.Schedulers;
 import java.time.Instant;
+import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.atomic.AtomicLong;
@@ -46,6 +49,7 @@ public class ApiSynchronizer extends AbstractApiSynchronizer implements Reposito
         EventType.UNPUBLISH_API,
         EventType.STOP_API
     );
+    private static final Set<EventType> MEMBER_API_RESYNC_EVENT_TYPES = INCREMENTAL_EVENT_TYPES;
     private final LatestEventFetcher eventsFetcher;
 
     public ApiSynchronizer(
@@ -96,6 +100,21 @@ public class ApiSynchronizer extends AbstractApiSynchronizer implements Reposito
                 }
             })
             .ignoreElement();
+    }
+
+    public Completable resyncMemberApis(Set<String> apiIds, Set<String> environments) {
+        if (apiIds == null || apiIds.isEmpty()) {
+            return Completable.complete();
+        }
+        List<Event> events = eventsFetcher.fetchLatestForApiIds(apiIds, environments, MEMBER_API_RESYNC_EVENT_TYPES);
+        if (events.isEmpty()) {
+            log.debug("No API events found to resync member APIs {}", apiIds);
+            return Completable.complete();
+        }
+        log.debug("Resyncing {} member API(s) after API Product change", events.size());
+        return processEvents(false, Flowable.fromIterable(events).buffer(bulkEvents()), environments)
+            .ignoreElements()
+            .subscribeOn(Schedulers.from(syncFetcherExecutor));
     }
 
     @Override

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/api/RepositoryApiMemberResyncTrigger.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/api/RepositoryApiMemberResyncTrigger.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.services.sync.process.repository.synchronizer.api;
+
+import io.gravitee.common.event.EventManager;
+import io.gravitee.gateway.handlers.api.event.ApiProductChangedEvent;
+import io.gravitee.gateway.handlers.api.event.ApiProductEventType;
+import io.gravitee.gateway.handlers.api.manager.ApiManager;
+import io.reactivex.rxjava3.core.Completable;
+import io.reactivex.rxjava3.disposables.CompositeDisposable;
+import io.reactivex.rxjava3.disposables.Disposable;
+import io.reactivex.rxjava3.schedulers.Schedulers;
+import java.util.Set;
+import java.util.concurrent.ThreadPoolExecutor;
+import lombok.CustomLog;
+
+/**
+ * Subscribes to API Product DEPLOY / UPDATE events and runs a single ordered
+ * pipeline on the sync deployer thread pool:
+ * <ol>
+ *   <li>Re-sync member APIs (deploy newly-eligible ones via the normal sync path)</li>
+ *   <li>Re-evaluate shard eligibility and undeploy any APIs that are no longer eligible</li>
+ * </ol>
+ * This ordering guarantees that a newly-eligible API is deployed <em>before</em>
+ * an ineligible one is undeployed, eliminating the brief unavailability window
+ * that would occur if undeploy were handled independently.
+ */
+@CustomLog
+public class RepositoryApiMemberResyncTrigger {
+
+    private final ApiSynchronizer apiSynchronizer;
+    private final ApiManager apiManager;
+    private final ThreadPoolExecutor syncDeployerExecutor;
+    private final CompositeDisposable disposables = new CompositeDisposable();
+
+    public RepositoryApiMemberResyncTrigger(
+        ApiSynchronizer apiSynchronizer,
+        ApiManager apiManager,
+        ThreadPoolExecutor syncDeployerExecutor,
+        EventManager eventManager
+    ) {
+        this.apiSynchronizer = apiSynchronizer;
+        this.apiManager = apiManager;
+        this.syncDeployerExecutor = syncDeployerExecutor;
+
+        eventManager.subscribeForEvents(
+            event -> {
+                if (event.content() instanceof ApiProductChangedEvent productEvent) {
+                    handleProductChange(productEvent.getProductId(), productEvent.getEnvironmentId(), productEvent.getApiIds());
+                }
+            },
+            ApiProductEventType.DEPLOY,
+            ApiProductEventType.UPDATE
+        );
+    }
+
+    private void handleProductChange(String productId, String environmentId, Set<String> apiIds) {
+        if (environmentId == null || apiIds == null || apiIds.isEmpty()) {
+            return;
+        }
+        final Disposable[] holder = new Disposable[1];
+        holder[0] = Completable.defer(() -> {
+            log.debug("Scheduling resync of {} member API(s) in environment [{}]", apiIds.size(), environmentId);
+            return apiSynchronizer
+                .resyncMemberApis(apiIds, Set.of(environmentId))
+                .andThen(
+                    Completable.fromAction(() -> {
+                        log.debug("Resync done — re-evaluating eligibility of {} API(s) for product [{}]", apiIds.size(), productId);
+                        apiManager.reEvaluateAfterProductChange(productId, apiIds);
+                    })
+                );
+        })
+            .subscribeOn(Schedulers.from(syncDeployerExecutor))
+            .doFinally(() -> {
+                Disposable disposable = holder[0];
+                if (disposable != null) {
+                    disposables.remove(disposable);
+                }
+            })
+            .subscribe(
+                () -> log.debug("Member API resync + re-evaluation completed for product [{}] in env [{}]", productId, environmentId),
+                error ->
+                    log.error(
+                        "Member API resync pipeline failed for product [{}] in env [{}]: {}",
+                        productId,
+                        environmentId,
+                        error.getMessage(),
+                        error
+                    )
+            );
+        disposables.add(holder[0]);
+    }
+
+    public void dispose() {
+        disposables.dispose();
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/fetcher/LatestEventFetcherTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/fetcher/LatestEventFetcherTest.java
@@ -25,6 +25,7 @@ import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Set;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
@@ -137,5 +138,29 @@ class LatestEventFetcherTest {
     void should_emit_on_error_when_repository_thrown_exception() {
         when(eventLatestRepository.search(any(), any(), any(), any())).thenThrow(new RuntimeException());
         cut.fetchLatest(null, null, Event.EventProperties.API_ID, Set.of(), Set.of()).test().assertError(RuntimeException.class);
+    }
+
+    @Test
+    void should_return_empty_list_when_fetching_events_for_empty_api_ids() {
+        Assertions.assertThat(cut.fetchLatestForApiIds(Set.of(), Set.of("env"), Set.of(EventType.PUBLISH_API))).isEmpty();
+        Assertions.assertThat(cut.fetchLatestForApiIds(null, Set.of("env"), Set.of(EventType.PUBLISH_API))).isEmpty();
+        verifyNoInteractions(eventLatestRepository);
+    }
+
+    @Test
+    void should_fetch_latest_events_for_specific_api_ids() {
+        Event event = new Event();
+        when(eventLatestRepository.search(any(), eq(Event.EventProperties.API_ID), isNull(), isNull())).thenReturn(List.of(event));
+
+        Assertions.assertThat(
+            cut.fetchLatestForApiIds(Set.of("api-1", "api-2"), Set.of("env"), Set.of(EventType.START_API))
+        ).containsExactly(event);
+    }
+
+    @Test
+    void should_return_empty_list_when_repository_search_fails_for_api_ids() {
+        when(eventLatestRepository.search(any(), any(), any(), any())).thenThrow(new RuntimeException("db down"));
+
+        Assertions.assertThat(cut.fetchLatestForApiIds(Set.of("api-1"), Set.of("env"), Set.of(EventType.PUBLISH_API))).isEmpty();
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/api/ApiSynchronizerTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/api/ApiSynchronizerTest.java
@@ -141,7 +141,7 @@ class ApiSynchronizerTest {
             new ThreadPoolExecutor(1, 1, 15L, TimeUnit.SECONDS, new LinkedBlockingQueue<>()),
             1 // appenderParallelism: sequential for test determinism
         );
-        when(eventsFetcher.bulkItems()).thenReturn(1);
+        lenient().when(eventsFetcher.bulkItems()).thenReturn(1);
         lenient().when(deployerFactory.createApiDeployer()).thenReturn(apiDeployer);
         lenient().when(apiDeployer.deploy(any())).thenReturn(Completable.complete());
         lenient().when(apiDeployer.doAfterDeployment(any())).thenReturn(Completable.complete());
@@ -350,6 +350,71 @@ class ApiSynchronizerTest {
             verify(apiDeployer).undeploy(any());
             verify(subscriptionDeployer).undeploy(any());
             verify(apiKeyDeployer).undeploy(any());
+        }
+    }
+
+    @Nested
+    class ResyncMemberApisTest {
+
+        @Test
+        void should_not_resync_when_api_ids_are_empty() throws InterruptedException {
+            cut.resyncMemberApis(Set.of(), Set.of("env")).test().await().assertComplete();
+
+            verifyNoInteractions(eventsFetcher);
+            verifyNoInteractions(apiDeployer);
+        }
+
+        @Test
+        void should_not_deploy_when_no_repository_events_found_for_member_apis() throws InterruptedException {
+            when(eventsFetcher.fetchLatestForApiIds(eq(Set.of("api-1")), eq(Set.of("env")), any())).thenReturn(List.of());
+
+            cut.resyncMemberApis(Set.of("api-1"), Set.of("env")).test().await().assertComplete();
+
+            verify(eventsFetcher).fetchLatestForApiIds(eq(Set.of("api-1")), eq(Set.of("env")), any());
+            verifyNoInteractions(apiDeployer);
+        }
+
+        @Test
+        void should_redeploy_member_api_from_repository_events() throws InterruptedException, JsonProcessingException {
+            Event event = new Event();
+            event.setId("api");
+            event.setPayload(objectMapper.writeValueAsString(repoApi));
+            event.setType(PUBLISH_API);
+
+            when(eventsFetcher.fetchLatestForApiIds(eq(Set.of("api")), eq(Set.of("env")), any())).thenReturn(List.of(event));
+            when(apiManager.requiredActionFor(argThat(argument -> argument.getId().equals("api")))).thenReturn(ActionOnApi.DEPLOY);
+
+            cut.resyncMemberApis(Set.of("api"), Set.of("env")).test().await().assertComplete();
+
+            verify(apiDeployer).deploy(any());
+            verify(apiDeployer).doAfterDeployment(any());
+        }
+
+        private io.gravitee.definition.model.v4.Api api;
+        private Api repoApi;
+
+        @BeforeEach
+        void init() throws JsonProcessingException {
+            api = new io.gravitee.definition.model.v4.Api();
+            api.setId("api");
+            api.setDefinitionVersion(DefinitionVersion.V4);
+            PlanSecurity planSecurity = new PlanSecurity();
+            planSecurity.setType("api-key");
+            io.gravitee.definition.model.v4.plan.Plan plan = io.gravitee.definition.model.v4.plan.Plan.builder()
+                .id("planId")
+                .security(planSecurity)
+                .status(PlanStatus.PUBLISHED)
+                .build();
+            api.setPlans(List.of(plan));
+
+            repoApi = new Api();
+            repoApi.setId("api");
+            repoApi.setName("name");
+            repoApi.setLifecycleState(LifecycleState.STARTED);
+            repoApi.setEnvironmentId("env");
+            repoApi.setDefinitionVersion(DefinitionVersion.V4);
+            repoApi.setType(ApiType.PROXY);
+            repoApi.setDefinition(objectMapper.writeValueAsString(api));
         }
     }
 }

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/api/RepositoryApiMemberResyncTriggerTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/api/RepositoryApiMemberResyncTriggerTest.java
@@ -1,0 +1,221 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.services.sync.process.repository.synchronizer.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.gravitee.common.event.EventListener;
+import io.gravitee.common.event.EventManager;
+import io.gravitee.common.event.impl.SimpleEvent;
+import io.gravitee.gateway.handlers.api.event.ApiProductChangedEvent;
+import io.gravitee.gateway.handlers.api.event.ApiProductEventType;
+import io.gravitee.gateway.handlers.api.manager.ApiManager;
+import io.reactivex.rxjava3.core.Completable;
+import io.reactivex.rxjava3.disposables.CompositeDisposable;
+import java.lang.reflect.Field;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class RepositoryApiMemberResyncTriggerTest {
+
+    @Mock
+    private ApiSynchronizer apiSynchronizer;
+
+    @Mock
+    private ApiManager apiManager;
+
+    @Mock
+    private EventManager eventManager;
+
+    @Captor
+    private ArgumentCaptor<EventListener<ApiProductEventType, ApiProductChangedEvent>> listenerCaptor;
+
+    private ThreadPoolExecutor syncDeployerExecutor;
+    private RepositoryApiMemberResyncTrigger cut;
+
+    @BeforeEach
+    void setUp() {
+        syncDeployerExecutor = new ThreadPoolExecutor(1, 1, 15L, TimeUnit.SECONDS, new LinkedBlockingQueue<>());
+        cut = new RepositoryApiMemberResyncTrigger(apiSynchronizer, apiManager, syncDeployerExecutor, eventManager);
+        verify(eventManager).subscribeForEvents(listenerCaptor.capture(), eq(ApiProductEventType.DEPLOY), eq(ApiProductEventType.UPDATE));
+    }
+
+    @AfterEach
+    void tearDown() {
+        cut.dispose();
+        syncDeployerExecutor.shutdown();
+    }
+
+    @Test
+    void should_resync_then_re_evaluate_on_product_update_event() throws Exception {
+        when(apiSynchronizer.resyncMemberApis(Set.of("api-1", "api-2"), Set.of("env-1"))).thenReturn(Completable.complete());
+
+        listenerCaptor
+            .getValue()
+            .onEvent(
+                new SimpleEvent<>(ApiProductEventType.UPDATE, new ApiProductChangedEvent("product-1", "env-1", Set.of("api-1", "api-2")))
+            );
+
+        awaitPipelineCompletion();
+        verify(apiSynchronizer).resyncMemberApis(Set.of("api-1", "api-2"), Set.of("env-1"));
+        verify(apiManager).reEvaluateAfterProductChange("product-1", Set.of("api-1", "api-2"));
+    }
+
+    @Test
+    void should_resync_then_re_evaluate_on_product_deploy_event() throws Exception {
+        when(apiSynchronizer.resyncMemberApis(Set.of("api-1"), Set.of("env-1"))).thenReturn(Completable.complete());
+
+        listenerCaptor
+            .getValue()
+            .onEvent(new SimpleEvent<>(ApiProductEventType.DEPLOY, new ApiProductChangedEvent("product-1", "env-1", Set.of("api-1"))));
+
+        awaitPipelineCompletion();
+        verify(apiSynchronizer).resyncMemberApis(Set.of("api-1"), Set.of("env-1"));
+        verify(apiManager).reEvaluateAfterProductChange("product-1", Set.of("api-1"));
+    }
+
+    @Test
+    void should_execute_resync_before_re_evaluate() throws Exception {
+        when(apiSynchronizer.resyncMemberApis(Set.of("api-1"), Set.of("env-1"))).thenReturn(Completable.complete());
+
+        listenerCaptor
+            .getValue()
+            .onEvent(new SimpleEvent<>(ApiProductEventType.UPDATE, new ApiProductChangedEvent("product-1", "env-1", Set.of("api-1"))));
+
+        awaitPipelineCompletion();
+        InOrder inOrder = Mockito.inOrder(apiSynchronizer, apiManager);
+        inOrder.verify(apiSynchronizer).resyncMemberApis(Set.of("api-1"), Set.of("env-1"));
+        inOrder.verify(apiManager).reEvaluateAfterProductChange("product-1", Set.of("api-1"));
+    }
+
+    @Test
+    void should_not_re_evaluate_when_resync_fails() throws Exception {
+        when(apiSynchronizer.resyncMemberApis(Set.of("api-1"), Set.of("env-1"))).thenReturn(
+            Completable.error(new RuntimeException("sync failure"))
+        );
+
+        listenerCaptor
+            .getValue()
+            .onEvent(new SimpleEvent<>(ApiProductEventType.UPDATE, new ApiProductChangedEvent("product-1", "env-1", Set.of("api-1"))));
+
+        awaitPipelineCompletion();
+        verify(apiManager, never()).reEvaluateAfterProductChange(any(), any());
+    }
+
+    @Test
+    void should_not_resync_when_environment_or_api_ids_are_missing() {
+        listenerCaptor
+            .getValue()
+            .onEvent(new SimpleEvent<>(ApiProductEventType.UPDATE, new ApiProductChangedEvent("product-1", null, Set.of("api-1"))));
+        listenerCaptor
+            .getValue()
+            .onEvent(new SimpleEvent<>(ApiProductEventType.UPDATE, new ApiProductChangedEvent("product-1", "env-1", null)));
+        listenerCaptor
+            .getValue()
+            .onEvent(new SimpleEvent<>(ApiProductEventType.UPDATE, new ApiProductChangedEvent("product-1", "env-1", Set.of())));
+
+        verify(apiSynchronizer, never()).resyncMemberApis(any(), any());
+        verify(apiManager, never()).reEvaluateAfterProductChange(any(), any());
+    }
+
+    @Test
+    void should_not_block_event_thread_while_pipeline_runs_on_background_executor() throws Exception {
+        CountDownLatch resyncStarted = new CountDownLatch(1);
+        CountDownLatch releaseResync = new CountDownLatch(1);
+        AtomicReference<String> resyncThreadName = new AtomicReference<>();
+
+        when(apiSynchronizer.resyncMemberApis(Set.of("api-1"), Set.of("env-1"))).thenReturn(
+            Completable.fromAction(() -> {
+                resyncThreadName.set(Thread.currentThread().getName());
+                resyncStarted.countDown();
+                releaseResync.await(5, TimeUnit.SECONDS);
+            })
+        );
+
+        String eventThreadName = Thread.currentThread().getName();
+        long startNanos = System.nanoTime();
+        listenerCaptor
+            .getValue()
+            .onEvent(new SimpleEvent<>(ApiProductEventType.UPDATE, new ApiProductChangedEvent("product-1", "env-1", Set.of("api-1"))));
+        long eventHandlerDurationNanos = System.nanoTime() - startNanos;
+
+        assertThat(eventHandlerDurationNanos).isLessThan(TimeUnit.MILLISECONDS.toNanos(200));
+        assertThat(resyncStarted.await(5, TimeUnit.SECONDS)).isTrue();
+        assertThat(resyncThreadName.get()).isNotEqualTo(eventThreadName);
+
+        releaseResync.countDown();
+        awaitPipelineCompletion();
+        verify(apiManager).reEvaluateAfterProductChange("product-1", Set.of("api-1"));
+    }
+
+    @Test
+    void should_remove_completed_disposable_after_pipeline() throws Exception {
+        when(apiSynchronizer.resyncMemberApis(Set.of("api-1"), Set.of("env-1"))).thenReturn(Completable.complete());
+
+        listenerCaptor
+            .getValue()
+            .onEvent(new SimpleEvent<>(ApiProductEventType.UPDATE, new ApiProductChangedEvent("product-1", "env-1", Set.of("api-1"))));
+
+        awaitPipelineCompletion();
+        awaitDisposableCleanup();
+        assertThat(readDisposableCount()).isZero();
+    }
+
+    private void awaitPipelineCompletion() throws Exception {
+        long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5);
+        while (syncDeployerExecutor.getCompletedTaskCount() < 1 && System.nanoTime() < deadline) {
+            Thread.sleep(10);
+        }
+        Thread.sleep(50);
+    }
+
+    private void awaitDisposableCleanup() throws Exception {
+        long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5);
+        while (readDisposableCount() > 0 && System.nanoTime() < deadline) {
+            Thread.sleep(10);
+        }
+    }
+
+    private int readDisposableCount() throws Exception {
+        Field disposablesField = RepositoryApiMemberResyncTrigger.class.getDeclaredField("disposables");
+        disposablesField.setAccessible(true);
+        CompositeDisposable disposables = (CompositeDisposable) disposablesField.get(cut);
+        return disposables.size();
+    }
+}

--- a/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/apiproduct/ApiProductSynchronizerTest.java
+++ b/gravitee-apim-gateway/gravitee-apim-gateway-services/gravitee-apim-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/process/repository/synchronizer/apiproduct/ApiProductSynchronizerTest.java
@@ -463,6 +463,45 @@ class ApiProductSynchronizerTest {
             assertThat(deployable.reactableApiProduct().getPlans()).isNullOrEmpty();
         }
 
+        @Test
+        void should_deserialize_product_tags_and_plan_tags_from_payload() throws InterruptedException, JsonProcessingException {
+            Event event = new Event();
+            event.setId("event-tags");
+            event.setType(DEPLOY_API_PRODUCT);
+            event.setCreatedAt(new Date());
+            event.setPayload(
+                objectMapper.writeValueAsString(
+                    Map.of(
+                        "id",
+                        "api-product-tagged",
+                        "name",
+                        "Tagged Product",
+                        "version",
+                        "1.0",
+                        "apiIds",
+                        Set.of("api-1"),
+                        "environmentId",
+                        "env-id",
+                        "tags",
+                        Set.of("internal", "partner"),
+                        "plans",
+                        List.of(Map.of("id", "plan-tagged", "name", "Tagged Plan", "status", "PUBLISHED", "tags", List.of("internal")))
+                    )
+                )
+            );
+
+            when(latestEventFetcher.fetchLatest(any(), any(), any(), any(), any())).thenReturn(Flowable.just(List.of(event)));
+            cut.synchronize(-1L, Instant.now().toEpochMilli(), Set.of()).test().await().assertComplete();
+
+            ArgumentCaptor<ApiProductReactorDeployable> captor = ArgumentCaptor.forClass(ApiProductReactorDeployable.class);
+            verify(apiProductDeployer).deploy(captor.capture());
+
+            ApiProductReactorDeployable deployable = captor.getValue();
+            assertThat(deployable.reactableApiProduct().getTags()).containsExactlyInAnyOrder("internal", "partner");
+            assertThat(deployable.reactableApiProduct().getPlans()).hasSize(1);
+            assertThat(deployable.reactableApiProduct().getPlans().get(0).getTags()).containsExactly("internal");
+        }
+
         private Event createDeployEventWithPlans(String apiProductId, List<Map<String, String>> plans) throws JsonProcessingException {
             Event event = new Event();
             event.setId("event-" + apiProductId);

--- a/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/ApiProductV4IntegrationTest.java
+++ b/gravitee-apim-integration-tests/src/test/java/io/gravitee/apim/integration/tests/http/ApiProductV4IntegrationTest.java
@@ -334,15 +334,15 @@ class ApiProductV4IntegrationTest {
         )
         void should_register_and_resolve_api_product_plan_security_types_for_api_key_jwt_and_mtls() {
             final String productId = "plan-state-d3-product";
-            deployApiProduct(product(productId, Set.of(API_1_ID)));
-            registerProductPlans(
-                productId,
+            ReactableApiProduct apiProduct = product(productId, Set.of(API_1_ID));
+            apiProduct.setPlans(
                 List.of(
                     productPlan("plan-state-d3-apikey", "api-key", PlanStatus.PUBLISHED),
                     productPlan("plan-state-d3-jwt", "jwt", PlanStatus.PUBLISHED),
                     productPlan("plan-state-d3-mtls", "mtls", PlanStatus.PUBLISHED)
                 )
             );
+            deployApiProduct(apiProduct);
 
             ApiProductRegistry apiProductRegistry = getBean(ApiProductRegistry.class);
             List<ApiProductRegistry.ApiProductPlanEntry> entries = apiProductRegistry.getApiProductPlanEntriesForApi(API_1_ID, ENV_ID);


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-14341
https://gravitee.atlassian.net/browse/APIM-14342


**Description**
Apply API Product sharding tags at gateway runtime, using the same tag-matching rules as APIs (GatewayConfiguration.hasMatchingTags).

**Depends on**: the persistence/validation PR that stores product tags and includes them in the deploy event payload. This PR only consumes tags from the sync payload; without that PR, tags will be empty and sharding will not take effect end-to-end.

**What changes**
ApiProductShardingFilter — central product/plan tag matching (plan with no tags always passes once the product matches).

ApiProductManagerImpl — skip/undeploy products whose tags do not match the gateway; on update, emit events for the union of previous and current member API IDs.

ApiProductRegistryImpl — pre-built reverse index (environmentId, apiId) → plan entries, filtered by product and plan tags; copy-on-write updates guarded by ReentrantReadWriteLock.

ApiManagerImpl — isApiShardEligible() falls back to the product registry when the API’s own tags do not match; per-API ReentrantLock for concurrent sync/product-event safety; listener undeploys member APIs when product changes remove eligibility.

Sync pipeline — ApiProductMapper maps tags from deploy payload; RepositoryApiMemberResyncTrigger re-syncs member APIs on product DEPLOY/UPDATE (fixes ordering where API sync runs before the product is indexed); 

LatestEventFetcher.fetchLatestForApiIds + ApiSynchronizer.resyncMemberApis.

Example
GW-internal (tags: internal)     GW-external (tags: external)
Product prod-abc tags={internal}, apiIds={api-pay}, plan-gold (published)
→ GW-internal: product deployed, api-pay deployed via product fallback
→ GW-external: product skipped, api-pay not deployed

Additional context
Review-only stack: can be reviewed independently of the persistence PR; merge only after that [PR](https://github.com/gravitee-io/gravitee-api-management/pull/17842).

Scope: gateway + sync + integration tests only — no DB, Management API, or Console changes.


The testing sheet with screenshots is present in the JIRA tickets mentioned.