### PR TITLE
feat(analytics): expose store-backed value listing for Gamma-only KEYWORD filters

### DIFF
--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-analytics.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/resources/openapi/openapi-analytics.yaml
@@ -1435,6 +1435,8 @@ components:
                 - MCP_PROXY_PROMPT
                 - API_TYPE
                 - ERROR_KEY
+                - REQUEST_ID
+                - TRANSACTION_ID
                 - EDGE_PROVIDER
                 - EDGE_PROCESS
                 - EDGE_CLIENT

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/observability/ObservabilityFiltersDefinitionResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/observability/ObservabilityFiltersDefinitionResourceTest.java
@@ -69,7 +69,7 @@ class ObservabilityFiltersDefinitionResourceTest extends AbstractResourceTest {
             .hasStatus(200)
             .asEntity(FilterSpecsResponse.class)
             .extracting(FilterSpecsResponse::getData)
-            .satisfies(filters -> assertThat(filters).hasSize(42));
+            .satisfies(filters -> assertThat(filters).hasSize(45));
     }
 
     @Test

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/analytics_engine/model/FilterSpec.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/core/analytics_engine/model/FilterSpec.java
@@ -78,5 +78,8 @@ public record FilterSpec(
         NATIVE_CONNECTION_STATUS,
         URI,
         ENTRYPOINT,
+        ERROR_KEY,
+        REQUEST_ID,
+        TRANSACTION_ID,
     }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/AnalyticsMeasuresAdapter.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/adapter/AnalyticsMeasuresAdapter.java
@@ -104,7 +104,12 @@ public interface AnalyticsMeasuresAdapter {
         return MetricSpec.Measure.valueOf(result.name());
     }
 
-    // API_TYPE should never reach this layer, because it *must* have been transformed to API IDs beforehand.
+    // These filter names exist in FilterSpec.Name for value-listing only and have no
+    // counterpart in the repository analytics Filter.Name enum — they must never reach
+    // the analytics query/facets path.
     @ValueMapping(source = "API_TYPE", target = MappingConstants.THROW_EXCEPTION)
+    @ValueMapping(source = "ERROR_KEY", target = MappingConstants.THROW_EXCEPTION)
+    @ValueMapping(source = "REQUEST_ID", target = MappingConstants.THROW_EXCEPTION)
+    @ValueMapping(source = "TRANSACTION_ID", target = MappingConstants.THROW_EXCEPTION)
     Filter.Name toFilterName(io.gravitee.apim.core.analytics_engine.model.FilterSpec.Name name);
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/query_service/analytics_engine/FilterValuesQueryServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/query_service/analytics_engine/FilterValuesQueryServiceImpl.java
@@ -111,6 +111,15 @@ public class FilterValuesQueryServiceImpl implements FilterValuesQueryService {
             case MCP_PROXY_TOOL -> "additional-metrics.keyword_mcp-proxy_tools/call";
             case MCP_PROXY_RESOURCE -> "additional-metrics.keyword_mcp-proxy_resources/read";
             case MCP_PROXY_PROMPT -> "additional-metrics.keyword_mcp-proxy_prompts/get";
+            case EDGE_PROVIDER -> "additional-metrics.keyword_edge_provider";
+            case EDGE_PROCESS -> "additional-metrics.keyword_edge_process";
+            case EDGE_CLIENT -> "client-identifier";
+            case EDGE_TYPE -> "additional-metrics.keyword_edge_type";
+            case MESSAGE_CONNECTOR_TYPE -> "connector-type";
+            case ENTRYPOINT -> "entrypoint-id";
+            case ERROR_KEY -> "error-key";
+            case REQUEST_ID -> "request-id";
+            case TRANSACTION_ID -> "transaction-id";
             case API_PRODUCT -> "api-product-id";
             case URI -> "uri";
             default -> throw new UnsupportedOperationException("No ES field mapping for filter: " + filterName);

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/resources/analytics/definition/analytics-definition.yaml
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/resources/analytics/definition/analytics-definition.yaml
@@ -1459,6 +1459,27 @@ spec:
               - EQ
               - IN
 
+        - name: ERROR_KEY
+          label: Error Key
+          type: KEYWORD
+          operators:
+              - EQ
+              - IN
+
+        - name: REQUEST_ID
+          label: Request ID
+          type: KEYWORD
+          operators:
+              - EQ
+              - IN
+
+        - name: TRANSACTION_ID
+          label: Transaction ID
+          type: KEYWORD
+          operators:
+              - EQ
+              - IN
+
         - name: API_PRODUCT
           label: API Product
           type: KEYWORD

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/query_service/analytics_engine/FilterValuesQueryServiceImplTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/query_service/analytics_engine/FilterValuesQueryServiceImplTest.java
@@ -30,10 +30,14 @@ import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.InjectMocks;
@@ -204,5 +208,30 @@ class FilterValuesQueryServiceImplTest {
 
         verify(analyticsRepository).searchFilterValues(any(), queryCaptor.capture());
         assertThat(queryCaptor.getValue().apiIds()).isNull();
+    }
+
+    @ParameterizedTest
+    @MethodSource("filterToEsFieldMappings")
+    void should_resolve_es_field_name(FilterSpec.Name filterName, String expectedEsField) {
+        when(analyticsRepository.searchFilterValues(any(), any())).thenReturn(new FilterValuesResult(List.of("v1"), null, 1));
+
+        service.searchFilterValues(ORG_ID, ENV_ID, filterName, null, null, 1, 10, null, null, null);
+
+        verify(analyticsRepository).searchFilterValues(any(), queryCaptor.capture());
+        assertThat(queryCaptor.getValue().esFieldName()).isEqualTo(expectedEsField);
+    }
+
+    static Stream<Arguments> filterToEsFieldMappings() {
+        return Stream.of(
+            Arguments.of(FilterSpec.Name.EDGE_PROVIDER, "additional-metrics.keyword_edge_provider"),
+            Arguments.of(FilterSpec.Name.EDGE_PROCESS, "additional-metrics.keyword_edge_process"),
+            Arguments.of(FilterSpec.Name.EDGE_CLIENT, "client-identifier"),
+            Arguments.of(FilterSpec.Name.EDGE_TYPE, "additional-metrics.keyword_edge_type"),
+            Arguments.of(FilterSpec.Name.MESSAGE_CONNECTOR_TYPE, "connector-type"),
+            Arguments.of(FilterSpec.Name.ENTRYPOINT, "entrypoint-id"),
+            Arguments.of(FilterSpec.Name.ERROR_KEY, "error-key"),
+            Arguments.of(FilterSpec.Name.REQUEST_ID, "request-id"),
+            Arguments.of(FilterSpec.Name.TRANSACTION_ID, "transaction-id")
+        );
     }
 }


### PR DESCRIPTION
## Summary

Extends the shared analytics platform to support value listing (`/observability/filters/{filterName}/values`) for KEYWORD filters that were previously unmapped — returning HTTP 400 or 500 instead of distinct stored values. This unblocks the Gamma observability filter UI for all filters in the unified catalog.

Closes [GMA-630](https://gravitee.atlassian.net/browse/GMA-630) | Refs GMA-420, GMA-422

## Changes

- **`FilterSpec.Name`** — Add `ERROR_KEY`, `REQUEST_ID`, `TRANSACTION_ID` to the enum (Gamma-only filters with no prior platform representation)
- **`analytics-definition.yaml`** — Register the 3 new filters as KEYWORD type with EQ/IN operators so `GetFilterValuesUseCase.findFilterSpec()` can resolve them
- **`FilterValuesQueryServiceImpl.resolveEsFieldName()`** — Add ES field mappings for 9 previously unmapped filters:

  | Filter | ES field | Source |
  |--------|----------|--------|
  | `ERROR_KEY` | `error-key` | Gamma-only (logs+analytics) |
  | `REQUEST_ID` | `request-id` | Gamma-only (logs) |
  | `TRANSACTION_ID` | `transaction-id` | Gamma-only (logs) |
  | `MESSAGE_CONNECTOR_TYPE` | `connector-type` | Was in enum+YAML, missing ES mapping |
  | `EDGE_PROVIDER` | `additional-metrics.keyword_edge_provider` | Was in enum+YAML, missing ES mapping |
  | `EDGE_PROCESS` | `additional-metrics.keyword_edge_process` | Was in enum+YAML, missing ES mapping |
  | `EDGE_CLIENT` | `client-identifier` | Was in enum+YAML, missing ES mapping |
  | `EDGE_TYPE` | `additional-metrics.keyword_edge_type` | Was in enum+YAML, missing ES mapping |
  | `ENTRYPOINT` | `entrypoint-id` | Was in enum, missing ES mapping |

- **`AnalyticsMeasuresAdapter`** — Exclude new enum values from the analytics query path (`THROW_EXCEPTION`) since they are value-listing-only and have no counterpart in the repository `Filter.Name` enum
- **`FilterValuesQueryServiceImplTest`** — Add parameterized test covering all 9 new ES field mappings

## Test plan

- [ ] `GET /gamma/.../observability/filters/ERROR_KEY/values` returns 200 with distinct `error-key` values (previously 400)
- [ ] Same for `REQUEST_ID`, `TRANSACTION_ID`, `MESSAGE_CONNECTOR_TYPE`, `EDGE_PROVIDER`, `EDGE_PROCESS`, `EDGE_CLIENT`, `EDGE_TYPE`
- [ ] `MCP_PROXY_TOOL`, `MCP_PROXY_RESOURCE`, `MCP_PROXY_PROMPT` continue to work (no regression)
- [ ] `HTTP_STATUS` (NUMBER type) still returns 400 (value listing unsupported for non-KEYWORD types)
- [ ] Values are scoped to the caller's authorized APIs (no authorization bypass)
- [ ] Existing analytics facets/measures queries are unaffected (the new enum values are excluded from the `AnalyticsMeasuresAdapter` mapper)

## Reviewer notes

The approach is **pure platform extension** (additive enum values, new switch cases, new YAML entries) — no Gamma adapter changes needed. The existing delegation chain (`GetObservabilityFilterValuesUseCase` → `ObservabilityFilterDataPortAdapter` → `GetFilterValuesUseCase` → `FilterValuesQueryServiceImpl`) works end-to-end without modification. All ES field names are cross-referenced against `HTTPFieldResolver`, `MessageFieldResolver`, and `RequestV2MetricsV4Fields`.

[GMA-630]: https://gravitee.atlassian.net/browse/GMA-630?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ