### PR TITLE
chore: bump gravitee-endpoint-azure-service-bus to 2.0.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -299,7 +299,7 @@
         <gravitee-endpoint-mqtt5.version>5.0.0</gravitee-endpoint-mqtt5.version>
         <gravitee-endpoint-rabbitmq.version>4.0.0</gravitee-endpoint-rabbitmq.version>
         <gravitee-endpoint-solace.version>4.0.1</gravitee-endpoint-solace.version>
-        <gravitee-endpoint-azure-service-bus.version>2.0.0</gravitee-endpoint-azure-service-bus.version>
+        <gravitee-endpoint-azure-service-bus.version>2.0.1</gravitee-endpoint-azure-service-bus.version>
         <gravitee-endpoint-agent-to-agent.version>2.0.0</gravitee-endpoint-agent-to-agent.version>
         <gravitee-policy-graphql-rate-limit.version>1.0.2</gravitee-policy-graphql-rate-limit.version>
         <gravitee-resource-schema-registry-confluent.version>4.1.0</gravitee-resource-schema-registry-confluent.version>


### PR DESCRIPTION
https://gravitee.atlassian.net/browse/APIM-14277