### PR TITLE
ci: skip full pipeline on gamma module version bump

### DIFF
--- a/.circleci/ci/src/index.ts
+++ b/.circleci/ci/src/index.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { changedFiles, isBlank, isSupportBranchOrMaster } from './utils';
+import { changedFiles, isBlank, isRootPomOnlyGammaModuleBump, isSupportBranchOrMaster } from './utils';
 import { argv } from 'node:process';
 import { buildCIPipeline, CircleCIEnvironment } from './pipelines';
 import * as fs from 'fs';
@@ -41,9 +41,13 @@ if (isBlank(CIRCLE_SHA1)) {
  *     - if the branch is supported ( CIRCLE_BRANCH is master or a support branch )
  *     - if we are working on a branch with changes committed on the base branch
  */
-const changed = isSupportBranchOrMaster(CIRCLE_BRANCH) ? Promise.resolve([]) : changedFiles(GIT_COMMON_COMMIT_HASH ?? GIT_BASE_BRANCH);
+const diffBase = GIT_COMMON_COMMIT_HASH ?? GIT_BASE_BRANCH;
+const changed = isSupportBranchOrMaster(CIRCLE_BRANCH) ? Promise.resolve([]) : changedFiles(diffBase);
 
 changed
+  .then((changes) =>
+    changes.includes('pom.xml') && isRootPomOnlyGammaModuleBump(diffBase) ? changes.filter((file) => file !== 'pom.xml') : changes,
+  )
   .then(
     (changes) =>
       ({

--- a/.circleci/ci/src/utils/git.ts
+++ b/.circleci/ci/src/utils/git.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { spawn } from 'node:child_process';
+import { spawn, spawnSync } from 'node:child_process';
 
 /**
  * Returns the files / directories changed between 2 commits
@@ -53,3 +53,22 @@ export const changedFiles = async (from: string, to = 'HEAD'): Promise<string[]>
 const diffCommand = (from: string, to: string) => `git --no-pager diff --name-only ${from} ${to}`;
 const keepFirstPathItem = (path: string) => path.split('/')[0];
 const removeDuplicate = (path: string, index: number, arr: string[]) => arr.indexOf(path) === index;
+
+/**
+ * Returns true when the only change in the root pom.xml is a version bump of one or more
+ * `gravitee-gamma-module-*.version` properties. Those modules are external dependencies that are
+ * not built nor tested by this repository, so such a bump must not trigger the full CI.
+ */
+export const isRootPomOnlyGammaModuleBump = (from: string, to = 'HEAD'): boolean => {
+  try {
+    const { stdout, status } = spawnSync('git', ['--no-pager', 'diff', '-U0', from, to, '--', 'pom.xml'], { encoding: 'utf-8' });
+    return status === 0 && isOnlyGammaModuleVersionBump(stdout);
+  } catch {
+    return false;
+  }
+};
+
+export const isOnlyGammaModuleVersionBump = (diff: string): boolean => {
+  const changedLines = diff.split('\n').filter((line) => /^[+-][^+-]/.test(line));
+  return changedLines.length > 0 && changedLines.every((line) => /<gravitee-gamma-module-[a-z0-9-]+\.version>/.test(line));
+};

--- a/.circleci/ci/src/utils/tests/git.spec.ts
+++ b/.circleci/ci/src/utils/tests/git.spec.ts
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { isOnlyGammaModuleVersionBump } from '../git';
+
+describe('isOnlyGammaModuleVersionBump', () => {
+  it('returns true when only a single gamma module version is bumped', () => {
+    const diff = `--- a/pom.xml
++++ b/pom.xml
+@@ -336 +336 @@
+-        <gravitee-gamma-module-aim.version>1.0.0-alpha.168</gravitee-gamma-module-aim.version>
++        <gravitee-gamma-module-aim.version>1.0.0-alpha.169</gravitee-gamma-module-aim.version>`;
+    expect(isOnlyGammaModuleVersionBump(diff)).toBe(true);
+  });
+
+  it('returns true when several gamma module versions are bumped', () => {
+    const diff = `--- a/pom.xml
++++ b/pom.xml
+-        <gravitee-gamma-module-aim.version>1.0.0-alpha.168</gravitee-gamma-module-aim.version>
++        <gravitee-gamma-module-aim.version>1.0.0-alpha.169</gravitee-gamma-module-aim.version>
+-        <gravitee-gamma-module-authz.version>1.0.0-alpha.19</gravitee-gamma-module-authz.version>
++        <gravitee-gamma-module-authz.version>1.0.0-alpha.20</gravitee-gamma-module-authz.version>`;
+    expect(isOnlyGammaModuleVersionBump(diff)).toBe(true);
+  });
+
+  it('returns false when another dependency version is bumped', () => {
+    const diff = `--- a/pom.xml
++++ b/pom.xml
+-        <gravitee-common.version>4.5.0</gravitee-common.version>
++        <gravitee-common.version>4.6.0</gravitee-common.version>`;
+    expect(isOnlyGammaModuleVersionBump(diff)).toBe(false);
+  });
+
+  it('returns false when a gamma bump is mixed with another change', () => {
+    const diff = `--- a/pom.xml
++++ b/pom.xml
+-        <gravitee-gamma-module-aim.version>1.0.0-alpha.168</gravitee-gamma-module-aim.version>
++        <gravitee-gamma-module-aim.version>1.0.0-alpha.169</gravitee-gamma-module-aim.version>
+-        <gravitee-common.version>4.5.0</gravitee-common.version>
++        <gravitee-common.version>4.6.0</gravitee-common.version>`;
+    expect(isOnlyGammaModuleVersionBump(diff)).toBe(false);
+  });
+
+  it('returns false for an empty diff', () => {
+    expect(isOnlyGammaModuleVersionBump('')).toBe(false);
+  });
+});


### PR DESCRIPTION
## What

The automated PRs that bump a `gravitee-gamma-module-*.version` property in the root `pom.xml` currently trigger the whole CI (all backend tests, frontend builds, sonar, helm...).

This happens because the change detection treats any `pom.xml` change as a global change (`shouldBuildAll`), so the per-module filtering is bypassed.

## Why

Gamma modules are external dependencies that are not built nor tested by this repository. A plain version bump of one of them doesn't need the full pipeline, so running it just wastes CI time on every alpha bump.

## How

When the only change in the root `pom.xml` is a bump of one or more `gravitee-gamma-module-*.version` properties, `pom.xml` is dropped from the list of changed files before the pipeline is generated. The full CI is no longer forced and only the always-on jobs run (fs_scan, Danger JS, validation).

The decision is based on parsing the actual diff content, not the branch name, so any other `pom.xml` change keeps the current behavior.

A unit test covers the parser (single gamma bump, multiple gamma bumps, other dependency bump, mixed change, empty diff).