### PR TITLE
feat(analytics): friendly HTTP status labels and Gamma observability fixes

### DIFF
--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/analytics/engine/api/query/HttpStatusCodeGroups.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/main/java/io/gravitee/repository/analytics/engine/api/query/HttpStatusCodeGroups.java
@@ -43,6 +43,25 @@ public final class HttpStatusCodeGroups {
      */
     public static final Map<String, Bounds> GROUP_BOUNDS;
 
+    /**
+     * Human-readable display labels for each status code group, keyed by canonical group name
+     * (e.g. {@code "2XX"} → {@code "2xx Success"}). Shared across the Gamma filter catalog
+     * ({@code StaticFilters}) and the bucket-name post-processor so that the label is
+     * defined in exactly one place.
+     */
+    public static final Map<String, String> FRIENDLY_LABELS = Map.of(
+        "1XX",
+        "1xx Informational",
+        "2XX",
+        "2xx Success",
+        "3XX",
+        "3xx Redirection",
+        "4XX",
+        "4xx Client Error",
+        "5XX",
+        "5xx Server Error"
+    );
+
     static {
         var bounds = new LinkedHashMap<String, Bounds>();
         bounds.put("1XX", new Bounds(100, 199));
@@ -83,5 +102,20 @@ public final class HttpStatusCodeGroups {
         return GROUP_BOUNDS.entrySet()
             .stream()
             .collect(Collectors.toUnmodifiableMap(e -> e.getValue().min() + "-" + e.getValue().max(), Map.Entry::getKey));
+    }
+
+    /**
+     * Builds a reverse lookup from ES bucket keys ({@code "100-199"}) to friendly group labels
+     * ({@code "1xx Informational"}). Uses {@link #FRIENDLY_LABELS} as the label source.
+     */
+    public static Map<String, String> esBucketKeyToFriendlyGroupLabel() {
+        return GROUP_BOUNDS.entrySet()
+            .stream()
+            .collect(
+                Collectors.toUnmodifiableMap(
+                    e -> e.getValue().min() + "-" + e.getValue().max(),
+                    e -> FRIENDLY_LABELS.getOrDefault(e.getKey(), e.getKey())
+                )
+            );
     }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-api/src/test/java/io/gravitee/repository/analytics/engine/api/query/HttpStatusCodeGroupsTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-api/src/test/java/io/gravitee/repository/analytics/engine/api/query/HttpStatusCodeGroupsTest.java
@@ -97,4 +97,46 @@ class HttpStatusCodeGroupsTest {
                 .containsEntry("500-599", "5XX");
         }
     }
+
+    @Nested
+    class FriendlyLabels {
+
+        @Test
+        void should_contain_all_five_groups() {
+            assertThat(HttpStatusCodeGroups.FRIENDLY_LABELS).hasSize(5);
+        }
+
+        @Test
+        void should_map_canonical_keys_to_friendly_labels() {
+            assertThat(HttpStatusCodeGroups.FRIENDLY_LABELS)
+                .containsEntry("1XX", "1xx Informational")
+                .containsEntry("2XX", "2xx Success")
+                .containsEntry("3XX", "3xx Redirection")
+                .containsEntry("4XX", "4xx Client Error")
+                .containsEntry("5XX", "5xx Server Error");
+        }
+    }
+
+    @Nested
+    class EsBucketKeyToFriendlyGroupLabel {
+
+        @Test
+        void should_return_all_five_groups() {
+            var map = HttpStatusCodeGroups.esBucketKeyToFriendlyGroupLabel();
+
+            assertThat(map).hasSize(5);
+        }
+
+        @Test
+        void should_map_es_key_to_friendly_label() {
+            var map = HttpStatusCodeGroups.esBucketKeyToFriendlyGroupLabel();
+
+            assertThat(map)
+                .containsEntry("100-199", "1xx Informational")
+                .containsEntry("200-299", "2xx Success")
+                .containsEntry("300-399", "3xx Redirection")
+                .containsEntry("400-499", "4xx Client Error")
+                .containsEntry("500-599", "5xx Server Error");
+        }
+    }
 }

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/analytics/engine/adapter/HTTPFacetsQueryAdapter.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/main/java/io/gravitee/repository/elasticsearch/v4/analytics/engine/adapter/HTTPFacetsQueryAdapter.java
@@ -115,20 +115,29 @@ public class HTTPFacetsQueryAdapter {
     }
 
     private JsonObject adaptFacet(MetricMeasuresQuery metric, Facet facet, Integer limit, List<NumberRange> ranges, boolean last) {
+        var rangeAggregation = resolveRangeAggregation(facet, ranges, last);
+        if (rangeAggregation != null) {
+            return rangeAggregation;
+        }
         if (last) {
-            return toLeaf(facet, metric, limit, ranges);
+            return toTermsLeaf(facet, metric, limit);
         }
         return json().put("terms", toTerms(facet));
     }
 
-    private JsonObject toLeaf(Facet facet, MetricMeasuresQuery metric, Integer limit, List<NumberRange> ranges) {
+    /**
+     * Range aggregations depend on the facet semantics, not on whether the facet is the last
+     * {@code by} dimension. {@code HTTP_STATUS_CODE_GROUP} must always bucket on status-code ranges
+     * so a follow-up {@code HTTP_STATUS} facet can drill down within each group.
+     */
+    private JsonObject resolveRangeAggregation(Facet facet, List<NumberRange> ranges, boolean last) {
         if (facet == Facet.HTTP_STATUS_CODE_GROUP) {
             return toRangeLeaf(Facet.HTTP_STATUS, NumberRange.forStatusCodeGroup());
         }
-        if (ranges == null || ranges.isEmpty()) {
-            return toTermsLeaf(facet, metric, limit);
+        if (last && ranges != null && !ranges.isEmpty()) {
+            return toRangeLeaf(facet, ranges);
         }
-        return toRangeLeaf(facet, ranges);
+        return null;
     }
 
     private JsonObject toRangeLeaf(Facet facet, List<NumberRange> ranges) {

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/analytics/engine/adapter/HTTPFacetsQueryAdapterTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/analytics/engine/adapter/HTTPFacetsQueryAdapterTest.java
@@ -245,6 +245,35 @@ class HTTPFacetsQueryAdapterTest extends AbstractQueryAdapterTest {
     }
 
     @Test
+    void should_build_query_with_status_code_group_then_status() throws JsonProcessingException {
+        var timeRange = buildTimeRange();
+        var filters = buildFilters();
+        var metrics = buildSortedMetric();
+
+        var facets = List.of(Facet.HTTP_STATUS_CODE_GROUP, Facet.HTTP_STATUS);
+        var limit = 5;
+
+        var query = new FacetsQuery(timeRange, filters, metrics, facets, limit);
+        var queryString = adapter.adapt(query);
+        var jsonQuery = JSON.readTree(queryString);
+
+        var groupAgg = jsonQuery.at("/aggs/HTTP_REQUESTS#HTTP_STATUS_CODE_GROUP");
+        assertThat(groupAgg.has("range")).isTrue();
+        assertThat(groupAgg.at("/range/field").asText()).isEqualTo("status");
+        assertThat(groupAgg.at("/range/ranges").size()).isEqualTo(5);
+        assertThat(groupAgg.at("/range/ranges/0/key").asText()).isEqualTo("100-199");
+
+        var nestedTerms = groupAgg.at("/aggs/HTTP_REQUESTS#HTTP_STATUS/terms/field");
+        assertThat(nestedTerms.asText()).isEqualTo("status");
+
+        var nestedSize = groupAgg.at("/aggs/HTTP_REQUESTS#HTTP_STATUS/terms/size").asInt();
+        assertThat(nestedSize).isEqualTo(limit);
+
+        var nestedMeasures = groupAgg.at("/aggs/HTTP_REQUESTS#HTTP_STATUS/aggs/HTTP_REQUESTS#COUNT");
+        assertThat(nestedMeasures).isNotNull();
+    }
+
+    @Test
     void should_build_request_ids_query_with_composite_aggregation() throws JsonProcessingException {
         var timeRange = buildTimeRange();
         var filters = buildFilters();

--- a/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/analytics/engine/adapter/HTTPTimeSeriesAdapterTest.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-elasticsearch/src/test/java/io/gravitee/repository/elasticsearch/v4/analytics/engine/adapter/HTTPTimeSeriesAdapterTest.java
@@ -72,4 +72,26 @@ public class HTTPTimeSeriesAdapterTest extends AbstractQueryAdapterTest {
         var gatewayResponseTimeDateHistogram = aggs.at("/HTTP_GATEWAY_RESPONSE_TIME#TIME_SERIES/date_histogram");
         assertThat(gatewayResponseTimeDateHistogram).isNotEmpty();
     }
+
+    @Test
+    void should_build_time_series_with_status_code_group_then_status() throws JsonProcessingException {
+        var timeRange = buildTimeRange();
+        var filters = buildFilters();
+        var metrics = buildSortedMetric();
+        var facets = List.of(Facet.HTTP_STATUS_CODE_GROUP, Facet.HTTP_STATUS);
+        var interval = Duration.ofHours(1).toMillis();
+        var limit = 5;
+
+        var query = new TimeSeriesQuery(timeRange, filters, interval, metrics, facets, limit, List.of());
+        var queryString = adapter.adapt(query);
+        var jsonQuery = JSON.readTree(queryString);
+
+        var groupAgg = jsonQuery.at("/aggs/HTTP_REQUESTS#TIME_SERIES/aggs/HTTP_REQUESTS#HTTP_STATUS_CODE_GROUP");
+        assertThat(groupAgg.has("range")).isTrue();
+        assertThat(groupAgg.at("/range/field").asText()).isEqualTo("status");
+        assertThat(groupAgg.at("/range/ranges/0/key").asText()).isEqualTo("100-199");
+
+        var nestedTerms = groupAgg.at("/aggs/HTTP_REQUESTS#HTTP_STATUS/terms/field");
+        assertThat(nestedTerms.asText()).isEqualTo("status");
+    }
 }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/analytics_engine/processors/BucketNamesPostProcessorImpl.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/analytics_engine/processors/BucketNamesPostProcessorImpl.java
@@ -43,39 +43,9 @@ public class BucketNamesPostProcessorImpl implements BucketNamesPostProcessor {
 
     private static final String UNKNOWN_APPLICATION = "Unknown";
 
-    private static final Map<String, String> STATUS_CODE_GROUP_FROM_ES_KEY = HttpStatusCodeGroups.esBucketKeyToGroupLabel();
+    private static final Map<String, String> STATUS_CODE_GROUP_FROM_ES_KEY = HttpStatusCodeGroups.esBucketKeyToFriendlyGroupLabel();
 
     private static final Map<String, String> HTTP_METHOD_BY_CODE = buildHttpMethodCodeMap();
-
-    private static final Map<String, String> HTTP_STATUS_LABELS = Map.ofEntries(
-        Map.entry("100", "100 Continue"),
-        Map.entry("101", "101 Switching Protocols"),
-        Map.entry("200", "200 OK"),
-        Map.entry("201", "201 Created"),
-        Map.entry("202", "202 Accepted"),
-        Map.entry("204", "204 No Content"),
-        Map.entry("301", "301 Moved Permanently"),
-        Map.entry("302", "302 Found"),
-        Map.entry("304", "304 Not Modified"),
-        Map.entry("307", "307 Temporary Redirect"),
-        Map.entry("308", "308 Permanent Redirect"),
-        Map.entry("400", "400 Bad Request"),
-        Map.entry("401", "401 Unauthorized"),
-        Map.entry("403", "403 Forbidden"),
-        Map.entry("404", "404 Not Found"),
-        Map.entry("405", "405 Method Not Allowed"),
-        Map.entry("408", "408 Request Timeout"),
-        Map.entry("409", "409 Conflict"),
-        Map.entry("413", "413 Payload Too Large"),
-        Map.entry("415", "415 Unsupported Media Type"),
-        Map.entry("422", "422 Unprocessable Entity"),
-        Map.entry("429", "429 Too Many Requests"),
-        Map.entry("500", "500 Internal Server Error"),
-        Map.entry("501", "501 Not Implemented"),
-        Map.entry("502", "502 Bad Gateway"),
-        Map.entry("503", "503 Service Unavailable"),
-        Map.entry("504", "504 Gateway Timeout")
-    );
 
     private static Map<String, String> buildHttpMethodCodeMap() {
         var methods = HttpMethod.values();
@@ -152,7 +122,7 @@ public class BucketNamesPostProcessorImpl implements BucketNamesPostProcessor {
         var bucketName = switch (facets.getFirst()) {
             case FacetSpec.Name.HTTP_STATUS_CODE_GROUP -> STATUS_CODE_GROUP_FROM_ES_KEY.getOrDefault(bucket.key(), bucket.key());
             case FacetSpec.Name.HTTP_METHOD -> HTTP_METHOD_BY_CODE.getOrDefault(bucket.key(), bucket.key());
-            case FacetSpec.Name.HTTP_STATUS -> HTTP_STATUS_LABELS.getOrDefault(bucket.key(), bucket.key());
+            case FacetSpec.Name.HTTP_STATUS -> HttpStatusLabels.labelForCode(bucket.key());
             case FacetSpec.Name.API -> {
                 var name = context.apiNamesById().get(bucket.key());
                 yield name != null ? name : bucket.key();

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/analytics_engine/processors/HttpStatusLabels.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/main/java/io/gravitee/apim/infra/domain_service/analytics_engine/processors/HttpStatusLabels.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.infra.domain_service.analytics_engine.processors;
+
+import io.netty.handler.codec.http.HttpResponseStatus;
+
+/**
+ * Resolves display labels for {@code HTTP_STATUS} facet buckets using Netty's canonical
+ * reason phrases — the same source as the gateway data plane.
+ */
+final class HttpStatusLabels {
+
+    private HttpStatusLabels() {}
+
+    static String labelForCode(String statusCodeKey) {
+        if (statusCodeKey == null || statusCodeKey.isBlank()) {
+            return statusCodeKey;
+        }
+        try {
+            var code = Integer.parseInt(statusCodeKey);
+            var reasonPhrase = normalizeReasonPhrase(code, statusCodeKey, HttpResponseStatus.valueOf(code).reasonPhrase());
+            if (reasonPhrase == null) {
+                return statusCodeKey;
+            }
+            if (reasonPhrase.startsWith(statusCodeKey + " ")) {
+                return reasonPhrase;
+            }
+            return code + " " + reasonPhrase;
+        } catch (NumberFormatException e) {
+            return statusCodeKey;
+        }
+    }
+
+    /**
+     * Netty appends {@code (code)} to synthetic reason phrases (e.g. {@code "999 Unknown Status (999)"}).
+     * Strip that suffix and, when Netty also prefixed the code, avoid duplicating it in the final label.
+     */
+    private static String normalizeReasonPhrase(int code, String statusCodeKey, String reasonPhrase) {
+        var suffix = " (" + code + ")";
+        if (!reasonPhrase.endsWith(suffix)) {
+            return reasonPhrase;
+        }
+        var trimmed = reasonPhrase.substring(0, reasonPhrase.length() - suffix.length()).trim();
+        return trimmed.isEmpty() ? null : trimmed;
+    }
+}

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/analytics_engine/processors/BucketNamesProcessorTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/analytics_engine/processors/BucketNamesProcessorTest.java
@@ -253,6 +253,62 @@ class BucketNamesProcessorTest {
         }
 
         @Test
+        void should_map_http_status_code_group_facet_buckets() {
+            var bucket1 = newStatusCodeRangeBucketResponse("200-299");
+            var bucket2 = newStatusCodeRangeBucketResponse("400-499");
+            var response = facetsResponse(bucket1, bucket2);
+
+            var mappedResponse = processor.mapBucketNames(context, List.of(HTTP_STATUS_CODE_GROUP), response);
+
+            var expected1 = new FacetBucketResponse("200-299", "2xx Success", null, bucket1.measures());
+            var expected2 = new FacetBucketResponse("400-499", "4xx Client Error", null, bucket2.measures());
+            var expectedResponse = facetsResponse(expected1, expected2);
+
+            assertThat(mappedResponse).isEqualTo(expectedResponse);
+        }
+
+        @Test
+        void should_map_common_http_status_codes_to_labeled_names() {
+            var bucket1 = newUnnamedBucketResponse("404");
+            var bucket2 = newUnnamedBucketResponse("500");
+            var response = facetsResponse(bucket1, bucket2);
+
+            var mappedResponse = processor.mapBucketNames(context, List.of(HTTP_STATUS), response);
+
+            var expected1 = new FacetBucketResponse("404", "404 Not Found", null, bucket1.measures());
+            var expected2 = new FacetBucketResponse("500", "500 Internal Server Error", null, bucket2.measures());
+            var expectedResponse = facetsResponse(expected1, expected2);
+
+            assertThat(mappedResponse).isEqualTo(expectedResponse);
+        }
+
+        @Test
+        void should_fallback_to_raw_key_for_unknown_http_status() {
+            var bucket = newUnnamedBucketResponse("999");
+            var response = facetsResponse(bucket);
+
+            var mappedResponse = processor.mapBucketNames(context, List.of(HTTP_STATUS), response);
+
+            var expected = new FacetBucketResponse("999", "999 Unknown Status", null, bucket.measures());
+            var expectedResponse = facetsResponse(expected);
+
+            assertThat(mappedResponse).isEqualTo(expectedResponse);
+        }
+
+        @Test
+        void should_normalize_synthetic_netty_status_code_without_redundant_suffix() {
+            var bucket = newUnnamedBucketResponse("418");
+            var response = facetsResponse(bucket);
+
+            var mappedResponse = processor.mapBucketNames(context, List.of(HTTP_STATUS), response);
+
+            var expected = new FacetBucketResponse("418", "418 Client Error", null, bucket.measures());
+            var expectedResponse = facetsResponse(expected);
+
+            assertThat(mappedResponse).isEqualTo(expectedResponse);
+        }
+
+        @Test
         void should_map_http_method_codes_to_names() {
             var bucket1 = newUnnamedBucketResponse("3");
             var bucket2 = newUnnamedBucketResponse("7");
@@ -322,7 +378,12 @@ class BucketNamesProcessorTest {
 
             var response = timeSeriesResponse(FIXED_TIME_KEY, FIXED_TIMESTAMP, facetBucketResponse);
 
-            var expectedFacetsResponse = new FacetBucketResponse("200-299", "2XX", null, List.of(new Measure(COUNT, FIXED_COUNT_VALUE)));
+            var expectedFacetsResponse = new FacetBucketResponse(
+                "200-299",
+                "2xx Success",
+                null,
+                List.of(new Measure(COUNT, FIXED_COUNT_VALUE))
+            );
 
             var expectedResponse = timeSeriesResponse(FIXED_TIME_KEY, FIXED_TIMESTAMP, expectedFacetsResponse);
 
@@ -492,6 +553,19 @@ class BucketNamesProcessorTest {
                 FIXED_TIMESTAMP,
                 getNamedApplicationBucketResponse(facetBucketResponse, List.of(innerNamedBucket1, innerNamedBucket2))
             );
+
+            assertThat(mappedResponse).isEqualTo(expectedResponse);
+        }
+
+        @Test
+        void should_fallback_to_raw_key_for_unknown_http_status_in_time_series() {
+            var bucket = newUnnamedBucketResponse("999");
+            var response = timeSeriesResponse(FIXED_TIME_KEY, FIXED_TIMESTAMP, bucket);
+
+            var mappedResponse = processor.mapBucketNames(context, List.of(HTTP_STATUS), response);
+
+            var expected = new FacetBucketResponse("999", "999 Unknown Status", null, bucket.measures());
+            var expectedResponse = timeSeriesResponse(FIXED_TIME_KEY, FIXED_TIMESTAMP, expected);
 
             assertThat(mappedResponse).isEqualTo(expectedResponse);
         }

--- a/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/analytics_engine/processors/HttpStatusLabelsTest.java
+++ b/gravitee-apim-rest-api/gravitee-apim-rest-api-service/src/test/java/io/gravitee/apim/infra/domain_service/analytics_engine/processors/HttpStatusLabelsTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.apim.infra.domain_service.analytics_engine.processors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class HttpStatusLabelsTest {
+
+    @Test
+    void should_resolve_registered_status_with_netty_reason_phrase() {
+        assertThat(HttpStatusLabels.labelForCode("404")).isEqualTo("404 Not Found");
+    }
+
+    @Test
+    void should_strip_redundant_code_suffix_from_synthetic_netty_reason_phrase() {
+        assertThat(HttpStatusLabels.labelForCode("999")).isEqualTo("999 Unknown Status");
+        assertThat(HttpStatusLabels.labelForCode("418")).isEqualTo("418 Client Error");
+    }
+
+    @Test
+    void should_fallback_to_raw_key_for_non_numeric_key() {
+        assertThat(HttpStatusLabels.labelForCode("not-a-code")).isEqualTo("not-a-code");
+    }
+}

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/filter/model/StaticFilters.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/filter/model/StaticFilters.java
@@ -22,7 +22,9 @@ import static io.gravitee.gamma.rest.core.observability.filter.model.FilterOpera
 
 import io.gravitee.gamma.rest.core.observability.filter.model.FilterSpec.EnumValue;
 import io.gravitee.gamma.rest.core.observability.filter.model.FilterSpec.Range;
+import io.gravitee.repository.analytics.engine.api.query.HttpStatusCodeGroups;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 /**
@@ -218,13 +220,11 @@ public enum StaticFilters {
             new EnumValue("OTHER", "Other")
         );
 
-        private static final List<EnumValue> STATUS_CODE_GROUPS = List.of(
-            new EnumValue("1XX", "1xx Informational"),
-            new EnumValue("2XX", "2xx Success"),
-            new EnumValue("3XX", "3xx Redirection"),
-            new EnumValue("4XX", "4xx Client Error"),
-            new EnumValue("5XX", "5xx Server Error")
-        );
+        private static final List<EnumValue> STATUS_CODE_GROUPS = HttpStatusCodeGroups.FRIENDLY_LABELS.entrySet()
+            .stream()
+            .sorted(Map.Entry.comparingByKey())
+            .map(e -> new EnumValue(e.getKey(), e.getValue()))
+            .toList();
 
         private static final List<EnumValue> MESSAGE_OPERATIONS = List.of(self("Publish"), self("Subscribe"));
 

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/filter/model/StaticFilters.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/filter/model/StaticFilters.java
@@ -22,9 +22,7 @@ import static io.gravitee.gamma.rest.core.observability.filter.model.FilterOpera
 
 import io.gravitee.gamma.rest.core.observability.filter.model.FilterSpec.EnumValue;
 import io.gravitee.gamma.rest.core.observability.filter.model.FilterSpec.Range;
-import io.gravitee.repository.analytics.engine.api.query.HttpStatusCodeGroups;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 
 /**
@@ -220,11 +218,13 @@ public enum StaticFilters {
             new EnumValue("OTHER", "Other")
         );
 
-        private static final List<EnumValue> STATUS_CODE_GROUPS = HttpStatusCodeGroups.FRIENDLY_LABELS.entrySet()
-            .stream()
-            .sorted(Map.Entry.comparingByKey())
-            .map(e -> new EnumValue(e.getKey(), e.getValue()))
-            .toList();
+        private static final List<EnumValue> STATUS_CODE_GROUPS = List.of(
+            new EnumValue("1XX", "1xx Informational"),
+            new EnumValue("2XX", "2xx Success"),
+            new EnumValue("3XX", "3xx Redirection"),
+            new EnumValue("4XX", "4xx Client Error"),
+            new EnumValue("5XX", "5xx Server Error")
+        );
 
         private static final List<EnumValue> MESSAGE_OPERATIONS = List.of(self("Publish"), self("Subscribe"));
 

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/logs/use_case/SearchObservabilityLogsUseCase.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/core/observability/logs/use_case/SearchObservabilityLogsUseCase.java
@@ -30,6 +30,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import lombok.AllArgsConstructor;
 
 /**
@@ -92,13 +93,14 @@ public class SearchObservabilityLogsUseCase {
         var accessibleApis = logsDataPort.loadAccessibleApis(input.organizationId, input.environmentId);
 
         var userApiFilter = extractApiFilter(conditions);
-        var scope = accessibleApiScope.computeScope(accessibleApis, LOGS_SUPPORTED_API_TYPES, userApiFilter);
+        var effectiveApiTypes = narrowApiTypes(conditions);
+        var scope = accessibleApiScope.computeScope(accessibleApis, effectiveApiTypes, userApiFilter);
 
         if (scope.apiIds().isEmpty()) {
             return new Output(LogsPage.EMPTY, page, perPage);
         }
 
-        var effectiveConditions = applyDefaultEntrypointScoping(removeApiConditions(conditions));
+        var effectiveConditions = applyDefaultEntrypointScoping(removeScopeConditions(conditions));
 
         var query = LogsSearchQuery.builder()
             .apiIds(scope.apiIds())
@@ -136,10 +138,36 @@ public class SearchObservabilityLogsUseCase {
             .collect(Collectors.toSet());
     }
 
-    private static List<FilterCondition> removeApiConditions(List<FilterCondition> conditions) {
+    /**
+     * Narrows {@link #LOGS_SUPPORTED_API_TYPES} when the caller supplies an explicit
+     * {@code API_TYPE} filter. Values are intersected with the supported set so that an
+     * unsupported type (e.g. {@code MESSAGE}) simply yields an empty scope instead of an error.
+     */
+    private static Set<ApiType> narrowApiTypes(List<FilterCondition> conditions) {
+        var requested = conditions
+            .stream()
+            .filter(c -> "API_TYPE".equals(c.name()))
+            .flatMap(c -> c.values().stream())
+            .flatMap(v -> {
+                try {
+                    return Stream.of(ApiType.valueOf(v));
+                } catch (IllegalArgumentException e) {
+                    return Stream.empty();
+                }
+            })
+            .collect(Collectors.toSet());
+
+        if (requested.isEmpty()) {
+            return LOGS_SUPPORTED_API_TYPES;
+        }
+        requested.retainAll(LOGS_SUPPORTED_API_TYPES);
+        return requested;
+    }
+
+    private static List<FilterCondition> removeScopeConditions(List<FilterCondition> conditions) {
         return conditions
             .stream()
-            .filter(c -> !"API".equals(c.name()))
+            .filter(c -> !"API".equals(c.name()) && !"API_TYPE".equals(c.name()))
             .toList();
     }
 

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/infra/adapter/AnalyticsBucketTypeEnricher.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/infra/adapter/AnalyticsBucketTypeEnricher.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gamma.rest.infra.adapter;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+/**
+ * Adds {@code type=GROUP|LEAF} discriminators to analytics bucket nodes so Gamma responses match
+ * the management v2 wire contract expected by dashboard widgets.
+ *
+ * @author GraviteeSource Team
+ */
+final class AnalyticsBucketTypeEnricher {
+
+    private static final String TYPE = "type";
+    private static final String BUCKETS = "buckets";
+    private static final String METRICS = "metrics";
+    private static final String GROUP = "GROUP";
+    private static final String LEAF = "LEAF";
+
+    private AnalyticsBucketTypeEnricher() {}
+
+    static void enrichFacetsResponse(ObjectNode root) {
+        enrichMetricBuckets(root, AnalyticsBucketTypeEnricher::enrichFacetBucket);
+    }
+
+    static void enrichTimeSeriesResponse(ObjectNode root) {
+        enrichMetricBuckets(root, AnalyticsBucketTypeEnricher::enrichTimeSeriesBucket);
+    }
+
+    private static void enrichMetricBuckets(ObjectNode root, BucketEnricher enricher) {
+        var metrics = root.get(METRICS);
+        if (metrics == null || !metrics.isArray()) {
+            return;
+        }
+        metrics.forEach(metric -> enrichBucketArray(metric.get(BUCKETS), enricher));
+    }
+
+    private static void enrichBucketArray(JsonNode buckets, BucketEnricher enricher) {
+        if (buckets == null || !buckets.isArray()) {
+            return;
+        }
+        buckets.forEach(bucket -> enricher.enrich(bucket));
+    }
+
+    private static void enrichFacetBucket(JsonNode bucket) {
+        if (!(bucket instanceof ObjectNode object)) {
+            return;
+        }
+        if (hasNestedBuckets(object)) {
+            object.put(TYPE, GROUP);
+            enrichBucketArray(object.get(BUCKETS), AnalyticsBucketTypeEnricher::enrichFacetBucket);
+            return;
+        }
+        object.put(TYPE, LEAF);
+    }
+
+    private static void enrichTimeSeriesBucket(JsonNode bucket) {
+        if (!(bucket instanceof ObjectNode object)) {
+            return;
+        }
+        if (hasNestedBuckets(object)) {
+            object.put(TYPE, GROUP);
+            enrichBucketArray(object.get(BUCKETS), AnalyticsBucketTypeEnricher::enrichFacetBucket);
+            return;
+        }
+        object.put(TYPE, LEAF);
+    }
+
+    private static boolean hasNestedBuckets(ObjectNode bucket) {
+        var nested = bucket.get(BUCKETS);
+        return nested != null && nested.isArray() && !nested.isEmpty();
+    }
+
+    @FunctionalInterface
+    private interface BucketEnricher {
+        void enrich(JsonNode bucket);
+    }
+}

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/infra/adapter/ObservabilityAnalyticsDataPortAdapter.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/infra/adapter/ObservabilityAnalyticsDataPortAdapter.java
@@ -17,6 +17,7 @@ package io.gravitee.gamma.rest.infra.adapter;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.gravitee.apim.core.analytics_engine.model.FacetMetricMeasuresRequest;
 import io.gravitee.apim.core.analytics_engine.model.FacetSpec;
 import io.gravitee.apim.core.analytics_engine.model.FacetsRequest;
@@ -102,7 +103,9 @@ public class ObservabilityAnalyticsDataPortAdapter implements ObservabilityAnaly
             toApimRanges(query.ranges())
         );
         var response = computeFacetsUseCase.execute(new ComputeFacetsUseCase.Input(auditInfo, apimRequest)).response();
-        return objectMapper.valueToTree(response);
+        var node = (ObjectNode) objectMapper.valueToTree(response);
+        AnalyticsBucketTypeEnricher.enrichFacetsResponse(node);
+        return node;
     }
 
     @Override
@@ -118,7 +121,9 @@ public class ObservabilityAnalyticsDataPortAdapter implements ObservabilityAnaly
             toApimRanges(query.ranges())
         );
         var response = computeTimeSeriesUseCase.execute(new ComputeTimeSeriesUseCase.Input(auditInfo, apimRequest)).response();
-        return objectMapper.valueToTree(response);
+        var node = (ObjectNode) objectMapper.valueToTree(response);
+        AnalyticsBucketTypeEnricher.enrichTimeSeriesResponse(node);
+        return node;
     }
 
     @Override

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/resources/observability/analytics/AnalyticsResource.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/resources/observability/analytics/AnalyticsResource.java
@@ -102,7 +102,7 @@ public class AnalyticsResource {
                 request != null && request.timeRange() != null ? request.timeRange().from() : null,
                 request != null && request.timeRange() != null ? request.timeRange().to() : null,
                 toFacetMetrics(request != null ? request.metrics() : null),
-                request != null && request.facets() != null ? request.facets() : List.of(),
+                request != null && request.by() != null ? request.by() : List.of(),
                 request != null ? request.limit() : null,
                 toRanges(request != null ? request.ranges() : null)
             )
@@ -127,7 +127,7 @@ public class AnalyticsResource {
                 request != null && request.timeRange() != null ? request.timeRange().to() : null,
                 request != null ? request.interval() : null,
                 toFacetMetrics(request != null ? request.metrics() : null),
-                request != null && request.facets() != null ? request.facets() : List.of(),
+                request != null && request.by() != null ? request.by() : List.of(),
                 request != null ? request.facetSize() : null,
                 toRanges(request != null ? request.ranges() : null)
             )

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/resources/observability/analytics/dto/AnalyticsFacetsRequestDto.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/resources/observability/analytics/dto/AnalyticsFacetsRequestDto.java
@@ -26,7 +26,7 @@ public record AnalyticsFacetsRequestDto(
     TimeRangeDto timeRange,
     List<FilterConditionDto> filters,
     List<FacetMetricQueryDto> metrics,
-    List<String> facets,
+    List<String> by,
     Integer limit,
     List<NumberRangeDto> ranges
 ) {}

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/resources/observability/analytics/dto/AnalyticsTimeSeriesRequestDto.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/java/io/gravitee/gamma/rest/resources/observability/analytics/dto/AnalyticsTimeSeriesRequestDto.java
@@ -27,7 +27,7 @@ public record AnalyticsTimeSeriesRequestDto(
     List<FilterConditionDto> filters,
     Long interval,
     List<FacetMetricQueryDto> metrics,
-    List<String> facets,
+    List<String> by,
     Integer facetSize,
     List<NumberRangeDto> ranges
 ) {}

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/main/resources/openapi/observability/openapi-observability.yaml
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/main/resources/openapi/observability/openapi-observability.yaml
@@ -863,7 +863,7 @@ paths:
                                           sorts:
                                               - measure: "COUNT"
                                                 order: "DESC"
-                                    facets: ["API"]
+                                    by: ["API"]
                                     limit: 10
                             by-status-with-ranges:
                                 summary: Status code group distribution
@@ -874,7 +874,7 @@ paths:
                                     metrics:
                                         - name: "HTTP_REQUESTS"
                                           measures: ["COUNT"]
-                                    facets: ["HTTP_STATUS"]
+                                    by: ["HTTP_STATUS"]
                                     ranges:
                                         - from: 100
                                           to: 199
@@ -939,7 +939,7 @@ paths:
                 Returns metric values bucketed by time intervals (e.g. per minute, per hour).
                 Use this endpoint to build line charts and histograms in the dashboard.
 
-                Each time bucket may optionally contain nested facet buckets when `facets` is
+                Each time bucket may optionally contain nested facet buckets when `by` is
                 provided, enabling per-API or per-status time-series breakdowns.
 
                 `interval` is in milliseconds (e.g. `60000` for 1 minute, `3600000` for 1 hour).
@@ -972,7 +972,7 @@ paths:
                                     metrics:
                                         - name: "HTTP_REQUESTS"
                                           measures: ["COUNT"]
-                                    facets: ["API"]
+                                    by: ["API"]
                                     facetSize: 5
             responses:
                 "200":
@@ -1693,7 +1693,7 @@ components:
         AnalyticsFacetsRequest:
             type: object
             description: Request body for the facets endpoint.
-            required: [metrics, facets]
+            required: [metrics, by]
             properties:
                 timeRange:
                     $ref: "#/components/schemas/TimeRange"
@@ -1706,7 +1706,7 @@ components:
                     description: Metrics to compute per facet bucket.
                     items:
                         $ref: "#/components/schemas/FacetMetricQuery"
-                facets:
+                by:
                     type: array
                     description: |
                         Facet dimensions to break down by (e.g. `API`, `HTTP_STATUS`,
@@ -1747,7 +1747,7 @@ components:
                     description: Metrics to compute per time bucket.
                     items:
                         $ref: "#/components/schemas/FacetMetricQuery"
-                facets:
+                by:
                     type: array
                     nullable: true
                     description: Optional facet dimensions for nested breakdown within each time bucket.
@@ -1807,6 +1807,7 @@ components:
             type: object
             description: |
                 A facet bucket. Leaf buckets carry `measures`; group buckets carry nested `buckets`.
+            required: [key, name, type]
             properties:
                 key:
                     type: string
@@ -1819,8 +1820,14 @@ components:
                         `API` → API display name, `APPLICATION` → application name,
                         `HTTP_METHOD` → method name (GET, POST, …),
                         `HTTP_STATUS` → labeled code (200 OK, 404 Not Found, …),
-                        `HTTP_STATUS_CODE_GROUP` → group label (2XX, 4XX, …).
+                        `HTTP_STATUS_CODE_GROUP` → friendly group label (2xx Success, 4xx Client Error, …).
                         Falls back to the raw key for unmapped facets.
+                type:
+                    type: string
+                    enum: [GROUP, LEAF]
+                    description: |
+                        Discriminator for nested facet trees. `GROUP` buckets contain nested
+                        `buckets`; `LEAF` buckets contain `measures`.
                 buckets:
                     type: array
                     nullable: true
@@ -1861,6 +1868,7 @@ components:
         TimeSeriesBucket:
             type: object
             description: A time-series bucket with optional nested facet buckets.
+            required: [key, type]
             properties:
                 key:
                     type: string
@@ -1869,6 +1877,12 @@ components:
                 name:
                     type: string
                     nullable: true
+                type:
+                    type: string
+                    enum: [GROUP, LEAF]
+                    description: |
+                        Discriminator for time-series buckets. `GROUP` buckets contain nested facet
+                        `buckets`; `LEAF` buckets contain `measures` only.
                 timestamp:
                     type: integer
                     format: int64

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/test/java/io/gravitee/gamma/rest/core/observability/filter/model/StaticFiltersContractTest.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/test/java/io/gravitee/gamma/rest/core/observability/filter/model/StaticFiltersContractTest.java
@@ -53,4 +53,15 @@ class StaticFiltersContractTest {
             .as("All canonical groups must be present in the StaticFilters catalog")
             .allSatisfy(canonicalKey -> assertThat(catalogKeys).contains(canonicalKey));
     }
+
+    @Test
+    void status_code_group_labels_should_match_friendly_labels() {
+        var spec = StaticFilters.HTTP_STATUS_CODE_GROUP.toSpec();
+
+        assertThat(spec.enumValues()).allSatisfy(enumValue ->
+            assertThat(HttpStatusCodeGroups.FRIENDLY_LABELS.get(enumValue.value()))
+                .as("Catalog label for '%s' must match HttpStatusCodeGroups.FRIENDLY_LABELS", enumValue.value())
+                .isEqualTo(enumValue.label())
+        );
+    }
 }

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/test/java/io/gravitee/gamma/rest/core/observability/logs/use_case/SearchObservabilityLogsUseCaseTest.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/test/java/io/gravitee/gamma/rest/core/observability/logs/use_case/SearchObservabilityLogsUseCaseTest.java
@@ -98,6 +98,16 @@ class SearchObservabilityLogsUseCaseTest {
                     Set.of(io.gravitee.gamma.rest.core.observability.filter.model.ApiType.HTTP_PROXY)
                 ),
                 new FilterSpec(
+                    "API_TYPE",
+                    "API Type",
+                    FilterType.ENUM,
+                    List.of(FilterOperator.EQ, FilterOperator.IN),
+                    null,
+                    null,
+                    Set.of(Signal.LOGS, Signal.ANALYTICS),
+                    io.gravitee.gamma.rest.core.observability.filter.model.ApiType.ALL
+                ),
+                new FilterSpec(
                     "APPLICATION",
                     "Application",
                     FilterType.KEYWORD,
@@ -179,6 +189,72 @@ class SearchObservabilityLogsUseCaseTest {
             var output = useCase.execute(new SearchObservabilityLogsUseCase.Input(ORG_ID, ENV_ID, filters, null, null, 1, 20));
 
             assertThat(output.data()).isEqualTo(LogsPage.EMPTY);
+        }
+
+        @Test
+        void should_narrow_scope_to_requested_api_type() {
+            when(logsDataPort.loadAccessibleApis(ORG_ID, ENV_ID)).thenReturn(
+                List.of(
+                    new AccessibleApi("api-proxy", "Proxy API", ApiType.HTTP_PROXY),
+                    new AccessibleApi("api-llm", "LLM API", ApiType.LLM),
+                    new AccessibleApi("api-mcp", "MCP API", ApiType.MCP)
+                )
+            );
+            when(logsDataPort.searchLogs(eq(ORG_ID), eq(ENV_ID), any())).thenReturn(LogsPage.EMPTY);
+
+            var filters = List.of(new FilterCondition("API_TYPE", FilterOperator.EQ, List.of("LLM")));
+            useCase.execute(new SearchObservabilityLogsUseCase.Input(ORG_ID, ENV_ID, filters, null, null, 1, 20));
+
+            var captor = ArgumentCaptor.forClass(LogsSearchQuery.class);
+            verify(logsDataPort).searchLogs(eq(ORG_ID), eq(ENV_ID), captor.capture());
+            assertThat(captor.getValue().apiIds()).containsExactly("api-llm");
+        }
+
+        @Test
+        void should_narrow_scope_to_multiple_api_types() {
+            when(logsDataPort.loadAccessibleApis(ORG_ID, ENV_ID)).thenReturn(
+                List.of(
+                    new AccessibleApi("api-proxy", "Proxy API", ApiType.HTTP_PROXY),
+                    new AccessibleApi("api-llm", "LLM API", ApiType.LLM),
+                    new AccessibleApi("api-mcp", "MCP API", ApiType.MCP)
+                )
+            );
+            when(logsDataPort.searchLogs(eq(ORG_ID), eq(ENV_ID), any())).thenReturn(LogsPage.EMPTY);
+
+            var filters = List.of(new FilterCondition("API_TYPE", FilterOperator.IN, List.of("LLM", "MCP")));
+            useCase.execute(new SearchObservabilityLogsUseCase.Input(ORG_ID, ENV_ID, filters, null, null, 1, 20));
+
+            var captor = ArgumentCaptor.forClass(LogsSearchQuery.class);
+            verify(logsDataPort).searchLogs(eq(ORG_ID), eq(ENV_ID), captor.capture());
+            assertThat(captor.getValue().apiIds()).containsExactlyInAnyOrder("api-llm", "api-mcp");
+        }
+
+        @Test
+        void should_return_empty_page_when_api_type_is_unsupported_for_logs() {
+            when(logsDataPort.loadAccessibleApis(ORG_ID, ENV_ID)).thenReturn(
+                List.of(
+                    new AccessibleApi("api-proxy", "Proxy API", ApiType.HTTP_PROXY),
+                    new AccessibleApi("api-message", "Message API", ApiType.MESSAGE)
+                )
+            );
+
+            var filters = List.of(new FilterCondition("API_TYPE", FilterOperator.EQ, List.of("MESSAGE")));
+            var output = useCase.execute(new SearchObservabilityLogsUseCase.Input(ORG_ID, ENV_ID, filters, null, null, 1, 20));
+
+            assertThat(output.data()).isEqualTo(LogsPage.EMPTY);
+        }
+
+        @Test
+        void should_not_pass_api_type_condition_to_data_port() {
+            when(logsDataPort.loadAccessibleApis(ORG_ID, ENV_ID)).thenReturn(List.of(new AccessibleApi("api-llm", "LLM API", ApiType.LLM)));
+            when(logsDataPort.searchLogs(eq(ORG_ID), eq(ENV_ID), any())).thenReturn(LogsPage.EMPTY);
+
+            var filters = List.of(new FilterCondition("API_TYPE", FilterOperator.EQ, List.of("LLM")));
+            useCase.execute(new SearchObservabilityLogsUseCase.Input(ORG_ID, ENV_ID, filters, null, null, 1, 20));
+
+            var captor = ArgumentCaptor.forClass(LogsSearchQuery.class);
+            verify(logsDataPort).searchLogs(eq(ORG_ID), eq(ENV_ID), captor.capture());
+            assertThat(captor.getValue().conditions()).noneMatch(c -> "API_TYPE".equals(c.name()));
         }
     }
 

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/test/java/io/gravitee/gamma/rest/infra/adapter/AnalyticsBucketTypeEnricherTest.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/test/java/io/gravitee/gamma/rest/infra/adapter/AnalyticsBucketTypeEnricherTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gamma.rest.infra.adapter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.gravitee.apim.core.analytics_engine.model.FacetBucketResponse;
+import io.gravitee.apim.core.analytics_engine.model.FacetsResponse;
+import io.gravitee.apim.core.analytics_engine.model.Measure;
+import io.gravitee.apim.core.analytics_engine.model.MetricFacetsResponse;
+import io.gravitee.apim.core.analytics_engine.model.MetricSpec;
+import io.gravitee.apim.core.analytics_engine.model.TimeSeriesBucketResponse;
+import io.gravitee.apim.core.analytics_engine.model.TimeSeriesMetricResponse;
+import io.gravitee.apim.core.analytics_engine.model.TimeSeriesResponse;
+import java.util.List;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class AnalyticsBucketTypeEnricherTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Test
+    void should_add_group_and_leaf_types_to_multi_level_facets_response() {
+        var leaf = new FacetBucketResponse("200", "200 OK", null, List.of(new Measure(MetricSpec.Measure.COUNT, 883)));
+        var group = new FacetBucketResponse("200", "200", List.of(leaf), null);
+        var response = new FacetsResponse(
+            List.of(new MetricFacetsResponse(MetricSpec.Name.HTTP_REQUESTS, MetricSpec.Unit.NUMBER, List.of(group)))
+        );
+
+        var node = (ObjectNode) objectMapper.valueToTree(response);
+        AnalyticsBucketTypeEnricher.enrichFacetsResponse(node);
+
+        assertThat(node.at("/metrics/0/buckets/0/type").asText()).isEqualTo("GROUP");
+        assertThat(node.at("/metrics/0/buckets/0/buckets/0/type").asText()).isEqualTo("LEAF");
+        assertThat(node.at("/metrics/0/buckets/0/buckets/0/measures/0/value").asInt()).isEqualTo(883);
+    }
+
+    @Test
+    void should_add_leaf_type_to_flat_facets_response() {
+        var leaf = new FacetBucketResponse("200", "200 OK", null, List.of(new Measure(MetricSpec.Measure.COUNT, 42)));
+        var response = new FacetsResponse(
+            List.of(new MetricFacetsResponse(MetricSpec.Name.HTTP_REQUESTS, MetricSpec.Unit.NUMBER, List.of(leaf)))
+        );
+
+        var node = (ObjectNode) objectMapper.valueToTree(response);
+        AnalyticsBucketTypeEnricher.enrichFacetsResponse(node);
+
+        assertThat(node.at("/metrics/0/buckets/0/type").asText()).isEqualTo("LEAF");
+    }
+
+    @Test
+    void should_treat_empty_nested_buckets_as_leaf() {
+        var leaf = new FacetBucketResponse("200-299", "2xx Success", List.of(), List.of(new Measure(MetricSpec.Measure.COUNT, 0)));
+        var response = new FacetsResponse(
+            List.of(new MetricFacetsResponse(MetricSpec.Name.HTTP_REQUESTS, MetricSpec.Unit.NUMBER, List.of(leaf)))
+        );
+
+        var node = (ObjectNode) objectMapper.valueToTree(response);
+        AnalyticsBucketTypeEnricher.enrichFacetsResponse(node);
+
+        assertThat(node.at("/metrics/0/buckets/0/type").asText()).isEqualTo("LEAF");
+    }
+
+    @Test
+    void should_add_group_and_leaf_types_to_time_series_response() {
+        var facetLeaf = new FacetBucketResponse("APP-1", "App 1", null, List.of(new Measure(MetricSpec.Measure.COUNT, 5)));
+        var timeBucket = new TimeSeriesBucketResponse("2026-06-10T00:00:00Z", null, 1_749_513_600_000L, List.of(facetLeaf), null);
+        var response = new TimeSeriesResponse(
+            List.of(new TimeSeriesMetricResponse(MetricSpec.Name.HTTP_REQUESTS, MetricSpec.Unit.NUMBER, List.of(timeBucket)))
+        );
+
+        var node = (ObjectNode) objectMapper.valueToTree(response);
+        AnalyticsBucketTypeEnricher.enrichTimeSeriesResponse(node);
+
+        assertThat(node.at("/metrics/0/buckets/0/type").asText()).isEqualTo("GROUP");
+        assertThat(node.at("/metrics/0/buckets/0/buckets/0/type").asText()).isEqualTo("LEAF");
+    }
+}

--- a/gravitee-gamma/gravitee-gamma-rest-api/src/test/java/io/gravitee/gamma/rest/resources/observability/analytics/dto/AnalyticsRequestDtoTest.java
+++ b/gravitee-gamma/gravitee-gamma-rest-api/src/test/java/io/gravitee/gamma/rest/resources/observability/analytics/dto/AnalyticsRequestDtoTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gamma.rest.resources.observability.analytics.dto;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class AnalyticsRequestDtoTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Test
+    void should_deserialize_facets_request_with_by_clause() throws Exception {
+        var json = """
+            {
+              "filters": [],
+              "by": ["MCP_PROXY_PROMPT"],
+              "metrics": [{"name": "HTTP_REQUESTS", "measures": ["COUNT"]}],
+              "limit": 5
+            }
+            """;
+
+        var request = objectMapper.readValue(json, AnalyticsFacetsRequestDto.class);
+
+        assertThat(request.by()).containsExactly("MCP_PROXY_PROMPT");
+        assertThat(request.limit()).isEqualTo(5);
+    }
+
+    @Test
+    void should_deserialize_time_series_request_with_by_clause() throws Exception {
+        var json = """
+            {
+              "interval": 60000,
+              "by": ["API"],
+              "metrics": [{"name": "HTTP_REQUESTS", "measures": ["COUNT"]}],
+              "facetSize": 5
+            }
+            """;
+
+        var request = objectMapper.readValue(json, AnalyticsTimeSeriesRequestDto.class);
+
+        assertThat(request.by()).containsExactly("API");
+        assertThat(request.facetSize()).isEqualTo(5);
+    }
+}


### PR DESCRIPTION
## Summary

Delivers friendly display labels for HTTP status facet buckets, fixes Gamma observability analytics/log blockers found while validating the Status Distribution doughnut, and aligns per-code labels with Netty reason phrases (gateway data plane source).

Refs [GMA-711](https://gravitee.atlassian.net/browse/GMA-711)

## Changes

### Friendly HTTP status labels (management v2 + Gamma)
- **`HttpStatusCodeGroups`** — `FRIENDLY_LABELS` map and `esBucketKeyToFriendlyGroupLabel()` as single source of truth
- **`HttpStatusLabels`** — per-code labels via Netty `HttpResponseStatus` (synthetic phrases fall back to raw key)
- **`BucketNamesPostProcessorImpl`** — friendly group labels + Netty-backed status labels
- **`StaticFilters`** — `STATUS_CODE_GROUPS` sourced from `FRIENDLY_LABELS`

### Gamma observability fixes
- **`SearchObservabilityLogsUseCase`** — narrow `API_TYPE` filter to logs-supported types
- **Analytics DTOs** — accept `by` clause (was `facets`)
- **`AnalyticsBucketTypeEnricher`** — `type: GROUP | LEAF`; empty `buckets` arrays treated as leaf

### Elasticsearch query fix (shared adapter)
- **`HTTPFacetsQueryAdapter`** — range aggregation for `HTTP_STATUS_CODE_GROUP` at any depth (fixes `by: [HTTP_STATUS_CODE_GROUP, HTTP_STATUS]`)

## Test plan

- [x] `HttpStatusCodeGroupsTest`
- [x] `HttpStatusLabelsTest` — Netty labels + synthetic fallback (418, 999)
- [x] `BucketNamesProcessorTest` — group/code labels, unknown fallback
- [x] `HTTPFacetsQueryAdapterTest` — multi-dim status group + status
- [x] `HTTPTimeSeriesAdapterTest` — nested range agg under date histogram
- [x] `SearchObservabilityLogsUseCaseTest` — API_TYPE narrowing
- [x] `AnalyticsRequestDtoTest` — `by` clause
- [x] `AnalyticsBucketTypeEnricherTest` — GROUP/LEAF + empty buckets
- [x] Local Docker Compose — ES repository plugin redeployed
- [ ] MCP Status Distribution doughnut — non-zero counts + friendly labels
- [ ] Multi-dim facets `by: [HTTP_STATUS_CODE_GROUP, HTTP_STATUS]` — nested GROUP → LEAF

## Reviewer notes

- Per-code labels now use Netty; codes with synthetic Netty phrases (e.g. unregistered 418/999 in this Netty version) intentionally fall back to the raw key.
- ES adapter fix is the critical path for doughnut counts when widgets use multi-dimension status grouping.
- Follow-up (separate ticket): `gamma-lib-observability` `status-palette.ts` maps `2XX` keys but ES returns `200-299` — affects stacked chart colors, not labels.

[GMA-711]: https://gravitee.atlassian.net/browse/GMA-711?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ