### PR TITLE
fix: add body field to V4 health check schema for POST/PUT methods

### DIFF
--- a/gravitee-apim-plugin/gravitee-apim-plugin-apiservice/gravitee-apim-plugin-apiservice-healthcheck-http/src/main/resources/schemas/schema-form.json
+++ b/gravitee-apim-plugin/gravitee-apim-plugin-apiservice/gravitee-apim-plugin-apiservice-healthcheck-http/src/main/resources/schemas/schema-form.json
@@ -47,6 +47,19 @@
         "required": ["name", "value"]
       }
     },
+    "body": {
+      "title": "Body",
+      "description": "The body of the health check request. Make sure to add a Content-Type header for POST/PUT HTTP method.",
+      "type": "string",
+      "format": "text",
+      "gioConfig": {
+        "displayIf": {
+          "$eq": {
+            "./method": ["POST", "PUT"]
+          }
+        }
+      }
+    },
     "assertion" : {
       "type" : "string",
       "title": "Assertion",


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-14444

## Description

The V4 health check schema was missing the `body` property, so the UI never displayed it  even though the backend already supported it. The field is conditionally shown only for POST and PUT methods, matching the existing V2 behavior.

## Additional context

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

