### PR TITLE
feat(permissions): add EDGE_CONFIGURATION permission and EDGE_MANAGER role

### DIFF
--- a/gravitee-apim-console-webui/src/entities/role/permission.fixtures.ts
+++ b/gravitee-apim-console-webui/src/entities/role/permission.fixtures.ts
@@ -44,6 +44,7 @@ export function fakePermissionsByScopes(attributes?: Partial<PermissionsByScopes
       'DASHBOARD',
       'DICTIONARY',
       'DOCUMENTATION',
+      'EDGE_CONFIGURATION',
       'ENTRYPOINT',
       'GROUP',
       'IDENTITY_PROVIDER_ACTIVATION',

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/organization/RoleScopesResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management/gravitee-apim-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/organization/RoleScopesResourceTest.java
@@ -62,6 +62,7 @@ public class RoleScopesResourceTest extends AbstractResourceTest {
             "DASHBOARD",
             "DICTIONARY",
             "DOCUMENTATION",
+            "EDGE_CONFIGURATION",
             "ENTRYPOINT",
             "GROUP",
             "IDENTITY_PROVIDER_ACTIVATION",

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/permissions/EnvironmentPermission.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/permissions/EnvironmentPermission.java
@@ -52,7 +52,8 @@ public enum EnvironmentPermission implements Permission {
     CLUSTER("CLUSTER", 4000),
     API_PRODUCT("API_PRODUCT", 4100),
     AUTHORIZATION("AUTHORIZATION", 4200),
-    PORTAL("PORTAL", 4300);
+    PORTAL("PORTAL", 4300),
+    EDGE_CONFIGURATION("EDGE_CONFIGURATION", 4400);
 
     String name;
     int mask;

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/permissions/RolePermission.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-model/src/main/java/io/gravitee/rest/api/model/permissions/RolePermission.java
@@ -93,6 +93,7 @@ public enum RolePermission {
     ENVIRONMENT_API_PRODUCT(RoleScope.ENVIRONMENT, EnvironmentPermission.API_PRODUCT),
     ENVIRONMENT_AUTHORIZATION(RoleScope.ENVIRONMENT, EnvironmentPermission.AUTHORIZATION),
     ENVIRONMENT_PORTAL(RoleScope.ENVIRONMENT, EnvironmentPermission.PORTAL),
+    ENVIRONMENT_EDGE_CONFIGURATION(RoleScope.ENVIRONMENT, EnvironmentPermission.EDGE_CONFIGURATION),
 
     ORGANIZATION_USERS(RoleScope.ORGANIZATION, OrganizationPermission.USER),
     ORGANIZATION_USERS_TOKEN(RoleScope.ORGANIZATION, OrganizationPermission.USER_TOKEN),

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/common/DefaultRoleEntityDefinition.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/common/DefaultRoleEntityDefinition.java
@@ -93,6 +93,23 @@ public interface DefaultRoleEntityDefinition {
             .build()
     );
 
+    NewRoleEntity ROLE_ENVIRONMENT_EDGE_MANAGER = new NewRoleEntity(
+        "EDGE_MANAGER",
+        "Environment Role. Created by Gravitee.io.",
+        ENVIRONMENT,
+        false,
+        Maps.<String, char[]>builder()
+            .put(
+                EnvironmentPermission.EDGE_CONFIGURATION.getName(),
+                new char[] { CREATE.getId(), READ.getId(), UPDATE.getId(), DELETE.getId() }
+            )
+            .put(EnvironmentPermission.API.getName(), new char[] { READ.getId() })
+            .put(EnvironmentPermission.APPLICATION.getName(), new char[] { READ.getId() })
+            .put(EnvironmentPermission.GROUP.getName(), new char[] { READ.getId() })
+            .put(EnvironmentPermission.PLATFORM.getName(), new char[] { READ.getId() })
+            .build()
+    );
+
     NewRoleEntity DEFAULT_ROLE_API_USER = new NewRoleEntity(
         "USER",
         "Default API Role. Created by Gravitee.io.",

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/RoleServiceImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/RoleServiceImpl.java
@@ -36,6 +36,7 @@ import static io.gravitee.rest.api.service.common.DefaultRoleEntityDefinition.RO
 import static io.gravitee.rest.api.service.common.DefaultRoleEntityDefinition.ROLE_API_REVIEWER;
 import static io.gravitee.rest.api.service.common.DefaultRoleEntityDefinition.ROLE_APPLICATION_OWNER;
 import static io.gravitee.rest.api.service.common.DefaultRoleEntityDefinition.ROLE_ENVIRONMENT_API_PUBLISHER;
+import static io.gravitee.rest.api.service.common.DefaultRoleEntityDefinition.ROLE_ENVIRONMENT_EDGE_MANAGER;
 import static io.gravitee.rest.api.service.common.DefaultRoleEntityDefinition.ROLE_ENVIRONMENT_FEDERATION_AGENT;
 import static io.gravitee.rest.api.service.common.DefaultRoleEntityDefinition.ROLE_INTEGRATION_OWNER;
 import static io.gravitee.rest.api.service.common.DefaultRoleEntityDefinition.ROLE_INTEGRATION_USER;
@@ -108,6 +109,7 @@ public class RoleServiceImpl extends AbstractService implements RoleService {
         Map.entry("<ORGANIZATION> USER (default)", DEFAULT_ROLE_ORGANIZATION_USER),
         Map.entry("<ENVIRONMENT> API_PUBLISHER", ROLE_ENVIRONMENT_API_PUBLISHER),
         Map.entry("<ENVIRONMENT> FEDERATION_AGENT", ROLE_ENVIRONMENT_FEDERATION_AGENT),
+        Map.entry("<ENVIRONMENT> EDGE_MANAGER", ROLE_ENVIRONMENT_EDGE_MANAGER),
         Map.entry("<ENVIRONMENT> USER (default)", DEFAULT_ROLE_ENVIRONMENT_USER),
         Map.entry("<API> USER (default)", DEFAULT_ROLE_API_USER),
         Map.entry("<API> OWNER", ROLE_API_OWNER),

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/EdgeRolesUpgrader.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/EdgeRolesUpgrader.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.impl.upgrade.upgrader;
+
+import static io.gravitee.rest.api.model.permissions.RoleScope.ENVIRONMENT;
+import static io.gravitee.rest.api.service.common.DefaultRoleEntityDefinition.ROLE_ENVIRONMENT_EDGE_MANAGER;
+
+import io.gravitee.node.api.upgrader.Upgrader;
+import io.gravitee.node.api.upgrader.UpgraderException;
+import io.gravitee.repository.management.api.OrganizationRepository;
+import io.gravitee.rest.api.service.RoleService;
+import io.gravitee.rest.api.service.common.ExecutionContext;
+import lombok.CustomLog;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.stereotype.Component;
+
+@CustomLog
+@Component
+public class EdgeRolesUpgrader implements Upgrader {
+
+    private final RoleService roleService;
+    private final OrganizationRepository organizationRepository;
+
+    @Autowired
+    public EdgeRolesUpgrader(RoleService roleService, @Lazy OrganizationRepository organizationRepository) {
+        this.roleService = roleService;
+        this.organizationRepository = organizationRepository;
+    }
+
+    @Override
+    public boolean upgrade() throws UpgraderException {
+        return this.wrapException(() -> {
+            organizationRepository
+                .findAll()
+                .forEach(organization -> {
+                    ExecutionContext executionContext = new ExecutionContext(organization);
+                    initializeEdgeRoles(executionContext);
+                    roleService.createOrUpdateSystemRoles(executionContext, executionContext.getOrganizationId());
+                });
+            return true;
+        });
+    }
+
+    private void initializeEdgeRoles(ExecutionContext executionContext) {
+        if (shouldCreateEdgeManagerRole(executionContext)) {
+            log.info("     - <ENVIRONMENT> EDGE_MANAGER");
+            roleService.create(executionContext, ROLE_ENVIRONMENT_EDGE_MANAGER);
+        }
+    }
+
+    private boolean shouldCreateEdgeManagerRole(final ExecutionContext executionContext) {
+        return roleService
+            .findByScopeAndName(ENVIRONMENT, ROLE_ENVIRONMENT_EDGE_MANAGER.getName(), executionContext.getOrganizationId())
+            .isEmpty();
+    }
+
+    @Override
+    public int getOrder() {
+        return UpgraderOrder.EDGE_ROLES_UPGRADER;
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/UpgraderOrder.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/UpgraderOrder.java
@@ -77,4 +77,5 @@ public class UpgraderOrder {
     public static final int ASSIGN_DEFAULT_API_PRODUCT_ROLE_TO_GROUPS_UPGRADER = 953;
     public static final int NATIVE_API_LOG_PERMISSION_UPGRADER = 954;
     public static final int OIDC_IDP_DEFAULT_SCOPES_UPGRADER = 709;
+    public static final int EDGE_ROLES_UPGRADER = 955;
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/EdgeRolesUpgraderTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/upgrade/upgrader/EdgeRolesUpgraderTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.impl.upgrade.upgrader;
+
+import static io.gravitee.rest.api.model.permissions.RoleScope.ENVIRONMENT;
+import static io.gravitee.rest.api.service.common.DefaultRoleEntityDefinition.ROLE_ENVIRONMENT_EDGE_MANAGER;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+import io.gravitee.node.api.upgrader.UpgraderException;
+import io.gravitee.repository.exceptions.TechnicalException;
+import io.gravitee.repository.management.api.OrganizationRepository;
+import io.gravitee.repository.management.model.Organization;
+import io.gravitee.rest.api.model.RoleEntity;
+import io.gravitee.rest.api.service.RoleService;
+import io.gravitee.rest.api.service.common.ExecutionContext;
+import io.gravitee.rest.api.service.common.GraviteeContext;
+import java.util.Optional;
+import java.util.Set;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.WARN)
+public class EdgeRolesUpgraderTest {
+
+    @InjectMocks
+    EdgeRolesUpgrader upgrader;
+
+    @Mock
+    RoleService roleService;
+
+    @Mock
+    OrganizationRepository organizationRepository;
+
+    @Test
+    public void upgrade_should_fail_because_of_exception() throws TechnicalException {
+        assertThrows(UpgraderException.class, () -> {
+            when(organizationRepository.findAll()).thenThrow(new RuntimeException());
+            upgrader.upgrade();
+        });
+    }
+
+    @Test
+    public void shouldCreateEdgeManagerRoleWhenNotPresent() throws UpgraderException, TechnicalException {
+        String organizationId = GraviteeContext.getDefaultOrganization();
+        Organization organization = mock(Organization.class);
+        when(organization.getId()).thenReturn(organizationId);
+        when(organizationRepository.findAll()).thenReturn(Set.of(organization));
+
+        ExecutionContext expectedExecutionContext = new ExecutionContext(organization);
+        when(roleService.findByScopeAndName(eq(ENVIRONMENT), eq(ROLE_ENVIRONMENT_EDGE_MANAGER.getName()), eq(organizationId))).thenReturn(
+            Optional.empty()
+        );
+
+        upgrader.upgrade();
+
+        verify(roleService).create(expectedExecutionContext, ROLE_ENVIRONMENT_EDGE_MANAGER);
+        verify(roleService).createOrUpdateSystemRoles(expectedExecutionContext, organizationId);
+    }
+
+    @Test
+    public void shouldNotCreateEdgeManagerWhenAlreadyPresent() throws UpgraderException, TechnicalException {
+        String organizationId = GraviteeContext.getDefaultOrganization();
+        Organization organization = mock(Organization.class);
+        when(organization.getId()).thenReturn(organizationId);
+        when(organizationRepository.findAll()).thenReturn(Set.of(organization));
+
+        when(roleService.findByScopeAndName(eq(ENVIRONMENT), eq(ROLE_ENVIRONMENT_EDGE_MANAGER.getName()), eq(organizationId))).thenReturn(
+            Optional.of(new RoleEntity())
+        );
+
+        upgrader.upgrade();
+
+        verify(roleService, never()).create(any(), eq(ROLE_ENVIRONMENT_EDGE_MANAGER));
+        verify(roleService).createOrUpdateSystemRoles(any(), eq(organizationId));
+    }
+
+    @Test
+    public void test_order() {
+        Assertions.assertEquals(UpgraderOrder.EDGE_ROLES_UPGRADER, upgrader.getOrder());
+    }
+}


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/GMA-728

## Description

Adds a new `EDGE_CONFIGURATION` permission under the ENVIRONMENT scope and a new default `EDGE_MANAGER` environment role, to protect the Edge Management resources.

- New `EnvironmentPermission.EDGE_CONFIGURATION` (mask 4400) + `RolePermission.ENVIRONMENT_EDGE_CONFIGURATION`
- New default role `EDGE_MANAGER`: `EDGE_CONFIGURATION` in CRUD, plus READ on API / APPLICATION / GROUP / PLATFORM
- ADMIN (ENVIRONMENT) automatically receives `EDGE_CONFIGURATION` in CRUD via `createOrUpdateSystemRoles`
- `EdgeRolesUpgrader` creates `EDGE_MANAGER` on existing installations and refreshes ADMIN

## Test plan

- Unit tests updated/added: `RoleScopesResourceTest`, `RoleService_CreateOrUpdateSystemRolesTest`, `EdgeRolesUpgraderTest`
- Manual: `/#!/_organization/roles` → ENVIRONMENT scope shows `EDGE_CONFIGURATION`; `EDGE_MANAGER` role present with the expected matrix; ADMIN has `EDGE_CONFIGURATION` in CRUD
