### PR TITLE
ci: fix and improve redis repository test job

### DIFF
--- a/.circleci/ci/src/jobs/test-container/job-redis-test-container.ts
+++ b/.circleci/ci/src/jobs/test-container/job-redis-test-container.ts
@@ -24,11 +24,11 @@ export class RedisTestContainerJob extends AbstractTestContainerJob {
       dynamicConfig,
       environment,
       'job-redis-test-container',
-      new parameters.CustomParametersList([new parameters.CustomParameter('redisVersion', 'string', '', 'Version of Redis to test')]),
+      new parameters.CustomParametersList([new parameters.CustomParameter('redisImage', 'string', '', 'Redis Docker image to test')]),
       new commands.Run({
-        name: 'Run Rate-limit repository tests with Redis << parameters.redisVersion >>',
+        name: 'Run Rate-limit repository tests with Redis << parameters.redisImage >>',
         command: `cd gravitee-apim-repository
-mvn -pl 'gravitee-apim-repository-redis' -am -s ../${config.maven.settingsFile} clean package --no-transfer-progress -Dskip.validation=true -DredisVersion=<< parameters.redisVersion >>`,
+mvn -pl 'gravitee-apim-repository-redis' -am -s ../${config.maven.settingsFile} clean package --no-transfer-progress -Dskip.validation=true -DredisImage=<< parameters.redisImage >>`,
       }),
     );
   }

--- a/.circleci/ci/src/pipelines/tests/resources/repositories-tests/repositories-tests.yml
+++ b/.circleci/ci/src/pipelines/tests/resources/repositories-tests/repositories-tests.yml
@@ -233,10 +233,10 @@ jobs:
       - cmd-notify-on-failure
   job-redis-test-container:
     parameters:
-      redisVersion:
+      redisImage:
         type: string
         default: ""
-        description: Version of Redis to test
+        description: Redis Docker image to test
     machine:
       image: ubuntu-2204:current
       docker_layer_caching: false
@@ -251,10 +251,10 @@ jobs:
           keys:
             - gravitee-api-management-v14-build-apim-{{ .Environment.CIRCLE_WORKFLOW_WORKSPACE_ID }}
       - run:
-          name: Run Rate-limit repository tests with Redis << parameters.redisVersion >>
+          name: Run Rate-limit repository tests with Redis << parameters.redisImage >>
           command: |-
             cd gravitee-apim-repository
-            mvn -pl 'gravitee-apim-repository-redis' -am -s ../.gravitee.settings.xml clean package --no-transfer-progress -Dskip.validation=true -DredisVersion=<< parameters.redisVersion >>
+            mvn -pl 'gravitee-apim-repository-redis' -am -s ../.gravitee.settings.xml clean package --no-transfer-progress -Dskip.validation=true -DredisImage=<< parameters.redisImage >>
       - run:
           name: Save test results
           command: |-
@@ -359,18 +359,19 @@ workflows:
                 - "2"
                 - "3"
       - job-redis-test-container:
-          name: Rate Limit repository tests - Redis << matrix.redisVersion >>
+          name: Rate Limit repository tests - Redis << matrix.redisImage >>
           context:
             - cicd-orchestrator
           requires:
             - Build
           matrix:
             parameters:
-              redisVersion:
-                - 6.2.6-v9
-                - 7.0.6-RC9
-                - 7.2.0-v7
-                - latest
+              redisImage:
+                - redis/redis-stack:6.2.6-v20
+                - redis/redis-stack:7.0.6-RC9
+                - redis/redis-stack:7.2.0-v20
+                - redis/redis-stack:7.4.0-v8
+                - redis:8
 orbs:
   keeper: gravitee-io/keeper@0.7.0
   slack: circleci/slack@4.12.5

--- a/.circleci/ci/src/workflows/workflow-repositories-tests.ts
+++ b/.circleci/ci/src/workflows/workflow-repositories-tests.ts
@@ -115,11 +115,17 @@ export class RepositoriesTestsWorkflow {
         },
       }),
       new workflow.WorkflowJob(redisTestContainerJob, {
-        name: 'Rate Limit repository tests - Redis << matrix.redisVersion >>',
+        name: 'Rate Limit repository tests - Redis << matrix.redisImage >>',
         context: ['cicd-orchestrator'],
         requires: [buildJobName],
         matrix: {
-          redisVersion: ['6.2.6-v9', '7.0.6-RC9', '7.2.0-v7', 'latest'],
+          redisImage: [
+            'redis/redis-stack:6.2.6-v20',
+            'redis/redis-stack:7.0.6-RC9',
+            'redis/redis-stack:7.2.0-v20',
+            'redis/redis-stack:7.4.0-v8',
+            'redis:8',
+          ],
         },
       }),
     ]);

--- a/gravitee-apim-repository/gravitee-apim-repository-redis/src/test/java/io/gravitee/repository/redis/RedisTestRepositoryConfiguration.java
+++ b/gravitee-apim-repository/gravitee-apim-repository-redis/src/test/java/io/gravitee/repository/redis/RedisTestRepositoryConfiguration.java
@@ -44,16 +44,16 @@ public class RedisTestRepositoryConfiguration {
 
     private static final Logger LOG = LoggerFactory.getLogger(RedisTestRepositoryConfiguration.class);
 
-    @Value("${redisStackVersion:6.2.6-v9}")
-    private String redisStackVersion;
+    @Value("${redisImage:redis/redis-stack:6.2.6-v9}")
+    private String redisImage;
 
     @Bean(destroyMethod = "stop")
     public GenericContainer<?> redisContainer() {
-        var redis = new GenericContainer<>(DockerImageName.parse("redis/redis-stack:" + redisStackVersion)).withExposedPorts(6379);
+        var redis = new GenericContainer<>(DockerImageName.parse(redisImage)).withExposedPorts(6379);
 
         redis.start();
 
-        LOG.info("Running tests with redis version: {}", redisStackVersion);
+        LOG.info("Running tests with redis image: {}", redisImage);
 
         return redis;
     }


### PR DESCRIPTION
## Issue

N/A

## Description

- Fix the CI snapshot and workflow that were not updated when the redis parameter was renamed
- Switch from a version-only parameter to a full image reference (`redisImage`) so the job can handle both `redis/redis-stack` and the official `redis` image
- Use `redis:8` (official image — RediSearch is bundled natively since Redis 8.0)
- Keep `redis/redis-stack` for 6.x/7.x where RediSearch is not available in the official image
- Update test matrix to latest available patch for each minor version:
  - `redis/redis-stack:6.2.6-v20`
  - `redis/redis-stack:7.0.6-RC9`
  - `redis/redis-stack:7.2.0-v20`
  - `redis/redis-stack:7.4.0-v8`
  - `redis:8`