### PR TITLE
fix: handle log details after migrating a v2 proxy

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/analytics/adapter/FindApiMetricsDetailQueryAdapter.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/analytics/adapter/FindApiMetricsDetailQueryAdapter.java
@@ -57,7 +57,19 @@ public class FindApiMetricsDetailQueryAdapter {
             );
         }
         if (query.requestId() != null) {
-            terms.add(JsonObject.of("term", JsonObject.of("request-id", query.requestId())));
+            terms.add(
+                JsonObject.of(
+                    "bool",
+                    JsonObject.of(
+                        "should",
+                        JsonArray.of(
+                            JsonObject.of("term", JsonObject.of("request-id", query.requestId())),
+                            JsonObject.of("term", JsonObject.of("id", query.requestId())),
+                            JsonObject.of("ids", JsonObject.of("values", JsonArray.of(query.requestId())))
+                        )
+                    )
+                )
+            );
         }
 
         if (!terms.isEmpty()) {

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/analytics/adapter/FindApiMetricsDetailResponseAdapter.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/analytics/adapter/FindApiMetricsDetailResponseAdapter.java
@@ -44,28 +44,29 @@ public class FindApiMetricsDetailResponseAdapter {
             .getHits()
             .stream()
             .findFirst()
-            .map(h -> buildFromSource(h.getSource()));
+            .map(h -> buildFromSource(h.getSource(), h.getId()));
     }
 
-    private static ApiMetricsDetail buildFromSource(JsonNode json) {
+    private static ApiMetricsDetail buildFromSource(JsonNode json, String hitId) {
+        var requestId = coalesceText(json, "request-id", "id");
         return ApiMetricsDetail.builder()
             .timestamp(asTextOrNull(json.get("@timestamp")))
-            .apiId(asTextOrNull(json.get("api-id")))
-            .requestId(asTextOrNull(json.get("request-id")))
-            .transactionId(asTextOrNull(json.get("transaction-id")))
+            .apiId(coalesceText(json, "api-id", "api"))
+            .requestId(requestId != null ? requestId : hitId)
+            .transactionId(coalesceText(json, "transaction-id", "transaction"))
             .host(asTextOrNull(json.get("host")))
-            .applicationId(asTextOrNull(json.get("application-id")))
-            .planId(asTextOrNull(json.get("plan-id")))
+            .applicationId(coalesceText(json, "application-id", "application"))
+            .planId(coalesceText(json, "plan-id", "plan"))
             .gateway(asTextOrNull(json.get("gateway")))
             .status(asIntOr(json.get("status"), 0))
             .uri(asTextOrNull(json.get("uri")))
             .requestContentLength(asLongOr(json.get("request-content-length"), 0))
             .responseContentLength(asLongOr(json.get("response-content-length"), 0))
             .remoteAddress(asTextOrNull(json.get("remote-address")))
-            .gatewayLatency(asLongOr(json.get("gateway-latency-ms"), 0))
-            .gatewayResponseTime(asLongOr(json.get("gateway-response-time-ms"), 0))
-            .endpointResponseTime(asLongOr(json.get("endpoint-response-time-ms"), 0))
-            .method(HttpMethod.get(asIntOr(json.get("http-method"), 0)))
+            .gatewayLatency(coalesceLong(json, "gateway-latency-ms", "proxy-latency"))
+            .gatewayResponseTime(coalesceLong(json, "gateway-response-time-ms", "response-time"))
+            .endpointResponseTime(coalesceLong(json, "endpoint-response-time-ms", "api-response-time"))
+            .method(HttpMethod.get(coalesceInt(json, "http-method", "method")))
             .endpoint(asTextOrNull(json.get("endpoint")))
             .message(asTextOrNull(json.get("error-message")))
             .errorKey(asTextOrNull(json.get("error-key")))
@@ -74,6 +75,27 @@ public class FindApiMetricsDetailResponseAdapter {
             .warnings(buildWarnings(json.get("warnings")))
             .additionalMetrics(asMapOrNull(json.get("additional-metrics")))
             .build();
+    }
+
+    private static String coalesceText(JsonNode json, String v4Field, String v2Field) {
+        var value = asTextOrNull(json.get(v4Field));
+        return value != null ? value : asTextOrNull(json.get(v2Field));
+    }
+
+    private static long coalesceLong(JsonNode json, String v4Field, String v2Field) {
+        var node = json.get(v4Field);
+        if (node != null && !node.isNull()) {
+            return node.asLong(0);
+        }
+        return asLongOr(json.get(v2Field), 0);
+    }
+
+    private static int coalesceInt(JsonNode json, String v4Field, String v2Field) {
+        var node = json.get(v4Field);
+        if (node != null && !node.isNull()) {
+            return node.asInt(0);
+        }
+        return asIntOr(json.get(v2Field), 0);
     }
 
     private static List<ConnectionDiagnostic> buildWarnings(JsonNode json) {

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/AbstractAdapterTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/AbstractAdapterTest.java
@@ -34,6 +34,12 @@ public abstract class AbstractAdapterTest {
     @SneakyThrows
     @NotNull
     protected SearchResponse buildSearchHit(String fileName) {
+        return buildSearchHit(fileName, "log-id");
+    }
+
+    @SneakyThrows
+    @NotNull
+    protected SearchResponse buildSearchHit(String fileName, String hitId) {
         final SearchResponse searchResponse = new SearchResponse();
         final SearchHits searchHits = new SearchHits();
         final SearchHit searchHit = new SearchHit();
@@ -42,7 +48,7 @@ public abstract class AbstractAdapterTest {
         final JsonNode jsonNode = objectMapper.readTree(loadFile("/hits/" + fileName));
 
         searchHit.setIndex("gravitee-v4-log");
-        searchHit.setId("log-id");
+        searchHit.setId(hitId);
         searchHit.setSource(jsonNode);
         searchHits.setHits(List.of(searchHit));
         searchHits.setTotal(new TotalHits(1L));

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/analytics/adapter/FindApiMetricsDetailQueryAdapterTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/analytics/adapter/FindApiMetricsDetailQueryAdapterTest.java
@@ -42,7 +42,7 @@ class FindApiMetricsDetailQueryAdapterTest {
                     "bool": {
                       "must": [
                         { "bool": { "should": [{ "term": { "api-id": "apiId" } }, { "term": { "api": "apiId" } }] } },
-                        { "term": { "request-id": "requestId" } }
+                        { "bool": { "should": [{ "term": { "request-id": "requestId" } }, { "term": { "id": "requestId" } }, { "ids": { "values": ["requestId"] } }] } }
                       ]
                     }
                   }
@@ -70,7 +70,7 @@ class FindApiMetricsDetailQueryAdapterTest {
                   "query": {
                     "bool": {
                       "must": [
-                        { "term": { "request-id": "requestId" } }
+                        { "bool": { "should": [{ "term": { "request-id": "requestId" } }, { "term": { "id": "requestId" } }, { "ids": { "values": ["requestId"] } }] } }
                       ]
                     }
                   }

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/analytics/adapter/FindApiMetricsDetailResponseAdapterTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/analytics/adapter/FindApiMetricsDetailResponseAdapterTest.java
@@ -71,5 +71,38 @@ class FindApiMetricsDetailResponseAdapterTest extends AbstractAdapterTest {
                 )
             );
         }
+
+        @Test
+        void should_build_api_metrics_detail_from_v2_source() {
+            final String v2RequestId = "c6b1a2e3-4d5f-6a7b-8c9d-0e1f2a3b4c5d";
+            final SearchResponse searchResponse = buildSearchHit("api-proxy-v2-metrics.json", v2RequestId);
+            final Optional<ApiMetricsDetail> apiMetricsDetail = FindApiMetricsDetailResponseAdapter.adaptFirst(searchResponse);
+
+            assertThat(apiMetricsDetail).isEqualTo(
+                Optional.of(
+                    ApiMetricsDetail.builder()
+                        .timestamp("2025-07-15T10:00:00.000+02:00")
+                        .apiId("f1608475-dd77-4603-a084-75dd77d60350")
+                        .requestId(v2RequestId)
+                        .transactionId("c6b1a2e3-4d5f-6a7b-8c9d-0e1f2a3b4c5d")
+                        .host("localhost:8082")
+                        .applicationId("1")
+                        .planId("a1b2c3d4-5e6f-7a8b-9c0d-e1f2a3b4c5d6")
+                        .gateway("gw-node-1")
+                        .status(200)
+                        .uri("/v2/echo")
+                        .requestContentLength(0L)
+                        .responseContentLength(140L)
+                        .remoteAddress("127.0.0.1")
+                        .gatewayLatency(5L)
+                        .gatewayResponseTime(42L)
+                        .endpointResponseTime(37L)
+                        .method(HttpMethod.GET)
+                        .endpoint("https://api.gravitee.io/echo")
+                        .warnings(List.of())
+                        .build()
+                )
+            );
+        }
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/resources/hits/api-proxy-v2-metrics.json
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/resources/hits/api-proxy-v2-metrics.json
@@ -1,0 +1,19 @@
+{
+  "api": "f1608475-dd77-4603-a084-75dd77d60350",
+  "transaction": "c6b1a2e3-4d5f-6a7b-8c9d-0e1f2a3b4c5d",
+  "host": "localhost:8082",
+  "application": "1",
+  "plan": "a1b2c3d4-5e6f-7a8b-9c0d-e1f2a3b4c5d6",
+  "gateway": "gw-node-1",
+  "status": 200,
+  "uri": "/v2/echo",
+  "request-content-length": 0,
+  "response-content-length": 140,
+  "remote-address": "127.0.0.1",
+  "proxy-latency": 5,
+  "response-time": 42,
+  "api-response-time": 37,
+  "method": 3,
+  "endpoint": "https://api.gravitee.io/echo",
+  "@timestamp": "2025-07-15T10:00:00.000+02:00"
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/ApiLogsMapper.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/mapper/ApiLogsMapper.java
@@ -15,15 +15,20 @@
  */
 package io.gravitee.rest.api.management.v2.rest.mapper;
 
+import io.gravitee.apim.core.analytics.model.ApiMetricsDetail;
 import io.gravitee.node.logging.NodeLoggerFactory;
 import io.gravitee.rest.api.management.v2.rest.model.ApiLog;
 import io.gravitee.rest.api.management.v2.rest.model.ApiLogDiagnostic;
+import io.gravitee.rest.api.management.v2.rest.model.ApiLogRequestContent;
 import io.gravitee.rest.api.management.v2.rest.model.ApiLogResponse;
+import io.gravitee.rest.api.management.v2.rest.model.ApiLogResponseContent;
+import io.gravitee.rest.api.management.v2.rest.model.HttpMethod;
 import io.gravitee.rest.api.management.v2.rest.resource.api.log.param.SearchLogsParam;
 import io.gravitee.rest.api.model.analytics.SearchLogsFilters;
 import io.gravitee.rest.api.model.v4.log.connection.ConnectionDiagnosticModel;
 import io.gravitee.rest.api.model.v4.log.connection.ConnectionLogDetail;
 import io.gravitee.rest.api.model.v4.log.connection.ConnectionLogModel;
+import java.time.OffsetDateTime;
 import java.util.List;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
@@ -46,4 +51,31 @@ public interface ApiLogsMapper {
     ApiLogResponse map(ConnectionLogDetail connectionLogDetail);
 
     ApiLogDiagnostic map(ConnectionDiagnosticModel connectionDiagnosticModel);
+
+    default ApiLogResponse mapFromMetricsDetail(ApiMetricsDetail metricsDetail) {
+        var response = new ApiLogResponse()
+            .apiId(metricsDetail.getApiId())
+            .requestId(metricsDetail.getRequestId())
+            .transactionId(metricsDetail.getTransactionId())
+            .requestEnded(true);
+
+        if (metricsDetail.getTimestamp() != null) {
+            response.timestamp(OffsetDateTime.parse(metricsDetail.getTimestamp()));
+        }
+
+        if (metricsDetail.getMethod() != null || metricsDetail.getUri() != null) {
+            var entrypointRequest = new ApiLogRequestContent();
+            if (metricsDetail.getMethod() != null) {
+                entrypointRequest.method(HttpMethod.valueOf(metricsDetail.getMethod().name()));
+            }
+            entrypointRequest.uri(metricsDetail.getUri());
+            response.entrypointRequest(entrypointRequest);
+        }
+
+        if (metricsDetail.getStatus() > 0) {
+            response.entrypointResponse(new ApiLogResponseContent().status(metricsDetail.getStatus()));
+        }
+
+        return response;
+    }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api/log/ApiLogsResource.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/main/java/io/gravitee/rest/api/management/v2/rest/resource/api/log/ApiLogsResource.java
@@ -17,6 +17,7 @@ package io.gravitee.rest.api.management.v2.rest.resource.api.log;
 
 import static io.gravitee.rest.api.management.v2.rest.pagination.PaginationInfo.computePaginationInfo;
 
+import io.gravitee.apim.core.analytics.use_case.FindApiMetricsDetailUseCase;
 import io.gravitee.apim.core.log.use_case.*;
 import io.gravitee.rest.api.management.v2.rest.mapper.ApiAggregatedMessageLogsMapper;
 import io.gravitee.rest.api.management.v2.rest.mapper.ApiLogsMapper;
@@ -65,6 +66,9 @@ public class ApiLogsResource extends AbstractResource {
 
     @Inject
     private SearchApiConnectionLogErrorKeysUseCase searchErrorKeysUseCase;
+
+    @Inject
+    private FindApiMetricsDetailUseCase findApiMetricsDetailUseCase;
 
     @GET
     @Produces(MediaType.APPLICATION_JSON)
@@ -125,10 +129,16 @@ public class ApiLogsResource extends AbstractResource {
     public ApiLogResponse getApiLog(@PathParam("requestId") String requestId) {
         var request = new SearchApiConnectionLogDetailUseCase.Input(apiId, requestId);
 
-        return searchConnectionLogUsecase
-            .execute(GraviteeContext.getExecutionContext(), request)
-            .connectionLogDetail()
-            .map(ApiLogsMapper.INSTANCE::map)
+        var logDetail = searchConnectionLogUsecase.execute(GraviteeContext.getExecutionContext(), request).connectionLogDetail();
+
+        if (logDetail.isPresent()) {
+            return ApiLogsMapper.INSTANCE.map(logDetail.get());
+        }
+
+        return findApiMetricsDetailUseCase
+            .execute(GraviteeContext.getExecutionContext(), new FindApiMetricsDetailUseCase.Input(apiId, requestId))
+            .apiMetricsDetail()
+            .map(ApiLogsMapper.INSTANCE::mapFromMetricsDetail)
             .orElseThrow(() -> new NotFoundException("No log found for api: " + apiId + " and requestId: " + requestId));
     }
 

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiLogsResourceTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-management-v2/gravitee-apim-rest-api-management-v2-rest/src/test/java/io/gravitee/rest/api/management/v2/rest/resource/api/ApiLogsResourceTest.java
@@ -19,6 +19,7 @@ import static assertions.MAPIAssertions.assertThat;
 import static io.gravitee.common.http.HttpStatusCode.*;
 import static org.mockito.Mockito.when;
 
+import fakes.FakeAnalyticsQueryService;
 import fixtures.core.log.model.MessageLogFixtures;
 import fixtures.core.model.PlanFixtures;
 import fixtures.repository.ConnectionLogDetailFixtures;
@@ -69,6 +70,9 @@ class ApiLogsResourceTest extends ApiResourceTest {
     @Inject
     ApplicationCrudServiceInMemory applicationStorageService;
 
+    @Inject
+    FakeAnalyticsQueryService fakeAnalyticsQueryService;
+
     WebTarget connectionLogsTarget;
     WebTarget messageLogsTarget;
     WebTarget connectionLogTarget;
@@ -100,6 +104,8 @@ class ApiLogsResourceTest extends ApiResourceTest {
             messageLogStorageService,
             planStorageService
         ).forEach(InMemoryAlternative::reset);
+        fakeAnalyticsQueryService.reset();
+        fakeAnalyticsQueryService.apiMetricsDetail = null;
     }
 
     @Override
@@ -722,7 +728,7 @@ class ApiLogsResourceTest extends ApiResourceTest {
         }
 
         @Test
-        void should_return_404_if_no_connection_log() {
+        void should_return_404_if_no_connection_log_and_no_metrics_detail() {
             final ConnectionLogDetail connectionLogDetail = new ConnectionLogDetailFixtures(API, "other-request-id").aConnectionLogDetail();
             connectionLogStorageService.initWithConnectionLogDetails(List.of(connectionLogDetail));
 
@@ -732,6 +738,38 @@ class ApiLogsResourceTest extends ApiResourceTest {
                 .asError()
                 .hasHttpStatus(NOT_FOUND_404)
                 .hasMessage("No log found for api: " + API + " and requestId: request-id");
+        }
+
+        @Test
+        void should_fallback_to_metrics_detail_when_no_connection_log() {
+            var metricsDetail = io.gravitee.rest.api.model.v4.analytics.ApiMetricsDetail.builder()
+                .timestamp("2023-10-22T10:15:30.000Z")
+                .apiId(API)
+                .requestId(REQUEST_ID)
+                .transactionId("tx-id")
+                .applicationId(APPLICATION.getId())
+                .planId(PLAN_1.getId())
+                .uri("/my-api/resource")
+                .status(200)
+                .method(io.gravitee.common.http.HttpMethod.GET)
+                .build();
+            fakeAnalyticsQueryService.apiMetricsDetail = metricsDetail;
+
+            final Response response = connectionLogTarget.request().get();
+
+            assertThat(response)
+                .hasStatus(OK_200)
+                .asEntity(ApiLogResponse.class)
+                .isEqualTo(
+                    new ApiLogResponse()
+                        .apiId(API)
+                        .requestId(REQUEST_ID)
+                        .transactionId("tx-id")
+                        .timestamp(Instant.parse("2023-10-22T10:15:30.000Z").atOffset(ZoneOffset.UTC))
+                        .requestEnded(true)
+                        .entrypointRequest(new ApiLogRequestContent().method(HttpMethod.GET).uri("/my-api/resource"))
+                        .entrypointResponse(new ApiLogResponseContent().status(200))
+                );
         }
     }
 


### PR DESCRIPTION
What was breaking: after migrating a v2 proxy to v4, the log table was showing up, but displaying the details was failing 🙈 

After this fix 👇 

This shows navigating between a log emitted while the API was v2, and a log emitted after the migration.

https://github.com/user-attachments/assets/20d9c7f5-4bff-4162-b4a4-663a9aea1219

